### PR TITLE
feat: tmux-style swap-pane (Prefix+{ / Prefix+})

### DIFF
--- a/daemon/configs/src/raw.rs
+++ b/daemon/configs/src/raw.rs
@@ -75,7 +75,7 @@ mod tests {
     fn empty_raw_returns_defaults() {
         let raw = RawConfigs::default();
         let merged = raw.apply_to(OzmuxConfigs::default());
-        assert_eq!(merged.shortcuts.bindings.len(), 32);
+        assert_eq!(merged.shortcuts.bindings.len(), 34);
         assert!(matches!(
             merged.shortcuts.bindings[0].action,
             Action::ClosePane

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -887,14 +887,24 @@ mod tests {
         let prev = s.bindings.iter().any(|b| {
             b.chord.key == Key::Char('{')
                 && b.chord.modifiers.shift
-                && matches!(b.action, Action::SwapPane { offset: SwapOffset::Prev })
+                && matches!(
+                    b.action,
+                    Action::SwapPane {
+                        offset: SwapOffset::Prev
+                    }
+                )
                 && b.repeatable
         });
         assert!(prev, "missing Prefix+{{ -> SwapPane(Prev) (repeatable)");
         let next = s.bindings.iter().any(|b| {
             b.chord.key == Key::Char('}')
                 && b.chord.modifiers.shift
-                && matches!(b.action, Action::SwapPane { offset: SwapOffset::Next })
+                && matches!(
+                    b.action,
+                    Action::SwapPane {
+                        offset: SwapOffset::Next
+                    }
+                )
                 && b.repeatable
         });
         assert!(next, "missing Prefix+}} -> SwapPane(Next) (repeatable)");

--- a/daemon/configs/src/shortcuts.rs
+++ b/daemon/configs/src/shortcuts.rs
@@ -447,6 +447,32 @@ impl Default for Shortcuts {
                     action: Action::NewWindow,
                     repeatable: false,
                 },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('{'),
+                        modifiers: Modifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::SwapPane {
+                        offset: SwapOffset::Prev,
+                    },
+                    repeatable: true,
+                },
+                Binding {
+                    chord: KeyChord {
+                        key: Key::Char('}'),
+                        modifiers: Modifiers {
+                            shift: true,
+                            ..Default::default()
+                        },
+                    },
+                    action: Action::SwapPane {
+                        offset: SwapOffset::Next,
+                    },
+                    repeatable: true,
+                },
             ],
             repeat_timeout_ms: 500,
         }
@@ -856,11 +882,30 @@ mod tests {
     }
 
     #[test]
+    fn default_bindings_include_swap_pane_prev_and_next() {
+        let s = Shortcuts::default();
+        let prev = s.bindings.iter().any(|b| {
+            b.chord.key == Key::Char('{')
+                && b.chord.modifiers.shift
+                && matches!(b.action, Action::SwapPane { offset: SwapOffset::Prev })
+                && b.repeatable
+        });
+        assert!(prev, "missing Prefix+{{ -> SwapPane(Prev) (repeatable)");
+        let next = s.bindings.iter().any(|b| {
+            b.chord.key == Key::Char('}')
+                && b.chord.modifiers.shift
+                && matches!(b.action, Action::SwapPane { offset: SwapOffset::Next })
+                && b.repeatable
+        });
+        assert!(next, "missing Prefix+}} -> SwapPane(Next) (repeatable)");
+    }
+
+    #[test]
     fn default_shortcuts_serializes_to_stable_json() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         assert_eq!(
             json,
-            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"},"repeatable":false},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"choose-tree"},"repeatable":false},{"key":"&","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"close-activity"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"},"repeatable":false},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"},"repeatable":false},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"},"repeatable":false},{"key":"n","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window","offset":"next"},"repeatable":true},{"key":"p","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window","offset":"prev"},"repeatable":true},{"key":"0","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":0},"repeatable":false},{"key":"1","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":1},"repeatable":false},{"key":"2","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":2},"repeatable":false},{"key":"3","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":3},"repeatable":false},{"key":"4","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":4},"repeatable":false},{"key":"5","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":5},"repeatable":false},{"key":"6","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":6},"repeatable":false},{"key":"7","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":7},"repeatable":false},{"key":"8","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":8},"repeatable":false},{"key":"9","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":9},"repeatable":false},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"},"repeatable":false},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"},"repeatable":false},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"},"repeatable":false},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"},"repeatable":false},{"key":"ArrowLeft","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"left"},"repeatable":true},{"key":"ArrowRight","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"right"},"repeatable":true},{"key":"ArrowUp","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"up"},"repeatable":true},{"key":"ArrowDown","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"down"},"repeatable":true},{"key":",","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"rename-window"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"new-window"},"repeatable":false}],"repeat_timeout_ms":500}"#
+            r#"{"prefix":{"key":"b","modifiers":{"ctrl":true,"shift":false,"alt":false,"meta":false},"timeout_ms":2000},"bindings":[{"key":"x","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"close-pane"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"split-pane","direction":"vertical"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"new-terminal-activity"},"repeatable":false},{"key":"w","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"choose-tree"},"repeatable":false},{"key":"&","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"close-activity"},"repeatable":false},{"key":"s","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"horizontal"},"repeatable":false},{"key":"v","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"break-activity-to-pane","direction":"vertical"},"repeatable":false},{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"next"},"repeatable":false},{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-activity","offset":"prev"},"repeatable":false},{"key":"n","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window","offset":"next"},"repeatable":true},{"key":"p","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window","offset":"prev"},"repeatable":true},{"key":"0","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":0},"repeatable":false},{"key":"1","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":1},"repeatable":false},{"key":"2","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":2},"repeatable":false},{"key":"3","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":3},"repeatable":false},{"key":"4","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":4},"repeatable":false},{"key":"5","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":5},"repeatable":false},{"key":"6","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":6},"repeatable":false},{"key":"7","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":7},"repeatable":false},{"key":"8","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":8},"repeatable":false},{"key":"9","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-window-number","index":9},"repeatable":false},{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"left"},"repeatable":false},{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"down"},"repeatable":false},{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"up"},"repeatable":false},{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"focus-pane","direction":"right"},"repeatable":false},{"key":"ArrowLeft","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"left"},"repeatable":true},{"key":"ArrowRight","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"right"},"repeatable":true},{"key":"ArrowUp","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"up"},"repeatable":true},{"key":"ArrowDown","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"resize-pane","direction":"down"},"repeatable":true},{"key":",","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":false},"action":{"type":"rename-window"},"repeatable":false},{"key":"c","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"new-window"},"repeatable":false},{"key":"{","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"swap-pane","offset":"prev"},"repeatable":true},{"key":"}","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":false},"action":{"type":"swap-pane","offset":"next"},"repeatable":true}],"repeat_timeout_ms":500}"#
         );
     }
 }

