### PR TITLE
Add Playwright MCP-based UI verification harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ docs/
 .vscode/
 !.vscode/extensions.json
 .worktrees
+# Playwright verification harness PID file
+.ozmux/
 .DS_Store
 *.suo
 *.ntvs*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@0.0.75",
+        "--isolated",
+        "--headless"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+Operational notes for Claude Code (the assistant) working in this repo.
+
+## UI verification workflow
+
+Use this when you have changed anything under `daemon/frontend/src/**`, the showcase, theme tokens, pane layout, or daemon-side endpoints that the UI consumes. Skip it for purely backend-internal changes that the UI does not exercise.
+
+### First-time setup (per checkout)
+
+1. Run prerequisites once:
+
+   ```bash
+   make dev-e2e-setup
+   ```
+
+   This installs JS dependencies, warms the Rust build cache, and downloads the Playwright Chromium binary.
+
+2. In Claude Code, approve the project-scoped Playwright MCP server once:
+
+   ```
+   /mcp
+   ```
+
+   Approve the `playwright` server. The pinned version is `@playwright/mcp@0.0.75` with `--isolated --headless`.
+
+### Verification loop
+
+1. Start the harness in the background:
+
+   ```bash
+   make dev-e2e
+   ```
+
+   Wait for the single `ready` line on stdout. If it errors with "port already in use", inspect with `lsof -nP -iTCP:<port> -sTCP:LISTEN` and free the port before retrying.
+
+2. Drive the browser via the Playwright MCP tools. Navigate to `http://localhost:5173`. Use `browser_snapshot` for DOM inspection, `browser_take_screenshot` for visual checks, and `browser_console_messages` to read errors.
+
+3. When done, stop everything:
+
+   ```bash
+   make dev-e2e-stop
+   ```
+
+### Failure modes
+
+| Symptom | Cause | Recovery |
+| --- | --- | --- |
+| `error: port 5173 is already in use.` | Stray Vite or another process | `lsof -nP -iTCP:5173 -sTCP:LISTEN`, kill the holder |
+| `error: port 3200 is already in use.` | Stray daemon | same, for port 3200 |
+| `error: harness already running (see .ozmux/e2e.pid).` | A previous harness is still up | `make dev-e2e-stop` |
+| `error: readiness timeout after 30s.` | Vite or daemon failed to come up | Read the last 20 lines printed from `.ozmux/logs/vite.log` and `.ozmux/logs/daemon.log` |
+| MCP tools missing or fail | Server not approved | Run `/mcp` and approve `playwright` |
+
+### What lives where
+
+- `scripts/dev-e2e.sh` — lifecycle script (start/stop/setup).
+- `Makefile` — `dev-e2e`, `dev-e2e-setup`, `dev-e2e-stop` targets dispatch to the script.
+- `.mcp.json` — registers `@playwright/mcp` (pinned).
+- `.ozmux/` — runtime state (PID file, logs); gitignored.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev-frontend dev-backend dev-daemon verify-out-dir clean help fix-lint
+.PHONY: build dev-frontend dev-backend dev-daemon dev-e2e dev-e2e-setup dev-e2e-stop verify-out-dir clean help fix-lint
 
 FRONTEND_DIR := daemon/frontend
 HTTP_DIR := daemon/core/src/http
@@ -10,7 +10,10 @@ help:
 	@echo "  build              - Build frontend to single HTML, then build release binary"
 	@echo "  dev-frontend       - Run vite dev server on :5173 with HMR"
 	@echo "  dev-backend        - Run axum server on :3200 (debug build redirects / to :5173)"
-	@echo "  dev-daemon         - Run daemon_bootstrap with OZMUX_EXTENSION_DIR=$(EXTENSIONS_DIR)"
+	@echo "  dev-daemon         - Run daemon_bootstrap with OZMUX_EXTENSION_ROOT=$(EXTENSIONS_DIR)"
+	@echo "  dev-e2e-setup      - One-time prerequisites for the Playwright UI verification harness"
+	@echo "  dev-e2e            - Launch vite + daemon for Playwright MCP verification (waits for ready)"
+	@echo "  dev-e2e-stop       - Stop the verification harness started by dev-e2e"
 	@echo "  clean              - Remove frontend node_modules, entire cargo target (workspace-wide), and built index.html"
 
 verify-out-dir:
