### PR TITLE
feat(cli): add `ozmux session create` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "daemon_bootstrap",
  "libc",
  "reqwest",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,4 @@ unicode-width = "0.2"
 bytes = "1"
 tokio-util = "0.7"
 clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "
 anyhow = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 libc = { workspace = true }
 daemon_bootstrap = { path = "../daemon/bootstrap" }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,6 +1,7 @@
 //! Top-level CLI subcommand modules.
 
 pub(crate) mod daemon;
+pub(crate) mod session;
 
 pub trait CommandExecute {
     async fn run(self) -> anyhow::Result<()>;

--- a/cli/src/commands/daemon.rs
+++ b/cli/src/commands/daemon.rs
@@ -1,6 +1,7 @@
 //! `ozmux daemon` subcommand dispatcher. Each sibling module implements one
-//! verb (start/stop/status).
+//! verb (start/stop/status), plus the shared `ensure_running` helper.
 
+use anyhow::Context;
 use clap::Subcommand;
 
 use crate::commands::CommandExecute;
@@ -28,4 +29,38 @@ impl CommandExecute for DaemonCommand {
             Self::Status => status::run().await,
         }
     }
+}
+
+/// Whether `ensure_running` found the daemon already up or started it.
+pub(crate) enum DaemonStartOutcome {
+    AlreadyRunning,
+    Started,
+}
+
+/// Ensures the ozmux daemon is running, spawning it detached if it is not.
+///
+/// Writes nothing to stdout or stderr on the success path, so callers with
+/// their own stdout contract (e.g. `session create`) get a clean stream.
+/// Spawn-failure diagnostics may still reach stderr.
+pub(crate) async fn ensure_running() -> anyhow::Result<DaemonStartOutcome> {
+    if start::is_running() {
+        return Ok(DaemonStartOutcome::AlreadyRunning);
+    }
+
+    let lock = start::acquire_lock()
+        .await
+        .context("acquire daemon launcher lock")?;
+
+    if start::is_running() {
+        drop(lock);
+        return Ok(DaemonStartOutcome::AlreadyRunning);
+    }
+
+    start::spawn_detached().context("spawn ozmux daemon")?;
+    start::wait_until_ready()
+        .await
+        .context("daemon did not become ready in time")?;
+    drop(lock);
+
+    Ok(DaemonStartOutcome::Started)
 }

--- a/cli/src/commands/daemon.rs
+++ b/cli/src/commands/daemon.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Context;
 use clap::Subcommand;
+use std::time::Duration;
 
 use crate::commands::CommandExecute;
 
@@ -63,4 +64,13 @@ pub(crate) async fn ensure_running() -> anyhow::Result<DaemonStartOutcome> {
     drop(lock);
 
     Ok(DaemonStartOutcome::Started)
+}
+
+/// Builds a `reqwest` client for HTTP requests to the local daemon, with the
+/// given per-request timeout.
+pub(crate) fn http_client(timeout: Duration) -> anyhow::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .build()
+        .context("build reqwest client")
 }

--- a/cli/src/commands/daemon/start.rs
+++ b/cli/src/commands/daemon/start.rs
@@ -137,10 +137,7 @@ fn detach_from_session(cmd: &mut std::process::Command) {
 }
 
 pub(super) async fn wait_until_ready() -> anyhow::Result<()> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .context("build reqwest client")?;
+    let client = super::http_client(Duration::from_secs(1))?;
 
     let deadline = Instant::now() + READY_TIMEOUT;
     loop {

--- a/cli/src/commands/daemon/start.rs
+++ b/cli/src/commands/daemon/start.rs
@@ -33,47 +33,24 @@ impl CommandExecute for StartArgs {
         if self.foreground {
             return daemon_bootstrap::run().await;
         }
-        start_detached().await
+        match super::ensure_running().await? {
+            super::DaemonStartOutcome::AlreadyRunning => {
+                eprintln!(
+                    "ozmux daemon already running on {}",
+                    daemon_bootstrap::HTTP_ADDR
+                );
+            }
+            super::DaemonStartOutcome::Started => {
+                if let Some(pid) = daemon_bootstrap::pidfile::read()? {
+                    println!("{pid}");
+                }
+            }
+        }
+        Ok(())
     }
 }
 
