### PR TITLE
Add Alacritty-compatible font config for the terminal

### DIFF
--- a/daemon/configs/src/error.rs
+++ b/daemon/configs/src/error.rs
@@ -42,6 +42,13 @@ pub enum OzmuxConfigsError {
         chord: crate::shortcuts::KeyChord,
     },
 
+    /// The configured font size is outside the supported range.
+    #[error("font size {size} is out of range (expected 0 < size <= 200)")]
+    InvalidFontSize {
+        /// The offending size value.
+        size: f32,
+    },
+
     /// Neither `$XDG_CONFIG_HOME` nor a home directory could be resolved.
     #[error("could not determine config directory (no $XDG_CONFIG_HOME and no home dir)")]
     HomeDirNotFound,

--- a/daemon/configs/src/font.rs
+++ b/daemon/configs/src/font.rs
@@ -2,14 +2,19 @@
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_FAMILY: &str = "ui-monospace, \"SF Mono\", Menlo, Consolas, monospace";
-const DEFAULT_SIZE: f32 = 16.0;
+#[cfg(target_os = "macos")]
+const DEFAULT_FAMILY: &str = "Menlo";
+#[cfg(target_os = "windows")]
+const DEFAULT_FAMILY: &str = "Consolas";
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+const DEFAULT_FAMILY: &str = "monospace";
+const DEFAULT_SIZE: f32 = 11.25;
 
 /// Fully-resolved font configuration for the terminal grid.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FontConfig {
-    /// Terminal font size in CSS pixels (deliberate deviation from
-    /// Alacritty's points — the value flows straight into a CSS `font-size`).
+    /// Terminal font size in points, matching Alacritty. The frontend
+    /// converts points to CSS pixels at render time.
     pub size: f32,
     /// Font family for normal-weight cells.
     pub normal_family: String,
