### PR TITLE
Add Ctrl+B → s / v shortcuts to split the active pane

### DIFF
--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -72,7 +72,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 1);
+        assert_eq!(merged.shortcuts.bindings.len(), 3);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -126,13 +126,33 @@ impl Default for Shortcuts {
                 },
                 timeout_ms: 2000,
             },
-            bindings: vec![Binding {
-                chord: KeyChord {
-                    key: Key::Char('x'),
-                    modifiers: Modifiers::default(),
+            bindings: vec![
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('x'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::ClosePane,
                 },
-                action: Action::ClosePane,
-            }],
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('s'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::SplitPane {
+                        direction: SplitDirection::Horizontal,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('v'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::SplitPane {
+                        direction: SplitDirection::Vertical,
+                    },
+                },
+            ],
         }
     }
 }
@@ -379,7 +399,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}}]}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/splitPane.test.ts
+++ b/daemon/frontend/src/layout/splitPane.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { splitPane } from './splitPane';
+
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.restoreAllMocks();
+});
+
+describe('splitPane', () => {
+  it('issues POST /windows/{wid}/panes/{pid}/split with horizontal orientation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await splitPane('wid-1', 'pid-42', 'horizontal');
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-42/split', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation: 'horizontal' }),
+    });
+  });
+
+  it('issues POST with vertical orientation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await splitPane('wid-1', 'pid-42', 'vertical');
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-42/split', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation: 'vertical' }),
+    });
+  });
+
+  it('warns on 500 (PTY spawn failed → daemon rollback) with payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await splitPane('wid-1', 'pid-1', 'horizontal');
+    expect(console.warn).toHaveBeenCalledWith(
+      'split pane failed',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-1',
+        orientation: 'horizontal',
+        status: 500,
+      }),
+    );
+  });
+
+  it('warns on network failure with payload', async () => {
+    const err = new Error('net');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await splitPane('wid-1', 'pid-x', 'vertical');
+    expect(console.warn).toHaveBeenCalledWith(
+      'split pane request errored',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-x',
+        orientation: 'vertical',
+        error: err,
+      }),
+    );
+  });
+});

--- a/daemon/frontend/src/layout/splitPane.test.ts
+++ b/daemon/frontend/src/layout/splitPane.test.ts
@@ -13,25 +13,17 @@ afterEach(() => {
 });
 
 describe('splitPane', () => {
-  it('issues POST /windows/{wid}/panes/{pid}/split with horizontal orientation', async () => {
+  it.each([
+    'horizontal',
+    'vertical',
+  ] as const)('issues POST /windows/{wid}/panes/{pid}/split with %s orientation', async (orientation) => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
     globalThis.fetch = fetchMock as typeof globalThis.fetch;
-    await splitPane('wid-1', 'pid-42', 'horizontal');
+    await splitPane('wid-1', 'pid-42', orientation);
     expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-42/split', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ orientation: 'horizontal' }),
-    });
-  });
-
-  it('issues POST with vertical orientation', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
-    globalThis.fetch = fetchMock as typeof globalThis.fetch;
-    await splitPane('wid-1', 'pid-42', 'vertical');
-    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-42/split', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ orientation: 'vertical' }),
+      body: JSON.stringify({ orientation }),
     });
   });
 

