### PR TITLE
feat: server-resolved resize-pane with repeatable shortcuts

### DIFF
--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,154 @@
+# TypeScript Coding Rules
+
+TypeScript code in this repo (`daemon/frontend`, `sdk/*`, `extensions/*`,
+`tools/*.ts`, and `biome-plugins/`) follows the rules below. These rules
+complement [`.claude/rules/styling.md`](styling.md) (Tailwind / theme
+tokens) and the conventions in `CLAUDE.md`. They mirror the spirit of
+[`.claude/rules/rust.md`](rust.md) for Rust — same taste, translated.
+
+## Comments
+
+Non-JSDoc line comments are restricted. The only permitted forms:
+
+| Form | Use |
+| --- | --- |
+| `// TODO: <text>` | Work to address later |
+| `// NOTE: <text>` | A non-obvious invariant, race, or warning to the reader |
+| `// biome-ignore <rule>: <text>` | Required justification on every biome suppression (already enforced) |
+| `// @ts-expect-error <text>` / `// @ts-ignore <text>` | Required justification on every TypeScript suppression |
+
+Forbidden:
+
+| Pattern | Example | Why |
+| --- | --- | --- |
+| Plain narrative comments | `// increments counter` | What the code does belongs in identifiers |
+| Block comments | `/* ... */` (non-JSDoc) | Same |
+| Commented-out code | `// const x = oldImpl();` | History lives in git |
+| `// NOTE:` with no concrete non-obvious info | `// NOTE: this is the handler` | Promote to identifier rename or delete |
+
+Note: `/** ... */` JSDoc is **not** a "line comment" for this rule — see the next section.
+
+The principle is the same as `rust.md`: if a comment is just restating
+what the code does, the code or its names need to do the work instead.
+A `// NOTE:` earns its keep only when it captures something a careful
+reader would otherwise miss (e.g. a race, a workaround for a specific
+upstream bug, an invariant that the surrounding code relies on).
+
+## JSDoc
+
+Required:
+
+| Place | Style |
+| --- | --- |
+| Every `export` (function, class, interface, type, const) | `/** ... */` — one-line summary, blank line, optional body |
+
+Not required (but recommended):
+
+- Module-level summaries (`/** @file ... */`) — unusual in this codebase; skip unless the file has a non-obvious responsibility.
+- Internal (non-exported) helpers — keep names good instead.
+- Test files (`*.test.ts(x)`) and test helpers (`__test-helpers.ts`).
+- Re-export-only files (`index.ts` with nothing but `export { ... }`).
+
+Style guide:
+
+- The first line is a noun phrase or third-person verb phrase, matching the Rust convention. Stay descriptive, not imperative.
+- Document parameters only when their meaning is non-obvious from the type/name. Don't write `@param name - The name.`.
+- Document return values only when their meaning is non-obvious or when the function has side effects worth flagging.
+- For React hooks, document side effects (effect dependencies, cleanup behavior, subscriptions) in the body.
+
+Forbidden:
+
+| Pattern | Why |
+| --- | --- |
+| `export` item with no JSDoc when the meaning is non-obvious from the name | Public API owes the reader an explanation |
+| Placeholder JSDoc like `/** TODO: write this */` | Don't ship empty docs |
+| `@param` / `@returns` that just restate the TypeScript type | Redundant; TS already says it |
+
+## Visibility — minimize export surface
+
+TypeScript has no `pub(crate)` equivalent. The analog is `export` (visible to other modules) vs unexported (file-local). Reach for unexported by default.
+
+Required:
+
+- A symbol that's only used in its defining file must not be `export`ed.
+- A symbol that's only used inside one parent directory should live in a file that lives next to its callers, not in a shared barrel.
+- Test files may freely import any symbol they need; if they need a non-exported symbol, **add a test-only export** (e.g. `export const __test_only = ...`) rather than widening the production surface.
+
+Forbidden:
+
+| Pattern | Why |
+| --- | --- |
+| Barrel `index.ts` files that re-export everything | Inflates the surface, hides what's actually used externally |
+| `export` on items with no out-of-file callers | Same as `pub` with no cross-crate callers in Rust |
+
+Recommended workflow when adding a new item:
+
+1. Start without `export`.
+2. If a sibling file needs it, add `export`.
+3. If multiple sibling files need it through a barrel, ask whether the barrel is earning its keep.
+
+## Imports
+
+Biome enforces import ordering. The rules here are the ones biome
+does NOT enforce:
+
+- Prefer **named imports** over namespace imports (`import * as foo`)
+  unless the namespace genuinely earns its keep (e.g. shadcn-style
+  primitives). Namespace imports hide what's actually used.
+- No wildcard re-exports (`export * from './foo'`) outside curated
+  prelude / shadcn-registry files.
+
+## Escape hatches
+
+TypeScript's escape hatches require justification, the same way Rust's
+`#[expect(..., reason = "...")]` does:
+
+```ts
+// biome-ignore lint/correctness/useExhaustiveDependencies: liveWid is load-bearing — the effect must re-run after the live container actually mounts
+useEffect(...);
+
+// @ts-expect-error vite-singlefile types lag the runtime API
+import vitePlugin from 'vite-plugin-singlefile';
+```
+
+- Always include a one-line reason. "Easier this way" or "the type is wrong" is not a reason — name the upstream bug, the specific tool limitation, or the non-obvious invariant that justifies the suppression.
+- Prefer `@ts-expect-error` (fails if the underlying error stops happening) over `@ts-ignore` (silently absorbs whatever).
+- Prefer the smallest scope possible: a single-line suppression over a file-level `biome-ignore-all`.
+
+## Tests
+
+Test files (`*.test.ts(x)`) have a loosened rule set:
+
+- `// NOTE:` is not required for inline setup helpers, mocks, fakes — names should still carry meaning.
+- Inline narrative comments **explaining what the test exercises** are acceptable when the assertion alone doesn't make the scenario obvious. But "step-by-step" running commentary is still discouraged — favor splitting into `describe` / `it` blocks instead.
+- JSDoc on test helpers is not required.
+
+## Enforcement
+
+Tool-enforced (biome):
+
+- Import ordering
+- `biome-ignore` requires a reason string (existing rule)
+- Inline-style / arbitrary Tailwind value bans (see `styling.md`)
+- Run via `pnpm lint` / `pnpm lint:fix` / `make fix-lint`
+
+Not tool-enforced — review-time check required. The following rules cannot
+be detected by biome and must be checked manually during code review (and
+by Claude when proposing changes):
+
+- Comment taxonomy — only `// TODO:` / `// NOTE:` / `// biome-ignore` / `// @ts-expect-error` (each with a reason)
+- JSDoc requirement on `export`s with non-obvious meaning
+- `export` visibility minimization
+- Justification quality on `biome-ignore` and `@ts-expect-error`
+- "No commented-out code"
+
+If you add a biome plugin or other tooling that detects any of these, move
+the corresponding entry into the tool-enforced list above.
+
+## Existing legitimate exceptions
+
+- `daemon/frontend/src/test-setup.ts` — jsdom shim setup uses block comments to delimit stub sections. Pre-existing; permitted as long as the surrounding context is non-trivial.
+- `daemon/frontend/src/vendor.d.ts` — third-party type re-export notes. Pre-existing; permitted.
+- `daemon/frontend/src/showcase/**` — design-system showcase files; comment requirements relaxed in line with the styling.md exception for the same files.
+
+(Append entries here as they are discovered, with a brief justification.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,14 @@ doc-comment policy, import discipline) are governed by
 [`.claude/rules/rust.md`](.claude/rules/rust.md). Applies to all crates
 under `cli/` and `daemon/*`.
 
+## TypeScript Coding Rules
+
+TypeScript style and conventions (restricted comment taxonomy, JSDoc on
+exports, export-visibility minimization, justified suppressions) are
+governed by [`.claude/rules/typescript.md`](.claude/rules/typescript.md).
+Applies to `daemon/frontend`, `sdk/*`, `extensions/*`, `tools/*.ts`, and
+`biome-plugins/`.
+
 ## UI verification workflow
 
 Use this when you have changed anything under `daemon/frontend/src/**`, the showcase, theme tokens, pane layout, or daemon-side endpoints that the UI consumes. Skip it for purely backend-internal changes that the UI does not exercise.

--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -75,7 +75,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 13);
+        assert_eq!(merged.shortcuts.bindings.len(), 17);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -111,6 +111,14 @@ pub struct Shortcuts {
     pub prefix: Prefix,
     /// Bindings dispatched while armed.
     pub bindings: Vec<Binding>,
+    /// Milliseconds during which a `repeatable` binding accepts its trigger
+    /// key without the prefix.
+    #[serde(default = "default_repeat_timeout_ms")]
+    pub repeat_timeout_ms: u64,
+}
+
+fn default_repeat_timeout_ms() -> u64 {
+    500
 }
 
 impl Default for Shortcuts {
@@ -133,6 +141,7 @@ impl Default for Shortcuts {
                         modifiers: Modifiers::default(),
                     },
                     action: Action::ClosePane,
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -142,6 +151,7 @@ impl Default for Shortcuts {
                     action: Action::SplitPane {
                         direction: SplitDirection::Horizontal,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -151,6 +161,7 @@ impl Default for Shortcuts {
                     action: Action::SplitPane {
                         direction: SplitDirection::Vertical,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -158,6 +169,7 @@ impl Default for Shortcuts {
                         modifiers: Modifiers::default(),
                     },
                     action: Action::NewTerminalActivity,
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -165,6 +177,7 @@ impl Default for Shortcuts {
                         modifiers: Modifiers::default(),
                     },
                     action: Action::CloseActivity,
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -177,6 +190,7 @@ impl Default for Shortcuts {
                     action: Action::BreakActivityToPane {
                         direction: SplitDirection::Horizontal,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -189,6 +203,7 @@ impl Default for Shortcuts {
                     action: Action::BreakActivityToPane {
                         direction: SplitDirection::Vertical,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -198,6 +213,7 @@ impl Default for Shortcuts {
                     action: Action::FocusActivity {
                         offset: ActivityOffset::Next,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -207,6 +223,7 @@ impl Default for Shortcuts {
                     action: Action::FocusActivity {
                         offset: ActivityOffset::Prev,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -216,6 +233,7 @@ impl Default for Shortcuts {
                     action: Action::FocusPane {
                         direction: Direction::Left,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -225,6 +243,7 @@ impl Default for Shortcuts {
                     action: Action::FocusPane {
                         direction: Direction::Down,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -234,6 +253,7 @@ impl Default for Shortcuts {
                     action: Action::FocusPane {
                         direction: Direction::Up,
                     },
+                    repeatable: false,
                 },
                 Binding {
                     chord: KeyChord {
@@ -243,8 +263,62 @@ impl Default for Shortcuts {
                     action: Action::FocusPane {
                         direction: Direction::Right,
                     },
+                    repeatable: false,
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::ArrowLeft,
+                        modifiers: Modifiers {
+                            ctrl: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::ResizePane {
+                        direction: Direction::Left,
+                    },
+                    repeatable: true,
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::ArrowRight,
+                        modifiers: Modifiers {
+                            ctrl: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::ResizePane {
+                        direction: Direction::Right,
+                    },
+                    repeatable: true,
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::ArrowUp,
+                        modifiers: Modifiers {
+                            ctrl: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::ResizePane {
+                        direction: Direction::Up,
+                    },
+                    repeatable: true,
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::ArrowDown,
+                        modifiers: Modifiers {
+                            ctrl: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::ResizePane {
+                        direction: Direction::Down,
+                    },
+                    repeatable: true,
                 },
             ],
+            repeat_timeout_ms: 500,
         }
     }
 }
@@ -267,6 +341,10 @@ pub struct Binding {
     pub chord: KeyChord,
     /// Action dispatched when the chord matches.
     pub action: Action,
+    /// Whether the trigger key can be repeated without the prefix within
+    /// `Shortcuts::repeat_timeout_ms` of the previous trigger.
+    #[serde(default)]
+    pub repeatable: bool,
 }
 
 /// All shortcut actions supported by ozmux v0.
@@ -550,11 +628,53 @@ mod tests {
     }
 
     #[test]
+    fn binding_deserializes_repeatable_flag() {
+        let toml = r#"
+            key = "ArrowRight"
+            modifiers = { ctrl = true }
+            repeatable = true
+            action = { type = "resize-pane", direction = "right" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert!(b.repeatable);
+        assert!(matches!(
+            b.action,
+            Action::ResizePane {
+                direction: Direction::Right
+            }
+        ));
+    }
+
+    #[test]
+    fn binding_repeatable_defaults_false_when_omitted() {
+        let toml = r#"
+            key = "x"
+            action = { type = "close-pane" }
+        "#;
+        let b: Binding = toml::from_str(toml).unwrap();
+        assert!(!b.repeatable);
+    }
+
+    #[test]
+    fn shortcuts_repeat_timeout_ms_defaults_to_500_when_omitted() {
+        let toml = r#"
+            bindings = []
+
+            [prefix]
+            key = "b"
+            modifiers = { ctrl = true }
+            timeout_ms = 2000
+        "#;
+        let s: Shortcuts = toml::from_str(toml).unwrap();
+        assert_eq!(s.repeat_timeout_ms, 500);
+    }
+
+    #[test]
     fn default_shortcuts_serializes_to_stable_json() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"}},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"}},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"}},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"}},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"}},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"}},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"}},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"}},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"}},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"}},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"}},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"}}]}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"},"repeatable":false},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"},"repeatable":false},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"},"repeatable":false},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"},"repeatable":false},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"},"repeatable":false},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"},"repeatable":false},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"},"repeatable":false},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"},"repeatable":false},{"key":"ArrowLeft","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"left"},"repeatable":true},{"key":"ArrowRight","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"right"},"repeatable":true},{"key":"ArrowUp","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"up"},"repeatable":true},{"key":"ArrowDown","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"down"},"repeatable":true}],"repeat_timeout_ms":500}"#
         );
     }
 }

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -269,7 +269,7 @@ impl Default for Shortcuts {
                     chord: KeyChord {
                         key: Key::ArrowLeft,
                         modifiers: Modifiers {
-                            ctrl: true,
+                            shift: true,
                             ..Default::default()
                         },
                     },
@@ -282,7 +282,7 @@ impl Default for Shortcuts {
                     chord: KeyChord {
                         key: Key::ArrowRight,
                         modifiers: Modifiers {
-                            ctrl: true,
+                            shift: true,
                             ..Default::default()
                         },
                     },
@@ -295,7 +295,7 @@ impl Default for Shortcuts {
                     chord: KeyChord {
                         key: Key::ArrowUp,
                         modifiers: Modifiers {
-                            ctrl: true,
+                            shift: true,
                             ..Default::default()
                         },
                     },
@@ -308,7 +308,7 @@ impl Default for Shortcuts {
                     chord: KeyChord {
                         key: Key::ArrowDown,
                         modifiers: Modifiers {
-                            ctrl: true,
+                            shift: true,
                             ..Default::default()
                         },
                     },
@@ -674,7 +674,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"},"repeatable":false},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"},"repeatable":false},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"},"repeatable":false},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"},"repeatable":false},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"},"repeatable":false},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"},"repeatable":false},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"},"repeatable":false},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"},"repeatable":false},{"key":"ArrowLeft","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"left"},"repeatable":true},{"key":"ArrowRight","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"right"},"repeatable":true},{"key":"ArrowUp","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"up"},"repeatable":true},{"key":"ArrowDown","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"down"},"repeatable":true}],"repeat_timeout_ms":500}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"},"repeatable":false},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-activity"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"},"repeatable":false},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"},"repeatable":false},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"},"repeatable":false},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"},"repeatable":false},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"},"repeatable":false},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"},"repeatable":false},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"},"repeatable":false},{"key":"ArrowLeft","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"left"},"repeatable":true},{"key":"ArrowRight","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"right"},"repeatable":true},{"key":"ArrowUp","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"up"},"repeatable":true},{"key":"ArrowDown","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"down"},"repeatable":true}],"repeat_timeout_ms":500}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/LayoutView.tsx
+++ b/daemon/frontend/src/layout/LayoutView.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import { type PointerEventHandler, type ReactNode, useEffect, useRef, useState } from 'react';
+import { type PointerEventHandler, type ReactNode, useEffect, useState } from 'react';
 import { cellHeightOf, cellWidthOf } from '../terminal/renderer/font';
 import { PaneContent } from './PaneContent';
 import { type Bounds, computePaneLayout } from './paneBounds';
@@ -42,24 +42,19 @@ interface LayoutViewProps {
 }
 
 export function LayoutView({ windowState: def, layoutState: layout }: LayoutViewProps) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [metrics, setMetrics] = useState<{ cellW: number; cellH: number } | null>(null);
   const liveWid = layout.status !== 'gone' && layout.view !== null ? layout.view.id : null;
 
-  // Probe cell metrics from the live container once it mounts. Metrics depend
-  // on the CSS font, not on layout size, so we measure once. `liveWid` is in
-  // the dep list so the effect re-runs after the live container actually
-  // attaches the ref (the prior render returned a placeholder without the ref).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: liveWid is the signal that the live container has rendered
+  // NOTE: font metrics depend on CSS font, not layout size — measure once.
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el || metrics !== null) return;
-    const cellW = cellWidthOf(el);
-    const cellH = cellHeightOf(el);
+    if (!container || metrics !== null) return;
+    const cellW = cellWidthOf(container);
+    const cellH = cellHeightOf(container);
     if (cellW > 0 && cellH > 0) setMetrics({ cellW, cellH });