--- a/daemon/frontend/src/layout/swapPane.test.ts
+++ b/daemon/frontend/src/layout/swapPane.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { swapPane } from './swapPane';
+import type { PaneId, WindowId } from './types';
+
+describe('swapPane', () => {
+  const wid = 'w1' as WindowId;
+  const pid = 'p1' as PaneId;
+
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    'prev',
+    'next',
+  ] as const)('POSTs %s offset to the swap-pane endpoint', async (offset) => {
+    await swapPane(wid, pid, offset);
+    expect(global.fetch).toHaveBeenCalledWith(`/windows/${wid}/panes/${pid}/swap`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ offset }),
+    });
+  });
+
+  it('console.warns on non-2xx response', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(null, { status: 500 }),
+    );
+    await swapPane(wid, pid, 'next');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('console.warns when fetch rejects', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('net down'));
+    await swapPane(wid, pid, 'prev');
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/daemon/frontend/src/layout/swapPane.ts
+++ b/daemon/frontend/src/layout/swapPane.ts
@@ -1,0 +1,22 @@
+import { swapPaneEndpoint } from '../terminal/api';
+import type { PaneId, WindowId } from './types';
+
+/** POSTs a swap request; the layout update arrives over the layout broadcast WS. */
+export async function swapPane(
+  windowId: WindowId,
+  paneId: PaneId,
+  offset: 'prev' | 'next',
+): Promise<void> {
+  try {
+    const resp = await fetch(swapPaneEndpoint(windowId, paneId), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ offset }),
+    });
+    if (!resp.ok) {
+      console.warn('swap pane failed', { windowId, paneId, offset, status: resp.status });
+    }
+  } catch (e) {
+    console.warn('swap pane request errored', { windowId, paneId, offset, error: e });
+  }
+}

--- a/daemon/frontend/src/shortcuts/actionDispatch.test.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PaneId, WindowId } from '../layout/types';
 import { makeShortcutContext } from './__test-helpers';
 import { actionToHandler } from './actionDispatch';
 import type { Action } from './wire';
