### PR TITLE
feat: Ctrl+B ] / [ shortcuts to cycle next / prev activity

### DIFF
--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -75,7 +75,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 7);
+        assert_eq!(merged.shortcuts.bindings.len(), 9);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -504,6 +504,7 @@ mod tests {
         "#;
         let b: Binding = toml::from_str(toml).unwrap();
         assert_eq!(b.chord.key, Key::Char('['));
+        assert_eq!(b.chord.modifiers, Modifiers::default());
         assert!(matches!(
             b.action,
             Action::FocusActivity {

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -190,6 +190,24 @@ impl Default for Shortcuts {
                         direction: SplitDirection::Vertical,
                     },
                 },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char(']'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusActivity {
+                        offset: ActivityOffset::Next,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('['),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusActivity {
+                        offset: ActivityOffset::Prev,
+                    },
+                },
             ],
         }
     }
@@ -462,11 +480,44 @@ mod tests {
     }
 
     #[test]
+    fn binding_deserializes_focus_activity_next() {
+        let toml = r#"
+            key = "]"
+            action = { type = "focus-activity", offset = "next" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert_eq!(b.chord.key, Key::Char(']'));
+        assert_eq!(b.chord.modifiers, Modifiers::default());
+        assert!(matches!(
+            b.action,
+            Action::FocusActivity {
+                offset: ActivityOffset::Next
+            }
+        ));
+    }
+
+    #[test]
+    fn binding_deserializes_focus_activity_prev() {
+        let toml = r#"
+            key = "["
+            action = { type = "focus-activity", offset = "prev" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert_eq!(b.chord.key, Key::Char('['));
+        assert!(matches!(
+            b.action,
+            Action::FocusActivity {
+                offset: ActivityOffset::Prev
+            }
+        ));
+    }
+
+    #[test]
     fn default_shortcuts_serializes_to_stable_json() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"}},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"}}]}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/cycleActivity.test.ts
+++ b/daemon/frontend/src/layout/cycleActivity.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cycleActivity } from './cycleActivity';
+
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.restoreAllMocks();
+});
+
+describe('cycleActivity', () => {
+  it.each([
+    'next',
+    'prev',
+  ] as const)('POSTs /windows/{wid}/panes/{pid}/cycle-activity with %s direction', async (direction) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await cycleActivity('wid-1', 'pid-42', direction);
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-42/cycle-activity', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+  });
+
+  it('warns on !ok status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await cycleActivity('wid-1', 'pid-1', 'next');
+    expect(console.warn).toHaveBeenCalledWith(
+      'cycle activity failed',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-1',
+        direction: 'next',
+        status: 404,
+      }),
+    );
+  });
+
+  it('warns on network failure', async () => {
+    const err = new Error('net');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    await cycleActivity('wid-1', 'pid-x', 'prev');
+    expect(console.warn).toHaveBeenCalledWith(
+      'cycle activity request errored',
+      expect.objectContaining({
+        windowId: 'wid-1',
+        paneId: 'pid-x',
+        direction: 'prev',
+        error: err,
+      }),
+    );
+  });
+});