-  }, [metrics, liveWid]);
+  }, [container, metrics]);
 
-  useWindowDimensions(liveWid, containerRef.current, {
+  useWindowDimensions(liveWid, container, {
     cellWidth: metrics?.cellW ?? 0,
     cellHeight: metrics?.cellH ?? 0,
   });
@@ -104,7 +99,7 @@ export function LayoutView({ windowState: def, layoutState: layout }: LayoutView
   };
 
   return (
-    <div ref={containerRef} className="relative h-dvh w-dvw bg-background">
+    <div ref={setContainer} className="relative h-dvh w-dvw bg-background">
       {view.panes.map((pane) => {
         const b = bounds.get(pane.id);
         if (!b) return null;

--- a/daemon/frontend/src/layout/LayoutView.tsx
+++ b/daemon/frontend/src/layout/LayoutView.tsx
@@ -1,10 +1,12 @@
 import { clsx } from 'clsx';
-import type { PointerEventHandler, ReactNode } from 'react';
+import { type PointerEventHandler, type ReactNode, useEffect, useRef, useState } from 'react';
+import { cellHeightOf, cellWidthOf } from '../terminal/renderer/font';
 import { PaneContent } from './PaneContent';
 import { type Bounds, computePaneLayout } from './paneBounds';
 import type { PaneId } from './types';
 import { UnknownLayoutNode } from './UnknownLayoutNode';
 import type { DefaultWindowState } from './useDefaultWindow';
+import { useWindowDimensions } from './useWindowDimensions';
 import type { LayoutState } from './useWindowLayout';
 
 interface AbsoluteBoxProps {
@@ -40,6 +42,28 @@ interface LayoutViewProps {
 }
 
 export function LayoutView({ windowState: def, layoutState: layout }: LayoutViewProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [metrics, setMetrics] = useState<{ cellW: number; cellH: number } | null>(null);
+  const liveWid = layout.status !== 'gone' && layout.view !== null ? layout.view.id : null;
+
+  // Probe cell metrics from the live container once it mounts. Metrics depend
+  // on the CSS font, not on layout size, so we measure once. `liveWid` is in
+  // the dep list so the effect re-runs after the live container actually
+  // attaches the ref (the prior render returned a placeholder without the ref).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: liveWid is the signal that the live container has rendered
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || metrics !== null) return;
+    const cellW = cellWidthOf(el);
+    const cellH = cellHeightOf(el);
+    if (cellW > 0 && cellH > 0) setMetrics({ cellW, cellH });
+  }, [metrics, liveWid]);
+
+  useWindowDimensions(liveWid, containerRef.current, {
+    cellWidth: metrics?.cellW ?? 0,
+    cellHeight: metrics?.cellH ?? 0,
+  });
+
   if (def.status === 'loading') {
     return (
       <div className="flex h-dvh w-dvw items-center justify-center text-muted-foreground">
@@ -80,7 +104,7 @@ export function LayoutView({ windowState: def, layoutState: layout }: LayoutView
   };
 
   return (
-    <div className="relative h-dvh w-dvw bg-background">
+    <div ref={containerRef} className="relative h-dvh w-dvw bg-background">
       {view.panes.map((pane) => {
         const b = bounds.get(pane.id);
         if (!b) return null;

--- a/daemon/frontend/src/layout/resizePane.test.ts
+++ b/daemon/frontend/src/layout/resizePane.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resizePane } from './resizePane';
+import type { PaneId, WindowId } from './types';
+
+describe('resizePane', () => {
+  const wid = 'w1' as WindowId;
+  const pid = 'p1' as PaneId;
+
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    'left',
+    'right',
+    'up',
+    'down',
+  ] as const)('POSTs %s direction with default amount=1', async (direction) => {
+    await resizePane(wid, pid, direction);
+    expect(global.fetch).toHaveBeenCalledWith(`/windows/${wid}/panes/${pid}/resize`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction, amount: 1 }),
+    });
+  });
+
+  it('forwards an explicit amount when provided', async () => {
+    await resizePane(wid, pid, 'right', 5);
+    expect(global.fetch).toHaveBeenCalledWith(`/windows/${wid}/panes/${pid}/resize`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction: 'right', amount: 5 }),
+    });
+  });
+
+  it('logs at debug and returns without throwing on 409', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('clamped at edge', { status: 409 }),
+    );
+    await expect(resizePane(wid, pid, 'left')).resolves.toBeUndefined();
+    expect(console.debug).toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('console.warns on other non-2xx responses', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(null, { status: 500 }),
+    );
+    await resizePane(wid, pid, 'left');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('console.warns when fetch rejects', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('net down'));
+    await resizePane(wid, pid, 'up');
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/daemon/frontend/src/layout/resizePane.ts
+++ b/daemon/frontend/src/layout/resizePane.ts
@@ -1,0 +1,35 @@
+import { resizePaneEndpoint } from '../terminal/api';
+import type { PaneId, WindowId } from './types';
+
+export type ResizeDirection = 'left' | 'right' | 'up' | 'down';
+
+export async function resizePane(
+  windowId: WindowId,
+  paneId: PaneId,
+  direction: ResizeDirection,
+  amount = 1,
+): Promise<void> {
+  try {
+    const resp = await fetch(resizePaneEndpoint(windowId, paneId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ direction, amount }),
+    });
+    if (resp.status === 409) {
+      // Backend clamped the resize at a layout edge; this is expected.
+      console.debug('resizePane: 409', await resp.text());
+      return;
+    }
+    if (!resp.ok) {
+      console.warn('resize pane failed', {
+        windowId,
+        paneId,
+        direction,
+        amount,
+        status: resp.status,
+      });
+    }
+  } catch (e) {
+    console.warn('resize pane request errored', { windowId, paneId, direction, amount, error: e });
+  }
+}

--- a/daemon/frontend/src/layout/resizePane.ts
+++ b/daemon/frontend/src/layout/resizePane.ts
@@ -16,7 +16,7 @@ export async function resizePane(
       body: JSON.stringify({ direction, amount }),
     });
     if (resp.status === 409) {
-      // Backend clamped the resize at a layout edge; this is expected.
+      // NOTE: 409 = WINDOW_NOT_MEASURED (page-load race) or PANE_NOT_IN_WINDOW (stale active pane). Drop quietly — user retries on next keypress.
       console.debug('resizePane: 409', await resp.text());
       return;
     }

--- a/daemon/frontend/src/layout/resizeWindow.test.ts
+++ b/daemon/frontend/src/layout/resizeWindow.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resizeWindow } from './resizeWindow';
+import type { WindowId } from './types';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('resizeWindow', () => {
+  it('PATCHes cols and rows', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await resizeWindow('w1' as WindowId, 120, 40);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/windows/w1/dimensions');
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(init?.body as string)).toEqual({ cols: 120, rows: 40 });
+  });
+});

--- a/daemon/frontend/src/layout/resizeWindow.ts
+++ b/daemon/frontend/src/layout/resizeWindow.ts
@@ -1,0 +1,19 @@
+import { windowDimensionsEndpoint } from '../terminal/api';
+import type { WindowId } from './types';
+
+/** PATCHes the daemon with new cell dimensions for the window. Failures are
+ *  logged via `console.warn` and swallowed; callers do not await success. */
+export async function resizeWindow(windowId: WindowId, cols: number, rows: number): Promise<void> {
+  try {
+    const resp = await fetch(windowDimensionsEndpoint(windowId), {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cols, rows }),
+    });
+    if (!resp.ok) {
+      console.warn('resizeWindow failed', { windowId, cols, rows, status: resp.status });
+    }
+  } catch (e) {
+    console.warn('resizeWindow request errored', { windowId, cols, rows, error: e });
+  }
+}

--- a/daemon/frontend/src/layout/useWindowDimensions.test.ts
+++ b/daemon/frontend/src/layout/useWindowDimensions.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WindowId } from './types';
+import { useWindowDimensions } from './useWindowDimensions';
+
+class FakeResizeObserver {
+  static cb: ResizeObserverCallback | null = null;
+  constructor(cb: ResizeObserverCallback) {
+    FakeResizeObserver.cb = cb;
+  }
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useWindowDimensions', () => {
+  it('PATCHes once on mount without debouncing', () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver as unknown as typeof ResizeObserver);
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'clientWidth', { value: 1200 });
+    Object.defineProperty(el, 'clientHeight', { value: 400 });
+    renderHook(() => useWindowDimensions('w1' as WindowId, el, { cellWidth: 10, cellHeight: 20 }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual({ cols: 120, rows: 20 });
+  });
+});

