### PR TITLE
feat: PR-C Phase 3 quick wins (CAT-008/011/017)

### DIFF
--- a/daemon/frontend/src/terminal/renderer/grid.ts
+++ b/daemon/frontend/src/terminal/renderer/grid.ts
@@ -176,12 +176,19 @@ function applyDelta(grid: Grid, frame: FrameDelta): void {
   grid.cursor = frame.cursor;
 }
 
+/**
+ * Module-scope segmenter for grapheme clustering. Stateless for the
+ * `'en' + 'grapheme'` configuration (locale-agnostic per Unicode 15.1
+ * default extended grapheme clusters); hoisting amortizes construction
+ * across all expandRunsToRow calls instead of allocating once per call.
+ */
+const GRAPHEME_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' });
+
 /** Reverses run coalescing: returns one Cell per grapheme cluster. */
 export function expandRunsToRow(runs: readonly Run[], _cols: number): Cell[] {
   const cells: Cell[] = [];
-  const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
   for (const run of runs) {
-    for (const { segment } of segmenter.segment(run.text)) {
+    for (const { segment } of GRAPHEME_SEGMENTER.segment(run.text)) {
       const w = widthOfGrapheme(segment);
       cells.push({
         text: segment,

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -148,7 +148,7 @@ impl TerminalService {
         let scrollback = ScrollbackBuffer::new();
         let (event_sender, _) = broadcast::channel(1024);
 
-        let (vt_chunk_tx, vt_chunk_rx) = tokio::sync::mpsc::channel::<Bytes>(128);
+        let (vt_chunk_tx, vt_chunk_rx) = tokio::sync::mpsc::channel::<Bytes>(512);
 
         spawn_pty_reader(
             reader,

--- a/daemon/terminal/src/service/terminal_handle.rs
+++ b/daemon/terminal/src/service/terminal_handle.rs
@@ -88,7 +88,7 @@ impl TerminalHandle {
     ) -> Self {
         let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
         let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
-        let (frame_broadcast, _frame_rx) = broadcast::channel::<WireMessage>(256);
+        let (frame_broadcast, _frame_rx) = broadcast::channel::<WireMessage>(2048);
         let drop_counter = Arc::new(DropCounter::new());
 
         let listener = TermListener {


### PR DESCRIPTION
## Summary

Implements 3 small Phase-3 catalogue items per spec at
`docs/superpowers/specs/2026-05-20-pr-c-quick-wins-design.md` (rev. 2).

- **CAT-008** broadcast channel cap 256 → 2048 (`terminal_handle.rs:91`) — widens slow-subscriber tolerance window. ~150 KB additional preallocation per activity (slot metadata only); payloads are ref-counted via `Bytes`.
- **CAT-011** PTY chunk mpsc cap 128 → 512 (`service.rs:151`) — reduces dropped chunks under sustained bursts. `reader.rs:49`'s `try_send`-with-silent-drop semantics explicitly preserved (the VX challenge during catalogue ratification rejected converting to `send().await`).
- **CAT-017** `Intl.Segmenter` hoisted to module-scope const `GRAPHEME_SEGMENTER` (`grid.ts`) — eliminates ~24 per-frame allocations at 60 fps. Single call site verified.

**Out of scope** (per spec §7, reviewer findings):
- CAT-012 (FrameRing 1 MiB + keyframe-preserving eviction) → PR-D (requires `replay()` API extension).
- CAT-014 (CSS containment + content-visibility) → future PR coupled with DOM scrollback (current renderer holds only viewport-sized rows, so `content-visibility: auto` has nothing to cull).

**Chain-PR**: branches from `feat/pr-b-observability` (#48).

## Test plan

- [x] `cargo test --workspace --tests -- --test-threads=1` passes (default features)
- [x] `cargo test --workspace --tests --features ozmux_cli/tracing-chrome -- --test-threads=1` passes
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `pnpm test` — 460 frontend + 66 SDK tests pass
- [x] `pnpm check-types`, `pnpm lint:ci` clean

## perf-baseline-full before/after

\`\`\`
| Stage | p50 base | p50 target | Δ p50 | p95 base | p95 target | Δ p95 |
|---|---|---|---|---|---|---|
| decode | 191.600 | 16.400 | -175.200 | 326.470 | 200.600 | -125.870 |
| store_apply | 1.900 | 1.900 | 0.000 | 12.070 | 12.200 | 0.130 |
| commit_end | 0.200 | 0.200 | -0.000 | 0.200 | 0.200 | -0.000 |
| server_to_ws_recv_us | 12362.750 | 19984.000 | 7621.250 | 19786.400 | 239684.200 | 219897.800 |
\`\`\`

**Interpretation**: PR-C's expected perf delta from a single allocation reduction (CAT-017) is microsecond-order, well below the single-shot noise floor of `make perf-baseline-full`. The large swings on `decode` and `server_to_ws_recv_us` are run-to-run variance (JIT, cache effects, wall-clock vs `performance.now()` skew between separate runs), not measurable impact from this PR. `store_apply` and `commit_end` are dominated by deterministic ops and stay stable across runs — the kind of stage where this loop has meaningful resolution.

**Workflow observations** (out of PR-C scope, noted for follow-up):
- `scripts/perf-baseline-full.sh` invokes `cargo bench ... broadcast_lag_rate` without `--features test-helpers` — the bench requires that feature, so `bench.txt` always contains an error message. Fix is one word; can be folded into PR-D or a separate cleanup PR.
- The script's `kill \$VITE_PID` targets the pnpm wrapper PID, not the actual Vite node process. Vite stays alive after the script exits, keeping the parent shell's pipe open. Cleanup requires `pkill -f vite.*5173` afterwards.
- Single-shot measurement is too noisy for ~10% improvements; CI gating would need statistical iterations (multi-run, p99-stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)