### PR TITLE
feat: pane activity tab bar with live terminal titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ docs/
 .worktrees
 # Playwright verification harness PID file
 .ozmux/
+# Playwright E2E artifacts
+daemon/frontend/test-results/
+daemon/frontend/playwright-report/
 # Playwright MCP session artifacts (snapshots, console logs)
 .playwright-mcp/
 # Brainstorming visual companion artifacts

--- a/daemon/frontend/e2e/pane-tabs.spec.ts
+++ b/daemon/frontend/e2e/pane-tabs.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('pane activity tab bar', () => {
+  test('Ctrl+B c adds a second tab and clicking it switches activity', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForSelector('.terminal-grid');
+
+    // Bootstrap pane starts with exactly one tab.
+    await expect(page.getByRole('tab')).toHaveCount(1);
+
+    // Ctrl+B c spawns a second terminal activity.
+    await page.keyboard.press('Control+b');
+    await page.keyboard.press('c');
+    await expect(page.getByRole('tab')).toHaveCount(2);
+
+    // The newly-spawned activity is active; click the first (inactive) tab.
+    const tabs = page.getByRole('tab');
+    const firstTab = tabs.first();
+    await expect(firstTab).toHaveAttribute('aria-selected', 'false');
+    await firstTab.click();
+    await expect(firstTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/daemon/frontend/src/layout/LayoutView.test.tsx
+++ b/daemon/frontend/src/layout/LayoutView.test.tsx
@@ -14,7 +14,11 @@ function fakeView(overrides: Partial<WindowView> = {}): WindowView {
     root_cell: 'cid-root',
     active_pane: 'pid-1',
     panes: [
-      { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }] },
+      {
+        id: 'pid-1',
+        active_activity: 'aid-1',
+        activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }],
+      },
     ],
     layout: {
       type: 'root',

--- a/daemon/frontend/src/layout/LayoutView.test.tsx
+++ b/daemon/frontend/src/layout/LayoutView.test.tsx
@@ -14,7 +14,7 @@ function fakeView(overrides: Partial<WindowView> = {}): WindowView {
     root_cell: 'cid-root',
     active_pane: 'pid-1',
     panes: [
-      { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal' }] },
+      { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }] },
     ],
     layout: {
       type: 'root',

--- a/daemon/frontend/src/layout/PaneContent.tsx
+++ b/daemon/frontend/src/layout/PaneContent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Terminal } from '../terminal/Terminal';
 import { ClickShield } from './ClickShield';
 import { PanePlaceholder } from './PanePlaceholder';
+import { PaneTabBar } from './PaneTabBar';
 import type { PaneView } from './types';
 import { useIframeKeydownBridge } from './useIframeKeydownBridge';
 
@@ -13,6 +14,17 @@ interface PaneContentProps {
 }
 
 export function PaneContent({ windowId, pane, isActive, onActivate }: PaneContentProps) {
+  return (
+    <div className="flex h-full w-full flex-col">
+      <PaneTabBar windowId={windowId} pane={pane} isActive={isActive} onActivate={onActivate} />
+      <div className="relative min-h-0 flex-1">
+        <PaneBody windowId={windowId} pane={pane} isActive={isActive} onActivate={onActivate} />
+      </div>
+    </div>
+  );
+}
+
+function PaneBody({ windowId, pane, isActive, onActivate }: PaneContentProps) {
   const activity = pane.activities.find((a) => a.id === pane.active_activity);
   if (!activity) return <PanePlaceholder paneId={pane.id} />;
 

--- a/daemon/frontend/src/layout/PaneTabBar.test.tsx
+++ b/daemon/frontend/src/layout/PaneTabBar.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PaneTabBar } from './PaneTabBar';
+import type { PaneView } from './types';
+
+const pane: PaneView = {
+  id: 'pid-1',
+  active_activity: 'aid-1',
+  activities: [
+    { id: 'aid-1', kind: 'terminal', title: 'zsh' },
+    { id: 'aid-2', kind: 'terminal', title: 'vim CLAUDE.md' },
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PaneTabBar', () => {
+  it('renders one tab per activity and marks the active one', () => {
+    render(<PaneTabBar windowId="wid-1" pane={pane} isActive onActivate={() => {}} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs).toHaveLength(2);
+    expect(screen.getByText('zsh')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('vim CLAUDE.md')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('POSTs the activate endpoint when an inactive tab is clicked', () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+    vi.stubGlobal('fetch', fetchMock);
+    render(<PaneTabBar windowId="wid-1" pane={pane} isActive onActivate={() => {}} />);
+    fireEvent.pointerDown(screen.getByText('vim CLAUDE.md'));
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/activities/aid-2/activate', {
+      method: 'POST',
+    });
+  });
+
+  it('activates the pane before the activity when the pane is inactive', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response())),
+    );
+    const onActivate = vi.fn();
+    render(<PaneTabBar windowId="wid-1" pane={pane} isActive={false} onActivate={onActivate} />);
+    fireEvent.pointerDown(screen.getByText('vim CLAUDE.md'));
+    expect(onActivate).toHaveBeenCalledOnce();
+  });
+});

