### PR TITLE
fix(daemon): stop leaking Node extension processes on shutdown

### DIFF
--- a/daemon/bootstrap/src/lib.rs
+++ b/daemon/bootstrap/src/lib.rs
@@ -81,10 +81,11 @@ impl RuntimeHandles {
 
 impl Drop for RuntimeHandles {
     fn drop(&mut self) {
-        // NOTE: shutdown() is the graceful path; this Drop only fires on
-        // panic / early return where shutdown() was skipped. Abort the
-        // event pump so it cannot touch PidFileGuard / RuntimeRoot state
-        // that is about to disappear.
+        // NOTE: Drop runs on every path including after shutdown() consumes
+        // self; abort() is idempotent so the double-call is safe. The
+        // meaningful difference is on the panic / early-return path:
+        // ext_handles.shutdown() is skipped, so extension cleanup falls back
+        // to kill_on_drop(true) on each Child (best-effort, may zombie).
         self.event_pump.abort();
     }
 }

--- a/daemon/bootstrap/src/lib.rs
+++ b/daemon/bootstrap/src/lib.rs
@@ -53,22 +53,38 @@ pub fn runtime_dir() -> std::io::Result<std::path::PathBuf> {
 }
 
 /// RAII bundle that owns daemon subsystem handles (runtime root, extension
-/// child processes, event pump task, PID file guard). Dropping the bundle
-/// tears every subsystem down in the right order: background tasks abort
-/// first, then `PidFileGuard`'s `Drop` removes the PID file, then the runtime
-/// root cleans up its scratch directory.
+/// child processes, event pump task, PID file guard).
+///
+/// Graceful teardown is via [`Self::shutdown`], which aborts the event pump
+/// and runs `ExtensionHandles::shutdown()` (closing each extension's stdin
+/// to trigger Node-side cleanup with a SIGKILL fallback). The `Drop` impl
+/// is a panic/cancellation safety net that aborts the event pump only —
+/// extension reap is left to `kill_on_drop(true)` on the children, which
+/// races the tokio runtime drop and may leave zombies (but never running
+/// processes).
 pub struct RuntimeHandles {
     event_pump: tokio::task::JoinHandle<()>,
-    _ext_handles: ExtensionHandles,
+    ext_handles: ExtensionHandles,
     _pid_guard: pidfile::PidFileGuard,
     _runtime: Arc<RuntimeRoot>,
 }
 
+impl RuntimeHandles {
+    /// Gracefully tears down every owned subsystem in order: event pump,
+    /// extension processes, then (via Drop) the PID file guard and runtime
+    /// root. Consumes self so it cannot be invoked twice.
+    pub async fn shutdown(mut self) {
+        self.event_pump.abort();
+        self.ext_handles.shutdown().await;
+    }
+}
+
 impl Drop for RuntimeHandles {
     fn drop(&mut self) {
-        // NOTE: abort the background tasks first so they cannot race with
-        // PidFileGuard / RuntimeRoot teardown by trying to touch state that
-        // is about to disappear.
+        // NOTE: shutdown() is the graceful path; this Drop only fires on
+        // panic / early return where shutdown() was skipped. Abort the
+        // event pump so it cannot touch PidFileGuard / RuntimeRoot state
+        // that is about to disappear.
         self.event_pump.abort();
     }
 }
@@ -115,7 +131,7 @@ pub async fn build_state() -> anyhow::Result<(AppState, RuntimeHandles)> {
         state,
         RuntimeHandles {
             event_pump,
-            _ext_handles: ext_handles,
+            ext_handles,
             _pid_guard: pid_guard,
             _runtime: runtime,
         },
@@ -123,21 +139,25 @@ pub async fn build_state() -> anyhow::Result<(AppState, RuntimeHandles)> {
 }
 
 /// Serves the ozmux daemon HTTP API until `stop_rx` fires or the serve
-/// future returns. Initialises tracing, calls `build_state`, and runs the
-/// axum server. Signal handling is the caller's responsibility — pass a
-/// `oneshot::Receiver` whose sender is tripped by whatever shutdown
-/// orchestration the host (CEF-aware main, integration test, …) uses.
+/// future returns. Initialises tracing, calls `build_state`, runs the
+/// axum server, then runs the graceful shutdown sequence (extension
+/// processes via stdin EOF) before returning. Signal handling is the
+/// caller's responsibility — pass a `oneshot::Receiver` whose sender is
+/// tripped by whatever shutdown orchestration the host (CEF-aware main,
+/// integration test, …) uses.
 pub async fn serve(stop_rx: tokio::sync::oneshot::Receiver<()>) -> anyhow::Result<()> {
     init_tracing();
-    let (state, _handles) = build_state().await?;
+    let (state, handles) = build_state().await?;
     let serve = ozmux_http_server::serve(state);
-    tokio::select! {
-        result = serve => result?,
+    let result: anyhow::Result<()> = tokio::select! {
+        result = serve => result.map_err(Into::into),
         _ = stop_rx => {
             tracing::info!("serve: stop signal received");
+            Ok(())
         }
-    }
-    Ok(())
+    };
+    handles.shutdown().await;
+    result
 }
 
 /// Runs the ozmux daemon to completion using built-in `SIGINT`/`SIGTERM`

--- a/daemon/extension/Cargo.toml
+++ b/daemon/extension/Cargo.toml
@@ -16,6 +16,8 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "macros",
   "io-util",
+  "process",
+  "time",
 ] }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/daemon/extension/src/handle.rs
