### PR TITLE
Extension Channel: one-way push (node → iframe) via async generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev-frontend dev-backend dev-daemon dev-e2e dev-e2e-setup dev-e2e-stop verify-out-dir clean help fix-lint test-frontend
+.PHONY: build dev-frontend dev-backend dev-daemon dev-e2e dev-e2e-setup dev-e2e-stop verify-out-dir clean help fix-lint test-frontend memo-build-sdk
 
 FRONTEND_DIR := daemon/frontend
 HTTP_DIR := daemon/core/src/http
@@ -25,6 +25,9 @@ verify-out-dir:
 		exit 1; \
 	fi
 
+memo-build-sdk:
+	pnpm --filter memo run build:sdk
+
 build:
 	pnpm --dir $(FRONTEND_DIR) install --frozen-lockfile
 	pnpm --dir $(FRONTEND_DIR) build
@@ -37,7 +40,7 @@ dev-frontend:
 dev-backend:
 	cargo run -p ozmux_core
 
-dev-daemon:
+dev-daemon: memo-build-sdk
 	OZMUX_EXTENSION_ROOT=$(OZMUX_EXTENSION_ROOT) cargo run -p daemon_bootstrap
 
 clean:
@@ -51,7 +54,7 @@ fix-lint:
 dev-e2e-setup:
 	./scripts/dev-e2e.sh setup
 
-dev-e2e:
+dev-e2e: memo-build-sdk
 	./scripts/dev-e2e.sh start
 
 dev-e2e-stop:

--- a/daemon/extension/tests/e2e.rs
+++ b/daemon/extension/tests/e2e.rs
@@ -131,3 +131,63 @@ async fn extension_crash_does_not_break_other_extensions() {
         "echo bin disappeared after crash extension died"
     );
 }
+
+#[tokio::test]
+async fn extension_streams_channel_events() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    let parent = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RuntimeRoot::new_in(parent.path(), std::process::id()).unwrap());
+    unsafe {
+        std::env::set_var("OZMUX_EXTENSION_ROOT", fixture_root());
+    }
+    let registry = ExtensionRegistry::default();
+    let _handles =
+        ExtensionHandles::load(&runtime, registry.clone()).expect("spawn extensions");
+
+    // Wait for clock-ext's handlers UDS to appear in the registry.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let sock = loop {
+        if let Some(p) = registry.handlers_sock_path("clock-ext")
+            && p.exists()
+        {
+            break p;
+        }
+        if Instant::now() > deadline {
+            panic!("clock-ext handlers sock never appeared");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    // The fixture pre-registers channels against the hardcoded aid
+    // "fixture-aid-1" before calling bootstrap(), so no daemon HTTP server
+    // is needed for this test.
+    let aid = "fixture-aid-1";
+
+    let stream = UnixStream::connect(&sock).await.unwrap();
+    let (read_half, mut write_half) = stream.into_split();
+    let mut lines = BufReader::new(read_half).lines();
+
+    let open = format!(
+        "{{\"aid\":\"{}\",\"frame\":{{\"kind\":\"sub.open\",\"id\":\"s1\",\"name\":\"ticks\",\"params\":{{\"n\":3}}}}}}\n",
+        aid
+    );
+    write_half.write_all(open.as_bytes()).await.unwrap();
+
+    let mut received = Vec::new();
+    for _ in 0..4 {
+        let line = tokio::time::timeout(Duration::from_secs(2), lines.next_line())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        received.push(v);
+    }
+    assert_eq!(received[0]["frame"]["kind"], "sub.data");
+    assert_eq!(received[0]["frame"]["payload"], serde_json::json!({"i": 0}));
+    assert_eq!(received[1]["frame"]["payload"], serde_json::json!({"i": 1}));
+    assert_eq!(received[2]["frame"]["payload"], serde_json::json!({"i": 2}));
+    assert_eq!(received[3]["frame"]["kind"], "sub.complete");
+}

--- a/daemon/extension/tests/e2e.rs
+++ b/daemon/extension/tests/e2e.rs
@@ -143,8 +143,7 @@ async fn extension_streams_channel_events() {
         std::env::set_var("OZMUX_EXTENSION_ROOT", fixture_root());
     }
     let registry = ExtensionRegistry::default();
-    let _handles =
-        ExtensionHandles::load(&runtime, registry.clone()).expect("spawn extensions");
+    let _handles = ExtensionHandles::load(&runtime, registry.clone()).expect("spawn extensions");
 
     // Wait for clock-ext's handlers UDS to appear in the registry.
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -169,10 +168,17 @@ async fn extension_streams_channel_events() {
     let (read_half, mut write_half) = stream.into_split();
     let mut lines = BufReader::new(read_half).lines();
 
-    let open = format!(
-        "{{\"aid\":\"{}\",\"frame\":{{\"kind\":\"sub.open\",\"id\":\"s1\",\"name\":\"ticks\",\"params\":{{\"n\":3}}}}}}\n",
-        aid
-    );
+    let open = serde_json::json!({
+        "aid": aid,
+        "frame": {
+            "kind": "sub.open",
+            "id": "s1",
+            "name": "ticks",
+            "params": { "n": 3 },
+        },
+    })
+    .to_string()
+        + "\n";
     write_half.write_all(open.as_bytes()).await.unwrap();
 
     let mut received = Vec::new();

--- a/daemon/extension/tests/fixtures/clock-ext/bootstrap.mjs
+++ b/daemon/extension/tests/fixtures/clock-ext/bootstrap.mjs
@@ -1,0 +1,19 @@
+import { bootstrap, registerActivityChannels } from "@ozmux/sdk/server";
+
+registerActivityChannels("fixture-aid-1", {
+  ticks: async function* ({ n }, { signal }) {
+    for (let i = 0; i < n; i++) {
+      if (signal.aborted) return;
+      yield { i };
+    }
+  },
+});
+
+await bootstrap({
+  commands: {
+    // No commands needed for this fixture — the e2e test connects to the
+    // handlers UDS directly. bootstrap() is invoked so the SDK plumbing
+    // (UDS listener etc.) is set up the same way as real extensions.
+    "clock-ext": async () => 0,
+  },
+});

--- a/daemon/extension/tests/fixtures/clock-ext/package.json
+++ b/daemon/extension/tests/fixtures/clock-ext/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "clock-ext",
+  "main": "bootstrap.mjs",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@ozmux/sdk": "workspace:*"
+  }
+}

--- a/daemon/http_server/src/handlers/activities.rs
+++ b/daemon/http_server/src/handlers/activities.rs
@@ -911,20 +911,43 @@ mod tests {
                     frame: &'a serde_json::value::RawValue,
                 }
                 let env: Env = serde_json::from_str(&line).unwrap();
-                #[derive(serde::Deserialize)]
-                struct Call {
-                    id: String,
-                    payload: serde_json::Value,
+                let raw: serde_json::Value = serde_json::from_str(env.frame.get()).unwrap();
+                let kind = raw["kind"].as_str().unwrap_or("");
+                let id = raw["id"].as_str().unwrap_or("").to_string();
+                match kind {
+                    "call" => {
+                        let payload = raw["payload"].clone();
+                        let resp = format!(
+                            r#"{{"aid":"{}","frame":{{"kind":"result","id":"{}","payload":{}}}}}"#,
+                            env.aid, id, payload
+                        );
+                        write_half
+                            .write_all((resp + "\n").as_bytes())
+                            .await
+                            .unwrap();
+                    }
+                    "sub.open" => {
+                        for i in 0..2 {
+                            let frame = format!(
+                                r#"{{"aid":"{}","frame":{{"kind":"sub.data","id":"{}","payload":{{"i":{}}}}}}}"#,
+                                env.aid, id, i
+                            );
+                            write_half
+                                .write_all((frame + "\n").as_bytes())
+                                .await
+                                .unwrap();
+                        }
+                        let done = format!(
+                            r#"{{"aid":"{}","frame":{{"kind":"sub.complete","id":"{}"}}}}"#,
+                            env.aid, id
+                        );
+                        write_half
+                            .write_all((done + "\n").as_bytes())
+                            .await
+                            .unwrap();
+                    }
+                    _ => { /* ignore other kinds in this test */ }
                 }
-                let call: Call = serde_json::from_str(env.frame.get()).unwrap();
-                let resp = format!(
-                    r#"{{"aid":"{}","frame":{{"kind":"result","id":"{}","payload":{}}}}}"#,
-                    env.aid, call.id, call.payload
-                );
-                write_half
-                    .write_all((resp + "\n").as_bytes())
-                    .await
-                    .unwrap();
             }
         });
 
