### PR TITLE
feat: break-activity-to-pane shortcut (Ctrl+B Shift+S / Shift+V)

### DIFF
--- a/daemon/configs/src/error.rs
+++ b/daemon/configs/src/error.rs
@@ -35,13 +35,6 @@ pub enum OzmuxConfigsError {
         chord: crate::shortcuts::KeyChord,
     },
 
-    /// A binding declared modifier keys, which are not yet supported.
-    #[error("modifier keys are not supported yet for binding {chord:?}")]
-    UnsupportedModifier {
-        /// Chord that used modifiers.
-        chord: crate::shortcuts::KeyChord,
-    },
-
     /// The configured font size is outside the supported range.
     #[error("font size {size} is out of range (expected 0 < size <= 200)")]
     InvalidFontSize {

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -148,6 +148,10 @@ mod tests {
         )
         .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
+        assert!(
+            merged.shortcuts.bindings[0].chord.modifiers.shift,
+            "shift modifier must survive parsing and merging"
+        );
         validate(&merged).unwrap();
     }
 

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -5,7 +5,7 @@ use crate::OzmuxConfigs;
 use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
 use crate::font::FontPatch;
-use crate::shortcuts::{Binding, Modifiers, Prefix};
+use crate::shortcuts::{Binding, Prefix};
 use crate::theme::ThemePatch;
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -49,16 +49,10 @@ impl RawConfigs {
     }
 }
 
-/// Walks `configs.shortcuts.bindings` and rejects duplicates or modifier-bearing
-/// chords (the latter is a v0 constraint).
+/// Walks `configs.shortcuts.bindings` and rejects duplicate chords.
 pub(crate) fn validate(configs: &OzmuxConfigs) -> OzmuxConfigsResult {
     let mut seen: HashSet<&crate::shortcuts::KeyChord> = HashSet::new();
     for b in &configs.shortcuts.bindings {
-        if b.chord.modifiers != Modifiers::default() {
-            return Err(OzmuxConfigsError::UnsupportedModifier {
-                chord: b.chord.clone(),
-            });
-        }
         if !seen.insert(&b.chord) {
             return Err(OzmuxConfigsError::DuplicateBinding {
                 chord: b.chord.clone(),
@@ -81,7 +75,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 5);
+        assert_eq!(merged.shortcuts.bindings.len(), 7);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane
@@ -143,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_modifier_in_binding() {
+    fn validate_accepts_modifier_in_binding() {
         let raw: RawConfigs = toml::from_str(
             r#"
             [[shortcuts.bindings]]
@@ -154,11 +148,7 @@ mod tests {
         )
         .unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        let err = validate(&merged).unwrap_err();
-        assert!(matches!(
-            err,
-            crate::OzmuxConfigsError::UnsupportedModifier { .. }
-        ));
+        validate(&merged).unwrap();
     }
 
     #[test]

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -166,6 +166,30 @@ impl Default for Shortcuts {
                     },
                     action: Action::CloseActivity,
                 },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('s'),
+                        modifiers: Modifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::BreakActivityToPane {
+                        direction: SplitDirection::Horizontal,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('v'),
+                        modifiers: Modifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::BreakActivityToPane {
+                        direction: SplitDirection::Vertical,
+                    },
+                },
             ],
         }
     }
@@ -223,6 +247,11 @@ pub enum Action {
     },
     /// Split the active pane.
     SplitPane {
+        /// Split direction.
+        direction: SplitDirection,
+    },
+    /// Split the active pane and move the active activity into the new pane.
+    BreakActivityToPane {
         /// Split direction.
         direction: SplitDirection,
     },
@@ -437,7 +466,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}}]}"#
         );
     }
 }

