### PR TITLE
feat(configs): load TOML config into OzmuxConfigs at daemon startup

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -1,0 +1,124 @@
+# Rust Coding Rules
+
+Rust code in this repo (`cli/`, `daemon/*`) follows the rules below. Edition 2024, toolchain pinned to 1.95. These rules complement [`.claude/rules/styling.md`](styling.md) (frontend) and the conventions documented in `CLAUDE.md`.
+
+## Module layout — no `mod.rs`
+
+Required:
+
+| Pattern | Example | Why |
+| --- | --- | --- |
+| Rust 2018+ module files | `foo.rs` + `foo/bar.rs` | One file declares the module; no ambiguity about which file is the module root |
+
+Forbidden:
+
+| Pattern | Example | Why |
+| --- | --- | --- |
+| `mod.rs` as module root | `foo/mod.rs` | Hard to navigate (many files all named `mod.rs`); editor tabs look identical |
+
+## Comments
+
+Non-doc line comments are restricted. The only permitted forms:
+
+| Form | Use |
+| --- | --- |
+| `// TODO: <text>` | Work to address later |
+| `// NOTE: <text>` | A non-obvious invariant or warning to the reader |
+| `// SAFETY: <text>` | Required justification for any `unsafe { ... }` block (rustc / clippy idiom) |
+
+Forbidden:
+
+| Pattern | Example | Why |
+| --- | --- | --- |
+| Plain narrative comments | `// increments counter` | What the code does belongs in identifiers |
+| Block comments | `/* ... */` | Same |
+| Commented-out code | `// let x = old_impl();` | History lives in git |
+
+Note: `///` and `//!` are **doc comments**, not "line comments" for this rule — see the next section.
+
+## Doc comments
+
+Required:
+
+| Place | Style |
+| --- | --- |
+| Every externally-public item (`pub` only — not `pub(crate)`, `pub(super)`, `pub(in path)`) | `///` — one-line summary, blank line, optional body |
+| Each file-level module — `lib.rs`, `main.rs`, and every `foo.rs` that declares a module | `//!` — module-level purpose in 1–3 lines |
+
+Equivalent attribute forms (`#[doc = "..."]`, `#[doc = include_str!("README.md")]`) count as doc comments and satisfy this rule.
+
+Not required (but recommended):
+
+- `pub(crate)` / `pub(super)` / `pub(in path)` items
+- Inline modules (`mod inner { ... }` inside another file)
+- `#[cfg(test)] mod tests { ... }` blocks and their contents
+
+Style guide:
+
+- The first line is a noun phrase or third-person singular verb phrase (e.g., `/// Returns the active pane.`). Stay descriptive, not imperative.
+- Code examples use triple backticks; hidden setup lines may be prefixed with `# `.
+- Invariants live under a `# Invariants` section.
+
+Forbidden:
+
+| Pattern | Why |
+| --- | --- |
+| Externally `pub` item with no doc | Public API owes the reader an explanation |
+| Placeholder doc like `/// TODO: write this` | Don't ship empty docs |
+
+## Imports
+
+Required:
+
+- Every `use` is declared at the top of the file (immediately after the `//!` if present).
+- All `use` statements form a single contiguous block — no blank lines separating `std`, external crates, and crate-local imports.
+
+Exception:
+
+- Inside `#[cfg(test)] mod tests { ... }` blocks, locally-scoped `use` statements are allowed (e.g., `use super::*;`, test-only fixtures). Test code is the only place where locality outweighs the "all imports at the top" rule.
+
+Forbidden:
+
+| Pattern | Example | Why |
+| --- | --- | --- |
+| `use` inside non-test functions or blocks | `fn f() { use std::io; ... }` | Spreads scope across the file |
+| Blank lines between `std` / external / crate `use`s | `use std::...;\n\nuse tokio::...;` | We do not group |
+| Glob import in consumer code | `use foo::*;` | Hides which symbols are in scope |
+
+Note on preludes: a module that *defines* a prelude (i.e., re-exports curated names for downstream consumers) may itself use `pub use foo::*;` inside its own definition. The rule above forbids glob imports in **consumer** code.
+
+## Escape hatches
+
+When a rule is physically impossible to follow (e.g., trybuild fixtures, generated code, FFI conventions), justify the exception with a one-line `// NOTE:` and apply a local lint allowance:
+
+```rust
+// NOTE: trybuild fixtures must be top-level files; module-layout rule doesn't apply here.
+#[expect(clippy::needless_pass_by_value, reason = "trybuild fixture signature")]
+```
+
+- Prefer `#[expect(..., reason = "...")]` over `#[allow(...)]`. `#[expect]` fails the build if the underlying lint stops firing, which prevents stale allowances from accumulating.
+- Fall back to `#[allow(...)]` only when `#[expect]` is impractical (e.g., conditionally compiled code where the lint may or may not trigger).
+
+"Hard to read" or "annoying" is not a valid reason.
+
+## Enforcement
+
+Tool-enforced:
+
+- `cargo clippy --fix --allow-dirty --allow-staged && cargo fmt`, or `make fix-lint`
+- Add `#![warn(missing_docs)]` to each crate's `lib.rs` / `main.rs` to enforce the doc requirement (rollout tracked separately)
+- CI runs the existing `clippy` and `fmt` checks
+
+Not tool-enforced — review-time check required. The following rules cannot currently be detected by `clippy` / `rustfmt` and must be checked manually during code review (and by Claude when proposing changes):
+
+- `mod.rs` ban
+- Comment taxonomy — only `// TODO:` / `// NOTE:` / `// SAFETY:`
+- File-level module `//!` requirement
+- "No blank lines between import groups"
+- `#[expect]` preference over `#[allow]`
+
+If you add a tool or script that detects any of these, move the corresponding entry into the tool-enforced list above.
+
+## Existing legitimate exceptions
+
+- (None recorded yet — append entries here as they are discovered, with a brief justification.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,13 @@ styles, no arbitrary values, no raw palette references) is governed by
 [`.claude/rules/styling.md`](.claude/rules/styling.md) and enforced by
 Biome GritQL plugins in `biome-plugins/`.
 
+## Rust Coding Rules
+
+Rust style and conventions (no `mod.rs`, restricted comment taxonomy,
+doc-comment policy, import discipline) are governed by
+[`.claude/rules/rust.md`](.claude/rules/rust.md). Applies to all crates
+under `cli/` and `daemon/*`.
+
 ## UI verification workflow
 
 Use this when you have changed anything under `daemon/frontend/src/**`, the showcase, theme tokens, pane layout, or daemon-side endpoints that the UI consumes. Skip it for purely backend-internal changes that the UI does not exercise.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ name = "daemon_bootstrap"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ozmux_configs",
  "ozmux_extension",
  "ozmux_http_server",
  "ozmux_multiplexer",
@@ -234,6 +235,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -347,6 +369,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -523,7 +556,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -561,6 +594,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -628,7 +670,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -649,7 +691,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -659,11 +701,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ozmux_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "tokio",
+]
+
+[[package]]
+name = "ozmux_configs"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.23",
+ "tracing",
 ]
 
 [[package]]
@@ -890,6 +952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,7 +989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -995,6 +1068,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1094,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1136,7 +1218,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1210,7 +1292,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1251,17 +1333,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1274,13 +1377,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -1390,7 +1513,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1587,7 +1710,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1604,11 +1727,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
   "cli",
   "daemon/bootstrap",
+  "daemon/configs",
+  "daemon/extension",
   "daemon/macros",
   "daemon/terminal",
   "daemon/multiplexer",
@@ -36,3 +38,5 @@ futures-util = { version = "0.3", default-features = false, features = [
 tempfile = "3"
 mime_guess = "2.0"
 libc = "0.2"
+toml = "0.8"
+dirs = "5"

--- a/daemon/bootstrap/Cargo.toml
+++ b/daemon/bootstrap/Cargo.toml
@@ -12,6 +12,7 @@ name = "daemon_bootstrap"
 path = "src/main.rs"
 
 [dependencies]
+ozmux_configs = { path = "../configs" }
 ozmux_extension = { path = "../extension" }
 ozmux_http_server = { path = "../http_server" }
 ozmux_multiplexer = { path = "../multiplexer" }

--- a/daemon/bootstrap/src/main.rs
+++ b/daemon/bootstrap/src/main.rs
@@ -1,3 +1,4 @@
+use ozmux_configs::OzmuxConfigs;
 use ozmux_extension::handle::ExtensionHandles;
 use ozmux_extension::registry::ExtensionRegistry;
 use ozmux_extension::runtime::RuntimeRoot;
@@ -16,6 +17,22 @@ async fn main() -> anyhow::Result<()> {
             }),
         )
         .init();
+
+    let configs = match OzmuxConfigs::load().await {
+        Ok(c) => {
+            tracing::info!(
+                prefix = ?c.shortcuts.prefix.chord,
+                bindings = c.shortcuts.bindings.len(),
+                "loaded ozmux config"
+            );
+            c
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to load ozmux config; aborting");
+            return Err(e.into());
+        }
+    };
+    let _ = configs;
 
     let parent = std::env::temp_dir().join("ozmux");
     std::fs::create_dir_all(&parent)?;