-async fn start_detached() -> anyhow::Result<()> {
-    if is_running() {
-        eprintln!(
-            "ozmux daemon already running on {}",
-            daemon_bootstrap::HTTP_ADDR
-        );
-        return Ok(());
-    }
-
-    let lock = acquire_lock()
-        .await
-        .context("acquire daemon launcher lock")?;
-
-    if is_running() {
-        eprintln!(
-            "ozmux daemon already running on {}",
-            daemon_bootstrap::HTTP_ADDR
-        );
-        drop(lock);
-        return Ok(());
-    }
-
-    spawn_detached().context("spawn ozmux daemon")?;
-
-    wait_until_ready()
-        .await
-        .context("daemon did not become ready in time")?;
-
-    drop(lock);
-
-    if let Some(pid) = daemon_bootstrap::pidfile::read()? {
-        println!("{pid}");
-    }
-    Ok(())
-}
-
-fn is_running() -> bool {
+pub(super) fn is_running() -> bool {
     let Ok(addr) = daemon_bootstrap::HTTP_ADDR.parse::<SocketAddr>() else {
         return false;
     };
@@ -85,7 +62,7 @@ fn runtime_dir() -> anyhow::Result<PathBuf> {
         .with_context(|| "create runtime dir at $TMPDIR/ozmux".to_string())
 }
 
-async fn acquire_lock() -> anyhow::Result<File> {
+pub(super) async fn acquire_lock() -> anyhow::Result<File> {
     let path = runtime_dir()?.join("daemon.lock");
     let file = OpenOptions::new()
         .create(true)
@@ -116,7 +93,7 @@ async fn acquire_lock() -> anyhow::Result<File> {
     }
 }
 
-fn spawn_detached() -> anyhow::Result<()> {
+pub(super) fn spawn_detached() -> anyhow::Result<()> {
     let exe = std::env::current_exe().context("resolve current executable")?;
     let (log, log_err) = open_daemon_log_pair()?;
 
@@ -159,7 +136,7 @@ fn detach_from_session(cmd: &mut std::process::Command) {
     }
 }
 
-async fn wait_until_ready() -> anyhow::Result<()> {
+pub(super) async fn wait_until_ready() -> anyhow::Result<()> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(1))
         .build()

--- a/cli/src/commands/daemon/status.rs
+++ b/cli/src/commands/daemon/status.rs
@@ -32,7 +32,7 @@ async fn run_status() -> anyhow::Result<i32> {
 }
 
 async fn check_health() -> bool {
-    let Ok(client) = reqwest::Client::builder().timeout(HEALTH_TIMEOUT).build() else {
+    let Ok(client) = super::http_client(HEALTH_TIMEOUT) else {
         return false;
     };
     matches!(client.get(daemon_bootstrap::HEALTH_URL).send().await, Ok(r) if r.status().is_success())

--- a/cli/src/commands/session.rs
+++ b/cli/src/commands/session.rs
@@ -1,0 +1,22 @@
+//! `ozmux session` subcommand dispatcher. Each sibling module implements one
+//! verb.
+
+use clap::Subcommand;
+
+use crate::commands::CommandExecute;
+
+pub(crate) mod create;
+
+#[derive(Subcommand)]
+pub enum SessionCommand {
+    /// Create a new session.
+    Create(create::CreateArgs),
+}
+
+impl CommandExecute for SessionCommand {
+    async fn run(self) -> anyhow::Result<()> {
+        match self {
+            Self::Create(args) => args.run().await,
+        }
+    }
+}

--- a/cli/src/commands/session/create.rs
+++ b/cli/src/commands/session/create.rs
@@ -39,10 +39,7 @@ impl CommandExecute for CreateArgs {
 }
 
 async fn create_session(name: Option<String>) -> anyhow::Result<String> {
-    let client = reqwest::Client::builder()
-        .timeout(CREATE_TIMEOUT)
-        .build()
-        .context("build reqwest client")?;
+    let client = daemon::http_client(CREATE_TIMEOUT)?;
     let url = format!("{}/sessions", daemon_bootstrap::HTTP_BASE_URL);
     let response = client
         .post(&url)

--- a/cli/src/commands/session/create.rs
+++ b/cli/src/commands/session/create.rs
@@ -1,0 +1,65 @@
+//! `ozmux session create` — create a session via the daemon's HTTP API.
+
+use anyhow::Context;
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use crate::commands::CommandExecute;
+use crate::commands::daemon;
+
+const CREATE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Arguments for the `session create` subcommand.
+#[derive(Args)]
+pub(crate) struct CreateArgs {
+    /// Name for the new session. The daemon assigns a default if omitted.
+    #[arg(short = 's', long)]
+    name: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateResponse {
+    id: String,
+}
+
+impl CommandExecute for CreateArgs {
+    async fn run(self) -> anyhow::Result<()> {
+        daemon::ensure_running().await?;
+        let id = create_session(self.name).await?;
+        println!("{id}");
+        Ok(())
+    }
+}
+
+async fn create_session(name: Option<String>) -> anyhow::Result<String> {
+    let client = reqwest::Client::builder()
+        .timeout(CREATE_TIMEOUT)
+        .build()
+        .context("build reqwest client")?;
+    let url = format!("{}/sessions", daemon_bootstrap::HTTP_BASE_URL);
+    let response = client
+        .post(&url)
+        .json(&CreateRequest { name })
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("daemon returned {status} for POST {url}: {body}");
+    }
+
+    let parsed: CreateResponse = response
+        .json()
+        .await
+        .context("parse session create response body")?;
+    Ok(parsed.id)
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,9 @@
-//! ozmux CLI entry point. Exposes the `daemon` subcommand group; new
-//! subcommands are added under `commands/`.
+//! ozmux CLI entry point. Exposes the `daemon` and `session` subcommand
+//! groups; new subcommands are added under `commands/`.
 
 use clap::{Parser, Subcommand};
 
-use crate::commands::{CommandExecute, daemon::DaemonCommand};
+use crate::commands::{CommandExecute, daemon::DaemonCommand, session::SessionCommand};
 
 mod commands;
 
@@ -25,12 +25,16 @@ enum Command {
     /// Daemon lifecycle commands.
     #[command(subcommand)]
     Daemon(DaemonCommand),
+    /// Session management commands.
+    #[command(subcommand)]
+    Session(SessionCommand),
 }
 
 impl CommandExecute for Command {
     async fn run(self) -> anyhow::Result<()> {
         match self {
             Self::Daemon(command) => command.run().await,
+            Self::Session(command) => command.run().await,
         }
     }
 }

--- a/cli/tests/session_create.rs
+++ b/cli/tests/session_create.rs
@@ -1,0 +1,91 @@
+//! Integration test for `ozmux session create`: verifies it creates a
+//! session via the daemon, auto-starting the daemon when none is running
+//! and reusing an already-running daemon otherwise.
+//!
+//! Like `daemon_lifecycle.rs`, this test binds the real TCP port 3200 and
+//! writes the real `$TMPDIR/ozmux/daemon.pid`. `cargo test` runs each
+//! integration-test file as its own binary sequentially, so it does not
+//! overlap with `daemon_lifecycle.rs`. The single test below runs both
+//! scenarios in sequence to avoid in-binary parallelism, and a drop guard
+//! stops the daemon even if an assertion panics partway through.
+
+use std::net::{SocketAddr, TcpStream};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+const DAEMON_ADDR: &str = "127.0.0.1:3200";
+const PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+
+struct DaemonStopGuard {
+    bin: String,
+}
+
+impl Drop for DaemonStopGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new(&self.bin)
+            .args(["daemon", "stop"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn session_create_autostarts_then_reuses_daemon() {
+    let bin = env!("CARGO_BIN_EXE_ozmux").to_string();
+    assert!(
+        !daemon_running(),
+        "a daemon is already running on {DAEMON_ADDR}; stop it before running this test"
+    );
+    let _guard = DaemonStopGuard { bin: bin.clone() };
+
+    let auto = run_create(&bin, "autostart-session").await;
+    assert!(
+        auto.status.success(),
+        "session create (auto-start) failed: {auto:?}"
+    );
+    assert_single_id_line(&auto.stdout, "auto-start");
+    assert!(
+        daemon_running(),
+        "daemon should be running after auto-start"
+    );
+
+    let reuse = run_create(&bin, "reuse-session").await;
+    assert!(
+        reuse.status.success(),
+        "session create (reuse) failed: {reuse:?}"
+    );
+    assert_single_id_line(&reuse.stdout, "reuse");
+}
+
+async fn run_create(bin: &str, name: &str) -> std::process::Output {
+    Command::new(bin)
+        .args(["session", "create", "-s", name])
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .expect("spawn ozmux session create")
+}
+
+fn daemon_running() -> bool {
+    let Ok(addr) = DAEMON_ADDR.parse::<SocketAddr>() else {
+        return false;
+    };
+    TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).is_ok()
+}
+
+fn assert_single_id_line(stdout: &[u8], label: &str) {
+    let text = String::from_utf8(stdout.to_vec()).expect("stdout is utf-8");
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "{label}: expected exactly one stdout line (the session id), got {lines:?}"
+    );
+    assert!(
+        !lines[0].trim().is_empty(),
+        "{label}: session id line is empty"
+    );
+}

--- a/cli/tests/session_create.rs
+++ b/cli/tests/session_create.rs
@@ -9,12 +9,12 @@
 //! scenarios in sequence to avoid in-binary parallelism, and a drop guard
 //! stops the daemon even if an assertion panics partway through.
 
+use daemon_bootstrap::HTTP_ADDR as DAEMON_ADDR;
 use std::net::{SocketAddr, TcpStream};
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
 
-const DAEMON_ADDR: &str = "127.0.0.1:3200";
 const PROBE_TIMEOUT: Duration = Duration::from_millis(200);
 
 struct DaemonStopGuard {


### PR DESCRIPTION
## Problem

The `ozmux` CLI could only manage the daemon lifecycle (`daemon {start,stop,status}`). There was no way to create a session from the command line — the only path was the web UI's `POST /sessions`. tmux-style session management from the CLI was missing.

## Solution

Adds a tmux-flavored `session` subcommand group with its first verb, `create`:

```
ozmux session create [-s|--name <NAME>]
```

`session create` auto-starts the daemon if it is not already running, `POST`s to the daemon's `/sessions` endpoint, and prints the new session id (and only the id) to stdout, so it composes cleanly in scripts (`SID=$(ozmux session create -s work)`).

Affected area: `cli/` only — the daemon's `POST /sessions` endpoint already existed and is unchanged.

Key changes:

- **`daemon::ensure_running`** — the detached-start logic was extracted out of `start_detached()` into a quiet, reusable core in `cli/src/commands/daemon.rs`. It writes nothing to stdout/stderr on success, so callers with their own stdout contract get a clean stream. The `daemon start` command keeps its PID / "already running" output in its own wrapper, so `daemon start`'s observable behavior is unchanged.
- **`session create`** — new `cli/src/commands/session.rs` dispatcher and `session/create.rs` command. The request omits `name` entirely when not provided; any `2xx` is treated as success; non-`2xx` bails with the status and response body.
- **`daemon::http_client`** — a shared helper that builds a timed `reqwest` client, deduplicating the client-builder boilerplate previously repeated in the start, status, and create paths.
- Enabled the `json` feature on the workspace `reqwest` dependency and added `serde` to the CLI crate.

## Test Plan

- [x] `cargo test -p ozmux_cli` — `daemon_lifecycle` and the new `session_create` integration test both pass. The new test is panic-safe (a `Drop` guard stops the daemon) and exercises both the auto-start and reuse paths, asserting stdout is exactly the session id.
- [x] `cargo clippy -p ozmux_cli --tests -- -D warnings` — clean.
- [x] `cargo fmt` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)