--- a/daemon/configs/tests/load.rs
+++ b/daemon/configs/tests/load.rs
@@ -27,7 +27,11 @@ async fn empty_file_yields_defaults() {
     let configs = load_with_overrides(Some(fixture("empty.toml")), None, None)
         .await
         .unwrap();
-    assert_eq!(configs.shortcuts.bindings.len(), 1);
+    let defaults = OzmuxConfigs::default();
+    assert_eq!(
+        configs.shortcuts.bindings.len(),
+        defaults.shortcuts.bindings.len()
+    );
     assert!(matches!(
         configs.shortcuts.bindings[0].action,
         Action::ClosePane
@@ -41,7 +45,11 @@ async fn prefix_override_keeps_default_bindings() {
         .unwrap();
     assert_eq!(configs.shortcuts.prefix.chord.key, Key::Char('a'));
     assert_eq!(configs.shortcuts.prefix.timeout_ms, 3000);
-    assert_eq!(configs.shortcuts.bindings.len(), 1);
+    let defaults = OzmuxConfigs::default();
+    assert_eq!(
+        configs.shortcuts.bindings.len(),
+        defaults.shortcuts.bindings.len()
+    );
     assert!(matches!(
         configs.shortcuts.bindings[0].action,
         Action::ClosePane
@@ -83,11 +91,18 @@ async fn duplicate_binding_rejected() {
 }
 
 #[tokio::test]
-async fn modifier_binding_rejected() {
-    let err = load_with_overrides(Some(fixture("modifier_binding.toml")), None, None)
+async fn modifier_binding_accepted() {
+    let configs = load_with_overrides(Some(fixture("modifier_binding.toml")), None, None)
         .await
-        .unwrap_err();
-    assert!(matches!(err, OzmuxConfigsError::UnsupportedModifier { .. }));
+        .unwrap();
+    assert!(
+        configs
+            .shortcuts
+            .bindings
+            .iter()
+            .any(|b| b.chord.modifiers.shift),
+        "a shift-modifier binding must load successfully"
+    );
 }
 
 #[tokio::test]

--- a/daemon/frontend/src/layout/breakActivityToPane.test.ts
+++ b/daemon/frontend/src/layout/breakActivityToPane.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { breakActivityToPane } from './breakActivityToPane';
+
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.restoreAllMocks();
+});
+
+describe('breakActivityToPane', () => {
+  it.each([
+    'horizontal',
+    'vertical',
+  ] as const)('issues POST .../activities/{aid}/break-to-pane with %s orientation', async (orientation) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await breakActivityToPane('wid-1', 'pid-42', 'aid-7', orientation);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/windows/wid-1/panes/pid-42/activities/aid-7/break-to-pane',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ orientation }),
+      },
+    );
+  });
+
+  it('warns on a 409 (single-activity pane) response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 409 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await breakActivityToPane('wid-1', 'pid-1', 'aid-1', 'horizontal');
+    expect(console.warn).toHaveBeenCalledWith(
+      'break activity to pane failed',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-1',
+        activityId: 'aid-1',
+        orientation: 'horizontal',
+        status: 409,
+      }),
+    );
+  });
+
+  it('warns on a network failure', async () => {
+    const err = new Error('net');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await breakActivityToPane('wid-1', 'pid-x', 'aid-x', 'vertical');
+    expect(console.warn).toHaveBeenCalledWith(
+      'break activity to pane request errored',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-x',
+        activityId: 'aid-x',
+        orientation: 'vertical',
+        error: err,
+      }),
+    );
+  });
+});

--- a/daemon/frontend/src/layout/breakActivityToPane.ts
+++ b/daemon/frontend/src/layout/breakActivityToPane.ts
@@ -1,0 +1,34 @@
+import { breakActivityToPaneEndpoint } from '../terminal/api';
+import type { ActivityId, PaneId, SplitOrientation, WindowId } from './types';
+
+export async function breakActivityToPane(
+  windowId: WindowId,
+  paneId: PaneId,
+  activityId: ActivityId,
+  orientation: SplitOrientation,
+): Promise<void> {
+  try {
+    const resp = await fetch(breakActivityToPaneEndpoint(windowId, paneId, activityId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ orientation }),
+    });
+    if (!resp.ok) {
+      console.warn('break activity to pane failed', {
+        windowId,
+        paneId,
+        activityId,
+        orientation,
+        status: resp.status,
+      });
+    }
+  } catch (e) {
+    console.warn('break activity to pane request errored', {
+      windowId,
+      paneId,
+      activityId,
+      orientation,
+      error: e,
+    });
+  }
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -156,17 +156,29 @@ describe('actionToHandler', () => {
     });
   });
 
-  it('maps break-activity-to-pane to a handler', () => {
-    const ctx = {
+  it('returns a handler that POSTs break-to-pane with vertical orientation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext({
       activeWindow: () => 'wid-1',
       activePane: () => 'pid-1',
       activeActivity: () => 'aid-1',
-    };
-    const handler = actionToHandler(
-      { type: 'break-activity-to-pane', direction: 'horizontal' },
-      ctx,
+    });
+    const handler = actionToHandler({ type: 'break-activity-to-pane', direction: 'vertical' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/windows/wid-1/panes/pid-1/activities/aid-1/break-to-pane',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ orientation: 'vertical' }),
+      },
     );
-    expect(handler).not.toBeNull();
   });
 
   it('close-activity handler is a no-op when active activity is null', async () => {

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -156,6 +156,19 @@ describe('actionToHandler', () => {
     });
   });
 