--- a/daemon/frontend/src/layout/splitPane.ts
+++ b/daemon/frontend/src/layout/splitPane.ts
@@ -1,0 +1,21 @@
+import { splitPaneEndpoint } from '../terminal/api';
+import type { PaneId, SplitOrientation, WindowId } from './types';
+
+export async function splitPane(
+  windowId: WindowId,
+  paneId: PaneId,
+  orientation: SplitOrientation,
+): Promise<void> {
+  try {
+    const resp = await fetch(splitPaneEndpoint(windowId, paneId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation }),
+    });
+    if (!resp.ok) {
+      console.warn('split pane failed', { windowId, paneId, orientation, status: resp.status });
+    }
+  } catch (e) {
+    console.warn('split pane request errored', { windowId, paneId, orientation, error: e });
+  }
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -48,6 +48,73 @@ describe('actionToHandler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('returns a handler that POSTs split with horizontal orientation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx: ShortcutContext = {
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+    };
+    const handler = actionToHandler(
+      { type: 'split-pane', direction: 'horizontal' },
+      ctx,
+    );
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation: 'horizontal' }),
+    });
+  });
+
+  it('returns a handler that POSTs split with vertical orientation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx: ShortcutContext = {
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+    };
+    const handler = actionToHandler(
+      { type: 'split-pane', direction: 'vertical' },
+      ctx,
+    );
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation: 'vertical' }),
+    });
+  });
+
+  it('split-pane handler is a no-op when active pane is null', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx: ShortcutContext = {
+      activeWindow: () => null,
+      activePane: () => null,
+    };
+    const handler = actionToHandler(
+      { type: 'split-pane', direction: 'horizontal' },
+      ctx,
+    );
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns null and warns for unknown action types', () => {
     const ctx: ShortcutContext = { activeWindow: () => null, activePane: () => null };
     const handler = actionToHandler({ type: 'totally-unknown' } as unknown as Action, ctx);

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -48,14 +48,17 @@ describe('actionToHandler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('returns a handler that POSTs split with horizontal orientation', async () => {
+  it.each([
+    'horizontal',
+    'vertical',
+  ] as const)('returns a handler that POSTs split with %s orientation', async (orientation) => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
     globalThis.fetch = fetchMock as typeof globalThis.fetch;
     const ctx: ShortcutContext = {
       activeWindow: () => 'wid-1',
       activePane: () => 'pid-1',
     };
-    const handler = actionToHandler({ type: 'split-pane', direction: 'horizontal' }, ctx);
+    const handler = actionToHandler({ type: 'split-pane', direction: orientation }, ctx);
     if (handler === null) {
       throw new Error('handler should not be null');
     }
@@ -65,28 +68,7 @@ describe('actionToHandler', () => {
     expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ orientation: 'horizontal' }),
-    });
-  });
-
-  it('returns a handler that POSTs split with vertical orientation', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
-    globalThis.fetch = fetchMock as typeof globalThis.fetch;
-    const ctx: ShortcutContext = {
-      activeWindow: () => 'wid-1',
-      activePane: () => 'pid-1',
-    };
-    const handler = actionToHandler({ type: 'split-pane', direction: 'vertical' }, ctx);
-    if (handler === null) {
-      throw new Error('handler should not be null');
-    }
-    handler();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ orientation: 'vertical' }),
+      body: JSON.stringify({ orientation }),
     });
   });
 

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -55,10 +55,7 @@ describe('actionToHandler', () => {
       activeWindow: () => 'wid-1',
       activePane: () => 'pid-1',
     };
-    const handler = actionToHandler(
-      { type: 'split-pane', direction: 'horizontal' },
-      ctx,
-    );
+    const handler = actionToHandler({ type: 'split-pane', direction: 'horizontal' }, ctx);
     if (handler === null) {
       throw new Error('handler should not be null');
     }
@@ -79,10 +76,7 @@ describe('actionToHandler', () => {
       activeWindow: () => 'wid-1',
       activePane: () => 'pid-1',
     };
-    const handler = actionToHandler(
-      { type: 'split-pane', direction: 'vertical' },
-      ctx,
-    );
+    const handler = actionToHandler({ type: 'split-pane', direction: 'vertical' }, ctx);
     if (handler === null) {
       throw new Error('handler should not be null');
     }
@@ -103,10 +97,7 @@ describe('actionToHandler', () => {
       activeWindow: () => null,
       activePane: () => null,
     };
-    const handler = actionToHandler(
-      { type: 'split-pane', direction: 'horizontal' },
-      ctx,
-    );
+    const handler = actionToHandler({ type: 'split-pane', direction: 'horizontal' }, ctx);
     if (handler === null) {
       throw new Error('handler should not be null');
     }

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -1,4 +1,5 @@
 import { closePane } from '../layout/closePane';
+import { splitPane } from '../layout/splitPane';
 import type { PaneId, WindowId } from '../layout/types';
 import type { Action } from './wire';
 
@@ -13,15 +14,24 @@ export interface ShortcutContext {
  * frontend has not implemented yet (`console.warn` once at construction).
  */
 export function actionToHandler(action: Action, ctx: ShortcutContext): (() => void) | null {
-  if (action.type === 'close-pane') {
-    return () => {
-      const w = ctx.activeWindow();
-      const p = ctx.activePane();
-      if (w && p) {
-        void closePane(w, p);
-      }
-    };
+  switch (action.type) {
+    case 'close-pane':
+      return () => withActivePane(ctx, closePane);
+    case 'split-pane': {
+      const orientation = action.direction;
+      return () => withActivePane(ctx, (w, p) => splitPane(w, p, orientation));
+    }
+    default:
+      console.warn('actionToHandler: unsupported action', action);
+      return null;
   }
-  console.warn('actionToHandler: unsupported action', action);
-  return null;
+}
+
+function withActivePane(
+  ctx: ShortcutContext,
+  run: (w: WindowId, p: PaneId) => void | Promise<void>,
+): void {
+  const w = ctx.activeWindow();
+  const p = ctx.activePane();
+  if (w && p) void run(w, p);
 }

--- a/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
@@ -15,11 +15,22 @@ const DEFAULT_PAYLOAD = {
       modifiers: { ctrl: false, shift: false, alt: false, meta: false },
       action: { type: 'close-pane' },
     },
+    {
+      key: 's',
+      modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      action: { type: 'split-pane', direction: 'horizontal' },
+    },
+    {
+      key: 'v',
+      modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      action: { type: 'split-pane', direction: 'vertical' },
+    },
   ],
 };
 
 const origFetch = globalThis.fetch;
 let closeFetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+let splitFetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 let configFetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 
 function press(opts: KeyboardEventInit & { key: string }) {
@@ -39,6 +50,7 @@ beforeEach(() => {
   // shouldAdvanceTime lets waitFor's polling interval fire under fake timers.
   vi.useFakeTimers({ shouldAdvanceTime: true });
   closeFetchMock = vi.fn<typeof fetch>().mockResolvedValue({ ok: true, status: 204 } as Response);
+  splitFetchMock = vi.fn<typeof fetch>().mockResolvedValue({ ok: true, status: 201 } as Response);
   configFetchMock = vi.fn<typeof fetch>().mockResolvedValue({
     ok: true,
     status: 200,
@@ -47,6 +59,7 @@ beforeEach(() => {
   globalThis.fetch = ((url: RequestInfo | URL, init?: RequestInit) => {
     const path = typeof url === 'string' ? url : url.toString();
     if (path === '/configs/shortcuts') return configFetchMock(url, init);
+    if (path.endsWith('/split')) return splitFetchMock(url, init);
     return closeFetchMock(url, init);
   }) as typeof globalThis.fetch;
   vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -198,6 +211,50 @@ describe('usePrefixMode', () => {
     await Promise.resolve();
     expect(closeFetchMock).not.toHaveBeenCalled();
 
+    expect(result.current.isArmed).toBe(false);
+  });
+
+  it('Ctrl+B → s fires the split-pane horizontal binding', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+      press({ key: 's' });
+    });
+    await waitFor(() =>
+      expect(splitFetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ orientation: 'horizontal' }),
+      }),
+    );
+  });
+
+  it('Ctrl+B → v fires the split-pane vertical binding', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+      press({ key: 'v' });
+    });
+    await waitFor(() =>
+      expect(splitFetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ orientation: 'vertical' }),
+      }),
+    );
+  });
+
+  it('Shift+S with modifier mismatch does NOT fire the unmodified "s" binding', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+      press({ key: 'S', shiftKey: true });
+    });
+    await Promise.resolve();
+    expect(splitFetchMock).not.toHaveBeenCalled();
     expect(result.current.isArmed).toBe(false);
   });
 

