### PR TITLE
ci: add Rust CI workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Problem
+
+<!-- What problem does this PR solve? Link related issues: Closes #123 -->
+
+## Solution
+
+<!-- What did you change and why this approach?
+     Mention which parts of the codebase are affected (engine, packages, mods, docs).
+     For UI changes, include screenshots: <details><summary>Screenshots</summary>paste here</details>
+     If this is a breaking change, add a ### Breaking Changes subsection below. -->

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,0 +1,29 @@
+name: ci-rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-rust-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -27,3 +27,16 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+      - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -40,3 +40,14 @@ jobs:
         with:
           shared-key: "ci"
       - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+      - run: cargo test --workspace --all-targets

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -51,3 +51,16 @@ jobs:
         with:
           shared-key: "ci"
       - run: cargo test --workspace --all-targets
+
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+      - run: cargo doc --workspace --no-deps

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -64,3 +64,12 @@ jobs:
         with:
           shared-key: "ci"
       - run: cargo doc --workspace --no-deps
+
+  deny:
+    name: deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = false
+no-default-features = false
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.93
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "0BSD",
+    "MPL-2.0",
+]
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Problem

The repository has no CI. Code quality regressions (formatting drift, clippy warnings, broken tests, broken docs, unsafe dependencies) can land on `main` undetected. Future contributors lack a shared signal for whether a PR is ready to review.

## Solution

Introduce a GitHub Actions workflow at `.github/workflows/ci-rust.yml` that runs five parallel jobs on every `pull_request` and on `push` to `main`:

- `fmt` — `cargo fmt --all -- --check`
- `lint` — `cargo clippy --workspace --all-targets -- -D warnings`
- `test` — `cargo test --workspace --all-targets`
- `doc` — `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings`
- `deny` — `cargo deny check` via `EmbarkStudios/cargo-deny-action@v2`

Toolchain is pinned via `rust-toolchain.toml` (Rust 1.95) for local/CI parity. Build cache is handled by `Swatinem/rust-cache@v2` with a shared key across the lint/test/doc jobs. Dependency policy lives in `deny.toml` (advisories, licenses, bans, sources). The workflow uses `concurrency.cancel-in-progress` to drop superseded PR runs while preserving `main` history. Workflow files are split per language (`ci-rust.yml`) so a future Node.js workflow can be added without conflict.

This PR also adds a project-wide `.github/pull_request_template.md` so future PRs follow a consistent Problem/Solution structure.

**Affected areas:** repo root (`.github/`), no runtime code changes.