--- a/daemon/bootstrap/src/main.rs
+++ b/daemon/bootstrap/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> anyhow::Result<()> {
             return Err(e.into());
         }
     };
+    // TODO: wire configs into AppState (subsequent PR).
     let _ = configs;
 
     let parent = std::env::temp_dir().join("ozmux");

--- a/daemon/configs/Cargo.toml
+++ b/daemon/configs/Cargo.toml
@@ -16,5 +16,6 @@ dirs = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }

--- a/daemon/configs/Cargo.toml
+++ b/daemon/configs/Cargo.toml
@@ -19,4 +19,3 @@ tracing = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
-toml = { workspace = true }

--- a/daemon/configs/Cargo.toml
+++ b/daemon/configs/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
+toml = { workspace = true }

--- a/daemon/configs/Cargo.toml
+++ b/daemon/configs/Cargo.toml
@@ -15,6 +15,13 @@ toml = { workspace = true }
 dirs = { workspace = true }
 tracing = { workspace = true }
 
+[features]
+test_support = []
+
+[[test]]
+name = "load"
+required-features = ["test_support"]
+
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/daemon/configs/Cargo.toml
+++ b/daemon/configs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ozmux_configs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+toml = { workspace = true }
+dirs = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }

--- a/daemon/configs/src/defaults.rs
+++ b/daemon/configs/src/defaults.rs
@@ -1,0 +1,54 @@
+//! Built-in default values for `OzmuxConfigs`, `Shortcuts`, and `Theme`.
+//! These are returned when the config file is absent and act as the merge
+//! baseline when it is present.
+
+use crate::OzmuxConfigs;
+use crate::shortcuts::{Action, Binding, Key, KeyChord, Modifiers, Prefix, Shortcuts};
+use crate::theme::Theme;
+
+#[expect(clippy::derivable_impls)]
+impl Default for OzmuxConfigs {
+    fn default() -> Self {
+        Self {
+            shortcuts: Shortcuts::default(),
+            theme: Theme::default(),
+        }
+    }
+}
+
+impl Default for Shortcuts {
+    fn default() -> Self {
+        Self {
+            prefix: Prefix {
+                chord: KeyChord {
+                    key: Key::Char('b'),
+                    modifiers: Modifiers {
+                        ctrl: true,
+                        ..Default::default()
+                    },
+                },
+                timeout_ms: 2000,
+            },
+            bindings: vec![Binding {
+                chord: KeyChord {
+                    key: Key::Char('x'),
+                    modifiers: Modifiers::default(),
+                },
+                action: Action::ClosePane,
+            }],
+        }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        // NOTE: values mirror Layer 1 raw tokens in daemon/frontend/src/styles/theme.css.
+        Self {
+            background: "#1a1b26".into(),
+            foreground: "#c0caf5".into(),
+            accent: "#414868".into(),
+            border: "#414868".into(),
+            destructive: "#f7768e".into(),
+        }
+    }
+}

--- a/daemon/configs/src/defaults.rs
+++ b/daemon/configs/src/defaults.rs
@@ -2,19 +2,8 @@
 //! These are returned when the config file is absent and act as the merge
 //! baseline when it is present.
 
-use crate::OzmuxConfigs;
 use crate::shortcuts::{Action, Binding, Key, KeyChord, Modifiers, Prefix, Shortcuts};
 use crate::theme::Theme;