--- a/daemon/frontend/src/layout/useWindowDimensions.ts
+++ b/daemon/frontend/src/layout/useWindowDimensions.ts
@@ -4,9 +4,9 @@ import type { WindowId } from './types';
 
 /** Options for `useWindowDimensions`. */
 export interface UseWindowDimensionsOptions {
-  /** Cell width in pixels (from the font-metrics probe). */
+  /** From the font-metrics probe. */
   cellWidth: number;
-  /** Cell height in pixels (from the font-metrics probe). */
+  /** From the font-metrics probe. */
   cellHeight: number;
   /** Debounce window for non-initial measurements (default 50ms). */
   debounceMs?: number;

--- a/daemon/frontend/src/layout/useWindowDimensions.ts
+++ b/daemon/frontend/src/layout/useWindowDimensions.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import { resizeWindow } from './resizeWindow';
+import type { WindowId } from './types';
+
+/** Options for `useWindowDimensions`. */
+export interface UseWindowDimensionsOptions {
+  /** Cell width in pixels (from the font-metrics probe). */
+  cellWidth: number;
+  /** Cell height in pixels (from the font-metrics probe). */
+  cellHeight: number;
+  /** Debounce window for non-initial measurements (default 50ms). */
+  debounceMs?: number;
+}
+
+/**
+ * Observes `container`'s size and PATCHes the server with cell dimensions.
+ * The first measurement is sent immediately (no debounce); subsequent ones
+ * are debounced by `debounceMs` (default 50ms). Repeated measurements that
+ * resolve to the same (cols, rows) are skipped.
+ */
+export function useWindowDimensions(
+  windowId: WindowId | null,
+  container: HTMLElement | null,
+  opts: UseWindowDimensionsOptions,
+): void {
+  const sentInitial = useRef(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const last = useRef<{ cols: number; rows: number } | null>(null);
+
+  useEffect(() => {
+    if (!windowId) return;
+    if (!container) return;
+    if (opts.cellWidth <= 0 || opts.cellHeight <= 0) return;
+    const measure = () => {
+      const cols = Math.max(1, Math.floor(container.clientWidth / opts.cellWidth));
+      const rows = Math.max(1, Math.floor(container.clientHeight / opts.cellHeight));
+      if (last.current?.cols === cols && last.current?.rows === rows) return;
+      last.current = { cols, rows };
+
+      if (!sentInitial.current) {
+        sentInitial.current = true;
+        void resizeWindow(windowId, cols, rows);
+        return;
+      }
+      if (timer.current !== null) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        void resizeWindow(windowId, cols, rows);
+        timer.current = null;
+      }, opts.debounceMs ?? 50);
+    };
+    const ro = new ResizeObserver(measure);
+    ro.observe(container);
+    measure();
+    return () => {
+      ro.disconnect();
+      if (timer.current !== null) {
+        clearTimeout(timer.current);
+        timer.current = null;
+      }
+    };
+  }, [windowId, container, opts.cellWidth, opts.cellHeight, opts.debounceMs]);
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -272,4 +272,44 @@ describe('actionToHandler', () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    'left',
+    'right',
+    'up',
+    'down',
+  ] as const)('returns a handler that POSTs resize with %s direction', async (direction) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 } as Response);
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext({
+      activeWindow: () => 'wid-1',
+      activePane: () => 'pid-1',
+    });
+    const handler = actionToHandler({ type: 'resize-pane', direction }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/windows/wid-1/panes/pid-1/resize');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ direction, amount: 1 });
+  });
+
+  it('returns a no-op resize handler when context lacks an active pane', async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    const ctx = makeShortcutContext();
+    const handler = actionToHandler({ type: 'resize-pane', direction: 'right' }, ctx);
+    if (handler === null) {
+      throw new Error('handler should not be null');
+    }
+    handler();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -4,6 +4,7 @@ import { closePane } from '../layout/closePane';
 import { cycleActivity } from '../layout/cycleActivity';
 import { focusPane } from '../layout/focusPane';
 import { newTerminalActivity } from '../layout/newTerminalActivity';
+import { resizePane } from '../layout/resizePane';
 import { splitPane } from '../layout/splitPane';
 import type { ActivityId, PaneId, WindowId } from '../layout/types';
 import type { Action } from './wire';
@@ -43,6 +44,10 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
     case 'focus-pane': {
       const direction = action.direction;
       return () => withActiveWindow(ctx, (w) => focusPane(w, direction));
+    }
+    case 'resize-pane': {
+      const direction = action.direction;
+      return () => withActivePane(ctx, (w, p) => resizePane(w, p, direction));
     }
     default:
       console.warn('actionToHandler: unsupported action', action);

--- a/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
@@ -267,3 +267,115 @@ describe('usePrefixMode', () => {
     expect(result.current.isArmed).toBe(false);
   });
 });
