### PR TITLE
feat: Ctrl+B c shortcut to spawn a new terminal activity

### DIFF
--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -72,7 +72,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 3);
+        assert_eq!(merged.shortcuts.bindings.len(), 4);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -152,6 +152,13 @@ impl Default for Shortcuts {
                         direction: SplitDirection::Vertical,
                     },
                 },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('c'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::NewTerminalActivity,
+                },
             ],
         }
     }
@@ -395,11 +402,23 @@ mod tests {
     }
 
     #[test]
+    fn binding_deserializes_new_terminal_activity() {
+        let toml = r#"
+            key = "c"
+            action = { type = "new-terminal-activity" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert_eq!(b.chord.key, Key::Char('c'));
+        assert_eq!(b.chord.modifiers, Modifiers::default());
+        assert!(matches!(b.action, Action::NewTerminalActivity));
+    }
+
+    #[test]
     fn default_shortcuts_serializes_to_stable_json() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}}]}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/newTerminalActivity.test.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { newTerminalActivity } from './newTerminalActivity';
+
+const origFetch = globalThis.fetch;
+const origRandomUUID = globalThis.crypto.randomUUID;
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.stubGlobal('crypto', {
+    ...globalThis.crypto,
+    randomUUID: () => 'aid-stub-uuid',
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.unstubAllGlobals();
+  globalThis.crypto.randomUUID = origRandomUUID;
+  vi.restoreAllMocks();
+});
+
+describe('newTerminalActivity', () => {
+  it('POSTs add then activate on the happy path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await newTerminalActivity('wid-1', 'pid-1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/windows/wid-1/panes/pid-1/activities', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activity: { activity_id: 'aid-stub-uuid', kind: { type: 'terminal' } },
+      }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/windows/wid-1/panes/pid-1/activities/aid-stub-uuid/activate',
+      { method: 'POST' },
+    );
+  });
+
+  it('does not POST activate when add fails with non-ok status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await newTerminalActivity('wid-1', 'pid-1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'new terminal activity failed',
+      expect.objectContaining({ windowId: 'wid-1', paneId: 'pid-1', status: 500 }),
+    );
+  });
+
+  it('does not POST activate when add throws', async () => {
+    const err = new Error('net');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await newTerminalActivity('wid-1', 'pid-1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      'new terminal activity request errored',
+      expect.objectContaining({ windowId: 'wid-1', paneId: 'pid-1', error: err }),
+    );
+  });
+
+  it('warns but does not throw when activate fails after add succeeded', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 201 } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 404 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await newTerminalActivity('wid-1', 'pid-1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledWith(
+      'activate new activity failed',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-1',
+        activityId: 'aid-stub-uuid',
+        status: 404,
+      }),
+    );
+  });
+});

--- a/daemon/frontend/src/layout/newTerminalActivity.test.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.test.ts
@@ -40,9 +40,7 @@ describe('newTerminalActivity', () => {
   });
 
   it('does not POST activate when add fails with non-ok status', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 } as Response);
     globalThis.fetch = fetchMock as typeof globalThis.fetch;
     await newTerminalActivity('wid-1', 'pid-1');
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/daemon/frontend/src/layout/newTerminalActivity.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.ts
@@ -1,10 +1,7 @@
 import { activateActivityEndpoint, addActivityEndpoint } from '../terminal/api';
 import type { PaneId, WindowId } from './types';
 