@@ -93,6 +98,21 @@ mod tests {
     fn empty_patch_returns_base() {
         let merged = FontPatch::default().apply_to(FontConfig::default());
         assert_eq!(merged, FontConfig::default());
+    }
+
+    #[test]
+    fn default_matches_alacritty() {
+        let d = FontConfig::default();
+        assert_eq!(d.size, 11.25);
+        #[cfg(target_os = "macos")]
+        assert_eq!(d.normal_family, "Menlo");
+        #[cfg(target_os = "windows")]
+        assert_eq!(d.normal_family, "Consolas");
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        assert_eq!(d.normal_family, "monospace");
+        assert_eq!(d.bold_family, d.normal_family);
+        assert_eq!(d.italic_family, d.normal_family);
+        assert_eq!(d.bold_italic_family, d.normal_family);
     }
 
     #[test]

--- a/daemon/configs/src/font.rs
+++ b/daemon/configs/src/font.rs
@@ -1,0 +1,152 @@
+//! Font configuration: Alacritty-compatible `[font]` section.
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_FAMILY: &str = "ui-monospace, \"SF Mono\", Menlo, Consolas, monospace";
+const DEFAULT_SIZE: f32 = 16.0;
+
+/// Fully-resolved font configuration for the terminal grid.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct FontConfig {
+    /// Terminal font size in CSS pixels (deliberate deviation from
+    /// Alacritty's points — the value flows straight into a CSS `font-size`).
+    pub size: f32,
+    /// Font family for normal-weight cells.
+    pub normal_family: String,
+    /// Font family for bold cells.
+    pub bold_family: String,
+    /// Font family for italic cells.
+    pub italic_family: String,
+    /// Font family for bold + italic cells.
+    pub bold_italic_family: String,
+}
+
+impl Default for FontConfig {
+    fn default() -> Self {
+        Self {
+            size: DEFAULT_SIZE,
+            normal_family: DEFAULT_FAMILY.into(),
+            bold_family: DEFAULT_FAMILY.into(),
+            italic_family: DEFAULT_FAMILY.into(),
+            bold_italic_family: DEFAULT_FAMILY.into(),
+        }
+    }
+}
+
+/// Per-face TOML patch — the body of `[font.normal]`, `[font.bold]`, etc.
+#[derive(Deserialize, Default, Clone, Debug)]
+pub struct FacePatch {
+    /// Family-name override for this face.
+    pub family: Option<String>,
+    /// Alacritty's `style` key — accepted for format compatibility and
+    /// discarded (the web renderer uses CSS weight/style).
+    pub style: Option<String>,
+}
+
+/// Per-field-optional view of the `[font]` section for TOML deserialization.
+#[derive(Deserialize, Default, Clone, Debug)]
+pub struct FontPatch {
+    /// Optional `[font].size` override.
+    pub size: Option<f32>,
+    /// Optional `[font.normal]` face.
+    pub normal: Option<FacePatch>,
+    /// Optional `[font.bold]` face.
+    pub bold: Option<FacePatch>,
+    /// Optional `[font.italic]` face.
+    pub italic: Option<FacePatch>,
+    /// Optional `[font.bold_italic]` face.
+    pub bold_italic: Option<FacePatch>,
+}
+
+impl FontPatch {
+    /// Resolves the patch against `base`. Applies Alacritty's fallback:
+    /// when a bold/italic/bold_italic `family` is unset, it defaults to the
+    /// resolved `normal` family rather than the base value.
+    pub fn apply_to(self, base: FontConfig) -> FontConfig {
+        let face_family = |f: Option<FacePatch>| f.and_then(|p| p.family);
+        let normal_family = face_family(self.normal).unwrap_or(base.normal_family);
+        let bold_family = face_family(self.bold).unwrap_or_else(|| normal_family.clone());
+        let italic_family = face_family(self.italic).unwrap_or_else(|| normal_family.clone());
+        let bold_italic_family =
+            face_family(self.bold_italic).unwrap_or_else(|| normal_family.clone());
+        FontConfig {
+            size: self.size.unwrap_or(base.size),
+            normal_family,
+            bold_family,
+            italic_family,
+            bold_italic_family,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_patch_returns_base() {
+        let merged = FontPatch::default().apply_to(FontConfig::default());
+        assert_eq!(merged, FontConfig::default());
+    }
+
+    #[test]
+    fn normal_only_falls_back_to_normal_for_bold_and_italic() {
+        let patch = FontPatch {
+            normal: Some(FacePatch {
+                family: Some("Hack Nerd Font".into()),
+                style: None,
+            }),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(FontConfig::default());
+        assert_eq!(merged.normal_family, "Hack Nerd Font");
+        assert_eq!(merged.bold_family, "Hack Nerd Font");
+        assert_eq!(merged.italic_family, "Hack Nerd Font");
+        assert_eq!(merged.bold_italic_family, "Hack Nerd Font");
+    }
+
+    #[test]
+    fn explicit_bold_family_overrides_fallback() {
+        let patch = FontPatch {
+            normal: Some(FacePatch {
+                family: Some("Hack Nerd Font".into()),
+                style: None,
+            }),
+            bold: Some(FacePatch {
+                family: Some("JetBrainsMono Nerd Font".into()),
+                style: None,
+            }),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(FontConfig::default());
+        assert_eq!(merged.bold_family, "JetBrainsMono Nerd Font");
+        assert_eq!(merged.italic_family, "Hack Nerd Font");
+    }
+
+    #[test]
+    fn size_override_applies() {
+        let patch = FontPatch {
+            size: Some(18.0),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(FontConfig::default());
+        assert_eq!(merged.size, 18.0);
+    }
+
+    #[test]
+    fn face_patch_deserializes_and_ignores_style() {
+        let patch: FontPatch = toml::from_str(
+            r#"
+            size = 14.0
+            [normal]
+            family = "Hack Nerd Font"
+            style = "Regular"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(patch.size, Some(14.0));
+        let normal = patch.normal.unwrap();
+        assert_eq!(normal.family.as_deref(), Some("Hack Nerd Font"));
+        assert_eq!(normal.style.as_deref(), Some("Regular"));
+    }
+}

--- a/daemon/configs/src/font.rs
+++ b/daemon/configs/src/font.rs
@@ -40,6 +40,12 @@ pub(crate) struct FacePatch {
     pub family: Option<String>,
     /// Alacritty's `style` key — accepted for format compatibility and
     /// discarded (the web renderer uses CSS weight/style).
+    // NOTE: read only by `#[cfg(test)]` code; `#[allow]` (not `#[expect]`)
+    // because the lint fires under `cargo build` but not `cargo test`.
+    #[allow(
+        dead_code,
+        reason = "accepted for Alacritty [font.*] compatibility, never applied"
+    )]
     pub style: Option<String>,
 }
 

--- a/daemon/configs/src/font.rs
+++ b/daemon/configs/src/font.rs
@@ -35,7 +35,7 @@ impl Default for FontConfig {
 
 /// Per-face TOML patch — the body of `[font.normal]`, `[font.bold]`, etc.
 #[derive(Deserialize, Default, Clone, Debug)]
-pub struct FacePatch {
+pub(crate) struct FacePatch {
     /// Family-name override for this face.
     pub family: Option<String>,
     /// Alacritty's `style` key — accepted for format compatibility and
@@ -45,7 +45,7 @@ pub struct FacePatch {
 
 /// Per-field-optional view of the `[font]` section for TOML deserialization.
 #[derive(Deserialize, Default, Clone, Debug)]
-pub struct FontPatch {
+pub(crate) struct FontPatch {
     /// Optional `[font].size` override.
     pub size: Option<f32>,
     /// Optional `[font.normal]` face.

--- a/daemon/configs/src/lib.rs
+++ b/daemon/configs/src/lib.rs
@@ -4,11 +4,13 @@
 
 #![warn(missing_docs)]
 
+use crate::font::FontConfig;
 use crate::shortcuts::Shortcuts;
 use crate::theme::Theme;
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
 
 pub mod error;
+pub mod font;
 mod path;
 mod raw;
 pub mod shortcuts;
@@ -21,6 +23,8 @@ pub struct OzmuxConfigs {
     pub shortcuts: Shortcuts,
     /// Theme configuration.
     pub theme: Theme,
+    /// Font configuration.
+    pub font: FontConfig,
 }
 
 impl OzmuxConfigs {

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -4,6 +4,7 @@
 use crate::OzmuxConfigs;
 use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
+use crate::font::FontPatch;
 use crate::shortcuts::{Binding, Modifiers, Prefix};
 use crate::theme::ThemePatch;
 use serde::Deserialize;
@@ -14,6 +15,7 @@ use std::collections::HashSet;
 pub(crate) struct RawConfigs {
     pub(crate) shortcuts: Option<RawShortcuts>,
     pub(crate) theme: Option<ThemePatch>,
+    pub(crate) font: Option<FontPatch>,
 }
 
 /// `[shortcuts]` shape with each subfield optional.
@@ -40,6 +42,9 @@ impl RawConfigs {
         if let Some(patch) = self.theme {
             base.theme = patch.apply_to(base.theme);
         }
+        if let Some(patch) = self.font {
+            base.font = patch.apply_to(base.font);
+        }
         base
     }
 }
@@ -59,6 +64,10 @@ pub(crate) fn validate(configs: &OzmuxConfigs) -> OzmuxConfigsResult {
                 chord: b.chord.clone(),
             });
         }
+    }
+    let size = configs.font.size;
+    if !(size > 0.0 && size <= 200.0) {
+        return Err(OzmuxConfigsError::InvalidFontSize { size });
     }
     Ok(())
 }
@@ -155,5 +164,53 @@ mod tests {
     #[test]
     fn validate_accepts_default_config() {
         validate(&OzmuxConfigs::default()).unwrap();
+    }
+
+    #[test]
+    fn font_section_merges_and_falls_back() {
+        let raw: RawConfigs = toml::from_str(
+            r#"
+            [font]
+            size = 15.0
+            [font.normal]
+            family = "Hack Nerd Font"
+            style = "Regular"
+            [font.offset]
+            x = 0
+        "#,
+        )
+        .unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.font.size, 15.0);
+        assert_eq!(merged.font.normal_family, "Hack Nerd Font");
+        assert_eq!(merged.font.bold_family, "Hack Nerd Font");
+    }
+
+    #[test]
+    fn absent_font_section_keeps_defaults() {
+        let raw = RawConfigs::default();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.font, crate::font::FontConfig::default());
+    }
+
+    #[test]
+    fn validate_rejects_zero_font_size() {
+        let raw: RawConfigs = toml::from_str("[font]\nsize = 0.0\n").unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        let err = validate(&merged).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::OzmuxConfigsError::InvalidFontSize { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_oversized_font() {
+        let raw: RawConfigs = toml::from_str("[font]\nsize = 999.0\n").unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert!(matches!(
+            validate(&merged).unwrap_err(),
+            crate::OzmuxConfigsError::InvalidFontSize { .. }
+        ));
     }
 }

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -66,7 +66,7 @@ pub(crate) fn validate(configs: &OzmuxConfigs) -> OzmuxConfigsResult {
         }
     }
     let size = configs.font.size;
-    if size <= 0.0 || size > 200.0 {
+    if !(size > 0.0 && size <= 200.0) {
         return Err(OzmuxConfigsError::InvalidFontSize { size });
     }
     Ok(())
@@ -207,6 +207,16 @@ mod tests {
     #[test]
     fn validate_rejects_oversized_font() {
         let raw: RawConfigs = toml::from_str("[font]\nsize = 999.0\n").unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert!(matches!(
+            validate(&merged).unwrap_err(),
+            crate::OzmuxConfigsError::InvalidFontSize { .. }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_nan_font_size() {
+        let raw: RawConfigs = toml::from_str("[font]\nsize = nan\n").unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert!(matches!(
             validate(&merged).unwrap_err(),

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -28,8 +28,8 @@ pub(crate) struct RawShortcuts {
 impl RawConfigs {
     /// Applies any populated fields onto `base` and returns the merged result.
     /// Within the `shortcuts` section, `prefix` and `bindings` are independently
-    /// optional; `bindings` is full-replace. The `theme` section uses
-    /// `ThemePatch::apply_to` for per-field merge.
+    /// optional; `bindings` is full-replace. The `theme` and `font` sections use
+    /// their respective `Patch::apply_to` for per-field merge.
     pub(crate) fn apply_to(self, mut base: OzmuxConfigs) -> OzmuxConfigs {
         if let Some(raw) = self.shortcuts {
             if let Some(prefix) = raw.prefix {
@@ -66,7 +66,7 @@ pub(crate) fn validate(configs: &OzmuxConfigs) -> OzmuxConfigsResult {
         }
     }
     let size = configs.font.size;
-    if !(size > 0.0 && size <= 200.0) {
+    if size <= 0.0 || size > 200.0 {
         return Err(OzmuxConfigsError::InvalidFontSize { size });
     }
     Ok(())

--- a/daemon/frontend/src/config/font.test.ts
+++ b/daemon/frontend/src/config/font.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getFontConfig, loadFontConfig, preloadFonts } from './font';
+import { getFontConfig, loadFontConfig, pointsToPx, preloadFonts } from './font';
 
 const origFetch = globalThis.fetch;
 
@@ -35,8 +35,14 @@ describe('loadFontConfig', () => {
       .fn<typeof fetch>()
       .mockResolvedValue({ ok: false, status: 500, statusText: 'err' } as Response);
     await loadFontConfig();
-    expect(getFontConfig().size).toBe(16);
-    expect(getFontConfig().normalFamily).toContain('ui-monospace');
+    expect(getFontConfig().size).toBe(11.25);
+    expect(getFontConfig().normalFamily).toBe('monospace');
+  });
+});
+
+describe('pointsToPx', () => {
+  it("converts points to CSS pixels (Alacritty's 11.25pt = 15px)", () => {
+    expect(pointsToPx(11.25)).toBe(15);
   });
 });
 

--- a/daemon/frontend/src/config/font.test.ts
+++ b/daemon/frontend/src/config/font.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getFontConfig, loadFontConfig } from './font';
+
+const origFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+});
+
+describe('loadFontConfig', () => {
+  it('populates the singleton from /configs/font', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        size: 18,
+        normal_family: 'Hack Nerd Font',
+        bold_family: 'Hack Nerd Font',
+        italic_family: 'Hack Nerd Font',
+        bold_italic_family: 'Hack Nerd Font',
+      }),
+    } as Response);
+    await loadFontConfig();
+    expect(getFontConfig()).toEqual({
+      size: 18,
+      normalFamily: 'Hack Nerd Font',
+      boldFamily: 'Hack Nerd Font',
+      italicFamily: 'Hack Nerd Font',
+      boldItalicFamily: 'Hack Nerd Font',
+    });
+  });
+
+  it('falls back to defaults when the fetch fails', async () => {
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue({ ok: false, status: 500, statusText: 'err' } as Response);
+    await loadFontConfig();
+    expect(getFontConfig().size).toBe(16);
+    expect(getFontConfig().normalFamily).toContain('ui-monospace');
+  });
+});

--- a/daemon/frontend/src/config/font.test.ts
+++ b/daemon/frontend/src/config/font.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getFontConfig, loadFontConfig } from './font';
+import { getFontConfig, loadFontConfig, preloadFonts } from './font';
 
 const origFetch = globalThis.fetch;
 
@@ -37,5 +37,17 @@ describe('loadFontConfig', () => {
     await loadFontConfig();
     expect(getFontConfig().size).toBe(16);
     expect(getFontConfig().normalFamily).toContain('ui-monospace');
+  });
+});
+
+describe('preloadFonts', () => {
+  it('resolves without throwing when document.fonts is unavailable', async () => {
+    const orig = document.fonts;
+    Object.defineProperty(document, 'fonts', { value: undefined, configurable: true });
+    try {
+      await expect(preloadFonts()).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(document, 'fonts', { value: orig, configurable: true });
+    }
   });
 });

--- a/daemon/frontend/src/config/font.ts
+++ b/daemon/frontend/src/config/font.ts
@@ -1,0 +1,77 @@
+/**
+ * Terminal font configuration fetched from `GET /configs/font`. Held in a
+ * module singleton so the renderer's runtime stylesheet (`palette.ts`) can
+ * read it synchronously. `loadFontConfig` must resolve before the first
+ * render — see `main.tsx`.
+ */
+import { fetchJson } from '../fetchJson';
+
+/** Resolved terminal font configuration (camelCase view of the API JSON). */
+export interface FontConfig {
+  size: number;
+  normalFamily: string;
+  boldFamily: string;
+  italicFamily: string;
+  boldItalicFamily: string;
+}
+
+const FALLBACK_STACK = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
+
+const DEFAULT_FONT_CONFIG: FontConfig = {
+  size: 16,
+  normalFamily: FALLBACK_STACK,
+  boldFamily: FALLBACK_STACK,
+  italicFamily: FALLBACK_STACK,
+  boldItalicFamily: FALLBACK_STACK,
+};
+
+let current: FontConfig = DEFAULT_FONT_CONFIG;
+
+/** Returns the active terminal font configuration. */
+export function getFontConfig(): FontConfig {
+  return current;
+}
+
+function str(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+/** Fetches `/configs/font` and updates the singleton. On any failure the
+ *  singleton is left at (or reset to) the built-in defaults. */
+export async function loadFontConfig(): Promise<void> {
+  try {
+    const raw = (await fetchJson('/configs/font')) as Record<string, unknown>;
+    current = {
+      size: typeof raw.size === 'number' && raw.size > 0 ? raw.size : DEFAULT_FONT_CONFIG.size,
+      normalFamily: str(raw.normal_family, FALLBACK_STACK),
+      boldFamily: str(raw.bold_family, FALLBACK_STACK),
+      italicFamily: str(raw.italic_family, FALLBACK_STACK),
+      boldItalicFamily: str(raw.bold_italic_family, FALLBACK_STACK),
+    };
+  } catch (e) {
+    console.warn('loadFontConfig: fetch failed, using defaults', e);
+    current = DEFAULT_FONT_CONFIG;
+  }
+}
+
+/** Forces each configured family into the browser FontFaceSet so cell
+ *  metrics are probed against the real font. `document.fonts.ready` alone
+ *  is unreliable for OS-installed (non-`@font-face`) fonts. */
+export async function preloadFonts(): Promise<void> {
+  if (typeof document === 'undefined' || !document.fonts) return;
+  const families = new Set([
+    current.normalFamily,
+    current.boldFamily,
+    current.italicFamily,
+    current.boldItalicFamily,
+  ]);
+  await Promise.all(
+    [...families].map(async (family) => {
+      try {
+        await document.fonts.load(`${current.size}px ${family}`);
+      } catch {
+        // Unparseable / unknown family — the CSS fallback handles it.
+      }
+    }),
+  );
+}

--- a/daemon/frontend/src/config/font.ts
+++ b/daemon/frontend/src/config/font.ts
@@ -15,15 +15,20 @@ export interface FontConfig {
   boldItalicFamily: string;
 }
 
-const FALLBACK_STACK = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace';
+const FALLBACK_FAMILY = 'monospace';
 
 const DEFAULT_FONT_CONFIG: FontConfig = {
-  size: 16,
-  normalFamily: FALLBACK_STACK,
-  boldFamily: FALLBACK_STACK,
-  italicFamily: FALLBACK_STACK,
-  boldItalicFamily: FALLBACK_STACK,
+  size: 11.25,
+  normalFamily: FALLBACK_FAMILY,
+  boldFamily: FALLBACK_FAMILY,
+  italicFamily: FALLBACK_FAMILY,
+  boldItalicFamily: FALLBACK_FAMILY,
 };
+
+/** Converts a points value to CSS pixels (CSS defines 1pt = 4/3 px). */
+export function pointsToPx(points: number): number {
+  return (points * 4) / 3;
+}
 
 let current: FontConfig = DEFAULT_FONT_CONFIG;
 
@@ -43,10 +48,10 @@ export async function loadFontConfig(): Promise<void> {
     const raw = (await fetchJson('/configs/font')) as Record<string, unknown>;
     current = {
       size: typeof raw.size === 'number' && raw.size > 0 ? raw.size : DEFAULT_FONT_CONFIG.size,
-      normalFamily: str(raw.normal_family, FALLBACK_STACK),
-      boldFamily: str(raw.bold_family, FALLBACK_STACK),
-      italicFamily: str(raw.italic_family, FALLBACK_STACK),
-      boldItalicFamily: str(raw.bold_italic_family, FALLBACK_STACK),
+      normalFamily: str(raw.normal_family, FALLBACK_FAMILY),
+      boldFamily: str(raw.bold_family, FALLBACK_FAMILY),
+      italicFamily: str(raw.italic_family, FALLBACK_FAMILY),
+      boldItalicFamily: str(raw.bold_italic_family, FALLBACK_FAMILY),
     };
   } catch (e) {
     console.warn('loadFontConfig: failed to load or parse font config, using defaults', e);
@@ -68,7 +73,7 @@ export async function preloadFonts(): Promise<void> {
   await Promise.all(
     [...families].map(async (family) => {
       try {
-        await document.fonts.load(`${current.size}px ${family}`);
+        await document.fonts.load(`${pointsToPx(current.size)}px ${family}`);
       } catch {
         // Unparseable / unknown family — the CSS fallback handles it.
       }

--- a/daemon/frontend/src/config/font.ts
+++ b/daemon/frontend/src/config/font.ts
@@ -49,7 +49,7 @@ export async function loadFontConfig(): Promise<void> {
       boldItalicFamily: str(raw.bold_italic_family, FALLBACK_STACK),
     };
   } catch (e) {
-    console.warn('loadFontConfig: fetch failed, using defaults', e);
+    console.warn('loadFontConfig: failed to load or parse font config, using defaults', e);
     current = DEFAULT_FONT_CONFIG;
   }
 }

--- a/daemon/frontend/src/main.tsx
+++ b/daemon/frontend/src/main.tsx
@@ -2,25 +2,32 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/theme.css';
 import { App } from './App.tsx';
+import { loadFontConfig, preloadFonts } from './config/font';
 
-const params = new URLSearchParams(window.location.search);
-const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
-const rootElement = document.getElementById('root');
-if (!rootElement) throw new Error('#root element not found');
-const root = createRoot(rootElement);
+async function bootstrap(): Promise<void> {
+  await loadFontConfig();
+  await preloadFonts();
 
-if (isShowcase) {
-  import('./showcase/TokenShowcase').then(({ TokenShowcase }) => {
+  const params = new URLSearchParams(window.location.search);
+  const isShowcase = import.meta.env.DEV && params.get('showcase') === 'tokens';
+  const rootElement = document.getElementById('root');
+  if (!rootElement) throw new Error('#root element not found');
+  const root = createRoot(rootElement);
+
+  if (isShowcase) {
+    const { TokenShowcase } = await import('./showcase/TokenShowcase');
     root.render(
       <StrictMode>
         <TokenShowcase />
       </StrictMode>,
     );
-  });
-} else {
-  root.render(
-    <StrictMode>
-      <App />
-    </StrictMode>,
-  );
+  } else {
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  }
 }
+
+void bootstrap();

--- a/daemon/frontend/src/terminal/renderer/Row.test.tsx
+++ b/daemon/frontend/src/terminal/renderer/Row.test.tsx
@@ -249,3 +249,43 @@ describe('Row links', () => {
     expect(out.querySelector('a')?.getAttribute('href')).toBe('https://overridden.example');
   });
 });
+
+describe('Row per-style font-family classes', () => {
+  it('applies tf-bold to a bold run', () => {
+    const cells: Cell[] = [makeCell({ text: 'A', style: 0b000001 /* STYLE_BOLD */ })];
+    const { container: out } = render(
+      <Row cells={cells} version={1} fm={fakeFm} hyperlinks={noHyperlinks} probeRef={container} />,
+    );
+    const span = out.querySelector('span');
+    expect(span?.className).toContain('tf-bold');
+  });
+
+  it('applies tf-italic to an italic run', () => {
+    const cells: Cell[] = [makeCell({ text: 'B', style: 0b000010 /* STYLE_ITALIC */ })];
+    const { container: out } = render(
+      <Row cells={cells} version={1} fm={fakeFm} hyperlinks={noHyperlinks} probeRef={container} />,
+    );
+    const span = out.querySelector('span');
+    expect(span?.className).toContain('tf-italic');
+  });
+
+  it('applies tf-bold-italic to a bold+italic run', () => {
+    const cells: Cell[] = [
+      makeCell({ text: 'C', style: 0b000011 /* STYLE_BOLD | STYLE_ITALIC */ }),
+    ];
+    const { container: out } = render(
+      <Row cells={cells} version={1} fm={fakeFm} hyperlinks={noHyperlinks} probeRef={container} />,
+    );
+    const span = out.querySelector('span');
+    expect(span?.className).toContain('tf-bold-italic');
+  });
+
+  it('does not add a tf-* class to a plain run', () => {
+    const cells: Cell[] = [makeCell({ text: 'D', style: 0 })];
+    const { container: out } = render(
+      <Row cells={cells} version={1} fm={fakeFm} hyperlinks={noHyperlinks} probeRef={container} />,
+    );
+    const span = out.querySelector('span');
+    expect(span?.className).not.toMatch(/tf-/);
+  });
+});

--- a/daemon/frontend/src/terminal/renderer/Row.tsx
+++ b/daemon/frontend/src/terminal/renderer/Row.tsx
@@ -13,7 +13,7 @@ import { clsx } from 'clsx';
 import { memo } from 'react';
 import type { Color } from '../protocol/frame';
 import { colorToCss, dimColor } from './colors';
-import { measureGlyph } from './font';
+import { faceClass, measureGlyph } from './font';
 import type { Cell } from './grid';
 
 interface RowProps {
@@ -59,12 +59,7 @@ function styleClasses(style: number): string {
 }
 
 function familyClass(style: number): string {
-  const bold = (style & STYLE_BOLD) !== 0;
-  const italic = (style & STYLE_ITALIC) !== 0;
-  if (bold && italic) return 'tf-bold-italic';
-  if (bold) return 'tf-bold';
-  if (italic) return 'tf-italic';
-  return '';
+  return faceClass((style & STYLE_BOLD) !== 0, (style & STYLE_ITALIC) !== 0);
 }
 
 function colorClass(c: Color, channel: 'fg' | 'bg'): string {

--- a/daemon/frontend/src/terminal/renderer/Row.tsx
+++ b/daemon/frontend/src/terminal/renderer/Row.tsx
@@ -58,6 +58,15 @@ function styleClasses(style: number): string {
   );
 }
 
+function familyClass(style: number): string {
+  const bold = (style & STYLE_BOLD) !== 0;
+  const italic = (style & STYLE_ITALIC) !== 0;
+  if (bold && italic) return 'tf-bold-italic';
+  if (bold) return 'tf-bold';
+  if (italic) return 'tf-italic';
+  return '';
+}
+
 function colorClass(c: Color, channel: 'fg' | 'bg'): string {
   if (c === null) return `${channel}-default`;
   if (typeof c === 'number') return `${channel}-${c}`;
@@ -214,7 +223,7 @@ export const Row = memo(function Row({ cells, fm, hyperlinks, probeRef }: RowPro
         const bgClass = !Array.isArray(run.bg)
           ? colorClass(run.style & STYLE_REVERSE ? run.fg : run.bg, 'bg')
           : '';
-        const attrClasses = styleClasses(run.style);
+        const attrClasses = clsx(styleClasses(run.style), familyClass(run.style));
         const inlineStyle: React.CSSProperties = colorInlineStyle(run.fg, run.bg, run.style);
         const text = swapSpacesForDecoration(run.text, run.style);
 

--- a/daemon/frontend/src/terminal/renderer/font.test.ts
+++ b/daemon/frontend/src/terminal/renderer/font.test.ts
@@ -117,13 +117,14 @@ describe('probe classes', () => {
     }) as typeof container.appendChild;
     try {
       cellWidthOf(container);
-      expect(seen.some((c) => c.includes('ozmux-font-probe'))).toBe(true);
+      expect(seen.some((c) => c.split(' ').includes('ozmux-font-probe'))).toBe(true);
     } finally {
       document.body.removeChild(container);
     }
   });
 
   it('measureGlyph bold probe carries tf-bold', () => {
+    injectTerminalPalette();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const seen: string[] = [];
@@ -134,7 +135,7 @@ describe('probe classes', () => {
     }) as typeof container.appendChild;
     try {
       measureGlyph(container, 'x', true, false);
-      expect(seen.some((c) => c.includes('tf-bold'))).toBe(true);
+      expect(seen.some((c) => c.split(' ').includes('tf-bold'))).toBe(true);
     } finally {
       document.body.removeChild(container);
     }

--- a/daemon/frontend/src/terminal/renderer/font.test.ts
+++ b/daemon/frontend/src/terminal/renderer/font.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { cellHeightOf, cellWidthOf, measureGlyph, widthOfGrapheme } from './font';
+import { injectTerminalPalette, removeTerminalPalette } from './palette';
 
 describe('widthOfGrapheme', () => {
   it('returns 1 for ASCII', () => {
@@ -95,6 +96,45 @@ describe('measureGlyph', () => {
       // jsdom returns the same width for both; we only assert no crash + numeric output.
       expect(typeof plain).toBe('number');
       expect(typeof bold).toBe('number');
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+});
+
+describe('probe classes', () => {
+  afterEach(() => removeTerminalPalette());
+
+  it('cellWidthOf probe carries the ozmux-font-probe class', () => {
+    injectTerminalPalette();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const seen: string[] = [];
+    const origAppend = container.appendChild.bind(container);
+    container.appendChild = ((node: Node) => {
+      if (node instanceof HTMLElement) seen.push(node.className);
+      return origAppend(node);
+    }) as typeof container.appendChild;
+    try {
+      cellWidthOf(container);
+      expect(seen.some((c) => c.includes('ozmux-font-probe'))).toBe(true);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
+  it('measureGlyph bold probe carries tf-bold', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const seen: string[] = [];
+    const origAppend = container.appendChild.bind(container);
+    container.appendChild = ((node: Node) => {
+      if (node instanceof HTMLElement) seen.push(node.className);
+      return origAppend(node);
+    }) as typeof container.appendChild;
+    try {
+      measureGlyph(container, 'x', true, false);
+      expect(seen.some((c) => c.includes('tf-bold'))).toBe(true);
     } finally {
       document.body.removeChild(container);
     }

--- a/daemon/frontend/src/terminal/renderer/font.ts
+++ b/daemon/frontend/src/terminal/renderer/font.ts
@@ -14,6 +14,28 @@ export interface FontMetrics {
   dpr: number;
 }
 
+/** Class that makes an element pick up the configured terminal font and size
+ *  from the runtime palette stylesheet (`palette.ts`). `font-mono` is the
+ *  pre-injection fallback. */
+export const PROBE_CLASS = 'ozmux-font-probe';
+
+/** Per-style font-family classes emitted by `palette.ts` and applied to run
+ *  spans (`Row.tsx`) and glyph probes. */
+export const FACE_BOLD = 'tf-bold';
+export const FACE_ITALIC = 'tf-italic';
+export const FACE_BOLD_ITALIC = 'tf-bold-italic';
+
+const PROBE_BASE_CLASS = `font-mono ${PROBE_CLASS} leading-none`;
+
+/** Returns the `tf-*` font-family class for a (bold, italic) pair, or `''`
+ *  for the normal face. */
+export function faceClass(bold: boolean, italic: boolean): string {
+  if (bold && italic) return FACE_BOLD_ITALIC;
+  if (bold) return FACE_BOLD;
+  if (italic) return FACE_ITALIC;
+  return '';
+}
+
 /** Returns the column width of one grapheme cluster (0, 1, or 2). */
 export function widthOfGrapheme(text: string): 0 | 1 | 2 {
   const w = stringWidth(text);
@@ -22,50 +44,48 @@ export function widthOfGrapheme(text: string): 0 | 1 | 2 {
   return 1;
 }
 
-/** Measures the rendered width of "W" in the monospace font.
- *  Used by Row.tsx for `letterSpacing = cellW - cellWidthOf(...)` to prevent
- *  sub-pixel drift on long rows (xterm.js `DomRenderer._setDefaultSpacing`).
- *
- *  NOTE: probe carries `font-mono ozmux-font-probe leading-none` — `ozmux-font-probe` is
- *  what makes the probe pick up the configured terminal font/size from the runtime palette
- *  stylesheet (`palette.ts`); `font-mono` is the pre-injection fallback. `container` only
- *  determines where the probe is attached (so it inherits the same theme tokens / parent
- *  stacking context). The container's own font does NOT need to be monospace. */
+/** Creates a hidden measurement probe inside `container`, reads its bounding
+ *  rect via `read`, then removes it. `container` only determines where the
+ *  probe attaches (for theme-token / stacking-context inheritance) — the
+ *  probe's own classes drive the measured font. */
+function withProbe<T>(
+  container: HTMLElement,
+  className: string,
+  text: string,
+  read: (rect: DOMRect) => T,
+  configure?: (probe: HTMLElement) => void,
+): T {
+  const probe = document.createElement('span');
+  probe.style.visibility = 'hidden';
+  probe.style.position = 'absolute';
+  probe.style.whiteSpace = 'pre';
+  probe.className = className;
+  configure?.(probe);
+  probe.textContent = text;
+  container.appendChild(probe);
+  const result = read(probe.getBoundingClientRect());
+  container.removeChild(probe);
+  return result;
+}
+
+/** Measures the rendered width of "W" in the terminal font. Used by Row.tsx
+ *  for `letterSpacing = cellW - cellWidthOf(...)` to prevent sub-pixel drift
+ *  on long rows (xterm.js `DomRenderer._setDefaultSpacing`). */
 export function cellWidthOf(container: HTMLElement): number {
-  const probe = document.createElement('span');
-  probe.style.visibility = 'hidden';
-  probe.style.position = 'absolute';
-  probe.style.whiteSpace = 'pre';
-  probe.className = 'font-mono ozmux-font-probe leading-none';
-  probe.textContent = 'W';
-  container.appendChild(probe);
-  const width = probe.getBoundingClientRect().width;
-  container.removeChild(probe);
-  return width;
+  return withProbe(container, PROBE_BASE_CLASS, 'W', (r) => r.width);
 }
 
-/** Measures the rendered line-height-1 height of one row in the monospace
- *  font. Mirrors `.terminal-grid` environment (font-mono ozmux-font-probe leading-none) so
- *  `cellH` matches the actual row line-box height.
- *
- *  NOTE: `ozmux-font-probe` picks up the configured terminal font/size from the runtime
- *  palette stylesheet (`palette.ts`); `font-mono` is the pre-injection fallback. */
+/** Measures the line-height-1 height of one row in the terminal font, so
+ *  `cellH` matches the actual row line-box height. */
 export function cellHeightOf(container: HTMLElement): number {
-  const probe = document.createElement('span');
-  probe.style.visibility = 'hidden';
-  probe.style.position = 'absolute';
-  probe.style.whiteSpace = 'pre';
-  probe.className = 'font-mono ozmux-font-probe leading-none';
-  probe.textContent = 'W';
-  container.appendChild(probe);
-  const height = probe.getBoundingClientRect().height;
-  container.removeChild(probe);
-  return height;
+  return withProbe(container, PROBE_BASE_CLASS, 'W', (r) => r.height);
 }
 
+// NOTE: keyed by (chars, bold, italic) only — must be cleared if the font
+// config changes at runtime (currently loaded once before first render).
 const glyphWidthCache = new Map<string, number>();
 
-/** Measures the rendered width of `chars` in the monospace font, optionally
+/** Measures the rendered width of `chars` in the terminal font, optionally
  *  with bold / italic applied. Cached by (chars, bold, italic) key. */
 export function measureGlyph(
   container: HTMLElement,
@@ -76,19 +96,17 @@ export function measureGlyph(
   const key = `${bold ? 'b' : ''}${italic ? 'i' : ''}|${chars}`;
   const hit = glyphWidthCache.get(key);
   if (hit !== undefined) return hit;
-  const probe = document.createElement('span');
-  probe.style.visibility = 'hidden';
-  probe.style.position = 'absolute';
-  probe.style.whiteSpace = 'pre';
-  const styleClass =
-    bold && italic ? ' tf-bold-italic' : bold ? ' tf-bold' : italic ? ' tf-italic' : '';
-  probe.className = `font-mono ozmux-font-probe leading-none${styleClass}`;
-  if (bold) probe.style.fontWeight = 'bold';
-  if (italic) probe.style.fontStyle = 'italic';
-  probe.textContent = chars;
-  container.appendChild(probe);
-  const width = probe.getBoundingClientRect().width;
-  container.removeChild(probe);
+  const face = faceClass(bold, italic);
+  const width = withProbe(
+    container,
+    face ? `${PROBE_BASE_CLASS} ${face}` : PROBE_BASE_CLASS,
+    chars,
+    (r) => r.width,
+    (probe) => {
+      if (bold) probe.style.fontWeight = 'bold';
+      if (italic) probe.style.fontStyle = 'italic';
+    },
+  );
   glyphWidthCache.set(key, width);
   return width;
 }

--- a/daemon/frontend/src/terminal/renderer/font.ts
+++ b/daemon/frontend/src/terminal/renderer/font.ts
@@ -26,10 +26,11 @@ export function widthOfGrapheme(text: string): 0 | 1 | 2 {
  *  Used by Row.tsx for `letterSpacing = cellW - cellWidthOf(...)` to prevent
  *  sub-pixel drift on long rows (xterm.js `DomRenderer._setDefaultSpacing`).
  *
- *  NOTE: probe carries `font-mono leading-none` so the measurement matches
- *  `.terminal-grid` itself — `container` only determines where the probe is
- *  attached (so it inherits the same theme tokens / parent stacking context).
- *  The container's own font does NOT need to be monospace. */
+ *  NOTE: probe carries `font-mono ozmux-font-probe leading-none` — `ozmux-font-probe` is
+ *  what makes the probe pick up the configured terminal font/size from the runtime palette
+ *  stylesheet (`palette.ts`); `font-mono` is the pre-injection fallback. `container` only
+ *  determines where the probe is attached (so it inherits the same theme tokens / parent
+ *  stacking context). The container's own font does NOT need to be monospace. */
 export function cellWidthOf(container: HTMLElement): number {
   const probe = document.createElement('span');
   probe.style.visibility = 'hidden';
@@ -44,8 +45,11 @@ export function cellWidthOf(container: HTMLElement): number {
 }
 
 /** Measures the rendered line-height-1 height of one row in the monospace
- *  font. Mirrors `.terminal-grid` environment (font-mono + leading-none) so
- *  `cellH` matches the actual row line-box height. */
+ *  font. Mirrors `.terminal-grid` environment (font-mono ozmux-font-probe leading-none) so
+ *  `cellH` matches the actual row line-box height.
+ *
+ *  NOTE: `ozmux-font-probe` picks up the configured terminal font/size from the runtime
+ *  palette stylesheet (`palette.ts`); `font-mono` is the pre-injection fallback. */
 export function cellHeightOf(container: HTMLElement): number {
   const probe = document.createElement('span');
   probe.style.visibility = 'hidden';

--- a/daemon/frontend/src/terminal/renderer/font.ts
+++ b/daemon/frontend/src/terminal/renderer/font.ts
@@ -35,7 +35,7 @@ export function cellWidthOf(container: HTMLElement): number {
   probe.style.visibility = 'hidden';
   probe.style.position = 'absolute';
   probe.style.whiteSpace = 'pre';
-  probe.className = 'font-mono leading-none';
+  probe.className = 'font-mono ozmux-font-probe leading-none';
   probe.textContent = 'W';
   container.appendChild(probe);
   const width = probe.getBoundingClientRect().width;
@@ -51,7 +51,7 @@ export function cellHeightOf(container: HTMLElement): number {
   probe.style.visibility = 'hidden';
   probe.style.position = 'absolute';
   probe.style.whiteSpace = 'pre';
-  probe.className = 'font-mono leading-none';
+  probe.className = 'font-mono ozmux-font-probe leading-none';
   probe.textContent = 'W';
   container.appendChild(probe);
   const height = probe.getBoundingClientRect().height;
@@ -76,7 +76,9 @@ export function measureGlyph(
   probe.style.visibility = 'hidden';
   probe.style.position = 'absolute';
   probe.style.whiteSpace = 'pre';
-  probe.className = 'font-mono leading-none';
+  const styleClass =
+    bold && italic ? ' tf-bold-italic' : bold ? ' tf-bold' : italic ? ' tf-italic' : '';
+  probe.className = `font-mono ozmux-font-probe leading-none${styleClass}`;
   if (bold) probe.style.fontWeight = 'bold';
   if (italic) probe.style.fontStyle = 'italic';
   probe.textContent = chars;

--- a/daemon/frontend/src/terminal/renderer/palette.test.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.test.ts
@@ -69,7 +69,7 @@ describe('injectTerminalPalette font rules', () => {
     injectTerminalPalette();
     const css = document.getElementById(STYLE_ID)?.textContent ?? '';
     expect(css).toMatch(/\.terminal-grid\s*\{[^}]*font-family:/);
-    expect(css).toMatch(/\.terminal-grid\s*\{[^}]*font-size:\s*16px/);
+    expect(css).toMatch(/\.terminal-grid\s*\{[^}]*font-size:\s*15px/);
   });
 
   it('emits per-style family classes for runs and probes', () => {

--- a/daemon/frontend/src/terminal/renderer/palette.test.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { injectTerminalPalette, removeTerminalPalette } from './palette';
-
-const STYLE_ID = 'ozmux-terminal-palette';
+import { injectTerminalPalette, removeTerminalPalette, STYLE_ID } from './palette';
 
 afterEach(() => {
   removeTerminalPalette();

--- a/daemon/frontend/src/terminal/renderer/palette.test.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.test.ts
@@ -75,10 +75,10 @@ describe('injectTerminalPalette font rules', () => {
   it('emits per-style family classes for runs and probes', () => {
     injectTerminalPalette();
     const css = document.getElementById(STYLE_ID)?.textContent ?? '';
-    expect(css).toContain('.terminal-grid .tf-bold');
+    expect(css).toContain('.terminal-grid .tf-bold { font-family:');
     expect(css).toContain('.terminal-grid .tf-italic');
     expect(css).toContain('.terminal-grid .tf-bold-italic');
     expect(css).toContain('.ozmux-font-probe');
-    expect(css).toContain('.ozmux-font-probe.tf-bold');
+    expect(css).toContain('.ozmux-font-probe.tf-bold { font-family:');
   });
 });

--- a/daemon/frontend/src/terminal/renderer/palette.test.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.test.ts
@@ -63,3 +63,22 @@ describe('injectTerminalPalette', () => {
     expect(styles.length).toBe(1);
   });
 });
+
+describe('injectTerminalPalette font rules', () => {
+  it('emits .terminal-grid font-family and font-size from the font config', () => {
+    injectTerminalPalette();
+    const css = document.getElementById(STYLE_ID)?.textContent ?? '';
+    expect(css).toMatch(/\.terminal-grid\s*\{[^}]*font-family:/);
+    expect(css).toMatch(/\.terminal-grid\s*\{[^}]*font-size:\s*16px/);
+  });
+
+  it('emits per-style family classes for runs and probes', () => {
+    injectTerminalPalette();
+    const css = document.getElementById(STYLE_ID)?.textContent ?? '';
+    expect(css).toContain('.terminal-grid .tf-bold');
+    expect(css).toContain('.terminal-grid .tf-italic');
+    expect(css).toContain('.terminal-grid .tf-bold-italic');
+    expect(css).toContain('.ozmux-font-probe');
+    expect(css).toContain('.ozmux-font-probe.tf-bold');
+  });
+});

--- a/daemon/frontend/src/terminal/renderer/palette.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.ts
@@ -3,9 +3,24 @@
 //! issue #4445 (CSP unsafe-inline) drove this pattern; truecolor stays on
 //! inline style. Re-invocation on theme/font/options change is idempotent.
 
+import { getFontConfig } from '../../config/font';
 import { colorToCss } from './colors';
 
 const STYLE_ID = 'ozmux-terminal-palette';
+
+function fontCss(): string {
+  const f = getFontConfig();
+  return [
+    `.terminal-grid { font-family: ${f.normalFamily}, monospace; font-size: ${f.size}px; }`,
+    `.terminal-grid .tf-bold { font-family: ${f.boldFamily}, monospace; }`,
+    `.terminal-grid .tf-italic { font-family: ${f.italicFamily}, monospace; }`,
+    `.terminal-grid .tf-bold-italic { font-family: ${f.boldItalicFamily}, monospace; }`,
+    `.ozmux-font-probe { font-family: ${f.normalFamily}, monospace; font-size: ${f.size}px; }`,
+    `.ozmux-font-probe.tf-bold { font-family: ${f.boldFamily}, monospace; }`,
+    `.ozmux-font-probe.tf-italic { font-family: ${f.italicFamily}, monospace; }`,
+    `.ozmux-font-probe.tf-bold-italic { font-family: ${f.boldItalicFamily}, monospace; }`,
+  ].join('\n');
+}
 
 function buildPaletteCss(): string {
   const lines: string[] = [];
@@ -29,6 +44,7 @@ function buildPaletteCss(): string {
   lines.push(`.terminal-grid span, .terminal-grid a { vertical-align: top; }`);
   // Native selection color uses theme token.
   lines.push(`.terminal-grid ::selection { background-color: var(--color-selection); }`);
+  lines.push(fontCss());
   return lines.join('\n');
 }
 

--- a/daemon/frontend/src/terminal/renderer/palette.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.ts
@@ -3,7 +3,7 @@
 //! issue #4445 (CSP unsafe-inline) drove this pattern; truecolor stays on
 //! inline style. Re-invocation on theme/font/options change is idempotent.
 
-import { getFontConfig } from '../../config/font';
+import { getFontConfig, pointsToPx } from '../../config/font';
 import { colorToCss } from './colors';
 
 const STYLE_ID = 'ozmux-terminal-palette';
@@ -11,11 +11,11 @@ const STYLE_ID = 'ozmux-terminal-palette';
 function fontCss(): string {
   const font = getFontConfig();
   return [
-    `.terminal-grid { font-family: ${font.normalFamily}, monospace; font-size: ${font.size}px; }`,
+    `.terminal-grid { font-family: ${font.normalFamily}, monospace; font-size: ${pointsToPx(font.size)}px; }`,
     `.terminal-grid .tf-bold { font-family: ${font.boldFamily}, monospace; }`,
     `.terminal-grid .tf-italic { font-family: ${font.italicFamily}, monospace; }`,
     `.terminal-grid .tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,
-    `.ozmux-font-probe { font-family: ${font.normalFamily}, monospace; font-size: ${font.size}px; }`,
+    `.ozmux-font-probe { font-family: ${font.normalFamily}, monospace; font-size: ${pointsToPx(font.size)}px; }`,
     `.ozmux-font-probe.tf-bold { font-family: ${font.boldFamily}, monospace; }`,
     `.ozmux-font-probe.tf-italic { font-family: ${font.italicFamily}, monospace; }`,
     `.ozmux-font-probe.tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,

--- a/daemon/frontend/src/terminal/renderer/palette.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.ts
@@ -5,21 +5,29 @@
 
 import { getFontConfig, pointsToPx } from '../../config/font';
 import { colorToCss } from './colors';
+import { FACE_BOLD, FACE_BOLD_ITALIC, FACE_ITALIC, PROBE_CLASS } from './font';
 
-const STYLE_ID = 'ozmux-terminal-palette';
+/** Element id of the runtime terminal stylesheet. */
+export const STYLE_ID = 'ozmux-terminal-palette';
 
 function fontCss(): string {
   const font = getFontConfig();
-  return [
-    `.terminal-grid { font-family: ${font.normalFamily}, monospace; font-size: ${pointsToPx(font.size)}px; }`,
-    `.terminal-grid .tf-bold { font-family: ${font.boldFamily}, monospace; }`,
-    `.terminal-grid .tf-italic { font-family: ${font.italicFamily}, monospace; }`,
-    `.terminal-grid .tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,
-    `.ozmux-font-probe { font-family: ${font.normalFamily}, monospace; font-size: ${pointsToPx(font.size)}px; }`,
-    `.ozmux-font-probe.tf-bold { font-family: ${font.boldFamily}, monospace; }`,
-    `.ozmux-font-probe.tf-italic { font-family: ${font.italicFamily}, monospace; }`,
-    `.ozmux-font-probe.tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,
-  ].join('\n');
+  const sizeRule = `font-size: ${pointsToPx(font.size)}px;`;
+  // Each face: the tf-* class (empty for normal) and its resolved family.
+  const faces: ReadonlyArray<readonly [string, string]> = [
+    ['', font.normalFamily],
+    [FACE_BOLD, font.boldFamily],
+    [FACE_ITALIC, font.italicFamily],
+    [FACE_BOLD_ITALIC, font.boldItalicFamily],
+  ];
+  const rules = [`.terminal-grid { ${sizeRule} }`, `.${PROBE_CLASS} { ${sizeRule} }`];
+  for (const [face, family] of faces) {
+    const decl = `font-family: ${family}, monospace;`;
+    // Runs are descendants of `.terminal-grid`; probes carry the class directly.
+    rules.push(`.terminal-grid${face ? ` .${face}` : ''} { ${decl} }`);
+    rules.push(`.${PROBE_CLASS}${face ? `.${face}` : ''} { ${decl} }`);
+  }
+  return rules.join('\n');
 }
 
 function buildPaletteCss(): string {

--- a/daemon/frontend/src/terminal/renderer/palette.ts
+++ b/daemon/frontend/src/terminal/renderer/palette.ts
@@ -9,16 +9,16 @@ import { colorToCss } from './colors';
 const STYLE_ID = 'ozmux-terminal-palette';
 
 function fontCss(): string {
-  const f = getFontConfig();
+  const font = getFontConfig();
   return [
-    `.terminal-grid { font-family: ${f.normalFamily}, monospace; font-size: ${f.size}px; }`,
-    `.terminal-grid .tf-bold { font-family: ${f.boldFamily}, monospace; }`,
-    `.terminal-grid .tf-italic { font-family: ${f.italicFamily}, monospace; }`,
-    `.terminal-grid .tf-bold-italic { font-family: ${f.boldItalicFamily}, monospace; }`,
-    `.ozmux-font-probe { font-family: ${f.normalFamily}, monospace; font-size: ${f.size}px; }`,
-    `.ozmux-font-probe.tf-bold { font-family: ${f.boldFamily}, monospace; }`,
-    `.ozmux-font-probe.tf-italic { font-family: ${f.italicFamily}, monospace; }`,
-    `.ozmux-font-probe.tf-bold-italic { font-family: ${f.boldItalicFamily}, monospace; }`,
+    `.terminal-grid { font-family: ${font.normalFamily}, monospace; font-size: ${font.size}px; }`,
+    `.terminal-grid .tf-bold { font-family: ${font.boldFamily}, monospace; }`,
+    `.terminal-grid .tf-italic { font-family: ${font.italicFamily}, monospace; }`,
+    `.terminal-grid .tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,
+    `.ozmux-font-probe { font-family: ${font.normalFamily}, monospace; font-size: ${font.size}px; }`,
+    `.ozmux-font-probe.tf-bold { font-family: ${font.boldFamily}, monospace; }`,
+    `.ozmux-font-probe.tf-italic { font-family: ${font.italicFamily}, monospace; }`,
+    `.ozmux-font-probe.tf-bold-italic { font-family: ${font.boldItalicFamily}, monospace; }`,
   ].join('\n');
 }
 

--- a/daemon/frontend/src/terminal/useTerminal.ts
+++ b/daemon/frontend/src/terminal/useTerminal.ts
@@ -91,8 +91,8 @@ export function useTerminal(
     injectTerminalPalette();
 
     // DOM probe: measure cell size in the .terminal-grid font environment.
-    // Probes carry `font-mono leading-none` (see font.ts) so the measurements
-    // match what Row.tsx + TerminalGrid.tsx will actually render.
+    // Probes carry `font-mono ozmux-font-probe leading-none` (see font.ts) so
+    // the measurements match what Row.tsx + TerminalGrid.tsx will actually render.
     const cellW = cellWidthOf(pane);
     const cellH = cellHeightOf(pane) || DEFAULT_FM.cellH;
     const measuredFm: FontMetrics = {

--- a/daemon/http_server/src/handlers/configs.rs
+++ b/daemon/http_server/src/handlers/configs.rs
@@ -1,3 +1,4 @@
 //! Handlers serving the loaded `OzmuxConfigs`. Read-only for now.
 
+pub mod font;
 pub mod shortcuts;

--- a/daemon/http_server/src/handlers/configs/font.rs
+++ b/daemon/http_server/src/handlers/configs/font.rs
@@ -1,0 +1,54 @@
+//! `GET /configs/font` returns the merged font configuration.
+
+use axum::Json;
+use axum::extract::State;
+use ozmux_configs::OzmuxConfigs;
+use ozmux_configs::font::FontConfig;
+use std::sync::Arc;
+
+/// Returns the active font configuration as JSON.
+pub async fn get(State(configs): State<Arc<OzmuxConfigs>>) -> Json<FontConfig> {
+    Json(configs.font.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::daemon_router;
+    use crate::test_helpers::fresh_state;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use ozmux_configs::font::FontConfig;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn get_returns_default_font_as_json() {
+        let response = daemon_router(fresh_state())
+            .oneshot(
+                Request::builder()
+                    .uri("/configs/font")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            content_type.starts_with("application/json"),
+            "got content-type {content_type}"
+        );
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let round_trip: FontConfig = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(round_trip, FontConfig::default());
+    }
+}

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -65,7 +65,9 @@ pub fn daemon_router(state: AppState) -> Router {
 
 /// Router for read-only config endpoints under `/configs`.
 pub fn configs_router() -> Router<AppState> {
-    Router::new().route("/shortcuts", get(handlers::configs::shortcuts::get))
+    Router::new()
+        .route("/shortcuts", get(handlers::configs::shortcuts::get))
+        .route("/font", get(handlers::configs::font::get))
 }
 
 pub fn sessions_router() -> Router<AppState> {


### PR DESCRIPTION
## Problem

Inside an ozmux terminal pane, NeoVim could not display file-type icons: the terminal had no configurable font, so Nerd Font glyphs were never available. ozmux had no way to set the terminal font at all.

## Solution

Add an Alacritty-compatible `[font]` configuration section so users can point the terminal at a Nerd Font (or any installed font). The TOML shape mirrors Alacritty's `[font]` / `[font.normal]` / `[font.bold]` / … layout, so a real `alacritty.toml` parses without error (unknown keys are ignored).

**`daemon/configs`** — new `FontConfig` / `FontPatch` types following the existing `theme` patch pattern. `size` is interpreted as points (Alacritty semantics, default `11.25`); `bold` / `italic` / `bold_italic` families fall back to the normal family when unset; defaults are platform-specific to match Alacritty (`Menlo` on macOS, `Consolas` on Windows, `monospace` elsewhere). Font size is validated to a sane range.

**`daemon/http_server`** — new read-only `GET /configs/font` endpoint serving the resolved config as JSON.

**`daemon/frontend`** — the renderer fetches `/configs/font` at startup and applies it through the runtime palette stylesheet (`palette.ts`). This is the only mechanism that works under Tailwind v4 `@theme inline`, where a runtime `--font-mono` override would be ignored. Per-style families are applied via `tf-*` classes on run spans, cell-metric probes measure against the configured font, and the `points → px` conversion happens at render time. The first render is gated on the config load so the grid never sizes against the wrong font.

Verified end-to-end with the dev harness: `/configs/font` serves the configured values and the terminal grid renders in the chosen font and size (checked with a `Hack Nerd Font` config — Nerd Font glyphs resolve). Backend tests cover config merge/validation and the endpoint; frontend vitest covers the fetch module, palette CSS emission, probe classes, and per-style row classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)