+
+const REPEAT_PAYLOAD = {
+  prefix: {
+    key: 'b',
+    modifiers: { ctrl: true, shift: false, alt: false, meta: false },
+    timeout_ms: 2000,
+  },
+  bindings: [
+    {
+      key: 'x',
+      modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      action: { type: 'close-pane' },
+      repeatable: false,
+    },
+    {
+      key: 'ArrowRight',
+      modifiers: { ctrl: true, shift: false, alt: false, meta: false },
+      action: { type: 'resize-pane', direction: 'right' },
+      repeatable: true,
+    },
+  ],
+  repeat_timeout_ms: 500,
+};
+
+describe('usePrefixMode repeat sub-mode', () => {
+  let resizeFetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    // Override the configFetchMock so the test uses REPEAT_PAYLOAD.
+    configFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => REPEAT_PAYLOAD,
+    } as Response);
+    resizeFetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 204,
+    } as Response);
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = ((url: RequestInfo | URL, init?: RequestInit) => {
+      const path = typeof url === 'string' ? url : url.toString();
+      if (path.endsWith('/resize')) return resizeFetchMock(url, init);
+      return previousFetch(url, init);
+    }) as typeof globalThis.fetch;
+  });
+
+  it('fires a repeatable binding and stays listening within repeat_timeout_ms', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+    });
+    expect(result.current.isArmed).toBe(true);
+
+    act(() => {
+      press({ key: 'ArrowRight', ctrlKey: true });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+
+    // Second press WITHOUT re-arming, within the 500ms repeat window.
+    act(() => {
+      press({ key: 'ArrowRight', ctrlKey: true, repeat: true });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('exits repeat mode when a non-repeatable chord arrives', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+      press({ key: 'ArrowRight', ctrlKey: true });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+
+    // 'x' is not repeatable; pressing it must NOT fire close-pane via
+    // repeat mode (we are no longer armed; the press should leak to
+    // the terminal). The close fetch mock is the default fetch, so
+    // we just assert resizeFetchMock did not increment.
+    act(() => {
+      press({ key: 'x' });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('disarms after repeat_timeout_ms with no further keypresses', async () => {
+    const { result } = renderHook(() => usePrefixMode(makeCtx()));
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    act(() => {
+      press({ key: 'b', ctrlKey: true });
+      press({ key: 'ArrowRight', ctrlKey: true });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+
+    // Advance fake timers past 500ms.
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // A second repeatable press now requires re-arming via prefix.
+    act(() => {
+      press({ key: 'ArrowRight', ctrlKey: true });
+    });
+    await Promise.resolve();
+    expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.test.ts
@@ -335,9 +335,11 @@ describe('usePrefixMode repeat sub-mode', () => {
     expect(resizeFetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('exits repeat mode when a non-repeatable chord arrives', async () => {
+  it('exits repeat mode when a non-repeatable chord arrives and forwards it to the terminal', async () => {
     const { result } = renderHook(() => usePrefixMode(makeCtx()));
     await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    // Enter repeat mode via prefix + repeatable chord.
     act(() => {
       press({ key: 'b', ctrlKey: true });
       press({ key: 'ArrowRight', ctrlKey: true });
@@ -345,15 +347,20 @@ describe('usePrefixMode repeat sub-mode', () => {
     await Promise.resolve();
     expect(resizeFetchMock).toHaveBeenCalledTimes(1);
 
-    // 'x' is not repeatable; pressing it must NOT fire close-pane via
-    // repeat mode (we are no longer armed; the press should leak to
-    // the terminal). The close fetch mock is the default fetch, so
-    // we just assert resizeFetchMock did not increment.
+    // Press 'x' (close-pane, NOT repeatable). It must NOT increment
+    // the repeatable handler AND must NOT be consumed (defaultPrevented
+    // stays false so the terminal receives it).
+    const xEvent = new KeyboardEvent('keydown', {
+      key: 'x',
+      bubbles: true,
+      cancelable: true,
+    });
     act(() => {
-      press({ key: 'x' });
+      document.dispatchEvent(xEvent);
     });
     await Promise.resolve();
     expect(resizeFetchMock).toHaveBeenCalledTimes(1);
+    expect(xEvent.defaultPrevented).toBe(false);
   });
 
   it('disarms after repeat_timeout_ms with no further keypresses', async () => {

--- a/daemon/frontend/src/shortcuts/usePrefixMode.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.ts
@@ -28,6 +28,7 @@ export interface PrefixModeState {
 interface ChordBinding {
   chord: KeyChord;
   handler: () => void;
+  repeatable: boolean;
 }
 
 const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta']);
@@ -35,9 +36,12 @@ const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta']);
 interface SharedState {
   bindings: ReadonlyArray<ChordBinding>;
   prefix: Prefix;
+  repeatTimeoutMs: number;
   armed: boolean;
+  repeatMode: boolean;
   setArmed: (next: boolean) => void;
-  timer: ReturnType<typeof setTimeout> | null;
+  prefixTimer: ReturnType<typeof setTimeout> | null;
+  repeatTimer: ReturnType<typeof setTimeout> | null;
 }
 
 let shared: SharedState | null = null;
@@ -50,7 +54,8 @@ function ensureDispatcher() {
     if (!shared) return;
     if (e.isComposing) return;
 
-    if (!shared.armed) {
+    // Branch 1: not armed AND not in repeat mode.
+    if (!shared.armed && !shared.repeatMode) {
       if (e.repeat) return;
       if (!matchesChord(e, shared.prefix)) return;
       e.preventDefault();
@@ -59,7 +64,35 @@ function ensureDispatcher() {
       return;
     }
 
-    // Armed mode consumes every event so it cannot leak to xterm.js or iframes.
+    // Branch 2: in repeat sub-mode — no prefix needed for repeatable
+    // bindings; e.repeat is accepted.
+    if (shared.repeatMode) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (MODIFIER_KEYS.has(e.key)) return;
+      const match = shared.bindings.find((b) => matchesChord(e, b.chord));
+      if (match?.repeatable) {
+        match.handler();
+        if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
+        shared.repeatTimer = setTimeout(() => {
+          if (shared) {
+            shared.repeatMode = false;
+            shared.repeatTimer = null;
+          }
+        }, shared.repeatTimeoutMs);
+        return;
+      }
+      // Non-repeatable chord exits repeat mode without consuming further.
+      shared.repeatMode = false;
+      if (shared.repeatTimer !== null) {
+        clearTimeout(shared.repeatTimer);
+        shared.repeatTimer = null;
+      }
+      return;
+    }
+
+    // Branch 3: armed mode (prefix has just been pressed). Consume every
+    // event so it cannot leak to xterm.js or iframes.
     e.preventDefault();
     e.stopPropagation();
 
@@ -71,7 +104,23 @@ function ensureDispatcher() {
     }
 
     const match = shared.bindings.find((b) => matchesChord(e, b.chord));
-    if (match) match.handler();
+    if (match) {
+      match.handler();
+      if (match.repeatable) {
+        // Transition from armed → repeat: disarm visibly but stay
+        // listening for further repeatable chords.
+        shared.setArmed(false);
+        shared.repeatMode = true;
+        if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
+        shared.repeatTimer = setTimeout(() => {
+          if (shared) {
+            shared.repeatMode = false;
+            shared.repeatTimer = null;
+          }
+        }, shared.repeatTimeoutMs);
+        return;
+      }
+    }
     shared.setArmed(false);
   };
   dispatcher = createKeyDispatcher(handler);
@@ -124,22 +173,22 @@ export function usePrefixMode(ctx: ShortcutContext): PrefixModeState {
       const bindings: ChordBinding[] = [];
       for (const b of parsed.bindings) {
         const handler = actionToHandler(b.action, ctx);
-        if (handler) bindings.push({ chord: b.chord, handler });
+        if (handler) bindings.push({ chord: b.chord, handler, repeatable: b.repeatable });
       }
 
       const setArmed = (next: boolean) => {
         if (!shared) return;
-        if (shared.timer !== null) {
-          clearTimeout(shared.timer);
-          shared.timer = null;
+        if (shared.prefixTimer !== null) {
+          clearTimeout(shared.prefixTimer);
+          shared.prefixTimer = null;
         }
         shared.armed = next;
         setIsArmed(next);
         if (next) {
-          shared.timer = setTimeout(() => {
+          shared.prefixTimer = setTimeout(() => {
             if (shared) {
               shared.armed = false;
-              shared.timer = null;
+              shared.prefixTimer = null;
             }
             setIsArmed(false);
           }, parsed.prefix.timeout_ms);
@@ -149,9 +198,12 @@ export function usePrefixMode(ctx: ShortcutContext): PrefixModeState {
       shared = {
         bindings,
         prefix: parsed.prefix,
+        repeatTimeoutMs: parsed.repeat_timeout_ms,
         armed: false,
+        repeatMode: false,
         setArmed,
-        timer: null,
+        prefixTimer: null,
+        repeatTimer: null,
       };
       ensureDispatcher().attachTo(document);
       setIfAlive({ status: 'ready', prefix: parsed.prefix });
@@ -159,8 +211,9 @@ export function usePrefixMode(ctx: ShortcutContext): PrefixModeState {
 
     return () => {
       cancelled = true;
-      if (shared && shared.timer !== null) {
-        clearTimeout(shared.timer);
+      if (shared) {
+        if (shared.prefixTimer !== null) clearTimeout(shared.prefixTimer);
+        if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
       }
       if (dispatcher) dispatcher.detachFrom(document);
       shared = null;
@@ -175,6 +228,10 @@ if (import.meta.hot) {
   // detach the old listener so we don't accumulate duplicate keydown handlers.
   import.meta.hot.dispose(() => {
     moduleDisposed = true;
+    if (shared) {
+      if (shared.prefixTimer !== null) clearTimeout(shared.prefixTimer);
+      if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
+    }
     if (dispatcher) dispatcher.detachFrom(document);
     shared = null;
     dispatcher = null;

--- a/daemon/frontend/src/shortcuts/usePrefixMode.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.ts
@@ -67,11 +67,12 @@ function ensureDispatcher() {
     // Branch 2: in repeat sub-mode — no prefix needed for repeatable
     // bindings; e.repeat is accepted.
     if (shared.repeatMode) {
-      e.preventDefault();
-      e.stopPropagation();
+      // Modifier-only keypress is ignored; don't consume.
       if (MODIFIER_KEYS.has(e.key)) return;
       const match = shared.bindings.find((b) => matchesChord(e, b.chord));
       if (match?.repeatable) {
+        e.preventDefault();
+        e.stopPropagation();
         match.handler();
         if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
         shared.repeatTimer = setTimeout(() => {
@@ -82,7 +83,8 @@ function ensureDispatcher() {
         }, shared.repeatTimeoutMs);
         return;
       }
-      // Non-repeatable chord exits repeat mode without consuming further.
+      // Non-repeatable / no-match chord exits repeat mode and is NOT
+      // consumed — falls through to the terminal as a normal key.
       shared.repeatMode = false;
       if (shared.repeatTimer !== null) {
         clearTimeout(shared.repeatTimer);

--- a/daemon/frontend/src/shortcuts/usePrefixMode.ts
+++ b/daemon/frontend/src/shortcuts/usePrefixMode.ts
@@ -48,13 +48,22 @@ let shared: SharedState | null = null;
 let dispatcher: KeyDispatcher | null = null;
 let moduleDisposed = false;
 
+function armRepeatTimer(state: SharedState) {
+  if (state.repeatTimer !== null) clearTimeout(state.repeatTimer);
+  state.repeatTimer = setTimeout(() => {
+    if (shared) {
+      shared.repeatMode = false;
+      shared.repeatTimer = null;
+    }
+  }, state.repeatTimeoutMs);
+}
+
 function ensureDispatcher() {
   if (dispatcher) return dispatcher;
   const handler = (e: KeyboardEvent) => {
     if (!shared) return;
     if (e.isComposing) return;
 
-    // Branch 1: not armed AND not in repeat mode.
     if (!shared.armed && !shared.repeatMode) {
       if (e.repeat) return;
       if (!matchesChord(e, shared.prefix)) return;
@@ -64,27 +73,17 @@ function ensureDispatcher() {
       return;
     }
 
-    // Branch 2: in repeat sub-mode — no prefix needed for repeatable
-    // bindings; e.repeat is accepted.
     if (shared.repeatMode) {
-      // Modifier-only keypress is ignored; don't consume.
       if (MODIFIER_KEYS.has(e.key)) return;
       const match = shared.bindings.find((b) => matchesChord(e, b.chord));
       if (match?.repeatable) {
         e.preventDefault();
         e.stopPropagation();
         match.handler();
-        if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
-        shared.repeatTimer = setTimeout(() => {
-          if (shared) {
-            shared.repeatMode = false;
-            shared.repeatTimer = null;
-          }
-        }, shared.repeatTimeoutMs);
+        armRepeatTimer(shared);
         return;
       }
-      // Non-repeatable / no-match chord exits repeat mode and is NOT
-      // consumed — falls through to the terminal as a normal key.
+      // NOTE: no preventDefault here — the chord must reach the terminal.
       shared.repeatMode = false;
       if (shared.repeatTimer !== null) {
         clearTimeout(shared.repeatTimer);
@@ -93,8 +92,7 @@ function ensureDispatcher() {
       return;
     }
 
-    // Branch 3: armed mode (prefix has just been pressed). Consume every
-    // event so it cannot leak to xterm.js or iframes.
+    // NOTE: in armed mode consume every event so it cannot leak to xterm.js or iframes.
     e.preventDefault();
     e.stopPropagation();
 
@@ -109,17 +107,9 @@ function ensureDispatcher() {
     if (match) {
       match.handler();
       if (match.repeatable) {
-        // Transition from armed → repeat: disarm visibly but stay
-        // listening for further repeatable chords.
         shared.setArmed(false);
         shared.repeatMode = true;
-        if (shared.repeatTimer !== null) clearTimeout(shared.repeatTimer);
-        shared.repeatTimer = setTimeout(() => {
-          if (shared) {
-            shared.repeatMode = false;
-            shared.repeatTimer = null;
-          }
-        }, shared.repeatTimeoutMs);
+        armRepeatTimer(shared);
         return;
       }
     }
@@ -226,8 +216,7 @@ export function usePrefixMode(ctx: ShortcutContext): PrefixModeState {
 }
 
 if (import.meta.hot) {
-  // Vite HMR replaces this module without re-running consumers' effects;
-  // detach the old listener so we don't accumulate duplicate keydown handlers.
+  // NOTE: detach the old listener on HMR dispose so we don't accumulate duplicate keydown handlers.
   import.meta.hot.dispose(() => {
     moduleDisposed = true;
     if (shared) {

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -12,8 +12,10 @@ const DEFAULT_JSON = {
       key: 'x',
       modifiers: { ctrl: false, shift: false, alt: false, meta: false },
       action: { type: 'close-pane' },
+      repeatable: false,
     },
   ],
+  repeat_timeout_ms: 500,
 };
 
 beforeEach(() => {
@@ -38,7 +40,67 @@ describe('parseShortcuts', () => {
         modifiers: { ctrl: false, shift: false, alt: false, meta: false },
       },
       action: { type: 'close-pane' },
+      repeatable: false,
     });
+    expect(out?.repeat_timeout_ms).toBe(500);
+  });
+
+  it.each([
+    'left',
+    'right',
+    'up',
+    'down',
+  ] as const)('parses a resize-pane binding with %s direction and repeatable=true', (direction) => {
+    const payload = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key:
+            direction === 'left'
+              ? 'ArrowLeft'
+              : direction === 'right'
+                ? 'ArrowRight'
+                : direction === 'up'
+                  ? 'ArrowUp'
+                  : 'ArrowDown',
+          modifiers: { ctrl: true, shift: false, alt: false, meta: false },
+          action: { type: 'resize-pane', direction },
+          repeatable: true,
+        },
+      ],
+    };
+    const out = parseShortcuts(payload);
+    expect(out).not.toBeNull();
+    expect(out?.bindings).toHaveLength(2);
+    expect(out?.bindings[1].action.type).toBe('resize-pane');
+    if (out?.bindings[1].action.type === 'resize-pane') {
+      expect(out.bindings[1].action.direction).toBe(direction);
+    }
+    expect(out?.bindings[1].repeatable).toBe(true);
+  });
+
+  it('defaults repeatable to false when the field is missing', () => {
+    const payload = {
+      ...DEFAULT_JSON,
+      bindings: [
+        {
+          key: 'x',
+          modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+          action: { type: 'close-pane' },
+        },
+      ],
+    };
+    const out = parseShortcuts(payload);
+    expect(out?.bindings).toHaveLength(1);
+    expect(out?.bindings[0].repeatable).toBe(false);
+  });
+
+  it('defaults repeat_timeout_ms to 500 when the field is missing', () => {
+    const { repeat_timeout_ms: _omit, ...without } = DEFAULT_JSON;
+    const out = parseShortcuts(without);
+    expect(out).not.toBeNull();
+    expect(out?.repeat_timeout_ms).toBe(500);
   });
 
   it('returns null when prefix is missing or malformed', () => {

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -48,6 +48,10 @@ const ActionSchema = z.discriminatedUnion('type', [
     type: z.literal('focus-pane'),
     direction: z.enum(['up', 'down', 'left', 'right']),
   }),
+  z.object({
+    type: z.literal('resize-pane'),
+    direction: z.enum(['up', 'down', 'left', 'right']),
+  }),
 ]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({
@@ -56,11 +60,13 @@ const PrefixSchema = KeyChordFieldsSchema.extend({
 
 const BindingSchema = KeyChordFieldsSchema.extend({
   action: ActionSchema,
+  repeatable: z.boolean().default(false),
 });
 
 const ShortcutsRawSchema = z.object({
   prefix: PrefixSchema,
   bindings: z.array(z.unknown()),
+  repeat_timeout_ms: z.number().int().nonnegative().default(500),
 });
 
 export type KeyChord = z.infer<typeof KeyChordFieldsSchema>;
@@ -69,10 +75,12 @@ export type Prefix = z.infer<typeof PrefixSchema>;
 export interface Binding {
   chord: KeyChord;
   action: Action;
+  repeatable: boolean;
 }
 export interface Shortcuts {
   prefix: Prefix;
   bindings: Binding[];
+  repeat_timeout_ms: number;
 }
 
 /**
@@ -96,8 +104,12 @@ export function parseShortcuts(raw: unknown): Shortcuts | null {
       console.warn('parseShortcuts: dropping binding', { entry, issues: parsed.error.issues });
       continue;
     }
-    const { key, modifiers, action } = parsed.data;
-    bindings.push({ chord: { key, modifiers }, action });
+    const { key, modifiers, action, repeatable } = parsed.data;
+    bindings.push({ chord: { key, modifiers }, action, repeatable });
   }
-  return { prefix: top.data.prefix, bindings };
+  return {
+    prefix: top.data.prefix,
+    bindings,
+    repeat_timeout_ms: top.data.repeat_timeout_ms,
+  };
 }

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -18,6 +18,8 @@ export const breakActivityToPaneEndpoint = (wid: string, pid: string, aid: strin
 export const cycleActivityEndpoint = (wid: string, pid: string) =>
   `/windows/${wid}/panes/${pid}/cycle-activity`;
 export const focusPaneEndpoint = (wid: string) => `/windows/${wid}/focus-pane`;
+export const resizePaneEndpoint = (wid: string, pid: string) =>
+  `/windows/${wid}/panes/${pid}/resize`;
 
 export const vtTerminalWsUrl = (
   windowId: string,

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -20,6 +20,7 @@ export const cycleActivityEndpoint = (wid: string, pid: string) =>
 export const focusPaneEndpoint = (wid: string) => `/windows/${wid}/focus-pane`;
 export const resizePaneEndpoint = (wid: string, pid: string) =>
   `/windows/${wid}/panes/${pid}/resize`;
+export const windowDimensionsEndpoint = (wid: string) => `/windows/${wid}/dimensions`;
 
 export const vtTerminalWsUrl = (
   windowId: string,

--- a/daemon/http_server/src/error.rs
+++ b/daemon/http_server/src/error.rs
@@ -41,6 +41,9 @@ pub enum HttpError {
 
     #[error("service unavailable: {0}")]
     ServiceUnavailable(String),
+
+    #[error("invalid dimensions: {field} must be >= 1")]
+    InvalidDimensions { field: &'static str },
 }
 
 pub type HttpResult<T = ()> = Result<T, HttpError>;
@@ -97,6 +100,9 @@ impl axum::response::IntoResponse for HttpError {
             HttpError::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND"),
             HttpError::ServiceUnavailable(_) => {
                 (StatusCode::SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE")
+            }
+            HttpError::InvalidDimensions { .. } => {
+                (StatusCode::UNPROCESSABLE_ENTITY, "INVALID_DIMENSIONS")
             }
             HttpError::Session(MultiplexerError::ActivityNotFound(_))
             | HttpError::Session(MultiplexerError::ActivityNotInPane { .. }) => {
@@ -282,5 +288,12 @@ mod tests {
         let err = HttpError::Session(MultiplexerError::WindowNotMeasured(WindowId::new()));
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn invalid_dimensions_maps_to_422_invalid_dimensions() {
+        let err = HttpError::InvalidDimensions { field: "cols" };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 }

--- a/daemon/http_server/src/error.rs
+++ b/daemon/http_server/src/error.rs
@@ -63,6 +63,9 @@ impl axum::response::IntoResponse for HttpError {
             HttpError::Session(MultiplexerError::PaneNotInWindow { .. }) => {
                 (StatusCode::CONFLICT, "PANE_NOT_IN_WINDOW")
             }
+            HttpError::Session(MultiplexerError::WindowNotMeasured(_)) => {
+                (StatusCode::CONFLICT, "WINDOW_NOT_MEASURED")
+            }
             HttpError::Session(MultiplexerError::CellNotFound(_)) => {
                 (StatusCode::NOT_FOUND, "CELL_NOT_FOUND")
             }
@@ -270,6 +273,13 @@ mod tests {
     #[test]
     fn cannot_remove_last_activity_maps_to_409() {
         let err = HttpError::Session(MultiplexerError::CannotRemoveLastActivity(PaneId::new()));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn window_not_measured_maps_to_409_window_not_measured() {
+        let err = HttpError::Session(MultiplexerError::WindowNotMeasured(WindowId::new()));
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
     }

--- a/daemon/http_server/src/error.rs
+++ b/daemon/http_server/src/error.rs
@@ -44,6 +44,9 @@ pub enum HttpError {
 
     #[error("invalid dimensions: {field} must be >= 1")]
     InvalidDimensions { field: &'static str },
+
+    #[error("invalid amount: must be >= 1")]
+    InvalidAmount,
 }
 
 pub type HttpResult<T = ()> = Result<T, HttpError>;
@@ -104,6 +107,7 @@ impl axum::response::IntoResponse for HttpError {
             HttpError::InvalidDimensions { .. } => {
                 (StatusCode::UNPROCESSABLE_ENTITY, "INVALID_DIMENSIONS")
             }
+            HttpError::InvalidAmount => (StatusCode::UNPROCESSABLE_ENTITY, "INVALID_AMOUNT"),
             HttpError::Session(MultiplexerError::ActivityNotFound(_))
             | HttpError::Session(MultiplexerError::ActivityNotInPane { .. }) => {
                 (StatusCode::NOT_FOUND, "ACTIVITY_NOT_FOUND")
@@ -293,6 +297,13 @@ mod tests {
     #[test]
     fn invalid_dimensions_maps_to_422_invalid_dimensions() {
         let err = HttpError::InvalidDimensions { field: "cols" };
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
+    fn invalid_amount_maps_to_422() {
+        let err = HttpError::InvalidAmount;
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }

--- a/daemon/http_server/src/handlers/windows.rs
+++ b/daemon/http_server/src/handlers/windows.rs
@@ -9,6 +9,7 @@ use ozmux_terminal::TerminalService;
 
 pub mod create;
 pub mod delete;
+pub mod dimensions;
 pub mod events;
 pub mod focus_pane;
 pub mod panes;

--- a/daemon/http_server/src/handlers/windows/dimensions.rs
+++ b/daemon/http_server/src/handlers/windows/dimensions.rs
@@ -1,0 +1,159 @@
+//! `PATCH /windows/{wid}/dimensions` — record the client's measured
+//! cell-grid dimensions for the window. Required input for the
+//! resize-pane algorithm.
+
+use crate::{
+    AppState,
+    error::{HttpError, HttpResult},
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_multiplexer::WindowId;
+use serde::Deserialize;
+
+/// Body for `PATCH /windows/{wid}/dimensions`. Both fields are required
+/// and must be `>= 1`; zero is rejected with `INVALID_DIMENSIONS`.
+#[derive(Deserialize)]
+pub struct DimensionsRequest {
+    cols: u16,
+    rows: u16,
+}
+
+/// Validate the request body and forward to
+/// [`AppState::set_window_dimensions`]. Returns `204 No Content` on
+/// success, `422 INVALID_DIMENSIONS` for zero cols/rows, and `404
+/// WINDOW_NOT_FOUND` when `wid` does not exist.
+pub async fn patch_dimensions(
+    State(state): State<AppState>,
+    Path(window_id): Path<WindowId>,
+    Json(body): Json<DimensionsRequest>,
+) -> HttpResult<StatusCode> {
+    if body.cols == 0 {
+        return Err(HttpError::InvalidDimensions { field: "cols" });
+    }
+    if body.rows == 0 {
+        return Err(HttpError::InvalidDimensions { field: "rows" });
+    }
+    state
+        .set_window_dimensions(&window_id, body.cols, body.rows)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{MultiplexerError, WindowDimensions, WindowId};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn patch_dimensions_returns_204_and_stores_value() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, state2) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/windows/{}/dimensions", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"cols":120,"rows":40}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let dims = state2
+            .multiplexer
+            .with_window_or_404(&wid, |w| Ok::<_, MultiplexerError>(w.dimensions.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            dims,
+            Some(WindowDimensions {
+                cols: 120,
+                rows: 40
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_dimensions_unknown_window_returns_404() {
+        let state = fresh_state();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/windows/{}/dimensions", WindowId::new()))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"cols":80,"rows":24}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn patch_dimensions_zero_cols_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/windows/{}/dimensions", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"cols":0,"rows":24}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn patch_dimensions_zero_rows_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/windows/{}/dimensions", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"cols":80,"rows":0}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn patch_dimensions_malformed_json_returns_400() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/windows/{}/dimensions", wid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"cols":"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/daemon/http_server/src/handlers/windows/panes.rs
+++ b/daemon/http_server/src/handlers/windows/panes.rs
@@ -9,6 +9,7 @@ pub mod activate;
 pub mod activities;
 pub mod close;
 pub mod cycle_activity;
+pub mod resize;
 pub mod spawn_terminal;
 pub mod split;
 
@@ -20,6 +21,7 @@ pub fn router() -> Router<AppState> {
             post(cycle_activity::cycle_activity),
         )
         .route("/{pane_id}/split", post(split::split))
+        .route("/{pane_id}/resize", post(resize::resize))
         .route("/{pane_id}", method_delete(close::close))
         .nest("/{pane_id}/activities", activities::router())
 }

--- a/daemon/http_server/src/handlers/windows/panes/resize.rs
+++ b/daemon/http_server/src/handlers/windows/panes/resize.rs
@@ -1,0 +1,253 @@
+//! `POST /windows/{wid}/panes/{pid}/resize` — direction-only resize.
+
+use crate::{
+    AppState,
+    error::{HttpError, HttpResult},
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_multiplexer::{PaneDirection, PaneId, WindowId};
+use serde::Deserialize;
+
+fn default_amount() -> u16 {
+    1
+}
+
+/// Request body for `POST /windows/{wid}/panes/{pid}/resize`.
+#[derive(Deserialize)]
+pub struct ResizeRequest {
+    direction: PaneDirection,
+    #[serde(default = "default_amount")]
+    amount: u16,
+}
+
+/// Handler for `POST /windows/{wid}/panes/{pid}/resize`. Rejects
+/// `amount == 0` with 422 and otherwise delegates to
+/// [`AppState::resize_pane`], which decides whether to broadcast.
+pub async fn resize(
+    State(state): State<AppState>,
+    Path((wid, pid)): Path<(WindowId, PaneId)>,
+    Json(body): Json<ResizeRequest>,
+) -> HttpResult<StatusCode> {
+    if body.amount == 0 {
+        return Err(HttpError::InvalidAmount);
+    }
+    state
+        .resize_pane(&wid, &pid, body.direction, body.amount)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{Activity, ActivityId, PaneId, Side, SplitOrientation, WindowId};
+    use tower::ServiceExt;
+
+    async fn split_via_window(
+        state: &crate::AppState,
+        wid: &WindowId,
+        target: &PaneId,
+        orient: SplitOrientation,
+    ) -> PaneId {
+        let new_pane_id = PaneId::new();
+        let new_activity_id = ActivityId::new();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| {
+                w.split_pane(
+                    target,
+                    new_pane_id.clone(),
+                    Activity::terminal(new_activity_id.clone()),
+                    Side::After,
+                    orient,
+                )
+            })
+            .await
+            .unwrap();
+        state
+            .multiplexer
+            .pane_owner_window
+            .insert(new_pane_id.clone(), wid.clone());
+        new_pane_id
+    }
+
+    #[tokio::test]
+    async fn resize_happy_path_returns_204_and_broadcasts() {
+        let state = fresh_state();
+        let (_sid, wid, left, _aid) = bootstrap_default(&state).await;
+        let _right = split_via_window(&state, &wid, &left, SplitOrientation::Horizontal).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, left))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let view = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("publish timed out")
+            .expect("recv error");
+        assert_eq!(view["id"].as_str(), Some(wid.as_ref()));
+    }
+
+    #[tokio::test]
+    async fn resize_no_op_returns_204_without_broadcast() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let view = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(view.is_err(), "no broadcast expected for soft no-op");
+    }
+
+    #[tokio::test]
+    async fn resize_unknown_pane_returns_404() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, PaneId::new()))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn resize_wrong_window_returns_409() {
+        let state = fresh_state();
+        let (sid, _wid_a, pid_a, _aid) = bootstrap_default(&state).await;
+        let (wid_b, _, _) = state
+            .multiplexer
+            .create_window(Some(&sid), None)
+            .await
+            .unwrap();
+        state.set_window_dimensions(&wid_b, 120, 40).await.unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid_b, pid_a))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn resize_window_not_measured_returns_409() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn resize_invalid_direction_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"sideways"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn resize_zero_amount_returns_422_invalid_amount() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"right","amount":0}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn resize_malformed_json_returns_400() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        state.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/resize", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"direction":"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/daemon/http_server/src/lib.rs
+++ b/daemon/http_server/src/lib.rs
@@ -96,6 +96,10 @@ pub fn windows_router() -> Router<AppState> {
                 .delete(handlers::windows::delete::delete),
         )
         .route(
+            "/{window_id}/dimensions",
+            axum::routing::patch(handlers::windows::dimensions::patch_dimensions),
+        )
+        .route(
             "/{window_id}/select",
             post(handlers::windows::select::select),
         )

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -346,6 +346,22 @@ impl AppState {
         Ok(())
     }
 
+    /// Update the cached cell dimensions for `wid`. Validation of
+    /// positive cols/rows is the handler's responsibility. Broadcasts a
+    /// layout update so subscribed clients observe the new geometry.
+    pub async fn set_window_dimensions(
+        &self,
+        wid: &WindowId,
+        cols: u16,
+        rows: u16,
+    ) -> HttpResult<()> {
+        self.multiplexer
+            .set_window_dimensions(wid, cols, rows)
+            .await?;
+        self.publish_window_layout(wid).await;
+        Ok(())
+    }
+
     /// Close a Window: tear down its Panes/Activities and run runtime
     /// cleanup. Delegates the data half to `multiplexer.close_window_data`
     /// and then issues PTY kills, extension registry forgets, and a layout

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -165,6 +165,7 @@ impl AppState {
         direction: ozmux_multiplexer::PaneDirection,
         amount: u16,
     ) -> HttpResult<()> {
+        self.ensure_pane_in_window(wid, pid)?;
         let outcome = self
             .multiplexer
             .resize_pane(wid, pid, direction, amount)
@@ -368,17 +369,20 @@ impl AppState {
 
     /// Update the cached cell dimensions for `wid`. Validation of
     /// positive cols/rows is the handler's responsibility. Broadcasts a
-    /// layout update so subscribed clients observe the new geometry.
+    /// layout update only when the dimensions actually change.
     pub async fn set_window_dimensions(
         &self,
         wid: &WindowId,
         cols: u16,
         rows: u16,
     ) -> HttpResult<()> {
-        self.multiplexer
+        let outcome = self
+            .multiplexer
             .set_window_dimensions(wid, cols, rows)
             .await?;
-        self.publish_window_layout(wid).await;
+        if matches!(outcome, ozmux_multiplexer::SetDimensionsOutcome::Applied) {
+            self.publish_window_layout(wid).await;
+        }
         Ok(())
     }
 

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -155,6 +155,26 @@ impl AppState {
         Ok(())
     }
 
+    /// Run the resize-pane algorithm via the multiplexer and publish a
+    /// layout update only if the mutation was applied. Per spec §5.2,
+    /// soft no-ops return 204 with no broadcast.
+    pub async fn resize_pane(
+        &self,
+        wid: &WindowId,
+        pid: &PaneId,
+        direction: ozmux_multiplexer::PaneDirection,
+        amount: u16,
+    ) -> HttpResult<()> {
+        let outcome = self
+            .multiplexer
+            .resize_pane(wid, pid, direction, amount)
+            .await?;
+        if matches!(outcome, ozmux_multiplexer::ResizePaneOutcome::Applied) {
+            self.publish_window_layout(wid).await;
+        }
+        Ok(())
+    }
+
     /// Add an Activity to a Pane and broadcast the new layout. For
     /// terminal-kind activities, also spawn the backing PTY; on spawn
     /// failure the activity record is rolled back before returning the

--- a/daemon/multiplexer/src/error.rs
+++ b/daemon/multiplexer/src/error.rs
@@ -15,6 +15,11 @@ pub enum MultiplexerError {
     #[error("window not found window-id={0}")]
     WindowNotFound(WindowId),
 
+    #[error(
+        "window {0} has no cached dimensions; the client must PATCH /windows/{{wid}}/dimensions before resize-pane"
+    )]
+    WindowNotMeasured(WindowId),
+
     #[error("pane {pane} does not belong to window {window}")]
     PaneNotInWindow { window: WindowId, pane: PaneId },
 

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -22,6 +22,15 @@ pub use window::resize::ResizePaneOutcome;
 /// `SetActiveOutcome` directly in new code.
 pub type SetActivePaneOutcome = SetActiveOutcome;
 
+/// Outcome of `set_window_dimensions`: whether the cached value changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetDimensionsOutcome {
+    /// New value differed from the previous one.
+    Applied,
+    /// Same as before; caller can skip side effects.
+    Unchanged,
+}
+
 /// In-memory domain model. Owns the multiplexer's three stores (sessions,
 /// windows, pane_owner_window index). Pure data — no PTY, no extension
 /// registry, no layout broadcast. Side-effecting orchestration lives in the
@@ -123,19 +132,23 @@ impl MultiplexerService {
         wid: &WindowId,
         cols: u16,
         rows: u16,
-    ) -> MultiplexerResult<()> {
+    ) -> MultiplexerResult<SetDimensionsOutcome> {
         self.with_window_or_404(wid, |w| {
+            let next = WindowDimensions { cols, rows };
+            if w.dimensions.as_ref() == Some(&next) {
+                return Ok(SetDimensionsOutcome::Unchanged);
+            }
             w.set_dimensions(cols, rows);
-            Ok(())
+            Ok(SetDimensionsOutcome::Applied)
         })
         .await
     }
 
     /// Run the resize-pane algorithm. The window's cached dimensions are
-    /// used as root `P`; if absent, returns `WindowNotMeasured`. A pane
-    /// id from another window returns `PaneNotInWindow`. Soft no-ops
-    /// (no matching ancestor split or shrinking budget zero) return
-    /// `Ok(NoOp)` without mutating.
+    /// used as root `P`; if absent, returns `WindowNotMeasured`. Soft
+    /// no-ops (no matching ancestor split or shrinking budget zero)
+    /// return `Ok(NoOp)` without mutating. Pane-ownership validation is
+    /// the caller's responsibility (see `AppState::resize_pane`).
     pub async fn resize_pane(
         &self,
         wid: &WindowId,
@@ -143,14 +156,6 @@ impl MultiplexerService {
         direction: PaneDirection,
         amount: u16,
     ) -> MultiplexerResult<ResizePaneOutcome> {
-        let owner = self.lookup_pane_window(pane)?;
-        if &owner != wid {
-            return Err(MultiplexerError::PaneNotInWindow {
-                window: wid.clone(),
-                pane: pane.clone(),
-            });
-        }
-
         self.with_window_or_404(wid, |w| {
             let dims = w
                 .dimensions
@@ -256,7 +261,8 @@ mod tests {
     async fn set_window_dimensions_stores_values() {
         let svc = MultiplexerService::default();
         let (wid, _, _) = svc.create_window(None, None).await.unwrap();
-        svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let outcome = svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        assert_eq!(outcome, SetDimensionsOutcome::Applied);
         let dims = svc
             .with_window_or_404(&wid, |w| {
                 Ok::<_, MultiplexerError>(w.dimensions.clone())
@@ -267,6 +273,16 @@ mod tests {
             dims,
             Some(crate::WindowDimensions { cols: 120, rows: 40 })
         );
+    }
+
+    #[tokio::test]
+    async fn set_window_dimensions_returns_unchanged_when_same_value() {
+        let svc = MultiplexerService::default();
+        let (wid, _, _) = svc.create_window(None, None).await.unwrap();
+        let first = svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        assert_eq!(first, SetDimensionsOutcome::Applied);
+        let second = svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        assert_eq!(second, SetDimensionsOutcome::Unchanged);
     }
 
     #[tokio::test]
@@ -302,16 +318,4 @@ mod tests {
         assert!(matches!(outcome, ResizePaneOutcome::NoOp));
     }
 
-    #[tokio::test]
-    async fn resize_pane_with_pane_in_wrong_window_returns_pane_not_in_window() {
-        let svc = MultiplexerService::default();
-        let (_wid_a, pid_a, _) = svc.create_window(None, None).await.unwrap();
-        let (wid_b, _pid_b, _) = svc.create_window(None, None).await.unwrap();
-        svc.set_window_dimensions(&wid_b, 120, 40).await.unwrap();
-        let err = svc
-            .resize_pane(&wid_b, &pid_a, PaneDirection::Right, 1)
-            .await
-            .unwrap_err();
-        assert!(matches!(err, MultiplexerError::PaneNotInWindow { .. }));
-    }
 }

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -16,6 +16,7 @@ pub use window::{
     LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
     Side, SplitCell, SplitOrientation, Window, WindowDimensions, WindowId, WindowState,
 };
+pub use window::resize::ResizePaneOutcome;
 
 /// Backwards-compatible alias for the active-pane outcome. Use
 /// `SetActiveOutcome` directly in new code.
@@ -130,6 +131,44 @@ impl MultiplexerService {
         .await
     }
 
+    /// Run the resize-pane algorithm. The window's cached dimensions are
+    /// used as root `P`; if absent, returns `WindowNotMeasured`. A pane
+    /// id from another window returns `PaneNotInWindow`. Soft no-ops
+    /// (no matching ancestor split or shrinking budget zero) return
+    /// `Ok(NoOp)` without mutating.
+    pub async fn resize_pane(
+        &self,
+        wid: &WindowId,
+        pane: &PaneId,
+        direction: PaneDirection,
+        amount: u16,
+    ) -> MultiplexerResult<ResizePaneOutcome> {
+        let owner = self.lookup_pane_window(pane)?;
+        if &owner != wid {
+            return Err(MultiplexerError::PaneNotInWindow {
+                window: wid.clone(),
+                pane: pane.clone(),
+            });
+        }
+
+        self.with_window_or_404(wid, |w| {
+            let dims = w
+                .dimensions
+                .clone()
+                .ok_or_else(|| MultiplexerError::WindowNotMeasured(wid.clone()))?;
+            Ok(crate::window::resize::resize_split_for_pane(
+                &mut w.cells,
+                &w.pane_to_cell,
+                pane,
+                direction,
+                amount,
+                dims.cols,
+                dims.rows,
+            ))
+        })
+        .await
+    }
+
     /// Rename a Session.
     pub async fn rename_session(&self, sid: &SessionId, name: String) -> MultiplexerResult<()> {
         let mut state = self.sessions.lock().await;
@@ -238,5 +277,41 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, MultiplexerError::WindowNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn resize_pane_returns_window_not_measured_when_dimensions_unset() {
+        let svc = MultiplexerService::default();
+        let (wid, pid, _aid) = svc.create_window(None, None).await.unwrap();
+        let err = svc
+            .resize_pane(&wid, &pid, PaneDirection::Right, 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::WindowNotMeasured(_)));
+    }
+
+    #[tokio::test]
+    async fn resize_pane_returns_no_op_when_single_pane_window() {
+        let svc = MultiplexerService::default();
+        let (wid, pid, _aid) = svc.create_window(None, None).await.unwrap();
+        svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let outcome = svc
+            .resize_pane(&wid, &pid, PaneDirection::Right, 1)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, ResizePaneOutcome::NoOp));
+    }
+
+    #[tokio::test]
+    async fn resize_pane_with_pane_in_wrong_window_returns_pane_not_in_window() {
+        let svc = MultiplexerService::default();
+        let (_wid_a, pid_a, _) = svc.create_window(None, None).await.unwrap();
+        let (wid_b, _pid_b, _) = svc.create_window(None, None).await.unwrap();
+        svc.set_window_dimensions(&wid_b, 120, 40).await.unwrap();
+        let err = svc
+            .resize_pane(&wid_b, &pid_a, PaneDirection::Right, 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::PaneNotInWindow { .. }));
     }
 }

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -14,7 +14,7 @@ pub use session::{Session, SessionId, SessionState};
 pub use window::{
     Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
     LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
-    Side, SplitCell, SplitOrientation, Window, WindowId, WindowState,
+    Side, SplitCell, SplitOrientation, Window, WindowDimensions, WindowId, WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -11,12 +11,12 @@ pub mod window;
 
 pub use error::{MultiplexerError, MultiplexerResult};
 pub use session::{Session, SessionId, SessionState};
+pub use window::resize::ResizePaneOutcome;
 pub use window::{
     Activity, ActivityId, ActivityKind, Cell, CellId, CloseOutcome, CycleDirection,
     LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
     Side, SplitCell, SplitOrientation, Window, WindowDimensions, WindowId, WindowState,
 };
-pub use window::resize::ResizePaneOutcome;
 
 /// Backwards-compatible alias for the active-pane outcome. Use
 /// `SetActiveOutcome` directly in new code.
@@ -264,14 +264,15 @@ mod tests {
         let outcome = svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
         assert_eq!(outcome, SetDimensionsOutcome::Applied);
         let dims = svc
-            .with_window_or_404(&wid, |w| {
-                Ok::<_, MultiplexerError>(w.dimensions.clone())
-            })
+            .with_window_or_404(&wid, |w| Ok::<_, MultiplexerError>(w.dimensions.clone()))
             .await
             .unwrap();
         assert_eq!(
             dims,
-            Some(crate::WindowDimensions { cols: 120, rows: 40 })
+            Some(crate::WindowDimensions {
+                cols: 120,
+                rows: 40
+            })
         );
     }
 
@@ -317,5 +318,4 @@ mod tests {
             .unwrap();
         assert!(matches!(outcome, ResizePaneOutcome::NoOp));
     }
-
 }

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -113,6 +113,23 @@ impl MultiplexerService {
         .await
     }
 
+    /// Replace the cached cell-grid dimensions for `wid`. The frontend
+    /// invokes this whenever the window-level container is measured;
+    /// the value is then read by `resize_pane` as the root `P` for the
+    /// cell algorithm.
+    pub async fn set_window_dimensions(
+        &self,
+        wid: &WindowId,
+        cols: u16,
+        rows: u16,
+    ) -> MultiplexerResult<()> {
+        self.with_window_or_404(wid, |w| {
+            w.set_dimensions(cols, rows);
+            Ok(())
+        })
+        .await
+    }
+
     /// Rename a Session.
     pub async fn rename_session(&self, sid: &SessionId, name: String) -> MultiplexerResult<()> {
         let mut state = self.sessions.lock().await;
@@ -189,5 +206,37 @@ impl MultiplexerService {
         let mut session_state = self.sessions.lock().await;
         let session = session_state.remove(sid)?;
         Ok(session.linked_windows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_window_dimensions_stores_values() {
+        let svc = MultiplexerService::default();
+        let (wid, _, _) = svc.create_window(None, None).await.unwrap();
+        svc.set_window_dimensions(&wid, 120, 40).await.unwrap();
+        let dims = svc
+            .with_window_or_404(&wid, |w| {
+                Ok::<_, MultiplexerError>(w.dimensions.clone())
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            dims,
+            Some(crate::WindowDimensions { cols: 120, rows: 40 })
+        );
+    }
+
+    #[tokio::test]
+    async fn set_window_dimensions_unknown_window_returns_window_not_found() {
+        let svc = MultiplexerService::default();
+        let err = svc
+            .set_window_dimensions(&WindowId::new(), 80, 24)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MultiplexerError::WindowNotFound(_)));
     }
 }

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -6,6 +6,7 @@
 pub mod cells;
 pub mod direction;
 pub mod pane;
+pub(super) mod resize;
 #[allow(clippy::module_inception)]
 mod window;
 

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -16,4 +16,4 @@ pub use cells::{
 pub use direction::PaneDirection;
 pub use pane::activity::{Activity, ActivityId, ActivityKind};
 pub use pane::{CycleDirection, Pane, PaneId, PaneState, SetActiveOutcome};
-pub use window::{Window, WindowId, WindowState};
+pub use window::{Window, WindowDimensions, WindowId, WindowState};

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -6,7 +6,7 @@
 pub mod cells;
 pub mod direction;
 pub mod pane;
-pub(super) mod resize;
+pub(crate) mod resize;
 #[allow(clippy::module_inception)]
 mod window;
 

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -382,6 +382,20 @@ impl LayoutCellState {
             .get_mut(id)
             .ok_or_else(|| MultiplexerError::CellNotFound(id.clone()))
     }
+
+    /// Sibling-module accessor returning the cell as an `Option`. Used by the
+    /// `resize` algorithm which routinely needs to short-circuit on missing
+    /// cells without manufacturing a `MultiplexerError`.
+    #[inline]
+    pub(super) fn get(&self, id: &CellId) -> Option<&Cell> {
+        self.0.get(id)
+    }
+
+    /// Sibling-module mutable accessor counterpart to [`Self::get`].
+    #[inline]
+    pub(super) fn get_mut(&mut self, id: &CellId) -> Option<&mut Cell> {
+        self.0.get_mut(id)
+    }
 }
 
 /// Internal record gathered by `plan_collapse` and consumed by `apply_collapse`.

--- a/daemon/multiplexer/src/window/resize.rs
+++ b/daemon/multiplexer/src/window/resize.rs
@@ -1,0 +1,585 @@
+//! Pure cell-algorithm for `resize-pane`. Walks an ancestor `Split`
+//! whose orientation matches the requested axis and re-weights it in
+//! integer cells per spec §7.
+
+use crate::window::cells::{Cell, CellId, LayoutCellState, SplitOrientation};
+use crate::window::direction::PaneDirection;
+use crate::window::pane::PaneId;
+use std::collections::HashMap;
+
+/// Hard floor on a leaf pane's cell count along the LEFTRIGHT axis.
+pub(crate) const MIN_PANE_COLS: u16 = 10;
+
+/// Hard floor on a leaf pane's cell count along the TOPBOTTOM axis.
+pub(crate) const MIN_PANE_ROWS: u16 = 3;
+
+/// Outcome of a resize call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResizePaneOutcome {
+    /// At least one cell of movement was applied; broadcast.
+    Applied,
+    /// No matching ancestor, or shrinking subtree has zero budget.
+    NoOp,
+}
+
+/// Per §7.1: each `PaneDirection` maps to a `SplitOrientation` axis
+/// and a signed delta direction. The matching ancestor split's
+/// `lhs_cells` is updated by `sign * applied_delta`.
+fn direction_to_axis_sign(d: PaneDirection) -> (SplitOrientation, i16) {
+    match d {
+        PaneDirection::Right => (SplitOrientation::Horizontal, 1),
+        PaneDirection::Left => (SplitOrientation::Horizontal, -1),
+        PaneDirection::Down => (SplitOrientation::Vertical, 1),
+        PaneDirection::Up => (SplitOrientation::Vertical, -1),
+    }
+}
+
+/// Walk up the parent chain from `start_cell`. Returns the id of the
+/// first ancestor `Cell::Split` whose orientation matches `axis`, or
+/// `None` if no such ancestor exists (the call is a NoOp).
+fn find_matching_ancestor(
+    state: &LayoutCellState,
+    start_cell: &CellId,
+    axis: SplitOrientation,
+) -> Option<CellId> {
+    let mut cursor = state.get(start_cell).and_then(|c| c.parent().cloned());
+    while let Some(parent_id) = cursor {
+        let parent = state.get(&parent_id)?;
+        match parent {
+            Cell::Split(s) if s.orientation == axis => return Some(parent_id),
+            _ => {
+                cursor = parent.parent().cloned();
+            }
+        }
+    }
+    None
+}
+
+/// Apply §7.4: for parent axis length `p` and a same-axis split with
+/// weights `lhs_w` / `rhs_w`, return `(lhs_cells, rhs_cells)`. The pair
+/// sums to exactly `p`. Zero total falls back to a 50/50 split,
+/// mirroring `split_ratio` at `cells.rs:218-226`.
+fn split_cells(p: u16, lhs_w: f32, rhs_w: f32) -> (u16, u16) {
+    let total = lhs_w + rhs_w;
+    let ratio = if total == 0.0 { 0.5 } else { lhs_w / total };
+    let lhs = (p as f32 * ratio).round_ties_even() as u16;
+    let lhs = lhs.min(p);
+    let rhs = p - lhs;
+    (lhs, rhs)
+}
+
+/// Walk from root to `target`, applying §7.4 at each same-axis split.
+/// `axis` is the resize axis; cross-axis splits pass `p` through.
+fn compute_p_at(
+    state: &LayoutCellState,
+    target: &CellId,
+    axis: SplitOrientation,
+    window_cells_on_axis: u16,
+) -> u16 {
+    let mut path: Vec<CellId> = Vec::new();
+    let mut cursor = Some(target.clone());
+    while let Some(c) = cursor {
+        path.push(c.clone());
+        cursor = state.get(&c).and_then(|cell| cell.parent().cloned());
+    }
+    path.reverse();
+
+    let mut p = window_cells_on_axis;
+    for window in path.windows(2) {
+        let parent_id = &window[0];
+        let child_id = &window[1];
+        let Some(Cell::Split(s)) = state.get(parent_id) else {
+            continue;
+        };
+        if s.orientation != axis {
+            continue;
+        }
+        let (lhs, rhs) = split_cells(p, s.lhs_weight, s.rhs_weight);
+        p = if child_id == &s.lhs_cell { lhs } else { rhs };
+    }
+    p
+}
+
+/// True iff every leaf descendant of `cell` would still satisfy
+/// `min_cells` if the cell's axis length were `p`. Per §7.2.
+fn satisfies_min_at(
+    state: &LayoutCellState,
+    cell: &CellId,
+    axis: SplitOrientation,
+    p: u16,
+    min_cells: u16,
+) -> bool {
+    let Some(node) = state.get(cell) else {
+        return true;
+    };
+    match node {
+        Cell::Root(r) => satisfies_min_at(state, &r.child, axis, p, min_cells),
+        Cell::Pane(_) => p >= min_cells,
+        Cell::Split(s) if s.orientation == axis => {
+            let (lhs, rhs) = split_cells(p, s.lhs_weight, s.rhs_weight);
+            satisfies_min_at(state, &s.lhs_cell, axis, lhs, min_cells)
+                && satisfies_min_at(state, &s.rhs_cell, axis, rhs, min_cells)
+        }
+        Cell::Split(s) => {
+            // Cross-axis: each child spans the full p on `axis`.
+            satisfies_min_at(state, &s.lhs_cell, axis, p, min_cells)
+                && satisfies_min_at(state, &s.rhs_cell, axis, p, min_cells)
+        }
+    }
+}
+
+/// Maximum cells removable from `cell` (current axis length `p_sub`)
+/// such that all leaves still satisfy `min_cells`. Per §7.2.
+fn available_to_shrink(
+    state: &LayoutCellState,
+    cell: &CellId,
+    axis: SplitOrientation,
+    p_sub: u16,
+    min_cells: u16,
+    requested: u16,
+) -> u16 {
+    if p_sub == 0 {
+        return 0;
+    }
+    let upper = requested.min(p_sub);
+    let mut max_d = 0u16;
+    for d in 1..=upper {
+        if satisfies_min_at(state, cell, axis, p_sub - d, min_cells) {
+            max_d = d;
+        } else {
+            break;
+        }
+    }
+    max_d
+}
+
+/// Per-pane entry: resolve direction → axis/sign → matching ancestor →
+/// availability → apply.
+pub(crate) fn resize_split_for_pane(
+    state: &mut LayoutCellState,
+    pane_to_cell: &HashMap<PaneId, CellId>,
+    pane: &PaneId,
+    direction: PaneDirection,
+    amount: u16,
+    window_cols: u16,
+    window_rows: u16,
+) -> ResizePaneOutcome {
+    let Some(leaf_id) = pane_to_cell.get(pane) else {
+        return ResizePaneOutcome::NoOp;
+    };
+    let (axis, sign) = direction_to_axis_sign(direction);
+    let Some(ancestor_id) = find_matching_ancestor(state, leaf_id, axis) else {
+        return ResizePaneOutcome::NoOp;
+    };
+
+    let window_p = match axis {
+        SplitOrientation::Horizontal => window_cols,
+        SplitOrientation::Vertical => window_rows,
+    };
+    let min_cells = match axis {
+        SplitOrientation::Horizontal => MIN_PANE_COLS,
+        SplitOrientation::Vertical => MIN_PANE_ROWS,
+    };
+    let p_ancestor = compute_p_at(state, &ancestor_id, axis, window_p);
+
+    let (current_lhs, current_rhs, lhs_cell, rhs_cell) = match state.get(&ancestor_id) {
+        Some(Cell::Split(s)) => {
+            let (lhs, rhs) = split_cells(p_ancestor, s.lhs_weight, s.rhs_weight);
+            (lhs, rhs, s.lhs_cell.clone(), s.rhs_cell.clone())
+        }
+        _ => return ResizePaneOutcome::NoOp,
+    };
+
+    let (shrink_cell, shrink_p) = if sign > 0 {
+        (rhs_cell, current_rhs)
+    } else {
+        (lhs_cell, current_lhs)
+    };
+
+    let applied = available_to_shrink(state, &shrink_cell, axis, shrink_p, min_cells, amount);
+    if applied == 0 {
+        return ResizePaneOutcome::NoOp;
+    }
+
+    let signed_delta = sign * applied as i16;
+    let new_lhs_cells: u16 =
+        ((current_lhs as i32) + (signed_delta as i32)).clamp(0, p_ancestor as i32) as u16;
+    let new_rhs_cells = p_ancestor - new_lhs_cells;
+    if p_ancestor == 0 {
+        return ResizePaneOutcome::NoOp;
+    }
+    let new_lhs_w = new_lhs_cells as f32 / p_ancestor as f32;
+    let new_rhs_w = new_rhs_cells as f32 / p_ancestor as f32;
+
+    if let Some(Cell::Split(s)) = state.get_mut(&ancestor_id) {
+        s.lhs_weight = new_lhs_w;
+        s.rhs_weight = new_rhs_w;
+    }
+
+    ResizePaneOutcome::Applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::window::cells::Side;
+    use crate::window::pane::activity::{Activity, ActivityId};
+    use crate::window::window::{Window, WindowId};
+
+    fn fresh_window_with_split(orientation: SplitOrientation) -> (Window, PaneId, PaneId) {
+        let pid_a = PaneId::new();
+        let pid_b = PaneId::new();
+        let activity = Activity::terminal(ActivityId::new());
+        let mut win =
+            Window::new_with_initial(WindowId::new(), "w".into(), pid_a.clone(), activity);
+        win.split_pane(
+            &pid_a,
+            pid_b.clone(),
+            Activity::terminal(ActivityId::new()),
+            Side::After,
+            orientation,
+        )
+        .unwrap();
+        (win, pid_a, pid_b)
+    }
+
+    #[test]
+    fn direction_to_axis_and_sign() {
+        assert_eq!(
+            direction_to_axis_sign(PaneDirection::Right),
+            (SplitOrientation::Horizontal, 1)
+        );
+        assert_eq!(
+            direction_to_axis_sign(PaneDirection::Left),
+            (SplitOrientation::Horizontal, -1)
+        );
+        assert_eq!(
+            direction_to_axis_sign(PaneDirection::Down),
+            (SplitOrientation::Vertical, 1)
+        );
+        assert_eq!(
+            direction_to_axis_sign(PaneDirection::Up),
+            (SplitOrientation::Vertical, -1)
+        );
+    }
+
+    #[test]
+    fn find_matching_ancestor_finds_split_when_orientation_matches() {
+        let (win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let found = find_matching_ancestor(&win.cells, leaf, SplitOrientation::Horizontal);
+        assert!(found.is_some());
+    }
+
+    #[test]
+    fn find_matching_ancestor_returns_none_when_no_ancestor_matches() {
+        let (win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let found = find_matching_ancestor(&win.cells, leaf, SplitOrientation::Vertical);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn compute_p_at_root_returns_window_axis_length() {
+        let (win, _, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let root = &win.root_cell;
+        let p = compute_p_at(&win.cells, root, SplitOrientation::Horizontal, 120);
+        assert_eq!(p, 120);
+    }
+
+    #[test]
+    fn compute_p_at_lhs_child_of_same_axis_split_is_lhs_rounded() {
+        // 50/50 horizontal split of width=120 → lhs gets round(60)=60.
+        let (win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let p = compute_p_at(&win.cells, leaf, SplitOrientation::Horizontal, 120);
+        assert_eq!(p, 60);
+    }
+
+    #[test]
+    fn compute_p_at_in_cross_axis_subtree_inherits_parent_p() {
+        let (win, pid_left, _) = fresh_window_with_split(SplitOrientation::Vertical);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let p_horizontal = compute_p_at(&win.cells, leaf, SplitOrientation::Horizontal, 120);
+        assert_eq!(p_horizontal, 120);
+    }
+
+    #[test]
+    fn satisfies_min_at_pane_passes_when_p_at_or_above_min() {
+        let (win, pid, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid).unwrap();
+        assert!(satisfies_min_at(
+            &win.cells,
+            leaf,
+            SplitOrientation::Horizontal,
+            10,
+            10,
+        ));
+        assert!(!satisfies_min_at(
+            &win.cells,
+            leaf,
+            SplitOrientation::Horizontal,
+            9,
+            10,
+        ));
+    }
+
+    #[test]
+    fn satisfies_min_at_same_axis_split_walks_both_children() {
+        let (win, pid, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid).unwrap();
+        assert!(satisfies_min_at(
+            &win.cells,
+            leaf,
+            SplitOrientation::Horizontal,
+            109,
+            10,
+        ));
+    }
+
+    #[test]
+    fn satisfies_min_at_codex_worked_example_rhs_subtree() {
+        // §7.2 worked example: rhs subtree is 10/100 weighted with min=10.
+        // P=110 OK; P=105 OK (lhs=round(105*10/110)=10); P=104 NOT OK.
+        let pid_a = PaneId::new();
+        let pid_b = PaneId::new();
+        let pid_c = PaneId::new();
+        let mut win = Window::new_with_initial(
+            WindowId::new(),
+            "w".into(),
+            pid_a.clone(),
+            Activity::terminal(ActivityId::new()),
+        );
+        win.split_pane(
+            &pid_a,
+            pid_b.clone(),
+            Activity::terminal(ActivityId::new()),
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
+        win.split_pane(
+            &pid_b,
+            pid_c.clone(),
+            Activity::terminal(ActivityId::new()),
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
+
+        let cell_b = win.pane_to_cell.get(&pid_b).unwrap().clone();
+        let inner_split_id = win.cells.get(&cell_b).unwrap().parent().unwrap().clone();
+        if let Some(Cell::Split(s)) = win.cells.get_mut(&inner_split_id) {
+            s.lhs_weight = 10.0;
+            s.rhs_weight = 100.0;
+        }
+
+        let inner_split = &inner_split_id;
+        assert!(satisfies_min_at(
+            &win.cells,
+            inner_split,
+            SplitOrientation::Horizontal,
+            110,
+            10,
+        ));
+        assert!(satisfies_min_at(
+            &win.cells,
+            inner_split,
+            SplitOrientation::Horizontal,
+            105,
+            10,
+        ));
+        assert!(!satisfies_min_at(
+            &win.cells,
+            inner_split,
+            SplitOrientation::Horizontal,
+            104,
+            10,
+        ));
+    }
+
+    #[test]
+    fn available_to_shrink_returns_zero_when_p_sub_is_zero() {
+        let (win, pid, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid).unwrap();
+        assert_eq!(
+            available_to_shrink(&win.cells, leaf, SplitOrientation::Horizontal, 0, 10, 5),
+            0
+        );
+    }
+
+    #[test]
+    fn available_to_shrink_caps_at_p_sub() {
+        let (win, pid, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf = win.pane_to_cell.get(&pid).unwrap();
+        assert_eq!(
+            available_to_shrink(&win.cells, leaf, SplitOrientation::Horizontal, 15, 10, 100),
+            5
+        );
+    }
+
+    #[test]
+    fn available_to_shrink_handles_zero_total_weight_split() {
+        let (mut win, _pid_a, pid_b) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let cell_b = win.pane_to_cell.get(&pid_b).unwrap().clone();
+        let split_id = win.cells.get(&cell_b).unwrap().parent().unwrap().clone();
+        if let Some(Cell::Split(s)) = win.cells.get_mut(&split_id) {
+            s.lhs_weight = 0.0;
+            s.rhs_weight = 0.0;
+        }
+        // P=20, min=10 → 0.5 fallback gives lhs=10, rhs=10 → both meet min.
+        // Shrink by 1 → P=19 → lhs=round(9.5)=10 (banker's), rhs=9 → rhs fails.
+        let result = available_to_shrink(
+            &win.cells,
+            &split_id,
+            SplitOrientation::Horizontal,
+            20,
+            10,
+            5,
+        );
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn resize_right_in_two_column_split_grows_lhs_shrinks_rhs() {
+        let (mut win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        win.dimensions = Some(crate::window::window::WindowDimensions {
+            cols: 120,
+            rows: 40,
+        });
+        let outcome = resize_split_for_pane(
+            &mut win.cells,
+            &win.pane_to_cell,
+            &pid_left,
+            PaneDirection::Right,
+            1,
+            120,
+            40,
+        );
+        assert_eq!(outcome, ResizePaneOutcome::Applied);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let p_after = compute_p_at(&win.cells, leaf, SplitOrientation::Horizontal, 120);
+        assert_eq!(p_after, 61);
+    }
+
+    #[test]
+    fn resize_right_in_two_column_split_with_active_in_rhs_still_shrinks_rhs() {
+        let (mut win, _pid_left, pid_right) = fresh_window_with_split(SplitOrientation::Horizontal);
+        win.dimensions = Some(crate::window::window::WindowDimensions {
+            cols: 120,
+            rows: 40,
+        });
+        let outcome = resize_split_for_pane(
+            &mut win.cells,
+            &win.pane_to_cell,
+            &pid_right,
+            PaneDirection::Right,
+            1,
+            120,
+            40,
+        );
+        assert_eq!(outcome, ResizePaneOutcome::Applied);
+        let leaf = win.pane_to_cell.get(&pid_right).unwrap();
+        let p_after = compute_p_at(&win.cells, leaf, SplitOrientation::Horizontal, 120);
+        assert_eq!(p_after, 59);
+    }
+
+    #[test]
+    fn resize_returns_no_op_when_no_matching_ancestor_orientation() {
+        let (mut win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        win.dimensions = Some(crate::window::window::WindowDimensions {
+            cols: 120,
+            rows: 40,
+        });
+        let outcome = resize_split_for_pane(
+            &mut win.cells,
+            &win.pane_to_cell,
+            &pid_left,
+            PaneDirection::Down,
+            1,
+            120,
+            40,
+        );
+        assert_eq!(outcome, ResizePaneOutcome::NoOp);
+    }
+
+    #[test]
+    fn resize_clamps_at_min_cells_when_shrinking_subtree_is_at_floor() {
+        let (mut win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let cell_left = win.pane_to_cell.get(&pid_left).unwrap().clone();
+        let split_id = win.cells.get(&cell_left).unwrap().parent().unwrap().clone();
+        if let Some(Cell::Split(s)) = win.cells.get_mut(&split_id) {
+            s.lhs_weight = 110.0;
+            s.rhs_weight = 10.0;
+        }
+        let outcome = resize_split_for_pane(
+            &mut win.cells,
+            &win.pane_to_cell,
+            &pid_left,
+            PaneDirection::Right,
+            5,
+            120,
+            40,
+        );
+        assert_eq!(outcome, ResizePaneOutcome::NoOp);
+    }
+
+    #[test]
+    fn resize_partially_applies_when_amount_exceeds_available_budget() {
+        // 50/50 horizontal split, P=120 → 60/60 cells. min=10. Budget = 50.
+        // Request 100 → should partially apply 50, leaving lhs at 110.
+        let (mut win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let outcome = resize_split_for_pane(
+            &mut win.cells,
+            &win.pane_to_cell,
+            &pid_left,
+            PaneDirection::Right,
+            100,
+            120,
+            40,
+        );
+        assert_eq!(outcome, ResizePaneOutcome::Applied);
+        let leaf = win.pane_to_cell.get(&pid_left).unwrap();
+        let p_after = compute_p_at(&win.cells, leaf, SplitOrientation::Horizontal, 120);
+        assert_eq!(p_after, 110);
+    }
+
+    #[test]
+    fn resize_no_drift_across_repeated_one_cell_adjustments() {
+        let (mut win, pid_left, _) = fresh_window_with_split(SplitOrientation::Horizontal);
+        let leaf_id = win.pane_to_cell.get(&pid_left).unwrap().clone();
+        let split_id = win.cells.get(&leaf_id).unwrap().parent().unwrap().clone();
+        let before = if let Some(Cell::Split(s)) = win.cells.get(&split_id) {
+            (s.lhs_weight, s.rhs_weight)
+        } else {
+            panic!("not a split")
+        };
+        for _ in 0..50 {
+            let _ = resize_split_for_pane(
+                &mut win.cells,
+                &win.pane_to_cell,
+                &pid_left,
+                PaneDirection::Right,
+                1,
+                120,
+                40,
+            );
+            let _ = resize_split_for_pane(
+                &mut win.cells,
+                &win.pane_to_cell,
+                &pid_left,
+                PaneDirection::Left,
+                1,
+                120,
+                40,
+            );
+        }
+        let after = if let Some(Cell::Split(s)) = win.cells.get(&split_id) {
+            (s.lhs_weight, s.rhs_weight)
+        } else {
+            panic!("not a split")
+        };
+        assert!((before.0 - after.0).abs() < 1e-3);
+        assert!((before.1 - after.1).abs() < 1e-3);
+    }
+}

--- a/daemon/multiplexer/src/window/resize.rs
+++ b/daemon/multiplexer/src/window/resize.rs
@@ -15,7 +15,7 @@ pub(crate) const MIN_PANE_ROWS: u16 = 3;
 
 /// Outcome of a resize call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ResizePaneOutcome {
+pub enum ResizePaneOutcome {
     /// At least one cell of movement was applied; broadcast.
     Applied,
     /// No matching ancestor, or shrinking subtree has zero budget.

--- a/daemon/multiplexer/src/window/resize.rs
+++ b/daemon/multiplexer/src/window/resize.rs
@@ -57,15 +57,12 @@ fn find_matching_ancestor(
 
 /// Apply §7.4: for parent axis length `p` and a same-axis split with
 /// weights `lhs_w` / `rhs_w`, return `(lhs_cells, rhs_cells)`. The pair
-/// sums to exactly `p`. Zero total falls back to a 50/50 split,
-/// mirroring `split_ratio` at `cells.rs:218-226`.
+/// sums to exactly `p`. Zero total falls back to a 50/50 split via
+/// `LayoutCellState::split_ratio`.
 fn split_cells(p: u16, lhs_w: f32, rhs_w: f32) -> (u16, u16) {
-    let total = lhs_w + rhs_w;
-    let ratio = if total == 0.0 { 0.5 } else { lhs_w / total };
-    let lhs = (p as f32 * ratio).round_ties_even() as u16;
-    let lhs = lhs.min(p);
-    let rhs = p - lhs;
-    (lhs, rhs)
+    let ratio = LayoutCellState::split_ratio(lhs_w, rhs_w);
+    let lhs = ((p as f32 * ratio).round_ties_even() as u16).min(p);
+    (lhs, p - lhs)
 }
 
 /// Walk from root to `target`, applying §7.4 at each same-axis split.
@@ -205,9 +202,6 @@ pub(crate) fn resize_split_for_pane(
     let new_lhs_cells: u16 =
         ((current_lhs as i32) + (signed_delta as i32)).clamp(0, p_ancestor as i32) as u16;
     let new_rhs_cells = p_ancestor - new_lhs_cells;
-    if p_ancestor == 0 {
-        return ResizePaneOutcome::NoOp;
-    }
     let new_lhs_w = new_lhs_cells as f32 / p_ancestor as f32;
     let new_rhs_w = new_rhs_cells as f32 / p_ancestor as f32;
 

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -540,7 +540,10 @@ mod tests {
         win.set_dimensions(120, 40);
         assert_eq!(
             win.dimensions,
-            Some(WindowDimensions { cols: 120, rows: 40 })
+            Some(WindowDimensions {
+                cols: 120,
+                rows: 40
+            })
         );
     }
 

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -10,6 +10,18 @@ use std::collections::HashMap;
 #[newtype(as_ref(str), display, new(uuid_v4_string), default)]
 pub struct WindowId(String);
 
+/// Cell-grid dimensions of a Window's outer container, as reported by
+/// the client. Used as the root `P` for the resize-pane algorithm.
+/// Per-activity cell dimensions live in `TerminalService` and are
+/// **not** mirrored here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WindowDimensions {
+    /// Number of cells along the LEFTRIGHT axis.
+    pub cols: u16,
+    /// Number of cells along the TOPBOTTOM axis.
+    pub rows: u16,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Window {
     pub id: WindowId,
@@ -21,6 +33,11 @@ pub struct Window {
     pub active_pane: PaneId,
     pub(crate) pane_active_points: HashMap<PaneId, u64>,
     pub(crate) next_active_point: u64,
+    /// Cell-grid dimensions reported by the client (root `P` for
+    /// resize-pane). `None` until the client first measures and sends
+    /// `PATCH /windows/{wid}/dimensions`.
+    #[serde(default)]
+    pub dimensions: Option<WindowDimensions>,
 }
 
 impl Window {
@@ -49,7 +66,14 @@ impl Window {
             active_pane: initial_pane_id,
             pane_active_points: HashMap::new(),
             next_active_point: 0,
+            dimensions: None,
         }
+    }
+
+    /// Replace the cached dimensions. Set on first client measurement
+    /// and updated on subsequent container resizes.
+    pub fn set_dimensions(&mut self, cols: u16, rows: u16) {
+        self.dimensions = Some(WindowDimensions { cols, rows });
     }
 
     /// Bump the per-window counter and record it as the new active pane's
@@ -504,6 +528,22 @@ mod tests {
             SetActiveOutcome::Unchanged,
         ));
         assert_eq!(win.next_active_point, before);
+    }
+
+    #[test]
+    fn new_window_starts_with_unset_dimensions() {
+        let (win, _, _) = fresh_window();
+        assert!(win.dimensions.is_none());
+    }
+
+    #[test]
+    fn window_set_dimensions_stores_cols_and_rows() {
+        let (mut win, _, _) = fresh_window();
+        win.set_dimensions(120, 40);
+        assert_eq!(
+            win.dimensions,
+            Some(WindowDimensions { cols: 120, rows: 40 })
+        );
     }
 
     #[test]

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -16,9 +16,7 @@ pub struct WindowId(String);
 /// **not** mirrored here.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WindowDimensions {
-    /// Number of cells along the LEFTRIGHT axis.
     pub cols: u16,
-    /// Number of cells along the TOPBOTTOM axis.
     pub rows: u16,
 }
 


### PR DESCRIPTION
## Problem

`Action::ResizePane` was declared in `Shortcuts` but the frontend dispatched a `console.warn` and dropped it — there was no way to resize a pane after creating one with `split-pane`. tmux has resize-pane with `bind-key -r` repeat semantics; ozmux did not.

## Solution

Server-resolved resize-pane: the client only sends a direction, the daemon resolves the target ancestor split and runs a tmux-style cell-based algorithm. The frontend now measures and reports window cell dimensions, dispatches resize requests on each press, and supports a 500ms repeat sub-mode that accepts `KeyboardEvent.repeat === true` so holding a key produces a smooth resize.

### Affected areas

**configs** (`daemon/configs`)
- `Binding.repeatable: bool` and `Shortcuts.repeat_timeout_ms: u64` (default 500) added.
- `Shortcuts::default()` adds four `Shift+ArrowLeft/Right/Up/Down` resize-pane bindings, all `repeatable: true`.

**multiplexer** (`daemon/multiplexer`)
- `Window.dimensions: Option<WindowDimensions>` field — the cached cell-grid size used as the root `P` for the resize algorithm. Defaults to `None` and is populated by the frontend on first measurement.
- `MultiplexerService::set_window_dimensions(wid, cols, rows)` and `MultiplexerService::resize_pane(wid, pane, direction, amount) -> ResizePaneOutcome`.
- New `MultiplexerError::WindowNotMeasured` for the pre-measurement race.
- `window/resize.rs` contains the pure cell algorithm: tmux-style ancestor walk, integer cell math with banker's rounding (`f32::round_ties_even`), zero-weight `split_ratio` fallback, and per-leaf min-validity check (`MIN_PANE_COLS=10`, `MIN_PANE_ROWS=3`).
- Algorithm is descendant-auto-rescale: only the matching ancestor's `lhs_weight` / `rhs_weight` are mutated; descendants re-derive their bounds via the existing `pane_bounds()` walker.

**http_server** (`daemon/http_server`)
- `PATCH /windows/{wid}/dimensions` body `{cols, rows}` → `204`. Validates `cols >= 1`, `rows >= 1` with a new `HttpError::InvalidDimensions { field }` (422 `INVALID_DIMENSIONS`).
- `POST /windows/{wid}/panes/{pid}/resize` body `{direction, amount?}` → `204`. Validates `amount >= 1` with a new `HttpError::InvalidAmount` (422 `INVALID_AMOUNT`). Broadcasts layout only when the algorithm returns `Applied`; soft no-ops (no matching ancestor or shrinking budget zero) complete with `204` and no broadcast.
- Error mapping table: `204` / `404 WINDOW_NOT_FOUND|PANE_NOT_FOUND` / `409 PANE_NOT_IN_WINDOW|WINDOW_NOT_MEASURED` / `415` (axum default for `MissingJsonContentType`) / `422 INVALID_DIMENSIONS|INVALID_AMOUNT` (axum default for `JsonDataError`) / `400` (axum default for `JsonSyntaxError`).

**frontend** (`daemon/frontend`)
- `wire.ts` zod schema accepts the new `resize-pane` action and `repeatable` / `repeat_timeout_ms` fields, defaulting both for backwards-compat with older payloads.
- `resizePane` (`POST .../resize`) and `resizeWindow` (`PATCH .../dimensions`) helpers added.
- `useWindowDimensions` hook measures the layout container via `ResizeObserver` + the existing `cellWidthOf` / `cellHeightOf` font probes from `terminal/renderer/font.ts`. First measurement is sent immediately (no debounce) so the keyboard race window is bounded to roughly the initial paint; subsequent updates debounced 50ms. `409 WINDOW_NOT_MEASURED` is logged at the debug level and dropped — the user retries with the next keypress.
- `LayoutView.tsx` mounts the hook above its conditional returns to comply with Rules of Hooks and accepts `WindowId | null`.
- `actionDispatch.ts` now wires `resize-pane` through `withActivePane` to the `resizePane` helper.
- `usePrefixMode.ts` dispatcher rewritten as a three-branch state machine (idle / armed / repeat) with separate `prefixTimer` and `repeatTimer`. Repeat sub-mode explicitly accepts `KeyboardEvent.repeat === true` so OS auto-repeat produces a continuous resize; a non-repeatable chord in repeat mode disarms **and** forwards the keystroke to the terminal (not consumed).

### Algorithm notes

- The direction-to-axis-sign mapping is tmux-literal: `Right`/`Down` map to `+1`, `Left`/`Up` to `-1`. Active pane position (lhs vs rhs of the ancestor split) does **not** affect the sign — the divider always moves in the requested direction. As a result, pressing `Shift+Right` on the rightmost pane of a 2-column split shrinks the active pane (matches tmux).
- `lhs_cells = round_ties_even(P * lhs_w / total)`, `rhs_cells = P - lhs_cells` is the single cells-from-P rule; the asymmetric remainder-on-rhs guarantees `lhs + rhs == P`. Zero total weight falls back to a `0.5` ratio, mirroring `LayoutCellState::split_ratio`.
- `available_to_shrink` does an integer search in `1..=min(requested, P_sub)`, breaking on the first delta that would push any leaf below min. `available_to_shrink_returns_zero_when_p_sub_is_zero` guards the degenerate case.

### Default key bindings (added)

After `Ctrl+B` (prefix):

| Key | Action |
|---|---|
| `Shift+←` | resize-pane Left (repeatable) |
| `Shift+→` | resize-pane Right (repeatable) |
| `Shift+↑` | resize-pane Up (repeatable) |
| `Shift+↓` | resize-pane Down (repeatable) |

Originally `Ctrl+Arrow` per tmux, but Ctrl+Left/Right are intercepted by the embedded browser (history navigation), so the defaults now use Shift.

### Test impact

- New tests across all crates and frontend (algorithm unit tests, HTTP handler tests for both endpoints, wire-parser tests, helper tests, hook tests, repeat sub-mode tests).
- Updated the existing `default_shortcuts_serializes_to_stable_json` snapshot to include `repeatable` on every binding and the new top-level `repeat_timeout_ms`.
- Updated `wire.test.ts` `DEFAULT_JSON` shape to match.

## Test Plan

- [ ] `cargo test --workspace` passes
- [ ] `pnpm test`, `pnpm check-types`, `pnpm lint` pass
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] In the browser: `Ctrl+B` then `Shift+→` resizes the active pane one cell right; holding `Shift+→` keeps resizing (OS auto-repeat) until released or 500ms idle
- [ ] After repeat mode, pressing a non-repeatable key (e.g. typing `x` while in repeat) disarms repeat mode and the `x` reaches the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)