-export async function newTerminalActivity(
-  windowId: WindowId,
-  paneId: PaneId,
-): Promise<void> {
+export async function newTerminalActivity(windowId: WindowId, paneId: PaneId): Promise<void> {
   const activityId = crypto.randomUUID();
   try {
     const resp = await fetch(addActivityEndpoint(windowId, paneId), {

--- a/daemon/frontend/src/layout/newTerminalActivity.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.ts
@@ -1,0 +1,54 @@
+import { activateActivityEndpoint, addActivityEndpoint } from '../terminal/api';
+import type { PaneId, WindowId } from './types';
+
+export async function newTerminalActivity(
+  windowId: WindowId,
+  paneId: PaneId,
+): Promise<void> {
+  const activityId = crypto.randomUUID();
+  try {
+    const resp = await fetch(addActivityEndpoint(windowId, paneId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        activity: { activity_id: activityId, kind: { type: 'terminal' } },
+      }),
+    });
+    if (!resp.ok) {
+      console.warn('new terminal activity failed', {
+        windowId,
+        paneId,
+        status: resp.status,
+      });
+      return;
+    }
+  } catch (e) {
+    console.warn('new terminal activity request errored', {
+      windowId,
+      paneId,
+      error: e,
+    });
+    return;
+  }
+
+  try {
+    const resp = await fetch(activateActivityEndpoint(windowId, paneId, activityId), {
+      method: 'POST',
+    });
+    if (!resp.ok) {
+      console.warn('activate new activity failed', {
+        windowId,
+        paneId,
+        activityId,
+        status: resp.status,
+      });
+    }
+  } catch (e) {
+    console.warn('activate new activity request errored', {
+      windowId,
+      paneId,
+      activityId,
+      error: e,
+    });
+  }
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = origFetch;
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -125,7 +126,6 @@ describe('actionToHandler', () => {
       '/windows/wid-1/panes/pid-1/activities/aid-stub/activate',
       { method: 'POST' },
     );
-    vi.unstubAllGlobals();
   });
 
   it('new-terminal-activity handler is a no-op when active pane is null', async () => {

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -94,4 +94,53 @@ describe('actionToHandler', () => {
     expect(handler).toBeNull();
     expect(console.warn).toHaveBeenCalled();
   });
+
+  it('returns a handler that POSTs add then activate for new-terminal-activity', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 201 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 204 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    vi.stubGlobal('crypto', {
+      ...globalThis.crypto,
+      randomUUID: () => 'aid-stub',
+    });
+    const ctx: ShortcutContext = {
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+    };
+    const handler = actionToHandler({ type: 'new-terminal-activity' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/windows/wid-1/panes/pid-1/activities',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/windows/wid-1/panes/pid-1/activities/aid-stub/activate',
+      { method: 'POST' },
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('new-terminal-activity handler is a no-op when active pane is null', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx: ShortcutContext = {
+      activeWindow: () => null,
+      activePane: () => null,
+    };
+    const handler = actionToHandler({ type: 'new-terminal-activity' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -1,4 +1,5 @@
 import { closePane } from '../layout/closePane';
+import { newTerminalActivity } from '../layout/newTerminalActivity';
 import { splitPane } from '../layout/splitPane';
 import type { PaneId, WindowId } from '../layout/types';
 import type { Action } from './wire';
@@ -21,6 +22,8 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
       const orientation = action.direction;
       return () => withActivePane(ctx, (w, p) => splitPane(w, p, orientation));
     }
+    case 'new-terminal-activity':
+      return () => withActivePane(ctx, newTerminalActivity);
     default:
       console.warn('actionToHandler: unsupported action', action);
       return null;

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -145,4 +145,21 @@ describe('parseShortcuts', () => {
     expect(parseShortcuts('nope')).toBeNull();
     expect(parseShortcuts(42)).toBeNull();
   });
+
+  it('parses a new-terminal-activity binding', () => {
+    const withNTA = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: 'c',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'new-terminal-activity' },
+        },
+      ],
+    };
+    const out = parseShortcuts(withNTA);
+    expect(out?.bindings).toHaveLength(2);
+    expect(out?.bindings[1].action).toEqual({ type: 'new-terminal-activity' });
+  });
 });

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -34,6 +34,7 @@ const ActionSchema = z.discriminatedUnion('type', [
     type: z.literal('split-pane'),
     direction: z.enum(['horizontal', 'vertical']),
   }),
+  z.object({ type: z.literal('new-terminal-activity') }),
 ]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -7,6 +7,10 @@ export const windowSelectEndpoint = (wid: string) => `/windows/${wid}/select`;
 
 export const splitPaneEndpoint = (wid: string, pid: string) => `/windows/${wid}/panes/${pid}/split`;
 export const closePaneEndpoint = (wid: string, pid: string) => `/windows/${wid}/panes/${pid}`;
+export const addActivityEndpoint = (wid: string, pid: string) =>
+  `/windows/${wid}/panes/${pid}/activities`;
+export const activateActivityEndpoint = (wid: string, pid: string, aid: string) =>
+  `/windows/${wid}/panes/${pid}/activities/${aid}/activate`;
 
 export const terminalWsUrl = (windowId: string, paneId: string, activityId: string) => {
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';

--- a/daemon/http_server/src/error.rs
+++ b/daemon/http_server/src/error.rs
@@ -108,6 +108,9 @@ impl axum::response::IntoResponse for HttpError {
             HttpError::Session(MultiplexerError::PaneAlreadyPlaced(_)) => {
                 (StatusCode::CONFLICT, "PANE_ALREADY_PLACED")
             }
+            HttpError::Session(MultiplexerError::CannotRemoveLastActivity(_)) => {
+                (StatusCode::CONFLICT, "CANNOT_REMOVE_LAST_ACTIVITY")
+            }
             // MissingParentCell, SplitTargetEqualsNewCell, ActivePaneMustBelongToWindow,
             // Terminal::Pty, FailedLaunch fall through → 500
             _ => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL"),
@@ -260,6 +263,13 @@ mod tests {
             window: WindowId::new(),
             pane: PaneId::new(),
         });
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn cannot_remove_last_activity_maps_to_409() {
+        let err = HttpError::Session(MultiplexerError::CannotRemoveLastActivity(PaneId::new()));
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
     }

--- a/daemon/http_server/src/handlers/windows/panes.rs
+++ b/daemon/http_server/src/handlers/windows/panes.rs
@@ -8,6 +8,7 @@ use ozmux_multiplexer::{SessionId, WindowId};
 pub mod activate;
 pub mod activities;
 pub mod close;
+pub mod spawn_terminal;
 pub mod split;
 
 pub fn router() -> Router<AppState> {

--- a/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
@@ -31,18 +31,7 @@ pub async fn add_to_pane(
         .await?;
 
     if matches!(activity_kind, ActivityKind::Terminal) {
-        if let Err(spawn_err) =
-            spawn_terminal_pty(&state, &wid, &pid, &aid).await
-        {
-            if let Err(rollback_err) = rollback_added_activity(&state, &wid, &pid, &aid).await {
-                tracing::warn!(
-                    error = %rollback_err,
-                    %wid, %pid, %aid,
-                    "failed to roll back added activity after PTY spawn failure"
-                );
-            }
-            return Err(spawn_err);
-        }
+        spawn_pty_with_rollback(&state, &wid, &pid, &aid).await?;
     }
 
     // NOTE: publish only after successful spawn so the frontend never sees a pane
@@ -53,6 +42,25 @@ pub async fn add_to_pane(
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "activity_id": aid })),
     ))
+}
+
+async fn spawn_pty_with_rollback(
+    state: &AppState,
+    wid: &WindowId,
+    pid: &PaneId,
+    aid: &ActivityId,
+) -> HttpResult<()> {
+    if let Err(spawn_err) = spawn_terminal_pty(state, wid, pid, aid).await {
+        if let Err(rollback_err) = rollback_added_activity(state, wid, pid, aid).await {
+            tracing::warn!(
+                error = %rollback_err,
+                %wid, %pid, %aid,
+                "failed to roll back added activity after PTY spawn failure"
+            );
+        }
+        return Err(spawn_err);
+    }
+    Ok(())
 }
 
 async fn rollback_added_activity(

--- a/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
@@ -1,10 +1,11 @@
 use crate::AppState;
-use crate::error::HttpError;
+use crate::error::{HttpError, HttpResult};
+use crate::handlers::publish_window_layout;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
-use ozmux_multiplexer::{PaneId, WindowId};
+use ozmux_multiplexer::{ActivityId, ActivityKind, MultiplexerError, PaneId, WindowId};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -16,8 +17,9 @@ pub async fn add_to_pane(
     State(state): State<AppState>,
     Path((wid, pid)): Path<(WindowId, PaneId)>,
     axum::Json(body): axum::Json<AddActivityRequest>,
-) -> Result<(StatusCode, axum::Json<serde_json::Value>), HttpError> {
+) -> HttpResult<(StatusCode, axum::Json<serde_json::Value>)> {
     let parsed = body.activity.into_parsed();
+    let activity_kind = parsed.activity.kind.clone();
     let aid = state
         .add_activity_to_pane(
             &wid,
@@ -26,10 +28,43 @@ pub async fn add_to_pane(
             parsed.extension_name.as_deref(),
         )
         .await?;
+
+    if matches!(activity_kind, ActivityKind::Terminal) {
+        if let Err(spawn_err) =
+            super::super::spawn_terminal::spawn_terminal_pty(&state, &wid, &pid, &aid).await
+        {
+            if let Err(rollback_err) = rollback_added_activity(&state, &wid, &pid, &aid).await {
+                tracing::warn!(
+                    error = %rollback_err,
+                    %wid, %pid, %aid,
+                    "failed to roll back added activity after PTY spawn failure"
+                );
+            }
+            return Err(spawn_err);
+        }
+    }
+
+    publish_window_layout(&state, &wid).await;
+
     Ok((
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "activity_id": aid })),
     ))
+}
+
+async fn rollback_added_activity(
+    state: &AppState,
+    wid: &WindowId,
+    pid: &PaneId,
+    aid: &ActivityId,
+) -> Result<(), HttpError> {
+    state
+        .multiplexer
+        .with_window_or_404(wid, |w| -> Result<(), MultiplexerError> {
+            w.pane_mut(pid)?.remove_activity(aid).map(|_| ())
+        })
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -111,9 +146,8 @@ mod tests {
     async fn add_to_pane_extension_kind_records_activity_owner_in_registry() {
         let state = test_helpers::fresh_state();
         let (_sid, wid, pid, _aid) = test_helpers::bootstrap_default(&state).await;
-        // The handler reads ownership info off `state.extensions`, so register
-        // the extension up-front. The wire `extension_name` is what drives
-        // `record_activity_owner` — the registration we're verifying.
+        // NOTE: register the extension up-front so `record_activity_owner` has
+        // something to verify; the wire `extension_name` drives the call.
         state
             .extensions
             .register("memo", std::path::Path::new("/tmp"));
@@ -170,5 +204,81 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn add_to_pane_spawns_pty_for_terminal_kind() {
+        let state = test_helpers::fresh_state();
+        let (_sid, wid, pid, _aid) = test_helpers::bootstrap_default(&state).await;
+        let terminal = state.terminal.clone();
+        let (router, _state) = test_helpers::router_with(state);
+        let new_aid = ActivityId::new();
+        let body = serde_json::json!({
+            "activity": {
+                "activity_id": new_aid,
+                "kind": { "type": "terminal" }
+            }
+        });
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{wid}/panes/{pid}/activities"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        if status == StatusCode::CREATED {
+            assert!(
+                terminal.subscriber_count(&new_aid).await.is_some(),
+                "Terminal activity must have a backing PTY after add_to_pane"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn add_to_pane_rolls_back_when_spawn_fails() {
+        let state = test_helpers::fresh_state();
+        let (_sid, wid, pid, _aid) = test_helpers::bootstrap_default(&state).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let new_aid = ActivityId::new();
+        state.terminal.inject_spawn_failure(new_aid.clone()).await;
+        let (router, state) = test_helpers::router_with(state);
+        let body = serde_json::json!({
+            "activity": {
+                "activity_id": new_aid,
+                "kind": { "type": "terminal" }
+            }
+        });
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{wid}/panes/{pid}/activities"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let pane_activities_len = state
+            .multiplexer
+            .with_window_or_404(&wid, |w| Ok::<_, ozmux_multiplexer::MultiplexerError>(
+                w.pane(&pid)
+                    .map(|p| p.activities.len())
+                    .unwrap_or(0),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            pane_activities_len, 1,
+            "rollback must remove the failed activity"
+        );
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(recv.is_err(), "no broadcast must be sent on rollback");
     }
 }

--- a/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/add_to_pane.rs
@@ -1,6 +1,7 @@
 use crate::AppState;
 use crate::error::{HttpError, HttpResult};
 use crate::handlers::publish_window_layout;
+use crate::handlers::windows::panes::spawn_terminal::spawn_terminal_pty;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -31,7 +32,7 @@ pub async fn add_to_pane(
 
     if matches!(activity_kind, ActivityKind::Terminal) {
         if let Err(spawn_err) =
-            super::super::spawn_terminal::spawn_terminal_pty(&state, &wid, &pid, &aid).await
+            spawn_terminal_pty(&state, &wid, &pid, &aid).await
         {
             if let Err(rollback_err) = rollback_added_activity(&state, &wid, &pid, &aid).await {
                 tracing::warn!(
@@ -44,6 +45,8 @@ pub async fn add_to_pane(
         }
     }
 
+    // NOTE: publish only after successful spawn so the frontend never sees a pane
+    // with a missing PTY (mirrors split.rs's "spawn must precede publish" invariant).
     publish_window_layout(&state, &wid).await;
 
     Ok((
@@ -265,13 +268,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        let pane_activities_len = state
+        let pane_activities_len: usize = state
             .multiplexer
-            .with_window_or_404(&wid, |w| Ok::<_, ozmux_multiplexer::MultiplexerError>(
-                w.pane(&pid)
-                    .map(|p| p.activities.len())
-                    .unwrap_or(0),
-            ))
+            .with_window_or_404(&wid, |w| -> ozmux_multiplexer::MultiplexerResult<usize> {
+                Ok(w.pane(&pid).map(|p| p.activities.len()).unwrap_or(0))
+            })
             .await
             .unwrap();
         assert_eq!(

--- a/daemon/http_server/src/handlers/windows/panes/spawn_terminal.rs
+++ b/daemon/http_server/src/handlers/windows/panes/spawn_terminal.rs
@@ -1,0 +1,38 @@
+//! Shared terminal PTY spawn used by `split.rs` and `add_to_pane.rs`.
+//!
+//! Rollback is the caller's responsibility because the rollback shape
+//! differs (split removes a pane subtree; add_activity removes a single
+//! activity from a pane).
+
+use crate::AppState;
+use crate::error::HttpResult;
+use ozmux_multiplexer::{ActivityId, PaneId, WindowId};
+use ozmux_terminal::SpawnOptions;
+
+/// Spawn the PTY for a freshly-added terminal Activity in `pid` of `wid`.
+/// Returns the underlying `TerminalError` on spawn failure; the caller
+/// owns the rollback.
+pub(super) async fn spawn_terminal_pty(
+    state: &AppState,
+    wid: &WindowId,
+    pid: &PaneId,
+    aid: &ActivityId,
+) -> HttpResult<()> {
+    let session_id = super::session_owning_window(state, wid).await;
+    state
+        .terminal
+        .spawn(
+            pid.clone(),
+            aid.clone(),
+            SpawnOptions {
+                cols: 80,
+                rows: 24,
+                shell: std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into()),
+                cwd: None,
+                window_id: Some(wid.clone()),
+                session_id,
+            },
+        )
+        .await?;
+    Ok(())
+}

--- a/daemon/http_server/src/handlers/windows/panes/split.rs
+++ b/daemon/http_server/src/handlers/windows/panes/split.rs
@@ -9,7 +9,6 @@ use axum::{
 use ozmux_multiplexer::{
     Activity, ActivityId, ActivityKind, MultiplexerResult, PaneId, Side, SplitOrientation, WindowId,
 };
-use ozmux_terminal::SpawnOptions;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -111,25 +110,13 @@ async fn spawn_pty_with_rollback(
     new_pane_id: &PaneId,
     new_activity_id: &ActivityId,
 ) -> HttpResult<()> {
-    let session_id = super::session_owning_window(state, wid).await;
-    let spawn_result = state
-        .terminal
-        .spawn(
-            new_pane_id.clone(),
-            new_activity_id.clone(),
-            SpawnOptions {
-                cols: 80,
-                rows: 24,
-                shell: std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into()),
-                cwd: None,
-                window_id: Some(wid.clone()),
-                session_id,
-            },
-        )
-        .await;
-    if let Err(spawn_err) = spawn_result {
+    if let Err(spawn_err) = super::spawn_terminal::spawn_terminal_pty(
+        state, wid, new_pane_id, new_activity_id,
+    )
+    .await
+    {
         rollback_split(state, wid, new_pane_id).await;
-        return Err(spawn_err.into());
+        return Err(spawn_err);
     }
     Ok(())
 }

--- a/daemon/http_server/src/handlers/windows/panes/split.rs
+++ b/daemon/http_server/src/handlers/windows/panes/split.rs
@@ -110,10 +110,8 @@ async fn spawn_pty_with_rollback(
     new_pane_id: &PaneId,
     new_activity_id: &ActivityId,
 ) -> HttpResult<()> {
-    if let Err(spawn_err) = super::spawn_terminal::spawn_terminal_pty(
-        state, wid, new_pane_id, new_activity_id,
-    )
-    .await
+    if let Err(spawn_err) =
+        super::spawn_terminal::spawn_terminal_pty(state, wid, new_pane_id, new_activity_id).await
     {
         rollback_split(state, wid, new_pane_id).await;
         return Err(spawn_err);

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -86,7 +86,7 @@ impl AppState {
         pid: &PaneId,
         activity: Activity,
         extension_name: Option<&str>,
-    ) -> HttpResult<ActivityId> {
+    ) -> MultiplexerResult<ActivityId> {
         let aid = activity.id.clone();
         self.multiplexer
             .with_window_or_404(wid, |w| w.pane_mut(pid)?.add_activity(activity))
@@ -94,7 +94,6 @@ impl AppState {
         if let Some(name) = extension_name {
             self.extensions.record_activity_owner(&aid, name);
         }
-        self.publish_window_layout(wid).await;
         Ok(aid)
     }
 

--- a/daemon/multiplexer/src/error.rs
+++ b/daemon/multiplexer/src/error.rs
@@ -78,6 +78,9 @@ pub enum MultiplexerError {
     #[error("activity {activity} is not in pane {pane}")]
     ActivityNotInPane { pane: PaneId, activity: ActivityId },
 
+    #[error("cannot remove the only activity in pane {0}")]
+    CannotRemoveLastActivity(PaneId),
+
     #[error("pane {pane} claimed to be in window {claimed} but is actually in {actual}")]
     PaneAttachmentMismatch {
         pane: PaneId,
@@ -125,5 +128,12 @@ mod tests {
         let wid = WindowId::new();
         let err = MultiplexerError::WindowNotAttachedToSession(wid.clone());
         assert!(err.to_string().contains(wid.as_ref()));
+    }
+
+    #[test]
+    fn cannot_remove_last_activity_carries_pane_id() {
+        let pid = PaneId::new();
+        let err = MultiplexerError::CannotRemoveLastActivity(pid.clone());
+        assert!(err.to_string().contains(pid.as_ref()));
     }
 }

--- a/daemon/multiplexer/src/window/pane/pane.rs
+++ b/daemon/multiplexer/src/window/pane/pane.rs
@@ -69,10 +69,7 @@ impl Pane {
     /// If the removed activity equals `active_activity`, the active activity
     /// is reset to the first remaining activity (mirroring the close cascade
     /// in `close_pane`).
-    pub fn remove_activity(
-        &mut self,
-        aid: &ActivityId,
-    ) -> MultiplexerResult<Activity> {
+    pub fn remove_activity(&mut self, aid: &ActivityId) -> MultiplexerResult<Activity> {
         if !self.has_activity(aid) {
             return Err(MultiplexerError::ActivityNotInPane {
                 pane: self.id.clone(),

--- a/daemon/multiplexer/src/window/pane/pane.rs
+++ b/daemon/multiplexer/src/window/pane/pane.rs
@@ -61,6 +61,39 @@ impl Pane {
         Ok(SetActiveOutcome::Changed)
     }
 
+    /// Remove an Activity by id and return the removed value.
+    ///
+    /// Refuses to remove the last activity — a pane with zero activities is
+    /// malformed; callers must ensure ≥1 other activity remains.
+    ///
+    /// If the removed activity equals `active_activity`, the active activity
+    /// is reset to the first remaining activity (mirroring the close cascade
+    /// in `close_pane`).
+    pub fn remove_activity(
+        &mut self,
+        aid: &ActivityId,
+    ) -> MultiplexerResult<Activity> {
+        if !self.has_activity(aid) {
+            return Err(MultiplexerError::ActivityNotInPane {
+                pane: self.id.clone(),
+                activity: aid.clone(),
+            });
+        }
+        if self.activities.len() == 1 {
+            return Err(MultiplexerError::CannotRemoveLastActivity(self.id.clone()));
+        }
+        let idx = self
+            .activities
+            .iter()
+            .position(|a| &a.id == aid)
+            .expect("has_activity returned true above");
+        let removed = self.activities.remove(idx);
+        if &self.active_activity == aid {
+            self.active_activity = self.activities[0].id.clone();
+        }
+        Ok(removed)
+    }
+
     pub fn activity(&self, aid: &ActivityId) -> Option<&Activity> {
         self.activities.iter().find(|a| &a.id == aid)
     }
@@ -195,5 +228,45 @@ mod tests {
         let phantom = ActivityId::new();
         let err = pane.set_active_activity(&phantom).unwrap_err();
         assert!(matches!(err, MultiplexerError::ActivityNotInPane { .. }));
+    }
+
+    #[test]
+    fn remove_activity_returns_removed_value() {
+        let (mut pane, _aid) = fresh_pane();
+        let new_aid = ActivityId::new();
+        pane.add_activity(Activity::terminal(new_aid.clone()))
+            .unwrap();
+        let removed = pane.remove_activity(&new_aid).unwrap();
+        assert_eq!(removed.id, new_aid);
+        assert_eq!(pane.activities.len(), 1);
+    }
+
+    #[test]
+    fn remove_activity_rejects_unknown_id() {
+        let (mut pane, _aid) = fresh_pane();
+        let phantom = ActivityId::new();
+        let err = pane.remove_activity(&phantom).unwrap_err();
+        assert!(matches!(err, MultiplexerError::ActivityNotInPane { .. }));
+    }
+
+    #[test]
+    fn remove_activity_rejects_when_only_activity_remains() {
+        let (mut pane, aid) = fresh_pane();
+        let err = pane.remove_activity(&aid).unwrap_err();
+        assert!(matches!(err, MultiplexerError::CannotRemoveLastActivity(_)));
+    }
+
+    #[test]
+    fn remove_activity_resets_active_when_removing_active() {
+        let (mut pane, original_aid) = fresh_pane();
+        let second_aid = ActivityId::new();
+        pane.add_activity(Activity::terminal(second_aid.clone()))
+            .unwrap();
+        let _ = pane.set_active_activity(&second_aid).unwrap();
+        assert_eq!(pane.active_activity, second_aid);
+
+        let _removed = pane.remove_activity(&second_aid).unwrap();
+        assert_eq!(pane.active_activity, original_aid);
+        assert_eq!(pane.activities.len(), 1);
     }
 }

--- a/daemon/terminal/src/pty.rs
+++ b/daemon/terminal/src/pty.rs
@@ -68,17 +68,20 @@ impl TerminalService {
         activity_id: ActivityId,
         opts: SpawnOptions,
     ) -> TerminalResult {
-        let mut ptys = self.ptys.write().await;
-        if ptys.contains_key(&activity_id) {
-            return Ok(());
-        }
-
+        // NOTE: check forced_failures BEFORE the ptys lock so the two locks are
+        // never held simultaneously. Consuming the failure here also takes
+        // precedence over the dup-key short-circuit below.
         #[cfg(any(test, feature = "test-helpers"))]
         {
             let mut forced = self.forced_failures.write().await;
             if forced.remove(&activity_id) {
                 return Err(TerminalError::Pty("forced test failure".into()));
             }
+        }
+
+        let mut ptys = self.ptys.write().await;
+        if ptys.contains_key(&activity_id) {
+            return Ok(());
         }
 
         let pty_pair = native_pty_system()

--- a/daemon/terminal/src/pty.rs
+++ b/daemon/terminal/src/pty.rs
@@ -7,6 +7,8 @@ use ozmux_multiplexer::{ActivityId, PaneId, SessionId, WindowId};
 use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io::Read, sync::Arc};
+#[cfg(any(test, feature = "test-helpers"))]
+use std::collections::HashSet;
 use tokio::sync::{RwLock, RwLockReadGuard, broadcast};
 
 pub(crate) mod pty_handle;
@@ -18,10 +20,23 @@ pub enum TerminalEvent {
     Exit { code: Option<i32> },
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct TerminalService {
     ptys: Arc<RwLock<HashMap<ActivityId, PtyHandle>>>,
     runtime_root: Option<Arc<RuntimeRoot>>,
+    #[cfg(any(test, feature = "test-helpers"))]
+    forced_failures: Arc<RwLock<HashSet<ActivityId>>>,
+}
+
+impl Default for TerminalService {
+    fn default() -> Self {
+        Self {
+            ptys: Arc::default(),
+            runtime_root: None,
+            #[cfg(any(test, feature = "test-helpers"))]
+            forced_failures: Arc::default(),
+        }
+    }
 }
 
 pub struct SpawnOptions {
@@ -42,6 +57,8 @@ impl TerminalService {
         Self {
             ptys: Arc::default(),
             runtime_root: Some(root),
+            #[cfg(any(test, feature = "test-helpers"))]
+            forced_failures: Arc::default(),
         }
     }
 
@@ -54,6 +71,14 @@ impl TerminalService {
         let mut ptys = self.ptys.write().await;
         if ptys.contains_key(&activity_id) {
             return Ok(());
+        }
+
+        #[cfg(any(test, feature = "test-helpers"))]
+        {
+            let mut forced = self.forced_failures.write().await;
+            if forced.remove(&activity_id) {
+                return Err(TerminalError::Pty("forced test failure".into()));
+            }
         }
 
         let pty_pair = native_pty_system()
@@ -150,6 +175,14 @@ impl TerminalService {
     ) -> TerminalResult<(Vec<u8>, broadcast::Receiver<TerminalEvent>)> {
         let handle = self.read(activity).await?;
         Ok(handle.snapshot_and_subscribe().await)
+    }
+
+    /// Test-only: register `aid` so the next call to `spawn` with this id
+    /// returns `TerminalError::Pty(...)` without touching the real PTY.
+    /// Consumed on use.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub async fn inject_spawn_failure(&self, aid: ActivityId) {
+        self.forced_failures.write().await.insert(aid);
     }
 
     /// Return the current broadcast subscriber count for an activity, or `None`
@@ -498,6 +531,29 @@ mod tests {
             !path.exists(),
             "service drop releases last Arc → RuntimeRoot Drop"
         );
+    }
+
+    #[tokio::test]
+    async fn inject_spawn_failure_makes_next_spawn_fail() {
+        let svc = TerminalService::default();
+        let aid = ActivityId::new();
+        svc.inject_spawn_failure(aid.clone()).await;
+        let result = svc
+            .spawn(
+                PaneId::new(),
+                aid.clone(),
+                SpawnOptions {
+                    cols: 80,
+                    rows: 24,
+                    shell: "/bin/sh".into(),
+                    cwd: None,
+                    window_id: None,
+                    session_id: None,
+                },
+            )
+            .await;
+        assert!(matches!(result, Err(TerminalError::Pty(_))));
+        assert!(svc.subscriber_count(&aid).await.is_none());
     }
 
     #[tokio::test]

--- a/daemon/terminal/src/pty.rs
+++ b/daemon/terminal/src/pty.rs
@@ -6,9 +6,9 @@ use ozmux_extension::runtime::RuntimeRoot;
 use ozmux_multiplexer::{ActivityId, PaneId, SessionId, WindowId};
 use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, io::Read, sync::Arc};
 #[cfg(any(test, feature = "test-helpers"))]
 use std::collections::HashSet;
+use std::{collections::HashMap, io::Read, sync::Arc};
 use tokio::sync::{RwLock, RwLockReadGuard, broadcast};
 
 pub(crate) mod pty_handle;
@@ -20,23 +20,12 @@ pub enum TerminalEvent {
     Exit { code: Option<i32> },
 }
 
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct TerminalService {
     ptys: Arc<RwLock<HashMap<ActivityId, PtyHandle>>>,
     runtime_root: Option<Arc<RuntimeRoot>>,
     #[cfg(any(test, feature = "test-helpers"))]
     forced_failures: Arc<RwLock<HashSet<ActivityId>>>,
-}
-
-impl Default for TerminalService {
-    fn default() -> Self {
-        Self {
-            ptys: Arc::default(),
-            runtime_root: None,
-            #[cfg(any(test, feature = "test-helpers"))]
-            forced_failures: Arc::default(),
-        }
-    }
 }
 
 pub struct SpawnOptions {


### PR DESCRIPTION
## Problem

There was no way to add another terminal activity to the active pane from the keyboard. Panes could be split, but stacking activities (tabs) inside a single pane required driving the API by hand.

## Solution

Adds an end-to-end shortcut path for creating a new terminal activity in the active pane, bound to `Ctrl+B c` by default. Affects `daemon/configs`, `daemon/multiplexer`, `daemon/http_server`, `daemon/terminal`, and `daemon/frontend`.

### Backend
- `multiplexer`: new `Pane::remove_activity` and `CannotRemoveLastActivity` error variant so callers can roll back a freshly added activity without leaving an empty pane.
- `http_server`: `add_to_pane` handler now spawns the PTY before publishing the activity, with a shared `spawn_pty_with_rollback` helper that mirrors `split.rs` and removes the activity on PTY failure. `CannotRemoveLastActivity` maps to HTTP 409.
- `terminal`: `spawn_terminal_pty` extracted and reused by both `add_to_pane` and `split`. Lock ordering in `TerminalService::spawn` was tightened (forced-failure check now happens before the `ptys` write lock) to remove a latent deadlock risk, and a `#[cfg(any(test, feature = "test-helpers"))]` `inject_spawn_failure` hook was added so integration tests can exercise the rollback path without a real PTY.

### Frontend
- New `newTerminalActivity` helper composes `addActivity` + `activateActivity` endpoint builders.
- `actionDispatch` routes the `new-terminal-activity` action to the helper; the shortcut schema accepts the new action.
- Default config binds `Ctrl+B` → `c` to `new-terminal-activity`.
- Vitest housekeeping: `vi.unstubAllGlobals` hoisted to `afterEach` so suites don't leak global stubs.

## Test plan

- [ ] `cargo test -p ozmux_multiplexer` — `remove_activity` and `CannotRemoveLastActivity` paths
- [ ] `cargo test -p ozmux_http_server` — `add_to_pane` rollback on PTY spawn failure (uses `inject_spawn_failure`)
- [ ] `cargo test -p ozmux_terminal` — spawn lock-ordering / forced-failure hook
- [ ] `pnpm test` — `newTerminalActivity`, `actionDispatch`, `wire` suites
- [ ] Manual: `make dev-e2e`, focus a pane, press `Ctrl+B c`, confirm a new terminal activity appears and becomes active

🤖 Generated with [Claude Code](https://claude.com/claude-code)