### PR TITLE
perf(terminal): NeoVim jk-stutter fix + lossless VT pipeline cleanups

### DIFF
--- a/daemon/frontend/src/terminal/renderer/grid.ts
+++ b/daemon/frontend/src/terminal/renderer/grid.ts
@@ -1,6 +1,14 @@
 import type { Color, Cursor, FrameDelta, FrameSnapshot, RenderFrame, Run } from '../protocol/frame';
 import { widthOfGrapheme } from './font';
 
+/**
+ * Module-scoped grapheme segmenter. Constructing `Intl.Segmenter` is expensive
+ * (browser allocates per-locale ICU data); hoisting to module scope amortizes
+ * the construction across every `expandRunsToRow` call for the lifetime of the
+ * page. Safe to share — `Intl.Segmenter.segment()` returns a fresh iterator.
+ */
+const GRAPHEME_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' });
+
 /** One terminal cell. */
 export interface Cell {
   text: string;
@@ -179,9 +187,8 @@ function applyDelta(grid: Grid, frame: FrameDelta): void {
 /** Reverses run coalescing: returns one Cell per grapheme cluster. */
 export function expandRunsToRow(runs: readonly Run[], _cols: number): Cell[] {
   const cells: Cell[] = [];
-  const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
   for (const run of runs) {
-    for (const { segment } of segmenter.segment(run.text)) {
+    for (const { segment } of GRAPHEME_SEGMENTER.segment(run.text)) {
       const w = widthOfGrapheme(segment);
       cells.push({
         text: segment,

--- a/daemon/terminal/src/service.rs
+++ b/daemon/terminal/src/service.rs
@@ -147,7 +147,7 @@ impl TerminalService {
         let scrollback = ScrollbackBuffer::new();
         let (event_sender, _) = broadcast::channel(1024);
 
-        let (vt_chunk_tx, vt_chunk_rx) = tokio::sync::mpsc::channel::<Bytes>(128);
+        let (vt_chunk_tx, vt_chunk_rx) = tokio::sync::mpsc::channel::<Bytes>(512);
 
         spawn_pty_reader(
             reader,
@@ -203,6 +203,7 @@ impl TerminalService {
             let dim = crate::vt::bridge::dim_for(cols, rows);
             let mut state = handle.vt_state.lock().expect("vt_state poisoned");
             state.term.resize(dim);
+            state.row_hashes.clear();
         }
 
         handle

--- a/daemon/terminal/src/service/terminal_handle.rs
+++ b/daemon/terminal/src/service/terminal_handle.rs
@@ -87,7 +87,7 @@ impl TerminalHandle {
     ) -> Self {
         let (reply_tx, reply_rx) = mpsc::unbounded_channel::<ReplyFrame>();
         let (control_tx, control_rx) = mpsc::channel::<ControlFrame>(64);
-        let (frame_broadcast, _frame_rx) = broadcast::channel::<WireMessage>(256);
+        let (frame_broadcast, _frame_rx) = broadcast::channel::<WireMessage>(2048);
         let drop_counter = Arc::new(DropCounter::new());
 
         let listener = TermListener {

--- a/daemon/terminal/src/vt/bridge.rs
+++ b/daemon/terminal/src/vt/bridge.rs
@@ -3,20 +3,26 @@
 //! Phase 1 advances `Term` only; frame emission and PtyWrite/control routing
 //! are wired in Phase 2.
 
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Instant;
 
 use alacritty_terminal::Term;
 use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::Line;
 use alacritty_terminal::term::Config;
+use alacritty_terminal::vte::ansi::{Color as AColor, NamedColor, Rgb};
 use bytes::Bytes;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::vt::coalescer::{Coalescer, DamageVerdict};
-use crate::vt::frame::{Cursor, RenderFrame, SnapshotReason, encode};
+use crate::vt::frame::{Cursor, CursorShape, RenderFrame, SnapshotReason, encode};
 use crate::vt::frame_builder::{
     DirtyRows, build_delta, build_mode, build_snapshot, collect_dirty_rows, extract_cursor,
+    viewport_row_to_line,
 };
 use crate::vt::frame_ring::{FrameRing, WireMessage};
 use crate::vt::hyperlink::HyperlinkInterner;
@@ -63,6 +69,19 @@ pub(crate) struct VtState {
     /// title has been set / after `ResetTitle`. Read by
     /// `TerminalService::all_titles` for tab labels.
     pub title: Option<String>,
+    /// Reusable scratch buffer for dirty row indices collected from
+    /// `Term::damage()`. Lives on `VtState` so the heap allocation
+    /// persists across emit cycles instead of being freshly allocated
+    /// on each call to `collect_dirty_rows`.
+    pub(crate) scratch_dirty: Vec<u16>,
+    /// Per-grid-line content hash captured at the time of the most recent
+    /// emit. The bridge filters `DirtyRows::Rows` against these hashes
+    /// before `decide_frame_kind` so cosmetic re-damage of unchanged rows
+    /// (e.g., alacritty's cursor-row implicit re-damage) does not inflate
+    /// the row count past the snapshot threshold or burn coalesce wins on
+    /// no-op deltas. Keyed by alacritty `Line(i32)` so scrollback rows
+    /// (negative indices) can be tracked too.
+    pub(crate) row_hashes: HashMap<i32, u64>,
 }
 
 impl VtState {
@@ -90,6 +109,8 @@ impl VtState {
             hyperlinks: HyperlinkInterner::new(),
             wire_broadcast,
             title: None,
+            scratch_dirty: Vec::new(),
+            row_hashes: HashMap::new(),
         }
     }
 
@@ -124,7 +145,7 @@ fn classify_damage(dirty: &DirtyRows, cursor_changed: bool) -> DamageVerdict {
             }
         }
         DirtyRows::Rows(rows) if rows.len() <= 1 => DamageVerdict::AtMostOneRow,
-        DirtyRows::Rows(_) => DamageVerdict::ManyRows,
+        DirtyRows::Rows(rows) => DamageVerdict::ManyRows { rows: rows.len() },
     }
 }
 
@@ -139,7 +160,7 @@ enum FrameKind {
 /// Policy, in priority order:
 /// 1. `state.first_emit` → `Snapshot { reason: Initial }` (bootstrap frame).
 /// 2. `DirtyRows::Full` → `Snapshot { reason: Resize }` (full damage after resize or clear).
-/// 3. Partial damage ≥ 70 % of total rows → `Snapshot { reason: Resize }` (bandwidth crossover).
+/// 3. Partial damage ≥ 85 % of total rows → `Snapshot { reason: Resize }` (bandwidth crossover).
 /// 4. Otherwise → `Delta { rows }`.
 fn decide_frame_kind(state: &VtState, dirty: DirtyRows) -> FrameKind {
     let total_rows = state.term.screen_lines() as u16;
@@ -153,7 +174,7 @@ fn decide_frame_kind(state: &VtState, dirty: DirtyRows) -> FrameKind {
             reason: SnapshotReason::Resize,
         },
         DirtyRows::Rows(rows) => {
-            if (rows.len() as u32) * 10 >= (total_rows as u32) * 7 {
+            if (rows.len() as u32) * 20 >= (total_rows as u32) * 17 {
                 FrameKind::Snapshot {
                     reason: SnapshotReason::Resize,
                 }
@@ -179,6 +200,78 @@ fn emit_frame_size_error(wb: &broadcast::Sender<WireMessage>, seq: u32) {
     let _ = wb.send(WireMessage::Text(json.to_string()));
 }
 
+/// Hashes a vte `NamedColor` discriminant into `h`.
+///
+/// vte `NamedColor` derives `Ord`/`PartialOrd` but NOT `Hash`. Discriminants
+/// are explicit (Foreground=256, etc.), so the `u32` cast preserves identity.
+fn hash_named_color(n: NamedColor, h: &mut DefaultHasher) {
+    (n as u32).hash(h);
+}
+
+/// Hashes a vte `Rgb` triple into `h` by walking its public fields, since
+/// `Rgb` derives `PartialEq`/`Default` but NOT `Hash`.
+fn hash_rgb(rgb: &Rgb, h: &mut DefaultHasher) {
+    rgb.r.hash(h);
+    rgb.g.hash(h);
+    rgb.b.hash(h);
+}
+
+/// Hashes a vte `Color` (`AColor`) value into `h` by walking the
+/// discriminant and payload, since `AColor` does NOT derive `Hash`.
+fn hash_acolor(c: &AColor, h: &mut DefaultHasher) {
+    match c {
+        AColor::Named(n) => {
+            0u8.hash(h);
+            hash_named_color(*n, h);
+        }
+        AColor::Spec(rgb) => {
+            1u8.hash(h);
+            hash_rgb(rgb, h);
+        }
+        AColor::Indexed(i) => {
+            2u8.hash(h);
+            i.hash(h);
+        }
+    }
+}
+
+/// Hashes an ozmux wire `CursorShape` into `h` by mapping the variant to a
+/// `u8`, since the wire type does NOT derive `Hash`.
+fn hash_cursor_shape(s: CursorShape, h: &mut DefaultHasher) {
+    let n: u8 = match s {
+        CursorShape::Block => 0,
+        CursorShape::Underline => 1,
+        CursorShape::Bar => 2,
+    };
+    n.hash(h);
+}
+
+/// Computes a content hash for a single grid row, including the cursor
+/// overlay if the cursor is visible and rendered on this `viewport_y`.
+fn hash_row<T>(term: &Term<T>, line: Line, cursor: &Cursor, viewport_y: u16) -> u64 {
+    let mut h = DefaultHasher::new();
+    for cell in &term.grid()[line] {
+        cell.c.hash(&mut h);
+        hash_acolor(&cell.fg, &mut h);
+        hash_acolor(&cell.bg, &mut h);
+        cell.flags.bits().hash(&mut h);
+        if let Some(hyp) = cell.hyperlink().as_ref() {
+            1u8.hash(&mut h);
+            hyp.uri().hash(&mut h);
+            hyp.id().hash(&mut h);
+        } else {
+            0u8.hash(&mut h);
+        }
+    }
+    if cursor.visible && viewport_y == cursor.y {
+        cursor.x.hash(&mut h);
+        cursor.y.hash(&mut h);
+        hash_cursor_shape(cursor.shape, &mut h);
+        cursor.blinking.hash(&mut h);
+    }
+    h.finish()
+}
+
 /// Emits a frame for the damage stashed on `VtState` and disarms the
 /// Coalescer. Called by [`run_bridge_task`] from both the chunk-immediate-flush
 /// path and the deadline-fires path. The `window_open_mode` is consumed via
@@ -190,7 +283,7 @@ fn emit_now(
 ) {
     let mut state = vt_state.lock().expect("vt_state poisoned");
 
-    let Some(dirty) = state.pending_damage.take() else {
+    let Some(mut dirty) = state.pending_damage.take() else {
         coalescer.disarm();
         *window_open_mode = None;
         return;
@@ -206,8 +299,33 @@ fn emit_now(
         .as_ref()
         .is_some_and(|prev| *prev == curr_cursor);
 
+    // NOTE: hash-filter DirtyRows::Rows BEFORE decide_frame_kind — otherwise
+    // the row-count threshold check false-promotes unchanged rows to Snapshot.
+    let mut kept_hashes: Vec<(i32, u64)> = Vec::new();
+    if let DirtyRows::Rows(rows) = &mut dirty {
+        let VtState {
+            ref term,
+            ref row_hashes,
+            ..
+        } = *state;
+        rows.retain(|&viewport_y| {
+            let line = viewport_row_to_line(term, viewport_y as i32);
+            let h = hash_row(term, line, &curr_cursor, viewport_y);
+            let stale = row_hashes.get(&line.0).copied();
+            if Some(h) == stale {
+                false
+            } else {
+                kept_hashes.push((line.0, h));
+                true
+            }
+        });
+    }
+
     let dirty_is_empty = matches!(&dirty, DirtyRows::Rows(r) if r.is_empty());
     if dirty_is_empty && prev_mode == curr_mode && cursor_unchanged && !state.first_emit {
+        // Reset alacritty's damage tracker so we don't re-walk the same
+        // damage on the next coalescer flush.
+        state.term.reset_damage();
         coalescer.disarm();
         return;
     }
@@ -215,6 +333,10 @@ fn emit_now(
     let kind = decide_frame_kind(&state, dirty);
     state.first_emit = false;
     let seq = state.frame_seq;
+
+    // NOTE: we track the consumed rows Vec from FrameKind::Delta so capacity
+    // can be reclaimed into scratch_dirty after the emit completes.
+    let mut consumed_rows: Option<Vec<u16>> = None;
     let frame = {
         let VtState {
             ref term,
@@ -226,7 +348,9 @@ fn emit_now(
                 RenderFrame::Snapshot(build_snapshot(term, seq, reason, hyperlinks))
             }
             FrameKind::Delta { rows } => {
-                RenderFrame::Delta(build_delta(term, seq, &rows, hyperlinks))
+                let frame = RenderFrame::Delta(build_delta(term, seq, &rows, hyperlinks));
+                consumed_rows = Some(rows);
+                frame
             }
         }
     };
@@ -257,6 +381,33 @@ fn emit_now(
             seq: binary_seq,
             encoded,
         });
+
+        match &frame {
+            RenderFrame::Delta(_) => {
+                for (line_i32, h) in kept_hashes {
+                    state.row_hashes.insert(line_i32, h);
+                }
+            }
+            RenderFrame::Snapshot(_) => {
+                state.row_hashes.clear();
+                let screen_rows = state.term.grid().screen_lines() as u16;
+                let snap_cursor = extract_cursor(&state.term);
+                let VtState {
+                    ref term,
+                    ref mut row_hashes,
+                    ..
+                } = *state;
+                for viewport_y in 0..screen_rows {
+                    let line = viewport_row_to_line(term, viewport_y as i32);
+                    let h = hash_row(term, line, &snap_cursor, viewport_y);
+                    row_hashes.insert(line.0, h);
+                }
+            }
+        }
+    }
+
+    if let Some(v) = consumed_rows {
+        state.scratch_dirty = v;
     }
 
     coalescer.disarm();
@@ -303,7 +454,9 @@ pub(crate) async fn run_bridge_task(
                     if window_open_mode.is_none() {
                         window_open_mode = Some(pre_advance_mode);
                     }
-                    state.pending_damage = Some(collect_dirty_rows(&mut state.term));
+                    let mut scratch = std::mem::take(&mut state.scratch_dirty);
+                    state.pending_damage = Some(collect_dirty_rows(&mut state.term, &mut scratch));
+                    state.scratch_dirty = scratch;
                 }
                 emit_now(&vt_state, &mut coalescer, &mut window_open_mode);
             }
@@ -318,7 +471,9 @@ pub(crate) async fn run_bridge_task(
                     if !coalescer.is_armed() && window_open_mode.is_none() {
                         window_open_mode = Some(pre_advance_mode);
                     }
-                    let dirty = collect_dirty_rows(&mut state.term);
+                    let mut scratch = std::mem::take(&mut state.scratch_dirty);
+                    let dirty = collect_dirty_rows(&mut state.term, &mut scratch);
+                    state.scratch_dirty = scratch;
                     let verdict = classify_damage(&dirty, state.cursor_changed());
                     let flush = coalescer.should_flush_immediately(
                         state.first_emit,

--- a/daemon/terminal/src/vt/coalescer.rs
+++ b/daemon/terminal/src/vt/coalescer.rs
@@ -18,8 +18,9 @@ pub enum DamageVerdict {
     Full,
     /// At most one row is dirty (interactive echo / cursor-only motion).
     AtMostOneRow,
-    /// Many rows dirty — must be coalesced.
-    ManyRows,
+    /// Two or more rows dirty. The row count drives the PR-E2b
+    /// immediate-flush cap in `Coalescer::should_flush_immediately`.
+    ManyRows { rows: usize },
     /// No rows dirty and cursor unchanged.
     Idle,
 }
@@ -44,6 +45,13 @@ impl Coalescer {
     pub const IDLE: Duration = Duration::from_millis(3);
     /// Hard ceiling: maximum time the first pending chunk waits.
     pub const MAX_CAP: Duration = Duration::from_millis(12);
+    /// Row-count cap for the immediate-flush branch that fires on
+    /// `ManyRows + pending_user_input`. NeoVim 1-line scroll in a TUI
+    /// dirties scrolled-in row + status line + (sometimes) tabline =
+    /// 2-3 rows; cap of 4 leaves headroom while still excluding bigger
+    /// redraws (`:redraw!`, mode-line transitions) from bypassing the
+    /// debounce window.
+    const MANY_ROWS_INSTANT_CAP: usize = 4;
 
     /// Constructs a disarmed Coalescer.
     pub fn new() -> Self {
@@ -82,7 +90,7 @@ impl Coalescer {
     ///
     /// `pending_user_input` is consumed *by the caller* on a `true` return —
     /// the caller flips the bool before invoking this method only when the
-    /// verdict is `AtMostOneRow`. This method is pure: it does not mutate state.
+    /// verdict warrants. This method is pure: it does not mutate state.
     ///
     /// # Invariants
     ///
@@ -93,6 +101,9 @@ impl Coalescer {
     /// rows blank) before content arrives. Routing Full through the coalescer
     /// window lets `wait_deadline`'s `try_recv` drain absorb the row-content
     /// chunk into the same emit.
+    ///
+    /// PR-E2b extends this with a `ManyRows` branch gated on a row cap and
+    /// the coalescer NOT being armed — see spec § 2 and § 7.
     pub fn should_flush_immediately(
         &self,
         is_bootstrap: bool,
@@ -102,10 +113,19 @@ impl Coalescer {
         if is_bootstrap {
             return true;
         }
-        if pending_user_input && matches!(verdict, DamageVerdict::AtMostOneRow) {
-            return true;
+        if !pending_user_input {
+            return false;
         }
-        false
+        match verdict {
+            DamageVerdict::AtMostOneRow => true,
+            // NOTE: the `armed_at.is_none()` guard protects post-Full coalescing —
+            // if a prior Full chunk is already debouncing, its window must run to
+            // completion rather than be cut short by a follow-up ManyRows chunk.
+            DamageVerdict::ManyRows { rows } if *rows <= Self::MANY_ROWS_INSTANT_CAP => {
+                self.armed_at.is_none()
+            }
+            _ => false,
+        }
     }
 
     /// Returns the next deadline as `min(last_chunk + IDLE, armed + MAX_CAP)`.
@@ -173,7 +193,7 @@ mod tests {
     fn should_flush_immediately_on_bootstrap() {
         let c = Coalescer::new();
         assert!(c.should_flush_immediately(true, &DamageVerdict::Idle, false));
-        assert!(c.should_flush_immediately(true, &DamageVerdict::ManyRows, false));
+        assert!(c.should_flush_immediately(true, &DamageVerdict::ManyRows { rows: 5 }, false));
     }
 
     #[test]
@@ -196,7 +216,7 @@ mod tests {
     #[test]
     fn should_not_flush_user_input_with_many_rows() {
         let c = Coalescer::new();
-        assert!(!c.should_flush_immediately(false, &DamageVerdict::ManyRows, true));
+        assert!(!c.should_flush_immediately(false, &DamageVerdict::ManyRows { rows: 8 }, true));
     }
 
     #[test]

--- a/daemon/terminal/src/vt/frame_builder.rs
+++ b/daemon/terminal/src/vt/frame_builder.rs
@@ -17,7 +17,6 @@ use alacritty_terminal::term::TermDamage;
 use alacritty_terminal::term::TermMode;
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::vte::ansi::{Color as AColor, NamedColor};
-use std::collections::HashMap;
 use unicode_width::UnicodeWidthChar;
 
 /// Outcome of damage inspection.
@@ -32,10 +31,18 @@ pub enum DirtyRows {
 /// Reads the damage tracker and returns row indices that changed.
 ///
 /// `&mut Term` is required because `Term::damage()` takes `&mut self`.
-pub(super) fn collect_dirty_rows<T>(term: &mut Term<T>) -> DirtyRows {
+/// `scratch_dirty` is cleared, filled with the dirty row indices, then
+/// moved into the returned `DirtyRows::Rows` variant via `mem::take`.
+/// The caller should reclaim the consumed `Vec` back into the scratch field
+/// after the emit completes so capacity persists across calls.
+pub(super) fn collect_dirty_rows<T>(term: &mut Term<T>, scratch_dirty: &mut Vec<u16>) -> DirtyRows {
     match term.damage() {
         TermDamage::Full => DirtyRows::Full,
-        TermDamage::Partial(iter) => DirtyRows::Rows(iter.map(|d| d.line as u16).collect()),
+        TermDamage::Partial(iter) => {
+            scratch_dirty.clear();
+            scratch_dirty.extend(iter.map(|d| d.line as u16));
+            DirtyRows::Rows(std::mem::take(scratch_dirty))
+        }
     }
 }
 
@@ -66,10 +73,10 @@ pub(crate) fn build_snapshot<T>(
 ) -> FrameSnapshot {
     let cols = term.columns() as u16;
     let rows = term.screen_lines() as u16;
-    let mut emitted: HashMap<HyperlinkWireId, HyperlinkUri> = HashMap::new();
+    let mut hyperlinks_opt: Option<Vec<(HyperlinkWireId, HyperlinkUri)>> = None;
     let rows_data: Vec<Row> = (0..rows as i32)
         .map(|y| Row {
-            runs: coalesce_row(term, y, interner, &mut emitted),
+            runs: coalesce_row(term, y, interner, &mut hyperlinks_opt),
         })
         .collect();
     FrameSnapshot {
@@ -80,7 +87,8 @@ pub(crate) fn build_snapshot<T>(
         rows_data,
         reason,
         modes: snapshot_modes(*term.mode()),
-        hyperlinks: emitted
+        hyperlinks: hyperlinks_opt
+            .unwrap_or_default()
             .into_iter()
             .map(|(id, uri)| Hyperlink { id, uri })
             .collect(),
@@ -99,19 +107,20 @@ pub(super) fn build_delta<T>(
     rows: &[u16],
     interner: &mut HyperlinkInterner,
 ) -> FrameDelta {
-    let mut emitted: HashMap<HyperlinkWireId, HyperlinkUri> = HashMap::new();
+    let mut hyperlinks_opt: Option<Vec<(HyperlinkWireId, HyperlinkUri)>> = None;
     let dirty_rows: Vec<DirtyRow> = rows
         .iter()
         .map(|&r| DirtyRow {
             row: r,
-            runs: coalesce_row(term, r as i32, interner, &mut emitted),
+            runs: coalesce_row(term, r as i32, interner, &mut hyperlinks_opt),
         })
         .collect();
     FrameDelta {
         seq,
         cursor: extract_cursor(term),
         dirty_rows,
-        hyperlinks: emitted
+        hyperlinks: hyperlinks_opt
+            .unwrap_or_default()
             .into_iter()
             .map(|(id, uri)| Hyperlink { id, uri })
             .collect(),
@@ -182,7 +191,7 @@ pub(crate) fn extract_cursor<T>(term: &Term<T>) -> Cursor {
 /// - `0 <= y < screen_lines`
 /// - `display_offset` fits in `i32`. ozmux uses the default
 ///   `scrolling_history = 10000`, far below `i32::MAX`.
-fn viewport_row_to_line<T>(term: &Term<T>, y: i32) -> Line {
+pub(super) fn viewport_row_to_line<T>(term: &Term<T>, y: i32) -> Line {
     debug_assert!(
         (0..term.screen_lines() as i32).contains(&y),
         "viewport row {y} out of range 0..{}",
@@ -219,7 +228,7 @@ fn coalesce_row<T>(
     term: &Term<T>,
     y: i32,
     interner: &mut HyperlinkInterner,
-    emitted_hyperlinks: &mut HashMap<HyperlinkWireId, HyperlinkUri>,
+    emitted_hyperlinks: &mut Option<Vec<(HyperlinkWireId, HyperlinkUri)>>,
 ) -> Vec<Run> {
     let cols = term.columns() as u16;
     let grid_row = &term.grid()[viewport_row_to_line(term, y)];
@@ -242,9 +251,10 @@ fn coalesce_row<T>(
         // Resolve hyperlink (alac String id → HyperlinkWireId via interner).
         let hyperlink_id = cell.hyperlink().map(|h| {
             let id = interner.intern(h.id(), h.uri().as_ref());
-            emitted_hyperlinks
-                .entry(id)
-                .or_insert_with(|| HyperlinkUri::new(h.uri().to_string()));
+            let v = emitted_hyperlinks.get_or_insert_with(Vec::new);
+            if !v.iter().any(|(k, _)| *k == id) {
+                v.push((id, HyperlinkUri::new(h.uri().to_string())));
+            }
             id
         });
         let cell_attrs = RunAttrs::from_cell(cell, hyperlink_id);
@@ -382,7 +392,8 @@ mod tests {
     fn collect_full_on_fresh_term() {
         let mut term = make_term(10, 3);
         // First damage query returns Full per alacritty contract.
-        assert_eq!(collect_dirty_rows(&mut term), DirtyRows::Full);
+        let mut scratch: Vec<u16> = Vec::new();
+        assert_eq!(collect_dirty_rows(&mut term, &mut scratch), DirtyRows::Full);
     }
 
     #[test]
@@ -404,10 +415,11 @@ mod tests {
     #[test]
     fn collect_partial_after_reset() {
         let mut term = make_term(10, 3);
-        let _ = collect_dirty_rows(&mut term);
+        let mut scratch: Vec<u16> = Vec::new();
+        let _ = collect_dirty_rows(&mut term, &mut scratch);
         term.reset_damage();
         // After reset with no input, alacritty returns Partial{cursor row}.
-        match collect_dirty_rows(&mut term) {
+        match collect_dirty_rows(&mut term, &mut scratch) {
             DirtyRows::Full => panic!("expected Partial after reset"),
             DirtyRows::Rows(rows) => {
                 // line_count is 1 (cursor blink dirties cursor row only).
@@ -647,7 +659,7 @@ mod tests {
         let mut term = make_term(10, 3);
         install_text(&mut term, "abc");
         let mut interner = HyperlinkInterner::new();
-        let mut emitted = HashMap::new();
+        let mut emitted: Option<Vec<(HyperlinkWireId, HyperlinkUri)>> = None;
         let runs = coalesce_row(&term, 0, &mut interner, &mut emitted);
         let merged: String = runs.iter().map(|r| r.text.as_str()).collect();
         assert!(merged.starts_with("abc"), "got: {merged:?}");
@@ -667,7 +679,7 @@ mod tests {
         }
         term.scroll_display(Scroll::Top);
         let mut interner = HyperlinkInterner::new();
-        let mut emitted = HashMap::new();
+        let mut emitted: Option<Vec<(HyperlinkWireId, HyperlinkUri)>> = None;
         let runs = coalesce_row(&term, 0, &mut interner, &mut emitted);
         let merged: String = runs.iter().map(|r| r.text.as_str()).collect();
         assert!(


### PR DESCRIPTION
**Base:** \`main\`. **Wire change:** none. **Frontend change:** Intl.Segmenter hoist only. **No tests, no observability instrumentation added.**

## TL;DR

Six atomic terminal-performance improvements as a **single commit** (~234 LOC / 6 files).

The headline change is the **NeoVim jk-stutter fix**: eliminates the 3-12 ms coalesce wait that every keystroke was paying. Measured pre-fix (on the verbose sibling branch \`feat/pr-e2b-immediate-flush\` with full instrumentation): \`coalesce_wait_seconds\` p99 = 3.10 ms, 200/200 samples in the 3-6 ms bucket. Post-fix: 0 samples. Per-keystroke latency drops from ~3 ms (typical autorepeat) / ~12 ms (worst-case at fast autorepeat) to ~0 ms.

## The 6 changes

| # | CAT | Change |
| --- | --- | --- |
| 1 | CAT-004 | \`decide_frame_kind\` snapshot promotion threshold 70% → 85% (\`* 10 >= * 7\` → \`* 20 >= * 17\`). Keeps Delta payloads on the wire in the 70-84% damage band where they remain smaller than a full snapshot. |
| 2 | CAT-005 | Per-row hash filter in \`emit_now\`: drops unchanged rows from \`DirtyRows::Rows\` before \`decide_frame_kind\` so the threshold counter doesn't misfire on idle viewports. \`row_hashes: HashMap<i32, u64>\` invalidated on resize. Hash uses std \`DefaultHasher\`; helpers walk \`vte::ansi::{Color, Rgb, NamedColor}\` manually since they don't derive \`Hash\` upstream. |
| 3 | CAT-006 | \`scratch_dirty: Vec<u16>\` reused across emits via \`mem::take\`; hyperlink accumulator switched from \`BTreeMap\` to \`Option<Vec<(K,V)>>\` (zero alloc on hyperlink-free sessions). |
| 4 | CAT-008/011 | \`vt_chunk_tx\` mpsc capacity 128 → 512; \`frame_broadcast\` capacity 256 → 2048. Reduces backpressure-induced silent drops on burst PTY output. |
| 5 | CAT-017 | \`Intl.Segmenter\` hoisted to module scope in \`renderer/grid.ts\` (one construction amortised across every \`expandRunsToRow\` call). |
| 6 | **jk-stutter fix** | \`DamageVerdict::ManyRows { rows: usize }\` struct variant + \`MANY_ROWS_INSTANT_CAP = 4\` const + new \`should_flush_immediately\` branch with \`armed_at.is_none()\` guard. The guard preserves alt-screen-entry post-Full coalescing. |

## How the fix works (jk-stutter)

Pre-fix: \`Coalescer::should_flush_immediately\` only fires on \`AtMostOneRow + pending_user_input\`. NeoVim 1-line scroll dirties ≥2 rows (scrolled row + status line) → verdict \`ManyRows\` → coalesce window → 3-12 ms wait per keystroke.

Post-fix: with \`pending_user_input\` set and \`ManyRows { rows <= 4 }\` and the coalescer not already armed, flush immediately. The row-count cap excludes larger redraws (\`:redraw!\`, mode-line transitions, alt-screen entry follow-ups). The \`armed_at.is_none()\` guard means a prior \`Full\` chunk that's debouncing for content (alt-screen entry pattern) does NOT get cut off by an incoming ManyRows.

## Verification

- \`cargo fmt --check\` ✓
- \`cargo clippy --workspace --all-targets -- -D warnings\` ✓
- \`cargo test -p ozmux_terminal\` 130 tests, 0 failed ✓
- \`cargo test --workspace\` clean (pre-existing extension/cli e2e failures are environmental, unrelated to this PR)
- \`make test-wire-contract\` ✓ (10 existing fixtures round-trip — no wire schema changes)
- \`pnpm test\`, \`pnpm check-types\`, \`pnpm lint:ci\` ✓

## Scope

This PR is **strictly pure performance**. By explicit user request:

- **No new tests** (the sister-branch \`feat/pr-e2b-immediate-flush\` has unit + integration tests + a synthetic load test \`tests/jk_scroll_synthetic.rs\` that empirically validates the 200 → 0 \`coalesce_wait\` drop)
- **No observability** (the sister-branch has 4 Prometheus metrics + a \`tracing::instrument\` span on \`emit_now\` for diagnosis)
- **No CAT-007 correctness fix** (mode-inline migration — eliminates a Text/Binary inter-channel ordering race; landed on the sister-branch)

Replaces #51 (which bundled all of the above into a 91-commit consolidated PR).