--- a/daemon/frontend/src/layout/cycleActivity.ts
+++ b/daemon/frontend/src/layout/cycleActivity.ts
@@ -1,0 +1,31 @@
+import { cycleActivityEndpoint } from '../terminal/api';
+import type { PaneId, WindowId } from './types';
+
+export async function cycleActivity(
+  windowId: WindowId,
+  paneId: PaneId,
+  direction: 'next' | 'prev',
+): Promise<void> {
+  try {
+    const resp = await fetch(cycleActivityEndpoint(windowId, paneId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+    if (!resp.ok) {
+      console.warn('cycle activity failed', {
+        windowId,
+        paneId,
+        direction,
+        status: resp.status,
+      });
+    }
+  } catch (e) {
+    console.warn('cycle activity request errored', {
+      windowId,
+      paneId,
+      direction,
+      error: e,
+    });
+  }
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -197,4 +197,41 @@ describe('actionToHandler', () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    'next',
+    'prev',
+  ] as const)('returns a handler that POSTs cycle-activity with %s direction', async (direction) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext({
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+    });
+    const handler = actionToHandler({ type: 'focus-activity', offset: direction }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/cycle-activity', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+  });
+
+  it('focus-activity handler is a no-op when active pane is null', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext();
+    const handler = actionToHandler({ type: 'focus-activity', offset: 'next' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -1,6 +1,7 @@
 import { breakActivityToPane } from '../layout/breakActivityToPane';
 import { closeActivity } from '../layout/closeActivity';
 import { closePane } from '../layout/closePane';
+import { cycleActivity } from '../layout/cycleActivity';
 import { newTerminalActivity } from '../layout/newTerminalActivity';
 import { splitPane } from '../layout/splitPane';
 import type { ActivityId, PaneId, WindowId } from '../layout/types';
@@ -34,6 +35,10 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
       return () => withActivePane(ctx, newTerminalActivity);
     case 'close-activity':
       return () => withActivePaneActivity(ctx, closeActivity);
+    case 'focus-activity': {
+      const direction = action.offset;
+      return () => withActivePane(ctx, (w, p) => cycleActivity(w, p, direction));
+    }
     default:
       console.warn('actionToHandler: unsupported action', action);
       return null;

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -198,4 +198,39 @@ describe('parseShortcuts', () => {
     expect(out?.bindings).toHaveLength(2);
     expect(out?.bindings[1].action).toEqual({ type: 'close-activity' });
   });
+
+  it.each(['next', 'prev'] as const)('parses a focus-activity binding with %s offset', (offset) => {
+    const withFA = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: offset === 'next' ? ']' : '[',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'focus-activity', offset },
+        },
+      ],
+    };
+    const out = parseShortcuts(withFA);
+    expect(out?.bindings).toHaveLength(2);
+    expect(out?.bindings[1].action).toEqual({ type: 'focus-activity', offset });
+  });
+
+  it('drops a focus-activity binding with an unknown offset (e.g. last)', () => {
+    const withBadOffset = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: 'l',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'focus-activity', offset: 'last' },
+        },
+      ],
+    };
+    const out = parseShortcuts(withBadOffset);
+    expect(out?.bindings).toHaveLength(1);
+    expect(out?.bindings[0].action.type).toBe('close-pane');
+    expect(console.warn).toHaveBeenCalled();
+  });
 });

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -40,6 +40,10 @@ const ActionSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('new-terminal-activity') }),
   z.object({ type: z.literal('close-activity') }),
+  z.object({
+    type: z.literal('focus-activity'),
+    offset: z.enum(['next', 'prev']),
+  }),
 ]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -15,6 +15,8 @@ export const closeActivityEndpoint = (wid: string, pid: string, aid: string) =>
   `/windows/${wid}/panes/${pid}/activities/${aid}`;
 export const breakActivityToPaneEndpoint = (wid: string, pid: string, aid: string) =>
   `/windows/${wid}/panes/${pid}/activities/${aid}/break-to-pane`;