--- a/daemon/frontend/src/layout/PaneTabBar.tsx
+++ b/daemon/frontend/src/layout/PaneTabBar.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import type { PointerEvent } from 'react';
-import { activateActivityEndpoint } from '../terminal/api';
+import { activateActivity } from './activateActivity';
 import type { ActivityId, PaneView } from './types';
 
 interface PaneTabBarProps {
@@ -17,9 +17,7 @@ export function PaneTabBar({ windowId, pane, isActive, onActivate }: PaneTabBarP
     // Pane focus first, then the activity switch — a single defined order.
     if (!isActive) onActivate();
     if (activityId === pane.active_activity) return;
-    fetch(activateActivityEndpoint(windowId, pane.id, activityId), { method: 'POST' }).catch(
-      (err) => console.warn('failed to activate activity', err),
-    );
+    void activateActivity(windowId, pane.id, activityId);
   };
 
   return (

--- a/daemon/frontend/src/layout/PaneTabBar.tsx
+++ b/daemon/frontend/src/layout/PaneTabBar.tsx
@@ -1,0 +1,57 @@
+import { clsx } from 'clsx';
+import type { PointerEvent } from 'react';
+import { activateActivityEndpoint } from '../terminal/api';
+import type { ActivityId, PaneView } from './types';
+
+interface PaneTabBarProps {
+  windowId: string;
+  pane: PaneView;
+  isActive: boolean;
+  onActivate: () => void;
+}
+
+export function PaneTabBar({ windowId, pane, isActive, onActivate }: PaneTabBarProps) {
+  const selectTab = (event: PointerEvent<HTMLButtonElement>, activityId: ActivityId) => {
+    // Do not let the click bubble to the pane container's activate handler.
+    event.stopPropagation();
+    // Pane focus first, then the activity switch — a single defined order.
+    if (!isActive) onActivate();
+    if (activityId === pane.active_activity) return;
+    fetch(activateActivityEndpoint(windowId, pane.id, activityId), { method: 'POST' }).catch(
+      (err) => console.warn('failed to activate activity', err),
+    );
+  };
+
+  return (
+    <div
+      role="tablist"
+      className={clsx(
+        'flex shrink-0 overflow-hidden bg-tmux-status-bar',
+        !isActive && 'opacity-60',
+      )}
+    >
+      {pane.activities.map((activity) => {
+        const selected = activity.id === pane.active_activity;
+        return (
+          <button
+            key={activity.id}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            title={activity.title}
+            onPointerDown={(event) => selectTab(event, activity.id)}
+            className={clsx(
+              'min-w-0 flex-1 truncate border-r border-tmux-pane-border px-3 py-1',
+              'text-left font-mono text-xs',
+              selected
+                ? 'border-t border-t-tmux-pane-active bg-background text-tmux-pane-active'
+                : 'text-muted-foreground',
+            )}
+          >
+            {activity.title}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/daemon/frontend/src/layout/activateActivity.ts
+++ b/daemon/frontend/src/layout/activateActivity.ts
@@ -1,0 +1,29 @@
+import { activateActivityEndpoint } from '../terminal/api';
+import type { ActivityId, PaneId, WindowId } from './types';
+
+export async function activateActivity(
+  windowId: WindowId,
+  paneId: PaneId,
+  activityId: ActivityId,
+): Promise<void> {
+  try {
+    const resp = await fetch(activateActivityEndpoint(windowId, paneId, activityId), {
+      method: 'POST',
+    });
+    if (!resp.ok) {
+      console.warn('activate activity failed', {
+        windowId,
+        paneId,
+        activityId,
+        status: resp.status,
+      });
+    }
+  } catch (e) {
+    console.warn('activate activity request errored', {
+      windowId,
+      paneId,
+      activityId,
+      error: e,
+    });
+  }
+}

--- a/daemon/frontend/src/layout/newTerminalActivity.test.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.test.ts
@@ -71,7 +71,7 @@ describe('newTerminalActivity', () => {
     await newTerminalActivity('wid-1', 'pid-1');
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(console.warn).toHaveBeenCalledWith(
-      'activate new activity failed',
+      'activate activity failed',
       expect.objectContaining({
         windowId: 'wid-1',
         paneId: 'pid-1',

--- a/daemon/frontend/src/layout/newTerminalActivity.ts
+++ b/daemon/frontend/src/layout/newTerminalActivity.ts
@@ -1,4 +1,5 @@
-import { activateActivityEndpoint, addActivityEndpoint } from '../terminal/api';
+import { addActivityEndpoint } from '../terminal/api';
+import { activateActivity } from './activateActivity';
 import type { PaneId, WindowId } from './types';
 
 export async function newTerminalActivity(windowId: WindowId, paneId: PaneId): Promise<void> {
@@ -28,24 +29,5 @@ export async function newTerminalActivity(windowId: WindowId, paneId: PaneId): P
     return;
   }
 
-  try {
-    const resp = await fetch(activateActivityEndpoint(windowId, paneId, activityId), {
-      method: 'POST',
-    });
-    if (!resp.ok) {
-      console.warn('activate new activity failed', {
-        windowId,
-        paneId,
-        activityId,
-        status: resp.status,
-      });
-    }
-  } catch (e) {
-    console.warn('activate new activity request errored', {
-      windowId,
-      paneId,
-      activityId,
-      error: e,
-    });
-  }
+  await activateActivity(windowId, paneId, activityId);
 }

--- a/daemon/frontend/src/layout/types.ts
+++ b/daemon/frontend/src/layout/types.ts
@@ -21,10 +21,17 @@ export type WindowLayoutNode =
     }
   | { type: 'pane'; cell_id: CellId; pane_id: PaneId };
 
+export interface ActivityView {
+  id: ActivityId;
+  kind: 'terminal' | 'extension';
+  title: string;
+  iframe_url?: string;
+}
+
 export interface PaneView {
   id: PaneId;
   active_activity: ActivityId;
-  activities: Array<{ id: ActivityId; kind: 'terminal' | 'extension'; iframe_url?: string }>;
+  activities: ActivityView[];
 }
 
 export interface WindowView {

--- a/daemon/frontend/src/layout/useWindowLayout.test.tsx
+++ b/daemon/frontend/src/layout/useWindowLayout.test.tsx
@@ -15,7 +15,7 @@ const fakeView = (overrides: Partial<WindowView> = {}): WindowView => ({
   root_cell: 'cid-root',
   active_pane: 'pid-1',
   panes: [
-    { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal' }] },
+    { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }] },
   ],
   layout: {
     type: 'root',

--- a/daemon/frontend/src/layout/useWindowLayout.test.tsx
+++ b/daemon/frontend/src/layout/useWindowLayout.test.tsx
@@ -15,7 +15,11 @@ const fakeView = (overrides: Partial<WindowView> = {}): WindowView => ({
   root_cell: 'cid-root',
   active_pane: 'pid-1',
   panes: [
-    { id: 'pid-1', active_activity: 'aid-1', activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }] },
+    {
+      id: 'pid-1',
+      active_activity: 'aid-1',
+      activities: [{ id: 'aid-1', kind: 'terminal', title: 'zsh' }],
+    },
   ],
   layout: {
     type: 'root',

--- a/daemon/http_server/src/handlers/windows.rs
+++ b/daemon/http_server/src/handlers/windows.rs
@@ -202,6 +202,7 @@ mod tests {
         let activities = panes[0]["activities"].as_array().unwrap();
         assert!(activities[0]["id"].is_string());
         assert_eq!(activities[0]["kind"].as_str(), Some("terminal"));
+        assert!(activities[0]["title"].is_string());
     }
 
     #[tokio::test]

--- a/daemon/http_server/src/handlers/windows.rs
+++ b/daemon/http_server/src/handlers/windows.rs
@@ -5,6 +5,7 @@ use axum::{
     extract::{Path, State},
 };
 use ozmux_multiplexer::{MultiplexerService, WindowId};
+use ozmux_terminal::TerminalService;
 
 pub mod create;
 pub mod delete;
@@ -15,10 +16,12 @@ pub mod select;
 
 pub async fn get(
     State(multiplexer): State<MultiplexerService>,
+    State(terminal): State<TerminalService>,
     Path(window_id): Path<WindowId>,
 ) -> HttpResult<Json<WindowView>> {
+    let titles = terminal.all_titles().await;
     let view = multiplexer
-        .with_window_or_404(&window_id, |w| WindowView::from_window(w))
+        .with_window_or_404(&window_id, |w| WindowView::from_window(w, &titles))
         .await?;
     Ok(Json(view))
 }

--- a/daemon/http_server/src/handlers/windows/events.rs
+++ b/daemon/http_server/src/handlers/windows/events.rs
@@ -17,9 +17,13 @@ pub async fn events(
 
 async fn handle_events_socket(socket: WebSocket, state: AppState, window_id: WindowId) {
     let (mut tx, _rx) = socket.split();
+    // NOTE: subscribe BEFORE building the snapshot so no layout/title
+    // re-broadcast can slip through the gap between snapshot and subscribe.
+    let mut receiver = state.layout_broadcast.subscribe_or_create(&window_id);
+    let titles = state.terminal.all_titles().await;
     let snapshot_and_rx = state
         .multiplexer
-        .with_window(&window_id, |w| WindowView::from_window(w))
+        .with_window(&window_id, |w| WindowView::from_window(w, &titles))
         .await;
     let Some(snapshot_result) = snapshot_and_rx else {
         close_with(&mut tx, 1011, "window_not_found").await;
@@ -41,7 +45,6 @@ async fn handle_events_socket(socket: WebSocket, state: AppState, window_id: Win
             return;
         }
     };
-    let mut receiver = state.layout_broadcast.subscribe_or_create(&window_id);
 
     if tx.send(Message::Text(snapshot_json.into())).await.is_err() {
         return;
@@ -252,7 +255,9 @@ mod tests {
                         .insert(new_pane_id.clone(), wid_.clone());
                     if let Some(view) = s
                         .multiplexer
-                        .with_window(&wid_, |w| WindowView::from_window(w))
+                        .with_window(&wid_, |w| {
+                            WindowView::from_window(w, &std::collections::HashMap::new())
+                        })
                         .await
                         && let Ok(view) = view
                         && let Ok(value) = serde_json::to_value(&view)

--- a/daemon/http_server/src/handlers/windows/panes/activities.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities.rs
@@ -67,22 +67,57 @@ impl ActivityInput {
     /// Convert the wire payload into a domain `Activity`, also surfacing the
     /// owning extension's name for Extension-kind activities.
     pub(super) fn into_parsed(self) -> ParsedActivity {
-        let (kind, extension_name) = match self.kind {
-            ActivityKindInput::Terminal => (ActivityKind::Terminal, None),
+        match self.kind {
+            ActivityKindInput::Terminal => {
+                // NOTE: build via Activity::terminal so a missing name defaults
+                // to "Terminal", matching every other terminal-creation path.
+                let mut activity = Activity::terminal(self.activity_id);
+                if let Some(name) = self.name {
+                    activity.name = name;
+                }
+                ParsedActivity {
+                    activity,
+                    extension_name: None,
+                }
+            }
             ActivityKindInput::Extension {
                 html_root,
                 extension_name,
-            } => (ActivityKind::Extension { html_root }, Some(extension_name)),
-        };
-        let activity = Activity {
-            id: self.activity_id,
-            name: self.name.unwrap_or_else(|| "Activity".into()),
-            kind,
-        };
-        ParsedActivity {
-            activity,
-            extension_name,
+            } => ParsedActivity {
+                activity: Activity {
+                    id: self.activity_id,
+                    name: self.name.unwrap_or_else(|| "Activity".into()),
+                    kind: ActivityKind::Extension { html_root },
+                },
+                extension_name: Some(extension_name),
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod into_parsed_tests {
+    use super::ActivityInput;
+
+    #[test]
+    fn terminal_without_name_defaults_to_terminal() {
+        let input: ActivityInput = serde_json::from_value(serde_json::json!({
+            "activity_id": "aid-1",
+            "kind": { "type": "terminal" }
+        }))
+        .unwrap();
+        assert_eq!(input.into_parsed().activity.name, "Terminal");
+    }
+
+    #[test]
+    fn terminal_with_explicit_name_is_preserved() {
+        let input: ActivityInput = serde_json::from_value(serde_json::json!({
+            "activity_id": "aid-1",
+            "name": "build",
+            "kind": { "type": "terminal" }
+        }))
+        .unwrap();
+        assert_eq!(input.into_parsed().activity.name, "build");
     }
 }
 

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod layout_broadcast;
 pub mod layout_dto;
 pub mod state;
 pub mod window_view;
+mod title_republish;
 
 pub use error::{HttpError, HttpResult};
 pub use state::AppState;
@@ -47,6 +48,7 @@ pub async fn serve(state: AppState) -> HttpResult {
     let listener = TcpListener::bind("127.0.0.1:3200")
         .await
         .map_err(|e| HttpError::FailedLaunch(e.to_string()))?;
+    tokio::spawn(title_republish::run(state.clone()));
     axum::serve(listener, daemon_router(state))
         .await
         .map_err(|e| HttpError::FailedLaunch(e.to_string()))?;

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -6,8 +6,8 @@ pub mod handlers;
 pub mod layout_broadcast;
 pub mod layout_dto;
 pub mod state;
-pub mod window_view;
 mod title_republish;
+pub mod window_view;
 
 pub use error::{HttpError, HttpResult};
 pub use state::AppState;

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -312,11 +312,13 @@ impl AppState {
     }
 
     /// Build the current Window layout snapshot under the Window lock and
-    /// broadcast it. Used by every handler that mutates a Window.
-    async fn publish_window_layout(&self, wid: &WindowId) {
+    /// broadcast it. Used by every handler that mutates a Window and by the
+    /// title-republish task.
+    pub(crate) async fn publish_window_layout(&self, wid: &WindowId) {
+        let titles = self.terminal.all_titles().await;
         let _ = self
             .multiplexer
-            .with_window(wid, |w| match WindowView::from_window(w) {
+            .with_window(wid, |w| match WindowView::from_window(w, &titles) {
                 Ok(view) => match serde_json::to_value(&view) {
                     Ok(value) => self.layout_broadcast.publish(wid, value),
                     Err(e) => tracing::warn!(error = %e, %wid, "skipped layout publish"),

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -315,6 +315,9 @@ impl AppState {
     /// broadcast it. Used by every handler that mutates a Window and by the
     /// title-republish task.
     pub(crate) async fn publish_window_layout(&self, wid: &WindowId) {
+        // NOTE: titles are snapshotted separately from the window state, so a
+        // published view's title can be one title-change cycle stale. This is
+        // benign — the next title change re-broadcasts the corrected view.
         let titles = self.terminal.all_titles().await;
         let _ = self
             .multiplexer

--- a/daemon/http_server/src/title_republish.rs
+++ b/daemon/http_server/src/title_republish.rs
@@ -1,0 +1,47 @@
+//! Background task: re-broadcasts a window's `WindowView` when one of its
+//! terminal titles changes, coalescing bursts within a short debounce window.
+
+use crate::AppState;
+use std::collections::HashSet;
+use std::time::Duration;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::time::Instant;
+
+/// Trailing debounce window. Terminal titles can change per redraw; this
+/// bounds the `WindowView` re-broadcast rate so a title storm cannot push
+/// a slow events-WS subscriber into `Lagged`.
+const DEBOUNCE: Duration = Duration::from_millis(150);
+
+/// Runs until the title-change channel closes (daemon shutdown).
+pub(crate) async fn run(state: AppState) {
+    let mut rx = state.terminal.subscribe_title_changes();
+    loop {
+        let first = match rx.recv().await {
+            Ok(wid) => wid,
+            Err(RecvError::Lagged(_)) => continue,
+            Err(RecvError::Closed) => return,
+        };
+        let mut pending = HashSet::from([first]);
+        let deadline = Instant::now() + DEBOUNCE;
+        let mut closed = false;
+        loop {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Ok(wid)) => {
+                    pending.insert(wid);
+                }
+                Ok(Err(RecvError::Lagged(_))) => continue,
+                Ok(Err(RecvError::Closed)) => {
+                    closed = true;
+                    break;
+                }
+                Err(_elapsed) => break,
+            }
+        }
+        for wid in pending.drain() {
+            state.publish_window_layout(&wid).await;
+        }
+        if closed {
+            return;
+        }
+    }
+}

--- a/daemon/http_server/src/window_view.rs
+++ b/daemon/http_server/src/window_view.rs
@@ -3,6 +3,7 @@ use ozmux_multiplexer::{
     Activity, ActivityId, ActivityKind, CellId, MultiplexerResult, Pane, PaneId, Window, WindowId,
 };
 use serde::Serialize;
+use std::collections::HashMap;
 
 #[derive(Serialize)]
 pub struct WindowView {
@@ -24,12 +25,22 @@ pub struct PaneView {
 #[derive(Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ActivityView {
-    Terminal { id: ActivityId },
-    Extension { id: ActivityId, iframe_url: String },
+    Terminal {
+        id: ActivityId,
+        title: String,
+    },
+    Extension {
+        id: ActivityId,
+        title: String,
+        iframe_url: String,
+    },
 }
 
 impl WindowView {
-    pub fn from_window(window: &Window) -> MultiplexerResult<Self> {
+    pub fn from_window(
+        window: &Window,
+        titles: &HashMap<ActivityId, String>,
+    ) -> MultiplexerResult<Self> {
         let pane_ids = window.cells.pane_ids_in_subtree(&window.root_cell)?;
         let panes = pane_ids
             .iter()
@@ -37,7 +48,7 @@ impl WindowView {
                 window
                     .panes
                     .get(pid)
-                    .map(|p| PaneView::from_pane(p, &window.id))
+                    .map(|p| PaneView::from_pane(p, &window.id, titles))
             })
             .collect();
         let layout = build_layout(&window.root_cell, &window.cells)?;
@@ -53,11 +64,11 @@ impl WindowView {
 }
 
 impl PaneView {
-    fn from_pane(pane: &Pane, wid: &WindowId) -> Self {
+    fn from_pane(pane: &Pane, wid: &WindowId, titles: &HashMap<ActivityId, String>) -> Self {
         let activities = pane
             .activities
             .iter()
-            .map(|a| ActivityView::from_activity(a, wid, &pane.id))
+            .map(|a| ActivityView::from_activity(a, wid, &pane.id, titles))
             .collect();
         Self {
             id: pane.id.clone(),
@@ -68,13 +79,24 @@ impl PaneView {
 }
 
 impl ActivityView {
-    fn from_activity(activity: &Activity, wid: &WindowId, pid: &PaneId) -> Self {
+    fn from_activity(
+        activity: &Activity,
+        wid: &WindowId,
+        pid: &PaneId,
+        titles: &HashMap<ActivityId, String>,
+    ) -> Self {
         match &activity.kind {
             ActivityKind::Terminal => Self::Terminal {
                 id: activity.id.clone(),
+                title: titles
+                    .get(&activity.id)
+                    .filter(|t| !t.is_empty())
+                    .cloned()
+                    .unwrap_or_else(|| activity.name.clone()),
             },
             ActivityKind::Extension { .. } => Self::Extension {
                 id: activity.id.clone(),
+                title: activity.name.clone(),
                 iframe_url: format!(
                     "/windows/{}/panes/{}/activities/{}/iframe/index.html",
                     wid, pid, activity.id

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -29,12 +29,25 @@ pub mod types;
 ///
 /// Each entry owns a `TerminalHandle` (PTY + scrollback + VT bridge) and is
 /// keyed by [`ActivityId`].
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct TerminalService {
     ptys: Arc<RwLock<HashMap<ActivityId, TerminalHandle>>>,
     runtime_root: Option<Arc<RuntimeRoot>>,
+    title_tx: broadcast::Sender<ozmux_multiplexer::WindowId>,
     #[cfg(any(test, feature = "test-helpers"))]
     forced_failures: Arc<RwLock<HashSet<ActivityId>>>,
+}
+
+impl Default for TerminalService {
+    fn default() -> Self {
+        Self {
+            ptys: Arc::default(),
+            runtime_root: None,
+            title_tx: broadcast::channel(256).0,
+            #[cfg(any(test, feature = "test-helpers"))]
+            forced_failures: Arc::default(),
+        }
+    }
 }
 
 impl TerminalService {
@@ -42,10 +55,8 @@ impl TerminalService {
     /// to spawned shells via `PATH`.
     pub fn with_runtime_root(root: Arc<RuntimeRoot>) -> Self {
         Self {
-            ptys: Arc::default(),
             runtime_root: Some(root),
-            #[cfg(any(test, feature = "test-helpers"))]
-            forced_failures: Arc::default(),
+            ..Self::default()
         }
     }
 
@@ -131,6 +142,8 @@ impl TerminalService {
             opts.rows,
             vt_chunk_tx,
             vt_chunk_rx,
+            opts.window_id.clone(),
+            self.title_tx.clone(),
         );
         ptys.insert(activity_id, handle);
         Ok(())
@@ -203,6 +216,31 @@ impl TerminalService {
             }
         }
         Ok(())
+    }
+
+    /// Subscribes to window-scoped terminal title-change notifications.
+    /// Each item is the `WindowId` of a window whose terminal title changed.
+    pub fn subscribe_title_changes(
+        &self,
+    ) -> broadcast::Receiver<ozmux_multiplexer::WindowId> {
+        self.title_tx.subscribe()
+    }
+
+    /// Snapshots the current sanitized title of every running terminal.
+    /// Activities with no title set are omitted.
+    pub async fn all_titles(&self) -> HashMap<ActivityId, String> {
+        let ptys = self.ptys.read().await;
+        ptys.iter()
+            .filter_map(|(aid, handle)| {
+                let title = handle
+                    .vt_state
+                    .lock()
+                    .expect("vt_state poisoned")
+                    .title
+                    .clone();
+                title.map(|t| (aid.clone(), t))
+            })
+            .collect()
     }
 
     /// Returns the current scrollback snapshot and a fresh broadcast receiver

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use bytes::Bytes;
 use ozmux_extension::runtime::RuntimeRoot;
-use ozmux_multiplexer::{ActivityId, PaneId};
+use ozmux_multiplexer::{ActivityId, PaneId, WindowId};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 #[cfg(any(test, feature = "test-helpers"))]
 use std::collections::HashSet;
@@ -33,7 +33,7 @@ pub mod types;
 pub struct TerminalService {
     ptys: Arc<RwLock<HashMap<ActivityId, TerminalHandle>>>,
     runtime_root: Option<Arc<RuntimeRoot>>,
-    title_tx: broadcast::Sender<ozmux_multiplexer::WindowId>,
+    title_tx: broadcast::Sender<WindowId>,
     #[cfg(any(test, feature = "test-helpers"))]
     forced_failures: Arc<RwLock<HashSet<ActivityId>>>,
 }
@@ -222,7 +222,7 @@ impl TerminalService {
     /// Each item is the `WindowId` of a window whose terminal title changed.
     pub fn subscribe_title_changes(
         &self,
-    ) -> broadcast::Receiver<ozmux_multiplexer::WindowId> {
+    ) -> broadcast::Receiver<WindowId> {
         self.title_tx.subscribe()
     }
 

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -229,6 +229,9 @@ impl TerminalService {
     /// Snapshots the current sanitized title of every running terminal.
     /// Activities with no title set are omitted.
     pub async fn all_titles(&self) -> HashMap<ActivityId, String> {
+        // NOTE: ptys lock is always acquired before vt_state locks. The bridge
+        // holds vt_state only briefly and never touches ptys, so this ordering
+        // cannot deadlock.
         let ptys = self.ptys.read().await;
         ptys.iter()
             .filter_map(|(aid, handle)| {

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -220,9 +220,7 @@ impl TerminalService {
 
     /// Subscribes to window-scoped terminal title-change notifications.
     /// Each item is the `WindowId` of a window whose terminal title changed.
-    pub fn subscribe_title_changes(
-        &self,
-    ) -> broadcast::Receiver<WindowId> {
+    pub fn subscribe_title_changes(&self) -> broadcast::Receiver<WindowId> {
         self.title_tx.subscribe()
     }
 

--- a/daemon/terminal/src/service/terminal_handle.rs
+++ b/daemon/terminal/src/service/terminal_handle.rs
@@ -6,6 +6,7 @@ use crate::vt::bridge::{VtState, run_bridge_task};
 use crate::vt::frame_ring::WireMessage;
 use crate::vt::listener::{ControlFrame, DropCounter, ReplyFrame, TermListener};
 use bytes::Bytes;
+use ozmux_multiplexer::WindowId;
 use portable_pty::{ChildKiller, MasterPty};
 use std::{io::Write, sync::Arc};
 use tokio::sync::{
@@ -81,6 +82,8 @@ impl TerminalHandle {
         rows: u16,
         vt_chunk_tx: mpsc::Sender<Bytes>,
         vt_chunk_rx: mpsc::Receiver<Bytes>,
+        window_id: Option<WindowId>,
+        title_tx: broadcast::Sender<WindowId>,
     ) -> Self {
         let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
         let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
@@ -108,6 +111,8 @@ impl TerminalHandle {
             vt_chunk_rx,
             reply_rx,
             control_rx,
+            window_id,
+            title_tx,
             vt_cancel.clone(),
         ));
 

--- a/daemon/terminal/src/vt.rs
+++ b/daemon/terminal/src/vt.rs
@@ -8,6 +8,7 @@ pub(crate) mod frame_ring;
 pub(crate) mod hyperlink;
 pub(crate) mod listener;
 pub(crate) mod mode_diff;
+pub(crate) mod title;
 
 pub use coalescer::Coalescer;
 pub use frame::{

--- a/daemon/terminal/src/vt/bridge.rs
+++ b/daemon/terminal/src/vt/bridge.rs
@@ -349,15 +349,30 @@ pub(crate) async fn run_bridge_task(
                 match ctrl {
                     None => break,
                     Some(ControlFrame::Title(raw)) => {
+                        // NOTE: shells re-emit the same OSC title on every prompt
+                        // redraw; only signal when the value actually changed so a
+                        // redraw storm cannot drive WindowView re-broadcasts.
                         let clean = sanitize_title(&raw);
-                        vt_state.lock().expect("vt_state poisoned").title = Some(clean);
-                        if let Some(wid) = &activity_window {
+                        let changed = {
+                            let mut state = vt_state.lock().expect("vt_state poisoned");
+                            let changed = state.title.as_deref() != Some(clean.as_str());
+                            if changed {
+                                state.title = Some(clean);
+                            }
+                            changed
+                        };
+                        if changed && let Some(wid) = &activity_window {
                             let _ = title_tx.send(wid.clone());
                         }
                     }
                     Some(ControlFrame::ResetTitle) => {
-                        vt_state.lock().expect("vt_state poisoned").title = None;
-                        if let Some(wid) = &activity_window {
+                        let changed = {
+                            let mut state = vt_state.lock().expect("vt_state poisoned");
+                            let changed = state.title.is_some();
+                            state.title = None;
+                            changed
+                        };
+                        if changed && let Some(wid) = &activity_window {
                             let _ = title_tx.send(wid.clone());
                         }
                     }
@@ -491,8 +506,18 @@ mod tests {
         let _ = handle.await;
     }
 
-    #[tokio::test]
-    async fn bridge_task_captures_and_sanitizes_title() {
+    struct TitleBridge {
+        control_tx: mpsc::Sender<ControlFrame>,
+        title_rx: broadcast::Receiver<ozmux_multiplexer::WindowId>,
+        vt_state: Arc<std::sync::Mutex<VtState>>,
+        wid: ozmux_multiplexer::WindowId,
+        cancel: CancellationToken,
+        handle: tokio::task::JoinHandle<()>,
+        // NOTE: kept alive so the bridge's pty_rx does not see a closed channel.
+        _pty_tx: mpsc::Sender<Bytes>,
+    }
+
+    fn spawn_title_bridge() -> TitleBridge {
         let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
         let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
         let drop_counter = Arc::new(DropCounter::new());
@@ -508,9 +533,8 @@ mod tests {
             listener,
             wire_broadcast,
         )));
-        let (_pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
-        let (title_tx, mut title_rx) =
-            broadcast::channel::<ozmux_multiplexer::WindowId>(8);
+        let (pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
+        let (title_tx, title_rx) = broadcast::channel::<ozmux_multiplexer::WindowId>(8);
         let wid = ozmux_multiplexer::WindowId::new();
         let cancel = CancellationToken::new();
         let handle = tokio::spawn(super::run_bridge_task(
@@ -522,79 +546,103 @@ mod tests {
             title_tx,
             cancel.clone(),
         ));
+        TitleBridge {
+            control_tx,
+            title_rx,
+            vt_state,
+            wid,
+            cancel,
+            handle,
+            _pty_tx: pty_tx,
+        }
+    }
 
-        control_tx
+    #[tokio::test]
+    async fn bridge_task_captures_and_sanitizes_title() {
+        let mut bridge = spawn_title_bridge();
+
+        bridge
+            .control_tx
             .send(ControlFrame::Title("hi\x07there".into()))
             .await
             .unwrap();
-        let signalled = title_rx.recv().await.unwrap();
-        assert_eq!(signalled, wid);
+        let signalled = bridge.title_rx.recv().await.unwrap();
+        assert_eq!(signalled, bridge.wid);
         assert_eq!(
-            vt_state.lock().unwrap().title.as_deref(),
+            bridge.vt_state.lock().unwrap().title.as_deref(),
             Some("hithere"),
             "control char should be stripped before storage"
         );
 
-        cancel.cancel();
-        let _ = handle.await;
+        bridge.cancel.cancel();
+        let _ = bridge.handle.await;
     }
 
     #[tokio::test]
     async fn bridge_task_reset_title_clears_stored_title() {
-        let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
-        let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
-        let drop_counter = Arc::new(DropCounter::new());
-        let listener = TermListener {
-            reply_tx,
-            control_tx: control_tx.clone(),
-            drop_counter,
-        };
-        let (wire_broadcast, _rx) = broadcast::channel::<WireMessage>(8);
-        let vt_state = Arc::new(std::sync::Mutex::new(VtState::new(
-            10,
-            3,
-            listener,
-            wire_broadcast,
-        )));
-        let (_pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
-        let (title_tx, mut title_rx) =
-            broadcast::channel::<ozmux_multiplexer::WindowId>(8);
-        let wid = ozmux_multiplexer::WindowId::new();
-        let cancel = CancellationToken::new();
-        let handle = tokio::spawn(super::run_bridge_task(
-            vt_state.clone(),
-            pty_rx,
-            reply_rx,
-            control_rx,
-            Some(wid.clone()),
-            title_tx,
-            cancel.clone(),
-        ));
+        let mut bridge = spawn_title_bridge();
 
-        control_tx
+        bridge
+            .control_tx
             .send(ControlFrame::Title("seed".into()))
             .await
             .unwrap();
-        let _ = title_rx.recv().await.unwrap();
+        let _ = bridge.title_rx.recv().await.unwrap();
         assert_eq!(
-            vt_state.lock().unwrap().title.as_deref(),
+            bridge.vt_state.lock().unwrap().title.as_deref(),
             Some("seed"),
             "initial title should be set"
         );
 
-        control_tx
+        bridge
+            .control_tx
             .send(ControlFrame::ResetTitle)
             .await
             .unwrap();
-        let _ = title_rx.recv().await.unwrap();
+        let _ = bridge.title_rx.recv().await.unwrap();
         assert_eq!(
-            vt_state.lock().unwrap().title,
+            bridge.vt_state.lock().unwrap().title,
             None,
             "title should be cleared after ResetTitle"
         );
 
-        cancel.cancel();
-        let _ = handle.await;
+        bridge.cancel.cancel();
+        let _ = bridge.handle.await;
+    }
+
+    #[tokio::test]
+    async fn bridge_task_suppresses_unchanged_title() {
+        let mut bridge = spawn_title_bridge();
+
+        bridge
+            .control_tx
+            .send(ControlFrame::Title("same".into()))
+            .await
+            .unwrap();
+        assert_eq!(bridge.title_rx.recv().await.unwrap(), bridge.wid);
+
+        bridge
+            .control_tx
+            .send(ControlFrame::Title("same".into()))
+            .await
+            .unwrap();
+        bridge
+            .control_tx
+            .send(ControlFrame::Title("different".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            bridge.title_rx.recv().await.unwrap(),
+            bridge.wid,
+            "only the changed title should be signalled; the repeat is dropped"
+        );
+        assert!(
+            bridge.title_rx.try_recv().is_err(),
+            "no extra signal for the unchanged title"
+        );
+
+        bridge.cancel.cancel();
+        let _ = bridge.handle.await;
     }
 
     #[tokio::test]

--- a/daemon/terminal/src/vt/bridge.rs
+++ b/daemon/terminal/src/vt/bridge.rs
@@ -540,6 +540,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bridge_task_reset_title_clears_stored_title() {
+        let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
+        let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
+        let drop_counter = Arc::new(DropCounter::new());
+        let listener = TermListener {
+            reply_tx,
+            control_tx: control_tx.clone(),
+            drop_counter,
+        };
+        let (wire_broadcast, _rx) = broadcast::channel::<WireMessage>(8);
+        let vt_state = Arc::new(std::sync::Mutex::new(VtState::new(
+            10,
+            3,
+            listener,
+            wire_broadcast,
+        )));
+        let (_pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
+        let (title_tx, mut title_rx) =
+            broadcast::channel::<ozmux_multiplexer::WindowId>(8);
+        let wid = ozmux_multiplexer::WindowId::new();
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(super::run_bridge_task(
+            vt_state.clone(),
+            pty_rx,
+            reply_rx,
+            control_rx,
+            Some(wid.clone()),
+            title_tx,
+            cancel.clone(),
+        ));
+
+        control_tx
+            .send(ControlFrame::Title("seed".into()))
+            .await
+            .unwrap();
+        let _ = title_rx.recv().await.unwrap();
+        assert_eq!(
+            vt_state.lock().unwrap().title.as_deref(),
+            Some("seed"),
+            "initial title should be set"
+        );
+
+        control_tx
+            .send(ControlFrame::ResetTitle)
+            .await
+            .unwrap();
+        let _ = title_rx.recv().await.unwrap();
+        assert_eq!(
+            vt_state.lock().unwrap().title,
+            None,
+            "title should be cleared after ResetTitle"
+        );
+
+        cancel.cancel();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
     async fn wire_broadcast_is_subscribable() {
         let (wire_broadcast, mut rx) = broadcast::channel::<WireMessage>(8);
         let state = VtState::new(10, 3, make_listener(), wire_broadcast.clone());

--- a/daemon/terminal/src/vt/bridge.rs
+++ b/daemon/terminal/src/vt/bridge.rs
@@ -21,6 +21,8 @@ use crate::vt::frame_builder::{
 use crate::vt::frame_ring::{FrameRing, WireMessage};
 use crate::vt::hyperlink::HyperlinkInterner;
 use crate::vt::listener::{ControlFrame, ReplyFrame, TermListener};
+use crate::vt::title::sanitize_title;
+use ozmux_multiplexer::WindowId;
 
 /// All state mutated by the VT bridge task, wrapped by `TerminalHandle` in
 /// `std::sync::Mutex` so the bridge can take a short non-await lock per
@@ -57,6 +59,10 @@ pub(crate) struct VtState {
     /// Broadcast of wire messages (Binary deltas + Text sidecars). All emit
     /// paths go through this sender; subscribers attach via subscribe_frames.
     pub wire_broadcast: broadcast::Sender<WireMessage>,
+    /// Most recent sanitized OSC terminal title, or `None` before any
+    /// title has been set / after `ResetTitle`. Read by
+    /// `TerminalService::all_titles` for tab labels.
+    pub title: Option<String>,
 }
 
 impl VtState {
@@ -83,6 +89,7 @@ impl VtState {
             prev_cursor: None,
             hyperlinks: HyperlinkInterner::new(),
             wire_broadcast,
+            title: None,
         }
     }
 
@@ -268,6 +275,8 @@ pub(crate) async fn run_bridge_task(
     mut pty_rx: mpsc::Receiver<Bytes>,
     mut reply_rx: mpsc::UnboundedReceiver<ReplyFrame>,
     mut control_rx: mpsc::Receiver<ControlFrame>,
+    activity_window: Option<WindowId>,
+    title_tx: broadcast::Sender<WindowId>,
     cancel: CancellationToken,
 ) {
     let mut coalescer = Coalescer::new();
@@ -337,8 +346,23 @@ pub(crate) async fn run_bridge_task(
                 }
             }
             ctrl = control_rx.recv() => {
-                if ctrl.is_none() {
-                    break;
+                match ctrl {
+                    None => break,
+                    Some(ControlFrame::Title(raw)) => {
+                        let clean = sanitize_title(&raw);
+                        vt_state.lock().expect("vt_state poisoned").title = Some(clean);
+                        if let Some(wid) = &activity_window {
+                            let _ = title_tx.send(wid.clone());
+                        }
+                    }
+                    Some(ControlFrame::ResetTitle) => {
+                        vt_state.lock().expect("vt_state poisoned").title = None;
+                        if let Some(wid) = &activity_window {
+                            let _ = title_tx.send(wid.clone());
+                        }
+                    }
+                    // NOTE: Bell and Clipboard remain intentionally dropped.
+                    Some(ControlFrame::Bell | ControlFrame::Clipboard { .. }) => {}
                 }
             }
         }
@@ -437,11 +461,14 @@ mod tests {
 
         let (pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
         let cancel = CancellationToken::new();
+        let (title_tx, _title_rx) = broadcast::channel::<ozmux_multiplexer::WindowId>(8);
         let handle = tokio::spawn(super::run_bridge_task(
             vt_state.clone(),
             pty_rx,
             reply_rx,
             control_rx,
+            None,
+            title_tx,
             cancel.clone(),
         ));
 
@@ -458,6 +485,54 @@ mod tests {
         assert!(
             line0_text.starts_with("hello"),
             "expected 'hello' on row 0, got: {line0_text:?}"
+        );
+
+        cancel.cancel();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn bridge_task_captures_and_sanitizes_title() {
+        let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
+        let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
+        let drop_counter = Arc::new(DropCounter::new());
+        let listener = TermListener {
+            reply_tx,
+            control_tx: control_tx.clone(),
+            drop_counter,
+        };
+        let (wire_broadcast, _rx) = broadcast::channel::<WireMessage>(8);
+        let vt_state = Arc::new(std::sync::Mutex::new(VtState::new(
+            10,
+            3,
+            listener,
+            wire_broadcast,
+        )));
+        let (_pty_tx, pty_rx) = mpsc::channel::<Bytes>(8);
+        let (title_tx, mut title_rx) =
+            broadcast::channel::<ozmux_multiplexer::WindowId>(8);
+        let wid = ozmux_multiplexer::WindowId::new();
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(super::run_bridge_task(
+            vt_state.clone(),
+            pty_rx,
+            reply_rx,
+            control_rx,
+            Some(wid.clone()),
+            title_tx,
+            cancel.clone(),
+        ));
+
+        control_tx
+            .send(ControlFrame::Title("hi\x07there".into()))
+            .await
+            .unwrap();
+        let signalled = title_rx.recv().await.unwrap();
+        assert_eq!(signalled, wid);
+        assert_eq!(
+            vt_state.lock().unwrap().title.as_deref(),
+            Some("hithere"),
+            "control char should be stripped before storage"
         );
 
         cancel.cancel();

--- a/daemon/terminal/src/vt/title.rs
+++ b/daemon/terminal/src/vt/title.rs
@@ -1,0 +1,60 @@
+//! Sanitization of OSC-supplied terminal titles for safe display as tab labels.
+
+/// Maximum length (in `char`s) of a sanitized title.
+const MAX_LEN: usize = 256;
+
+/// Returns a display-safe copy of an OSC terminal title.
+///
+/// OSC 0/2 title content is fully attacker-controlled. This strips C0/C1
+/// control characters, zero-width and bidi-override characters, and caps
+/// the length so a hostile title cannot corrupt or spoof the tab bar.
+pub(crate) fn sanitize_title(raw: &str) -> String {
+    let cleaned: String = raw.chars().filter(|c| !is_disallowed(*c)).collect();
+    if cleaned.chars().count() > MAX_LEN {
+        cleaned
+            .chars()
+            .take(MAX_LEN - 1)
+            .chain(std::iter::once('…'))
+            .collect()
+    } else {
+        cleaned
+    }
+}
+
+fn is_disallowed(c: char) -> bool {
+    let u = c as u32;
+    u <= 0x1F
+        || (0x7F..=0x9F).contains(&u)
+        || matches!(
+            c,
+            '\u{200B}'..='\u{200F}' | '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{FEFF}'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_title;
+
+    #[test]
+    fn strips_control_chars() {
+        assert_eq!(sanitize_title("hi\x07\x1bthere"), "hithere");
+        assert_eq!(sanitize_title("clean title"), "clean title");
+    }
+
+    #[test]
+    fn strips_bidi_override() {
+        assert_eq!(sanitize_title("a\u{202e}b"), "ab");
+    }
+
+    #[test]
+    fn caps_length_with_ellipsis() {
+        let out = sanitize_title(&"x".repeat(500));
+        assert_eq!(out.chars().count(), 256);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn short_title_unchanged() {
+        assert_eq!(sanitize_title(&"x".repeat(256)).chars().count(), 256);
+    }
+}


### PR DESCRIPTION
## Problem

A pane can host multiple activities (terminal/extension), but the UI gave
no way to see them or switch between them — only the active activity was
ever visible. Terminal activities also had no live title: the tab/label
could only show the static activity name, never reflecting the running
program or the shell's OSC 0/2 title.

## Solution

Adds a per-pane activity tab bar driven by live terminal titles, spanning
the terminal daemon, the HTTP server, and the frontend.

**`daemon/terminal`**
- Capture OSC 0/2 titles in the VT bridge and store the latest sanitized
  title in `VtState`. `sanitize_title` strips C0/C1 controls, zero-width
  and bidi-override characters, and caps length — OSC title content is
  attacker-controlled, so it must not be able to spoof or corrupt the tab
  bar.
- Broadcast window-scoped title-change notifications via a new
  `subscribe_title_changes` channel; `all_titles` snapshots current
  titles. Title changes are de-duplicated at the source so a shell
  re-emitting the same title per prompt redraw does not trigger work.

**`daemon/http_server`**
- `WindowView` now carries an activity `title`, resolved from the live
  terminal title (falling back to the activity name).
- A background `title_republish` task re-broadcasts the `WindowView` on
  title changes, coalescing bursts within a short debounce window so a
  title storm cannot push a slow events-WS subscriber into `Lagged`.
- New terminal activities default their name to `\"Terminal\"`.

**`daemon/frontend`**
- New `PaneTabBar` component renders one tab per activity above the pane
  content, marks the active one, and switches activity on click.
- Shared `activateActivity` helper de-duplicates the activation request
  used by the tab bar and by `newTerminalActivity`.
- `ActivityView` is promoted to a named type carrying `title`.

Tested with unit tests across all three crates/packages and a Playwright
e2e (`Ctrl+B c` adds a tab, clicking switches activity).