--- a/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
@@ -214,34 +214,21 @@ describe('usePrefixMode', () => {
     expect(result.current.isArmed).toBe(false);
   });
 
-  it('Ctrl+B → s fires the split-pane horizontal binding', async () => {
+  it.each([
+    ['s', 'horizontal'],
+    ['v', 'vertical'],
+  ] as const)('Ctrl+B → %s fires the split-pane %s binding', async (key, orientation) => {
     const { result } = renderHook(() => usePrefixMode(makeCtx()));
     await waitFor(() => expect(result.current.status).toBe('ready'));
     act(() => {
       press({ key: 'b', ctrlKey: true });
-      press({ key: 's' });
+      press({ key });
     });
     await waitFor(() =>
       expect(splitFetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ orientation: 'horizontal' }),
-      }),
-    );
-  });
-
-  it('Ctrl+B → v fires the split-pane vertical binding', async () => {
-    const { result } = renderHook(() => usePrefixMode(makeCtx()));
-    await waitFor(() => expect(result.current.status).toBe('ready'));
-    act(() => {
-      press({ key: 'b', ctrlKey: true });
-      press({ key: 'v' });
-    });
-    await waitFor(() =>
-      expect(splitFetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/split', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ orientation: 'vertical' }),
+        body: JSON.stringify({ orientation }),
       }),
     );
   });

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -82,6 +82,47 @@ describe('parseShortcuts', () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('parses a split-pane binding with horizontal direction', () => {
+    const withSplit = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: 's',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'split-pane', direction: 'horizontal' },
+        },
+        {
+          key: 'v',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'split-pane', direction: 'vertical' },
+        },
+      ],
+    };
+    const out = parseShortcuts(withSplit);
+    expect(out?.bindings).toHaveLength(3);
+    expect(out?.bindings[1].action).toEqual({ type: 'split-pane', direction: 'horizontal' });
+    expect(out?.bindings[2].action).toEqual({ type: 'split-pane', direction: 'vertical' });
+  });
+
+  it('drops a split-pane binding with an invalid direction', () => {
+    const withBadDir = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: 's',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'split-pane', direction: 'diagonal' },
+        },
+      ],
+    };
+    const out = parseShortcuts(withBadDir);
+    expect(out?.bindings).toHaveLength(1);
+    expect(out?.bindings[0].action.type).toBe('close-pane');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
   it('drops bindings whose key is not a known token', () => {
     const withWeirdKey = {
       ...DEFAULT_JSON,

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -28,7 +28,13 @@ const KeyChordFieldsSchema = z.object({
   modifiers: ModifiersSchema,
 });
 
-const ActionSchema = z.discriminatedUnion('type', [z.object({ type: z.literal('close-pane') })]);
+const ActionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('close-pane') }),
+  z.object({
+    type: z.literal('split-pane'),
+    direction: z.enum(['horizontal', 'vertical']),
+  }),
+]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({
   timeout_ms: z.number().int().nonnegative(),

--- a/daemon/frontend/src/terminal/Terminal.test.tsx
+++ b/daemon/frontend/src/terminal/Terminal.test.tsx
@@ -20,11 +20,11 @@ vi.mock('./useXtermTerminal', () => ({
 import { Terminal } from './Terminal';
 
 describe('<Terminal>', () => {
-  it('does NOT call focus or blur on initial mount when isActive=true', () => {
+  it('calls focus (not blur) on initial mount when isActive=true', () => {
     focusSpy.mockClear();
     blurSpy.mockClear();
     render(<Terminal windowId="wid" paneId="pid" activityId="aid" isActive={true} />);
-    expect(focusSpy).not.toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalledTimes(1);
     expect(blurSpy).not.toHaveBeenCalled();
   });
 

--- a/daemon/frontend/src/terminal/Terminal.tsx
+++ b/daemon/frontend/src/terminal/Terminal.tsx
@@ -16,8 +16,7 @@ export function Terminal({ windowId, paneId, activityId, isActive }: TerminalPro
   const socket = useTerminalSocket(windowId, paneId, activityId, reconnectKey);
   const { focus, blur } = useXtermTerminal(containerRef, socket);
 
-  // Seed with `false` so that mounting with `isActive=true` (e.g. a freshly
-  // split pane promoted to active by the daemon) triggers focus.
+  // Seeded false so an initial isActive=true mount registers as a transition.
   const prevActiveRef = useRef(false);
   // biome-ignore lint/correctness/useExhaustiveDependencies: focus/blur are stabilized by React Compiler; adding them would re-run on every render and defeat transition-only semantics
   useEffect(() => {

--- a/daemon/frontend/src/terminal/Terminal.tsx
+++ b/daemon/frontend/src/terminal/Terminal.tsx
@@ -16,7 +16,9 @@ export function Terminal({ windowId, paneId, activityId, isActive }: TerminalPro
   const socket = useTerminalSocket(windowId, paneId, activityId, reconnectKey);
   const { focus, blur } = useXtermTerminal(containerRef, socket);
 
-  const prevActiveRef = useRef(isActive);
+  // Seed with `false` so that mounting with `isActive=true` (e.g. a freshly
+  // split pane promoted to active by the daemon) triggers focus.
+  const prevActiveRef = useRef(false);
   // biome-ignore lint/correctness/useExhaustiveDependencies: focus/blur are stabilized by React Compiler; adding them would re-run on every render and defeat transition-only semantics
   useEffect(() => {
     if (isActive && !prevActiveRef.current) focus();

--- a/daemon/http_server/src/handlers/windows/panes/split.rs
+++ b/daemon/http_server/src/handlers/windows/panes/split.rs
@@ -84,14 +84,17 @@ async fn split_in_window(
             .record_pane_and_activity_owners(&new_pane_id, &new_activity_id, name);
     }
 
-    publish_window_layout(state, wid).await;
-
-    // Only Terminal activities are backed by a PTY. Extension activities live
-    // in an iframe, so spawning a shell for them creates an orphan child
-    // process whose output nothing ever reads.
+    // NOTE: PTY spawn must precede the layout publish. If published first,
+    // the frontend opens the terminal WS against an activity TerminalService
+    // doesn't know yet; `snapshot_and_subscribe` returns NotFound, the
+    // connection closes with 1011, and the new pane is stuck in a
+    // "Disconnected" state with no auto-recovery. Extension activities live
+    // in an iframe (no PTY) so they skip the spawn.
     if matches!(activity_kind, ActivityKind::Terminal) {
         spawn_pty_with_rollback(state, wid, &new_pane_id, &new_activity_id).await?;
     }
+
+    publish_window_layout(state, wid).await;
 
     Ok((
         StatusCode::CREATED,
@@ -132,6 +135,8 @@ async fn spawn_pty_with_rollback(
 }
 
 async fn rollback_split(state: &AppState, wid: &WindowId, new_pane_id: &PaneId) {
+    // NOTE: spawn happens before publish, so the frontend never saw the new
+    // pane — no layout re-broadcast is needed on rollback.
     let closed = state
         .multiplexer
         .with_window_or_404(wid, |w| w.close_pane(new_pane_id))
@@ -145,7 +150,6 @@ async fn rollback_split(state: &AppState, wid: &WindowId, new_pane_id: &PaneId) 
         return;
     }
     state.multiplexer.pane_owner_window.remove(new_pane_id);
-    publish_window_layout(state, wid).await;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

ozmux had no shortcut to split the active pane. The TOML config already defined `Action::SplitPane { direction }` and the daemon endpoint `POST /windows/{wid}/panes/{pid}/split` was complete, but the frontend dropped any `split-pane` binding during config parse and the default `Shortcuts` only contained `Ctrl+B → x` (close pane). Users who wanted to split a pane had to do it via the HTTP API directly.

Two follow-up issues surfaced during manual verification and were fixed in this same branch:

1. After a successful split the new pane briefly showed a `Disconnected` banner before the terminal rendered. Root cause: the daemon broadcast the new layout before `TerminalService` finished registering the activity, so the frontend opened the terminal WebSocket against an unknown activity, the server closed with code 1011, and `useTerminalSocket` flipped to `disconnected` with no auto-retry.
2. The new pane never received keyboard focus. Root cause: `Terminal.tsx`'s focus effect was transition-only (`false → true`), and `prevActiveRef` was seeded with `isActive`, so a freshly-mounted active pane never registered as a transition. An existing test had locked this behavior in.

## Solution

### Default keybindings

`Shortcuts::default()` now ships three bindings: `x → close-pane`, `s → split-pane horizontal` (new pane to the right), `v → split-pane vertical` (new pane below). Tmux-style `%` / `"` were considered but rejected: the current chord matcher (`chord.ts:27`) requires exact modifier equality and `raw.rs::validate` rejects any non-default modifier, so `Shift+%` would silently never fire and could not be patched in TOML either. Lifting either constraint is out of scope. `s` / `v` are physically reachable on every keyboard layout we care about.

### Frontend wiring

- **New helper** `daemon/frontend/src/layout/splitPane.ts` — fire-and-forget POST mirroring `closePane.ts`. Body is `{ orientation }` only; the daemon mints the new pane id, creates a Terminal activity, and defaults `side` to `after`. Errors log via `console.warn`; UI state arrives over the existing layout-broadcast WebSocket.
- **Schema** `wire.ts` `ActionSchema` is now a `z.discriminatedUnion('type', ...)` with both `close-pane` and `split-pane` variants. Invalid `direction` values are dropped per-binding by the existing `parseShortcuts` policy.
- **Dispatcher** `actionDispatch.ts` was refactored from an if-chain to a `switch`, with `withActivePane(ctx, run)` extracted so the close-pane and split-pane branches share the active-pane-or-bail pattern.
- **Integration coverage** `usePrefixMode.test.ts` exercises `Ctrl+B → s` / `Ctrl+B → v` end-to-end via real `KeyboardEvent` dispatch, plus a `Shift+S` regression test that mirrors the existing `Shift+X` non-fire case.

### Bug fixes

- `daemon/http_server/src/handlers/windows/panes/split.rs` — reorder so `spawn_pty_with_rollback` runs before `publish_window_layout`. The rollback's redundant re-publish is dropped (the frontend never saw the pane in the first place).
- `daemon/frontend/src/terminal/Terminal.tsx` — seed `prevActiveRef` with `false` so a mount with `isActive=true` registers as a transition and calls `focus()`. The locked-in `does NOT call focus...` test is inverted accordingly.

### Affected areas

- `daemon/configs` — `Shortcuts::default()` extended, `default_shortcuts_serializes_to_stable_json` snapshot updated, `raw.rs::empty_raw_returns_defaults` binding-count assertion updated.
- `daemon/http_server` — `split.rs` spawn-before-publish ordering.
- `daemon/frontend` — new `layout/splitPane.ts`; modified `shortcuts/wire.ts`, `shortcuts/actionDispatch.ts`, `terminal/Terminal.tsx`; tests added/updated across `splitPane.test.ts`, `wire.test.ts`, `actionDispatch.test.ts`, `usePrefixMode.test.ts`, `Terminal.test.tsx`.

Design and implementation plan documents (gitignored under `docs/`) drove the work; both were reviewed twice by parallel agents (Codex + Claude) before and after revision.

## Test plan

- [ ] `pnpm --dir daemon/frontend exec vitest run` — 85/85 pass
- [ ] `cargo test --workspace` — all crates green (configs 25, http_server 119, multiplexer 23, terminal 23, …)
- [ ] `pnpm lint` — biome clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --check` — clean
- [ ] Manual: `make dev-e2e`, open `http://localhost:5173`, verify:
  - `Ctrl+B → s` splits horizontally, new pane on the right, focus moves to it, shell prompt appears without a Disconnected banner flash
  - `Ctrl+B → v` splits vertically, new pane below, focus moves
  - `Ctrl+B → x` still closes the active pane (regression check)
  - `Ctrl+B → Shift+S` does nothing (modifier mismatch)