+  it('maps break-activity-to-pane to a handler', () => {
+    const ctx = {
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+      activeActivity: () => 'aid-1',
+    };
+    const handler = actionToHandler(
+      { type: 'break-activity-to-pane', direction: 'horizontal' },
+      ctx,
+    );
+    expect(handler).not.toBeNull();
+  });
+
   it('close-activity handler is a no-op when active activity is null', async () => {
     const fetchMock = vi.fn();
     globalThis.fetch = fetchMock as typeof globalThis.fetch;

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -1,3 +1,4 @@
+import { breakActivityToPane } from '../layout/breakActivityToPane';
 import { closeActivity } from '../layout/closeActivity';
 import { closePane } from '../layout/closePane';
 import { newTerminalActivity } from '../layout/newTerminalActivity';
@@ -23,6 +24,11 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
     case 'split-pane': {
       const orientation = action.direction;
       return () => withActivePane(ctx, (w, p) => splitPane(w, p, orientation));
+    }
+    case 'break-activity-to-pane': {
+      const orientation = action.direction;
+      return () =>
+        withActivePaneActivity(ctx, (w, p, a) => breakActivityToPane(w, p, a, orientation));
     }
     case 'new-terminal-activity':
       return () => withActivePane(ctx, newTerminalActivity);

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -163,6 +163,25 @@ describe('parseShortcuts', () => {
     expect(out?.bindings[1].action).toEqual({ type: 'new-terminal-activity' });
   });
 
+  it('parses a break-activity-to-pane binding', () => {
+    const out = parseShortcuts({
+      ...DEFAULT_JSON,
+      bindings: [
+        {
+          key: 's',
+          modifiers: { ctrl: false, shift: true, alt: false, meta: false },
+          action: { type: 'break-activity-to-pane', direction: 'horizontal' },
+        },
+      ],
+    });
+    expect(out?.bindings).toHaveLength(1);
+    expect(out?.bindings[0].action).toEqual({
+      type: 'break-activity-to-pane',
+      direction: 'horizontal',
+    });
+    expect(out?.bindings[0].chord.modifiers.shift).toBe(true);
+  });
+
   it('parses a close-activity binding', () => {
     const withCloseActivity = {
       ...DEFAULT_JSON,

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -34,6 +34,10 @@ const ActionSchema = z.discriminatedUnion('type', [
     type: z.literal('split-pane'),
     direction: z.enum(['horizontal', 'vertical']),
   }),
+  z.object({
+    type: z.literal('break-activity-to-pane'),
+    direction: z.enum(['horizontal', 'vertical']),
+  }),
   z.object({ type: z.literal('new-terminal-activity') }),
   z.object({ type: z.literal('close-activity') }),
 ]);

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -13,6 +13,8 @@ export const activateActivityEndpoint = (wid: string, pid: string, aid: string) 
   `/windows/${wid}/panes/${pid}/activities/${aid}/activate`;
 export const closeActivityEndpoint = (wid: string, pid: string, aid: string) =>
   `/windows/${wid}/panes/${pid}/activities/${aid}`;
+export const breakActivityToPaneEndpoint = (wid: string, pid: string, aid: string) =>
+  `/windows/${wid}/panes/${pid}/activities/${aid}/break-to-pane`;
 
 export const vtTerminalWsUrl = (
   windowId: string,

--- a/daemon/http_server/src/handlers/windows/panes/activities.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 pub mod activate;
 pub mod add_to_pane;
+pub mod break_to_pane;
 pub mod close_activity;
 pub mod handlers_ws;
 pub mod iframe_serve;
@@ -23,6 +24,10 @@ pub fn router() -> Router<AppState> {
             method_delete(close_activity::close_activity),
         )
         .route("/{activity_id}/activate", post(activate::activate))
+        .route(
+            "/{activity_id}/break-to-pane",
+            post(break_to_pane::break_to_pane),
+        )
         .route("/{activity_id}/terminal/ws", get(terminal_ws::terminal_ws))
         .route("/{activity_id}/handlers/ws", get(handlers_ws::handlers_ws))
         .route(

--- a/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
@@ -253,5 +253,32 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let new_pid: PaneId = serde_json::from_value(v["new_pane_id"].clone()).unwrap();
         assert_eq!(registry.pane_owner(&new_pid).as_deref(), Some("memo"));
+        assert_eq!(
+            registry.activity_owner(&ext_aid).as_deref(),
+            Some("memo"),
+            "moving an extension activity must not drop its activity->owner row"
+        );
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_with_wrong_wid_returns_409() {
+        let state = fresh_state();
+        let (sid, wid_a, pid_a, aid_a) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid_a, &pid_a).await;
+        let (wid_b, _, _) = state
+            .multiplexer
+            .create_window(Some(&sid), None)
+            .await
+            .unwrap();
+        let (router, _state) = router_with(state);
+        let resp = post_break(
+            router,
+            &wid_b,
+            &pid_a,
+            &aid_a,
+            r#"{"orientation":"horizontal"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 }

--- a/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
@@ -190,6 +190,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn break_to_pane_sibling_pty_stays_alive() {
+        // Spec guarantee: moving an activity must not disturb sibling PTYs in
+        // the source pane.
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let sibling_aid = add_second_activity(&state, &wid, &pid).await;
+        for spawn_aid in [&aid, &sibling_aid] {
+            state
+                .terminal
+                .spawn(
+                    pid.clone(),
+                    spawn_aid.clone(),
+                    ozmux_terminal::SpawnOptions {
+                        cols: 80,
+                        rows: 24,
+                        shell: "/bin/sh".to_string(),
+                        cwd: None,
+                        window_id: None,
+                        session_id: None,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let terminal = state.terminal.clone();
+        let (router, _state) = router_with(state);
+        let resp = post_break(router, &wid, &pid, &aid, r#"{"orientation":"horizontal"}"#).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert!(
+            terminal.subscriber_count(&sibling_aid).await.is_some(),
+            "the sibling activity's PTY must survive the move"
+        );
+    }
+
+    #[tokio::test]
     async fn break_to_pane_new_pane_is_activatable() {
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;

--- a/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
@@ -49,7 +49,9 @@ pub async fn break_to_pane(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use crate::test_helpers::{
+        add_activity_via_window, bootstrap_default, fresh_state, router_with,
+    };
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
     use ozmux_multiplexer::{Activity, ActivityId, PaneId, WindowId};
@@ -77,26 +79,11 @@ mod tests {
             .unwrap()
     }
 
-    async fn add_second_activity(
-        state: &crate::AppState,
-        wid: &WindowId,
-        pid: &PaneId,
-    ) -> ActivityId {
-        let activity = Activity::terminal(ActivityId::new());
-        let aid = activity.id.clone();
-        state
-            .multiplexer
-            .with_window_or_404(wid, |w| w.pane_mut(pid)?.add_activity(activity))
-            .await
-            .unwrap();
-        aid
-    }
-
     #[tokio::test]
     async fn break_to_pane_returns_201_and_new_pane_id() {
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid, &pid).await;
+        let _second = add_activity_via_window(&state, &wid, &pid).await;
         let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
         let (router, _state) = router_with(state);
 
@@ -134,7 +121,7 @@ mod tests {
     async fn break_to_pane_unknown_activity_returns_404() {
         let state = fresh_state();
         let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid, &pid).await;
+        let _second = add_activity_via_window(&state, &wid, &pid).await;
         let (router, _state) = router_with(state);
         let resp = post_break(
             router,
@@ -151,7 +138,7 @@ mod tests {
     async fn break_to_pane_duplicate_new_pane_id_returns_409() {
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid, &pid).await;
+        let _second = add_activity_via_window(&state, &wid, &pid).await;
         let (router, _state) = router_with(state);
         let body = format!(r#"{{"orientation":"horizontal","new_pane_id":"{pid}"}}"#);
         let resp = post_break(router, &wid, &pid, &aid, &body).await;
@@ -162,7 +149,7 @@ mod tests {
     async fn break_to_pane_moved_activity_pty_is_not_respawned() {
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid, &pid).await;
+        let _second = add_activity_via_window(&state, &wid, &pid).await;
         state
             .terminal
             .spawn(
@@ -191,11 +178,11 @@ mod tests {
 
     #[tokio::test]
     async fn break_to_pane_sibling_pty_stays_alive() {
-        // Spec guarantee: moving an activity must not disturb sibling PTYs in
+        // NOTE: moving an activity must not disturb sibling PTYs in
         // the source pane.
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
-        let sibling_aid = add_second_activity(&state, &wid, &pid).await;
+        let sibling_aid = add_activity_via_window(&state, &wid, &pid).await;
         for spawn_aid in [&aid, &sibling_aid] {
             state
                 .terminal
@@ -228,7 +215,7 @@ mod tests {
     async fn break_to_pane_new_pane_is_activatable() {
         let state = fresh_state();
         let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid, &pid).await;
+        let _second = add_activity_via_window(&state, &wid, &pid).await;
         let (router, _state) = router_with(state);
         let resp = post_break(
             router.clone(),
@@ -299,7 +286,7 @@ mod tests {
     async fn break_to_pane_with_wrong_wid_returns_409() {
         let state = fresh_state();
         let (sid, wid_a, pid_a, aid_a) = bootstrap_default(&state).await;
-        let _second = add_second_activity(&state, &wid_a, &pid_a).await;
+        let _second = add_activity_via_window(&state, &wid_a, &pid_a).await;
         let (wid_b, _, _) = state
             .multiplexer
             .create_window(Some(&sid), None)

--- a/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/break_to_pane.rs
@@ -1,0 +1,257 @@
+//! `POST /windows/{wid}/panes/{pid}/activities/{aid}/break-to-pane` — split
+//! the pane and move the activity into the new pane.
+
+use crate::state::BreakActivityInput;
+use crate::{AppState, error::HttpResult};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_multiplexer::{ActivityId, PaneId, Side, SplitOrientation, WindowId};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct BreakToPaneRequest {
+    orientation: SplitOrientation,
+    #[serde(default)]
+    side: Side,
+    /// Client-supplied id for the new Pane. When absent the server picks one.
+    #[serde(default)]
+    new_pane_id: Option<PaneId>,
+}
+
+/// Splits the target pane and moves the activity into the new pane.
+pub async fn break_to_pane(
+    State(state): State<AppState>,
+    Path((wid, pid, aid)): Path<(WindowId, PaneId, ActivityId)>,
+    Json(req): Json<BreakToPaneRequest>,
+) -> HttpResult<(StatusCode, Json<serde_json::Value>)> {
+    let new_pane_id = req.new_pane_id.unwrap_or_default();
+    let created = state
+        .break_activity_to_pane(
+            &wid,
+            &pid,
+            &aid,
+            BreakActivityInput {
+                new_pane_id,
+                side: req.side,
+                orientation: req.orientation,
+            },
+        )
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "new_pane_id": created })),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{Activity, ActivityId, PaneId, WindowId};
+    use tower::ServiceExt;
+
+    async fn post_break(
+        router: axum::Router,
+        wid: &WindowId,
+        pid: &PaneId,
+        aid: &ActivityId,
+        body: &str,
+    ) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/windows/{wid}/panes/{pid}/activities/{aid}/break-to-pane"
+                    ))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn add_second_activity(
+        state: &crate::AppState,
+        wid: &WindowId,
+        pid: &PaneId,
+    ) -> ActivityId {
+        let activity = Activity::terminal(ActivityId::new());
+        let aid = activity.id.clone();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| w.pane_mut(pid)?.add_activity(activity))
+            .await
+            .unwrap();
+        aid
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_returns_201_and_new_pane_id() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid, &pid).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _state) = router_with(state);
+
+        let resp = post_break(
+            router,
+            &wid,
+            &pid,
+            &aid,
+            r#"{"orientation":"horizontal","side":"after"}"#,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["new_pane_id"].is_string());
+
+        let view = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("publish timed out")
+            .expect("recv error");
+        assert_eq!(view["id"].as_str(), Some(wid.as_ref()));
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_single_activity_returns_409() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let (router, _state) = router_with(state);
+        let resp = post_break(router, &wid, &pid, &aid, r#"{"orientation":"horizontal"}"#).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_unknown_activity_returns_404() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid, &pid).await;
+        let (router, _state) = router_with(state);
+        let resp = post_break(
+            router,
+            &wid,
+            &pid,
+            &ActivityId::new(),
+            r#"{"orientation":"horizontal"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_duplicate_new_pane_id_returns_409() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid, &pid).await;
+        let (router, _state) = router_with(state);
+        let body = format!(r#"{{"orientation":"horizontal","new_pane_id":"{pid}"}}"#);
+        let resp = post_break(router, &wid, &pid, &aid, &body).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_moved_activity_pty_is_not_respawned() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid, &pid).await;
+        state
+            .terminal
+            .spawn(
+                pid.clone(),
+                aid.clone(),
+                ozmux_terminal::SpawnOptions {
+                    cols: 80,
+                    rows: 24,
+                    shell: "/bin/sh".to_string(),
+                    cwd: None,
+                    window_id: None,
+                    session_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        let terminal = state.terminal.clone();
+        let (router, _state) = router_with(state);
+        let resp = post_break(router, &wid, &pid, &aid, r#"{"orientation":"horizontal"}"#).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert!(
+            terminal.subscriber_count(&aid).await.is_some(),
+            "moved activity keeps its original PTY"
+        );
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_new_pane_is_activatable() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid) = bootstrap_default(&state).await;
+        let _second = add_second_activity(&state, &wid, &pid).await;
+        let (router, _state) = router_with(state);
+        let resp = post_break(
+            router.clone(),
+            &wid,
+            &pid,
+            &aid,
+            r#"{"orientation":"horizontal"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let new_pid = v["new_pane_id"].as_str().unwrap();
+
+        let activate = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{wid}/panes/{new_pid}/activate"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(activate.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn break_to_pane_extension_activity_records_new_pane_owner() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        state
+            .extensions
+            .register("memo", std::path::Path::new("/tmp"));
+        let ext_activity =
+            Activity::extension(ActivityId::new(), "ext", std::path::PathBuf::from("/tmp"));
+        let ext_aid = ext_activity.id.clone();
+        state
+            .multiplexer
+            .with_window_or_404(&wid, |w| w.pane_mut(&pid)?.add_activity(ext_activity))
+            .await
+            .unwrap();
+        state.extensions.record_activity_owner(&ext_aid, "memo");
+        let registry = state.extensions.clone();
+        let (router, _state) = router_with(state);
+
+        let resp = post_break(
+            router,
+            &wid,
+            &pid,
+            &ext_aid,
+            r#"{"orientation":"horizontal"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let new_pid: PaneId = serde_json::from_value(v["new_pane_id"].clone()).unwrap();
+        assert_eq!(registry.pane_owner(&new_pid).as_deref(), Some("memo"));
+    }
+}

--- a/daemon/http_server/src/handlers/windows/panes/activities/close_activity.rs
+++ b/daemon/http_server/src/handlers/windows/panes/activities/close_activity.rs
@@ -22,28 +22,13 @@ pub async fn close_activity(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use crate::test_helpers::{
+        add_activity_via_window, bootstrap_default, fresh_state, router_with,
+    };
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use ozmux_multiplexer::{Activity, ActivityId, PaneId, WindowId};
+    use ozmux_multiplexer::ActivityId;
     use tower::ServiceExt;
-
-    async fn add_activity_via_window(
-        state: &crate::AppState,
-        wid: &WindowId,
-        pid: &PaneId,
-    ) -> ActivityId {
-        let new_aid = ActivityId::new();
-        state
-            .multiplexer
-            .with_window_or_404(wid, |w| {
-                w.pane_mut(pid)?
-                    .add_activity(Activity::terminal(new_aid.clone()))
-            })
-            .await
-            .unwrap();
-        new_aid
-    }
 
     #[tokio::test]
     async fn close_activity_returns_204_when_pane_has_two() {

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -110,7 +110,7 @@ pub fn windows_router() -> Router<AppState> {
 pub(crate) mod test_helpers {
     use super::{AppState, daemon_router};
     use axum::Router;
-    use ozmux_multiplexer::{ActivityId, PaneId, SessionId, WindowId};
+    use ozmux_multiplexer::{Activity, ActivityId, PaneId, SessionId, WindowId};
 
     pub(crate) fn fresh_state() -> AppState {
         AppState::new(
@@ -155,6 +155,25 @@ pub(crate) mod test_helpers {
             .await
             .unwrap();
         (sid, wid, pid, aid)
+    }
+
+    /// Insert a fresh terminal Activity into an existing pane via the
+    /// multiplexer, bypassing PTY spawn. Returns the new ActivityId.
+    pub(crate) async fn add_activity_via_window(
+        state: &AppState,
+        wid: &WindowId,
+        pid: &PaneId,
+    ) -> ActivityId {
+        let aid = ActivityId::new();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| {
+                w.pane_mut(pid)?
+                    .add_activity(Activity::terminal(aid.clone()))
+            })
+            .await
+            .unwrap();
+        aid
     }
 }
 

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -34,6 +34,16 @@ pub struct SplitOutcome {
     pub new_activity_id: ActivityId,
 }
 
+/// Input bundle for [`AppState::break_activity_to_pane`].
+pub struct BreakActivityInput {
+    /// Id for the new pane (caller-supplied or server-generated).
+    pub new_pane_id: PaneId,
+    /// Which side of the target pane the new pane appears on.
+    pub side: Side,
+    /// Axis along which to split.
+    pub orientation: SplitOrientation,
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub multiplexer: MultiplexerService,
@@ -222,6 +232,47 @@ impl AppState {
             new_pane_id,
             new_activity_id,
         })
+    }
+
+    /// Split `target_pane_id` and move the Activity `aid` from it into the
+    /// new Pane. No PTY is spawned — the moved Activity keeps its existing
+    /// one. Returns the id of the new Pane.
+    pub async fn break_activity_to_pane(
+        &self,
+        wid: &WindowId,
+        target_pane_id: &PaneId,
+        aid: &ActivityId,
+        input: BreakActivityInput,
+    ) -> HttpResult<PaneId> {
+        self.ensure_pane_in_window(wid, target_pane_id)?;
+        let new_pane_id = input.new_pane_id.clone();
+
+        self.multiplexer
+            .with_window_or_404(wid, |w| -> MultiplexerResult<_> {
+                w.break_activity_to_pane(
+                    target_pane_id,
+                    aid,
+                    new_pane_id.clone(),
+                    input.side,
+                    input.orientation,
+                )
+            })
+            .await?;
+
+        self.multiplexer
+            .pane_owner_window
+            .insert(new_pane_id.clone(), wid.clone());
+
+        // For an Extension-kind Activity the activity->owner registry row is
+        // still valid (the ActivityId is unchanged); only the new pane->owner
+        // row is missing. `activity_owner` returns `None` for terminal
+        // activities, so this is a no-op in the common case.
+        if let Some(name) = self.extensions.activity_owner(aid) {
+            self.extensions.record_pane_owner(&new_pane_id, &name);
+        }
+
+        self.publish_window_layout(wid).await;
+        Ok(new_pane_id)
     }
 
     /// Close a Pane: remove it from the cell tree, tear down extension

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -245,7 +245,7 @@ impl AppState {
         input: BreakActivityInput,
     ) -> HttpResult<PaneId> {
         self.ensure_pane_in_window(wid, target_pane_id)?;
-        let new_pane_id = input.new_pane_id.clone();
+        let new_pane_id = input.new_pane_id;
 
         self.multiplexer
             .with_window_or_404(wid, |w| -> MultiplexerResult<_> {

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -263,8 +263,8 @@ impl AppState {
             .pane_owner_window
             .insert(new_pane_id.clone(), wid.clone());
 
-        // For an Extension-kind Activity the activity->owner registry row is
-        // still valid (the ActivityId is unchanged); only the new pane->owner
+        // NOTE: For an Extension-kind Activity the activity->owner registry row
+        // is still valid (the ActivityId is unchanged); only the new pane->owner
         // row is missing. `activity_owner` returns `None` for terminal
         // activities, so this is a no-op in the common case.
         if let Some(name) = self.extensions.activity_owner(aid) {

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -114,9 +114,9 @@ impl Window {
         side: Side,
         orientation: SplitOrientation,
     ) -> MultiplexerResult<()> {
-        if self.panes.contains_key(&new_pane_id) {
-            return Err(MultiplexerError::PaneIdConflict(new_pane_id));
-        }
+        // NOTE: `new_pane_id` is not pre-checked here — `split_pane` rejects
+        // a collision before any mutation, which preserves the rollback-free
+        // ordering and avoids a duplicate `HashMap::contains_key` lookup.
         let target = self.pane(target_pane_id)?;
         let moved = match target.activity(aid) {
             Some(activity) => activity.clone(),

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -89,6 +89,54 @@ impl Window {
         Ok(())
     }
 
+    /// Split `target_pane_id` and move the Activity `aid` out of it into the
+    /// freshly-created Pane.
+    ///
+    /// The moved Activity becomes the sole Activity of the new Pane, and the
+    /// new Pane becomes `active_pane`. The Activity is *cloned* into the new
+    /// Pane first and removed from the source Pane second, so the only
+    /// fallible mutation (`split_pane`) runs before the irreversible one and
+    /// no rollback path is needed. Between those two steps the same
+    /// `ActivityId` is briefly present in both Panes; this is safe only
+    /// because the whole method runs under the per-Window lock.
+    ///
+    /// # Errors
+    ///
+    /// - `PaneIdConflict` — `new_pane_id` is already in use.
+    /// - `PaneNotFound` — `target_pane_id` is not in this Window.
+    /// - `ActivityNotInPane` — `aid` is not an Activity of the target Pane.
+    /// - `CannotRemoveLastActivity` — the target Pane holds only `aid`.
+    pub fn break_activity_to_pane(
+        &mut self,
+        target_pane_id: &PaneId,
+        aid: &ActivityId,
+        new_pane_id: PaneId,
+        side: Side,
+        orientation: SplitOrientation,
+    ) -> MultiplexerResult<()> {
+        if self.panes.contains_key(&new_pane_id) {
+            return Err(MultiplexerError::PaneIdConflict(new_pane_id));
+        }
+        let target = self.pane(target_pane_id)?;
+        let moved = match target.activity(aid) {
+            Some(activity) => activity.clone(),
+            None => {
+                return Err(MultiplexerError::ActivityNotInPane {
+                    pane: target_pane_id.clone(),
+                    activity: aid.clone(),
+                });
+            }
+        };
+        if target.activities.len() == 1 {
+            return Err(MultiplexerError::CannotRemoveLastActivity(
+                target_pane_id.clone(),
+            ));
+        }
+        self.split_pane(target_pane_id, new_pane_id, moved, side, orientation)?;
+        self.pane_mut(target_pane_id)?.remove_activity(aid)?;
+        Ok(())
+    }
+
     /// Close a Pane. Returns the ids of the activities that were destroyed,
     /// so the caller can tear down PTYs and extension registry entries.
     pub fn close_pane(&mut self, pane_id: &PaneId) -> MultiplexerResult<Vec<ActivityId>> {
@@ -207,6 +255,122 @@ mod tests {
     use super::*;
     use crate::window::cells::{Side, SplitOrientation};
     use crate::window::pane::activity::{Activity, ActivityId};
+
+    fn window_with_two_activities() -> (Window, PaneId, ActivityId, ActivityId) {
+        let pid = PaneId::new();
+        let a0 = Activity::terminal(ActivityId::new());
+        let a1 = Activity::terminal(ActivityId::new());
+        let a0_id = a0.id.clone();
+        let a1_id = a1.id.clone();
+        let mut win = Window::new_with_initial(WindowId::new(), "w".into(), pid.clone(), a0);
+        win.pane_mut(&pid).unwrap().add_activity(a1).unwrap();
+        (win, pid, a0_id, a1_id)
+    }
+
+    #[test]
+    fn break_activity_moves_active_activity_into_new_pane() {
+        let (mut win, pid, a0_id, a1_id) = window_with_two_activities();
+        let _ = win
+            .pane_mut(&pid)
+            .unwrap()
+            .set_active_activity(&a1_id)
+            .unwrap();
+        let new_pid = PaneId::new();
+
+        win.break_activity_to_pane(
+            &pid,
+            &a1_id,
+            new_pid.clone(),
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
+
+        let src = win.pane(&pid).unwrap();
+        assert!(
+            !src.has_activity(&a1_id),
+            "moved activity left the source pane"
+        );
+        assert_eq!(
+            src.active_activity, a0_id,
+            "source active falls back to first remaining"
+        );
+
+        let new_pane = win.pane(&new_pid).unwrap();
+        assert_eq!(new_pane.activities.len(), 1);
+        assert!(new_pane.has_activity(&a1_id));
+        assert_eq!(new_pane.active_activity, a1_id);
+
+        assert_eq!(win.active_pane, new_pid, "new pane becomes active");
+    }
+
+    #[test]
+    fn break_activity_preserves_remaining_order_when_moving_non_active() {
+        let (mut win, pid, a0_id, a1_id) = window_with_two_activities();
+        win.break_activity_to_pane(
+            &pid,
+            &a1_id,
+            PaneId::new(),
+            Side::After,
+            SplitOrientation::Vertical,
+        )
+        .unwrap();
+        let src = win.pane(&pid).unwrap();
+        assert_eq!(src.activities.len(), 1);
+        assert_eq!(src.activities[0].id, a0_id);
+        assert_eq!(
+            src.active_activity, a0_id,
+            "non-active move leaves source active unchanged"
+        );
+    }
+
+    #[test]
+    fn break_activity_rejects_single_activity_pane() {
+        let pid = PaneId::new();
+        let only = Activity::terminal(ActivityId::new());
+        let only_id = only.id.clone();
+        let mut win = Window::new_with_initial(WindowId::new(), "w".into(), pid.clone(), only);
+        let err = win
+            .break_activity_to_pane(
+                &pid,
+                &only_id,
+                PaneId::new(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::CannotRemoveLastActivity(_)));
+    }
+
+    #[test]
+    fn break_activity_rejects_unknown_activity() {
+        let (mut win, pid, _a0, _a1) = window_with_two_activities();
+        let err = win
+            .break_activity_to_pane(
+                &pid,
+                &ActivityId::new(),
+                PaneId::new(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::ActivityNotInPane { .. }));
+    }
+
+    #[test]
+    fn break_activity_rejects_duplicate_new_pane_id() {
+        let (mut win, pid, _a0, a1_id) = window_with_two_activities();
+        let err = win
+            .break_activity_to_pane(
+                &pid,
+                &a1_id,
+                pid.clone(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::PaneIdConflict(_)));
+    }
 
     fn fresh_window() -> (Window, PaneId, ActivityId) {
         let wid = WindowId::new();


### PR DESCRIPTION
## Problem

Multi-activity panes (the tab bar shipped in #25) have no way to **tear an existing activity out into its own split pane**. `Ctrl+B s` / `v` only split the pane by spawning a *new* terminal activity — there is no shortcut to relocate a running activity.

Related follow-up: #26 (terminal re-mount + scrollback reset when an activity moves between panes — accepted v0 limitation, tracked separately).

## Solution

Add a `Ctrl+B Shift+S` / `Ctrl+B Shift+V` shortcut that splits the active pane and moves the currently-active activity into the new pane. The moved activity keeps its existing PTY — `TerminalService` is keyed entirely by `ActivityId`, so the shell, scrollback, and frame stream survive the move untouched.

### Affected areas

- **`ozmux_multiplexer`** — new `Window::break_activity_to_pane` domain method. Clone-first ordering: validate, clone the `Activity`, call existing `Window::split_pane` (seeds the new pane with the clone, sets `active_pane`), then `Pane::remove_activity` from the source. The only fallible mutation runs before the irreversible step, so no rollback path is needed. Pane-scoped removal is enforced (never a window-wide lookup) — the same `ActivityId` is briefly present in both panes between `split_pane` and `remove_activity`, which is safe only under the per-Window lock.
- **`ozmux_http_server`** — `AppState::break_activity_to_pane` orchestrates the call, inserts the `pane_owner_window` row for the new pane, copies the extension pane-owner registry row when applicable, and publishes the layout. **No PTY spawn.** New `POST /windows/{wid}/panes/{pid}/activities/{aid}/break-to-pane` endpoint.
- **`ozmux_configs`** — new `Action::BreakActivityToPane { direction }` variant. Two default bindings: `Shift+S` → horizontal, `Shift+V` → vertical. The v0 "no modifier keys" validator constraint is lifted (`UnsupportedModifier` error variant removed) so modifier-bearing bindings load.
- **`ozmux-ui` (frontend)** — `break-activity-to-pane` zod variant, endpoint builder, `breakActivityToPane.ts` fetch helper, and `actionDispatch` case. Single-activity case is a server-enforced no-op (server returns 409; frontend `console.warn`s).

### Known limitations

Both documented in the design doc and accepted for v0:
1. **Stale `OZMUX_PANE_ID`** — the moved shell's environment variable still points to the original pane id. A running process's environment cannot be mutated.
2. **Scrollback reset on move** — the moved activity's `<Terminal>` re-mounts under the new pane (different React parent). The reconnect uses a full snapshot rather than `ResumeReplay`; on-screen content is preserved but client-side scrollback position is lost. Tracked in #26.

### Testing

- **multiplexer**: 5 new unit tests covering active/non-active move, order preservation, and all rejection paths.
- **http_server**: 8 integration tests covering happy path, 404/409 cases, layout broadcast, PTY non-respawn, sibling-PTY survival, new-pane activatability, and extension pane-owner propagation.
- **configs**: validator-accepts-modifier coverage; stable-JSON snapshot updated; `modifier_binding_rejected` repurposed to `modifier_binding_accepted`.
- **frontend**: wire parsing, helper URL/payload/warn assertions, full-dispatch test (fetch invocation + payload verification).

All checks green: `cargo test` (multiplexer 33, http_server 142, configs 38), `cargo clippy --workspace --all-targets`, `pnpm test` (278), `pnpm check-types`, `pnpm lint`.
