### PR TITLE
feat: directional pane focus (Prefix + h/j/k/l)

### DIFF
--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -75,7 +75,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 9);
+        assert_eq!(merged.shortcuts.bindings.len(), 13);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -208,6 +208,42 @@ impl Default for Shortcuts {
                         offset: ActivityOffset::Prev,
                     },
                 },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('h'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusPane {
+                        direction: Direction::Left,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('j'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusPane {
+                        direction: Direction::Down,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('k'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusPane {
+                        direction: Direction::Up,
+                    },
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('l'),
+                        modifiers: Modifiers::default(),
+                    },
+                    action: Action::FocusPane {
+                        direction: Direction::Right,
+                    },
+                },
             ],
         }
     }
@@ -518,7 +554,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"}},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"}},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"}},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"}},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"}},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"}},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"}}]}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/focusPane.test.ts
+++ b/daemon/frontend/src/layout/focusPane.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { focusPane } from './focusPane';
+import type { WindowId } from './types';
+
+describe('focusPane', () => {
+  const wid = 'w1' as WindowId;
+
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    'up',
+    'down',
+    'left',
+    'right',
+  ] as const)('POSTs %s direction to the focus-pane endpoint', async (direction) => {
+    await focusPane(wid, direction);
+    expect(global.fetch).toHaveBeenCalledWith(`/windows/${wid}/focus-pane`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+  });
+
+  it('console.warns on non-2xx response', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(null, { status: 500 }),
+    );
+    await focusPane(wid, 'left');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('console.warns when fetch rejects', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('net down'));
+    await focusPane(wid, 'right');
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/daemon/frontend/src/layout/focusPane.ts
+++ b/daemon/frontend/src/layout/focusPane.ts
@@ -1,0 +1,17 @@
+import { focusPaneEndpoint } from '../terminal/api';
+import type { PaneDirection, WindowId } from './types';
+
+export async function focusPane(windowId: WindowId, direction: PaneDirection): Promise<void> {
+  try {
+    const resp = await fetch(focusPaneEndpoint(windowId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+    if (!resp.ok) {
+      console.warn('focus pane failed', { windowId, direction, status: resp.status });
+    }
+  } catch (e) {
+    console.warn('focus pane request errored', { windowId, direction, error: e });
+  }
+}

--- a/daemon/frontend/src/layout/paneBounds.ts
+++ b/daemon/frontend/src/layout/paneBounds.ts
@@ -32,30 +32,30 @@ export function computePaneLayout(
   return out;
 }
 
-function walk(node: WindowLayoutNode, b: Bounds, out: PaneLayout): void {
+function walk(node: WindowLayoutNode, bounds: Bounds, out: PaneLayout): void {
   switch (node.type) {
     case 'pane':
-      out.panes.set(node.pane_id, b);
+      out.panes.set(node.pane_id, bounds);
       return;
     case 'root':
-      walk(node.child, b, out);
+      walk(node.child, bounds, out);
       return;
     case 'split': {
       const ratio = normalizeRatio(node.split_ratio);
       if (node.orientation === 'horizontal') {
-        const lhsW = b.w * ratio;
-        walk(node.lhs, { x: b.x, y: b.y, w: lhsW, h: b.h }, out);
-        walk(node.rhs, { x: b.x + lhsW, y: b.y, w: b.w - lhsW, h: b.h }, out);
+        const lhsW = bounds.w * ratio;
+        walk(node.lhs, { x: bounds.x, y: bounds.y, w: lhsW, h: bounds.h }, out);
+        walk(node.rhs, { x: bounds.x + lhsW, y: bounds.y, w: bounds.w - lhsW, h: bounds.h }, out);
       } else {
-        const lhsH = b.h * ratio;
-        walk(node.lhs, { x: b.x, y: b.y, w: b.w, h: lhsH }, out);
-        walk(node.rhs, { x: b.x, y: b.y + lhsH, w: b.w, h: b.h - lhsH }, out);
+        const lhsH = bounds.h * ratio;
+        walk(node.lhs, { x: bounds.x, y: bounds.y, w: bounds.w, h: lhsH }, out);
+        walk(node.rhs, { x: bounds.x, y: bounds.y + lhsH, w: bounds.w, h: bounds.h - lhsH }, out);
       }
       return;
     }
     default: {
       const u = node as unknown as { type: string; cell_id: CellId };
-      out.unknown.push({ cell_id: u.cell_id, type: u.type, bounds: b });
+      out.unknown.push({ cell_id: u.cell_id, type: u.type, bounds });
       return;
     }
   }

--- a/daemon/frontend/src/layout/types.ts
+++ b/daemon/frontend/src/layout/types.ts
@@ -9,6 +9,8 @@ export type SessionId = string;
 
 export type SplitOrientation = 'horizontal' | 'vertical';
 
+export type PaneDirection = 'up' | 'down' | 'left' | 'right';
+
 export type WindowLayoutNode =
   | { type: 'root'; cell_id: CellId; child: WindowLayoutNode }
   | {

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -234,4 +234,42 @@ describe('actionToHandler', () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    'up',
+    'down',
+    'left',
+    'right',
+  ] as const)('returns a handler that POSTs focus-pane with %s direction', async (direction) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext({
+      activeWindow: () => 'wid-1',
+    });
+    const handler = actionToHandler({ type: 'focus-pane', direction }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/focus-pane', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction }),
+    });
+  });
+
+  it('focus-pane handler is a no-op when active window is null', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext({ activeWindow: () => null });
+    const handler = actionToHandler({ type: 'focus-pane', direction: 'left' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -2,6 +2,7 @@ import { breakActivityToPane } from '../layout/breakActivityToPane';
 import { closeActivity } from '../layout/closeActivity';
 import { closePane } from '../layout/closePane';
 import { cycleActivity } from '../layout/cycleActivity';
+import { focusPane } from '../layout/focusPane';
 import { newTerminalActivity } from '../layout/newTerminalActivity';
 import { splitPane } from '../layout/splitPane';
 import type { ActivityId, PaneId, WindowId } from '../layout/types';
@@ -39,10 +40,19 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
       const direction = action.offset;
       return () => withActivePane(ctx, (w, p) => cycleActivity(w, p, direction));
     }
+    case 'focus-pane': {
+      const direction = action.direction;
+      return () => withActiveWindow(ctx, (w) => focusPane(w, direction));
+    }
     default:
       console.warn('actionToHandler: unsupported action', action);
       return null;
   }
+}
+
+function withActiveWindow(ctx: ShortcutContext, run: (w: WindowId) => void | Promise<void>): void {
+  const w = ctx.activeWindow();
+  if (w) void run(w);
 }
 
 function withActivePane(

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -71,7 +71,7 @@ describe('parseShortcuts', () => {
         {
           key: 'q',
           modifiers: { ctrl: false, shift: false, alt: false, meta: false },
-          action: { type: 'focus-pane', direction: 'up' },
+          action: { type: 'swap-pane', offset: 'next' },
         },
       ],
     };
@@ -80,6 +80,29 @@ describe('parseShortcuts', () => {
     expect(out?.bindings).toHaveLength(1);
     expect(out?.bindings[0].action.type).toBe('close-pane');
     expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'up',
+    'down',
+    'left',
+    'right',
+  ] as const)('parses a focus-pane binding with %s direction', (direction) => {
+    const payload = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: 'k',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'focus-pane', direction },
+        },
+      ],
+    };
+    const out = parseShortcuts(payload);
+    expect(out).not.toBeNull();
+    expect(out?.bindings).toHaveLength(2);
+    expect(out?.bindings[1].action).toEqual({ type: 'focus-pane', direction });
   });
 
   it('parses a split-pane binding with horizontal direction', () => {

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -44,6 +44,10 @@ const ActionSchema = z.discriminatedUnion('type', [
     type: z.literal('focus-activity'),
     offset: z.enum(['next', 'prev']),
   }),
+  z.object({
+    type: z.literal('focus-pane'),
+    direction: z.enum(['up', 'down', 'left', 'right']),
+  }),
 ]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -17,6 +17,7 @@ export const breakActivityToPaneEndpoint = (wid: string, pid: string, aid: strin
   `/windows/${wid}/panes/${pid}/activities/${aid}/break-to-pane`;
 export const cycleActivityEndpoint = (wid: string, pid: string) =>
   `/windows/${wid}/panes/${pid}/cycle-activity`;
+export const focusPaneEndpoint = (wid: string) => `/windows/${wid}/focus-pane`;
 
 export const vtTerminalWsUrl = (
   windowId: string,

--- a/daemon/http_server/src/handlers/windows.rs
+++ b/daemon/http_server/src/handlers/windows.rs
@@ -10,6 +10,7 @@ use ozmux_terminal::TerminalService;
 pub mod create;
 pub mod delete;
 pub mod events;
+pub mod focus_pane;
 pub mod panes;
 pub mod rename;
 pub mod select;

--- a/daemon/http_server/src/handlers/windows/focus_pane.rs
+++ b/daemon/http_server/src/handlers/windows/focus_pane.rs
@@ -1,6 +1,5 @@
 //! `POST /windows/{wid}/focus-pane` — moves focus to the geometric neighbor
-//! in the requested direction. Translates `configs::Direction` to the
-//! domain-level `multiplexer::PaneDirection` at the boundary.
+//! in the requested direction.
 
 use crate::{AppState, error::HttpResult};
 use axum::{
@@ -8,7 +7,6 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
-use ozmux_configs::shortcuts::Direction;
 use ozmux_multiplexer::{PaneDirection, WindowId};
 use serde::Deserialize;
 
@@ -16,7 +14,7 @@ use serde::Deserialize;
 /// to move focus toward, relative to the window's currently active pane.
 #[derive(Deserialize)]
 pub struct FocusPaneRequest {
-    direction: Direction,
+    direction: PaneDirection,
 }
 
 /// Move focus to the geometric neighbor of the active pane in the requested
@@ -28,18 +26,9 @@ pub async fn focus_pane(
     Json(req): Json<FocusPaneRequest>,
 ) -> HttpResult<StatusCode> {
     state
-        .focus_pane_direction(&window_id, to_domain(req.direction))
+        .focus_pane_direction(&window_id, req.direction)
         .await?;
     Ok(StatusCode::NO_CONTENT)
-}
-
-fn to_domain(d: Direction) -> PaneDirection {
-    match d {
-        Direction::Up => PaneDirection::Up,
-        Direction::Down => PaneDirection::Down,
-        Direction::Left => PaneDirection::Left,
-        Direction::Right => PaneDirection::Right,
-    }
 }
 
 #[cfg(test)]

--- a/daemon/http_server/src/handlers/windows/focus_pane.rs
+++ b/daemon/http_server/src/handlers/windows/focus_pane.rs
@@ -1,0 +1,195 @@
+//! `POST /windows/{wid}/focus-pane` — moves focus to the geometric neighbor
+//! in the requested direction. Translates `configs::Direction` to the
+//! domain-level `multiplexer::PaneDirection` at the boundary.
+
+use crate::{AppState, error::HttpResult};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_configs::shortcuts::Direction;
+use ozmux_multiplexer::{PaneDirection, WindowId};
+use serde::Deserialize;
+
+/// Body for `POST /windows/{wid}/focus-pane`. Carries the cardinal direction
+/// to move focus toward, relative to the window's currently active pane.
+#[derive(Deserialize)]
+pub struct FocusPaneRequest {
+    direction: Direction,
+}
+
+/// Move focus to the geometric neighbor of the active pane in the requested
+/// `direction`. Returns `204 No Content` whether or not the active pane
+/// changed (single-pane windows and direction with no neighbor are no-ops).
+pub async fn focus_pane(
+    State(state): State<AppState>,
+    Path(window_id): Path<WindowId>,
+    Json(req): Json<FocusPaneRequest>,
+) -> HttpResult<StatusCode> {
+    state
+        .focus_pane_direction(&window_id, to_domain(req.direction))
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn to_domain(d: Direction) -> PaneDirection {
+    match d {
+        Direction::Up => PaneDirection::Up,
+        Direction::Down => PaneDirection::Down,
+        Direction::Left => PaneDirection::Left,
+        Direction::Right => PaneDirection::Right,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{
+        Activity, ActivityId, MultiplexerError, PaneId, Side, SplitOrientation, WindowId,
+    };
+    use tower::ServiceExt;
+
+    async fn split_via_window(
+        state: &crate::AppState,
+        wid: &WindowId,
+        target: &PaneId,
+        orient: SplitOrientation,
+    ) -> PaneId {
+        let new_pane_id = PaneId::new();
+        let new_activity_id = ActivityId::new();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| {
+                w.split_pane(
+                    target,
+                    new_pane_id.clone(),
+                    Activity::terminal(new_activity_id.clone()),
+                    Side::After,
+                    orient,
+                )
+            })
+            .await
+            .unwrap();
+        state
+            .multiplexer
+            .pane_owner_window
+            .insert(new_pane_id.clone(), wid.clone());
+        new_pane_id
+    }
+
+    #[tokio::test]
+    async fn focus_pane_right_returns_204_and_updates_active_pane() {
+        let state = fresh_state();
+        let (_sid, wid, left, _aid) = bootstrap_default(&state).await;
+        let right = split_via_window(&state, &wid, &left, SplitOrientation::Horizontal).await;
+        let _ = state
+            .multiplexer
+            .with_window_or_404(&wid, |w| w.set_active_pane(&left))
+            .await
+            .unwrap();
+        let (router, state2) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/focus-pane", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let active = state2
+            .multiplexer
+            .with_window_or_404(&wid, |w| Ok::<_, MultiplexerError>(w.active_pane.clone()))
+            .await
+            .unwrap();
+        assert_eq!(active, right);
+    }
+
+    #[tokio::test]
+    async fn focus_pane_single_pane_returns_204_without_change() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, state2) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/focus-pane", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"left"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let active = state2
+            .multiplexer
+            .with_window_or_404(&wid, |w| Ok::<_, MultiplexerError>(w.active_pane.clone()))
+            .await
+            .unwrap();
+        assert_eq!(active, pid);
+    }
+
+    #[tokio::test]
+    async fn focus_pane_unknown_window_returns_404() {
+        let state = fresh_state();
+        let _ = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/focus-pane", WindowId::new()))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn focus_pane_unknown_direction_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/focus-pane", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"sideways"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn focus_pane_malformed_json_returns_400() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/focus-pane", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/daemon/http_server/src/layout_dto.rs
+++ b/daemon/http_server/src/layout_dto.rs
@@ -40,7 +40,7 @@ fn build_node(cell_id: &CellId, cells: &LayoutCellState) -> MultiplexerResult<Wi
             })
         }
         Cell::Split(s) => {
-            let split_ratio = compute_split_ratio(s.lhs_weight, s.rhs_weight);
+            let split_ratio = LayoutCellState::split_ratio(s.lhs_weight, s.rhs_weight);
             let lhs = build_node(&s.lhs_cell, cells)?;
             let rhs = build_node(&s.rhs_cell, cells)?;
             Ok(WindowLayoutNode::Split {
@@ -55,15 +55,6 @@ fn build_node(cell_id: &CellId, cells: &LayoutCellState) -> MultiplexerResult<Wi
             cell_id: cell_id.clone(),
             pane_id: p.pane.clone(),
         }),
-    }
-}
-
-fn compute_split_ratio(lhs_weight: f32, rhs_weight: f32) -> f32 {
-    let total = lhs_weight + rhs_weight;
-    if total == 0.0 {
-        0.5
-    } else {
-        lhs_weight / total
     }
 }
 
@@ -156,12 +147,12 @@ mod tests {
 
     #[test]
     fn compute_split_ratio_handles_zero_sum_with_half() {
-        assert_eq!(compute_split_ratio(0.0, 0.0), 0.5);
+        assert_eq!(LayoutCellState::split_ratio(0.0, 0.0), 0.5);
     }
 
     #[test]
     fn compute_split_ratio_normalizes_unbalanced_weights() {
-        let r = compute_split_ratio(3.0, 1.0);
+        let r = LayoutCellState::split_ratio(3.0, 1.0);
         assert!((r - 0.75).abs() < f32::EPSILON);
     }
 }

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -100,6 +100,10 @@ pub fn windows_router() -> Router<AppState> {
             post(handlers::windows::select::select),
         )
         .route(
+            "/{window_id}/focus-pane",
+            post(handlers::windows::focus_pane::focus_pane),
+        )
+        .route(
             "/{window_id}/events",
             get(handlers::windows::events::events),
         )

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -7,8 +7,8 @@ use ozmux_configs::OzmuxConfigs;
 use ozmux_extension::ExtensionRegistry;
 use ozmux_multiplexer::{
     Activity, ActivityId, ActivityKind, CycleDirection, MultiplexerError, MultiplexerResult,
-    MultiplexerService, PaneId, SessionId, SetActiveOutcome, SetActivePaneOutcome, Side,
-    SplitOrientation, WindowId,
+    MultiplexerService, PaneDirection, PaneId, SessionId, SetActiveOutcome, SetActivePaneOutcome,
+    Side, SplitOrientation, WindowId,
 };
 use ozmux_terminal::TerminalService;
 use std::sync::Arc;
@@ -125,6 +125,31 @@ impl AppState {
             })
             .await?;
         if matches!(outcome, SetActivePaneOutcome::Changed) {
+            self.publish_window_layout(wid).await;
+        }
+        Ok(())
+    }
+
+    /// Move focus from the currently active pane to its geometric neighbor in
+    /// `direction`. Resolves and activates inside one window-lock acquisition
+    /// to avoid TOCTOU between lookup and set, and broadcasts the new layout
+    /// only when the active pane actually changes.
+    pub async fn focus_pane_direction(
+        &self,
+        wid: &WindowId,
+        direction: PaneDirection,
+    ) -> HttpResult {
+        let outcome = self
+            .multiplexer
+            .with_window_or_404(wid, |w| -> MultiplexerResult<SetActiveOutcome> {
+                let from = w.active_pane.clone();
+                match w.pane_in_direction(&from, direction)? {
+                    Some(target) => w.set_active_pane(&target),
+                    None => Ok(SetActiveOutcome::Unchanged),
+                }
+            })
+            .await?;
+        if matches!(outcome, SetActiveOutcome::Changed) {
             self.publish_window_layout(wid).await;
         }
         Ok(())

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -141,10 +141,10 @@ impl AppState {
     ) -> HttpResult {
         let outcome = self
             .multiplexer
-            .with_window_or_404(wid, |w| -> MultiplexerResult<SetActiveOutcome> {
-                let from = w.active_pane.clone();
-                match w.pane_in_direction(&from, direction)? {
-                    Some(target) => w.set_active_pane(&target),
+            .with_window_or_404(wid, |window| -> MultiplexerResult<SetActiveOutcome> {
+                let from = window.active_pane.clone();
+                match window.pane_in_direction(&from, direction)? {
+                    Some(target) => window.set_active_pane(&target),
                     None => Ok(SetActiveOutcome::Unchanged),
                 }
             })

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -13,8 +13,8 @@ pub use error::{MultiplexerError, MultiplexerResult};
 pub use session::{Session, SessionId, SessionState};
 pub use window::{
     Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
-    LayoutCellState, Pane, PaneCell, PaneId, PaneState, Rect, RootCell, SetActiveOutcome, Side,
-    SplitCell, SplitOrientation, Window, WindowId, WindowState,
+    LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, Rect, RootCell,
+    SetActiveOutcome, Side, SplitCell, SplitOrientation, Window, WindowId, WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -13,8 +13,8 @@ pub use error::{MultiplexerError, MultiplexerResult};
 pub use session::{Session, SessionId, SessionState};
 pub use window::{
     Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
-    LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, Rect, RootCell,
-    SetActiveOutcome, Side, SplitCell, SplitOrientation, Window, WindowId, WindowState,
+    LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
+    Side, SplitCell, SplitOrientation, Window, WindowId, WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -13,7 +13,7 @@ pub use error::{MultiplexerError, MultiplexerResult};
 pub use session::{Session, SessionId, SessionState};
 pub use window::{
     Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
-    LayoutCellState, Pane, PaneCell, PaneId, PaneState, RootCell, SetActiveOutcome, Side,
+    LayoutCellState, Pane, PaneCell, PaneId, PaneState, Rect, RootCell, SetActiveOutcome, Side,
     SplitCell, SplitOrientation, Window, WindowId, WindowState,
 };
 

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -10,7 +10,7 @@ pub mod pane;
 mod window;
 
 pub use cells::{
-    Cell, CellId, CloseOutcome, LayoutCellState, PaneCell, Rect, RootCell, Side, SplitCell,
+    Cell, CellId, CloseOutcome, LayoutCellState, PaneCell, RootCell, Side, SplitCell,
     SplitOrientation,
 };
 pub use direction::PaneDirection;

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -9,7 +9,7 @@ pub mod pane;
 mod window;
 
 pub use cells::{
-    Cell, CellId, CloseOutcome, LayoutCellState, PaneCell, RootCell, Side, SplitCell,
+    Cell, CellId, CloseOutcome, LayoutCellState, PaneCell, Rect, RootCell, Side, SplitCell,
     SplitOrientation,
 };
 pub use pane::activity::{Activity, ActivityId, ActivityKind};

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -4,6 +4,7 @@
 //! `ozmux_multiplexer::window::{Window, WindowId, PaneId, ActivityId, ...}`.
 
 pub mod cells;
+pub mod direction;
 pub mod pane;
 #[allow(clippy::module_inception)]
 mod window;
@@ -12,6 +13,7 @@ pub use cells::{
     Cell, CellId, CloseOutcome, LayoutCellState, PaneCell, Rect, RootCell, Side, SplitCell,
     SplitOrientation,
 };
+pub use direction::PaneDirection;
 pub use pane::activity::{Activity, ActivityId, ActivityKind};
 pub use pane::{CycleDirection, Pane, PaneId, PaneState, SetActiveOutcome};
 pub use window::{Window, WindowId, WindowState};

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -252,7 +252,7 @@ impl LayoutCellState {
     /// Descends the cell subtree rooted at `id` and pushes one `(PaneId, Rect)` per leaf into `out`,
     /// with `bounds` as the rectangle allotted to this subtree.
     ///
-    /// - `Cell::Pane` is a leaf: emit `(pane, b)`.
+    /// - `Cell::Pane` is a leaf: emit `(pane, bounds)`.
     /// - `Cell::Root` passes `bounds` straight through to its single child.
     /// - `Cell::Split` divides `bounds` along its orientation using
     ///   `Self::split_ratio` and recurses into lhs then rhs. The trailing

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -6,6 +6,19 @@ use ozmux_macros::NewType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Axis-aligned rectangle in normalized window coordinates (`x, y, w, h` ∈ [0, 1]).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Rect {
+    /// Left edge.
+    pub x: f32,
+    /// Top edge.
+    pub y: f32,
+    /// Width.
+    pub w: f32,
+    /// Height.
+    pub h: f32,
+}
+
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct LayoutCellState(HashMap<CellId, Cell>);
 
@@ -204,6 +217,111 @@ impl LayoutCellState {
             Cell::Pane(p) => out.push(p.pane.clone()),
         }
         Ok(())
+    }
+
+    /// Normalize `lhs_weight` / `rhs_weight` into a 0..1 ratio. Returns `0.5`
+    /// when both weights are zero so callers do not need to special-case it.
+    pub fn split_ratio(lhs_weight: f32, rhs_weight: f32) -> f32 {
+        let total = lhs_weight + rhs_weight;
+        if total == 0.0 {
+            0.5
+        } else {
+            lhs_weight / total
+        }
+    }
+
+    /// Compute each pane's normalized rectangle. Returns leaves in DFS
+    /// left-to-right order, matching `pane_ids_in_subtree`.
+    ///
+    /// # Invariants
+    ///
+    /// - Siblings under one `Cell::Split` are produced contiguously and their
+    ///   bounds sum to the parent rect because `rhs_size = parent_size - lhs_size`.
+    pub fn pane_bounds(&self, root: &CellId) -> MultiplexerResult<Vec<(PaneId, Rect)>> {
+        let mut out = Vec::new();
+        self.walk_bounds(
+            root,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            },
+            &mut out,
+        )?;
+        Ok(out)
+    }
+
+    fn walk_bounds(
+        &self,
+        id: &CellId,
+        b: Rect,
+        out: &mut Vec<(PaneId, Rect)>,
+    ) -> MultiplexerResult<()> {
+        match self.cell(id)? {
+            Cell::Pane(p) => {
+                out.push((p.pane.clone(), b));
+                Ok(())
+            }
+            Cell::Root(r) => {
+                let child = r.child.clone();
+                self.walk_bounds(&child, b, out)
+            }
+            Cell::Split(s) => {
+                let orientation = s.orientation;
+                let ratio = Self::split_ratio(s.lhs_weight, s.rhs_weight);
+                let lhs_cell = s.lhs_cell.clone();
+                let rhs_cell = s.rhs_cell.clone();
+                match orientation {
+                    SplitOrientation::Horizontal => {
+                        let lhs_w = b.w * ratio;
+                        self.walk_bounds(
+                            &lhs_cell,
+                            Rect {
+                                x: b.x,
+                                y: b.y,
+                                w: lhs_w,
+                                h: b.h,
+                            },
+                            out,
+                        )?;
+                        self.walk_bounds(
+                            &rhs_cell,
+                            Rect {
+                                x: b.x + lhs_w,
+                                y: b.y,
+                                w: b.w - lhs_w,
+                                h: b.h,
+                            },
+                            out,
+                        )
+                    }
+                    SplitOrientation::Vertical => {
+                        let lhs_h = b.h * ratio;
+                        self.walk_bounds(
+                            &lhs_cell,
+                            Rect {
+                                x: b.x,
+                                y: b.y,
+                                w: b.w,
+                                h: lhs_h,
+                            },
+                            out,
+                        )?;
+                        self.walk_bounds(
+                            &rhs_cell,
+                            Rect {
+                                x: b.x,
+                                y: b.y + lhs_h,
+                                w: b.w,
+                                h: b.h - lhs_h,
+                            },
+                            out,
+                        )
+                    }
+                }
+            }
+        }
     }
 
     /// Drop every cell in `start`'s subtree (including `start` itself).
@@ -627,6 +745,131 @@ mod tests {
         expected.sort();
         assert_eq!(ids, expected);
         let _ = outer;
+    }
+
+    #[test]
+    fn pane_bounds_single_pane_fills_unit_rect() {
+        let mut state = LayoutCellState::default();
+        let p = pid();
+        let (root_id, _) = state.new_window_layout(p.clone());
+
+        let bounds = state.pane_bounds(&root_id).unwrap();
+        assert_eq!(bounds.len(), 1);
+        assert_eq!(bounds[0].0, p);
+        assert_eq!(
+            bounds[0].1,
+            Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn pane_bounds_horizontal_split_returns_left_then_right_halves() {
+        let mut state = LayoutCellState::default();
+        let (root_id, lhs) = state.new_window_layout(pid());
+        let rhs = state.new_pane(pid(), None);
+        state
+            .split_cell(
+                lhs.clone(),
+                rhs.clone(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
+            .unwrap();
+
+        let bounds = state.pane_bounds(&root_id).unwrap();
+        assert_eq!(bounds.len(), 2);
+        let lhs_pane = match state.cell(&lhs).unwrap() {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => unreachable!(),
+        };
+        let rhs_pane = match state.cell(&rhs).unwrap() {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            bounds[0],
+            (
+                lhs_pane,
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    w: 0.5,
+                    h: 1.0
+                }
+            )
+        );
+        assert_eq!(
+            bounds[1],
+            (
+                rhs_pane,
+                Rect {
+                    x: 0.5,
+                    y: 0.0,
+                    w: 0.5,
+                    h: 1.0
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn pane_bounds_vertical_split_stacks_top_then_bottom() {
+        let mut state = LayoutCellState::default();
+        let (root_id, top) = state.new_window_layout(pid());
+        let bottom = state.new_pane(pid(), None);
+        state
+            .split_cell(
+                top.clone(),
+                bottom.clone(),
+                Side::After,
+                SplitOrientation::Vertical,
+            )
+            .unwrap();
+
+        let bounds = state.pane_bounds(&root_id).unwrap();
+        let top_pane = match state.cell(&top).unwrap() {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => unreachable!(),
+        };
+        let bottom_pane = match state.cell(&bottom).unwrap() {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            bounds[0],
+            (
+                top_pane,
+                Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    w: 1.0,
+                    h: 0.5
+                }
+            )
+        );
+        assert_eq!(
+            bounds[1],
+            (
+                bottom_pane,
+                Rect {
+                    x: 0.0,
+                    y: 0.5,
+                    w: 1.0,
+                    h: 0.5
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn split_ratio_normalizes_zero_total_to_half() {
+        assert_eq!(LayoutCellState::split_ratio(0.0, 0.0), 0.5);
+        assert_eq!(LayoutCellState::split_ratio(1.0, 3.0), 0.25);
     }
 
     #[test]

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -8,14 +8,10 @@ use std::collections::HashMap;
 
 /// Axis-aligned rectangle in normalized window coordinates (`x, y, w, h` ∈ [0, 1]).
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Rect {
-    /// Left edge.
+pub(crate) struct Rect {
     pub x: f32,
-    /// Top edge.
     pub y: f32,
-    /// Width.
     pub w: f32,
-    /// Height.
     pub h: f32,
 }
 
@@ -237,7 +233,7 @@ impl LayoutCellState {
     ///
     /// - Siblings under one `Cell::Split` are produced contiguously and their
     ///   bounds sum to the parent rect because `rhs_size = parent_size - lhs_size`.
-    pub fn pane_bounds(&self, root: &CellId) -> MultiplexerResult<Vec<(PaneId, Rect)>> {
+    pub(crate) fn pane_bounds(&self, root: &CellId) -> MultiplexerResult<Vec<(PaneId, Rect)>> {
         let mut out = Vec::new();
         self.walk_bounds(
             root,

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -226,8 +226,8 @@ impl LayoutCellState {
         }
     }
 
-    /// Compute each pane's normalized rectangle. Returns leaves in DFS
-    /// left-to-right order, matching `pane_ids_in_subtree`.
+    /// Compute each pane's normalized rectangle.
+    /// Returns leaves in DFS left-to-right order, matching `pane_ids_in_subtree`.
     ///
     /// # Invariants
     ///
@@ -248,13 +248,13 @@ impl LayoutCellState {
         Ok(out)
     }
 
-    /// Recursive worker for `pane_bounds`. Descends the cell subtree rooted at
-    /// `id` and pushes one `(PaneId, Rect)` per leaf into `out`, with `b` as
-    /// the rectangle allotted to this subtree.
+    /// Recursive worker for `pane_bounds`.
+    /// Descends the cell subtree rooted at `id` and pushes one `(PaneId, Rect)` per leaf into `out`,
+    /// with `bounds` as the rectangle allotted to this subtree.
     ///
     /// - `Cell::Pane` is a leaf: emit `(pane, b)`.
-    /// - `Cell::Root` passes `b` straight through to its single child.
-    /// - `Cell::Split` divides `b` along its orientation using
+    /// - `Cell::Root` passes `bounds` straight through to its single child.
+    /// - `Cell::Split` divides `bounds` along its orientation using
     ///   `Self::split_ratio` and recurses into lhs then rhs. The trailing
     ///   side's size is computed as `parent_size - lhs_size` (not as a
     ///   separate multiplication) so siblings always sum exactly to the
@@ -271,17 +271,17 @@ impl LayoutCellState {
     fn walk_bounds(
         &self,
         id: &CellId,
-        b: Rect,
+        bounds: Rect,
         out: &mut Vec<(PaneId, Rect)>,
     ) -> MultiplexerResult<()> {
         match self.cell(id)? {
             Cell::Pane(p) => {
-                out.push((p.pane.clone(), b));
+                out.push((p.pane.clone(), bounds));
                 Ok(())
             }
             Cell::Root(r) => {
                 let child = r.child.clone();
-                self.walk_bounds(&child, b, out)
+                self.walk_bounds(&child, bounds, out)
             }
             Cell::Split(s) => {
                 let orientation = s.orientation;
@@ -290,36 +290,36 @@ impl LayoutCellState {
                 let rhs_cell = s.rhs_cell.clone();
                 match orientation {
                     SplitOrientation::Horizontal => {
-                        let lhs_w = b.w * ratio;
+                        let lhs_w = bounds.w * ratio;
                         self.walk_bounds(
                             &lhs_cell,
                             Rect {
-                                x: b.x,
-                                y: b.y,
+                                x: bounds.x,
+                                y: bounds.y,
                                 w: lhs_w,
-                                h: b.h,
+                                h: bounds.h,
                             },
                             out,
                         )?;
                         self.walk_bounds(
                             &rhs_cell,
                             Rect {
-                                x: b.x + lhs_w,
-                                y: b.y,
-                                w: b.w - lhs_w,
-                                h: b.h,
+                                x: bounds.x + lhs_w,
+                                y: bounds.y,
+                                w: bounds.w - lhs_w,
+                                h: bounds.h,
                             },
                             out,
                         )
                     }
                     SplitOrientation::Vertical => {
-                        let lhs_h = b.h * ratio;
+                        let lhs_h = bounds.h * ratio;
                         self.walk_bounds(
                             &lhs_cell,
                             Rect {
-                                x: b.x,
-                                y: b.y,
-                                w: b.w,
+                                x: bounds.x,
+                                y: bounds.y,
+                                w: bounds.w,
                                 h: lhs_h,
                             },
                             out,
@@ -327,10 +327,10 @@ impl LayoutCellState {
                         self.walk_bounds(
                             &rhs_cell,
                             Rect {
-                                x: b.x,
-                                y: b.y + lhs_h,
-                                w: b.w,
-                                h: b.h - lhs_h,
+                                x: bounds.x,
+                                y: bounds.y + lhs_h,
+                                w: bounds.w,
+                                h: bounds.h - lhs_h,
                             },
                             out,
                         )

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -248,6 +248,26 @@ impl LayoutCellState {
         Ok(out)
     }
 
+    /// Recursive worker for `pane_bounds`. Descends the cell subtree rooted at
+    /// `id` and pushes one `(PaneId, Rect)` per leaf into `out`, with `b` as
+    /// the rectangle allotted to this subtree.
+    ///
+    /// - `Cell::Pane` is a leaf: emit `(pane, b)`.
+    /// - `Cell::Root` passes `b` straight through to its single child.
+    /// - `Cell::Split` divides `b` along its orientation using
+    ///   `Self::split_ratio` and recurses into lhs then rhs. The trailing
+    ///   side's size is computed as `parent_size - lhs_size` (not as a
+    ///   separate multiplication) so siblings always sum exactly to the
+    ///   parent rect — `Window::pane_in_direction`'s adjacency test relies
+    ///   on this exactness.
+    ///
+    /// The lhs-before-rhs descent fixes the output as DFS left-to-right
+    /// order, matching `pane_ids_in_subtree`. `pick_best` consumes that
+    /// order to break ties on equal `active_point`.
+    ///
+    /// Each arm clones the child `CellId`s (and `orientation` for splits)
+    /// before recursing so the immutable borrow taken by `self.cell(id)?`
+    /// is released before the recursive `&self` reborrow.
     fn walk_bounds(
         &self,
         id: &CellId,

--- a/daemon/multiplexer/src/window/direction.rs
+++ b/daemon/multiplexer/src/window/direction.rs
@@ -80,8 +80,7 @@ fn overlaps_perpendicular(me: Rect, other: Rect, direction: PaneDirection) -> bo
     a0 + PANE_ADJACENCY_EPS < b1 && b0 + PANE_ADJACENCY_EPS < a1
 }
 
-/// Pick the candidate with the largest `score`. Ties are broken by first
-/// occurrence in `panes`, mirroring tmux's `window_pane_choose_best`.
+/// Pick the candidate with the largest `score`.
 fn pick_best<F: Fn(&PaneId) -> u64>(
     panes: &[(PaneId, Rect)],
     from: &PaneId,
@@ -91,20 +90,16 @@ fn pick_best<F: Fn(&PaneId) -> u64>(
     score: &F,
 ) -> Option<PaneId> {
     let mut best: Option<(&PaneId, u64)> = None;
-    for (pid, b) in panes {
-        if pid == from {
-            continue;
-        }
-        if !touches_edge(*b, direction, edge) {
-            continue;
-        }
-        if !overlaps_perpendicular(me, *b, direction) {
-            continue;
-        }
-        let s = score(pid);
+    for (pid, _) in panes
+        .iter()
+        .filter(|(pid, _)| pid != from)
+        .filter(|(_, rect)| touches_edge(*rect, direction, edge))
+        .filter(|(_, rect)| overlaps_perpendicular(me, *rect, direction))
+    {
+        let score = score(pid);
         best = match best {
-            None => Some((pid, s)),
-            Some((_, bs)) if s > bs => Some((pid, s)),
+            None => Some((pid, score)),
+            Some((_, bs)) if score > bs => Some((pid, score)),
             Some(prev) => Some(prev),
         };
     }

--- a/daemon/multiplexer/src/window/direction.rs
+++ b/daemon/multiplexer/src/window/direction.rs
@@ -1,0 +1,33 @@
+//! Direction-resolution algorithm for `Window::pane_in_direction`. Owns the
+//! `PaneDirection` enum and pure adjacency / overlap helpers. No I/O.
+
+use serde::{Deserialize, Serialize};
+
+/// Cardinal direction for pane-focus movement. Distinct from
+/// `ozmux_configs::Direction` (UX layer) to keep the multiplexer crate free
+/// of a `configs` dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneDirection {
+    /// Move focus toward the top of the window.
+    Up,
+    /// Move focus toward the bottom of the window.
+    Down,
+    /// Move focus toward the left of the window.
+    Left,
+    /// Move focus toward the right of the window.
+    Right,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_direction_serializes_kebab_case() {
+        let json = serde_json::to_string(&PaneDirection::Up).unwrap();
+        assert_eq!(json, "\"up\"");
+        let back: PaneDirection = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, PaneDirection::Up);
+    }
+}

--- a/daemon/multiplexer/src/window/direction.rs
+++ b/daemon/multiplexer/src/window/direction.rs
@@ -23,28 +23,60 @@ pub enum PaneDirection {
     Right,
 }
 
-const PANE_ADJACENCY_EPS: f32 = 1e-7;
+impl PaneDirection {
+    /// Edge of `rect` that leads in this direction (the edge you'd cross when
+    /// moving toward `self`).
+    fn primary_edge(self, rect: Rect) -> f32 {
+        match self {
+            Self::Up => rect.y,
+            Self::Down => rect.y + rect.h,
+            Self::Left => rect.x,
+            Self::Right => rect.x + rect.w,
+        }
+    }
 
-/// `true` when `other`'s opposite edge equals `edge` to within
-/// `PANE_ADJACENCY_EPS`.
-fn touches_edge(other: Rect, direction: PaneDirection, edge: f32) -> bool {
-    let other_edge = match direction {
-        PaneDirection::Up => other.y + other.h,
-        PaneDirection::Down => other.y,
-        PaneDirection::Left => other.x + other.w,
-        PaneDirection::Right => other.x,
-    };
-    (other_edge - edge).abs() < PANE_ADJACENCY_EPS
+    /// Edge of `rect` that faces away from this direction — the edge a
+    /// candidate neighbor must align with to count as adjacent.
+    fn opposite_edge(self, rect: Rect) -> f32 {
+        match self {
+            Self::Up => rect.y + rect.h,
+            Self::Down => rect.y,
+            Self::Left => rect.x + rect.w,
+            Self::Right => rect.x,
+        }
+    }
+
+    /// Perpendicular-axis range `(start, end)` of `rect` for overlap checks.
+    fn perpendicular_range(self, rect: Rect) -> (f32, f32) {
+        match self {
+            Self::Up | Self::Down => (rect.x, rect.x + rect.w),
+            Self::Left | Self::Right => (rect.y, rect.y + rect.h),
+        }
+    }
+
+    /// Window-side to fold the search edge to when the primary pass finds
+    /// nothing (wrap-around).
+    fn wrap_edge(self) -> f32 {
+        match self {
+            Self::Up | Self::Left => 1.0,
+            Self::Down | Self::Right => 0.0,
+        }
+    }
 }
 
-/// Half-open interval overlap on the perpendicular axis.
+const PANE_ADJACENCY_EPS: f32 = 1e-7;
+
+/// Returns true when `other`'s opposite-facing edge sits within
+/// `PANE_ADJACENCY_EPS` of `edge`.
+fn touches_edge(other: Rect, direction: PaneDirection, edge: f32) -> bool {
+    (direction.opposite_edge(other) - edge).abs() < PANE_ADJACENCY_EPS
+}
+
+/// Half-open interval overlap of `me` and `other` along the axis perpendicular
+/// to `direction`.
 fn overlaps_perpendicular(me: Rect, other: Rect, direction: PaneDirection) -> bool {
-    let (a0, a1, b0, b1) = match direction {
-        PaneDirection::Up | PaneDirection::Down => (me.x, me.x + me.w, other.x, other.x + other.w),
-        PaneDirection::Left | PaneDirection::Right => {
-            (me.y, me.y + me.h, other.y, other.y + other.h)
-        }
-    };
+    let (a0, a1) = direction.perpendicular_range(me);
+    let (b0, b1) = direction.perpendicular_range(other);
     a0 + PANE_ADJACENCY_EPS < b1 && b0 + PANE_ADJACENCY_EPS < a1
 }
 
@@ -88,20 +120,17 @@ fn find_in_direction<F: Fn(&PaneId) -> u64>(
     from: &PaneId,
     score: F,
 ) -> Option<PaneId> {
-    let primary_edge = match direction {
-        PaneDirection::Up => me.y,
-        PaneDirection::Down => me.y + me.h,
-        PaneDirection::Left => me.x,
-        PaneDirection::Right => me.x + me.w,
-    };
-    if let Some(p) = pick_best(panes, from, me, direction, primary_edge, &score) {
+    if let Some(p) = pick_best(
+        panes,
+        from,
+        me,
+        direction,
+        direction.primary_edge(me),
+        &score,
+    ) {
         return Some(p);
     }
-    let wrap_edge = match direction {
-        PaneDirection::Up | PaneDirection::Left => 1.0,
-        PaneDirection::Down | PaneDirection::Right => 0.0,
-    };
-    pick_best(panes, from, me, direction, wrap_edge, &score)
+    pick_best(panes, from, me, direction, direction.wrap_edge(), &score)
 }
 
 impl Window {

--- a/daemon/multiplexer/src/window/direction.rs
+++ b/daemon/multiplexer/src/window/direction.rs
@@ -1,6 +1,10 @@
 //! Direction-resolution algorithm for `Window::pane_in_direction`. Owns the
 //! `PaneDirection` enum and pure adjacency / overlap helpers. No I/O.
 
+use crate::error::{MultiplexerError, MultiplexerResult};
+use crate::window::cells::Rect;
+use crate::window::pane::PaneId;
+use crate::window::window::Window;
 use serde::{Deserialize, Serialize};
 
 /// Cardinal direction for pane-focus movement. Distinct from
@@ -19,9 +23,115 @@ pub enum PaneDirection {
     Right,
 }
 
+const PANE_ADJACENCY_EPS: f32 = 1e-7;
+
+/// `true` when `other`'s opposite edge equals `edge` to within
+/// `PANE_ADJACENCY_EPS`.
+fn touches_edge(other: Rect, direction: PaneDirection, edge: f32) -> bool {
+    let other_edge = match direction {
+        PaneDirection::Up => other.y + other.h,
+        PaneDirection::Down => other.y,
+        PaneDirection::Left => other.x + other.w,
+        PaneDirection::Right => other.x,
+    };
+    (other_edge - edge).abs() < PANE_ADJACENCY_EPS
+}
+
+/// Half-open interval overlap on the perpendicular axis.
+fn overlaps_perpendicular(me: Rect, other: Rect, direction: PaneDirection) -> bool {
+    let (a0, a1, b0, b1) = match direction {
+        PaneDirection::Up | PaneDirection::Down => (me.x, me.x + me.w, other.x, other.x + other.w),
+        PaneDirection::Left | PaneDirection::Right => {
+            (me.y, me.y + me.h, other.y, other.y + other.h)
+        }
+    };
+    a0 + PANE_ADJACENCY_EPS < b1 && b0 + PANE_ADJACENCY_EPS < a1
+}
+
+/// Pick the candidate with the largest `score`. Ties are broken by first
+/// occurrence in `panes`, mirroring tmux's `window_pane_choose_best`.
+fn pick_best<F: Fn(&PaneId) -> u64>(
+    panes: &[(PaneId, Rect)],
+    from: &PaneId,
+    me: Rect,
+    direction: PaneDirection,
+    edge: f32,
+    score: &F,
+) -> Option<PaneId> {
+    let mut best: Option<(&PaneId, u64)> = None;
+    for (pid, b) in panes {
+        if pid == from {
+            continue;
+        }
+        if !touches_edge(*b, direction, edge) {
+            continue;
+        }
+        if !overlaps_perpendicular(me, *b, direction) {
+            continue;
+        }
+        let s = score(pid);
+        best = match best {
+            None => Some((pid, s)),
+            Some((_, bs)) if s > bs => Some((pid, s)),
+            Some(prev) => Some(prev),
+        };
+    }
+    best.map(|(p, _)| p.clone())
+}
+
+/// Two-pass adjacency search: primary edge first, then the opposite-side
+/// wrap edge if the primary pass returned nothing.
+fn find_in_direction<F: Fn(&PaneId) -> u64>(
+    me: Rect,
+    direction: PaneDirection,
+    panes: &[(PaneId, Rect)],
+    from: &PaneId,
+    score: F,
+) -> Option<PaneId> {
+    let primary_edge = match direction {
+        PaneDirection::Up => me.y,
+        PaneDirection::Down => me.y + me.h,
+        PaneDirection::Left => me.x,
+        PaneDirection::Right => me.x + me.w,
+    };
+    if let Some(p) = pick_best(panes, from, me, direction, primary_edge, &score) {
+        return Some(p);
+    }
+    let wrap_edge = match direction {
+        PaneDirection::Up | PaneDirection::Left => 1.0,
+        PaneDirection::Down | PaneDirection::Right => 0.0,
+    };
+    pick_best(panes, from, me, direction, wrap_edge, &score)
+}
+
+impl Window {
+    /// Resolve the pane that should receive focus when moving `direction`
+    /// from `from`. Returns `Ok(None)` when no candidate exists (single-pane
+    /// window or pathological layout); never picks `from` itself.
+    pub fn pane_in_direction(
+        &self,
+        from: &PaneId,
+        direction: PaneDirection,
+    ) -> MultiplexerResult<Option<PaneId>> {
+        let panes = self.cells.pane_bounds(&self.root_cell)?;
+        let me = panes
+            .iter()
+            .find(|(pid, _)| pid == from)
+            .map(|(_, r)| *r)
+            .ok_or_else(|| MultiplexerError::PaneNotFound(from.clone()))?;
+        let score = |pid: &PaneId| self.pane_active_points.get(pid).copied().unwrap_or(0);
+        Ok(find_in_direction(me, direction, &panes, from, score))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::window::cells::{Side, SplitOrientation};
+    use crate::window::pane::PaneId;
+    use crate::window::pane::activity::{Activity, ActivityId};
+    use crate::window::window::Window;
+    use crate::window::window::WindowId;
 
     #[test]
     fn pane_direction_serializes_kebab_case() {
@@ -29,5 +139,162 @@ mod tests {
         assert_eq!(json, "\"up\"");
         let back: PaneDirection = serde_json::from_str(&json).unwrap();
         assert_eq!(back, PaneDirection::Up);
+    }
+
+    fn fresh_window() -> Window {
+        Window::new_with_initial(
+            WindowId::new(),
+            "t".into(),
+            PaneId::new(),
+            Activity::terminal(ActivityId::new()),
+        )
+    }
+
+    fn split(window: &mut Window, target: &PaneId, orient: SplitOrientation, side: Side) -> PaneId {
+        let new = PaneId::new();
+        window
+            .split_pane(
+                target,
+                new.clone(),
+                Activity::terminal(ActivityId::new()),
+                side,
+                orient,
+            )
+            .unwrap();
+        new
+    }
+
+    #[test]
+    fn pane_in_direction_horizontal_split_right_then_left_wraps() {
+        let mut w = fresh_window();
+        let left = w.active_pane.clone();
+        let right = split(&mut w, &left, SplitOrientation::Horizontal, Side::After);
+
+        assert_eq!(
+            w.pane_in_direction(&left, PaneDirection::Right).unwrap(),
+            Some(right.clone()),
+        );
+        assert_eq!(
+            w.pane_in_direction(&left, PaneDirection::Left).unwrap(),
+            Some(right.clone()),
+            "wrap from left edge picks the rightmost pane",
+        );
+        assert_eq!(
+            w.pane_in_direction(&right, PaneDirection::Up).unwrap(),
+            None,
+            "1xN strip has no candidate on the perpendicular axis",
+        );
+    }
+
+    #[test]
+    fn pane_in_direction_vertical_split_down_and_up() {
+        let mut w = fresh_window();
+        let top = w.active_pane.clone();
+        let bottom = split(&mut w, &top, SplitOrientation::Vertical, Side::After);
+        assert_eq!(
+            w.pane_in_direction(&top, PaneDirection::Down).unwrap(),
+            Some(bottom.clone()),
+        );
+        assert_eq!(
+            w.pane_in_direction(&top, PaneDirection::Up).unwrap(),
+            Some(bottom.clone()),
+            "wrap from top edge",
+        );
+    }
+
+    #[test]
+    fn pane_in_direction_single_pane_returns_none() {
+        let w = fresh_window();
+        for d in [
+            PaneDirection::Up,
+            PaneDirection::Down,
+            PaneDirection::Left,
+            PaneDirection::Right,
+        ] {
+            assert_eq!(w.pane_in_direction(&w.active_pane, d).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn pane_in_direction_two_by_two_grid_picks_geometric_neighbor() {
+        let mut w = fresh_window();
+        // Build a 2x2 grid:
+        //   tl | tr
+        //   ---+---
+        //   bl | br
+        let tl = w.active_pane.clone();
+        let tr = split(&mut w, &tl, SplitOrientation::Horizontal, Side::After);
+        let bl = split(&mut w, &tl, SplitOrientation::Vertical, Side::After);
+        let br = split(&mut w, &tr, SplitOrientation::Vertical, Side::After);
+
+        assert_eq!(
+            w.pane_in_direction(&tl, PaneDirection::Right).unwrap(),
+            Some(tr.clone())
+        );
+        assert_eq!(
+            w.pane_in_direction(&tl, PaneDirection::Down).unwrap(),
+            Some(bl.clone())
+        );
+        assert_eq!(
+            w.pane_in_direction(&br, PaneDirection::Left).unwrap(),
+            Some(bl.clone())
+        );
+        assert_eq!(
+            w.pane_in_direction(&br, PaneDirection::Up).unwrap(),
+            Some(tr.clone())
+        );
+    }
+
+    #[test]
+    fn pane_in_direction_deep_horizontal_split_keeps_immediate_neighbor() {
+        // Repeatedly split the rightmost pane horizontally. After enough
+        // levels the rightmost pane's width is below the old EPS = 1e-5,
+        // which used to misfire. The new algorithm must still return its
+        // immediate left neighbor (not a wrap target).
+        let mut w = fresh_window();
+        let mut current = w.active_pane.clone();
+        let mut second_last = current.clone();
+        for _ in 0..20 {
+            second_last = current.clone();
+            current = split(&mut w, &current, SplitOrientation::Horizontal, Side::After);
+        }
+        assert_eq!(
+            w.pane_in_direction(&current, PaneDirection::Left).unwrap(),
+            Some(second_last),
+        );
+    }
+
+    #[test]
+    fn pane_in_direction_tiebreak_prefers_most_recent_active_point() {
+        // Layout:
+        //   ┌────┬────┐
+        //   │ tl │    │
+        //   ├────┤ r  │
+        //   │ bl │    │
+        //   └────┴────┘
+        // Then move Left from `r`: candidates are `tl` and `bl`. The one
+        // most recently activated wins.
+        let mut w = fresh_window();
+        let tl = w.active_pane.clone();
+        let r = split(&mut w, &tl, SplitOrientation::Horizontal, Side::After);
+        let bl = split(&mut w, &tl, SplitOrientation::Vertical, Side::After);
+
+        // Activate tl most recently.
+        let _ = w.set_active_pane(&bl).unwrap();
+        let _ = w.set_active_pane(&tl).unwrap();
+        let _ = w.set_active_pane(&r).unwrap();
+        assert_eq!(
+            w.pane_in_direction(&r, PaneDirection::Left).unwrap(),
+            Some(tl.clone()),
+            "tl was activated more recently than bl",
+        );
+
+        // Now flip: activate bl most recently.
+        let _ = w.set_active_pane(&bl).unwrap();
+        let _ = w.set_active_pane(&r).unwrap();
+        assert_eq!(
+            w.pane_in_direction(&r, PaneDirection::Left).unwrap(),
+            Some(bl.clone()),
+        );
     }
 }

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -19,6 +19,8 @@ pub struct Window {
     pub pane_to_cell: HashMap<PaneId, CellId>,
     pub root_cell: CellId,
     pub active_pane: PaneId,
+    pub(crate) pane_active_points: HashMap<PaneId, u64>,
+    pub(crate) next_active_point: u64,
 }
 
 impl Window {
@@ -45,7 +47,19 @@ impl Window {
             pane_to_cell,
             root_cell,
             active_pane: initial_pane_id,
+            pane_active_points: HashMap::new(),
+            next_active_point: 0,
         }
+    }
+
+    /// Bump the per-window counter and record it as the new active pane's
+    /// activation point. The tiebreak in `Window::pane_in_direction` reads
+    /// from `pane_active_points`; a missing entry is treated as `0`, so we
+    /// only need to insert when a pane actually becomes active.
+    fn record_active_point(&mut self, pane_id: &PaneId) {
+        self.next_active_point += 1;
+        self.pane_active_points
+            .insert(pane_id.clone(), self.next_active_point);
     }
 
     pub fn rename(&mut self, name: impl Into<String>) {
@@ -85,7 +99,8 @@ impl Window {
         self.pane_to_cell.insert(new_pane_id.clone(), new_cell_id);
         let pane = Pane::new(new_pane_id.clone(), new_activity);
         self.panes.insert(pane);
-        self.active_pane = new_pane_id;
+        self.active_pane = new_pane_id.clone();
+        self.record_active_point(&new_pane_id);
         Ok(())
     }
 
@@ -151,10 +166,12 @@ impl Window {
         let outcome = self.cells.close_cell(&cell_id)?;
         let survivor_pane_id = self.cells.leftmost_pane(outcome.survivor())?.clone();
         if &self.active_pane == pane_id {
-            self.active_pane = survivor_pane_id;
+            self.active_pane = survivor_pane_id.clone();
+            self.record_active_point(&survivor_pane_id);
         }
         let pane = self.panes.remove(pane_id)?;
         self.pane_to_cell.remove(pane_id);
+        self.pane_active_points.remove(pane_id);
         Ok(pane.activities.into_iter().map(|a| a.id).collect())
     }
 
@@ -168,6 +185,7 @@ impl Window {
             return Ok(SetActiveOutcome::Unchanged);
         }
         self.active_pane = pane_id.clone();
+        self.record_active_point(pane_id);
         Ok(SetActiveOutcome::Changed)
     }
 
@@ -442,5 +460,72 @@ mod tests {
         let (mut win, pid, _) = fresh_window();
         let err = win.close_pane(&pid).unwrap_err();
         assert!(matches!(err, MultiplexerError::CannotCloseLastPane(_)));
+    }
+
+    fn sample_window() -> Window {
+        Window::new_with_initial(
+            WindowId::new(),
+            "test".into(),
+            PaneId::new(),
+            Activity::terminal(ActivityId::new()),
+        )
+    }
+
+    #[test]
+    fn new_window_starts_with_empty_active_point_table() {
+        let win = sample_window();
+        assert_eq!(win.next_active_point, 0);
+        assert!(win.pane_active_points.is_empty());
+    }
+
+    #[test]
+    fn set_active_pane_records_active_point() {
+        let mut win = sample_window();
+        let original = win.active_pane.clone();
+        let other = PaneId::new();
+        win.split_pane(
+            &original,
+            other.clone(),
+            Activity::terminal(ActivityId::new()),
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
+        let first_point = *win.pane_active_points.get(&other).unwrap();
+        assert!(first_point >= 1);
+
+        win.set_active_pane(&original).unwrap();
+        let original_point = *win.pane_active_points.get(&original).unwrap();
+        assert!(
+            original_point > first_point,
+            "switching back must increment past the previous max",
+        );
+    }
+
+    #[test]
+    fn set_active_pane_unchanged_does_not_bump_counter() {
+        let mut win = sample_window();
+        let active = win.active_pane.clone();
+        let before = win.next_active_point;
+        win.set_active_pane(&active).unwrap();
+        assert_eq!(win.next_active_point, before);
+    }
+
+    #[test]
+    fn close_pane_removes_active_point_entry() {
+        let mut win = sample_window();
+        let original = win.active_pane.clone();
+        let new_pane = PaneId::new();
+        win.split_pane(
+            &original,
+            new_pane.clone(),
+            Activity::terminal(ActivityId::new()),
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
+        assert!(win.pane_active_points.contains_key(&new_pane));
+        win.close_pane(&new_pane).unwrap();
+        assert!(!win.pane_active_points.contains_key(&new_pane));
     }
 }

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -494,7 +494,10 @@ mod tests {
         let first_point = *win.pane_active_points.get(&other).unwrap();
         assert!(first_point >= 1);
 
-        win.set_active_pane(&original).unwrap();
+        assert!(matches!(
+            win.set_active_pane(&original).unwrap(),
+            SetActiveOutcome::Changed,
+        ));
         let original_point = *win.pane_active_points.get(&original).unwrap();
         assert!(
             original_point > first_point,
@@ -507,7 +510,10 @@ mod tests {
         let mut win = sample_window();
         let active = win.active_pane.clone();
         let before = win.next_active_point;
-        win.set_active_pane(&active).unwrap();
+        assert!(matches!(
+            win.set_active_pane(&active).unwrap(),
+            SetActiveOutcome::Unchanged,
+        ));
         assert_eq!(win.next_active_point, before);
     }
 

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -462,26 +462,16 @@ mod tests {
         assert!(matches!(err, MultiplexerError::CannotCloseLastPane(_)));
     }
 
-    fn sample_window() -> Window {
-        Window::new_with_initial(
-            WindowId::new(),
-            "test".into(),
-            PaneId::new(),
-            Activity::terminal(ActivityId::new()),
-        )
-    }
-
     #[test]
     fn new_window_starts_with_empty_active_point_table() {
-        let win = sample_window();
+        let (win, _, _) = fresh_window();
         assert_eq!(win.next_active_point, 0);
         assert!(win.pane_active_points.is_empty());
     }
 
     #[test]
     fn set_active_pane_records_active_point() {
-        let mut win = sample_window();
-        let original = win.active_pane.clone();
+        let (mut win, original, _) = fresh_window();
         let other = PaneId::new();
         win.split_pane(
             &original,
@@ -507,8 +497,7 @@ mod tests {
 
     #[test]
     fn set_active_pane_unchanged_does_not_bump_counter() {
-        let mut win = sample_window();
-        let active = win.active_pane.clone();
+        let (mut win, active, _) = fresh_window();
         let before = win.next_active_point;
         assert!(matches!(
             win.set_active_pane(&active).unwrap(),
@@ -519,8 +508,7 @@ mod tests {
 
     #[test]
     fn close_pane_removes_active_point_entry() {
-        let mut win = sample_window();
-        let original = win.active_pane.clone();
+        let (mut win, original, _) = fresh_window();
         let new_pane = PaneId::new();
         win.split_pane(
             &original,


### PR DESCRIPTION
## Problem

ozmux had no way to move pane focus by direction. The only existing
shortcut for switching between panes was `Ctrl+B ] / [` (cycle activities
inside the active pane), which does not address window-level pane
navigation. Vim/tmux users expect `Prefix + h/j/k/l` to move focus left /
down / up / right, and this is the most commonly missed shortcut on a
fresh ozmux install.

The `Action::FocusPane { direction }` variant was already declared in the
shortcut config schema but was unwired end-to-end.

## Solution

Wires the schema through every layer and adds the direction-resolution
algorithm.

**Approach.** Backend resolves the target pane geometrically by computing
each pane's `Rect` in `[0, 1]` normalized window coordinates from the
cell tree, then runs a two-pass adjacency search modeled on tmux's
`window_pane_find_*`:

1. Primary edge = the edge of the active pane that leads in the requested
   direction. Candidates are panes whose opposite-facing edge sits within
   `PANE_ADJACENCY_EPS = 1e-7` of that edge and overlap on the
   perpendicular axis.
2. If the primary pass returns nothing (the active pane is at the window
   boundary), the second pass folds the edge to the opposite side of the
   window (1.0 / 0.0) and re-runs the same predicate, producing the
   wrap-around behavior.

Tiebreak is by per-pane `active_point`: a monotonic counter on `Window`
bumps a `pane_active_points: HashMap<PaneId, u64>` entry every time
`active_pane` changes via `set_active_pane`, `split_pane`, or the
survivor-promotion path in `close_pane`. Strict-`>` comparison plus DFS
scan order from `pane_bounds` means the most-recently-active candidate
wins, with first-occurrence tiebreak on equal scores — same semantics as
tmux's `window_pane_choose_best`.

The earlier draft used an `EPS`-based "am I at the boundary?" predicate,
which Codex review caught as broken once a pane's own size approaches
EPS (e.g., 17+ same-axis splits make a pane narrower than `1e-5`). The
two-pass formulation sidesteps that question entirely.

**Affected areas.**

- `daemon/multiplexer` — `Rect` + `LayoutCellState::pane_bounds(root) ->
  Vec<(PaneId, Rect)>` (DFS-ordered), `PaneDirection` enum, per-`Window`
  `pane_active_points` + `next_active_point`, and the
  `Window::pane_in_direction` algorithm with private helpers
  (`touches_edge`, `overlaps_perpendicular`, `pick_best`,
  `find_in_direction`). The shared `compute_split_ratio` is extracted
  into `LayoutCellState::split_ratio` and reused by the existing
  `layout_dto.rs`.
- `daemon/http_server` — `POST /windows/{wid}/focus-pane` handler +
  `AppState::focus_pane_direction`. Resolve and activate run inside one
  `with_window_or_404` closure to avoid TOCTOU between two lock
  acquisitions, and `publish_window_layout` only fires on
  `SetActiveOutcome::Changed`. Status codes match the `cycle_activity`
  precedent: `204` (success including no-op), `422` (unknown
  direction), `400` (malformed JSON), `404` (unknown window).
- `daemon/configs` — `Shortcuts::default()` gains four
  `FocusPane` bindings (`h`/`j`/`k`/`l` → Left/Down/Up/Right, no
  modifier) and the stable-JSON golden test is regenerated.
- `daemon/frontend` — wire schema adds the `focus-pane` action, the
  dispatcher adds a `withActiveWindow` helper and a `focus-pane` case,
  and a new `layout/focusPane.ts` POSTs to the endpoint following the
  existing `cycleActivity.ts` pattern. No UI changes — the active-pane
  outline already reacts to `WindowView` updates.

**Layering.** `configs::Direction` (UX layer) and
`multiplexer::PaneDirection` (domain) are kept separate so the
multiplexer crate does not depend on `configs`. Both enums serialize to
the same kebab-case JSON, so the HTTP body deserializes straight into
`PaneDirection`; no manual translation function is needed.

**Spec / plan.** Design and plan documents are in `docs/superpowers/`
(gitignored). The design went through Codex review before
implementation; the post-review revisions are documented inline in §12
of the spec.

## Test plan

- [x] `cargo test --workspace` — full Rust suite green
- [x] `pnpm test` — full TypeScript suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `pnpm lint:ci` — clean
- [x] `pnpm check-types` — clean
- [x] New multiplexer tests cover: 2-pane horizontal / vertical splits,
      2x2 grid, single-pane window, wrap-around, 20-level deep-split
      regression (pane width below the old `1e-5` EPS), and the
      most-recent / first-occurrence tiebreak with `active_point`
- [x] HTTP handler tests cover all four status codes
      (204 / 422 / 400 / 404) plus the single-pane no-op path
- [x] Frontend tests cover wire round-trip for all four directions, the
      dispatcher → POST integration, and `focusPane`'s error / reject
      branches
- [ ] Manual verification with `make dev-e2e`: split a few panes
      (`Ctrl+B s / v`), then walk `h/j/k/l` around. Confirm wrap at
      window edges lands on the opposite side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)