### PR TITLE
Introduce Tokyo Night design token system + dev-only showcase

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,13 @@
       "trailingCommas": "all"
     }
   },
+  "css": {
+    "parser": {
+      "cssModules": false,
+      "allowWrongLineComments": false,
+      "tailwindDirectives": true
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/daemon/frontend/src/App.tsx
+++ b/daemon/frontend/src/App.tsx
@@ -1,3 +1,12 @@
 export function App() {
-  return <div className="text-3xl underline">Hello World!</div>;
+  return (
+    <div className="min-h-screen bg-background text-foreground font-mono p-6">
+      <h1 className="text-xl text-primary">Hello World!</h1>
+      <p className="text-base text-muted-foreground mt-2">
+        Tokens are wired up. Visit{' '}
+        <code className="bg-card text-primary px-1 rounded-sm">?showcase=tokens</code> to see them
+        all.
+      </p>
+    </div>
+  );
 }

--- a/daemon/frontend/src/index.css
+++ b/daemon/frontend/src/index.css
@@ -1,1 +1,0 @@
-@import "tailwindcss";

--- a/daemon/frontend/src/main.tsx
+++ b/daemon/frontend/src/main.tsx
@@ -5,7 +5,9 @@ import { App } from './App.tsx';
 
 const params = new URLSearchParams(window.location.search);
 const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
-const root = createRoot(document.getElementById('root')!);
+const rootElement = document.getElementById('root');
+if (!rootElement) throw new Error('#root element not found');
+const root = createRoot(rootElement);
 
 if (isShowcase) {
   import('./showcase/TokenShowcase').then(({ TokenShowcase }) => {

--- a/daemon/frontend/src/main.tsx
+++ b/daemon/frontend/src/main.tsx
@@ -3,8 +3,25 @@ import { createRoot } from 'react-dom/client';
 import './styles/theme.css';
 import { App } from './App.tsx';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+async function bootstrap() {
+  const params = new URLSearchParams(window.location.search);
+  const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
+  const root = createRoot(document.getElementById('root')!);
+
+  if (isShowcase) {
+    const { TokenShowcase } = await import('./showcase/TokenShowcase');
+    root.render(
+      <StrictMode>
+        <TokenShowcase />
+      </StrictMode>,
+    );
+  } else {
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  }
+}
+
+bootstrap();

--- a/daemon/frontend/src/main.tsx
+++ b/daemon/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import './index.css';
+import './styles/theme.css';
 import { App } from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(

--- a/daemon/frontend/src/main.tsx
+++ b/daemon/frontend/src/main.tsx
@@ -3,25 +3,22 @@ import { createRoot } from 'react-dom/client';
 import './styles/theme.css';
 import { App } from './App.tsx';
 
-async function bootstrap() {
-  const params = new URLSearchParams(window.location.search);
-  const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
-  const root = createRoot(document.getElementById('root')!);
+const params = new URLSearchParams(window.location.search);
+const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
+const root = createRoot(document.getElementById('root')!);
 
-  if (isShowcase) {
-    const { TokenShowcase } = await import('./showcase/TokenShowcase');
+if (isShowcase) {
+  import('./showcase/TokenShowcase').then(({ TokenShowcase }) => {
     root.render(
       <StrictMode>
         <TokenShowcase />
       </StrictMode>,
     );
-  } else {
-    root.render(
-      <StrictMode>
-        <App />
-      </StrictMode>,
-    );
-  }
+  });
+} else {
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
 }
-
-bootstrap();

--- a/daemon/frontend/src/showcase/ColorSection.tsx
+++ b/daemon/frontend/src/showcase/ColorSection.tsx
@@ -7,6 +7,13 @@ type TokenRow = {
   bgClass: string;
   /** Literal Tailwind foreground class for the paired -foreground token, or null */
   textClass: string | null;
+  /**
+   * Underlying Layer 1 variable backing this token (e.g. `--tn-bg`).
+   * `@theme inline` does NOT emit `--color-*` into `:root` at runtime — it only
+   * inlines `var(--tn-*)` into the generated utility classes. To resolve the
+   * actual hex value at runtime we must read the Layer 1 variable directly.
+   */
+  rawVar: string;
 };
 
 type Group = {
@@ -18,46 +25,112 @@ const GROUPS: Group[] = [
   {
     title: 'Surfaces',
     rows: [
-      { name: 'background', bgClass: 'bg-background', textClass: 'text-foreground' },
-      { name: 'card', bgClass: 'bg-card', textClass: 'text-card-foreground' },
-      { name: 'popover', bgClass: 'bg-popover', textClass: 'text-popover-foreground' },
-      { name: 'muted', bgClass: 'bg-muted', textClass: 'text-muted-foreground' },
+      {
+        name: 'background',
+        bgClass: 'bg-background',
+        textClass: 'text-foreground',
+        rawVar: '--tn-bg',
+      },
+      {
+        name: 'card',
+        bgClass: 'bg-card',
+        textClass: 'text-card-foreground',
+        rawVar: '--tn-bg-card',
+      },
+      {
+        name: 'popover',
+        bgClass: 'bg-popover',
+        textClass: 'text-popover-foreground',
+        rawVar: '--tn-bg-popover',
+      },
+      {
+        name: 'muted',
+        bgClass: 'bg-muted',
+        textClass: 'text-muted-foreground',
+        rawVar: '--tn-bg-muted',
+      },
     ],
   },
   {
     title: 'Action / Emphasis',
     rows: [
-      { name: 'primary', bgClass: 'bg-primary', textClass: 'text-primary-foreground' },
-      { name: 'secondary', bgClass: 'bg-secondary', textClass: 'text-secondary-foreground' },
-      { name: 'accent', bgClass: 'bg-accent', textClass: 'text-accent-foreground' },
-      { name: 'destructive', bgClass: 'bg-destructive', textClass: 'text-destructive-foreground' },
+      {
+        name: 'primary',
+        bgClass: 'bg-primary',
+        textClass: 'text-primary-foreground',
+        rawVar: '--tn-blue',
+      },
+      {
+        name: 'secondary',
+        bgClass: 'bg-secondary',
+        textClass: 'text-secondary-foreground',
+        rawVar: '--tn-magenta',
+      },
+      {
+        name: 'accent',
+        bgClass: 'bg-accent',
+        textClass: 'text-accent-foreground',
+        rawVar: '--tn-border',
+      },
+      {
+        name: 'destructive',
+        bgClass: 'bg-destructive',
+        textClass: 'text-destructive-foreground',
+        rawVar: '--tn-red',
+      },
     ],
   },
   {
     title: 'Form & Boundary',
     rows: [
-      { name: 'border', bgClass: 'bg-border', textClass: null },
-      { name: 'input', bgClass: 'bg-input', textClass: null },
-      { name: 'ring', bgClass: 'bg-ring', textClass: null },
+      { name: 'border', bgClass: 'bg-border', textClass: null, rawVar: '--tn-border' },
+      { name: 'input', bgClass: 'bg-input', textClass: null, rawVar: '--tn-border' },
+      { name: 'ring', bgClass: 'bg-ring', textClass: null, rawVar: '--tn-blue' },
     ],
   },
   {
     title: 'Status',
     rows: [
-      { name: 'success', bgClass: 'bg-success', textClass: 'text-success-foreground' },
-      { name: 'warning', bgClass: 'bg-warning', textClass: 'text-warning-foreground' },
-      { name: 'info', bgClass: 'bg-info', textClass: 'text-info-foreground' },
+      {
+        name: 'success',
+        bgClass: 'bg-success',
+        textClass: 'text-success-foreground',
+        rawVar: '--tn-green',
+      },
+      {
+        name: 'warning',
+        bgClass: 'bg-warning',
+        textClass: 'text-warning-foreground',
+        rawVar: '--tn-yellow',
+      },
+      {
+        name: 'info',
+        bgClass: 'bg-info',
+        textClass: 'text-info-foreground',
+        rawVar: '--tn-cyan',
+      },
     ],
   },
   {
     title: 'tmux',
     rows: [
-      { name: 'tmux-pane-border', bgClass: 'bg-tmux-pane-border', textClass: null },
-      { name: 'tmux-pane-active', bgClass: 'bg-tmux-pane-active', textClass: null },
+      {
+        name: 'tmux-pane-border',
+        bgClass: 'bg-tmux-pane-border',
+        textClass: null,
+        rawVar: '--tn-border',
+      },
+      {
+        name: 'tmux-pane-active',
+        bgClass: 'bg-tmux-pane-active',
+        textClass: null,
+        rawVar: '--tn-blue',
+      },
       {
         name: 'tmux-status-bar',
         bgClass: 'bg-tmux-status-bar',
         textClass: 'text-tmux-status-bar-foreground',
+        rawVar: '--tn-bg-status',
       },
     ],
   },
@@ -73,7 +146,7 @@ function hexToRgb(hex: string): [number, number, number] | null {
 function relLuminance([r, g, b]: [number, number, number]): number {
   const lin = (c: number) => {
     const s = c / 255;
-    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
   };
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
@@ -89,19 +162,6 @@ function contrast(a: string, b: string): number | null {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-// Under @theme inline, semantic tokens store as `var(--tn-*)`. Resolve the chain.
-function readVar(style: CSSStyleDeclaration, name: string): string {
-  let value = style.getPropertyValue(`--color-${name}`).trim();
-  let depth = 0;
-  while (depth < 8) {
-    const ref = value.match(/^var\((--[^,)\s]+)/);
-    if (!ref) break;
-    value = style.getPropertyValue(ref[1]).trim();
-    depth += 1;
-  }
-  return value;
-}
-
 export function ColorSection() {
   const [resolved, setResolved] = useState<Record<string, string>>({});
 
@@ -110,7 +170,7 @@ export function ColorSection() {
     const map: Record<string, string> = {};
     for (const g of GROUPS) {
       for (const r of g.rows) {
-        map[r.name] = readVar(style, r.name);
+        map[r.name] = style.getPropertyValue(r.rawVar).trim();
       }
     }
     setResolved(map);

--- a/daemon/frontend/src/showcase/ColorSection.tsx
+++ b/daemon/frontend/src/showcase/ColorSection.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+
+type TokenRow = {
+  /** CSS variable suffix shown in UI, without the --color- prefix */
+  name: string;
+  /** Literal Tailwind background class — must appear verbatim for Tailwind to emit it */
+  bgClass: string;
+  /** Literal Tailwind foreground class for the paired -foreground token, or null */
+  textClass: string | null;
+};
+
+type Group = {
+  title: string;
+  rows: TokenRow[];
+};
+
+const GROUPS: Group[] = [
+  {
+    title: 'Surfaces',
+    rows: [
+      { name: 'background', bgClass: 'bg-background', textClass: 'text-foreground' },
+      { name: 'card', bgClass: 'bg-card', textClass: 'text-card-foreground' },
+      { name: 'popover', bgClass: 'bg-popover', textClass: 'text-popover-foreground' },
+      { name: 'muted', bgClass: 'bg-muted', textClass: 'text-muted-foreground' },
+    ],
+  },
+  {
+    title: 'Action / Emphasis',
+    rows: [
+      { name: 'primary', bgClass: 'bg-primary', textClass: 'text-primary-foreground' },
+      { name: 'secondary', bgClass: 'bg-secondary', textClass: 'text-secondary-foreground' },
+      { name: 'accent', bgClass: 'bg-accent', textClass: 'text-accent-foreground' },
+      { name: 'destructive', bgClass: 'bg-destructive', textClass: 'text-destructive-foreground' },
+    ],
+  },
+  {
+    title: 'Form & Boundary',
+    rows: [
+      { name: 'border', bgClass: 'bg-border', textClass: null },
+      { name: 'input', bgClass: 'bg-input', textClass: null },
+      { name: 'ring', bgClass: 'bg-ring', textClass: null },
+    ],
+  },
+  {
+    title: 'Status',
+    rows: [
+      { name: 'success', bgClass: 'bg-success', textClass: 'text-success-foreground' },
+      { name: 'warning', bgClass: 'bg-warning', textClass: 'text-warning-foreground' },
+      { name: 'info', bgClass: 'bg-info', textClass: 'text-info-foreground' },
+    ],
+  },
+  {
+    title: 'tmux',
+    rows: [
+      { name: 'tmux-pane-border', bgClass: 'bg-tmux-pane-border', textClass: null },
+      { name: 'tmux-pane-active', bgClass: 'bg-tmux-pane-active', textClass: null },
+      {
+        name: 'tmux-status-bar',
+        bgClass: 'bg-tmux-status-bar',
+        textClass: 'text-tmux-status-bar-foreground',
+      },
+    ],
+  },
+];
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const m = hex.trim().match(/^#?([0-9a-f]{6})$/i);
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+function relLuminance([r, g, b]: [number, number, number]): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: string, b: string): number | null {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  if (!ra || !rb) return null;
+  const la = relLuminance(ra);
+  const lb = relLuminance(rb);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function readVar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(`--color-${name}`).trim();
+}
+
+export function ColorSection() {
+  const [resolved, setResolved] = useState<Record<string, string>>({});
+  const [bg, setBg] = useState<string>('');
+
+  useEffect(() => {
+    const map: Record<string, string> = {};
+    for (const g of GROUPS) {
+      for (const r of g.rows) {
+        map[r.name] = readVar(r.name);
+      }
+    }
+    setResolved(map);
+    setBg(readVar('background'));
+  }, []);
+
+  return (
+    <section className="mb-12">
+      <h2 className="text-lg text-foreground mb-4">Colors</h2>
+      {GROUPS.map((g) => (
+        <div key={g.title} className="mb-6">
+          <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">{g.title}</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            {g.rows.map((r) => {
+              const value = resolved[r.name] ?? '';
+              const ratio = bg && value ? contrast(value, bg) : null;
+              const textClass = r.textClass ?? 'text-foreground';
+              return (
+                <div
+                  key={r.name}
+                  className={`${r.bgClass} ${textClass} border border-border rounded-md p-3 flex flex-col gap-1`}
+                >
+                  <div className="text-sm font-mono">--color-{r.name}</div>
+                  <div className="text-xs opacity-80 font-mono">{value || '…'}</div>
+                  {ratio !== null && (
+                    <div className="text-xs opacity-80 font-mono">
+                      {ratio.toFixed(2)}:1 vs background
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/daemon/frontend/src/showcase/ColorSection.tsx
+++ b/daemon/frontend/src/showcase/ColorSection.tsx
@@ -90,7 +90,17 @@ function contrast(a: string, b: string): number | null {
 }
 
 function readVar(name: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(`--color-${name}`).trim();
+  const style = getComputedStyle(document.documentElement);
+  let value = style.getPropertyValue(`--color-${name}`).trim();
+  // Under @theme inline, semantic tokens store as `var(--tn-*)`. Resolve the chain.
+  let depth = 0;
+  while (depth < 8) {
+    const ref = value.match(/^var\((--[^,)\s]+)/);
+    if (!ref) break;
+    value = style.getPropertyValue(ref[1]).trim();
+    depth += 1;
+  }
+  return value;
 }
 
 export function ColorSection() {

--- a/daemon/frontend/src/showcase/ColorSection.tsx
+++ b/daemon/frontend/src/showcase/ColorSection.tsx
@@ -89,10 +89,9 @@ function contrast(a: string, b: string): number | null {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-function readVar(name: string): string {
-  const style = getComputedStyle(document.documentElement);
+// Under @theme inline, semantic tokens store as `var(--tn-*)`. Resolve the chain.
+function readVar(style: CSSStyleDeclaration, name: string): string {
   let value = style.getPropertyValue(`--color-${name}`).trim();
-  // Under @theme inline, semantic tokens store as `var(--tn-*)`. Resolve the chain.
   let depth = 0;
   while (depth < 8) {
     const ref = value.match(/^var\((--[^,)\s]+)/);
@@ -105,18 +104,19 @@ function readVar(name: string): string {
 
 export function ColorSection() {
   const [resolved, setResolved] = useState<Record<string, string>>({});
-  const [bg, setBg] = useState<string>('');
 
   useEffect(() => {
+    const style = getComputedStyle(document.documentElement);
     const map: Record<string, string> = {};
     for (const g of GROUPS) {
       for (const r of g.rows) {
-        map[r.name] = readVar(r.name);
+        map[r.name] = readVar(style, r.name);
       }
     }
     setResolved(map);
-    setBg(readVar('background'));
   }, []);
+
+  const bg = resolved.background ?? '';
 
   return (
     <section className="mb-12">

--- a/daemon/frontend/src/showcase/PaneMockup.tsx
+++ b/daemon/frontend/src/showcase/PaneMockup.tsx
@@ -1,0 +1,44 @@
+export function PaneMockup() {
+  return (
+    <section className="mb-12">
+      <h2 className="text-lg text-foreground mb-4">Pane Mockup</h2>
+      <p className="text-sm text-muted-foreground mb-3">
+        End-to-end token usage in a tmux-style mini-UI. All colors, sizes, and borders come from
+        semantic tokens.
+      </p>
+      <div className="border border-border rounded-md overflow-hidden font-mono text-sm">
+        <div className="grid grid-cols-[1.4fr_1fr] min-h-[200px]">
+          {/* Left pane: active */}
+          <div className="bg-background text-foreground p-3 border-2 border-tmux-pane-active">
+            <div>
+              <span className="text-muted-foreground">$</span>{' '}
+              <span className="text-primary">cargo</span> run
+            </div>
+            <div className="text-success"> ✓ Compiled in 1.2s</div>
+            <div>
+              <span className="text-muted-foreground">$</span>{' '}
+              <span className="text-primary">git</span> status
+            </div>
+            <div className="text-warning"> M src/main.rs</div>
+            <div className="text-warning"> M src/lib.rs</div>
+          </div>
+
+          {/* Right pane: inactive */}
+          <div className="bg-background text-foreground p-3 border border-tmux-pane-border">
+            <div className="text-muted-foreground">[logs]</div>
+            <div>listening :8080</div>
+            <div className="text-success">200 GET /api/sessions</div>
+            <div className="text-info">101 WS /api/stream</div>
+            <div className="text-destructive">404 GET /favicon.ico</div>
+          </div>
+        </div>
+
+        {/* Status bar */}
+        <div className="bg-tmux-status-bar text-tmux-status-bar-foreground px-3 py-1 text-xs flex justify-between border-t border-border">
+          <span>ozmux · main</span>
+          <span className="text-muted-foreground">2 panes</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/daemon/frontend/src/showcase/PaneMockup.tsx
+++ b/daemon/frontend/src/showcase/PaneMockup.tsx
@@ -8,7 +8,6 @@ export function PaneMockup() {
       </p>
       <div className="border border-border rounded-md overflow-hidden font-mono text-sm">
         <div className="grid grid-cols-[1.4fr_1fr] min-h-[200px]">
-          {/* Left pane: active */}
           <div className="bg-background text-foreground p-3 border-2 border-tmux-pane-active">
             <div>
               <span className="text-muted-foreground">$</span>{' '}
@@ -23,7 +22,6 @@ export function PaneMockup() {
             <div className="text-warning"> M src/lib.rs</div>
           </div>
 
-          {/* Right pane: inactive */}
           <div className="bg-background text-foreground p-3 border border-tmux-pane-border">
             <div className="text-muted-foreground">[logs]</div>
             <div>listening :8080</div>
@@ -33,7 +31,6 @@ export function PaneMockup() {
           </div>
         </div>
 
-        {/* Status bar */}
         <div className="bg-tmux-status-bar text-tmux-status-bar-foreground px-3 py-1 text-xs flex justify-between border-t border-border">
           <span>ozmux · main</span>
           <span className="text-muted-foreground">2 panes</span>

--- a/daemon/frontend/src/showcase/RadiusSection.tsx
+++ b/daemon/frontend/src/showcase/RadiusSection.tsx
@@ -1,0 +1,23 @@
+const RADII = [
+  { name: 'rounded-sm', token: '--radius-sm', px: '2px' },
+  { name: 'rounded-md', token: '--radius-md', px: '4px (default)' },
+  { name: 'rounded-lg', token: '--radius-lg', px: '6px' },
+  { name: 'rounded-xl', token: '--radius-xl', px: '8px' },
+] as const;
+
+export function RadiusSection() {
+  return (
+    <section className="mb-12">
+      <h2 className="text-lg text-foreground mb-4">Border Radius</h2>
+      <div className="border border-border rounded-md p-3 flex flex-wrap gap-4">
+        {RADII.map((r) => (
+          <div key={r.name} className="flex flex-col items-center gap-2">
+            <div className={`${r.name} bg-primary w-20 h-20`} />
+            <div className="text-xs font-mono text-foreground">{r.name}</div>
+            <div className="text-xs font-mono text-muted-foreground">{r.px}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/daemon/frontend/src/showcase/RadiusSection.tsx
+++ b/daemon/frontend/src/showcase/RadiusSection.tsx
@@ -1,8 +1,8 @@
 const RADII = [
-  { name: 'rounded-sm', token: '--radius-sm', px: '2px' },
-  { name: 'rounded-md', token: '--radius-md', px: '4px (default)' },
-  { name: 'rounded-lg', token: '--radius-lg', px: '6px' },
-  { name: 'rounded-xl', token: '--radius-xl', px: '8px' },
+  { name: 'rounded-sm', px: '2px' },
+  { name: 'rounded-md', px: '4px (default)' },
+  { name: 'rounded-lg', px: '6px' },
+  { name: 'rounded-xl', px: '8px' },
 ] as const;
 
 export function RadiusSection() {

--- a/daemon/frontend/src/showcase/SpacingSection.tsx
+++ b/daemon/frontend/src/showcase/SpacingSection.tsx
@@ -1,13 +1,13 @@
 const STEPS = [
-  { name: '1', widthClass: 'w-1' },
-  { name: '2', widthClass: 'w-2' },
-  { name: '3', widthClass: 'w-3' },
-  { name: '4', widthClass: 'w-4' },
-  { name: '6', widthClass: 'w-6' },
-  { name: '8', widthClass: 'w-8' },
-  { name: '12', widthClass: 'w-12' },
-  { name: '16', widthClass: 'w-16' },
-  { name: '24', widthClass: 'w-24' },
+  { name: '1', widthClass: 'w-1', px: 4 },
+  { name: '2', widthClass: 'w-2', px: 8 },
+  { name: '3', widthClass: 'w-3', px: 12 },
+  { name: '4', widthClass: 'w-4', px: 16 },
+  { name: '6', widthClass: 'w-6', px: 24 },
+  { name: '8', widthClass: 'w-8', px: 32 },
+  { name: '12', widthClass: 'w-12', px: 48 },
+  { name: '16', widthClass: 'w-16', px: 64 },
+  { name: '24', widthClass: 'w-24', px: 96 },
 ] as const;
 
 export function SpacingSection() {
@@ -22,9 +22,7 @@ export function SpacingSection() {
           <div key={s.name} className="flex items-center gap-3">
             <div className="text-xs font-mono text-muted-foreground w-12 shrink-0">{s.name}</div>
             <div className={`${s.widthClass} h-4 bg-primary rounded-sm`} />
-            <div className="text-xs font-mono text-muted-foreground">
-              {parseInt(s.name, 10) * 4}px
-            </div>
+            <div className="text-xs font-mono text-muted-foreground">{s.px}px</div>
           </div>
         ))}
       </div>

--- a/daemon/frontend/src/showcase/SpacingSection.tsx
+++ b/daemon/frontend/src/showcase/SpacingSection.tsx
@@ -1,0 +1,33 @@
+const STEPS = [
+  { name: '1', widthClass: 'w-1' },
+  { name: '2', widthClass: 'w-2' },
+  { name: '3', widthClass: 'w-3' },
+  { name: '4', widthClass: 'w-4' },
+  { name: '6', widthClass: 'w-6' },
+  { name: '8', widthClass: 'w-8' },
+  { name: '12', widthClass: 'w-12' },
+  { name: '16', widthClass: 'w-16' },
+  { name: '24', widthClass: 'w-24' },
+] as const;
+
+export function SpacingSection() {
+  return (
+    <section className="mb-12">
+      <h2 className="text-lg text-foreground mb-4">Spacing</h2>
+      <p className="text-sm text-muted-foreground mb-3">
+        Tailwind v4 default 4px grid (--spacing: 0.25rem). Steps shown as horizontal bars.
+      </p>
+      <div className="border border-border rounded-md p-3 flex flex-col gap-2">
+        {STEPS.map((s) => (
+          <div key={s.name} className="flex items-center gap-3">
+            <div className="text-xs font-mono text-muted-foreground w-12 shrink-0">{s.name}</div>
+            <div className={`${s.widthClass} h-4 bg-primary rounded-sm`} />
+            <div className="text-xs font-mono text-muted-foreground">
+              {parseInt(s.name, 10) * 4}px
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,0 +1,8 @@
+export function TokenShowcase() {
+  return (
+    <div className="min-h-screen bg-background text-foreground font-mono p-6">
+      <h1 className="text-xl text-primary">Token Showcase</h1>
+      <p className="text-base text-muted-foreground mt-2">Sections coming in subsequent tasks.</p>
+    </div>
+  );
+}

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,4 +1,5 @@
 import { ColorSection } from './ColorSection';
+import { PaneMockup } from './PaneMockup';
 import { RadiusSection } from './RadiusSection';
 import { SpacingSection } from './SpacingSection';
 import { TypographySection } from './TypographySection';
@@ -11,6 +12,7 @@ export function TokenShowcase() {
       <TypographySection />
       <SpacingSection />
       <RadiusSection />
+      <PaneMockup />
     </div>
   );
 }

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,4 +1,5 @@
 import { ColorSection } from './ColorSection';
+import { RadiusSection } from './RadiusSection';
 import { SpacingSection } from './SpacingSection';
 import { TypographySection } from './TypographySection';
 
@@ -9,6 +10,7 @@ export function TokenShowcase() {
       <ColorSection />
       <TypographySection />
       <SpacingSection />
+      <RadiusSection />
     </div>
   );
 }

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,8 +1,10 @@
+import { ColorSection } from './ColorSection';
+
 export function TokenShowcase() {
   return (
     <div className="min-h-screen bg-background text-foreground font-mono p-6">
-      <h1 className="text-xl text-primary">Token Showcase</h1>
-      <p className="text-base text-muted-foreground mt-2">Sections coming in subsequent tasks.</p>
+      <h1 className="text-xl text-primary mb-6">Token Showcase</h1>
+      <ColorSection />
     </div>
   );
 }

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,10 +1,12 @@
 import { ColorSection } from './ColorSection';
+import { TypographySection } from './TypographySection';
 
 export function TokenShowcase() {
   return (
     <div className="min-h-screen bg-background text-foreground font-mono p-6">
       <h1 className="text-xl text-primary mb-6">Token Showcase</h1>
       <ColorSection />
+      <TypographySection />
     </div>
   );
 }

--- a/daemon/frontend/src/showcase/TokenShowcase.tsx
+++ b/daemon/frontend/src/showcase/TokenShowcase.tsx
@@ -1,4 +1,5 @@
 import { ColorSection } from './ColorSection';
+import { SpacingSection } from './SpacingSection';
 import { TypographySection } from './TypographySection';
 
 export function TokenShowcase() {
@@ -7,6 +8,7 @@ export function TokenShowcase() {
       <h1 className="text-xl text-primary mb-6">Token Showcase</h1>
       <ColorSection />
       <TypographySection />
+      <SpacingSection />
     </div>
   );
 }

--- a/daemon/frontend/src/showcase/TypographySection.tsx
+++ b/daemon/frontend/src/showcase/TypographySection.tsx
@@ -1,0 +1,37 @@
+const SIZES = [
+  { token: 'text-xs', label: 'xs (12px)' },
+  { token: 'text-sm', label: 'sm (13px)' },
+  { token: 'text-base', label: 'base (14px) — default' },
+  { token: 'text-lg', label: 'lg (16px)' },
+  { token: 'text-xl', label: 'xl (18px)' },
+] as const;
+
+const SAMPLE = 'The quick brown fox jumps over the lazy dog · 0123456789 · 日本語サンプル';
+
+export function TypographySection() {
+  return (
+    <section className="mb-12">
+      <h2 className="text-lg text-foreground mb-4">Typography</h2>
+
+      <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">Mono</h3>
+      <div className="border border-border rounded-md p-3 mb-6">
+        {SIZES.map((s) => (
+          <div key={s.token} className="mb-3 last:mb-0">
+            <div className="text-xs text-muted-foreground font-mono mb-1">{s.label}</div>
+            <div className={`${s.token} font-mono text-foreground`}>{SAMPLE}</div>
+          </div>
+        ))}
+      </div>
+
+      <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">Sans</h3>
+      <div className="border border-border rounded-md p-3">
+        {SIZES.map((s) => (
+          <div key={s.token} className="mb-3 last:mb-0">
+            <div className="text-xs text-muted-foreground font-mono mb-1">{s.label}</div>
+            <div className={`${s.token} font-sans text-foreground`}>{SAMPLE}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/daemon/frontend/src/showcase/TypographySection.tsx
+++ b/daemon/frontend/src/showcase/TypographySection.tsx
@@ -8,30 +8,28 @@ const SIZES = [
 
 const SAMPLE = 'The quick brown fox jumps over the lazy dog · 0123456789 · 日本語サンプル';
 
+function FontStack({ label, fontClass }: { label: string; fontClass: string }) {
+  return (
+    <>
+      <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">{label}</h3>
+      <div className="border border-border rounded-md p-3 mb-6 last:mb-0">
+        {SIZES.map((s) => (
+          <div key={s.token} className="mb-3 last:mb-0">
+            <div className="text-xs text-muted-foreground font-mono mb-1">{s.label}</div>
+            <div className={`${s.token} ${fontClass} text-foreground`}>{SAMPLE}</div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
 export function TypographySection() {
   return (
     <section className="mb-12">
       <h2 className="text-lg text-foreground mb-4">Typography</h2>
-
-      <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">Mono</h3>
-      <div className="border border-border rounded-md p-3 mb-6">
-        {SIZES.map((s) => (
-          <div key={s.token} className="mb-3 last:mb-0">
-            <div className="text-xs text-muted-foreground font-mono mb-1">{s.label}</div>
-            <div className={`${s.token} font-mono text-foreground`}>{SAMPLE}</div>
-          </div>
-        ))}
-      </div>
-
-      <h3 className="text-sm text-muted-foreground mb-2 uppercase tracking-wide">Sans</h3>
-      <div className="border border-border rounded-md p-3">
-        {SIZES.map((s) => (
-          <div key={s.token} className="mb-3 last:mb-0">
-            <div className="text-xs text-muted-foreground font-mono mb-1">{s.label}</div>
-            <div className={`${s.token} font-sans text-foreground`}>{SAMPLE}</div>
-          </div>
-        ))}
-      </div>
+      <FontStack label="Mono" fontClass="font-mono" />
+      <FontStack label="Sans" fontClass="font-sans" />
     </section>
   );
 }

--- a/daemon/frontend/src/styles/theme.css
+++ b/daemon/frontend/src/styles/theme.css
@@ -1,0 +1,91 @@
+@import 'tailwindcss';
+
+/* ============================================================
+ * Layer 1 — Raw palette (Tokyo Night night)
+ * Future color themes override these on a [data-theme="X"] block.
+ * Do NOT reference --tn-* variables from components.
+ * ============================================================ */
+:root {
+  --tn-bg: #1a1b26;
+  --tn-bg-card: #24283b;
+  --tn-bg-popover: #1f2335;
+  --tn-bg-muted: #292e42;
+  --tn-bg-status: #16161e;
+
+  --tn-fg: #c0caf5;
+  --tn-fg-muted: #9aa5ce;
+
+  --tn-border: #414868;
+  --tn-blue: #7aa2f7;
+  --tn-magenta: #bb9af7;
+  --tn-green: #9ece6a;
+  --tn-yellow: #e0af68;
+  --tn-cyan: #7dcfff;
+  --tn-red: #f7768e;
+}
+
+/* ============================================================
+ * Layer 2 — Semantic tokens (Tailwind v4 @theme inline)
+ * Reference Layer 1 only. Components consume utilities derived
+ * from these names (e.g. bg-background, text-foreground).
+ * ============================================================ */
+@theme inline {
+  /* Surfaces */
+  --color-background: var(--tn-bg);
+  --color-foreground: var(--tn-fg);
+  --color-card: var(--tn-bg-card);
+  --color-card-foreground: var(--tn-fg);
+  --color-popover: var(--tn-bg-popover);
+  --color-popover-foreground: var(--tn-fg);
+  --color-muted: var(--tn-bg-muted);
+  --color-muted-foreground: var(--tn-fg-muted);
+
+  /* Action / emphasis */
+  --color-primary: var(--tn-blue);
+  --color-primary-foreground: var(--tn-bg);
+  --color-secondary: var(--tn-magenta);
+  --color-secondary-foreground: var(--tn-bg);
+  --color-accent: var(--tn-border);
+  --color-accent-foreground: var(--tn-fg);
+  --color-destructive: var(--tn-red);
+  --color-destructive-foreground: var(--tn-bg);
+
+  /* Form / boundary */
+  --color-border: var(--tn-border);
+  --color-input: var(--tn-border);
+  --color-ring: var(--tn-blue);
+
+  /* Status */
+  --color-success: var(--tn-green);
+  --color-success-foreground: var(--tn-bg);
+  --color-warning: var(--tn-yellow);
+  --color-warning-foreground: var(--tn-bg);
+  --color-info: var(--tn-cyan);
+  --color-info-foreground: var(--tn-bg);
+
+  /* tmux-specific */
+  --color-tmux-pane-border: var(--tn-border);
+  --color-tmux-pane-active: var(--tn-blue);
+  --color-tmux-status-bar: var(--tn-bg-status);
+  --color-tmux-status-bar-foreground: var(--tn-blue);
+
+  /* Typography */
+  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-sans: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1rem;
+  --text-sm: 0.8125rem;
+  --text-sm--line-height: 1.125rem;
+  --text-base: 0.875rem;
+  --text-base--line-height: 1.25rem;
+  --text-lg: 1rem;
+  --text-lg--line-height: 1.5rem;
+  --text-xl: 1.125rem;
+  --text-xl--line-height: 1.625rem;
+
+  /* Radius */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.25rem;
+  --radius-lg: 0.375rem;
+  --radius-xl: 0.5rem;
+}

--- a/daemon/frontend/src/styles/theme.css
+++ b/daemon/frontend/src/styles/theme.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 /* ============================================================
  * Layer 1 — Raw palette (Tokyo Night night)
@@ -64,8 +64,8 @@
   --color-tmux-status-bar: var(--tn-bg-status);
   --color-tmux-status-bar-foreground: var(--tn-blue);
 
-  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  --font-sans: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans: system-ui, -apple-system, "Segoe UI", sans-serif;
   --text-xs: 0.75rem;
   --text-xs--line-height: 1rem;
   --text-sm: 0.8125rem;

--- a/daemon/frontend/src/styles/theme.css
+++ b/daemon/frontend/src/styles/theme.css
@@ -30,7 +30,6 @@
  * from these names (e.g. bg-background, text-foreground).
  * ============================================================ */
 @theme inline {
-  /* Surfaces */
   --color-background: var(--tn-bg);
   --color-foreground: var(--tn-fg);
   --color-card: var(--tn-bg-card);
@@ -40,7 +39,6 @@
   --color-muted: var(--tn-bg-muted);
   --color-muted-foreground: var(--tn-fg-muted);
 
-  /* Action / emphasis */
   --color-primary: var(--tn-blue);
   --color-primary-foreground: var(--tn-bg);
   --color-secondary: var(--tn-magenta);
@@ -50,12 +48,10 @@
   --color-destructive: var(--tn-red);
   --color-destructive-foreground: var(--tn-bg);
 
-  /* Form / boundary */
   --color-border: var(--tn-border);
   --color-input: var(--tn-border);
   --color-ring: var(--tn-blue);
 
-  /* Status */
   --color-success: var(--tn-green);
   --color-success-foreground: var(--tn-bg);
   --color-warning: var(--tn-yellow);
@@ -63,13 +59,11 @@
   --color-info: var(--tn-cyan);
   --color-info-foreground: var(--tn-bg);
 
-  /* tmux-specific */
   --color-tmux-pane-border: var(--tn-border);
   --color-tmux-pane-active: var(--tn-blue);
   --color-tmux-status-bar: var(--tn-bg-status);
   --color-tmux-status-bar-foreground: var(--tn-blue);
 
-  /* Typography */
   --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
   --font-sans: system-ui, -apple-system, 'Segoe UI', sans-serif;
   --text-xs: 0.75rem;
@@ -83,7 +77,6 @@
   --text-xl: 1.125rem;
   --text-xl--line-height: 1.625rem;
 
-  /* Radius */
   --radius-sm: 0.125rem;
   --radius-md: 0.25rem;
   --radius-lg: 0.375rem;


### PR DESCRIPTION
## Problem

The frontend at `daemon/frontend/` had no design vocabulary. Components used raw Tailwind utilities (`text-3xl underline` Hello World) with no shared color, typography, spacing, or radius decisions. Any future UI work would either accumulate ad-hoc style choices or require a token rewrite later. There was also no way to visually inspect the design system as it grew.

## Solution

Introduce a Tailwind v4 design token system with a 3-layer architecture, plus a dev-only token showcase page for ongoing visual verification.

### Architecture

```
Layer 1: Raw palette       (Tokyo Night, --tn-*)
            ↓ referenced by
Layer 2: Semantic tokens   (--color-background, --color-primary, ... via @theme inline)
            ↓ generates
Layer 3: Tailwind utilities (auto-generated: bg-background, text-foreground, ...)
```

- **Layer 1** (`:root`) holds the Tokyo Night raw color values.
- **Layer 2** (`@theme inline`) declares semantic tokens. The `inline` modifier preserves the `var(--tn-*)` reference at build time, so future themes can override Layer 1 via `[data-theme=\"X\"] { --tn-bg: ...; }` blocks without touching Layer 2 or any component.
- **Layer 3** is auto-generated by Tailwind. Components consume only semantic utilities (`bg-background`, `text-foreground`, `border-tmux-pane-active`, etc.).

### Token catalog

| Category | Tokens |
|---|---|
| Surfaces | `background`, `foreground`, `card(/-foreground)`, `popover(/-foreground)`, `muted(/-foreground)` |
| Action | `primary(/-foreground)`, `secondary(/-foreground)`, `accent(/-foreground)`, `destructive(/-foreground)` |
| Form | `border`, `input`, `ring` |
| Status | `success(/-foreground)`, `warning(/-foreground)`, `info(/-foreground)` |
| tmux-specific | `tmux-pane-border`, `tmux-pane-active`, `tmux-status-bar(/-foreground)` |
| Typography | `font-mono`, `font-sans`, `text-xs/sm/base/lg/xl` (each paired with `--text-*--line-height`) |
| Radius | `radius-sm/md/lg/xl` |

All foreground/background pairings clear WCAG AA (≥4.5:1). `muted-foreground` was deliberately set to `#9aa5ce` instead of the dimmer `#565f89` (which fails AA at 2.76:1).

### Component rules (documented; enforcement deferred)

- No raw hex values in components. No `bg-[#...]` arbitrary color values.
- Typography: only `text-xs / sm / base / lg / xl`. No `text-[15px]`.
- Spacing: only Tailwind scale (`p-2`, `gap-3`). No `p-[7px]`.
- Radius: only `rounded-sm/md/lg/xl`.
- Border width: `border` (1px) or `border-2` (2px).
- No `shadow-*` (border-emphasis aesthetic).
- No `dark:` modifiers — theme switching goes through `data-theme` on root.
- Components MUST NOT reference Layer 1 (`--tn-*`) directly.

### Dev-only token showcase

Visit `http://localhost:5173/?showcase=tokens` in dev to inspect:

1. **Colors** — every semantic token grouped by category, with resolved value and computed contrast ratio against `--color-background`
2. **Typography** — every text size in mono and sans
3. **Spacing** — 4px-grid scale visualized as horizontal bars
4. **Border Radius** — sample squares for each radius step
5. **Pane Mockup** — tmux-style mini-UI rendered with real semantic tokens

The showcase is loaded via a dev-gated dynamic `import('./showcase/TokenShowcase')` from `main.tsx`. In production, `import.meta.env.DEV` is statically replaced with `false`, so Vite tree-shakes the entire showcase chunk. Verified: `grep -c -E 'TokenShowcase|ColorSection|...' daemon/core/src/http/index.html` returns `0`.

### Files affected

- `daemon/frontend/src/styles/theme.css` (new) — token system
- `daemon/frontend/src/main.tsx` — bootstrap with dev-gated dynamic showcase import
- `daemon/frontend/src/App.tsx` — applies tokens (smoke test)
- `daemon/frontend/src/showcase/*` (new) — TokenShowcase + 5 section components
- `daemon/frontend/src/index.css` — deleted (folded into `theme.css`)

### Out of scope (tracked for follow-ups)

- Light / additional theme variants
- Theme switcher UI
- Lint enforcement of component rules (ESLint `no-restricted-syntax` for raw hex / arbitrary color values)
- Custom motion tokens

## Test plan

- [x] `pnpm --dir daemon/frontend check-types` — clean
- [x] `pnpm --dir daemon/frontend exec biome check` — only the pre-existing `noNonNullAssertion` warning on `main.tsx:8` (carried over from the original code, not introduced by this branch)
- [x] `pnpm --dir daemon/frontend build` — succeeds, single-file output ~202 kB
- [x] Production bundle isolation: `grep -c -E 'TokenShowcase\|ColorSection\|TypographySection\|SpacingSection\|RadiusSection\|PaneMockup' daemon/core/src/http/index.html` returns `0`
- [x] Production bundle still contains App: `grep -c 'Hello World' daemon/core/src/http/index.html` returns `1`
- [ ] Open `http://localhost:5173/` — App renders with Tokyo Night background
- [ ] Open `http://localhost:5173/?showcase=tokens` — all 5 showcase sections render correctly with non-empty contrast ratios in the Colors section

🤖 Generated with [Claude Code](https://claude.com/claude-code)