@@ -975,6 +998,32 @@ mod tests {
         assert_eq!(resp["kind"], "result");
         assert_eq!(resp["id"], "1");
         assert_eq!(resp["payload"], serde_json::json!({"v": 1}));
+
+        // sub.open → expect two sub.data then sub.complete, transparently relayed.
+        ws.send(TMessage::Text(
+            r#"{"kind":"sub.open","id":"s1","name":"counter","params":{}}"#.into(),
+        ))
+        .await
+        .unwrap();
+        let mut got = Vec::new();
+        for _ in 0..3 {
+            let msg = tokio::time::timeout(Duration::from_secs(2), ws.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            let TMessage::Text(text) = msg else {
+                panic!("expected text")
+            };
+            got.push(serde_json::from_str::<serde_json::Value>(&text).unwrap());
+        }
+        assert_eq!(got[0]["kind"], "sub.data");
+        assert_eq!(got[0]["id"], "s1");
+        assert_eq!(got[0]["payload"], serde_json::json!({"i": 0}));
+        assert_eq!(got[1]["kind"], "sub.data");
+        assert_eq!(got[1]["payload"], serde_json::json!({"i": 1}));
+        assert_eq!(got[2]["kind"], "sub.complete");
+        assert_eq!(got[2]["id"], "s1");
 
         ws.close(None).await.ok();
         server.abort();

--- a/daemon/http_server/src/handlers/activities.rs
+++ b/daemon/http_server/src/handlers/activities.rs
@@ -913,40 +913,35 @@ mod tests {
                 let env: Env = serde_json::from_str(&line).unwrap();
                 let raw: serde_json::Value = serde_json::from_str(env.frame.get()).unwrap();
                 let kind = raw["kind"].as_str().unwrap_or("");
-                let id = raw["id"].as_str().unwrap_or("").to_string();
-                match kind {
-                    "call" => {
-                        let payload = raw["payload"].clone();
-                        let resp = format!(
-                            r#"{{"aid":"{}","frame":{{"kind":"result","id":"{}","payload":{}}}}}"#,
-                            env.aid, id, payload
-                        );
-                        write_half
-                            .write_all((resp + "\n").as_bytes())
-                            .await
-                            .unwrap();
-                    }
+                let id = raw["id"].as_str().unwrap_or("");
+                let frames: Vec<serde_json::Value> = match kind {
+                    "call" => vec![serde_json::json!({
+                        "kind": "result",
+                        "id": id,
+                        "payload": raw["payload"],
+                    })],
                     "sub.open" => {
-                        for i in 0..2 {
-                            let frame = format!(
-                                r#"{{"aid":"{}","frame":{{"kind":"sub.data","id":"{}","payload":{{"i":{}}}}}}}"#,
-                                env.aid, id, i
-                            );
-                            write_half
-                                .write_all((frame + "\n").as_bytes())
-                                .await
-                                .unwrap();
-                        }
-                        let done = format!(
-                            r#"{{"aid":"{}","frame":{{"kind":"sub.complete","id":"{}"}}}}"#,
-                            env.aid, id
-                        );
-                        write_half
-                            .write_all((done + "\n").as_bytes())
-                            .await
-                            .unwrap();
+                        let mut out = (0..2)
+                            .map(|i| {
+                                serde_json::json!({
+                                    "kind": "sub.data",
+                                    "id": id,
+                                    "payload": { "i": i },
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        out.push(serde_json::json!({
+                            "kind": "sub.complete",
+                            "id": id,
+                        }));
+                        out
                     }
-                    _ => { /* ignore other kinds in this test */ }
+                    _ => continue,
+                };
+                for frame in frames {
+                    let envelope = serde_json::json!({ "aid": env.aid, "frame": frame });
+                    let line = envelope.to_string() + "\n";
+                    write_half.write_all(line.as_bytes()).await.unwrap();
                 }
             }
         });

--- a/extensions/memo/bootstrap.ts
+++ b/extensions/memo/bootstrap.ts
@@ -1,10 +1,11 @@
 import {
+  abortableSleep,
   bootstrap,
   createActivity,
   createPane,
   splitPane,
-  type ChannelMap,
   type ChannelCtx,
+  type ChannelMap,
   type HandlerMap,
 } from "@ozmux/sdk/server";
 import { fileURLToPath } from "node:url";
@@ -20,20 +21,6 @@ interface MemoChannels extends ChannelMap {
   ) => AsyncGenerator<{ time: string }>;
 }
 
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    const onAbort = () => {
-      clearTimeout(t);
-      resolve();
-    };
-    const t = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
 bootstrap({
   commands: {
     memo: async (ctx) => {
@@ -47,7 +34,7 @@ bootstrap({
           clock: async function* ({ intervalMs }, { signal }) {
             yield { time: new Date().toISOString() };
             while (!signal.aborted) {
-              await sleep(intervalMs, signal);
+              await abortableSleep(intervalMs, signal);
               if (signal.aborted) return;
               yield { time: new Date().toISOString() };
             }

--- a/extensions/memo/bootstrap.ts
+++ b/extensions/memo/bootstrap.ts
@@ -1,9 +1,10 @@
-// extensions/memo/bootstrap.ts
 import {
   bootstrap,
   createActivity,
   createPane,
   splitPane,
+  type ChannelMap,
+  type ChannelCtx,
   type HandlerMap,
 } from "@ozmux/sdk/server";
 import { fileURLToPath } from "node:url";
@@ -12,19 +13,48 @@ interface MemoHandlers extends HandlerMap {
   greet: (req: { name: string }) => Promise<{ message: string }>;
 }
 
+interface MemoChannels extends ChannelMap {
+  clock: (
+    params: { intervalMs: number },
+    ctx: ChannelCtx,
+  ) => AsyncGenerator<{ time: string }>;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 bootstrap({
   commands: {
     memo: async (ctx) => {
       ctx.stdout.write(`memo invoked in pane ${ctx.pane.paneId}\n`);
-      const activityId = await createActivity<MemoHandlers>({
+      const activityId = await createActivity<MemoHandlers, MemoChannels>({
         html: fileURLToPath(new URL("./index.html", import.meta.url)),
         handlers: {
           greet: async ({ name }) => ({ message: `Hello, ${name}!` }),
         },
+        channels: {
+          clock: async function* ({ intervalMs }, { signal }) {
+            yield { time: new Date().toISOString() };
+            while (!signal.aborted) {
+              await sleep(intervalMs, signal);
+              if (signal.aborted) return;
+              yield { time: new Date().toISOString() };
+            }
+          },
+        },
       });
-      const pane = await createPane({
-        activityId,
-      });
+      const pane = await createPane({ activityId });
       await splitPane({
         target: ctx.pane.paneId,
         paneToPlace: pane,

--- a/extensions/memo/build-sdk.mjs
+++ b/extensions/memo/build-sdk.mjs
@@ -1,0 +1,16 @@
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [resolve(here, "iframe-entry.ts")],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  outfile: resolve(here, "dist/sdk.js"),
+  sourcemap: false,
+  logLevel: "info",
+});

--- a/extensions/memo/iframe-entry.ts
+++ b/extensions/memo/iframe-entry.ts
@@ -1,0 +1,1 @@
+export * from "@ozmux/sdk/iframe";

--- a/extensions/memo/index.html
+++ b/extensions/memo/index.html
@@ -20,54 +20,72 @@
         border: 1px solid #414868;
       }
       button[disabled] { opacity: 0.5; }
-      #result { margin-top: 1rem; }
+      #result, #clock { margin-top: 1rem; }
     </style>
   </head>
   <body>
     <h1>Memo</h1>
-    <p>handler RPC demo</p>
-    <input id="name" type="text" placeholder="Your name" />
-    <button id="send" disabled>Send</button>
-    <p id="result"></p>
+    <section>
+      <p>handler RPC demo</p>
+      <input id="name" type="text" placeholder="Your name" />
+      <button id="send">Send</button>
+      <p id="result"></p>
+    </section>
+    <section>
+      <p>channel demo</p>
+      <button id="start-clock">Start clock</button>
+      <button id="stop-clock" disabled>Stop clock</button>
+      <p id="clock">(idle)</p>
+    </section>
 
     <script type="module">
-      const aid = location.pathname.split('/')[2];
-      const ws = new WebSocket(`ws://${location.host}/activities/${aid}/handlers/ws`);
-      const pending = new Map();
-      let seq = 0;
-      const sendBtn = document.getElementById('send');
-      const result = document.getElementById('result');
+      import { createClient } from "./dist/sdk.js";
 
-      ws.onopen = () => { sendBtn.disabled = false; };
-      ws.onclose = () => {
-        sendBtn.disabled = true;
-        setTimeout(() => location.reload(), 1000);
-      };
-      ws.onmessage = (ev) => {
-        const f = JSON.parse(ev.data);
-        const p = pending.get(f.id);
-        if (!p) return;
-        pending.delete(f.id);
-        if (f.kind === 'result') p.resolve(f.payload);
-        else if (f.kind === 'error') p.reject(new Error(`${f.code}: ${f.message}`));
-      };
+      const client = createClient();
+      const sendBtn = document.getElementById("send");
+      const result = document.getElementById("result");
+      const startBtn = document.getElementById("start-clock");
+      const stopBtn = document.getElementById("stop-clock");
+      const clockEl = document.getElementById("clock");
 
-      function call(name, payload) {
-        const id = String(++seq);
-        return new Promise((resolve, reject) => {
-          pending.set(id, { resolve, reject });
-          ws.send(JSON.stringify({ kind: 'call', id, name, payload }));
-        });
-      }
-
-      sendBtn.addEventListener('click', async () => {
-        const name = document.getElementById('name').value;
+      sendBtn.addEventListener("click", async () => {
+        const name = document.getElementById("name").value;
         try {
-          const resp = await call('greet', { name });
+          const resp = await client.call("greet", { name });
           result.textContent = resp.message;
         } catch (e) {
           result.textContent = `error: ${e.message}`;
         }
+      });
+
+      let activeAbort = null;
+
+      startBtn.addEventListener("click", async () => {
+        if (activeAbort) return;
+        const ac = new AbortController();
+        activeAbort = ac;
+        startBtn.disabled = true;
+        stopBtn.disabled = false;
+        try {
+          for await (const ev of client.subscribe(
+            "clock",
+            { intervalMs: 1000 },
+            { signal: ac.signal },
+          )) {
+            clockEl.textContent = ev.time;
+          }
+          clockEl.textContent = "(stopped)";
+        } catch (e) {
+          clockEl.textContent = `error: ${e.message}`;
+        } finally {
+          if (activeAbort === ac) activeAbort = null;
+          startBtn.disabled = false;
+          stopBtn.disabled = true;
+        }
+      });
+
+      stopBtn.addEventListener("click", () => {
+        activeAbort?.abort();
       });
     </script>
   </body>

--- a/extensions/memo/package.json
+++ b/extensions/memo/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "build:sdk": "node build-sdk.mjs"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "esbuild": "^0.25.0",
     "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
         specifier: ^2.4.11
         version: 2.4.14
 
+  daemon/extension/tests/fixtures/clock-ext:
+    dependencies:
+      '@ozmux/sdk':
+        specifier: workspace:*
+        version: link:../../../../../sdk/typescript
+
   daemon/extension/tests/fixtures/crash-ext:
     dependencies:
       '@ozmux/sdk':
@@ -139,6 +145,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -355,6 +364,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -830,6 +995,11 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1523,6 +1693,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@exodus/bytes@1.15.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1914,6 +2162,35 @@ snapshots:
   entities@8.0.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -11,6 +11,10 @@
     "./cmd-shim": {
       "types": "./src/server/cmd-shim.ts",
       "default": "./src/server/cmd-shim.ts"
+    },
+    "./iframe": {
+      "types": "./src/iframe/index.ts",
+      "default": "./src/iframe/index.ts"
     }
   },
   "scripts": {

--- a/sdk/typescript/src/iframe/client.test.ts
+++ b/sdk/typescript/src/iframe/client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+type Listener = (ev: { data: string }) => void;
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+  url: string;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: Listener | null = null;
+  sent: string[] = [];
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.onopen?.();
+    });
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+  pushFrame(frame: unknown) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  (globalThis as any).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  delete (globalThis as any).WebSocket;
+});
+
+describe("createClient.call", () => {
+  it("sends a call frame and resolves with the result payload", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const p = client.call<{ name: string }, { hi: string }>("greet", {
+      name: "x",
+    });
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    expect(ws.sent).toHaveLength(1);
+    const sent = JSON.parse(ws.sent[0]!);
+    expect(sent.kind).toBe("call");
+    expect(sent.name).toBe("greet");
+    expect(sent.payload).toEqual({ name: "x" });
+    ws.pushFrame({ kind: "result", id: sent.id, payload: { hi: "yo" } });
+    await expect(p).resolves.toEqual({ hi: "yo" });
+  });
+
+  it("rejects the call promise on an error frame", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const p = client.call("boom", {});
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    const sent = JSON.parse(ws.sent[0]!);
+    ws.pushFrame({
+      kind: "error",
+      id: sent.id,
+      code: "HANDLER_ERROR",
+      message: "nope",
+    });
+    await expect(p).rejects.toMatchObject({ message: "nope" });
+  });
+
+  it("rejects pending calls when the WS closes", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const p = client.call("greet", {});
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    ws.close();
+    await expect(p).rejects.toThrow();
+  });
+});

--- a/sdk/typescript/src/iframe/client.test.ts
+++ b/sdk/typescript/src/iframe/client.test.ts
@@ -92,3 +92,104 @@ describe("createClient.call", () => {
     await expect(p).rejects.toThrow();
   });
 });
+
+describe("createClient.subscribe", () => {
+  it("yields data frames in order and ends on sub.complete", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const iter = client.subscribe<{ n: number }, { v: number }>("count", {
+      n: 3,
+    });
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    const open = JSON.parse(ws.sent[0]!);
+    expect(open.kind).toBe("sub.open");
+    expect(open.params).toEqual({ n: 3 });
+    const id = open.id;
+    ws.pushFrame({ kind: "sub.data", id, payload: { v: 0 } });
+    ws.pushFrame({ kind: "sub.data", id, payload: { v: 1 } });
+    ws.pushFrame({ kind: "sub.complete", id });
+    const collected: { v: number }[] = [];
+    for await (const ev of iter) collected.push(ev);
+    expect(collected).toEqual([{ v: 0 }, { v: 1 }]);
+  });
+
+  it("throws inside for-await when a sub.error arrives", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const iter = client.subscribe("x", {});
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    const id = JSON.parse(ws.sent[0]!).id;
+    ws.pushFrame({ kind: "sub.data", id, payload: 1 });
+    ws.pushFrame({
+      kind: "sub.error",
+      id,
+      code: "HANDLER_ERROR",
+      message: "boom",
+    });
+    let threw: Error | null = null;
+    try {
+      for await (const ev of iter) void ev;
+    } catch (e) {
+      threw = e as Error;
+    }
+    expect(threw?.message).toBe("boom");
+  });
+
+  it("sends sub.cancel and stops iteration on AbortSignal.abort()", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const ac = new AbortController();
+    const iter = client.subscribe("x", {}, { signal: ac.signal });
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    const id = JSON.parse(ws.sent[0]!).id;
+    ws.pushFrame({ kind: "sub.data", id, payload: 1 });
+
+    const it = iter[Symbol.asyncIterator]();
+    const first = await it.next();
+    expect(first.value).toBe(1);
+    ac.abort();
+    const after = await it.next();
+    expect(after.done).toBe(true);
+
+    const cancelFrame = JSON.parse(ws.sent[1]!);
+    expect(cancelFrame).toEqual({ kind: "sub.cancel", id });
+  });
+
+  it("returns done:true immediately if signal.aborted before subscribe", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const ac = new AbortController();
+    ac.abort();
+    const iter = client.subscribe("x", {}, { signal: ac.signal });
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    expect(ws.sent).toHaveLength(0);
+    const it = iter[Symbol.asyncIterator]();
+    const r = await it.next();
+    expect(r.done).toBe(true);
+  });
+
+  it("multiplexes call() and subscribe() without id collision", async () => {
+    const { createClient } = await import("./client.ts");
+    const client = createClient({ activityId: "aid-1", url: "ws://t/x" });
+    const ws = MockWebSocket.instances[0]!;
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+
+    const callP = client.call("hi", {});
+    const subIter = client.subscribe("s", {});
+    await new Promise<void>((r) => queueMicrotask(() => r()));
+    const frames = ws.sent.map((s) => JSON.parse(s));
+    expect(frames[0].kind).toBe("call");
+    expect(frames[1].kind).toBe("sub.open");
+    expect(frames[0].id).not.toBe(frames[1].id);
+
+    ws.pushFrame({ kind: "result", id: frames[0].id, payload: "ok" });
+    ws.pushFrame({ kind: "sub.complete", id: frames[1].id });
+    await expect(callP).resolves.toBe("ok");
+    const it = subIter[Symbol.asyncIterator]();
+    expect((await it.next()).done).toBe(true);
+  });
+});

--- a/sdk/typescript/src/iframe/client.ts
+++ b/sdk/typescript/src/iframe/client.ts
@@ -13,6 +13,7 @@ import type {
 // package itself does not depend on `lib: ["DOM"]` (server code shares the
 // tsconfig). Declare the small surface we use.
 interface MinimalWebSocket {
+  readonly readyState: 0 | 1 | 2 | 3;
   send(data: string): void;
   close(): void;
   onopen: (() => void) | null;
@@ -30,11 +31,19 @@ interface MinimalLocation {
 }
 interface MinimalAbortSignal {
   readonly aborted: boolean;
-  addEventListener(type: "abort", listener: () => void): void;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
 }
 
 declare const WebSocket: MinimalWebSocketCtor;
 declare const window: { location: MinimalLocation };
+
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
 
 export interface CreateClientOptions {
   activityId?: string;
@@ -62,6 +71,7 @@ interface SubState {
   done: boolean;
   error: Error | null;
   waker: { resolve: () => void } | null;
+  detach: () => void;
   cancel: () => void;
 }
 
@@ -90,6 +100,12 @@ function inferUrl(aid: string): string {
   return `${proto}//${window.location.host}/activities/${aid}/handlers/ws`;
 }
 
+function toRpcError(frame: HandlerErrorFrame | SubErrorFrame): Error {
+  const err = new Error(frame.message) as Error & { code?: string };
+  err.code = frame.code;
+  return err;
+}
+
 export function createClient(opts: CreateClientOptions = {}): Client {
   const aid = opts.activityId ?? inferActivityId();
   const url = opts.url ?? inferUrl(aid);
@@ -98,19 +114,14 @@ export function createClient(opts: CreateClientOptions = {}): Client {
   const pendingCalls = new Map<string, PendingCall>();
   const subs = new Map<string, SubState>();
   const outbox: string[] = [];
-  let open = false;
-  let closed = false;
   let seq = 0;
   const nextId = () => `c${seq++}`;
-
-  const flush = () => {
-    if (!open) return;
-    for (const line of outbox.splice(0)) ws.send(line);
-  };
+  const isOpen = () => ws.readyState === WS_OPEN;
+  const isClosed = () => ws.readyState === WS_CLOSED;
 
   const send = (frame: HandlerCallFrame | SubOpenFrame | SubCancelFrame) => {
     const line = JSON.stringify(frame);
-    if (open) ws.send(line);
+    if (isOpen()) ws.send(line);
     else outbox.push(line);
   };
 
@@ -119,6 +130,7 @@ export function createClient(opts: CreateClientOptions = {}): Client {
     for (const p of pendingCalls.values()) p.reject(err);
     pendingCalls.clear();
     for (const s of subs.values()) {
+      s.detach();
       s.error = err;
       s.done = true;
       s.waker?.resolve();
@@ -126,20 +138,25 @@ export function createClient(opts: CreateClientOptions = {}): Client {
     subs.clear();
   };
 
+  const finishSub = (id: string, error: Error | null) => {
+    const s = subs.get(id);
+    if (!s) return;
+    s.detach();
+    s.error = error;
+    s.done = true;
+    s.waker?.resolve();
+    subs.delete(id);
+  };
+
   ws.onopen = () => {
-    open = true;
-    flush();
+    for (const line of outbox.splice(0)) ws.send(line);
   };
-  ws.onclose = () => {
-    if (closed) return;
-    closed = true;
-    open = false;
-    failAll();
-  };
+  ws.onclose = () => failAll();
   ws.onerror = () => {
-    if (closed) return;
+    // Errors precede `close`; cleanup happens there.
   };
   ws.onmessage = (ev) => {
+    if (typeof ev.data !== "string") return;
     let f:
       | HandlerResultFrame
       | HandlerErrorFrame
@@ -147,59 +164,44 @@ export function createClient(opts: CreateClientOptions = {}): Client {
       | SubCompleteFrame
       | SubErrorFrame;
     try {
-      f = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+      f = JSON.parse(ev.data);
     } catch {
       return;
     }
-    if (f.kind === "result") {
-      const p = pendingCalls.get(f.id);
-      if (p) {
+    switch (f.kind) {
+      case "result": {
+        const p = pendingCalls.get(f.id);
+        if (!p) return;
         pendingCalls.delete(f.id);
         p.resolve(f.payload);
+        return;
       }
-      return;
-    }
-    if (f.kind === "error") {
-      const p = pendingCalls.get(f.id);
-      if (p) {
+      case "error": {
+        const p = pendingCalls.get(f.id);
+        if (!p) return;
         pendingCalls.delete(f.id);
-        const err = new Error(f.message);
-        (err as Error & { code?: string }).code = f.code;
-        p.reject(err);
+        p.reject(toRpcError(f));
+        return;
       }
-      return;
-    }
-    if (f.kind === "sub.data") {
-      const s = subs.get(f.id);
-      if (!s || s.done) return;
-      s.queue.push(f.payload);
-      s.waker?.resolve();
-      return;
-    }
-    if (f.kind === "sub.complete") {
-      const s = subs.get(f.id);
-      if (!s) return;
-      s.done = true;
-      s.waker?.resolve();
-      subs.delete(f.id);
-      return;
-    }
-    if (f.kind === "sub.error") {
-      const s = subs.get(f.id);
-      if (!s) return;
-      const err = new Error(f.message);
-      (err as Error & { code?: string }).code = f.code;
-      s.error = err;
-      s.done = true;
-      s.waker?.resolve();
-      subs.delete(f.id);
-      return;
+      case "sub.data": {
+        const s = subs.get(f.id);
+        if (!s || s.done) return;
+        s.queue.push(f.payload);
+        s.waker?.resolve();
+        return;
+      }
+      case "sub.complete":
+        finishSub(f.id, null);
+        return;
+      case "sub.error":
+        finishSub(f.id, toRpcError(f));
+        return;
     }
   };
 
   return {
     call<Req, Resp>(name: string, payload: Req): Promise<Resp> {
-      if (closed) return Promise.reject(new ConnectionClosedError());
+      if (isClosed()) return Promise.reject(new ConnectionClosedError());
       const id = nextId();
       return new Promise<Resp>((resolve, reject) => {
         pendingCalls.set(id, {
@@ -217,29 +219,39 @@ export function createClient(opts: CreateClientOptions = {}): Client {
     ): AsyncIterable<Event> {
       const id = nextId();
       const signal = opts.signal;
+      let onAbort: (() => void) | null = null;
       const state: SubState = {
         queue: [],
         done: false,
         error: null,
         waker: null,
+        detach: () => {
+          if (onAbort && signal) {
+            signal.removeEventListener("abort", onAbort);
+            onAbort = null;
+          }
+        },
         cancel: () => {
           if (state.done) return;
           state.done = true;
+          state.detach();
           subs.delete(id);
           send({ kind: "sub.cancel", id });
         },
       };
 
-      const startAborted = signal?.aborted === true;
-      if (startAborted) {
+      if (signal?.aborted) {
         state.done = true;
       } else {
         subs.set(id, state);
         send({ kind: "sub.open", id, name, params });
-        signal?.addEventListener("abort", () => {
-          state.cancel();
-          state.waker?.resolve();
-        });
+        if (signal) {
+          onAbort = () => {
+            state.cancel();
+            state.waker?.resolve();
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
       }
 
       return {
@@ -269,9 +281,7 @@ export function createClient(opts: CreateClientOptions = {}): Client {
     },
 
     close() {
-      if (closed) return;
-      closed = true;
-      open = false;
+      if (isClosed()) return;
       ws.close();
       failAll();
     },

--- a/sdk/typescript/src/iframe/client.ts
+++ b/sdk/typescript/src/iframe/client.ts
@@ -1,0 +1,279 @@
+import type {
+  HandlerCallFrame,
+  HandlerErrorFrame,
+  HandlerResultFrame,
+  SubCancelFrame,
+  SubCompleteFrame,
+  SubDataFrame,
+  SubErrorFrame,
+  SubOpenFrame,
+} from "../server/protocol.ts";
+
+// Minimal ambient types — this SDK module targets the browser but the SDK
+// package itself does not depend on `lib: ["DOM"]` (server code shares the
+// tsconfig). Declare the small surface we use.
+interface MinimalWebSocket {
+  send(data: string): void;
+  close(): void;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+}
+interface MinimalWebSocketCtor {
+  new (url: string): MinimalWebSocket;
+}
+interface MinimalLocation {
+  protocol: string;
+  host: string;
+  pathname: string;
+}
+interface MinimalAbortSignal {
+  readonly aborted: boolean;
+  addEventListener(type: "abort", listener: () => void): void;
+}
+
+declare const WebSocket: MinimalWebSocketCtor;
+declare const window: { location: MinimalLocation };
+
+export interface CreateClientOptions {
+  activityId?: string;
+  url?: string;
+}
+
+export interface SubscribeOptions {
+  signal?: MinimalAbortSignal;
+}
+
+export class ConnectionClosedError extends Error {
+  constructor() {
+    super("ozmux iframe SDK: WebSocket connection closed");
+    this.name = "ConnectionClosedError";
+  }
+}
+
+interface PendingCall {
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+}
+
+interface SubState {
+  queue: unknown[];
+  done: boolean;
+  error: Error | null;
+  waker: { resolve: () => void } | null;
+  cancel: () => void;
+}
+
+export interface Client {
+  call<Req, Resp>(name: string, payload: Req): Promise<Resp>;
+  subscribe<Params, Event>(
+    name: string,
+    params: Params,
+    opts?: SubscribeOptions,
+  ): AsyncIterable<Event>;
+  close(): void;
+}
+
+function inferActivityId(): string {
+  const m = window.location.pathname.match(/^\/activities\/([^/]+)\/iframe\//);
+  if (!m) {
+    throw new Error(
+      "ozmux iframe SDK: cannot infer activityId from pathname; pass activityId explicitly",
+    );
+  }
+  return m[1]!;
+}
+
+function inferUrl(aid: string): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${window.location.host}/activities/${aid}/handlers/ws`;
+}
+
+export function createClient(opts: CreateClientOptions = {}): Client {
+  const aid = opts.activityId ?? inferActivityId();
+  const url = opts.url ?? inferUrl(aid);
+  const ws = new WebSocket(url);
+
+  const pendingCalls = new Map<string, PendingCall>();
+  const subs = new Map<string, SubState>();
+  const outbox: string[] = [];
+  let open = false;
+  let closed = false;
+  let seq = 0;
+  const nextId = () => `c${seq++}`;
+
+  const flush = () => {
+    if (!open) return;
+    for (const line of outbox.splice(0)) ws.send(line);
+  };
+
+  const send = (frame: HandlerCallFrame | SubOpenFrame | SubCancelFrame) => {
+    const line = JSON.stringify(frame);
+    if (open) ws.send(line);
+    else outbox.push(line);
+  };
+
+  const failAll = () => {
+    const err = new ConnectionClosedError();
+    for (const p of pendingCalls.values()) p.reject(err);
+    pendingCalls.clear();
+    for (const s of subs.values()) {
+      s.error = err;
+      s.done = true;
+      s.waker?.resolve();
+    }
+    subs.clear();
+  };
+
+  ws.onopen = () => {
+    open = true;
+    flush();
+  };
+  ws.onclose = () => {
+    if (closed) return;
+    closed = true;
+    open = false;
+    failAll();
+  };
+  ws.onerror = () => {
+    if (closed) return;
+  };
+  ws.onmessage = (ev) => {
+    let f:
+      | HandlerResultFrame
+      | HandlerErrorFrame
+      | SubDataFrame
+      | SubCompleteFrame
+      | SubErrorFrame;
+    try {
+      f = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+    } catch {
+      return;
+    }
+    if (f.kind === "result") {
+      const p = pendingCalls.get(f.id);
+      if (p) {
+        pendingCalls.delete(f.id);
+        p.resolve(f.payload);
+      }
+      return;
+    }
+    if (f.kind === "error") {
+      const p = pendingCalls.get(f.id);
+      if (p) {
+        pendingCalls.delete(f.id);
+        const err = new Error(f.message);
+        (err as Error & { code?: string }).code = f.code;
+        p.reject(err);
+      }
+      return;
+    }
+    if (f.kind === "sub.data") {
+      const s = subs.get(f.id);
+      if (!s || s.done) return;
+      s.queue.push(f.payload);
+      s.waker?.resolve();
+      return;
+    }
+    if (f.kind === "sub.complete") {
+      const s = subs.get(f.id);
+      if (!s) return;
+      s.done = true;
+      s.waker?.resolve();
+      subs.delete(f.id);
+      return;
+    }
+    if (f.kind === "sub.error") {
+      const s = subs.get(f.id);
+      if (!s) return;
+      const err = new Error(f.message);
+      (err as Error & { code?: string }).code = f.code;
+      s.error = err;
+      s.done = true;
+      s.waker?.resolve();
+      subs.delete(f.id);
+      return;
+    }
+  };
+
+  return {
+    call<Req, Resp>(name: string, payload: Req): Promise<Resp> {
+      if (closed) return Promise.reject(new ConnectionClosedError());
+      const id = nextId();
+      return new Promise<Resp>((resolve, reject) => {
+        pendingCalls.set(id, {
+          resolve: (v) => resolve(v as Resp),
+          reject,
+        });
+        send({ kind: "call", id, name, payload });
+      });
+    },
+
+    subscribe<Params, Event>(
+      name: string,
+      params: Params,
+      opts: SubscribeOptions = {},
+    ): AsyncIterable<Event> {
+      const id = nextId();
+      const signal = opts.signal;
+      const state: SubState = {
+        queue: [],
+        done: false,
+        error: null,
+        waker: null,
+        cancel: () => {
+          if (state.done) return;
+          state.done = true;
+          subs.delete(id);
+          send({ kind: "sub.cancel", id });
+        },
+      };
+
+      const startAborted = signal?.aborted === true;
+      if (startAborted) {
+        state.done = true;
+      } else {
+        subs.set(id, state);
+        send({ kind: "sub.open", id, name, params });
+        signal?.addEventListener("abort", () => {
+          state.cancel();
+          state.waker?.resolve();
+        });
+      }
+
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<Event> {
+          return {
+            async next(): Promise<IteratorResult<Event>> {
+              while (true) {
+                if (state.queue.length > 0) {
+                  const v = state.queue.shift() as Event;
+                  return { value: v, done: false };
+                }
+                if (state.error) throw state.error;
+                if (state.done) return { value: undefined, done: true };
+                await new Promise<void>((resolve) => {
+                  state.waker = { resolve };
+                });
+                state.waker = null;
+              }
+            },
+            async return(): Promise<IteratorResult<Event>> {
+              state.cancel();
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      };
+    },
+
+    close() {
+      if (closed) return;
+      closed = true;
+      open = false;
+      ws.close();
+      failAll();
+    },
+  };
+}

--- a/sdk/typescript/src/iframe/index.ts
+++ b/sdk/typescript/src/iframe/index.ts
@@ -1,0 +1,7 @@
+export {
+  createClient,
+  ConnectionClosedError,
+  type Client,
+  type CreateClientOptions,
+  type SubscribeOptions,
+} from "./client.ts";

--- a/sdk/typescript/src/server/activity.test.ts
+++ b/sdk/typescript/src/server/activity.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createActivity } from "./activity.ts";
+import * as channelsServer from "./channels-server.ts";
+import { __resetActivityChannelsForTests } from "./channels-server.ts";
 import * as daemonClient from "./daemon-client.ts";
 import {
   __resetActivityHandlersForTests,
@@ -11,6 +13,7 @@ let postJsonSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   __resetActivityHandlersForTests();
+  __resetActivityChannelsForTests();
   postJsonSpy = vi
     .spyOn(daemonClient, "postJson")
     .mockResolvedValue({ activity_id: "aid-42" });
@@ -41,6 +44,20 @@ describe("createActivity", () => {
   it("works without handlers (backward compatible)", async () => {
     const aid = await createActivity({ html: "/tmp/x" });
     expect(aid).toBe("aid-42");
+  });
+
+  it("registers channels under the returned aid when provided", async () => {
+    const registerSpy = vi.spyOn(channelsServer, "registerActivityChannels");
+    const tick = async function* (): AsyncGenerator<{ t: number }> {
+      yield { t: 1 };
+    };
+    const aid = await createActivity({
+      html: "/tmp/x",
+      channels: { tick },
+    });
+    expect(aid).toBe("aid-42");
+    expect(registerSpy).toHaveBeenCalledWith("aid-42", { tick });
+    registerSpy.mockRestore();
   });
 });
 

--- a/sdk/typescript/src/server/activity.test.ts
+++ b/sdk/typescript/src/server/activity.test.ts
@@ -3,12 +3,9 @@ import { createActivity } from "./activity.ts";
 import * as channelsServer from "./channels-server.ts";
 import { __resetActivityChannelsForTests } from "./channels-server.ts";
 import * as daemonClient from "./daemon-client.ts";
-import {
-  __resetActivityHandlersForTests,
-  registerActivityHandlers,
-} from "./handlers-server.ts";
+import * as handlersServer from "./handlers-server.ts";
+import { __resetActivityHandlersForTests } from "./handlers-server.ts";
 
-// Replace postJson with a spy that returns a stable aid
 let postJsonSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -30,6 +27,7 @@ describe("createActivity", () => {
   });
 
   it("registers handlers under the returned aid when provided", async () => {
+    const registerSpy = vi.spyOn(handlersServer, "registerActivityHandlers");
     const greet = vi.fn(async ({ name }: { name: string }) => ({
       message: `Hello, ${name}!`,
     }));
@@ -38,12 +36,25 @@ describe("createActivity", () => {
       handlers: { greet },
     });
     expect(aid).toBe("aid-42");
-    expect(greet).not.toHaveBeenCalled();
+    expect(registerSpy).toHaveBeenCalledWith("aid-42", { greet });
+    registerSpy.mockRestore();
   });
 
-  it("works without handlers (backward compatible)", async () => {
+  it("works without handlers or channels", async () => {
+    const registerHandlersSpy = vi.spyOn(
+      handlersServer,
+      "registerActivityHandlers",
+    );
+    const registerChannelsSpy = vi.spyOn(
+      channelsServer,
+      "registerActivityChannels",
+    );
     const aid = await createActivity({ html: "/tmp/x" });
     expect(aid).toBe("aid-42");
+    expect(registerHandlersSpy).not.toHaveBeenCalled();
+    expect(registerChannelsSpy).not.toHaveBeenCalled();
+    registerHandlersSpy.mockRestore();
+    registerChannelsSpy.mockRestore();
   });
 
   it("registers channels under the returned aid when provided", async () => {
@@ -58,13 +69,5 @@ describe("createActivity", () => {
     expect(aid).toBe("aid-42");
     expect(registerSpy).toHaveBeenCalledWith("aid-42", { tick });
     registerSpy.mockRestore();
-  });
-});
-
-describe("createActivity ⇄ handlers-server", () => {
-  it("activity handlers are visible to the dispatcher", async () => {
-    const fn = vi.fn(async () => ({ ok: true }));
-    await createActivity({ html: "/tmp/x", handlers: { ping: fn } });
-    expect(typeof registerActivityHandlers).toBe("function");
   });
 });

--- a/sdk/typescript/src/server/activity.ts
+++ b/sdk/typescript/src/server/activity.ts
@@ -1,20 +1,29 @@
 import * as path from "node:path";
+import {
+  type ChannelMap,
+  registerActivityChannels,
+} from "./channels-server.ts";
 import { postJson } from "./daemon-client.ts";
 import {
-  registerActivityHandlers,
   type HandlerMap,
+  registerActivityHandlers,
 } from "./handlers-server.ts";
 
 export type ActivityId = string;
 
-export interface CreateActivityArgs<H extends HandlerMap = HandlerMap> {
+export interface CreateActivityArgs<
+  H extends HandlerMap = HandlerMap,
+  C extends ChannelMap = ChannelMap,
+> {
   html: string;
   handlers?: H;
+  channels?: C;
 }
 
-export async function createActivity<H extends HandlerMap = HandlerMap>(
-  args: CreateActivityArgs<H>,
-): Promise<ActivityId> {
+export async function createActivity<
+  H extends HandlerMap = HandlerMap,
+  C extends ChannelMap = ChannelMap,
+>(args: CreateActivityArgs<H, C>): Promise<ActivityId> {
   const html = path.resolve(args.html);
   const { activity_id } = await postJson<{ activity_id: ActivityId }>(
     "/activities",
@@ -22,6 +31,9 @@ export async function createActivity<H extends HandlerMap = HandlerMap>(
   );
   if (args.handlers) {
     registerActivityHandlers(activity_id, args.handlers);
+  }
+  if (args.channels) {
+    registerActivityChannels(activity_id, args.channels);
   }
   return activity_id;
 }

--- a/sdk/typescript/src/server/channels-server.test.ts
+++ b/sdk/typescript/src/server/channels-server.test.ts
@@ -1,0 +1,209 @@
+import * as fs from "node:fs/promises";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  bindHandlersServer,
+  registerActivityHandlers,
+  __resetActivityHandlersForTests,
+} from "./handlers-server.ts";
+import {
+  registerActivityChannels,
+  __resetActivityChannelsForTests,
+} from "./channels-server.ts";
+
+let server: net.Server | undefined;
+let sockPath = "";
+
+beforeEach(async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ozmux-test-"));
+  sockPath = path.join(dir, "chan.handlers.sock");
+  __resetActivityHandlersForTests();
+  __resetActivityChannelsForTests();
+});
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((res) => server!.close(() => res()));
+    server = undefined;
+  }
+});
+
+function connect(): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const s = net.connect(sockPath);
+    s.once("connect", () => resolve(s));
+    s.once("error", reject);
+  });
+}
+
+function lineReader(s: net.Socket): () => Promise<string> {
+  const queue: string[] = [];
+  const wakers: Array<(line: string) => void> = [];
+  let buf = "";
+  s.on("data", (chunk) => {
+    buf += chunk.toString("utf8");
+    while (true) {
+      const idx = buf.indexOf("\n");
+      if (idx === -1) break;
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      const w = wakers.shift();
+      if (w) w(line);
+      else queue.push(line);
+    }
+  });
+  return () =>
+    new Promise<string>((resolve) => {
+      const q = queue.shift();
+      if (q !== undefined) resolve(q);
+      else wakers.push(resolve);
+    });
+}
+
+describe("channels-server: happy path", () => {
+  it("streams sub.data then sub.complete when the generator returns", async () => {
+    server = await bindHandlersServer(sockPath);
+    registerActivityChannels("aid-1", {
+      counter: async function* ({ n }: { n: number }) {
+        for (let i = 0; i < n; i++) yield { i };
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "s1", name: "counter", params: { n: 2 } },
+      }) + "\n",
+    );
+    const a = JSON.parse(await next()).frame;
+    const b = JSON.parse(await next()).frame;
+    const c = JSON.parse(await next()).frame;
+    expect(a).toEqual({ kind: "sub.data", id: "s1", payload: { i: 0 } });
+    expect(b).toEqual({ kind: "sub.data", id: "s1", payload: { i: 1 } });
+    expect(c).toEqual({ kind: "sub.complete", id: "s1" });
+    s.destroy();
+  });
+
+  it("returns sub.error UNKNOWN_CHANNEL for an unregistered name", async () => {
+    server = await bindHandlersServer(sockPath);
+    registerActivityChannels("aid-1", {});
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "s9", name: "ghost", params: {} },
+      }) + "\n",
+    );
+    const env = JSON.parse(await next());
+    expect(env.frame).toEqual({
+      kind: "sub.error",
+      id: "s9",
+      code: "UNKNOWN_CHANNEL",
+      message: "ghost",
+    });
+    s.destroy();
+  });
+
+  it("returns sub.error HANDLER_ERROR when the generator throws", async () => {
+    server = await bindHandlersServer(sockPath);
+    registerActivityChannels("aid-1", {
+      boom: async function* () {
+        yield { ok: 1 };
+        throw new Error("nope");
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "s2", name: "boom", params: {} },
+      }) + "\n",
+    );
+    const a = JSON.parse(await next()).frame;
+    const b = JSON.parse(await next()).frame;
+    expect(a).toEqual({ kind: "sub.data", id: "s2", payload: { ok: 1 } });
+    expect(b.kind).toBe("sub.error");
+    expect(b.code).toBe("HANDLER_ERROR");
+    expect(b.message).toContain("nope");
+    s.destroy();
+  });
+
+  it("ignores call to a channel name and sub.open to a handler name (cross-namespace)", async () => {
+    server = await bindHandlersServer(sockPath);
+    registerActivityHandlers("aid-1", {
+      hi: async () => ({ ok: 1 }),
+    });
+    registerActivityChannels("aid-1", {
+      tick: async function* () {
+        yield { t: 1 };
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    // sub.open with handler name -> UNKNOWN_CHANNEL
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "x", name: "hi", params: {} },
+      }) + "\n",
+    );
+    const r1 = JSON.parse(await next()).frame;
+    expect(r1.kind).toBe("sub.error");
+    expect(r1.code).toBe("UNKNOWN_CHANNEL");
+    // call with channel name -> UNKNOWN_HANDLER
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "call", id: "y", name: "tick", payload: {} },
+      }) + "\n",
+    );
+    const r2 = JSON.parse(await next()).frame;
+    expect(r2.kind).toBe("error");
+    expect(r2.code).toBe("UNKNOWN_HANDLER");
+    s.destroy();
+  });
+
+  it("supports two concurrent subscriptions on the same connection", async () => {
+    server = await bindHandlersServer(sockPath);
+    registerActivityChannels("aid-1", {
+      a: async function* () {
+        yield { from: "a", v: 1 };
+        yield { from: "a", v: 2 };
+      },
+      b: async function* () {
+        yield { from: "b", v: 1 };
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "1", name: "a", params: {} },
+      }) + "\n",
+    );
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "2", name: "b", params: {} },
+      }) + "\n",
+    );
+    const collected: any[] = [];
+    for (let i = 0; i < 5; i++) collected.push(JSON.parse(await next()).frame);
+    const byId: Record<string, any[]> = {};
+    for (const f of collected) {
+      (byId[f.id] ??= []).push(f);
+    }
+    expect(byId["1"]?.[0].payload).toEqual({ from: "a", v: 1 });
+    expect(byId["1"]?.[1].payload).toEqual({ from: "a", v: 2 });
+    expect(byId["1"]?.[2].kind).toBe("sub.complete");
+    expect(byId["2"]?.[0].payload).toEqual({ from: "b", v: 1 });
+    expect(byId["2"]?.[1].kind).toBe("sub.complete");
+    s.destroy();
+  });
+});

--- a/sdk/typescript/src/server/channels-server.test.ts
+++ b/sdk/typescript/src/server/channels-server.test.ts
@@ -304,3 +304,49 @@ describe("channels-server: cancellation", () => {
     s.destroy();
   });
 });
+
+describe("channels-server: connection lifecycle", () => {
+  it("aborts all subscriptions on the connection when the socket closes", async () => {
+    server = await bindHandlersServer(sockPath);
+    const aborted: string[] = [];
+    registerActivityChannels("aid-1", {
+      hang: async function* (
+        params: { tag: string },
+        { signal }: { signal: AbortSignal },
+      ) {
+        try {
+          yield { tag: params.tag };
+          await new Promise<void>((_resolve, reject) => {
+            signal.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          });
+        } catch {
+          aborted.push(params.tag);
+        }
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "1", name: "hang", params: { tag: "A" } },
+      }) + "\n",
+    );
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "2", name: "hang", params: { tag: "B" } },
+      }) + "\n",
+    );
+    // Read both initial sub.data frames (any order).
+    JSON.parse(await next());
+    JSON.parse(await next());
+
+    s.destroy();
+    await vi.waitFor(() => expect(aborted.sort()).toEqual(["A", "B"]), {
+      timeout: 1000,
+    });
+  });
+});

--- a/sdk/typescript/src/server/channels-server.test.ts
+++ b/sdk/typescript/src/server/channels-server.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   bindHandlersServer,
   registerActivityHandlers,
@@ -204,6 +204,103 @@ describe("channels-server: happy path", () => {
     expect(byId["1"]?.[2].kind).toBe("sub.complete");
     expect(byId["2"]?.[0].payload).toEqual({ from: "b", v: 1 });
     expect(byId["2"]?.[1].kind).toBe("sub.complete");
+    s.destroy();
+  });
+});
+
+describe("channels-server: cancellation", () => {
+  it("aborts the generator's signal and runs finally on sub.cancel", async () => {
+    server = await bindHandlersServer(sockPath);
+    let finallyRan = false;
+    let signalSeen: AbortSignal | undefined;
+    registerActivityChannels("aid-1", {
+      slow: async function* (_p: unknown, { signal }: { signal: AbortSignal }) {
+        signalSeen = signal;
+        try {
+          for (;;) {
+            if (signal.aborted) return;
+            yield { tick: Date.now() };
+            await new Promise<void>((resolve) => {
+              const t = setTimeout(resolve, 10);
+              signal.addEventListener("abort", () => {
+                clearTimeout(t);
+                resolve();
+              });
+            });
+          }
+        } finally {
+          finallyRan = true;
+        }
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "s1", name: "slow", params: {} },
+      }) + "\n",
+    );
+    // Read at least one data frame, then cancel.
+    const first = JSON.parse(await next()).frame;
+    expect(first.kind).toBe("sub.data");
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.cancel", id: "s1" },
+      }) + "\n",
+    );
+    // Drain until we see sub.complete.
+    let saw: unknown;
+    for (let i = 0; i < 20; i++) {
+      const env = JSON.parse(await next()).frame;
+      if (env.kind === "sub.complete") {
+        saw = env;
+        break;
+      }
+    }
+    expect((saw as { kind: string }).kind).toBe("sub.complete");
+    await vi.waitFor(() => expect(finallyRan).toBe(true));
+    expect(signalSeen?.aborted).toBe(true);
+    s.destroy();
+  });
+
+  it("drops sub.data emitted after cancel", async () => {
+    server = await bindHandlersServer(sockPath);
+    let resumeYield: () => void = () => {};
+    registerActivityChannels("aid-1", {
+      gated: async function* () {
+        yield { first: true };
+        await new Promise<void>((resolve) => {
+          resumeYield = resolve;
+        });
+        yield { afterCancel: true };
+      },
+    });
+    const s = await connect();
+    const next = lineReader(s);
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.open", id: "s1", name: "gated", params: {} },
+      }) + "\n",
+    );
+    const first = JSON.parse(await next()).frame;
+    expect(first).toEqual({ kind: "sub.data", id: "s1", payload: { first: true } });
+    s.write(
+      JSON.stringify({
+        aid: "aid-1",
+        frame: { kind: "sub.cancel", id: "s1" },
+      }) + "\n",
+    );
+    // Wait for the cancel frame to be read and dispatched on the server
+    // side before letting the generator resume; without this, the
+    // generator's next yield wins the microtask vs macrotask race.
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    resumeYield();
+    // Next frame must be sub.complete, not the dropped afterCancel data.
+    const after = JSON.parse(await next()).frame;
+    expect(after.kind).toBe("sub.complete");
     s.destroy();
   });
 });

--- a/sdk/typescript/src/server/channels-server.ts
+++ b/sdk/typescript/src/server/channels-server.ts
@@ -1,0 +1,125 @@
+import type * as net from "node:net";
+import type {
+  SubOpenFrame,
+  SubCancelFrame,
+  HandlerServerFrame,
+} from "./protocol.ts";
+
+type ActivityId = string;
+type SubId = string;
+
+export type ChannelCtx = { signal: AbortSignal };
+export type ChannelGenerator<P = never, T = unknown> = (
+  params: P,
+  ctx: ChannelCtx,
+) => AsyncGenerator<T, void, undefined>;
+export type ChannelMap = Record<string, ChannelGenerator<any, any>>;
+
+const activityChannels = new Map<ActivityId, ChannelMap>();
+
+export function registerActivityChannels(
+  aid: ActivityId,
+  channels: ChannelMap,
+): void {
+  activityChannels.set(aid, channels);
+}
+
+/** Test-only escape hatch; not exported from the package barrel. */
+export function __resetActivityChannelsForTests(): void {
+  activityChannels.clear();
+  for (const map of perConnection.values()) {
+    for (const ac of map.values()) ac.abort();
+    map.clear();
+  }
+  perConnection.clear();
+}
+
+// Per-connection subscription tracking. Sockets are removed explicitly on
+// close via `abortAllForConnection`, so a regular Map is fine.
+const perConnection = new Map<net.Socket, Map<SubId, AbortController>>();
+
+function getSubs(conn: net.Socket): Map<SubId, AbortController> {
+  let m = perConnection.get(conn);
+  if (!m) {
+    m = new Map();
+    perConnection.set(conn, m);
+  }
+  return m;
+}
+
+function writeFrame(
+  conn: net.Socket,
+  aid: ActivityId,
+  frame: HandlerServerFrame,
+): void {
+  if (conn.destroyed || !conn.writable) return;
+  conn.write(JSON.stringify({ aid, frame }) + "\n");
+}
+
+export function handleSubOpen(
+  conn: net.Socket,
+  aid: ActivityId,
+  open: SubOpenFrame,
+): void {
+  const channels = activityChannels.get(aid) ?? {};
+  const gen = channels[open.name];
+  if (!gen) {
+    writeFrame(conn, aid, {
+      kind: "sub.error",
+      id: open.id,
+      code: "UNKNOWN_CHANNEL",
+      message: open.name,
+    });
+    return;
+  }
+  const ac = new AbortController();
+  const subs = getSubs(conn);
+  subs.set(open.id, ac);
+
+  void (async () => {
+    try {
+      const iter = gen(open.params as never, { signal: ac.signal });
+      for await (const value of iter) {
+        if (ac.signal.aborted) break;
+        writeFrame(conn, aid, {
+          kind: "sub.data",
+          id: open.id,
+          payload: value,
+        });
+      }
+      writeFrame(conn, aid, { kind: "sub.complete", id: open.id });
+    } catch (e) {
+      if (!ac.signal.aborted) {
+        writeFrame(conn, aid, {
+          kind: "sub.error",
+          id: open.id,
+          code: "HANDLER_ERROR",
+          message: e instanceof Error ? e.message : String(e),
+        });
+      } else {
+        // Cancelled-then-threw is a normal cancel; emit complete.
+        writeFrame(conn, aid, { kind: "sub.complete", id: open.id });
+      }
+    } finally {
+      subs.delete(open.id);
+    }
+  })();
+}
+
+export function handleSubCancel(
+  conn: net.Socket,
+  _aid: ActivityId,
+  cancel: SubCancelFrame,
+): void {
+  const subs = perConnection.get(conn);
+  const ac = subs?.get(cancel.id);
+  if (ac) ac.abort();
+}
+
+export function abortAllForConnection(conn: net.Socket): void {
+  const subs = perConnection.get(conn);
+  if (!subs) return;
+  for (const ac of subs.values()) ac.abort();
+  subs.clear();
+  perConnection.delete(conn);
+}

--- a/sdk/typescript/src/server/channels-server.ts
+++ b/sdk/typescript/src/server/channels-server.ts
@@ -47,7 +47,8 @@ function getSubs(conn: net.Socket): Map<SubId, AbortController> {
   return m;
 }
 
-function writeFrame(
+/** Write a server frame wrapped in the {aid, frame} NDJSON envelope. */
+export function writeServerFrame(
   conn: net.Socket,
   aid: ActivityId,
   frame: HandlerServerFrame,
@@ -64,7 +65,7 @@ export function handleSubOpen(
   const channels = activityChannels.get(aid) ?? {};
   const gen = channels[open.name];
   if (!gen) {
-    writeFrame(conn, aid, {
+    writeServerFrame(conn, aid, {
       kind: "sub.error",
       id: open.id,
       code: "UNKNOWN_CHANNEL",
@@ -81,29 +82,39 @@ export function handleSubOpen(
       const iter = gen(open.params as never, { signal: ac.signal });
       for await (const value of iter) {
         if (ac.signal.aborted) break;
-        writeFrame(conn, aid, {
+        writeServerFrame(conn, aid, {
           kind: "sub.data",
           id: open.id,
           payload: value,
         });
       }
-      writeFrame(conn, aid, { kind: "sub.complete", id: open.id });
+      writeServerFrame(conn, aid, { kind: "sub.complete", id: open.id });
     } catch (e) {
-      if (!ac.signal.aborted) {
-        writeFrame(conn, aid, {
+      // An abort-driven throw is a normal cancel; emit `sub.complete`. Other
+      // throws are reported as `sub.error` so the iframe sees the failure.
+      if (ac.signal.aborted && isAbortError(e)) {
+        writeServerFrame(conn, aid, { kind: "sub.complete", id: open.id });
+      } else {
+        writeServerFrame(conn, aid, {
           kind: "sub.error",
           id: open.id,
           code: "HANDLER_ERROR",
           message: e instanceof Error ? e.message : String(e),
         });
-      } else {
-        // Cancelled-then-threw is a normal cancel; emit complete.
-        writeFrame(conn, aid, { kind: "sub.complete", id: open.id });
       }
     } finally {
       subs.delete(open.id);
     }
   })();
+}
+
+function isAbortError(e: unknown): boolean {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "name" in e &&
+    (e as { name?: unknown }).name === "AbortError"
+  );
 }
 
 export function handleSubCancel(

--- a/sdk/typescript/src/server/handlers-server.ts
+++ b/sdk/typescript/src/server/handlers-server.ts
@@ -1,6 +1,11 @@
 import type * as net from "node:net";
 import { bindServer } from "./bootstrap.ts";
 import type { HandlerServerFrame, HandlerUdsEnvelope } from "./protocol.ts";
+import {
+  handleSubOpen,
+  handleSubCancel,
+  abortAllForConnection,
+} from "./channels-server.ts";
 
 export type HandlerMap = Record<string, (req: never) => Promise<unknown>>;
 type ActivityId = string;
@@ -33,13 +38,11 @@ function onConnection(conn: net.Socket): void {
       const line = buf.slice(0, idx);
       buf = buf.slice(idx + 1);
       handleLine(conn, line).catch((err) => {
-        // A malformed frame should not tear down the channel.
         console.error("handlers-server: handleLine threw", err);
       });
     }
   });
-  // Node's default error handler would crash the process; the daemon closing
-  // the UDS triggers EOF here, not a fatal error.
+  conn.on("close", () => abortAllForConnection(conn));
   conn.on("error", () => {});
 }
 
@@ -48,12 +51,21 @@ async function handleLine(conn: net.Socket, line: string): Promise<void> {
   try {
     env = JSON.parse(line) as HandlerUdsEnvelope;
   } catch {
-    return; // ignore non-JSON noise
+    return;
   }
-  if (env.frame.kind !== "call") {
-    return; // only "call" is expected inbound on this side
+  const f = env.frame;
+  if (f.kind === "sub.open") {
+    handleSubOpen(conn, env.aid, f);
+    return;
   }
-  const call = env.frame;
+  if (f.kind === "sub.cancel") {
+    handleSubCancel(conn, env.aid, f);
+    return;
+  }
+  if (f.kind !== "call") {
+    return;
+  }
+  const call = f;
   const handlers = activityHandlers.get(env.aid) ?? {};
   const fn = handlers[call.name];
   let resp: HandlerServerFrame;

--- a/sdk/typescript/src/server/handlers-server.ts
+++ b/sdk/typescript/src/server/handlers-server.ts
@@ -2,9 +2,10 @@ import type * as net from "node:net";
 import { bindServer } from "./bootstrap.ts";
 import type { HandlerServerFrame, HandlerUdsEnvelope } from "./protocol.ts";
 import {
-  handleSubOpen,
-  handleSubCancel,
   abortAllForConnection,
+  handleSubCancel,
+  handleSubOpen,
+  writeServerFrame,
 } from "./channels-server.ts";
 
 export type HandlerMap = Record<string, (req: never) => Promise<unknown>>;
@@ -43,6 +44,7 @@ function onConnection(conn: net.Socket): void {
     }
   });
   conn.on("close", () => abortAllForConnection(conn));
+  // EPIPE / ECONNRESET on peer-close are delivered here; `close` handles cleanup.
   conn.on("error", () => {});
 }
 
@@ -65,29 +67,28 @@ async function handleLine(conn: net.Socket, line: string): Promise<void> {
   if (f.kind !== "call") {
     return;
   }
-  const call = f;
   const handlers = activityHandlers.get(env.aid) ?? {};
-  const fn = handlers[call.name];
-  let resp: HandlerServerFrame;
-  if (!fn) {
-    resp = {
+  const fn = handlers[f.name];
+  const resp: HandlerServerFrame = !fn
+    ? { kind: "error", id: f.id, code: "UNKNOWN_HANDLER", message: f.name }
+    : await invokeHandler(fn, f.id, f.payload);
+  writeServerFrame(conn, env.aid, resp);
+}
+
+async function invokeHandler(
+  fn: (req: never) => Promise<unknown>,
+  id: string,
+  payload: unknown,
+): Promise<HandlerServerFrame> {
+  try {
+    const result = await fn(payload as never);
+    return { kind: "result", id, payload: result };
+  } catch (e) {
+    return {
       kind: "error",
-      id: call.id,
-      code: "UNKNOWN_HANDLER",
-      message: call.name,
+      id,
+      code: "HANDLER_ERROR",
+      message: e instanceof Error ? e.message : String(e),
     };
-  } else {
-    try {
-      const result = await fn(call.payload as never);
-      resp = { kind: "result", id: call.id, payload: result };
-    } catch (e) {
-      resp = {
-        kind: "error",
-        id: call.id,
-        code: "HANDLER_ERROR",
-        message: e instanceof Error ? e.message : String(e),
-      };
-    }
   }
-  conn.write(JSON.stringify({ aid: env.aid, frame: resp }) + "\n");
 }

--- a/sdk/typescript/src/server/index.ts
+++ b/sdk/typescript/src/server/index.ts
@@ -1,4 +1,10 @@
 export * from "./activity.ts";
 export type { HandlerMap } from "./handlers-server.ts";
+export {
+  type ChannelCtx,
+  type ChannelGenerator,
+  type ChannelMap,
+  registerActivityChannels,
+} from "./channels-server.ts";
 export * from "./pane.ts";
 export { bootstrap, type CommandContext, type CommandHandler } from "./bootstrap.ts";

--- a/sdk/typescript/src/server/index.ts
+++ b/sdk/typescript/src/server/index.ts
@@ -6,5 +6,6 @@ export {
   type ChannelMap,
   registerActivityChannels,
 } from "./channels-server.ts";
+export { abortableSleep } from "./timing.ts";
 export * from "./pane.ts";
 export { bootstrap, type CommandContext, type CommandHandler } from "./bootstrap.ts";

--- a/sdk/typescript/src/server/protocol.ts
+++ b/sdk/typescript/src/server/protocol.ts
@@ -46,17 +46,41 @@ export interface HandlerErrorFrame {
   code: string;
   message: string;
 }
-export interface HandlerPushFrame {
-  kind: "push";
-  topic: string;
+
+// Channel frames (one-way: extension → iframe; iframe sends open/cancel only in v1)
+export interface SubOpenFrame {
+  kind: "sub.open";
+  id: string;
+  name: string;
+  params: unknown;
+}
+export interface SubDataFrame {
+  kind: "sub.data";
+  id: string;
   payload: unknown;
 }
+export interface SubCompleteFrame {
+  kind: "sub.complete";
+  id: string;
+}
+export interface SubErrorFrame {
+  kind: "sub.error";
+  id: string;
+  code: string;
+  message: string;
+}
+export interface SubCancelFrame {
+  kind: "sub.cancel";
+  id: string;
+}
 
-export type HandlerClientFrame = HandlerCallFrame;
+export type HandlerClientFrame = HandlerCallFrame | SubOpenFrame | SubCancelFrame;
 export type HandlerServerFrame =
   | HandlerResultFrame
   | HandlerErrorFrame
-  | HandlerPushFrame;
+  | SubDataFrame
+  | SubCompleteFrame
+  | SubErrorFrame;
 
 /** NDJSON envelope written by the daemon onto the handlers UDS. */
 export interface HandlerUdsEnvelope {

--- a/sdk/typescript/src/server/timing.ts
+++ b/sdk/typescript/src/server/timing.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve after `ms` milliseconds, or immediately if `signal` is aborted.
+ * Removes the abort listener on the timeout path so callers can reuse a
+ * long-lived AbortSignal across many sleeps without leaking listeners.
+ */
+export function abortableSleep(
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}


### PR DESCRIPTION
## Problem

`createActivity`'s `handlers` only support single-shot RPC (`call → result/error`). Extensions cannot push continuous data to iframes — progress events, file-watcher notifications, live state, periodic updates. The existing protocol had a `HandlerPushFrame` type defined but never emitted or consumed.

## Solution

Add a one-way **Channel** primitive (extension → iframe push) layered on top of the existing handlers UDS, modeled as `async function*(params, { signal }): AsyncGenerator<T>`. v1 is server-push only; the wire envelope is shaped to allow future bidirectional channels without a protocol break.

### Wire protocol (`sdk/typescript/src/server/protocol.ts`)

Removed the unused `HandlerPushFrame`. Added five new frame kinds sharing the existing `{aid, frame}` NDJSON envelope and the `id` namespace as `call`/`result`:

| Kind | Direction | Purpose |
|---|---|---|
| `sub.open` | iframe → ext | start a subscription |
| `sub.data` | ext → iframe | yielded value |
| `sub.complete` | ext → iframe | generator returned cleanly |
| `sub.error` | ext → iframe | generator threw / channel unknown |
| `sub.cancel` | iframe → ext | `AbortController.abort()` |

### Extension SDK (Node)

New `channels-server.ts` owns a per-activity channel registry and a per-connection `Map<subId, AbortController>`. `createActivity` accepts a `channels` map in addition to `handlers`. Generator cancellation, post-cancel drop, connection-scoped cleanup on socket close, and AbortError reclassification (cancelled-then-AbortError emits `sub.complete`, real errors emit `sub.error`) are all handled.

```ts
await createActivity<MemoHandlers, MemoChannels>({
  html: "./index.html",
  handlers: { greet: async ({ name }) => ({ message: `Hello, ${name}!` }) },
  channels: {
    clock: async function* ({ intervalMs }, { signal }) {
      yield { time: new Date().toISOString() };
      while (!signal.aborted) {
        await abortableSleep(intervalMs, signal);
        if (signal.aborted) return;
        yield { time: new Date().toISOString() };
      }
    },
  },
});
```

### Browser SDK — new package export `@ozmux/sdk/iframe`

A single WebSocket multiplexes `call` and `subscribe` via per-frame `id`. `subscribe` returns an `AsyncIterable<Event>` that respects an optional `AbortSignal` and cleans up the abort listener on every terminal path (cancel / complete / error / close).

```ts
const client = createClient();
const resp = await client.call("greet", { name: "world" });

const ac = new AbortController();
for await (const ev of client.subscribe("clock", { intervalMs: 1000 }, { signal: ac.signal })) {
  clockEl.textContent = ev.time;
}
```

### Daemon (Rust) — no production change

`activities.rs::bridge` is a transparent NDJSON relay; new frame kinds pass through unchanged. The existing `handlers_ws_round_trip_through_uds_mock` is extended to confirm `sub.*` frames transit unmodified.

### Memo extension migration

Replaced the hand-rolled WebSocket client with `@ozmux/sdk/iframe` via an esbuild bundle (`extensions/memo/build-sdk.mjs` → `dist/sdk.js`). The iframe demonstrates both `call('greet')` and `subscribe('clock')` with start/stop controls. `Makefile` runs `pnpm --filter memo run build:sdk` as a prerequisite for `dev-daemon` and `dev-e2e`.

### Why this shape (vs. alternatives)

Parallel research confirmed that the modern convergence for iframe ↔ host streaming is consumer-initiated subscriptions with async generators: **Tauri v2 `Channel<T>`**, **tRPC v11 subscriptions**, **gRPC server-streaming via Connect-Web**, **Electron MessagePort reply streams**, and **SignalR streaming hubs** all picked this shape. It is also the structural plural form of the existing `handlers: { name: (req) => Promise<resp> }` API — same registration site, same scope, same cancellation contract.

### Affected areas

- `sdk/typescript/src/server/{protocol.ts,channels-server.ts,handlers-server.ts,activity.ts,index.ts,timing.ts}`
- `sdk/typescript/src/iframe/{client.ts,index.ts}` (new)
- `sdk/typescript/package.json` (`./iframe` export)
- `daemon/http_server/src/handlers/activities.rs` (test only)
- `daemon/extension/tests/{e2e.rs,fixtures/clock-ext/}` (new fixture + e2e)
- `extensions/memo/{bootstrap.ts,index.html,build-sdk.mjs,iframe-entry.ts,package.json}`
- `Makefile`

### Tests

- `pnpm --filter @ozmux/sdk test`: 50 passed (channels-server, iframe client, activity)
- `cargo test --workspace`: all pass, including new `extension_streams_channel_events` e2e and extended `handlers_ws_round_trip_through_uds_mock`
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`, `pnpm check-types`, `pnpm lint:ci`: clean
- Manual UI verification (Playwright MCP): greet RPC, clock subscribe (ticks every 1s), stop button transitions to "(stopped)"; no console errors

### Out of scope (v1)

- Bidirectional channels (iframe → ext push). The envelope reserves room; SDK does not expose it.
- Reconnection / event replay.
- Backpressure / credit-based flow control.
- Shared bundler tool for extension authors (each extension currently runs esbuild itself).

### Breaking changes

`HandlerPushFrame` (kind: `"push"`) was removed from `@ozmux/sdk` protocol types. It was never emitted or consumed anywhere — verified with a repo-wide grep — so no published surface depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)