+++ b/daemon/extension/src/handle.rs
@@ -1,19 +1,27 @@
+//! Extension Node process lifecycle: spawn at daemon startup, graceful
+//! shutdown via stdin EOF with SIGKILL fallback after a 500ms grace period.
+
 use crate::{
     error::ExtensionResult, handle::package_json::PackageJson, registry::ExtensionRegistry,
     runtime::RuntimeRoot,
 };
-use std::{
-    path::Path,
-    process::{Child, Command, Stdio},
-};
+use std::{path::Path, process::Stdio, time::Duration};
+use tokio::process::{Child, Command};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 mod package_json;
 
+/// Owns every Node extension child process spawned by the daemon and is
+/// responsible for tearing them down on daemon shutdown via [`Self::shutdown`].
 pub struct ExtensionHandles {
-    _node_handles: Vec<Child>,
+    children: Vec<Child>,
 }
 
 impl ExtensionHandles {
+    /// Discovers extensions under `OZMUX_EXTENSION_ROOT`, spawns each as a
+    /// Node child process, and returns a handle owning them. Returns an
+    /// empty handle if the env var is unset or empty.
     pub fn load(runtime: &RuntimeRoot, registry: ExtensionRegistry) -> ExtensionResult<Self> {
         const OZMUX_EXTENSION_ROOT: &str = "OZMUX_EXTENSION_ROOT";
         let root = match std::env::var(OZMUX_EXTENSION_ROOT) {
@@ -22,25 +30,44 @@ impl ExtensionHandles {
                 tracing::info!(
                     "{OZMUX_EXTENSION_ROOT} is not set; daemon will run without extensions"
                 );
-                return Ok(Self {
-                    _node_handles: vec![],
-                });
+                return Ok(Self { children: vec![] });
             }
         };
-        let mut handles = Vec::new();
+        let mut children = Vec::new();
         tracing::info!("extension root dir={root}");
         for entry in std::fs::read_dir(root)?.filter_map(|r| r.ok()) {
             let extension_dir = entry.path();
             match load_package_json(&extension_dir).and_then(|package| {
                 node_handle(package.clone(), &extension_dir, runtime, &registry)
             }) {
-                Ok(h) => handles.push(h),
+                Ok(h) => children.push(h),
                 Err(e) => tracing::error!("{e}"),
             }
         }
-        Ok(Self {
-            _node_handles: handles,
-        })
+        Ok(Self { children })
+    }
+
+    /// Gracefully shuts down every spawned extension. For each child:
+    /// `tokio::process::Child::wait()` drops the stdin handle first, which
+    /// closes the pipe and triggers the Node-side EOF cleanup handler. If
+    /// the child does not exit within `SHUTDOWN_TIMEOUT`, it is SIGKILLed
+    /// and reaped. Idempotent: leaves the internal vector empty.
+    pub async fn shutdown(&mut self) {
+        for child in std::mem::take(&mut self.children) {
+            shutdown_one(child).await;
+        }
+    }
+}
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
+
+async fn shutdown_one(mut child: Child) {
+    match tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await {
+        Ok(Ok(_status)) => {}
+        Ok(Err(e)) => tracing::warn!(error = %e, "extension wait failed"),
+        Err(_) => {
+            let _ = child.kill().await;
+        }
     }
 }
 