@@ -409,6 +410,42 @@ describe('actionToHandler', () => {
     }
     handler();
     expect(openChooseTree).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'prev',
+    'next',
+  ] as const)('returns a handler that POSTs swap-pane with %s offset', async (offset) => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const ctx = makeShortcutContext({
+      activeWindow: () => 'wid-1' as WindowId,
+      activePane: () => 'pid-1' as PaneId,
+    });
+    const handler = actionToHandler({ type: 'swap-pane', offset }, ctx);
+    expect(handler).not.toBeNull();
+    handler?.();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('/windows/wid-1/panes/pid-1/swap', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ offset }),
+    });
+  });
+
+  it('swap-pane handler is a no-op when active pane is null', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const ctx = makeShortcutContext({
+      activeWindow: () => 'wid-1' as WindowId,
+      activePane: () => null,
+    });
+    const handler = actionToHandler({ type: 'swap-pane', offset: 'next' }, ctx);
+    handler?.();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('returns a handler that POSTs /windows with the active session id', async () => {

--- a/daemon/frontend/src/shortcuts/actionDispatch.ts
+++ b/daemon/frontend/src/shortcuts/actionDispatch.ts
@@ -7,6 +7,7 @@ import { focusPane } from '../layout/focusPane';
 import { newTerminalActivity } from '../layout/newTerminalActivity';
 import { resizePane } from '../layout/resizePane';
 import { splitPane } from '../layout/splitPane';
+import { swapPane } from '../layout/swapPane';
 import type { ActivityId, PaneId, WindowId } from '../layout/types';
 import type { SessionView } from '../statusbar/types';
 import { windowSelect } from '../statusbar/windowSelect';
@@ -85,6 +86,10 @@ export function actionToHandler(action: Action, ctx: ShortcutContext): (() => vo
     case 'focus-pane': {
       const direction = action.direction;
       return () => withActiveWindow(ctx, (w) => focusPane(w, direction));
+    }
+    case 'swap-pane': {
+      const offset = action.offset;
+      return () => withActivePane(ctx, (w, p) => swapPane(w, p, offset));
     }
     case 'resize-pane': {
       const direction = action.direction;

--- a/daemon/frontend/src/shortcuts/wire.test.ts
+++ b/daemon/frontend/src/shortcuts/wire.test.ts
@@ -125,7 +125,31 @@ describe('parseShortcuts', () => {
     ).toBeNull();
   });
 
-  it('drops bindings with unknown action type but keeps the rest', () => {
+  it('parses a swap-pane binding for prev and next offsets', () => {
+    const payload = {
+      ...DEFAULT_JSON,
+      bindings: [
+        DEFAULT_JSON.bindings[0],
+        {
+          key: '{',
+          modifiers: { ctrl: false, shift: true, alt: false, meta: false },
+          action: { type: 'swap-pane', offset: 'prev' },
+        },
+        {
+          key: '}',
+          modifiers: { ctrl: false, shift: true, alt: false, meta: false },
+          action: { type: 'swap-pane', offset: 'next' },
+        },
+      ],
+    };
+    const out = parseShortcuts(payload);
+    expect(out).not.toBeNull();
+    expect(out?.bindings).toHaveLength(3);
+    expect(out?.bindings[1].action).toEqual({ type: 'swap-pane', offset: 'prev' });
+    expect(out?.bindings[2].action).toEqual({ type: 'swap-pane', offset: 'next' });
+  });
+
+  it('drops bindings with an unknown action type but keeps the rest', () => {
     const withUnknown = {
       ...DEFAULT_JSON,
       bindings: [
@@ -133,7 +157,7 @@ describe('parseShortcuts', () => {
         {
           key: 'q',
           modifiers: { ctrl: false, shift: false, alt: false, meta: false },
-          action: { type: 'swap-pane', offset: 'next' },
+          action: { type: 'definitely-not-a-real-action' },
         },
       ],
     };

--- a/daemon/frontend/src/shortcuts/wire.ts
+++ b/daemon/frontend/src/shortcuts/wire.ts
@@ -63,6 +63,10 @@ const ActionSchema = z.discriminatedUnion('type', [
     type: z.literal('resize-pane'),
     direction: z.enum(['up', 'down', 'left', 'right']),
   }),
+  z.object({
+    type: z.literal('swap-pane'),
+    offset: z.enum(['prev', 'next']),
+  }),
 ]);
 
 const PrefixSchema = KeyChordFieldsSchema.extend({

--- a/daemon/frontend/src/terminal/api.ts
+++ b/daemon/frontend/src/terminal/api.ts
@@ -20,6 +20,7 @@ export const cycleActivityEndpoint = (wid: string, pid: string) =>
 export const focusPaneEndpoint = (wid: string) => `/windows/${wid}/focus-pane`;
 export const resizePaneEndpoint = (wid: string, pid: string) =>
   `/windows/${wid}/panes/${pid}/resize`;
+export const swapPaneEndpoint = (wid: string, pid: string) => `/windows/${wid}/panes/${pid}/swap`;
 export const windowDimensionsEndpoint = (wid: string) => `/windows/${wid}/dimensions`;
 
 export const vtTerminalWsUrl = (

--- a/daemon/http_server/src/handlers/windows/panes.rs
+++ b/daemon/http_server/src/handlers/windows/panes.rs
@@ -12,6 +12,7 @@ pub mod cycle_activity;
 pub mod resize;
 pub mod spawn_terminal;
 pub mod split;
+pub mod swap;
 
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -22,6 +23,7 @@ pub fn router() -> Router<AppState> {
         )
         .route("/{pane_id}/split", post(split::split))
         .route("/{pane_id}/resize", post(resize::resize))
+        .route("/{pane_id}/swap", post(swap::swap))
         .route("/{pane_id}", method_delete(close::close))
         .nest("/{pane_id}/activities", activities::router())
 }

--- a/daemon/http_server/src/handlers/windows/panes/swap.rs
+++ b/daemon/http_server/src/handlers/windows/panes/swap.rs
@@ -10,14 +10,12 @@ use axum::{
 use ozmux_multiplexer::{PaneId, SwapOffset, WindowId};
 use serde::Deserialize;
 
-/// Request body: `{ "offset": "prev" | "next" }`.
 #[derive(Deserialize)]
 pub struct SwapRequest {
     offset: SwapOffset,
 }
 
-/// Handler for `POST /windows/{wid}/panes/{pid}/swap`. Delegates to
-/// [`AppState::swap_pane`], which decides whether to broadcast.
+/// Handler for `POST /windows/{wid}/panes/{pid}/swap`.
 pub async fn swap(
     State(state): State<AppState>,
     Path((wid, pid)): Path<(WindowId, PaneId)>,

--- a/daemon/http_server/src/handlers/windows/panes/swap.rs
+++ b/daemon/http_server/src/handlers/windows/panes/swap.rs
@@ -1,0 +1,194 @@
+//! `POST /windows/{wid}/panes/{pid}/swap` — swap the named pane with its
+//! previous/next neighbor in pane-index order.
+
+use crate::{AppState, error::HttpResult};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use ozmux_multiplexer::{PaneId, SwapOffset, WindowId};
+use serde::Deserialize;
+
+/// Request body: `{ "offset": "prev" | "next" }`.
+#[derive(Deserialize)]
+pub struct SwapRequest {
+    offset: SwapOffset,
+}
+
+/// Handler for `POST /windows/{wid}/panes/{pid}/swap`. Delegates to
+/// [`AppState::swap_pane`], which decides whether to broadcast.
+pub async fn swap(
+    State(state): State<AppState>,
+    Path((wid, pid)): Path<(WindowId, PaneId)>,
+    Json(body): Json<SwapRequest>,
+) -> HttpResult<StatusCode> {
+    state.swap_pane(&wid, &pid, body.offset).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{bootstrap_default, fresh_state, router_with};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use ozmux_multiplexer::{Activity, ActivityId, PaneId, Side, SplitOrientation, WindowId};
+    use tower::ServiceExt;
+
+    async fn split_via_window(
+        state: &crate::AppState,
+        wid: &WindowId,
+        target: &PaneId,
+        orient: SplitOrientation,
+    ) -> PaneId {
+        let new_pane_id = PaneId::new();
+        let new_activity_id = ActivityId::new();
+        state
+            .multiplexer
+            .with_window_or_404(wid, |w| {
+                w.split_pane(
+                    target,
+                    new_pane_id.clone(),
+                    Activity::terminal(new_activity_id.clone()),
+                    Side::After,
+                    orient,
+                )
+            })
+            .await
+            .unwrap();
+        state
+            .multiplexer
+            .pane_owner_window
+            .insert(new_pane_id.clone(), wid.clone());
+        new_pane_id
+    }
+
+    #[tokio::test]
+    async fn swap_happy_path_returns_204_and_broadcasts() {
+        let state = fresh_state();
+        let (_sid, wid, left, _aid) = bootstrap_default(&state).await;
+        let _right = split_via_window(&state, &wid, &left, SplitOrientation::Horizontal).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid, left))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let view = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("publish timed out")
+            .expect("recv error");
+        assert_eq!(view["id"].as_str(), Some(wid.as_ref()));
+    }
+
+    #[tokio::test]
+    async fn swap_single_pane_returns_204_without_broadcast() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let mut rx = state.layout_broadcast.subscribe_or_create(&wid);
+        let (router, _state) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        let view = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(view.is_err(), "no broadcast expected for single-pane no-op");
+    }
+
+    #[tokio::test]
+    async fn swap_unknown_pane_returns_404() {
+        let state = fresh_state();
+        let (_sid, wid, _pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid, PaneId::new()))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn swap_wrong_window_returns_409() {
+        let state = fresh_state();
+        let (sid, _wid_a, pid_a, _aid) = bootstrap_default(&state).await;
+        let (wid_b, _, _) = state
+            .multiplexer
+            .create_window(Some(&sid), None)
+            .await
+            .unwrap();
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid_b, pid_a))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"next"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn swap_invalid_offset_returns_422() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"sideways"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn swap_malformed_json_returns_400() {
+        let state = fresh_state();
+        let (_sid, wid, pid, _aid) = bootstrap_default(&state).await;
+        let (router, _) = router_with(state);
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/windows/{}/panes/{}/swap", wid, pid))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"offset":"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/daemon/http_server/src/state.rs
+++ b/daemon/http_server/src/state.rs
@@ -282,6 +282,27 @@ impl AppState {
         Ok(())
     }
 
+    /// Swap the named pane's contents with its prev/next neighbor in the
+    /// window's pane-index order. Publishes a layout update only when the
+    /// mutation was applied (a single-pane window returns Ok and skips the
+    /// broadcast, matching `resize_pane`'s soft-no-op behavior).
+    pub async fn swap_pane(
+        &self,
+        wid: &WindowId,
+        pid: &PaneId,
+        offset: ozmux_multiplexer::SwapOffset,
+    ) -> HttpResult<()> {
+        self.ensure_pane_in_window(wid, pid)?;
+        let outcome = self
+            .multiplexer
+            .with_window_or_404(wid, |w| w.swap_pane(pid, offset))
+            .await?;
+        if matches!(outcome, ozmux_multiplexer::SwapOutcome::Swapped { .. }) {
+            self.publish_window_layout(wid).await;
+        }
+        Ok(())
+    }
+
     /// Add an Activity to a Pane and broadcast the new layout. For
     /// terminal-kind activities, also spawn the backing PTY; on spawn
     /// failure the activity record is rolled back before returning the

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -15,7 +15,8 @@ pub use window::resize::ResizePaneOutcome;
 pub use window::{
     Activity, ActivityId, ActivityKind, BrowserProfile, Cell, CellId, CloseOutcome, CycleDirection,
     LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
-    Side, SplitCell, SplitOrientation, Window, WindowDimensions, WindowId, WindowState,
+    Side, SplitCell, SplitOrientation, SwapOffset, SwapOutcome, Window, WindowDimensions,
+    WindowId, WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/lib.rs
+++ b/daemon/multiplexer/src/lib.rs
@@ -15,8 +15,8 @@ pub use window::resize::ResizePaneOutcome;
 pub use window::{
     Activity, ActivityId, ActivityKind, BrowserProfile, Cell, CellId, CloseOutcome, CycleDirection,
     LayoutCellState, Pane, PaneCell, PaneDirection, PaneId, PaneState, RootCell, SetActiveOutcome,
-    Side, SplitCell, SplitOrientation, SwapOffset, SwapOutcome, Window, WindowDimensions,
-    WindowId, WindowState,
+    Side, SplitCell, SplitOrientation, SwapOffset, SwapOutcome, Window, WindowDimensions, WindowId,
+    WindowState,
 };
 
 /// Backwards-compatible alias for the active-pane outcome. Use

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -7,7 +7,7 @@ pub mod cells;
 pub mod direction;
 pub mod pane;
 pub(crate) mod resize;
-pub mod swap;
+pub(crate) mod swap;
 #[allow(clippy::module_inception)]
 mod window;
 

--- a/daemon/multiplexer/src/window.rs
+++ b/daemon/multiplexer/src/window.rs
@@ -7,6 +7,7 @@ pub mod cells;
 pub mod direction;
 pub mod pane;
 pub(crate) mod resize;
+pub mod swap;
 #[allow(clippy::module_inception)]
 mod window;
 
@@ -17,4 +18,5 @@ pub use cells::{
 pub use direction::PaneDirection;
 pub use pane::activity::{Activity, ActivityId, ActivityKind, BrowserProfile};
 pub use pane::{CycleDirection, Pane, PaneId, PaneState, SetActiveOutcome};
+pub use swap::{SwapOffset, SwapOutcome};
 pub use window::{Window, WindowDimensions, WindowId, WindowState};

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -231,6 +231,28 @@ impl LayoutCellState {
         Ok(())
     }
 
+    /// Swap the `pane:` field of two `PaneCell` leaves. Errors with
+    /// `InvalidCellType` if either id resolves to `Cell::Root` or
+    /// `Cell::Split`. Cell ids, parent pointers, splits, and weights are
+    /// untouched — only the pane payload of each cell moves.
+    pub fn swap_panes(&mut self, a: &CellId, b: &CellId) -> MultiplexerResult {
+        let pane_a = match self.cell(a)? {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => return Err(MultiplexerError::InvalidCellType(a.clone())),
+        };
+        let pane_b = match self.cell(b)? {
+            Cell::Pane(p) => p.pane.clone(),
+            _ => return Err(MultiplexerError::InvalidCellType(b.clone())),
+        };
+        if let Cell::Pane(p) = self.cell_mut(a)? {
+            p.pane = pane_b;
+        }
+        if let Cell::Pane(p) = self.cell_mut(b)? {
+            p.pane = pane_a;
+        }
+        Ok(())
+    }
+
     fn collect_panes(&self, id: &CellId, out: &mut Vec<PaneId>) -> MultiplexerResult {
         match self.cell(id)? {
             Cell::Root(r) => {
@@ -977,5 +999,46 @@ mod tests {
         assert!(state.cell(&split_id).is_err());
         assert!(state.cell(&pane_a).is_err());
         assert!(state.cell(&pane_b).is_err());
+    }
+
+    #[test]
+    fn swap_panes_exchanges_pane_field_between_two_pane_cells() {
+        let mut state = LayoutCellState::default();
+        let pa = PaneId::new();
+        let pb = PaneId::new();
+        let (_root, cell_a) = state.new_window_layout(pa.clone());
+        let cell_b = state.new_pane(pb.clone(), None);
+        let _split = state
+            .split_cell(cell_a.clone(), cell_b.clone(), Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+
+        state.swap_panes(&cell_a, &cell_b).unwrap();
+
+        match state.cell(&cell_a).unwrap() {
+            Cell::Pane(p) => assert_eq!(p.pane, pb),
+            _ => panic!("cell_a should still be a Pane"),
+        }
+        match state.cell(&cell_b).unwrap() {
+            Cell::Pane(p) => assert_eq!(p.pane, pa),
+            _ => panic!("cell_b should still be a Pane"),
+        }
+    }
+
+    #[test]
+    fn swap_panes_errors_when_either_cell_is_not_a_pane() {
+        let mut state = LayoutCellState::default();
+        let pa = PaneId::new();
+        let pb = PaneId::new();
+        let (root, cell_a) = state.new_window_layout(pa.clone());
+        let cell_b = state.new_pane(pb.clone(), None);
+        let split = state
+            .split_cell(cell_a.clone(), cell_b, Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+
+        let err = state.swap_panes(&cell_a, &split).unwrap_err();
+        assert!(matches!(err, MultiplexerError::InvalidCellType(_)));
+
+        let err = state.swap_panes(&root, &cell_a).unwrap_err();
+        assert!(matches!(err, MultiplexerError::InvalidCellType(_)));
     }
 }

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -190,17 +190,18 @@ impl LayoutCellState {
         }
     }
 
-    /// Collect every `PaneId` reachable from `start`'s subtree (Root or Split
-    /// roots are descended; Pane leaves contribute their `PaneId`).
+    /// Collect every `PaneId` reachable from `start`'s subtree, in
+    /// depth-first lhs-before-rhs order.
     pub fn pane_ids_in_subtree(&self, start: &CellId) -> MultiplexerResult<Vec<PaneId>> {
-        let mut out = Vec::new();
-        self.collect_panes(start, &mut out)?;
-        Ok(out)
+        Ok(self
+            .ordered_pane_cells(start)?
+            .into_iter()
+            .map(|(_, p)| p)
+            .collect())
     }
 
-    /// Same traversal as `pane_ids_in_subtree` but also yields each leaf's
-    /// `CellId`. Used by `Window::swap_pane` to address two cells for the
-    /// pane-field swap.
+    /// Collect every pane leaf reachable from `start`, yielding each leaf's
+    /// (`CellId`, `PaneId`) in depth-first lhs-before-rhs order.
     pub(crate) fn ordered_pane_cells(
         &self,
         start: &CellId,
@@ -236,37 +237,13 @@ impl LayoutCellState {
     /// `Cell::Split`. Cell ids, parent pointers, splits, and weights are
     /// untouched — only the pane payload of each cell moves.
     pub(crate) fn swap_panes(&mut self, a: &CellId, b: &CellId) -> MultiplexerResult {
-        let pane_a = match self.cell(a)? {
-            Cell::Pane(p) => p.pane.clone(),
-            _ => return Err(MultiplexerError::InvalidCellType(a.clone())),
+        let [Some(cell_a), Some(cell_b)] = self.0.get_disjoint_mut([a, b]) else {
+            return Err(MultiplexerError::CellNotFound(a.clone()));
         };
-        let pane_b = match self.cell(b)? {
-            Cell::Pane(p) => p.pane.clone(),
-            _ => return Err(MultiplexerError::InvalidCellType(b.clone())),
+        let (Cell::Pane(pa), Cell::Pane(pb)) = (cell_a, cell_b) else {
+            return Err(MultiplexerError::InvalidCellType(a.clone()));
         };
-        if let Cell::Pane(p) = self.cell_mut(a)? {
-            p.pane = pane_b;
-        }
-        if let Cell::Pane(p) = self.cell_mut(b)? {
-            p.pane = pane_a;
-        }
-        Ok(())
-    }
-
-    fn collect_panes(&self, id: &CellId, out: &mut Vec<PaneId>) -> MultiplexerResult {
-        match self.cell(id)? {
-            Cell::Root(r) => {
-                let child = r.child.clone();
-                self.collect_panes(&child, out)?;
-            }
-            Cell::Split(s) => {
-                let lhs = s.lhs_cell.clone();
-                let rhs = s.rhs_cell.clone();
-                self.collect_panes(&lhs, out)?;
-                self.collect_panes(&rhs, out)?;
-            }
-            Cell::Pane(p) => out.push(p.pane.clone()),
-        }
+        std::mem::swap(&mut pa.pane, &mut pb.pane);
         Ok(())
     }
 

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -198,6 +198,39 @@ impl LayoutCellState {
         Ok(out)
     }
 
+    /// Same traversal as `pane_ids_in_subtree` but also yields each leaf's
+    /// `CellId`. Used by `Window::swap_pane` to address two cells for the
+    /// pane-field swap.
+    pub fn ordered_pane_cells(
+        &self,
+        start: &CellId,
+    ) -> MultiplexerResult<Vec<(CellId, PaneId)>> {
+        let mut out = Vec::new();
+        self.collect_pane_cells(start, &mut out)?;
+        Ok(out)
+    }
+
+    fn collect_pane_cells(
+        &self,
+        id: &CellId,
+        out: &mut Vec<(CellId, PaneId)>,
+    ) -> MultiplexerResult {
+        match self.cell(id)? {
+            Cell::Root(r) => {
+                let child = r.child.clone();
+                self.collect_pane_cells(&child, out)?;
+            }
+            Cell::Split(s) => {
+                let lhs = s.lhs_cell.clone();
+                let rhs = s.rhs_cell.clone();
+                self.collect_pane_cells(&lhs, out)?;
+                self.collect_pane_cells(&rhs, out)?;
+            }
+            Cell::Pane(p) => out.push((id.clone(), p.pane.clone())),
+        }
+        Ok(())
+    }
+
     fn collect_panes(&self, id: &CellId, out: &mut Vec<PaneId>) -> MultiplexerResult {
         match self.cell(id)? {
             Cell::Root(r) => {
@@ -900,6 +933,29 @@ mod tests {
     fn split_ratio_normalizes_zero_total_to_half() {
         assert_eq!(LayoutCellState::split_ratio(0.0, 0.0), 0.5);
         assert_eq!(LayoutCellState::split_ratio(1.0, 3.0), 0.25);
+    }
+
+    #[test]
+    fn ordered_pane_cells_returns_cell_id_and_pane_id_in_dfs_order() {
+        let mut state = LayoutCellState::default();
+        let pa = PaneId::new();
+        let pb = PaneId::new();
+        let pc = PaneId::new();
+        let (root, cell_a) = state.new_window_layout(pa.clone());
+        let cell_b = state.new_pane(pb.clone(), None);
+        let split_ab = state
+            .split_cell(cell_a.clone(), cell_b.clone(), Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+        let cell_c = state.new_pane(pc.clone(), None);
+        let _split_abc = state
+            .split_cell(split_ab, cell_c.clone(), Side::After, SplitOrientation::Vertical)
+            .unwrap();
+
+        let ordered = state.ordered_pane_cells(&root).unwrap();
+        assert_eq!(
+            ordered,
+            vec![(cell_a, pa), (cell_b, pb), (cell_c, pc)]
+        );
     }
 
     #[test]

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -966,18 +966,25 @@ mod tests {
         let (root, cell_a) = state.new_window_layout(pa.clone());
         let cell_b = state.new_pane(pb.clone(), None);
         let split_ab = state
-            .split_cell(cell_a.clone(), cell_b.clone(), Side::After, SplitOrientation::Horizontal)
+            .split_cell(
+                cell_a.clone(),
+                cell_b.clone(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
             .unwrap();
         let cell_c = state.new_pane(pc.clone(), None);
         let _split_abc = state
-            .split_cell(split_ab, cell_c.clone(), Side::After, SplitOrientation::Vertical)
+            .split_cell(
+                split_ab,
+                cell_c.clone(),
+                Side::After,
+                SplitOrientation::Vertical,
+            )
             .unwrap();
 
         let ordered = state.ordered_pane_cells(&root).unwrap();
-        assert_eq!(
-            ordered,
-            vec![(cell_a, pa), (cell_b, pb), (cell_c, pc)]
-        );
+        assert_eq!(ordered, vec![(cell_a, pa), (cell_b, pb), (cell_c, pc)]);
     }
 
     #[test]
@@ -1009,7 +1016,12 @@ mod tests {
         let (_root, cell_a) = state.new_window_layout(pa.clone());
         let cell_b = state.new_pane(pb.clone(), None);
         let _split = state
-            .split_cell(cell_a.clone(), cell_b.clone(), Side::After, SplitOrientation::Horizontal)
+            .split_cell(
+                cell_a.clone(),
+                cell_b.clone(),
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
             .unwrap();
 
         state.swap_panes(&cell_a, &cell_b).unwrap();
@@ -1032,7 +1044,12 @@ mod tests {
         let (root, cell_a) = state.new_window_layout(pa.clone());
         let cell_b = state.new_pane(pb.clone(), None);
         let split = state
-            .split_cell(cell_a.clone(), cell_b, Side::After, SplitOrientation::Horizontal)
+            .split_cell(
+                cell_a.clone(),
+                cell_b,
+                Side::After,
+                SplitOrientation::Horizontal,
+            )
             .unwrap();
 
         let err = state.swap_panes(&cell_a, &split).unwrap_err();

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -201,7 +201,8 @@ impl LayoutCellState {
     /// Same traversal as `pane_ids_in_subtree` but also yields each leaf's
     /// `CellId`. Used by `Window::swap_pane` to address two cells for the
     /// pane-field swap.
-    pub fn ordered_pane_cells(
+    #[expect(dead_code, reason = "Window::swap_pane is implemented in a follow-up task")]
+    pub(crate) fn ordered_pane_cells(
         &self,
         start: &CellId,
     ) -> MultiplexerResult<Vec<(CellId, PaneId)>> {
@@ -235,7 +236,8 @@ impl LayoutCellState {
     /// `InvalidCellType` if either id resolves to `Cell::Root` or
     /// `Cell::Split`. Cell ids, parent pointers, splits, and weights are
     /// untouched — only the pane payload of each cell moves.
-    pub fn swap_panes(&mut self, a: &CellId, b: &CellId) -> MultiplexerResult {
+    #[expect(dead_code, reason = "Window::swap_pane is implemented in a follow-up task")]
+    pub(crate) fn swap_panes(&mut self, a: &CellId, b: &CellId) -> MultiplexerResult {
         let pane_a = match self.cell(a)? {
             Cell::Pane(p) => p.pane.clone(),
             _ => return Err(MultiplexerError::InvalidCellType(a.clone())),

--- a/daemon/multiplexer/src/window/cells.rs
+++ b/daemon/multiplexer/src/window/cells.rs
@@ -201,7 +201,6 @@ impl LayoutCellState {
     /// Same traversal as `pane_ids_in_subtree` but also yields each leaf's
     /// `CellId`. Used by `Window::swap_pane` to address two cells for the
     /// pane-field swap.
-    #[expect(dead_code, reason = "Window::swap_pane is implemented in a follow-up task")]
     pub(crate) fn ordered_pane_cells(
         &self,
         start: &CellId,
@@ -236,7 +235,6 @@ impl LayoutCellState {
     /// `InvalidCellType` if either id resolves to `Cell::Root` or
     /// `Cell::Split`. Cell ids, parent pointers, splits, and weights are
     /// untouched — only the pane payload of each cell moves.
-    #[expect(dead_code, reason = "Window::swap_pane is implemented in a follow-up task")]
     pub(crate) fn swap_panes(&mut self, a: &CellId, b: &CellId) -> MultiplexerResult {
         let pane_a = match self.cell(a)? {
             Cell::Pane(p) => p.pane.clone(),

--- a/daemon/multiplexer/src/window/swap.rs
+++ b/daemon/multiplexer/src/window/swap.rs
@@ -1,0 +1,29 @@
+//! Pane swap types: traversal offset and mutation outcome.
+
+use crate::window::pane::PaneId;
+use serde::{Deserialize, Serialize};
+
+/// Selects the swap target relative to the active pane in the depth-first
+/// leaf traversal of the window's cell tree. Mirrors
+/// `ozmux_configs::SwapOffset` so the multiplexer crate stays free of the
+/// `configs` dependency (same pattern as `PaneDirection`).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SwapOffset {
+    /// Swap with the previous pane (wraps around at the start).
+    Prev,
+    /// Swap with the next pane (wraps around at the end).
+    Next,
+}
+
+/// Result of `Window::swap_pane`: whether a swap actually happened, and if
+/// so, the id of the pane that traded places.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SwapOutcome {
+    /// A swap was applied. `other_pane` is the id whose cell now hosts the
+    /// caller's `pane` argument's previous cell.
+    Swapped { other_pane: PaneId },
+    /// Single-pane window — no swap target exists. Callers should treat as
+    /// a soft no-op (HTTP 204, no broadcast).
+    NoOp,
+}

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -617,8 +617,14 @@ mod swap_tests {
 
         let pb = PaneId::new();
         let ab = Activity::terminal(ActivityId::new());
-        w.split_pane(&pa, pb.clone(), ab, Side::After, SplitOrientation::Horizontal)
-            .unwrap();
+        w.split_pane(
+            &pa,
+            pb.clone(),
+            ab,
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
 
         let pc = PaneId::new();
         let ac = Activity::terminal(ActivityId::new());
@@ -656,7 +662,12 @@ mod swap_tests {
         assert_eq!(pane_order(&w), vec![pa.clone(), pb.clone(), pc.clone()]);
 
         let out = w.swap_pane(&pa, SwapOffset::Next).unwrap();
-        assert_eq!(out, SwapOutcome::Swapped { other_pane: pb.clone() });
+        assert_eq!(
+            out,
+            SwapOutcome::Swapped {
+                other_pane: pb.clone()
+            }
+        );
         assert_eq!(pane_order(&w), vec![pb.clone(), pa.clone(), pc]);
     }
 
@@ -664,7 +675,12 @@ mod swap_tests {
     fn swap_pane_prev_wraps_around_from_first() {
         let (mut w, pa, pb, pc) = three_pane_window();
         let out = w.swap_pane(&pa, SwapOffset::Prev).unwrap();
-        assert_eq!(out, SwapOutcome::Swapped { other_pane: pc.clone() });
+        assert_eq!(
+            out,
+            SwapOutcome::Swapped {
+                other_pane: pc.clone()
+            }
+        );
         assert_eq!(pane_order(&w), vec![pc, pb, pa]);
     }
 
@@ -672,7 +688,12 @@ mod swap_tests {
     fn swap_pane_next_wraps_around_from_last() {
         let (mut w, pa, pb, pc) = three_pane_window();
         let out = w.swap_pane(&pc, SwapOffset::Next).unwrap();
-        assert_eq!(out, SwapOutcome::Swapped { other_pane: pa.clone() });
+        assert_eq!(
+            out,
+            SwapOutcome::Swapped {
+                other_pane: pa.clone()
+            }
+        );
         assert_eq!(pane_order(&w), vec![pc, pb, pa]);
     }
 
@@ -714,14 +735,26 @@ mod swap_tests {
         let mut wn = Window::new_with_initial(wid.clone(), "w".into(), pa.clone(), aa);
         let pb = PaneId::new();
         let ab = Activity::terminal(ActivityId::new());
-        wn.split_pane(&pa, pb.clone(), ab, Side::After, SplitOrientation::Horizontal)
-            .unwrap();
+        wn.split_pane(
+            &pa,
+            pb.clone(),
+            ab,
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
 
         let aa2 = Activity::terminal(ActivityId::new());
         let mut wp = Window::new_with_initial(wid, "w".into(), pa.clone(), aa2);
         let ab2 = Activity::terminal(ActivityId::new());
-        wp.split_pane(&pa, pb.clone(), ab2, Side::After, SplitOrientation::Horizontal)
-            .unwrap();
+        wp.split_pane(
+            &pa,
+            pb.clone(),
+            ab2,
+            Side::After,
+            SplitOrientation::Horizontal,
+        )
+        .unwrap();
 
         wn.swap_pane(&pa, SwapOffset::Next).unwrap();
         wp.swap_pane(&pa, SwapOffset::Prev).unwrap();

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -2,6 +2,7 @@ use crate::error::{MultiplexerError, MultiplexerResult};
 use crate::window::cells::{CellId, LayoutCellState, Side, SplitOrientation};
 use crate::window::pane::activity::{Activity, ActivityId};
 use crate::window::pane::{Pane, PaneId, PaneState, SetActiveOutcome};
+use crate::window::swap::{SwapOffset, SwapOutcome};
 use ozmux_macros::NewType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -195,6 +196,42 @@ impl Window {
         self.pane_to_cell.remove(pane_id);
         self.pane_active_points.remove(pane_id);
         Ok(pane.activities.into_iter().map(|a| a.id).collect())
+    }
+
+    /// Swap the named pane's contents with its previous or next neighbor in
+    /// the depth-first leaf traversal of the cell tree. Returns
+    /// `SwapOutcome::NoOp` for a single-pane window. The active pane id is
+    /// not mutated — the same `PaneId` is now hosted by a different cell,
+    /// so focus visually follows the swap.
+    pub fn swap_pane(
+        &mut self,
+        pane: &PaneId,
+        offset: SwapOffset,
+    ) -> MultiplexerResult<SwapOutcome> {
+        let ordered = self.cells.ordered_pane_cells(&self.root_cell)?;
+        if ordered.len() < 2 {
+            return Ok(SwapOutcome::NoOp);
+        }
+        let i = ordered
+            .iter()
+            .position(|(_, p)| p == pane)
+            .ok_or_else(|| MultiplexerError::PaneNotFound(pane.clone()))?;
+        let len = ordered.len() as isize;
+        let delta: isize = match offset {
+            SwapOffset::Prev => -1,
+            SwapOffset::Next => 1,
+        };
+        let j = ((i as isize + delta).rem_euclid(len)) as usize;
+
+        let cell_i = ordered[i].0.clone();
+        let cell_j = ordered[j].0.clone();
+        let other_pane = ordered[j].1.clone();
+
+        self.cells.swap_panes(&cell_i, &cell_j)?;
+        self.pane_to_cell.insert(pane.clone(), cell_j);
+        self.pane_to_cell.insert(other_pane.clone(), cell_i);
+
+        Ok(SwapOutcome::Swapped { other_pane })
     }
 
     /// Set the active pane in this Window. Returns `Unchanged` so the caller
@@ -562,5 +599,132 @@ mod tests {
         assert!(win.pane_active_points.contains_key(&new_pane));
         win.close_pane(&new_pane).unwrap();
         assert!(!win.pane_active_points.contains_key(&new_pane));
+    }
+}
+
+#[cfg(test)]
+mod swap_tests {
+    use super::*;
+    use crate::window::cells::{Side, SplitOrientation};
+    use crate::window::pane::activity::{Activity, ActivityId};
+    use crate::window::swap::{SwapOffset, SwapOutcome};
+
+    fn three_pane_window() -> (Window, PaneId, PaneId, PaneId) {
+        let wid = WindowId::new();
+        let pa = PaneId::new();
+        let aa = Activity::terminal(ActivityId::new());
+        let mut w = Window::new_with_initial(wid, "w".into(), pa.clone(), aa);
+
+        let pb = PaneId::new();
+        let ab = Activity::terminal(ActivityId::new());
+        w.split_pane(&pa, pb.clone(), ab, Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+
+        let pc = PaneId::new();
+        let ac = Activity::terminal(ActivityId::new());
+        w.split_pane(&pb, pc.clone(), ac, Side::After, SplitOrientation::Vertical)
+            .unwrap();
+
+        (w, pa, pb, pc)
+    }
+
+    fn pane_order(w: &Window) -> Vec<PaneId> {
+        w.cells
+            .ordered_pane_cells(&w.root_cell)
+            .unwrap()
+            .into_iter()
+            .map(|(_, p)| p)
+            .collect()
+    }
+
+    #[test]
+    fn swap_pane_in_single_pane_window_returns_noop() {
+        let wid = WindowId::new();
+        let pa = PaneId::new();
+        let aa = Activity::terminal(ActivityId::new());
+        let mut w = Window::new_with_initial(wid, "w".into(), pa.clone(), aa);
+
+        let out = w.swap_pane(&pa, SwapOffset::Next).unwrap();
+        assert_eq!(out, SwapOutcome::NoOp);
+        let out = w.swap_pane(&pa, SwapOffset::Prev).unwrap();
+        assert_eq!(out, SwapOutcome::NoOp);
+    }
+
+    #[test]
+    fn swap_pane_next_moves_active_pane_one_slot_forward() {
+        let (mut w, pa, pb, pc) = three_pane_window();
+        assert_eq!(pane_order(&w), vec![pa.clone(), pb.clone(), pc.clone()]);
+
+        let out = w.swap_pane(&pa, SwapOffset::Next).unwrap();
+        assert_eq!(out, SwapOutcome::Swapped { other_pane: pb.clone() });
+        assert_eq!(pane_order(&w), vec![pb.clone(), pa.clone(), pc]);
+    }
+
+    #[test]
+    fn swap_pane_prev_wraps_around_from_first() {
+        let (mut w, pa, pb, pc) = three_pane_window();
+        let out = w.swap_pane(&pa, SwapOffset::Prev).unwrap();
+        assert_eq!(out, SwapOutcome::Swapped { other_pane: pc.clone() });
+        assert_eq!(pane_order(&w), vec![pc, pb, pa]);
+    }
+
+    #[test]
+    fn swap_pane_next_wraps_around_from_last() {
+        let (mut w, pa, pb, pc) = three_pane_window();
+        let out = w.swap_pane(&pc, SwapOffset::Next).unwrap();
+        assert_eq!(out, SwapOutcome::Swapped { other_pane: pa.clone() });
+        assert_eq!(pane_order(&w), vec![pc, pb, pa]);
+    }
+
+    #[test]
+    fn swap_pane_prev_is_inverse_of_next() {
+        let (mut w, _pa, pb, _pc) = three_pane_window();
+        let before = pane_order(&w);
+        w.swap_pane(&pb, SwapOffset::Next).unwrap();
+        w.swap_pane(&pb, SwapOffset::Prev).unwrap();
+        assert_eq!(pane_order(&w), before);
+    }
+
+    #[test]
+    fn swap_pane_preserves_active_pane_id_and_pane_to_cell_bijection() {
+        let (mut w, pa, pb, _pc) = three_pane_window();
+        let active_before = w.active_pane.clone();
+        w.swap_pane(&pa, SwapOffset::Next).unwrap();
+        assert_eq!(w.active_pane, active_before);
+
+        for (cell_id, pane_id) in w.cells.ordered_pane_cells(&w.root_cell).unwrap() {
+            assert_eq!(w.pane_to_cell.get(&pane_id), Some(&cell_id));
+        }
+        let _ = pb;
+    }
+
+    #[test]
+    fn swap_pane_unknown_pane_returns_pane_not_found() {
+        let (mut w, _pa, _pb, _pc) = three_pane_window();
+        let stranger = PaneId::new();
+        let err = w.swap_pane(&stranger, SwapOffset::Next).unwrap_err();
+        assert!(matches!(err, MultiplexerError::PaneNotFound(_)));
+    }
+
+    #[test]
+    fn swap_pane_with_two_panes_prev_and_next_produce_same_state() {
+        let wid = WindowId::new();
+        let pa = PaneId::new();
+        let aa = Activity::terminal(ActivityId::new());
+        let mut wn = Window::new_with_initial(wid.clone(), "w".into(), pa.clone(), aa);
+        let pb = PaneId::new();
+        let ab = Activity::terminal(ActivityId::new());
+        wn.split_pane(&pa, pb.clone(), ab, Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+
+        let aa2 = Activity::terminal(ActivityId::new());
+        let mut wp = Window::new_with_initial(wid, "w".into(), pa.clone(), aa2);
+        let ab2 = Activity::terminal(ActivityId::new());
+        wp.split_pane(&pa, pb.clone(), ab2, Side::After, SplitOrientation::Horizontal)
+            .unwrap();
+
+        wn.swap_pane(&pa, SwapOffset::Next).unwrap();
+        wp.swap_pane(&pa, SwapOffset::Prev).unwrap();
+        assert_eq!(pane_order(&wn), pane_order(&wp));
     }
 }

--- a/daemon/multiplexer/src/window/window.rs
+++ b/daemon/multiplexer/src/window/window.rs
@@ -208,10 +208,10 @@ impl Window {
         pane: &PaneId,
         offset: SwapOffset,
     ) -> MultiplexerResult<SwapOutcome> {
-        let ordered = self.cells.ordered_pane_cells(&self.root_cell)?;
-        if ordered.len() < 2 {
+        if self.panes.len() < 2 {
             return Ok(SwapOutcome::NoOp);
         }
+        let ordered = self.cells.ordered_pane_cells(&self.root_cell)?;
         let i = ordered
             .iter()
             .position(|(_, p)| p == pane)


### PR DESCRIPTION
## Problem

ozmux had no way to swap a pane's contents with a sibling — once a window had three or more panes, the only way to rearrange them was to close and re-split. tmux solves this with `Prefix+{` / `Prefix+}` to rotate the active pane backward/forward through pane-index order; this PR brings the same shortcut to ozmux.

The `Action::SwapPane { offset: SwapOffset }` enum had been defined in `daemon/configs/src/shortcuts.rs` for a while but was completely unwired (no default binding, no multiplexer method, no HTTP route, no frontend handler).

## Solution

End-to-end wiring of `swap-pane` from the keystroke down to the cell tree, kept as faithful to tmux's semantics as the rest of the codebase.

**Keybindings:** `Prefix+{` → `SwapPane(Prev)`, `Prefix+}` → `SwapPane(Next)`, both `repeatable: true` so the user can hold the prefix and tap to keep rotating. Both bindings explicitly declare `Modifiers { shift: true }` to match how US keyboards emit `{` / `}` (the frontend chord matcher requires exact modifier equality).

**Selection rule:** depth-first lhs-before-rhs traversal of the window's cell tree — the same ordering used by `WindowView.panes` and by tmux's pane index. Selection wraps at the edges.

**Mutation strategy:** swap the `pane: PaneId` field inside two `PaneCell` leaves; do *not* reparent cells. This keeps `CellId`s, parent pointers, split orientations, weights, and the `active_pane: PaneId` itself untouched — only the visual position of each pane's contents moves. The `pane_to_cell` index gets its two affected entries flipped. Because `active_pane` is a `PaneId` (not a `CellId`), focus visually follows the swap automatically.

**Affected layers:**

- **`daemon/multiplexer`** — new `SwapOffset` / `SwapOutcome` types (mirroring `ozmux_configs::SwapOffset` locally, same pattern as `PaneDirection`, so the crate stays free of a `configs` dependency). Two new `LayoutCellState` helpers (`ordered_pane_cells`, `swap_panes`) plus `Window::swap_pane`. The pre-existing `pane_ids_in_subtree` was collapsed onto the new `ordered_pane_cells` so there's one DFS walker instead of two.
- **`daemon/http_server`** — `AppState::swap_pane` (mirrors `resize_pane`'s soft-no-op + broadcast pattern) and a new handler at `POST /windows/{wid}/panes/{pid}/swap` with body `{ "offset": "prev" | "next" }`.
- **`daemon/configs`** — two new default bindings (`Prefix+{`, `Prefix+}`); the hard-coded binding count and stable-JSON golden were updated.
- **`daemon/frontend`** — new `swap-pane` variant in the zod `ActionSchema`; new `swapPane()` helper that POSTs to the new endpoint (no client-side store mutation — layout broadcast drives the re-render); new `case 'swap-pane'` in `actionDispatch`. The existing `wire.test.ts` test that asserted `swap-pane` was dropped as unknown was inverted to assert it now parses, with a separate "drops unknown action" test using a new sentinel name to preserve the original coverage.

**Status codes** follow `resize_pane`: 204 (success or single-pane no-op), 404 (unknown pane), 409 (pane belongs to a different window), 422 (invalid `offset`), 400 (malformed JSON).

**Tests:** 7 multiplexer unit tests (single-pane no-op, three-pane forward, both wrap-around edges, prev/next inverse, active-pane + `pane_to_cell` bijection preserved, unknown-pane error, two-pane equivalence) + 6 HTTP integration tests (mirroring `resize.rs` minus the `window_not_measured` case which doesn't apply) + 3 frontend tests for `swapPane()` + 2 dispatch tests + 1 wire-schema test.

Verified end-to-end against a live daemon: 3-pane window, swap active (last) with `Next` wraps to first; `Prev` inverts; 3 consecutive `Next` calls produce the expected rotation; 404/422 error paths return correct status codes.

## Test plan

- [ ] `cargo test` passes across the workspace
- [ ] `pnpm test` and `pnpm check-types` pass
- [ ] `pnpm lint:ci` is clean
- [ ] In a 3+ pane window, `Prefix+}` moves the active pane's content one slot forward; `Prefix+{` moves it back; wraparound works at both edges
- [ ] Holding the prefix window open and tapping `}` / `{` (repeatable) keeps rotating without re-arming

🤖 Generated with [Claude Code](https://claude.com/claude-code)