+export const cycleActivityEndpoint = (wid: string, pid: string) =>
+  `/windows/${wid}/panes/${pid}/cycle-activity`;
 
 export const vtTerminalWsUrl = (
   windowId: string,

--- a/daemon/http_server/src/handlers/windows/panes.rs
+++ b/daemon/http_server/src/handlers/windows/panes.rs
@@ -15,7 +15,10 @@ pub mod split;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/{pane_id}/activate", post(activate::activate))
-        .route("/{pane_id}/cycle-activity", post(cycle_activity::cycle_activity))
+        .route(
+            "/{pane_id}/cycle-activity",
+            post(cycle_activity::cycle_activity),
+        )
         .route("/{pane_id}/split", post(split::split))
         .route("/{pane_id}", method_delete(close::close))
         .nest("/{pane_id}/activities", activities::router())

--- a/daemon/http_server/src/handlers/windows/panes.rs
+++ b/daemon/http_server/src/handlers/windows/panes.rs
@@ -8,12 +8,14 @@ use ozmux_multiplexer::{SessionId, WindowId};
 pub mod activate;
 pub mod activities;
 pub mod close;
+pub mod cycle_activity;
 pub mod spawn_terminal;
 pub mod split;
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/{pane_id}/activate", post(activate::activate))
+        .route("/{pane_id}/cycle-activity", post(cycle_activity::cycle_activity))
         .route("/{pane_id}/split", post(split::split))
         .route("/{pane_id}", method_delete(close::close))
         .nest("/{pane_id}/activities", activities::router())

--- a/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
+++ b/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
@@ -25,34 +25,19 @@ pub async fn cycle_activity(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use crate::test_helpers::{
+        add_activity_via_window, bootstrap_default, fresh_state, router_with,
+    };
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use ozmux_multiplexer::{Activity, ActivityId, PaneId};
+    use ozmux_multiplexer::PaneId;
     use tower::ServiceExt;
-
-    async fn add_activity(
-        state: &crate::AppState,
-        wid: &ozmux_multiplexer::WindowId,
-        pid: &PaneId,
-    ) -> ActivityId {
-        let aid = ActivityId::new();
-        state
-            .multiplexer
-            .with_window_or_404(wid, |w| {
-                w.pane_mut(pid)?
-                    .add_activity(Activity::terminal(aid.clone()))
-            })
-            .await
-            .unwrap();
-        aid
-    }
 
     #[tokio::test]
     async fn cycle_next_changes_active_and_publishes() {
         let state = fresh_state();
         let (_sid, wid, pid, _aid0) = bootstrap_default(&state).await;
-        let aid1 = add_activity(&state, &wid, &pid).await;
+        let aid1 = add_activity_via_window(&state, &wid, &pid).await;
         let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
         let (router, _state) = router_with(state);
         let resp = router

--- a/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
+++ b/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
@@ -50,7 +50,7 @@ mod tests {
     #[tokio::test]
     async fn cycle_next_changes_active_and_publishes() {
         let state = fresh_state();
-        let (_sid, wid, pid, aid0) = bootstrap_default(&state).await;
+        let (_sid, wid, pid, _aid0) = bootstrap_default(&state).await;
         let aid1 = add_activity(&state, &wid, &pid).await;
         let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
         let (router, _state) = router_with(state);
@@ -71,7 +71,11 @@ mod tests {
             .expect("publish timed out")
             .expect("recv error");
         assert_eq!(view["id"].as_str(), Some(wid.as_ref()));
-        let _ = (aid0, aid1);
+        assert_eq!(
+            view["panes"][0]["active_activity"].as_str(),
+            Some(aid1.as_ref()),
+            "cycle_next must advance active_activity to the second activity"
+        );
     }
 
     #[tokio::test]
@@ -92,7 +96,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-        let res = tokio::time::timeout(std::time::Duration::from_millis(80), rx.recv()).await;
+        let res = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
         assert!(res.is_err(), "Unchanged outcome must not publish");
     }
 

--- a/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
+++ b/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
@@ -1,0 +1,155 @@
+use crate::{AppState, error::HttpResult};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_multiplexer::{CycleDirection, PaneId, WindowId};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct CycleRequest {
+    direction: CycleDirection,
+}
+
+pub async fn cycle_activity(
+    State(state): State<AppState>,
+    Path((wid, pid)): Path<(WindowId, PaneId)>,
+    Json(req): Json<CycleRequest>,
+) -> HttpResult<StatusCode> {
+    state
+        .cycle_active_activity(&wid, &pid, req.direction)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{Activity, ActivityId, PaneId};
+    use tower::ServiceExt;
+
+    async fn add_activity(
+        state: &crate::AppState,
+        wid: &ozmux_multiplexer::WindowId,
+        pid: &PaneId,
+    ) -> ActivityId {
+        let aid = ActivityId::new();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| {
+                w.pane_mut(pid)?.add_activity(Activity::terminal(aid.clone()))
+            })
+            .await
+            .unwrap();
+        aid
+    }
+
+    #[tokio::test]
+    async fn cycle_next_changes_active_and_publishes() {
+        let state = fresh_state();
+        let (_sid, wid, pid, aid0) = bootstrap_default(&state).await;
+        let aid1 = add_activity(&state, &wid, &pid).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let view = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("publish timed out")
+            .expect("recv error");
+        assert_eq!(view["id"].as_str(), Some(wid.as_ref()));
+        let _ = (aid0, aid1);
+    }
+
+    #[tokio::test]
+    async fn cycle_single_activity_no_publish() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let res = tokio::time::timeout(std::time::Duration::from_millis(80), rx.recv()).await;
+        assert!(res.is_err(), "Unchanged outcome must not publish");
+    }
+
+    #[tokio::test]
+    async fn cycle_unknown_pane_returns_404() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, PaneId::new()))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cycle_invalid_direction_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"sideways"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn cycle_malformed_json_returns_400() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
+++ b/daemon/http_server/src/handlers/windows/panes/cycle_activity.rs
@@ -40,7 +40,8 @@ mod tests {
         state
             .multiplexer
             .with_window_or_404(wid, |w| {
-                w.pane_mut(pid)?.add_activity(Activity::terminal(aid.clone()))
+                w.pane_mut(pid)?
+                    .add_activity(Activity::terminal(aid.clone()))
             })
             .await
             .unwrap();
@@ -109,7 +110,11 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri(format!("/windows/{}/panes/{}/cycle-activity", wid, PaneId::new()))
+                    .uri(format!(
+                        "/windows/{}/panes/{}/cycle-activity",
+                        wid,
+                        PaneId::new()
+                    ))
                     .header("content-type", "application/json")
                     .body(Body::from(r#"{"direction":"next"}"#))
                     .unwrap(),

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -6,8 +6,9 @@ use axum::extract::FromRef;
 use ozmux_configs::OzmuxConfigs;
 use ozmux_extension::ExtensionRegistry;
 use ozmux_multiplexer::{
-    Activity, ActivityId, ActivityKind, MultiplexerError, MultiplexerResult, MultiplexerService,
-    PaneId, SessionId, SetActiveOutcome, SetActivePaneOutcome, Side, SplitOrientation, WindowId,
+    Activity, ActivityId, ActivityKind, CycleDirection, MultiplexerError, MultiplexerResult,
+    MultiplexerService, PaneId, SessionId, SetActiveOutcome, SetActivePaneOutcome, Side,
+    SplitOrientation, WindowId,
 };
 use ozmux_terminal::TerminalService;
 use std::sync::Arc;
@@ -84,6 +85,22 @@ impl AppState {
         let outcome = self
             .multiplexer
             .with_window_or_404(wid, |w| w.pane_mut(pid)?.set_active_activity(aid))
+            .await?;
+        if matches!(outcome, SetActiveOutcome::Changed) {
+            self.publish_window_layout(wid).await;
+        }
+        Ok(())
+    }
+
+    pub async fn cycle_active_activity(
+        &self,
+        wid: &WindowId,
+        pid: &PaneId,
+        direction: CycleDirection,
+    ) -> HttpResult {
+        let outcome = self
+            .multiplexer
+            .with_window_or_404(wid, |w| w.pane_mut(pid)?.cycle_active_activity(direction))
             .await?;
         if matches!(outcome, SetActiveOutcome::Changed) {
             self.publish_window_layout(wid).await;

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -12,9 +12,9 @@ pub mod window;
 pub use error::{MultiplexerError, MultiplexerResult};
 pub use session::{Session, SessionId, SessionState};
 pub use window::{
-    Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, LayoutCellState, Pane,
-    PaneCell, PaneId, PaneState, RootCell, SetActiveOutcome, Side, SplitCell, SplitOrientation,
-    Window, WindowId, WindowState,
+    Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
+    LayoutCellState, Pane, PaneCell, PaneId, PaneState, RootCell, SetActiveOutcome, Side,
+    SplitCell, SplitOrientation, Window, WindowId, WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -13,5 +13,5 @@ pub use cells::{
     SplitOrientation,
 };
 pub use pane::activity::{Activity, ActivityId, ActivityKind};
-pub use pane::{Pane, PaneId, PaneState, SetActiveOutcome};
+pub use pane::{CycleDirection, Pane, PaneId, PaneState, SetActiveOutcome};
 pub use window::{Window, WindowId, WindowState};

--- a/daemon/multiplexer/src/window/pane.rs
+++ b/daemon/multiplexer/src/window/pane.rs
@@ -4,4 +4,4 @@ pub mod activity;
 
 #[allow(clippy::module_inception)]
 mod pane;
-pub use pane::{Pane, PaneId, PaneState, SetActiveOutcome};
+pub use pane::{CycleDirection, Pane, PaneId, PaneState, SetActiveOutcome};

--- a/daemon/multiplexer/src/window/pane/pane.rs
+++ b/daemon/multiplexer/src/window/pane/pane.rs
@@ -15,6 +15,18 @@ pub enum SetActiveOutcome {
     Changed,
 }
 
+/// Direction to step the active activity within a Pane, used by
+/// `cycle_active_activity`. Serializes as `"next"` / `"prev"` so the HTTP
+/// body can deserialize it directly.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CycleDirection {
+    /// Step to the next activity in `activities` order.
+    Next,
+    /// Step to the previous activity in `activities` order.
+    Prev,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Pane {
     pub id: PaneId,
@@ -265,5 +277,13 @@ mod tests {
         let _removed = pane.remove_activity(&second_aid).unwrap();
         assert_eq!(pane.active_activity, original_aid);
         assert_eq!(pane.activities.len(), 1);
+    }
+
+    #[test]
+    fn cycle_direction_serde_kebab_case() {
+        let next = serde_json::to_string(&CycleDirection::Next).unwrap();
+        assert_eq!(next, "\"next\"");
+        let back: CycleDirection = serde_json::from_str("\"prev\"").unwrap();
+        assert!(matches!(back, CycleDirection::Prev));
     }
 }

--- a/daemon/multiplexer/src/window/pane/pane.rs
+++ b/daemon/multiplexer/src/window/pane/pane.rs
@@ -73,6 +73,31 @@ impl Pane {
         Ok(SetActiveOutcome::Changed)
     }
 
+    /// Step `active_activity` to the next or previous entry in `activities`
+    /// with wrap-around. Single-activity panes return `Unchanged`. Returns
+    /// `ActivityNotInPane` if the invariant `active_activity ∈ activities`
+    /// is broken.
+    pub fn cycle_active_activity(
+        &mut self,
+        direction: CycleDirection,
+    ) -> MultiplexerResult<SetActiveOutcome> {
+        let idx = self
+            .activities
+            .iter()
+            .position(|a| a.id == self.active_activity)
+            .ok_or_else(|| MultiplexerError::ActivityNotInPane {
+                pane: self.id.clone(),
+                activity: self.active_activity.clone(),
+            })?;
+        let len = self.activities.len();
+        let new_idx = match direction {
+            CycleDirection::Next => (idx + 1) % len,
+            CycleDirection::Prev => idx.checked_sub(1).unwrap_or(len - 1),
+        };
+        let target = self.activities[new_idx].id.clone();
+        self.set_active_activity(&target)
+    }
+
     /// Remove an Activity by id and return the removed value.
     ///
     /// Refuses to remove the last activity — a pane with zero activities is
@@ -285,5 +310,54 @@ mod tests {
         assert_eq!(next, "\"next\"");
         let back: CycleDirection = serde_json::from_str("\"prev\"").unwrap();
         assert!(matches!(back, CycleDirection::Prev));
+    }
+
+    fn pane_with_three_activities() -> (Pane, ActivityId, ActivityId, ActivityId) {
+        let pid = PaneId::new();
+        let a1 = ActivityId::new();
+        let a2 = ActivityId::new();
+        let a3 = ActivityId::new();
+        let mut pane = Pane::new(pid, Activity::terminal(a1.clone()));
+        pane.add_activity(Activity::terminal(a2.clone())).unwrap();
+        pane.add_activity(Activity::terminal(a3.clone())).unwrap();
+        (pane, a1, a2, a3)
+    }
+
+    #[test]
+    fn cycle_next_advances_to_next_activity() {
+        let (mut pane, a1, a2, _a3) = pane_with_three_activities();
+        assert_eq!(pane.active_activity, a1);
+        let outcome = pane.cycle_active_activity(CycleDirection::Next).unwrap();
+        assert!(matches!(outcome, SetActiveOutcome::Changed));
+        assert_eq!(pane.active_activity, a2);
+    }
+
+    #[test]
+    fn cycle_next_wraps_to_first() {
+        let (mut pane, a1, _a2, a3) = pane_with_three_activities();
+        let _ = pane.set_active_activity(&a3).unwrap();
+        let outcome = pane.cycle_active_activity(CycleDirection::Next).unwrap();
+        assert!(matches!(outcome, SetActiveOutcome::Changed));
+        assert_eq!(pane.active_activity, a1);
+    }
+
+    #[test]
+    fn cycle_prev_wraps_to_last() {
+        let (mut pane, a1, _a2, a3) = pane_with_three_activities();
+        assert_eq!(pane.active_activity, a1);
+        let outcome = pane.cycle_active_activity(CycleDirection::Prev).unwrap();
+        assert!(matches!(outcome, SetActiveOutcome::Changed));
+        assert_eq!(pane.active_activity, a3);
+    }
+
+    #[test]
+    fn cycle_single_activity_returns_unchanged() {
+        let (mut pane, aid) = fresh_pane();
+        let outcome_next = pane.cycle_active_activity(CycleDirection::Next).unwrap();
+        assert!(matches!(outcome_next, SetActiveOutcome::Unchanged));
+        assert_eq!(pane.active_activity, aid);
+        let outcome_prev = pane.cycle_active_activity(CycleDirection::Prev).unwrap();
+        assert!(matches!(outcome_prev, SetActiveOutcome::Unchanged));
+        assert_eq!(pane.active_activity, aid);
     }
 }

--- a/daemon/multiplexer/src/window/pane/pane.rs
+++ b/daemon/multiplexer/src/window/pane/pane.rs
@@ -15,9 +15,8 @@ pub enum SetActiveOutcome {
     Changed,
 }
 
-/// Direction to step the active activity within a Pane, used by
-/// `cycle_active_activity`. Serializes as `"next"` / `"prev"` so the HTTP
-/// body can deserialize it directly.
+/// Direction to step the active activity within a Pane. Serializes as
+/// kebab-case (`"next"` / `"prev"`).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CycleDirection {


### PR DESCRIPTION
## Problem

The pane activity tab bar (introduced in #25) supports multiple activities per pane and is clickable, but there is no keyboard shortcut to cycle through them. Users must move their hand to the trackpad to switch tabs.

## Solution

Add Ctrl+B `]` (next) and Ctrl+B `[` (prev) shortcuts to cycle the active activity within the active pane, with wrap-around at both ends. Vim-style binding, no conflict with existing defaults.

The direction is resolved on the **backend** rather than the frontend: the browser sends only `next` or `prev`, and the daemon computes the new active activity. This keeps the wrap-around semantics in one place and avoids a stale-list race the frontend would otherwise have.

**Spec:** `docs/superpowers/specs/2026-05-16-focus-activity-shortcut-design.md` (gitignored — design notes only)

**Affected areas:**

- `daemon/multiplexer` — new `pub CycleDirection { Next, Prev }` enum + `Pane::cycle_active_activity(direction)` method. Unsigned modular arithmetic (`(idx + 1) % len` for Next, `idx.checked_sub(1).unwrap_or(len - 1)` for Prev) — pane invariant `len >= 1` makes panics impossible. Delegates to `set_active_activity`, so single-activity panes correctly return `Unchanged`.
- `daemon/http_server` — new `AppState::cycle_active_activity` wrapper mirroring `activate_activity` (publishes internally only on `Changed`); new handler `POST /windows/{wid}/panes/{pid}/cycle-activity` with JSON body `{\"direction\":\"next\"|\"prev\"}` returning `204`. Route lives on the pane router (not under `/activities/`) to avoid collision with the bare `/{activity_id}` segment.
- `daemon/configs` — two new entries in `Shortcuts::default()` (`]` → `FocusActivity { Next }`, `[` → `FocusActivity { Prev }`). The stable-JSON regression test is updated in lock-step.
- `daemon/frontend` — `wire.ts` accepts the `focus-activity` action variant (only `next`/`prev`; `last` is dropped with a warning since the backend doesn't track last-active yet). New `cycleActivity()` fetch helper + `cycleActivityEndpoint` URL builder. `actionDispatch` routes `focus-activity` → `cycleActivity` through the existing `withActivePane` helper.

**Test coverage:**

- 4 multiplexer unit tests (Next/Prev advance, wrap, single-activity unchanged)
- 5 http_server integration tests (204 + publish, 204 no-publish, 404 unknown pane, 422 invalid direction, 400 malformed JSON)
- 2 configs TOML round-trip tests + updated stable-JSON literal
- Frontend `wire.test.ts` covers focus-activity parse + unknown-offset drop
- Frontend `cycleActivity.test.ts` covers URL/body/warn paths
- Frontend `actionDispatch.test.ts` covers handler dispatch and null-pane no-op

End-to-end manually verified via direct `curl POST /cycle-activity` against the running daemon (204 returned, single-activity case skips broadcast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)