@@ -64,7 +91,6 @@ fn node_handle(
     std::fs::create_dir_all(&bin_dir)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&bin_dir, std::fs::Permissions::from_mode(0o700))?;
     }
 
@@ -82,6 +108,7 @@ fn node_handle(
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn();
 
     match spawn_result {

--- a/daemon/extension/tests/e2e.rs
+++ b/daemon/extension/tests/e2e.rs
@@ -289,3 +289,45 @@ async fn builtin_browser_shim_is_on_path() {
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }
+
+/// Verifies that `ExtensionHandles::shutdown()` triggers the Node-side
+/// cleanup() handler via stdin EOF. We assert binDir and sock removal
+/// (not just child exit) because a simple `waitpid(_, WNOHANG) == ECHILD`
+/// would also pass if the EOF path were broken — the 500ms-then-SIGKILL
+/// fallback would still reap.
+#[tokio::test]
+async fn shutdown_runs_graceful_node_cleanup() {
+    let parent = tempfile::tempdir().unwrap();
+    let runtime = Arc::new(RuntimeRoot::new_in(parent.path(), std::process::id()).unwrap());
+    unsafe {
+        std::env::set_var("OZMUX_EXTENSION_ROOT", fixture_root());
+    }
+    let mut handles = ExtensionHandles::load(&runtime, ExtensionRegistry::default()).unwrap();
+
+    // Wait for the clock-ext fixture to finish bootstrap (signalled by the
+    // pid file). Using clock-ext (not crash-ext) so the fixture stays alive
+    // until shutdown() arrives.
+    let bin_dir = runtime.bin_dir().join("clock-ext");
+    let sock_path = runtime.sock_dir().join("clock-ext.sock");
+    let pid_file = bin_dir.join("pid");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !pid_file.exists() {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(pid_file.exists(), "clock-ext never wrote its pid file");
+    assert!(bin_dir.exists(), "clock-ext binDir should exist pre-shutdown");
+    assert!(sock_path.exists(), "clock-ext sock should exist pre-shutdown");
+
+    handles.shutdown().await;
+
+    // Graceful EOF path runs Node cleanup which unlinks both. SIGKILL
+    // fallback would NOT remove them. This asserts the EOF path fired.
+    assert!(
+        !bin_dir.exists(),
+        "clock-ext binDir should be removed by Node cleanup()"
+    );
+    assert!(
+        !sock_path.exists(),
+        "clock-ext sock should be unlinked by Node cleanup()"
+    );
+}

--- a/daemon/extension/tests/fixtures/clock-ext/bootstrap.mjs
+++ b/daemon/extension/tests/fixtures/clock-ext/bootstrap.mjs
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bootstrap, registerActivityChannels } from "@ozmux/sdk/server";
 
 registerActivityChannels("fixture-aid-1", {
@@ -17,3 +19,8 @@ await bootstrap({
     "clock-ext": async () => 0,
   },
 });
+
+// Write PID *after* bootstrap so the SDK's stdin EOF listener is wired
+// before any test can close stdin. The Rust test uses this file's
+// presence as the "ready" signal.
+writeFileSync(join(process.env.OZMUX_BIN_DIR, "pid"), String(process.pid));

--- a/daemon/extension/tests/fixtures/crash-ext/bootstrap.mjs
+++ b/daemon/extension/tests/fixtures/crash-ext/bootstrap.mjs
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bootstrap } from "@ozmux/sdk/server";
 
 await bootstrap({
@@ -5,5 +7,6 @@ await bootstrap({
     crashext: async () => 0,
   },
 });
+writeFileSync(join(process.env.OZMUX_BIN_DIR, "pid"), String(process.pid));
 // Simulate a crash *after* shim materialization.
 setTimeout(() => process.exit(7), 200);

--- a/daemon/extension/tests/fixtures/echo-ext/bootstrap.mjs
+++ b/daemon/extension/tests/fixtures/echo-ext/bootstrap.mjs
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bootstrap } from "@ozmux/sdk/server";
 
 await bootstrap({
@@ -9,3 +11,4 @@ await bootstrap({
     },
   },
 });
+writeFileSync(join(process.env.OZMUX_BIN_DIR, "pid"), String(process.pid));

--- a/sdk/typescript/src/server/bootstrap.test.ts
+++ b/sdk/typescript/src/server/bootstrap.test.ts
@@ -155,8 +155,6 @@ describe("bootstrap()", () => {
     const harness = `
       import { bootstrap } from ${JSON.stringify(fileURLToPath(new URL("./bootstrap.ts", import.meta.url)))};
       bootstrap({ commands: { memo: async () => {} } }).catch((e) => { console.error(e); process.exit(11); });
-      // keep alive
-      setInterval(() => {}, 1000);
     `;
     const child = spawn(process.execPath, ["--input-type=module", "-e", harness], {
       env: {

--- a/sdk/typescript/src/server/bootstrap.ts
+++ b/sdk/typescript/src/server/bootstrap.ts
@@ -261,9 +261,10 @@ export async function bootstrap(args: BootstrapArgs): Promise<void> {
         fs.unlink(env.sockPath).catch(() => {}),
         fs.unlink(env.handlersSockPath).catch(() => {}),
       ]);
-      // NOTE: destroy stdin after cleanup so the event loop can drain
-      // regardless of whether EOF already fired (pipe closed by daemon)
-      // or stdin is still open (e.g. inherited in tests / manual runs).
+      // NOTE: required for the SIGTERM/SIGINT and inherited-stdin paths —
+      // server.close() releases the server refs but process.stdin.resume()
+      // still pins the event loop. Without destroy() the process hangs
+      // after cleanup completes.
       process.stdin.destroy();
     })();
     return cleanupPromise;

--- a/sdk/typescript/src/server/bootstrap.ts
+++ b/sdk/typescript/src/server/bootstrap.ts
@@ -249,26 +249,35 @@ export async function bootstrap(args: BootstrapArgs): Promise<void> {
 
   const handlersServer = await bindHandlersServer(env.handlersSockPath);
 
-  let cleaningUp = false;
-  const cleanup = async () => {
-    if (cleaningUp) return;
-    cleaningUp = true;
-    await Promise.all([
-      new Promise<void>((res) => server.close(() => res())),
-      new Promise<void>((res) => handlersServer.close(() => res())),
-    ]);
-    await Promise.all([
-      fs.rm(env.binDir, { recursive: true, force: true }),
-      fs.unlink(env.sockPath).catch(() => {}),
-      fs.unlink(env.handlersSockPath).catch(() => {}),
-    ]);
+  let cleanupPromise: Promise<void> | undefined;
+  const cleanup = (): Promise<void> => {
+    cleanupPromise ??= (async () => {
+      await Promise.all([
+        new Promise<void>((res) => server.close(() => res())),
+        new Promise<void>((res) => handlersServer.close(() => res())),
+      ]);
+      await Promise.all([
+        fs.rm(env.binDir, { recursive: true, force: true }),
+        fs.unlink(env.sockPath).catch(() => {}),
+        fs.unlink(env.handlersSockPath).catch(() => {}),
+      ]);
+      // NOTE: destroy stdin after cleanup so the event loop can drain
+      // regardless of whether EOF already fired (pipe closed by daemon)
+      // or stdin is still open (e.g. inherited in tests / manual runs).
+      process.stdin.destroy();
+    })();
+    return cleanupPromise;
   };
+
   for (const sig of ["SIGTERM", "SIGINT"] as const) {
-    process.on(sig, () => {
-      cleanup().finally(() => process.exit(0));
+    process.once(sig, () => {
+      void cleanup();
     });
   }
-  process.on("beforeExit", () => {
-    cleanup();
+  // NOTE: extension stdin is reserved by the SDK as a parent-death channel —
+  // any other consumer that reads stdin will steal the EOF and break shutdown.
+  process.stdin.once("end", () => {
+    void cleanup();
   });
+  process.stdin.resume();
 }


### PR DESCRIPTION
## Problem

`ozmux daemon` was leaking Node extension processes on every shutdown. Observed in the wild: 2063 orphaned `node bootstrap.{mjs,ts}` processes (PPID 1) accumulated across repeated `make dev` / Tauri Close cycles.

Two independent root causes:

1. **Daemon-scoped child lifecycle violation** — `daemon/extension/src/handle.rs` stored Node children in `Vec<std::process::Child>` with no `Drop` and no `shutdown()`. `std::process::Child` does not kill the child on drop (per Rust docs), so daemon exit reparented every extension to init.
2. **Parent-death undetectable from child** — the daemon spawned Node with `stdin(Stdio::piped())` but `sdk/typescript/src/server/bootstrap.ts` only listened for `SIGTERM`/`SIGINT`/`beforeExit`, never for stdin EOF. So even when daemon exited via `SIGKILL`/abort/OOM (where Rust cleanup cannot run), the child had no way to notice.

## Solution

Three-layer defense, no new `unsafe` in production code:

```
graceful shutdown (SIGTERM/SIGINT → daemon)
  ↓
Rust: ExtensionHandles::shutdown() — tokio::process::Child::wait()
       drops stdin before waiting, which closes the pipe
  ↓
Node: process.stdin.on('end', cleanup) → server.close + binDir rm
  ↓
Node: event loop drains (no process.exit() — avoids racing in-flight promises)
  ↓ (if Node doesn't exit within 500ms)
Rust: child.kill().await — SIGKILL fallback + reap

abnormal shutdown (panic unwind / early return)
  ↓
Rust: kill_on_drop(true) sends SIGKILL — best-effort reap

fatal shutdown (daemon SIGKILL/abort/OOM)
  ↓
Rust cannot run — OS closes pipe writer fd → Node sees EOF → cleanup → exit
  (requires SDK-bootstrap-based extension with a responsive event loop)
```

### Affected areas

- **`daemon/extension`** — migrated `handle.rs` from `std::process` to `tokio::process`, added `ExtensionHandles::shutdown()` (drops stdin via `Child::wait()`, falls back to `child.kill().await` after a 500ms grace period), added `kill_on_drop(true)` as the panic-path safety net. Added the `process` and `time` tokio features.
- **`daemon/bootstrap`** — `RuntimeHandles` now exposes `pub async fn shutdown(self)` which the `serve()` path awaits after the `tokio::select!` resolves. `Drop` retained as a panic safety net (event-pump abort only).
- **`sdk/typescript`** — replaced the `cleaningUp` boolean with a `cleanupPromise` singleton, registered a `process.stdin.once('end', cleanup)` + `process.stdin.resume()` handler for parent-death detection, and removed `process.exit(0)` so the event loop drains naturally (avoids race-killing in-flight cleanup promises). Also calls `process.stdin.destroy()` at the end of cleanup so the SIGTERM-to-Node path doesn't hang on a pinned stdin keepalive.
- **`daemon/extension/tests`** — new `shutdown_runs_graceful_node_cleanup` integration test that asserts binDir/sock removal post-shutdown. Removal only happens if the Node-side EOF cleanup actually fired — a simple `waitpid ECHILD` would pass even if the EOF path were broken (the 500ms SIGKILL fallback would also reap). Test fixtures now write their PID after `bootstrap()` returns so tests can synchronize on extension readiness.

### Verified

- New integration test passes (`cargo test -p ozmux_extension --test e2e shutdown_runs_graceful_node_cleanup`).
- Full workspace tests pass (`cargo test`, `pnpm test`).
- Manual verification on macOS (Darwin 25.3.0):
  - `ozmux daemon stop` (SIGTERM): 0 leaked Node processes
  - `kill -9 \$(cat \$TMPDIR/ozmux/daemon.pid)` (SIGKILL): 0 leaked Node processes (Node sees pipe EOF and self-exits)
  - 5× start/stop stress loop: 0 accumulation
  - `make dev` + Tauri Close button: 0 leaked Node processes

### Design

Spec: `docs/superpowers/specs/2026-05-21-extension-process-leak-design.md` (gitignored; available in the worktree).

### Out of scope (follow-up)

- Parallel `shutdown_one` (currently sequential, fine while N ≤ ~18 within the CLI's 10s SIGTERM budget)
- CLI `ozmux daemon stop` killpg conversion
- Grandchild process handling (current SDK does not encourage `child_process.spawn`)
- Deprecated `pub async fn run()` removal
- `stderr(Stdio::piped())` drain (pre-existing concern, separate)