@@ -44,3 +47,12 @@ fix-lint:
 	cargo clippy --fix --allow-dirty --allow-staged
 	cargo fmt
 	pnpm lint:fix
+
+dev-e2e-setup:
+	./scripts/dev-e2e.sh setup
+
+dev-e2e:
+	./scripts/dev-e2e.sh start
+
+dev-e2e-stop:
+	./scripts/dev-e2e.sh stop

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -43,17 +43,17 @@ cmd_start() {
   : > "${daemon_log}"
 
   echo "start: launching vite (logs: ${vite_log})" >&2
-  (cd "${REPO_ROOT}/daemon/frontend" && pnpm dev) \
+  (cd "${REPO_ROOT}/daemon/frontend" && exec pnpm dev) \
     >"${vite_log}" 2>&1 &
   local vite_pid=$!
+  printf '%s\n' "${vite_pid}" > "${PID_FILE}"
 
   echo "start: launching daemon (logs: ${daemon_log})" >&2
-  (cd "${REPO_ROOT}" && OZMUX_EXTENSION_ROOT="${REPO_ROOT}/extensions" \
+  (cd "${REPO_ROOT}" && exec env OZMUX_EXTENSION_ROOT="${REPO_ROOT}/extensions" \
     cargo run -p daemon_bootstrap) \
     >"${daemon_log}" 2>&1 &
   local daemon_pid=$!
-
-  printf '%s\n%s\n' "${vite_pid}" "${daemon_pid}" > "${PID_FILE}"
+  printf '%s\n' "${daemon_pid}" >> "${PID_FILE}"
 
   echo "start: waiting for /health (max ${READY_TIMEOUT_SECONDS}s)" >&2
   local deadline=$(( $(date +%s) + READY_TIMEOUT_SECONDS ))

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -32,7 +32,50 @@ cmd_start() {
   handle_existing_pid_file
   require_free_port "${VITE_PORT}"
   require_free_port "${DAEMON_PORT}"
-  echo "start: pre-flight ok (servers not yet implemented)" >&2
+
+  mkdir -p "$(dirname "${PID_FILE}")"
+
+  local log_dir="${REPO_ROOT}/.ozmux/logs"
+  mkdir -p "${log_dir}"
+  local vite_log="${log_dir}/vite.log"
+  local daemon_log="${log_dir}/daemon.log"
+  : > "${vite_log}"
+  : > "${daemon_log}"
+
+  echo "start: launching vite (logs: ${vite_log})" >&2
+  (cd "${REPO_ROOT}/daemon/frontend" && pnpm dev) \
+    >"${vite_log}" 2>&1 &
+  local vite_pid=$!
+
+  echo "start: launching daemon (logs: ${daemon_log})" >&2
+  (cd "${REPO_ROOT}" && OZMUX_EXTENSION_ROOT="${REPO_ROOT}/extensions" \
+    cargo run -p daemon_bootstrap) \
+    >"${daemon_log}" 2>&1 &
+  local daemon_pid=$!
+
+  printf '%s\n%s\n' "${vite_pid}" "${daemon_pid}" > "${PID_FILE}"
+
+  echo "start: waiting for /health (max ${READY_TIMEOUT_SECONDS}s)" >&2
+  local deadline=$(( $(date +%s) + READY_TIMEOUT_SECONDS ))
+  while (( $(date +%s) < deadline )); do
+    if curl -fsS "http://localhost:${VITE_PORT}/health" >/dev/null 2>&1; then
+      echo "ready"
+      return 0
+    fi
+    if ! pid_alive "${vite_pid}" || ! pid_alive "${daemon_pid}"; then
+      echo "error: a child process exited before readiness." >&2
+      echo "---- vite (last 20 lines) ----" >&2; tail -n 20 "${vite_log}" >&2 || true
+      echo "---- daemon (last 20 lines) --" >&2; tail -n 20 "${daemon_log}" >&2 || true
+      cmd_stop || true
+      exit 1
+    fi
+    sleep 0.5
+  done
+
+  echo "error: readiness timeout after ${READY_TIMEOUT_SECONDS}s." >&2
+  echo "---- vite (last 20 lines) ----" >&2; tail -n 20 "${vite_log}" >&2 || true
+  echo "---- daemon (last 20 lines) --" >&2; tail -n 20 "${daemon_log}" >&2 || true
+  cmd_stop || true
   exit 1
 }
 cmd_stop()  { echo "stop: not yet implemented" >&2;  return 1; }

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -28,7 +28,53 @@ main() {
 }
 
 cmd_setup() { echo "setup: not yet implemented" >&2; exit 1; }
-cmd_start() { echo "start: not yet implemented" >&2; exit 1; }
+cmd_start() {
+  handle_existing_pid_file
+  require_free_port "${VITE_PORT}"
+  require_free_port "${DAEMON_PORT}"
+  echo "start: pre-flight ok (servers not yet implemented)" >&2
+  exit 1
+}
 cmd_stop()  { echo "stop: not yet implemented" >&2;  exit 1; }
+
+port_in_use() {
+  # Returns 0 (success) when the TCP port is being listened on.
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+require_free_port() {
+  local port="$1"
+  if port_in_use "$port"; then
+    echo "error: port ${port} is already in use." >&2
+    echo "       inspect with: lsof -nP -iTCP:${port} -sTCP:LISTEN" >&2
+    exit 1
+  fi
+}
+
+pid_alive() {
+  # Returns 0 if the given PID belongs to a live process.
+  local pid="$1"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+handle_existing_pid_file() {
+  # If a PID file exists, decide whether it is stale (delete it) or live (refuse).
+  [[ -f "${PID_FILE}" ]] || return 0
+  local any_alive=0
+  while IFS= read -r pid; do
+    [[ -z "${pid}" ]] && continue
+    if pid_alive "${pid}"; then
+      any_alive=1
+    fi
+  done < "${PID_FILE}"
+  if [[ "${any_alive}" -eq 1 ]]; then
+    echo "error: harness already running (see ${PID_FILE})." >&2
+    echo "       run: make dev-e2e:stop" >&2
+    exit 1
+  fi
+  echo "info: removing stale ${PID_FILE}" >&2
+  rm -f "${PID_FILE}"
+}
 
 main "$@"

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -27,7 +27,7 @@ main() {
   esac
 }
 
-cmd_setup() { echo "setup: not yet implemented" >&2; exit 1; }
+cmd_setup() { echo "setup: not yet implemented" >&2; return 1; }
 cmd_start() {
   handle_existing_pid_file
   require_free_port "${VITE_PORT}"
@@ -35,7 +35,7 @@ cmd_start() {
   echo "start: pre-flight ok (servers not yet implemented)" >&2
   exit 1
 }
-cmd_stop()  { echo "stop: not yet implemented" >&2;  exit 1; }
+cmd_stop()  { echo "stop: not yet implemented" >&2;  return 1; }
 
 port_in_use() {
   # Returns 0 (success) when the TCP port is being listened on.
@@ -70,7 +70,7 @@ handle_existing_pid_file() {
   done < "${PID_FILE}"
   if [[ "${any_alive}" -eq 1 ]]; then
     echo "error: harness already running (see ${PID_FILE})." >&2
-    echo "       run: make dev-e2e:stop" >&2
+    echo "       run: make dev-e2e-stop" >&2
     exit 1
   fi
   echo "info: removing stale ${PID_FILE}" >&2

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -84,7 +84,47 @@ cmd_start() {
   cmd_stop || true
   exit 1
 }
-cmd_stop()  { echo "stop: not yet implemented" >&2;  return 1; }
+cmd_stop() {
+  if [[ ! -f "${PID_FILE}" ]]; then
+    echo "stop: nothing to do (no ${PID_FILE})" >&2
+    return 0
+  fi
+
+  local -a pids=()
+  while IFS= read -r pid; do
+    [[ -n "${pid}" ]] && pids+=("${pid}")
+  done < "${PID_FILE}"
+
+  # Each pid is a process-group leader (cmd_start ran with `set -m`).
+  # `kill -TERM -- -<pid>` signals the whole group, including grandchildren that
+  # the spawned process forked (e.g. pnpm's vite child).
+  for pid in "${pids[@]}"; do
+    if pid_alive "${pid}"; then
+      echo "stop: SIGTERM group ${pid}" >&2
+      kill -TERM -- "-${pid}" 2>/dev/null || true
+    fi
+  done
+
+  # Give them up to 5 seconds to exit cleanly.
+  local deadline=$(( $(date +%s) + 5 ))
+  while (( $(date +%s) < deadline )); do
+    local any_alive=0
+    for pid in "${pids[@]}"; do
+      if pid_alive "${pid}"; then any_alive=1; fi
+    done
+    [[ "${any_alive}" -eq 0 ]] && break
+    sleep 0.2
+  done
+
+  for pid in "${pids[@]}"; do
+    if pid_alive "${pid}"; then
+      echo "stop: SIGKILL group ${pid}" >&2
+      kill -KILL -- "-${pid}" 2>/dev/null || true
+    fi
+  done
+
+  rm -f "${PID_FILE}"
+}
 
 port_in_use() {
   # Returns 0 (success) when the TCP port is being listened on.

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/dev-e2e.sh — lifecycle for the Playwright UI verification harness.
+# Subcommands:
+#   setup  — one-time prerequisites (pnpm install, cargo build, browser install)
+#   start  — launch vite (5173) + daemon (3200) in the background, wait for ready
+#   stop   — kill the running harness via .ozmux/e2e.pid
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PID_FILE="${REPO_ROOT}/.ozmux/e2e.pid"
+VITE_PORT=5173
+DAEMON_PORT=3200
+READY_TIMEOUT_SECONDS=30
+
+usage() {
+  echo "usage: $0 {setup|start|stop}" >&2
+  exit 64
+}
+
+main() {
+  [[ $# -eq 1 ]] || usage
+  case "$1" in
+    setup) cmd_setup ;;
+    start) cmd_start ;;
+    stop)  cmd_stop ;;
+    *)     usage ;;
+  esac
+}
+
+cmd_setup() { echo "setup: not yet implemented" >&2; exit 1; }
+cmd_start() { echo "start: not yet implemented" >&2; exit 1; }
+cmd_stop()  { echo "stop: not yet implemented" >&2;  exit 1; }
+
+main "$@"

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -42,6 +42,10 @@ cmd_start() {
   : > "${vite_log}"
   : > "${daemon_log}"
 
+  # Enable job control so each `&` job becomes its own process group leader.
+  # That makes `$!` equal the PGID, so cmd_stop can take down the whole group.
+  set -m
+
   echo "start: launching vite (logs: ${vite_log})" >&2
   (cd "${REPO_ROOT}/daemon/frontend" && exec pnpm dev) \
     >"${vite_log}" 2>&1 &
@@ -54,6 +58,8 @@ cmd_start() {
     >"${daemon_log}" 2>&1 &
   local daemon_pid=$!
   printf '%s\n' "${daemon_pid}" >> "${PID_FILE}"
+
+  set +m
 
   echo "start: waiting for /health (max ${READY_TIMEOUT_SECONDS}s)" >&2
   local deadline=$(( $(date +%s) + READY_TIMEOUT_SECONDS ))

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -27,7 +27,18 @@ main() {
   esac
 }
 
-cmd_setup() { echo "setup: not yet implemented" >&2; return 1; }
+cmd_setup() {
+  echo "setup: pnpm install --frozen-lockfile" >&2
+  (cd "${REPO_ROOT}" && pnpm install --frozen-lockfile)
+
+  echo "setup: cargo build -p daemon_bootstrap" >&2
+  (cd "${REPO_ROOT}" && cargo build -p daemon_bootstrap)
+
+  echo "setup: install Playwright Chromium" >&2
+  (cd "${REPO_ROOT}" && npx -y playwright@1 install chromium)
+
+  echo "setup: complete" >&2
+}
 cmd_start() {
   handle_existing_pid_file
   require_free_port "${VITE_PORT}"


### PR DESCRIPTION
## Problem

There is no way for Claude Code (the assistant) to self-verify UI changes during development. After editing the React frontend, theme tokens, or pane layout, the only feedback loop is asking the user to look at the browser. We want a reproducible, single-command way for the assistant to drive a real browser against a running ozmux instance.

## Solution

A Playwright MCP-based verification harness wired to three Make targets.

- **`make dev-e2e-setup`** — one-time prerequisites: `pnpm install --frozen-lockfile`, `cargo build -p daemon_bootstrap`, and Chromium download.
- **`make dev-e2e`** — pre-flight port/PID-file checks, then spawns Vite (5173) and `daemon_bootstrap` (3200) in the background, polls `/health` (which Vite proxies to the daemon, so a single 200 proves both processes are up), and prints `ready` on stdout. 30 s timeout with last-20-lines log dump on failure.
- **`make dev-e2e-stop`** — process-group SIGTERM with SIGKILL fallback after a 5 s graceful window. Uses `set -m` in `cmd_start` so each spawned PID is a process-group leader, which lets `kill -- -<pgid>` reach grandchildren that pnpm forks.

Other components:

- `.mcp.json` — registers `@playwright/mcp@0.0.75` with `--isolated --headless`. Project-scoped; the operator approves it once via `/mcp`.
- `CLAUDE.md` — documents when and how the assistant should use the harness, plus a failure-modes table.
- `.ozmux/` — runtime state (PID file, per-run logs); gitignored.

### Design notes

- **Why poll `/health` via Vite instead of probing the daemon WebSocket?** The WS route requires an `activity_id` parameter, so it isn't suitable for a parameter-free readiness probe. `GET /health` exists on the daemon and Vite already proxies it, giving a single check that covers both processes.
- **Why `set -m` + process-group kills?** During implementation we found that pnpm forks an internal child for `vite`, and SIGTERM to the pnpm PID does not propagate to that grandchild. Job control in `cmd_start` makes each `&` job its own process group, so `cmd_stop` can take down the entire tree.
- **Why no `OZMUX_DATA_DIR`?** No such env var exists in the codebase. The daemon already isolates runtime state under PID-keyed `/tmp` roots, so verification runs do not pollute the developer's persistent state.

### Files

```
 .gitignore         |   2 +
 .mcp.json          |  13 ++++
 CLAUDE.md          |  60 ++++++++++++++++++
 Makefile           |  16 ++++-
 scripts/dev-e2e.sh | 180 +++++++++++++++++++++++++++++++++++++++++++++++++++++
```

## Test Plan

- [x] `make dev-e2e-setup` completes without errors and downloads Chromium to `~/Library/Caches/ms-playwright/`.
- [x] `make dev-e2e` prints exactly `ready` on stdout when both servers come up.
- [x] `curl http://localhost:5173/health` and `curl http://localhost:3200/health` both return 200 while the harness is running.
- [x] `make dev-e2e-stop` cleanly terminates both server process groups; ports 5173 and 3200 are freed; PID file is removed.
- [x] Pre-flight refuses to start when either port is already occupied, with a `lsof` hint.
- [x] Stale PID file is removed automatically; live PID file produces a "harness already running" error pointing the operator to `make dev-e2e-stop`.
- [ ] Approve `playwright` once via `/mcp` in a Claude Code session and capture a screenshot of `http://localhost:5173` — human-in-the-loop acceptance check.

## Follow-ups (not blocking)

- Pin Chromium install to the version `@playwright/mcp@0.0.75` actually requires (currently uses floating `playwright@1`).
- Consider running the pre-built `target/debug/daemon_bootstrap` directly instead of `cargo run` so the 30 s readiness window only covers server boot, not a potential cold rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)