-
-#[expect(clippy::derivable_impls)]
-impl Default for OzmuxConfigs {
-    fn default() -> Self {
-        Self {
-            shortcuts: Shortcuts::default(),
-            theme: Theme::default(),
-        }
-    }
-}
 
 impl Default for Shortcuts {
     fn default() -> Self {

--- a/daemon/configs/src/error.rs
+++ b/daemon/configs/src/error.rs
@@ -1,0 +1,69 @@
+//! Error type for ozmux config loading.
+
+use std::path::PathBuf;
+
+/// Result alias used throughout the `ozmux_configs` crate.
+pub type OzmuxConfigsResult<T = ()> = Result<T, OzmuxConfigsError>;
+
+/// Errors that can occur while resolving, reading, or parsing the config file.
+#[derive(Debug, thiserror::Error)]
+pub enum OzmuxConfigsError {
+    /// Reading the config file failed for a reason other than `NotFound`.
+    #[error("failed to read config file at {path}")]
+    Io {
+        /// Path that was being read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The config file contains invalid TOML.
+    #[error("failed to parse TOML at {path}")]
+    ParseToml {
+        /// Path of the offending file.
+        path: PathBuf,
+        /// Underlying parser error.
+        #[source]
+        source: toml::de::Error,
+    },
+
+    /// A semantic constraint was violated.
+    #[error("invalid config: {message}")]
+    InvalidConfig {
+        /// Human-readable explanation.
+        message: String,
+    },
+
+    /// The same key chord appears more than once.
+    #[error("duplicate binding for chord {chord:?}")]
+    DuplicateBinding {
+        /// Chord that was duplicated.
+        chord: crate::shortcuts::KeyChord,
+    },
+
+    /// A binding declared modifier keys, which are not yet supported.
+    #[error("modifier keys are not supported yet for binding {chord:?}")]
+    UnsupportedModifier {
+        /// Chord that used modifiers.
+        chord: crate::shortcuts::KeyChord,
+    },
+
+    /// Neither `$XDG_CONFIG_HOME` nor a home directory could be resolved.
+    #[error("could not determine config directory (no $XDG_CONFIG_HOME and no home dir)")]
+    HomeDirNotFound,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_dir_not_found_display() {
+        let err = OzmuxConfigsError::HomeDirNotFound;
+        assert_eq!(
+            err.to_string(),
+            "could not determine config directory (no $XDG_CONFIG_HOME and no home dir)"
+        );
+    }
+}

--- a/daemon/configs/src/error.rs
+++ b/daemon/configs/src/error.rs
@@ -28,13 +28,6 @@ pub enum OzmuxConfigsError {
         source: toml::de::Error,
     },
 
-    /// A semantic constraint was violated.
-    #[error("invalid config: {message}")]
-    InvalidConfig {
-        /// Human-readable explanation.
-        message: String,
-    },
-
     /// The same key chord appears more than once.
     #[error("duplicate binding for chord {chord:?}")]
     DuplicateBinding {

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -10,6 +10,7 @@ use crate::theme::Theme;
 pub mod error;
 pub mod shortcuts;
 pub mod theme;
+pub(crate) mod path;
 pub(crate) mod raw;
 
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -57,8 +57,8 @@ impl OzmuxConfigs {
         };
 
         let raw: raw::RawConfigs =
-            toml::from_str(&text).map_err(|source| OzmuxConfigsError::ParseToml {
-                path: configured_path.clone(),
+            toml::from_str(&text).map_err(move |source| OzmuxConfigsError::ParseToml {
+                path: configured_path,
                 source,
             })?;
 
@@ -77,8 +77,8 @@ pub mod test_support {
     use crate::path;
     use std::path::PathBuf;
 
-    /// Loads `OzmuxConfigs` while honoring a caller-provided env, used by
-    /// integration tests to avoid mutating process-wide env vars.
+    /// Loads [`OzmuxConfigs`] against a caller-controlled environment instead
+    /// of the process-wide one.
     pub async fn load_with_overrides(
         ozmux_config: Option<PathBuf>,
         xdg_config_home: Option<PathBuf>,
@@ -92,8 +92,8 @@ pub mod test_support {
         impl path::Env for FixedEnv {
             fn var(&self, key: &str) -> Option<String> {
                 match key {
-                    "OZMUX_CONFIG" => self.ozmux.clone(),
-                    "XDG_CONFIG_HOME" => self.xdg.clone(),
+                    path::ENV_OZMUX_CONFIG => self.ozmux.clone(),
+                    path::ENV_XDG_CONFIG_HOME => self.xdg.clone(),
                     _ => None,
                 }
             }

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -4,8 +4,54 @@
 
 #![warn(missing_docs)]
 
+use crate::shortcuts::{Action, Binding, Key, KeyChord, Modifiers, Prefix, Shortcuts};
+use crate::theme::Theme;
+
 pub mod error;
 pub mod shortcuts;
 pub mod theme;
+pub(crate) mod raw;
 
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
+
+/// Fully-resolved ozmux configuration.
+#[derive(Clone, Debug)]
+pub struct OzmuxConfigs {
+    /// Shortcut configuration.
+    pub shortcuts: Shortcuts,
+    /// Theme configuration.
+    pub theme: Theme,
+}
+
+impl Default for OzmuxConfigs {
+    fn default() -> Self {
+        Self {
+            shortcuts: Shortcuts {
+                prefix: Prefix {
+                    chord: KeyChord {
+                        key: Key::Char('b'),
+                        modifiers: Modifiers {
+                            ctrl: true,
+                            ..Default::default()
+                        },
+                    },
+                    timeout_ms: 2000,
+                },
+                bindings: vec![Binding {
+                    chord: KeyChord {
+                        key: Key::Char('x'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::ClosePane,
+                }],
+            },
+            theme: Theme {
+                background: "#1a1b26".into(),
+                foreground: "#c0caf5".into(),
+                accent: "#414868".into(),
+                border: "#414868".into(),
+                destructive: "#f7768e".into(),
+            },
+        }
+    }
+}

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -6,5 +6,6 @@
 
 pub mod error;
 pub mod shortcuts;
+pub mod theme;
 
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -4,17 +4,16 @@
 
 #![warn(missing_docs)]
 
-pub mod error;
-pub mod shortcuts;
-pub mod theme;
 mod defaults;
+pub mod error;
 pub(crate) mod path;
 pub(crate) mod raw;
-
-pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
+pub mod shortcuts;
+pub mod theme;
 
 use crate::shortcuts::Shortcuts;
 use crate::theme::Theme;
+pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
 
 /// Fully-resolved ozmux configuration.
 #[derive(Clone, Debug, Default)]
@@ -57,12 +56,11 @@ impl OzmuxConfigs {
             }
         };
 
-        let raw: raw::RawConfigs = toml::from_str(&text).map_err(|source| {
-            OzmuxConfigsError::ParseToml {
+        let raw: raw::RawConfigs =
+            toml::from_str(&text).map_err(|source| OzmuxConfigsError::ParseToml {
                 path: configured_path.clone(),
                 source,
-            }
-        })?;
+            })?;
 
         let merged = raw.apply_to(Self::default());
         raw::validate(&merged)?;

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -4,16 +4,17 @@
 
 #![warn(missing_docs)]
 
-use crate::shortcuts::{Action, Binding, Key, KeyChord, Modifiers, Prefix, Shortcuts};
-use crate::theme::Theme;
-
 pub mod error;
 pub mod shortcuts;
 pub mod theme;
+mod defaults;
 pub(crate) mod path;
 pub(crate) mod raw;
 
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
+
+use crate::shortcuts::Shortcuts;
+use crate::theme::Theme;
 
 /// Fully-resolved ozmux configuration.
 #[derive(Clone, Debug)]
@@ -22,37 +23,4 @@ pub struct OzmuxConfigs {
     pub shortcuts: Shortcuts,
     /// Theme configuration.
     pub theme: Theme,
-}
-
-impl Default for OzmuxConfigs {
-    fn default() -> Self {
-        Self {
-            shortcuts: Shortcuts {
-                prefix: Prefix {
-                    chord: KeyChord {
-                        key: Key::Char('b'),
-                        modifiers: Modifiers {
-                            ctrl: true,
-                            ..Default::default()
-                        },
-                    },
-                    timeout_ms: 2000,
-                },
-                bindings: vec![Binding {
-                    chord: KeyChord {
-                        key: Key::Char('x'),
-                        modifiers: Modifiers::default(),
-                    },
-                    action: Action::ClosePane,
-                }],
-            },
-            theme: Theme {
-                background: "#1a1b26".into(),
-                foreground: "#c0caf5".into(),
-                accent: "#414868".into(),
-                border: "#414868".into(),
-                destructive: "#f7768e".into(),
-            },
-        }
-    }
 }

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -1,0 +1,5 @@
+//! Config loader for ozmux. Reads `~/.config/ozmux/config.toml`
+//! (or `$OZMUX_CONFIG` / `$XDG_CONFIG_HOME` overrides) and resolves it
+//! against built-in defaults.
+
+#![warn(missing_docs)]

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -69,3 +69,45 @@ impl OzmuxConfigs {
         Ok(merged)
     }
 }
+
+#[cfg(feature = "test_support")]
+pub mod test_support {
+    //! Test-only helpers. Enabled via the `test_support` cargo feature.
+
+    use crate::OzmuxConfigs;
+    use crate::OzmuxConfigsResult;
+    use crate::path;
+    use std::path::PathBuf;
+
+    /// Loads `OzmuxConfigs` while honoring a caller-provided env, used by
+    /// integration tests to avoid mutating process-wide env vars.
+    pub async fn load_with_overrides(
+        ozmux_config: Option<PathBuf>,
+        xdg_config_home: Option<PathBuf>,
+        home_dir: Option<PathBuf>,
+    ) -> OzmuxConfigsResult<OzmuxConfigs> {
+        struct FixedEnv {
+            ozmux: Option<String>,
+            xdg: Option<String>,
+            home: Option<PathBuf>,
+        }
+        impl path::Env for FixedEnv {
+            fn var(&self, key: &str) -> Option<String> {
+                match key {
+                    "OZMUX_CONFIG" => self.ozmux.clone(),
+                    "XDG_CONFIG_HOME" => self.xdg.clone(),
+                    _ => None,
+                }
+            }
+            fn home_dir(&self) -> Option<PathBuf> {
+                self.home.clone()
+            }
+        }
+        let env = FixedEnv {
+            ozmux: ozmux_config.map(|p| p.to_string_lossy().into_owned()),
+            xdg: xdg_config_home.map(|p| p.to_string_lossy().into_owned()),
+            home: home_dir,
+        };
+        OzmuxConfigs::load_with_env(&env).await
+    }
+}

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -3,3 +3,8 @@
 //! against built-in defaults.
 
 #![warn(missing_docs)]
+
+pub mod error;
+pub mod shortcuts;
+
+pub use error::{OzmuxConfigsError, OzmuxConfigsResult};

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -17,7 +17,7 @@ use crate::shortcuts::Shortcuts;
 use crate::theme::Theme;
 
 /// Fully-resolved ozmux configuration.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct OzmuxConfigs {
     /// Shortcut configuration.
     pub shortcuts: Shortcuts,

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -24,3 +24,48 @@ pub struct OzmuxConfigs {
     /// Theme configuration.
     pub theme: Theme,
 }
+
+impl OzmuxConfigs {
+    /// Loads the config from disk, merges it onto the built-in defaults, and
+    /// validates the result.
+    ///
+    /// Returns `Default::default()` when the resolved path does not exist.
+    /// Any other I/O failure, TOML parse error, or validation failure is
+    /// surfaced as `OzmuxConfigsError`.
+    pub async fn load() -> OzmuxConfigsResult<Self> {
+        Self::load_with_env(&path::SystemEnv).await
+    }
+
+    pub(crate) async fn load_with_env(env: &dyn path::Env) -> OzmuxConfigsResult<Self> {
+        let configured_path = path::resolve_config_path(env)?;
+        tracing::info!(path = %configured_path.display(), "resolving ozmux config path");
+
+        let text = match tokio::fs::read_to_string(&configured_path).await {
+            Ok(t) => t,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::info!(
+                    path = %configured_path.display(),
+                    "ozmux config not found; using defaults"
+                );
+                return Ok(Self::default());
+            }
+            Err(source) => {
+                return Err(OzmuxConfigsError::Io {
+                    path: configured_path,
+                    source,
+                });
+            }
+        };
+
+        let raw: raw::RawConfigs = toml::from_str(&text).map_err(|source| {
+            OzmuxConfigsError::ParseToml {
+                path: configured_path.clone(),
+                source,
+            }
+        })?;
+
+        let merged = raw.apply_to(Self::default());
+        raw::validate(&merged)?;
+        Ok(merged)
+    }
+}

--- a/daemon/configs/src/path.rs
+++ b/daemon/configs/src/path.rs
@@ -2,8 +2,6 @@
 //! behind a trait so tests can substitute a deterministic implementation
 //! without mutating process-wide environment variables.
 
-#![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
-
 use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
 use std::path::PathBuf;
@@ -17,7 +15,6 @@ pub(crate) trait Env {
 }
 
 /// Production `Env` implementation that delegates to `std::env` and `dirs`.
-#[cfg_attr(test, expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
 pub(crate) struct SystemEnv;
 
 impl Env for SystemEnv {

--- a/daemon/configs/src/path.rs
+++ b/daemon/configs/src/path.rs
@@ -2,9 +2,6 @@
 //! behind a trait so tests can substitute a deterministic implementation
 //! without mutating process-wide environment variables.
 
-// `SystemEnv` and `resolve_config_path` are intentionally unused until
-// `OzmuxConfigs::load` is wired up in a subsequent task. The `#[expect]`
-// will start failing at that point, signalling that the attribute can be removed.
 #![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
 
 use crate::OzmuxConfigsError;

--- a/daemon/configs/src/path.rs
+++ b/daemon/configs/src/path.rs
@@ -72,7 +72,10 @@ mod tests {
             ]),
             home: Some(PathBuf::from("/should/be/ignored/home")),
         };
-        assert_eq!(resolve_config_path(&env).unwrap(), PathBuf::from("/tmp/x.toml"));
+        assert_eq!(
+            resolve_config_path(&env).unwrap(),
+            PathBuf::from("/tmp/x.toml")
+        );
     }
 
     #[test]

--- a/daemon/configs/src/path.rs
+++ b/daemon/configs/src/path.rs
@@ -6,6 +6,11 @@ use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
 use std::path::PathBuf;
 
+pub(crate) const ENV_OZMUX_CONFIG: &str = "OZMUX_CONFIG";
+pub(crate) const ENV_XDG_CONFIG_HOME: &str = "XDG_CONFIG_HOME";
+const CONFIG_REL_PATH: &str = "ozmux/config.toml";
+const HOME_CONFIG_DIR: &str = ".config";
+
 /// Abstraction over the environment lookups `resolve_config_path` performs.
 pub(crate) trait Env {
     /// Returns the value of `key`, treating an empty string as unset.
@@ -32,14 +37,14 @@ impl Env for SystemEnv {
 /// `<home_dir>/.config/ozmux/config.toml`. Returns `HomeDirNotFound` only
 /// when all three lookups fail.
 pub(crate) fn resolve_config_path(env: &dyn Env) -> OzmuxConfigsResult<PathBuf> {
-    if let Some(p) = env.var("OZMUX_CONFIG") {
+    if let Some(p) = env.var(ENV_OZMUX_CONFIG) {
         return Ok(PathBuf::from(p));
     }
-    if let Some(xdg) = env.var("XDG_CONFIG_HOME") {
-        return Ok(PathBuf::from(xdg).join("ozmux/config.toml"));
+    if let Some(xdg) = env.var(ENV_XDG_CONFIG_HOME) {
+        return Ok(PathBuf::from(xdg).join(CONFIG_REL_PATH));
     }
     if let Some(home) = env.home_dir() {
-        return Ok(home.join(".config/ozmux/config.toml"));
+        return Ok(home.join(HOME_CONFIG_DIR).join(CONFIG_REL_PATH));
     }
     Err(OzmuxConfigsError::HomeDirNotFound)
 }

--- a/daemon/configs/src/path.rs
+++ b/daemon/configs/src/path.rs
@@ -1,0 +1,129 @@
+//! Resolves which file `OzmuxConfigs::load` should read. Wraps env access
+//! behind a trait so tests can substitute a deterministic implementation
+//! without mutating process-wide environment variables.
+
+// `SystemEnv` and `resolve_config_path` are intentionally unused until
+// `OzmuxConfigs::load` is wired up in a subsequent task. The `#[expect]`
+// will start failing at that point, signalling that the attribute can be removed.
+#![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
+
+use crate::OzmuxConfigsError;
+use crate::OzmuxConfigsResult;
+use std::path::PathBuf;
+
+/// Abstraction over the environment lookups `resolve_config_path` performs.
+pub(crate) trait Env {
+    /// Returns the value of `key`, treating an empty string as unset.
+    fn var(&self, key: &str) -> Option<String>;
+    /// Returns the user's home directory, if known.
+    fn home_dir(&self) -> Option<PathBuf>;
+}
+
+/// Production `Env` implementation that delegates to `std::env` and `dirs`.
+#[cfg_attr(test, expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
+pub(crate) struct SystemEnv;
+
+impl Env for SystemEnv {
+    fn var(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok().filter(|s| !s.is_empty())
+    }
+    fn home_dir(&self) -> Option<PathBuf> {
+        dirs::home_dir()
+    }
+}
+
+/// Returns the path that `OzmuxConfigs::load` should read.
+///
+/// Precedence: `$OZMUX_CONFIG` → `$XDG_CONFIG_HOME/ozmux/config.toml` →
+/// `<home_dir>/.config/ozmux/config.toml`. Returns `HomeDirNotFound` only
+/// when all three lookups fail.
+pub(crate) fn resolve_config_path(env: &dyn Env) -> OzmuxConfigsResult<PathBuf> {
+    if let Some(p) = env.var("OZMUX_CONFIG") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Some(xdg) = env.var("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(xdg).join("ozmux/config.toml"));
+    }
+    if let Some(home) = env.home_dir() {
+        return Ok(home.join(".config/ozmux/config.toml"));
+    }
+    Err(OzmuxConfigsError::HomeDirNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct FakeEnv {
+        vars: HashMap<String, String>,
+        home: Option<PathBuf>,
+    }
+
+    impl Env for FakeEnv {
+        fn var(&self, key: &str) -> Option<String> {
+            self.vars.get(key).cloned().filter(|s| !s.is_empty())
+        }
+        fn home_dir(&self) -> Option<PathBuf> {
+            self.home.clone()
+        }
+    }
+
+    #[test]
+    fn ozmux_config_takes_precedence() {
+        let env = FakeEnv {
+            vars: HashMap::from([
+                ("OZMUX_CONFIG".into(), "/tmp/x.toml".into()),
+                ("XDG_CONFIG_HOME".into(), "/should/be/ignored".into()),
+            ]),
+            home: Some(PathBuf::from("/should/be/ignored/home")),
+        };
+        assert_eq!(resolve_config_path(&env).unwrap(), PathBuf::from("/tmp/x.toml"));
+    }
+
+    #[test]
+    fn xdg_used_when_ozmux_config_absent() {
+        let env = FakeEnv {
+            vars: HashMap::from([("XDG_CONFIG_HOME".into(), "/cfg".into())]),
+            home: Some(PathBuf::from("/home/u")),
+        };
+        assert_eq!(
+            resolve_config_path(&env).unwrap(),
+            PathBuf::from("/cfg/ozmux/config.toml")
+        );
+    }
+
+    #[test]
+    fn home_fallback_when_xdg_absent() {
+        let env = FakeEnv {
+            vars: HashMap::new(),
+            home: Some(PathBuf::from("/home/u")),
+        };
+        assert_eq!(
+            resolve_config_path(&env).unwrap(),
+            PathBuf::from("/home/u/.config/ozmux/config.toml")
+        );
+    }
+
+    #[test]
+    fn empty_xdg_is_ignored() {
+        let env = FakeEnv {
+            vars: HashMap::from([("XDG_CONFIG_HOME".into(), "".into())]),
+            home: Some(PathBuf::from("/home/u")),
+        };
+        assert_eq!(
+            resolve_config_path(&env).unwrap(),
+            PathBuf::from("/home/u/.config/ozmux/config.toml")
+        );
+    }
+
+    #[test]
+    fn home_dir_not_found_when_all_absent() {
+        let env = FakeEnv {
+            vars: HashMap::new(),
+            home: None,
+        };
+        let err = resolve_config_path(&env).unwrap_err();
+        assert!(matches!(err, OzmuxConfigsError::HomeDirNotFound));
+    }
+}

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -1,6 +1,11 @@
 //! TOML-deserialization layer for `OzmuxConfigs`. Holds optional sections
 //! and merges them onto a baseline `OzmuxConfigs::default()`.
 
+// These items are intentionally unused until `OzmuxConfigs::load` is wired
+// up in a subsequent task. The `#[expect]` will start failing at that point,
+// signalling that the attribute can be removed.
+#![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
+
 use crate::OzmuxConfigs;
 use crate::shortcuts::{Binding, Prefix};
 use crate::theme::ThemePatch;

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -1,11 +1,6 @@
 //! TOML-deserialization layer for `OzmuxConfigs`. Holds optional sections
 //! and merges them onto a baseline `OzmuxConfigs::default()`.
 
-// These items are intentionally unused until `OzmuxConfigs::load` is wired
-// up in a subsequent task. The `#[expect]` will start failing at that point,
-// signalling that the attribute can be removed.
-#![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
-
 use crate::OzmuxConfigs;
 use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -7,9 +7,12 @@
 #![cfg_attr(not(test), expect(dead_code, reason = "consumed by OzmuxConfigs::load in a subsequent task"))]
 
 use crate::OzmuxConfigs;
-use crate::shortcuts::{Binding, Prefix};
+use crate::OzmuxConfigsError;
+use crate::OzmuxConfigsResult;
+use crate::shortcuts::{Binding, Modifiers, Prefix};
 use crate::theme::ThemePatch;
 use serde::Deserialize;
+use std::collections::HashSet;
 
 /// Top-level TOML shape: every section is optional.
 #[derive(Deserialize, Default)]
@@ -46,6 +49,25 @@ impl RawConfigs {
     }
 }
 
+/// Walks `configs.shortcuts.bindings` and rejects duplicates or modifier-bearing
+/// chords (the latter is a v0 constraint).
+pub(crate) fn validate(configs: &OzmuxConfigs) -> OzmuxConfigsResult {
+    let mut seen: HashSet<&crate::shortcuts::KeyChord> = HashSet::new();
+    for b in &configs.shortcuts.bindings {
+        if b.chord.modifiers != Modifiers::default() {
+            return Err(OzmuxConfigsError::UnsupportedModifier {
+                chord: b.chord.clone(),
+            });
+        }
+        if !seen.insert(&b.chord) {
+            return Err(OzmuxConfigsError::DuplicateBinding {
+                chord: b.chord.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,5 +102,39 @@ mod tests {
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert_eq!(merged.shortcuts.bindings.len(), 1);
         assert!(matches!(merged.shortcuts.bindings[0].action, Action::CloseWindow));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_binding() {
+        let raw: RawConfigs = toml::from_str(r#"
+            [[shortcuts.bindings]]
+            key = "x"
+            action = { type = "close-pane" }
+
+            [[shortcuts.bindings]]
+            key = "x"
+            action = { type = "close-window" }
+        "#).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        let err = validate(&merged).unwrap_err();
+        assert!(matches!(err, crate::OzmuxConfigsError::DuplicateBinding { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_modifier_in_binding() {
+        let raw: RawConfigs = toml::from_str(r#"
+            [[shortcuts.bindings]]
+            key = "x"
+            modifiers = { shift = true }
+            action = { type = "close-pane" }
+        "#).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        let err = validate(&merged).unwrap_err();
+        assert!(matches!(err, crate::OzmuxConfigsError::UnsupportedModifier { .. }));
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        validate(&OzmuxConfigs::default()).unwrap();
     }
 }

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -73,15 +73,21 @@ mod tests {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert_eq!(merged.shortcuts.bindings.len(), 1);
-        assert!(matches!(merged.shortcuts.bindings[0].action, Action::ClosePane));
+        assert!(matches!(
+            merged.shortcuts.bindings[0].action,
+            Action::ClosePane
+        ));
     }
 
     #[test]
     fn theme_patch_preserves_unset_fields() {
-        let raw: RawConfigs = toml::from_str(r##"
+        let raw: RawConfigs = toml::from_str(
+            r##"
             [theme]
             accent = "#deadbe"
-        "##).unwrap();
+        "##,
+        )
+        .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert_eq!(merged.theme.accent, "#deadbe");
         assert_eq!(merged.theme.background, "#1a1b26");
@@ -89,19 +95,26 @@ mod tests {
 
     #[test]
     fn bindings_fully_replace_defaults() {
-        let raw: RawConfigs = toml::from_str(r#"
+        let raw: RawConfigs = toml::from_str(
+            r#"
             [[shortcuts.bindings]]
             key = "y"
             action = { type = "close-window" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert_eq!(merged.shortcuts.bindings.len(), 1);
-        assert!(matches!(merged.shortcuts.bindings[0].action, Action::CloseWindow));
+        assert!(matches!(
+            merged.shortcuts.bindings[0].action,
+            Action::CloseWindow
+        ));
     }
 
     #[test]
     fn validate_rejects_duplicate_binding() {
-        let raw: RawConfigs = toml::from_str(r#"
+        let raw: RawConfigs = toml::from_str(
+            r#"
             [[shortcuts.bindings]]
             key = "x"
             action = { type = "close-pane" }
@@ -109,23 +122,34 @@ mod tests {
             [[shortcuts.bindings]]
             key = "x"
             action = { type = "close-window" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         let err = validate(&merged).unwrap_err();
-        assert!(matches!(err, crate::OzmuxConfigsError::DuplicateBinding { .. }));
+        assert!(matches!(
+            err,
+            crate::OzmuxConfigsError::DuplicateBinding { .. }
+        ));
     }
 
     #[test]
     fn validate_rejects_modifier_in_binding() {
-        let raw: RawConfigs = toml::from_str(r#"
+        let raw: RawConfigs = toml::from_str(
+            r#"
             [[shortcuts.bindings]]
             key = "x"
             modifiers = { shift = true }
             action = { type = "close-pane" }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         let err = validate(&merged).unwrap_err();
-        assert!(matches!(err, crate::OzmuxConfigsError::UnsupportedModifier { .. }));
+        assert!(matches!(
+            err,
+            crate::OzmuxConfigsError::UnsupportedModifier { .. }
+        ));
     }
 
     #[test]

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -1,0 +1,79 @@
+//! TOML-deserialization layer for `OzmuxConfigs`. Holds optional sections
+//! and merges them onto a baseline `OzmuxConfigs::default()`.
+
+use crate::OzmuxConfigs;
+use crate::shortcuts::{Binding, Prefix};
+use crate::theme::ThemePatch;
+use serde::Deserialize;
+
+/// Top-level TOML shape: every section is optional.
+#[derive(Deserialize, Default)]
+pub(crate) struct RawConfigs {
+    pub(crate) shortcuts: Option<RawShortcuts>,
+    pub(crate) theme: Option<ThemePatch>,
+}
+
+/// `[shortcuts]` shape with each subfield optional.
+#[derive(Deserialize, Default)]
+pub(crate) struct RawShortcuts {
+    pub(crate) prefix: Option<Prefix>,
+    pub(crate) bindings: Option<Vec<Binding>>,
+}
+
+impl RawConfigs {
+    /// Applies any populated fields onto `base` and returns the merged result.
+    /// Within the `shortcuts` section, `prefix` and `bindings` are independently
+    /// optional; `bindings` is full-replace. The `theme` section uses
+    /// `ThemePatch::apply_to` for per-field merge.
+    pub(crate) fn apply_to(self, mut base: OzmuxConfigs) -> OzmuxConfigs {
+        if let Some(raw) = self.shortcuts {
+            if let Some(prefix) = raw.prefix {
+                base.shortcuts.prefix = prefix;
+            }
+            if let Some(bindings) = raw.bindings {
+                base.shortcuts.bindings = bindings;
+            }
+        }
+        if let Some(patch) = self.theme {
+            base.theme = patch.apply_to(base.theme);
+        }
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shortcuts::Action;
+
+    #[test]
+    fn empty_raw_returns_defaults() {
+        let raw = RawConfigs::default();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.shortcuts.bindings.len(), 1);
+        assert!(matches!(merged.shortcuts.bindings[0].action, Action::ClosePane));
+    }
+
+    #[test]
+    fn theme_patch_preserves_unset_fields() {
+        let raw: RawConfigs = toml::from_str(r##"
+            [theme]
+            accent = "#deadbe"
+        "##).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.theme.accent, "#deadbe");
+        assert_eq!(merged.theme.background, "#1a1b26");
+    }
+
+    #[test]
+    fn bindings_fully_replace_defaults() {
+        let raw: RawConfigs = toml::from_str(r#"
+            [[shortcuts.bindings]]
+            key = "y"
+            action = { type = "close-window" }
+        "#).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.shortcuts.bindings.len(), 1);
+        assert!(matches!(merged.shortcuts.bindings[0].action, Action::CloseWindow));
+    }
+}

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -335,7 +335,9 @@ mod tests {
         let b: Binding = toml::from_str(toml).unwrap();
         assert!(matches!(
             b.action,
-            Action::SplitPane { direction: SplitDirection::Horizontal }
+            Action::SplitPane {
+                direction: SplitDirection::Horizontal
+            }
         ));
     }
 
@@ -346,9 +348,6 @@ mod tests {
             action = { type = "focus-window-number", index = 0 }
         "#;
         let b: Binding = toml::from_str(toml).unwrap();
-        assert!(matches!(
-            b.action,
-            Action::FocusWindowNumber { index: 0 }
-        ));
+        assert!(matches!(b.action, Action::FocusWindowNumber { index: 0 }));
     }
 }

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -1,0 +1,55 @@
+//! Shortcut domain types: keys, modifiers, chords, prefix, bindings, actions.
+
+use serde::{Deserialize, Serialize};
+
+/// Logical key. v0 covers ASCII characters and a small set of named keys.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub enum Key {
+    /// Single character key (`Key::Char('b')` for `"b"`).
+    Char(char),
+    /// `Escape` key.
+    Escape,
+    /// `Space` key.
+    Space,
+    /// `Enter` key.
+    Enter,
+    /// `Tab` key.
+    Tab,
+    /// `Backspace` key.
+    Backspace,
+    /// `ArrowUp`.
+    ArrowUp,
+    /// `ArrowDown`.
+    ArrowDown,
+    /// `ArrowLeft`.
+    ArrowLeft,
+    /// `ArrowRight`.
+    ArrowRight,
+    /// Forward-compatibility variant for unknown logical key names.
+    Other(String),
+}
+
+/// Modifier flags accompanying a `Key`.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug, Default)]
+#[serde(default)]
+pub struct Modifiers {
+    /// `Ctrl` is held.
+    pub ctrl: bool,
+    /// `Shift` is held.
+    pub shift: bool,
+    /// `Alt`/`Option` is held.
+    pub alt: bool,
+    /// `Meta`/`Command`/`Super` is held.
+    pub meta: bool,
+}
+
+/// A single keyboard chord (key plus modifier set).
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct KeyChord {
+    /// Logical key.
+    pub key: Key,
+    /// Held modifiers.
+    #[serde(default)]
+    pub modifiers: Modifiers,
+}

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -106,7 +106,7 @@ pub struct KeyChord {
 }
 
 /// User-facing shortcut configuration.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Shortcuts {
     /// The "armed" prefix chord.
     pub prefix: Prefix,
@@ -115,7 +115,7 @@ pub struct Shortcuts {
 }
 
 /// Prefix chord and timeout used to "arm" the shortcut dispatcher.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Prefix {
     /// Chord that arms the dispatcher.
     #[serde(flatten)]
@@ -125,7 +125,7 @@ pub struct Prefix {
 }
 
 /// One armed-mode binding: a chord to listen for and the action to dispatch.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Binding {
     /// Chord pressed while armed.
     #[serde(flatten)]
@@ -135,7 +135,7 @@ pub struct Binding {
 }
 
 /// All shortcut actions supported by ozmux v0.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Action {
     /// Close the active pane.

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -50,27 +50,26 @@ impl Key {
             }
         }
     }
-
-    fn to_token(&self) -> String {
-        match self {
-            Key::Char(c) => c.to_string(),
-            Key::Escape => "Escape".into(),
-            Key::Space => "Space".into(),
-            Key::Enter => "Enter".into(),
-            Key::Tab => "Tab".into(),
-            Key::Backspace => "Backspace".into(),
-            Key::ArrowUp => "ArrowUp".into(),
-            Key::ArrowDown => "ArrowDown".into(),
-            Key::ArrowLeft => "ArrowLeft".into(),
-            Key::ArrowRight => "ArrowRight".into(),
-            Key::Other(s) => s.clone(),
-        }
-    }
 }
 
 impl serde::Serialize for Key {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        ser.serialize_str(&self.to_token())
+        match self {
+            Key::Char(c) => {
+                let mut buf = [0u8; 4];
+                ser.serialize_str(c.encode_utf8(&mut buf))
+            }
+            Key::Escape => ser.serialize_str("Escape"),
+            Key::Space => ser.serialize_str("Space"),
+            Key::Enter => ser.serialize_str("Enter"),
+            Key::Tab => ser.serialize_str("Tab"),
+            Key::Backspace => ser.serialize_str("Backspace"),
+            Key::ArrowUp => ser.serialize_str("ArrowUp"),
+            Key::ArrowDown => ser.serialize_str("ArrowDown"),
+            Key::ArrowLeft => ser.serialize_str("ArrowLeft"),
+            Key::ArrowRight => ser.serialize_str("ArrowRight"),
+            Key::Other(s) => ser.serialize_str(s),
+        }
     }
 }
 

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -105,6 +105,164 @@ pub struct KeyChord {
     pub modifiers: Modifiers,
 }
 
+/// User-facing shortcut configuration.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Shortcuts {
+    /// The "armed" prefix chord.
+    pub prefix: Prefix,
+    /// Bindings dispatched while armed.
+    pub bindings: Vec<Binding>,
+}
+
+/// Prefix chord and timeout used to "arm" the shortcut dispatcher.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Prefix {
+    /// Chord that arms the dispatcher.
+    #[serde(flatten)]
+    pub chord: KeyChord,
+    /// Milliseconds to wait for the follow-up key before disarming.
+    pub timeout_ms: u64,
+}
+
+/// One armed-mode binding: a chord to listen for and the action to dispatch.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Binding {
+    /// Chord pressed while armed.
+    #[serde(flatten)]
+    pub chord: KeyChord,
+    /// Action dispatched when the chord matches.
+    pub action: Action,
+}
+
+/// All shortcut actions supported by ozmux v0.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum Action {
+    /// Close the active pane.
+    ClosePane,
+    /// Close the active window.
+    CloseWindow,
+    /// Close the active session.
+    CloseSession,
+    /// Move pane focus in a direction.
+    FocusPane {
+        /// Direction to move focus.
+        direction: Direction,
+    },
+    /// Move window focus by offset.
+    FocusWindow {
+        /// Window offset to apply.
+        offset: WindowOffset,
+    },
+    /// Jump to a window by index.
+    FocusWindowNumber {
+        /// Target window index (0–9 in practice).
+        index: u8,
+    },
+    /// Move activity focus by offset.
+    FocusActivity {
+        /// Activity offset to apply.
+        offset: ActivityOffset,
+    },
+    /// Split the active pane.
+    SplitPane {
+        /// Split direction.
+        direction: SplitDirection,
+    },
+    /// Create a new window.
+    NewWindow,
+    /// Create a new session.
+    NewSession,
+    /// Add a new terminal activity to the active pane.
+    NewTerminalActivity,
+    /// Add a new extension activity to the active pane.
+    NewExtensionActivity,
+    /// Rename the active session.
+    RenameSession,
+    /// Rename the active window.
+    RenameWindow,
+    /// Rename the active activity.
+    RenameActivity,
+    /// Close the active activity.
+    CloseActivity,
+    /// Show the window list.
+    ListWindows,
+    /// Show the activity list for the active pane.
+    ListActivities,
+    /// Resize the active pane in a direction.
+    ResizePane {
+        /// Resize direction.
+        direction: Direction,
+    },
+    /// Toggle zoom/maximize on the active pane.
+    ZoomPane,
+    /// Swap the active pane with a sibling.
+    SwapPane {
+        /// Swap offset.
+        offset: SwapOffset,
+    },
+    /// Break the active pane into a new window.
+    BreakPaneToWindow,
+}
+
+/// Layout direction shared by `FocusPane` and `ResizePane`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Direction {
+    /// Up.
+    Up,
+    /// Down.
+    Down,
+    /// Left.
+    Left,
+    /// Right.
+    Right,
+}
+
+/// Split orientation for `SplitPane`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SplitDirection {
+    /// New pane to the right of the current one.
+    Horizontal,
+    /// New pane below the current one.
+    Vertical,
+}
+
+/// Window offset selectors for `FocusWindow`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum WindowOffset {
+    /// Next window.
+    Next,
+    /// Previous window.
+    Prev,
+    /// Last-active window.
+    Last,
+}
+
+/// Activity offset selectors for `FocusActivity`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActivityOffset {
+    /// Next activity in the active pane.
+    Next,
+    /// Previous activity in the active pane.
+    Prev,
+    /// Last-active activity in the active pane.
+    Last,
+}
+
+/// Swap offset selectors for `SwapPane`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SwapOffset {
+    /// Swap with the previous sibling.
+    Prev,
+    /// Swap with the next sibling.
+    Next,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,5 +298,57 @@ mod tests {
         assert_eq!(s, "\"x\"");
         let back: Key = serde_json::from_str(&s).unwrap();
         assert_eq!(back, key);
+    }
+
+    #[test]
+    fn prefix_deserializes_with_default_modifiers() {
+        let toml = r#"
+            key = "b"
+            modifiers = { ctrl = true }
+            timeout_ms = 2000
+        "#;
+        let p: Prefix = toml::from_str(toml).unwrap();
+        assert_eq!(p.chord.key, Key::Char('b'));
+        assert!(p.chord.modifiers.ctrl);
+        assert!(!p.chord.modifiers.shift);
+        assert_eq!(p.timeout_ms, 2000);
+    }
+
+    #[test]
+    fn binding_deserializes_close_pane() {
+        let toml = r#"
+            key = "x"
+            action = { type = "close-pane" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert_eq!(b.chord.key, Key::Char('x'));
+        assert_eq!(b.chord.modifiers, Modifiers::default());
+        assert!(matches!(b.action, Action::ClosePane));
+    }
+
+    #[test]
+    fn binding_deserializes_split_pane_with_direction() {
+        let toml = r#"
+            key = "%"
+            action = { type = "split-pane", direction = "horizontal" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert!(matches!(
+            b.action,
+            Action::SplitPane { direction: SplitDirection::Horizontal }
+        ));
+    }
+
+    #[test]
+    fn binding_deserializes_focus_window_number() {
+        let toml = r#"
+            key = "0"
+            action = { type = "focus-window-number", index = 0 }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert!(matches!(
+            b.action,
+            Action::FocusWindowNumber { index: 0 }
+        ));
     }
 }

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -3,8 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Logical key. v0 covers ASCII characters and a small set of named keys.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
-#[serde(rename_all = "kebab-case")]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Key {
     /// Single character key (`Key::Char('b')` for `"b"`).
     Char(char),
@@ -30,6 +29,58 @@ pub enum Key {
     Other(String),
 }
 
+impl Key {
+    fn from_token(s: &str) -> Self {
+        match s {
+            "Escape" => Key::Escape,
+            "Space" => Key::Space,
+            "Enter" => Key::Enter,
+            "Tab" => Key::Tab,
+            "Backspace" => Key::Backspace,
+            "ArrowUp" => Key::ArrowUp,
+            "ArrowDown" => Key::ArrowDown,
+            "ArrowLeft" => Key::ArrowLeft,
+            "ArrowRight" => Key::ArrowRight,
+            other => {
+                let mut chars = other.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(c), None) => Key::Char(c),
+                    _ => Key::Other(other.to_string()),
+                }
+            }
+        }
+    }
+
+    fn to_token(&self) -> String {
+        match self {
+            Key::Char(c) => c.to_string(),
+            Key::Escape => "Escape".into(),
+            Key::Space => "Space".into(),
+            Key::Enter => "Enter".into(),
+            Key::Tab => "Tab".into(),
+            Key::Backspace => "Backspace".into(),
+            Key::ArrowUp => "ArrowUp".into(),
+            Key::ArrowDown => "ArrowDown".into(),
+            Key::ArrowLeft => "ArrowLeft".into(),
+            Key::ArrowRight => "ArrowRight".into(),
+            Key::Other(s) => s.clone(),
+        }
+    }
+}
+
+impl serde::Serialize for Key {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_token())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Key {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Ok(Key::from_token(&s))
+    }
+}
+
 /// Modifier flags accompanying a `Key`.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug, Default)]
 #[serde(default)]
@@ -52,4 +103,42 @@ pub struct KeyChord {
     /// Held modifiers.
     #[serde(default)]
     pub modifiers: Modifiers,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_parses_single_char() {
+        let v: Key = serde_json::from_str("\"b\"").unwrap();
+        assert_eq!(v, Key::Char('b'));
+    }
+
+    #[test]
+    fn key_parses_named_escape() {
+        let v: Key = serde_json::from_str("\"Escape\"").unwrap();
+        assert_eq!(v, Key::Escape);
+    }
+
+    #[test]
+    fn key_parses_named_arrow_up_lowercase() {
+        let v: Key = serde_json::from_str("\"ArrowUp\"").unwrap();
+        assert_eq!(v, Key::ArrowUp);
+    }
+
+    #[test]
+    fn key_parses_unknown_as_other() {
+        let v: Key = serde_json::from_str("\"f12\"").unwrap();
+        assert_eq!(v, Key::Other("f12".to_string()));
+    }
+
+    #[test]
+    fn key_roundtrip_char() {
+        let key = Key::Char('x');
+        let s = serde_json::to_string(&key).unwrap();
+        assert_eq!(s, "\"x\"");
+        let back: Key = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, key);
+    }
 }

--- a/daemon/configs/src/theme.rs
+++ b/daemon/configs/src/theme.rs
@@ -34,23 +34,14 @@ pub struct ThemePatch {
 
 impl ThemePatch {
     /// Applies any `Some` fields onto `base` and returns the merged `Theme`.
-    pub fn apply_to(self, mut base: Theme) -> Theme {
-        if let Some(v) = self.background {
-            base.background = v;
+    pub fn apply_to(self, base: Theme) -> Theme {
+        Theme {
+            background: self.background.unwrap_or(base.background),
+            foreground: self.foreground.unwrap_or(base.foreground),
+            accent: self.accent.unwrap_or(base.accent),
+            border: self.border.unwrap_or(base.border),
+            destructive: self.destructive.unwrap_or(base.destructive),
         }
-        if let Some(v) = self.foreground {
-            base.foreground = v;
-        }
-        if let Some(v) = self.accent {
-            base.accent = v;
-        }
-        if let Some(v) = self.border {
-            base.border = v;
-        }
-        if let Some(v) = self.destructive {
-            base.destructive = v;
-        }
-        base
     }
 }
 

--- a/daemon/configs/src/theme.rs
+++ b/daemon/configs/src/theme.rs
@@ -1,0 +1,99 @@
+//! Theme tokens and patching for per-field merge against defaults.
+
+use serde::{Deserialize, Serialize};
+
+/// Fully-resolved theme: five semantic color tokens that ozmux exposes to the UI.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct Theme {
+    /// `--color-background` token.
+    pub background: String,
+    /// `--color-foreground` token.
+    pub foreground: String,
+    /// `--color-accent` token.
+    pub accent: String,
+    /// `--color-border` token.
+    pub border: String,
+    /// `--color-destructive` token.
+    pub destructive: String,
+}
+
+/// Per-field-optional view of `Theme` used for TOML deserialization.
+#[derive(Deserialize, Default, Clone, Debug)]
+pub struct ThemePatch {
+    /// Optional override for `Theme::background`.
+    pub background: Option<String>,
+    /// Optional override for `Theme::foreground`.
+    pub foreground: Option<String>,
+    /// Optional override for `Theme::accent`.
+    pub accent: Option<String>,
+    /// Optional override for `Theme::border`.
+    pub border: Option<String>,
+    /// Optional override for `Theme::destructive`.
+    pub destructive: Option<String>,
+}
+
+impl ThemePatch {
+    /// Applies any `Some` fields onto `base` and returns the merged `Theme`.
+    pub fn apply_to(self, mut base: Theme) -> Theme {
+        if let Some(v) = self.background {
+            base.background = v;
+        }
+        if let Some(v) = self.foreground {
+            base.foreground = v;
+        }
+        if let Some(v) = self.accent {
+            base.accent = v;
+        }
+        if let Some(v) = self.border {
+            base.border = v;
+        }
+        if let Some(v) = self.destructive {
+            base.destructive = v;
+        }
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_theme() -> Theme {
+        Theme {
+            background: "#000000".into(),
+            foreground: "#ffffff".into(),
+            accent: "#111111".into(),
+            border: "#222222".into(),
+            destructive: "#ff0000".into(),
+        }
+    }
+
+    #[test]
+    fn theme_patch_apply_overrides_only_set_fields() {
+        let patch = ThemePatch {
+            accent: Some("#abcdef".into()),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(sample_theme());
+        assert_eq!(merged.accent, "#abcdef");
+        assert_eq!(merged.background, "#000000");
+        assert_eq!(merged.foreground, "#ffffff");
+        assert_eq!(merged.border, "#222222");
+        assert_eq!(merged.destructive, "#ff0000");
+    }
+
+    #[test]
+    fn theme_patch_empty_returns_base() {
+        let patch = ThemePatch::default();
+        let merged = patch.apply_to(sample_theme());
+        assert_eq!(merged, sample_theme());
+    }
+
+    #[test]
+    fn theme_patch_deserializes_partial_toml() {
+        let raw = r##"accent = "#abcdef""##;
+        let patch: ThemePatch = toml::from_str(raw).unwrap();
+        assert_eq!(patch.accent.as_deref(), Some("#abcdef"));
+        assert!(patch.background.is_none());
+    }
+}

--- a/daemon/configs/tests/fixtures/bindings_replace.toml
+++ b/daemon/configs/tests/fixtures/bindings_replace.toml
@@ -1,0 +1,3 @@
+[[shortcuts.bindings]]
+key = "y"
+action = { type = "close-window" }

--- a/daemon/configs/tests/fixtures/duplicate_binding.toml
+++ b/daemon/configs/tests/fixtures/duplicate_binding.toml
@@ -1,0 +1,7 @@
+[[shortcuts.bindings]]
+key = "x"
+action = { type = "close-pane" }
+
+[[shortcuts.bindings]]
+key = "x"
+action = { type = "close-window" }

--- a/daemon/configs/tests/fixtures/modifier_binding.toml
+++ b/daemon/configs/tests/fixtures/modifier_binding.toml
@@ -1,0 +1,4 @@
+[[shortcuts.bindings]]
+key = "x"
+modifiers = { shift = true }
+action = { type = "close-pane" }

--- a/daemon/configs/tests/fixtures/prefix_only.toml
+++ b/daemon/configs/tests/fixtures/prefix_only.toml
@@ -1,0 +1,4 @@
+[shortcuts.prefix]
+key = "a"
+modifiers = { ctrl = true }
+timeout_ms = 3000

--- a/daemon/configs/tests/fixtures/syntax_error.toml
+++ b/daemon/configs/tests/fixtures/syntax_error.toml
@@ -1,0 +1,2 @@
+[shortcuts.prefix
+key = "a"

--- a/daemon/configs/tests/fixtures/theme_accent.toml
+++ b/daemon/configs/tests/fixtures/theme_accent.toml
@@ -1,0 +1,2 @@
+[theme]
+accent = "#deadbe"

--- a/daemon/configs/tests/fixtures/unknown_action.toml
+++ b/daemon/configs/tests/fixtures/unknown_action.toml
@@ -1,0 +1,3 @@
+[[shortcuts.bindings]]
+key = "x"
+action = { type = "no-such-action" }

--- a/daemon/configs/tests/load.rs
+++ b/daemon/configs/tests/load.rs
@@ -1,0 +1,99 @@
+use ozmux_configs::shortcuts::{Action, Key};
+use ozmux_configs::test_support::load_with_overrides;
+use ozmux_configs::{OzmuxConfigs, OzmuxConfigsError};
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures").join(name)
+}
+
+#[tokio::test]
+async fn missing_file_yields_defaults() {
+    let nonexistent = fixture("does_not_exist.toml");
+    let configs = load_with_overrides(Some(nonexistent), None, None).await.unwrap();
+    let defaults = OzmuxConfigs::default();
+    assert_eq!(
+        configs.shortcuts.bindings.len(),
+        defaults.shortcuts.bindings.len()
+    );
+}
+
+#[tokio::test]
+async fn empty_file_yields_defaults() {
+    let configs = load_with_overrides(Some(fixture("empty.toml")), None, None)
+        .await
+        .unwrap();
+    assert_eq!(configs.shortcuts.bindings.len(), 1);
+    assert!(matches!(configs.shortcuts.bindings[0].action, Action::ClosePane));
+}
+
+#[tokio::test]
+async fn prefix_override_keeps_default_bindings() {
+    let configs = load_with_overrides(Some(fixture("prefix_only.toml")), None, None)
+        .await
+        .unwrap();
+    assert_eq!(configs.shortcuts.prefix.chord.key, Key::Char('a'));
+    assert_eq!(configs.shortcuts.prefix.timeout_ms, 3000);
+    assert_eq!(configs.shortcuts.bindings.len(), 1);
+    assert!(matches!(configs.shortcuts.bindings[0].action, Action::ClosePane));
+}
+
+#[tokio::test]
+async fn bindings_section_fully_replaces_defaults() {
+    let configs = load_with_overrides(Some(fixture("bindings_replace.toml")), None, None)
+        .await
+        .unwrap();
+    assert_eq!(configs.shortcuts.bindings.len(), 1);
+    assert_eq!(configs.shortcuts.bindings[0].chord.key, Key::Char('y'));
+    assert!(matches!(configs.shortcuts.bindings[0].action, Action::CloseWindow));
+}
+
+#[tokio::test]
+async fn theme_patch_preserves_other_fields() {
+    let configs = load_with_overrides(Some(fixture("theme_accent.toml")), None, None)
+        .await
+        .unwrap();
+    assert_eq!(configs.theme.accent, "#deadbe");
+    let defaults = OzmuxConfigs::default();
+    assert_eq!(configs.theme.background, defaults.theme.background);
+    assert_eq!(configs.theme.foreground, defaults.theme.foreground);
+    assert_eq!(configs.theme.border, defaults.theme.border);
+    assert_eq!(configs.theme.destructive, defaults.theme.destructive);
+}
+
+#[tokio::test]
+async fn duplicate_binding_rejected() {
+    let err = load_with_overrides(Some(fixture("duplicate_binding.toml")), None, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OzmuxConfigsError::DuplicateBinding { .. }));
+}
+
+#[tokio::test]
+async fn modifier_binding_rejected() {
+    let err = load_with_overrides(Some(fixture("modifier_binding.toml")), None, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OzmuxConfigsError::UnsupportedModifier { .. }));
+}
+
+#[tokio::test]
+async fn syntax_error_surfaces_parse_toml() {
+    let err = load_with_overrides(Some(fixture("syntax_error.toml")), None, None)
+        .await
+        .unwrap_err();
+    match err {
+        OzmuxConfigsError::ParseToml { path, .. } => {
+            assert!(path.ends_with("syntax_error.toml"));
+        }
+        other => panic!("expected ParseToml, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unknown_action_surfaces_parse_toml() {
+    let err = load_with_overrides(Some(fixture("unknown_action.toml")), None, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OzmuxConfigsError::ParseToml { .. }));
+}

--- a/daemon/configs/tests/load.rs
+++ b/daemon/configs/tests/load.rs
@@ -4,13 +4,17 @@ use ozmux_configs::{OzmuxConfigs, OzmuxConfigsError};
 use std::path::PathBuf;
 
 fn fixture(name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures").join(name)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
 }
 
 #[tokio::test]
 async fn missing_file_yields_defaults() {
     let nonexistent = fixture("does_not_exist.toml");
-    let configs = load_with_overrides(Some(nonexistent), None, None).await.unwrap();
+    let configs = load_with_overrides(Some(nonexistent), None, None)
+        .await
+        .unwrap();
     let defaults = OzmuxConfigs::default();
     assert_eq!(
         configs.shortcuts.bindings.len(),
@@ -24,7 +28,10 @@ async fn empty_file_yields_defaults() {
         .await
         .unwrap();
     assert_eq!(configs.shortcuts.bindings.len(), 1);
-    assert!(matches!(configs.shortcuts.bindings[0].action, Action::ClosePane));
+    assert!(matches!(
+        configs.shortcuts.bindings[0].action,
+        Action::ClosePane
+    ));
 }
 
 #[tokio::test]
@@ -35,7 +42,10 @@ async fn prefix_override_keeps_default_bindings() {
     assert_eq!(configs.shortcuts.prefix.chord.key, Key::Char('a'));
     assert_eq!(configs.shortcuts.prefix.timeout_ms, 3000);
     assert_eq!(configs.shortcuts.bindings.len(), 1);
-    assert!(matches!(configs.shortcuts.bindings[0].action, Action::ClosePane));
+    assert!(matches!(
+        configs.shortcuts.bindings[0].action,
+        Action::ClosePane
+    ));
 }
 
 #[tokio::test]
@@ -45,7 +55,10 @@ async fn bindings_section_fully_replaces_defaults() {
         .unwrap();
     assert_eq!(configs.shortcuts.bindings.len(), 1);
     assert_eq!(configs.shortcuts.bindings[0].chord.key, Key::Char('y'));
-    assert!(matches!(configs.shortcuts.bindings[0].action, Action::CloseWindow));
+    assert!(matches!(
+        configs.shortcuts.bindings[0].action,
+        Action::CloseWindow
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

ozmux has no config file: prefix key and the single `Ctrl+B → x` binding are hard-coded in the React frontend (`App.tsx`, `usePrefixMode.ts`). Before we can expand the shortcut surface (window/pane navigation, activity switching, etc.) or theme it, the daemon needs a typed config it can load at startup and later hand to the frontend.

## Solution

Adds a new `daemon/configs` Rust crate (`ozmux_configs`) that loads `OzmuxConfigs::load().await?` from a TOML file and wires it into `daemon_bootstrap` for fail-fast startup. Frontend integration (HTTP endpoint, removing the hard-coded bindings) is intentionally out of scope and will land in a follow-up PR.

### What's in the crate

- **Path resolution** — `$OZMUX_CONFIG` → `$XDG_CONFIG_HOME/ozmux/config.toml` → `~/.config/ozmux/config.toml`. An `Env` trait abstracts process env so integration tests don't mutate `std::env`.
- **Merge semantics** — TOML deserializes into `RawConfigs` (section-optional). `RawConfigs::apply_to(OzmuxConfigs::default())` merges section-by-section: `bindings` is full-replace, `theme` is per-field via `ThemePatch::apply_to`. Missing file ⇒ defaults.
- **Typed `Action` enum** — 22 actions covering the catalog drafted in `docs/memo.md` (close/split/focus pane, focus/jump window, activity nav, resize, zoom, swap, break, rename, list, …). `#[serde(tag = "type", rename_all = "kebab-case")]`.
- **`Key` custom serde** — single char (`\"b\"`) deserializes to `Key::Char('b')`; named keys (`\"Escape\"`, `\"ArrowUp\"`, …) map to variants; unknown strings fall back to `Key::Other(s)` for forward compat. No String allocation in the serialize path.
- **v0 validation** — duplicate chords are rejected as `DuplicateBinding`; bindings carrying modifier flags are rejected as `UnsupportedModifier` (the type allows them but the dispatcher doesn't exist yet).
- **Errors** — `OzmuxConfigsError` (thiserror enum) + `OzmuxConfigsResult<T = ()>` in `daemon/configs/src/error.rs`.

### Bootstrap wiring

`daemon/bootstrap/src/main.rs` now calls `OzmuxConfigs::load().await` right after tracing is initialized. On success it logs prefix + binding count. On failure it logs `failed to load ozmux config; aborting` and exits non-zero — broken configs should be loud, not silently absorbed. The loaded value is held in a `// TODO:`-marked local until the next PR consumes it from `AppState`.

### Affected areas

- New crate: `daemon/configs/` (7 source files + 9 fixtures + 1 integration test file)
- `Cargo.toml` workspace: adds `daemon/configs` and registers the previously-unlisted `daemon/extension` as members; adds `toml = \"0.8\"` and `dirs = \"5\"` workspace deps
- `daemon/bootstrap`: adds `ozmux_configs` path dep + the load call in `main()`
- Specs/plans: `docs/superpowers/specs/2026-05-13-ozmux-configs-design.md`, `docs/superpowers/plans/2026-05-13-ozmux-configs.md` (the design and execution plan that produced this PR)

### Out of scope

- Wiring `OzmuxConfigs` into `AppState` and exposing it over HTTP
- Replacing the frontend's hard-coded prefix/bindings with the config-driven values
- Config reload / file watch / SIGHUP
- Layered merge (default + user + per-project)
- Enabling modifier-bearing bindings

## Test plan

- [x] `cargo test -p ozmux_configs --features test_support` — 33 tests pass (24 unit + 9 integration)
- [x] `cargo clippy -p ozmux_configs -p daemon_bootstrap --features test_support --all-targets -- -D warnings` — clean
- [x] `cargo build -p daemon_bootstrap` — clean
- [x] Smoke: no config file → daemon starts, logs `loaded ozmux config bindings=1` with default Ctrl+B prefix
- [x] Smoke: `OZMUX_CONFIG=/tmp/bad.toml` with unclosed bracket → daemon exits non-zero, logs `failed to load ozmux config; aborting` with the path
- [ ] Reviewer: spot-check `daemon/configs/tests/fixtures/*.toml` to confirm the user-facing TOML shape is what we want before frontend consumes it