### PR TITLE
Tier 2: Visual quality bundle for bevy_terminal_renderer

### DIFF
--- a/crates/bevy_terminal_renderer/src/glyph/atlas.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/atlas.rs
@@ -80,7 +80,7 @@ impl GlyphAtlas {
         }
         let font = fonts.choice(&key.face);
         let ch = char::from_u32(key.codepoint)?;
-        let scale = ab_glyph::PxScale::from(key.size_px as f32);
+        let scale = ab_glyph::PxScale::from(fonts.px_scale_value(key.size_px));
         let scaled = font.as_scaled(scale);
         let glyph_id = scaled.glyph_id(ch);
         // NOTE: ab_glyph maps unknown codepoints to glyph ID 0 (notdef), and

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -46,6 +46,13 @@ pub struct CellMetrics {
     pub underline_position_phys: f32,
     /// Underline stroke thickness in physical pixels.
     pub underline_thickness_phys: f32,
+    /// Worst-case rightward overflow in physical px across all four faces
+    /// (Regular/Italic/Bold/BoldItalic) over ASCII printable codepoints,
+    /// measured as `max(0, outline_glyph(...).px_bounds().max.x - cell_w_phys_floor)`.
+    /// Used by the shader to paint the rightmost column's overflow pixels
+    /// inside the bg_padding strip; used by `resize_terminals_to_node` to
+    /// reserve that strip from the available node width.
+    pub max_overflow_phys: f32,
 }
 
 /// Cross-crate public Resource exposing the current `CellMetrics` for
@@ -82,6 +89,35 @@ pub struct TerminalFonts {
     /// metrics requests. Zero extra memory cost — both crates borrow the
     /// same static slice.
     pub(crate) regular_ttf_bytes: &'static [u8],
+}
+
+/// Computes the worst-case rightward overflow (in physical px) over ASCII
+/// printable codepoints for a single scaled face. Uses the same
+/// `outline_glyph(...).px_bounds()` path as the atlas rasterizer, so the
+/// value matches what the shader actually samples.
+///
+/// `cell_w_phys_floor` is the floored advance the renderer uses as cell
+/// pitch. The overflow is how far past that floor the rasterized bitmap
+/// reaches.
+fn max_ascii_overflow_for_face(face: &FontArc, px_scale: f32, cell_w_phys_floor: f32) -> f32 {
+    let scaled = face.as_scaled(ab_glyph::PxScale::from(px_scale));
+    let mut worst = 0.0_f32;
+    for codepoint in 0x20u8..=0x7Eu8 {
+        let ch = codepoint as char;
+        let gid = scaled.glyph_id(ch);
+        if gid.0 == 0 {
+            continue;
+        }
+        let outlined = match scaled.outline_glyph(gid.with_scale(px_scale)) {
+            Some(o) => o,
+            None => continue,
+        };
+        let overflow = outlined.px_bounds().max.x - cell_w_phys_floor;
+        if overflow > worst {
+            worst = overflow;
+        }
+    }
+    worst.max(0.0)
 }
 
 impl TerminalFonts {
@@ -139,6 +175,12 @@ impl TerminalFonts {
                 (-ascent_phys * 0.07, (ascent_phys / 14.0).max(1.0))
             };
 
+        let cell_w_phys_floor = advance_phys.floor().max(1.0);
+        let max_overflow_phys = [&self.regular, &self.italic, &self.bold, &self.bold_italic]
+            .iter()
+            .map(|face| max_ascii_overflow_for_face(face, px_scale_value, cell_w_phys_floor))
+            .fold(0.0_f32, f32::max);
+
         CellMetrics {
             advance_phys,
             line_height_phys,
@@ -146,6 +188,7 @@ impl TerminalFonts {
             descent_phys,
             underline_position_phys,
             underline_thickness_phys,
+            max_overflow_phys,
         }
     }
 }
@@ -237,6 +280,43 @@ mod tests {
             m.underline_thickness_phys >= 1.0,
             "underline_thickness_phys = {}",
             m.underline_thickness_phys
+        );
+    }
+
+    /// JBM at 12 px must report a non-zero `max_overflow_phys` because
+    /// glyphs like `W` rasterize past the floored advance.
+    #[test]
+    fn cell_metrics_px_reports_nonzero_max_overflow_for_jbm() {
+        let fonts = TerminalFonts::default();
+        let m = fonts.cell_metrics_px(12);
+        assert!(
+            m.max_overflow_phys > 0.0,
+            "max_overflow_phys = {} (expected > 0 driven by wide ASCII glyphs)",
+            m.max_overflow_phys
+        );
+    }
+
+    /// `max_overflow_phys` must cover the worst face — independently
+    /// measuring BoldItalic '%' (a known wide italic glyph) must not
+    /// exceed what `cell_metrics_px` returned.
+    #[test]
+    fn cell_metrics_px_max_overflow_covers_all_faces() {
+        let fonts = TerminalFonts::default();
+        let m = fonts.cell_metrics_px(12);
+
+        let face = TtfFace::parse(fonts.regular_ttf_bytes, 0).unwrap();
+        let upem = f32::from(face.units_per_em());
+        let em_scale = (i32::from(face.ascender()) - i32::from(face.descender())) as f32 / upem;
+        let px_scale = 12.0_f32 * em_scale;
+        let cell_w_phys_floor = m.advance_phys.floor().max(1.0);
+
+        let bi_overflow =
+            max_ascii_overflow_for_face(&fonts.bold_italic, px_scale, cell_w_phys_floor);
+        assert!(
+            bi_overflow <= m.max_overflow_phys + 0.001,
+            "BoldItalic overflow = {} exceeded reported max_overflow_phys = {}",
+            bi_overflow,
+            m.max_overflow_phys,
         );
     }
 

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -97,30 +97,43 @@ impl TerminalFonts {
     /// Returns full pixel metrics for the regular face at the requested
     /// physical pixel size. See [`CellMetrics`] for individual field semantics.
     pub fn cell_metrics_px(&self, phys_size_px: u16) -> CellMetrics {
+        let face = TtfFace::parse(self.regular_ttf_bytes, 0)
+            .expect("JetBrainsMono-Regular ttf-parser parse");
+        // NOTE: cast to i32 before subtraction. ascender() / descender() return
+        // i16, and (asc − desc) can exceed i16::MAX for fonts where the
+        // typographic envelope is unusually tall. JBM (1320) is safe; a
+        // user-provided font might not be.
+        let asc = i32::from(face.ascender());
+        let desc = i32::from(face.descender());
+        let upem = f32::from(face.units_per_em());
+        let em_scale = (asc - desc) as f32 / upem;
+        let phys_size_px_f = f32::from(phys_size_px);
+        let px_scale_value = phys_size_px_f * em_scale;
+
         let scaled = self
             .regular
-            .as_scaled(ab_glyph::PxScale::from(phys_size_px as f32));
+            .as_scaled(ab_glyph::PxScale::from(px_scale_value));
         let advance_phys = scaled.h_advance(scaled.glyph_id('0'));
         let ascent_phys = scaled.ascent();
         let descent_phys = scaled.descent().abs();
 
-        let face = TtfFace::parse(self.regular_ttf_bytes, 0)
-            .expect("JetBrainsMono-Regular ttf-parser parse");
-        let upem = face.units_per_em() as f32;
-        let scale = phys_size_px as f32 / upem;
+        // NOTE: scale for ttf-parser font-unit values: phys_size_px is the
+        // em-square (1 em = upem font units = phys_size_px physical pixels).
+        // px_scale_value is already inflated for ab_glyph's PxScale convention
+        // and must not be used here — that would double-count the em_scale factor.
+        let scale = phys_size_px_f / upem;
 
         // NOTE: ab_glyph's PxScale maps em-square exactly to px so
         // ascent+descent==px_size and line_gap()==0. Use the hhea typographic
         // values from ttf-parser instead so the real typographic line gap is
         // preserved (drives correct line spacing).
-        let line_height_phys =
-            (face.ascender() - face.descender() + face.line_gap()) as f32 * scale;
+        let line_height_phys = (asc - desc + i32::from(face.line_gap())) as f32 * scale;
 
         let (underline_position_phys, underline_thickness_phys) =
             if let Some(u) = face.underline_metrics() {
                 (
-                    u.position as f32 * scale,
-                    (u.thickness as f32 * scale).max(1.0),
+                    f32::from(u.position) * scale,
+                    (f32::from(u.thickness) * scale).max(1.0),
                 )
             } else {
                 (-ascent_phys * 0.07, (ascent_phys / 14.0).max(1.0))
@@ -188,30 +201,30 @@ mod tests {
     use super::*;
 
     /// `cell_metrics_px(12)` returns sensible values for JetBrains Mono Regular 12px.
-    /// Empirical reference values (`docs/plans/2026-05-25-bevy-font-render-design.md` Background):
-    ///   advance(`0`) ≈ 5.45,  line_height ≈ 14.4,  ascent ≈ 10.0,  descent ≈ 2.6
+    /// Empirical reference values after em-square scaling (JBM 1.32 multiplier):
+    ///   advance(`0`) ≈ 7.2,  line_height ≈ 15.8,  ascent ≈ 12.x,  descent ≈ 3.x
     /// underline_position is negative (below baseline), underline_thickness is positive.
     #[test]
     fn jetbrains_mono_12px_metrics_are_sensible() {
         let fonts = TerminalFonts::default();
         let m = fonts.cell_metrics_px(12);
         assert!(
-            m.advance_phys > 5.0 && m.advance_phys < 6.0,
-            "advance_phys = {}",
+            m.advance_phys > 7.0 && m.advance_phys < 7.5,
+            "advance_phys = {} (CSS/Terminal.app range)",
             m.advance_phys
         );
         assert!(
-            m.line_height_phys > 13.0 && m.line_height_phys < 16.0,
+            m.line_height_phys > 15.0 && m.line_height_phys < 17.0,
             "line_height_phys = {}",
             m.line_height_phys
         );
         assert!(
-            m.ascent_phys > 9.0 && m.ascent_phys < 11.0,
+            m.ascent_phys > 11.5 && m.ascent_phys < 13.0,
             "ascent_phys = {}",
             m.ascent_phys
         );
         assert!(
-            m.descent_phys > 1.0 && m.descent_phys < 4.0,
+            m.descent_phys > 2.5 && m.descent_phys < 4.5,
             "descent_phys = {}",
             m.descent_phys
         );
@@ -250,6 +263,6 @@ mod tests {
             .get_resource::<TerminalCellMetricsResource>()
             .expect("TerminalCellMetricsResource should be inserted by Startup");
         assert_eq!(res.phys_font_size, 12);
-        assert!(res.metrics.advance_phys > 5.0 && res.metrics.advance_phys < 6.0);
+        assert!(res.metrics.advance_phys > 7.0 && res.metrics.advance_phys < 7.5);
     }
 }

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -168,9 +168,8 @@ impl TerminalFonts {
         let asc = i32::from(face.ascender());
         let desc = i32::from(face.descender());
         let upem = f32::from(face.units_per_em());
-        let em_scale = (asc - desc) as f32 / upem;
+        let px_scale_value = self.px_scale_value(phys_size_px);
         let phys_size_px_f = f32::from(phys_size_px);
-        let px_scale_value = phys_size_px_f * em_scale;
 
         let scaled = self
             .regular
@@ -216,6 +215,26 @@ impl TerminalFonts {
             underline_thickness_phys,
             max_overflow_phys,
         }
+    }
+
+    /// Returns the actual `PxScale` value fed to `ab_glyph` for the given
+    /// CSS-pixel font size. Multiplies by `em_scale = (ascender − descender)
+    /// / units_per_em` (derived from the Regular face's hhea/head tables)
+    /// so the input size is interpreted as the em-square in physical pixels
+    /// (CSS / Terminal.app convention), not as `ab_glyph::PxScale`'s
+    /// native "ascent + |descent|" interpretation.
+    ///
+    /// Used by both `cell_metrics_px` (for advance / ascent / descent
+    /// derivation) and `glyph/atlas.rs` (for glyph rasterization), so both
+    /// agree on the actual rendering scale.
+    pub(crate) fn px_scale_value(&self, phys_size_px: u16) -> f32 {
+        let face = TtfFace::parse(self.regular_ttf_bytes, 0)
+            .expect("JetBrainsMono-Regular ttf-parser parse");
+        let asc = i32::from(face.ascender());
+        let desc = i32::from(face.descender());
+        let upem = f32::from(face.units_per_em());
+        let em_scale = (asc - desc) as f32 / upem;
+        f32::from(phys_size_px) * em_scale
     }
 }
 
@@ -354,6 +373,29 @@ mod tests {
         let m24 = fonts.cell_metrics_px(24);
         assert!((m24.advance_phys - m12.advance_phys * 2.0).abs() < 0.5);
         assert!((m24.line_height_phys - m12.line_height_phys * 2.0).abs() < 0.5);
+    }
+
+    /// `cell_metrics_px` and `glyph/atlas.rs` must rasterize at the SAME
+    /// PxScale, otherwise atlas glyphs are physically smaller (or larger)
+    /// than the cell pitch and either leave blank gutters on the right
+    /// (atlas < cell) or overflow without coverage (atlas > cell).
+    /// This test guards against accidental divergence.
+    #[test]
+    fn px_scale_value_matches_cell_metrics_internal_use() {
+        let fonts = TerminalFonts::default();
+        let phys = 12u16;
+        let helper_value = fonts.px_scale_value(phys);
+        let metrics = fonts.cell_metrics_px(phys);
+        let scaled = fonts
+            .regular
+            .as_scaled(ab_glyph::PxScale::from(helper_value));
+        let expected_advance = scaled.h_advance(scaled.glyph_id('0'));
+        assert!(
+            (metrics.advance_phys - expected_advance).abs() < 0.001,
+            "cell_metrics advance = {} disagrees with px_scale_value-derived advance = {}",
+            metrics.advance_phys,
+            expected_advance,
+        );
     }
 
     /// `init_cell_metrics_from_primary_window` reads the PrimaryWindow's

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -1,20 +1,47 @@
 use ab_glyph::{Font, FontArc, ScaleFont};
 use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
 use ttf_parser::Face as TtfFace;
+
+/// Font size in CSS pixels; multiplied by the PrimaryWindow's
+/// `scale_factor` to obtain the physical pixel size fed to
+/// `cell_metrics_px`.
+pub(crate) const FONT_SIZE_PX: f32 = 12.0;
 
 #[derive(Default)]
 pub struct TerminalFontPlugin;
 
 impl Plugin for TerminalFontPlugin {
     fn build(&self, app: &mut App) {
-        let fonts = TerminalFonts::default();
-        let default_metrics = fonts.cell_metrics_px(12);
-        app.insert_resource(fonts);
-        app.insert_resource(TerminalCellMetricsResource {
-            metrics: default_metrics,
-            phys_font_size: 12,
-        });
+        app.insert_resource(TerminalFonts::default());
+        app.add_systems(Startup, init_cell_metrics_from_primary_window);
     }
+}
+
+/// Inserts `TerminalCellMetricsResource` at Startup based on the
+/// PrimaryWindow's current scale_factor. Bevy 0.18's winit runner writes
+/// the OS-reported scale_factor into the Window during `create_windows()`
+/// (in `resumed()`), which runs before the first `App::update()` — so this
+/// Startup system sees the correct DPR on its very first invocation,
+/// eliminating the 1-frame Retina jitter where the resource would
+/// otherwise hold DPR=1.0 values.
+///
+/// `Single<&Window, With<PrimaryWindow>>` refuses to run the system unless
+/// exactly one matching entity exists; under `MinimalPlugins` (no Window)
+/// the system is silently skipped, and consumers' test helpers continue
+/// to insert `TerminalCellMetricsResource` manually.
+fn init_cell_metrics_from_primary_window(
+    mut commands: Commands,
+    fonts: Res<TerminalFonts>,
+    window: Single<&Window, With<PrimaryWindow>>,
+) {
+    let dpr = window.scale_factor();
+    let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
+    let metrics = fonts.cell_metrics_px(phys_font_size);
+    commands.insert_resource(TerminalCellMetricsResource {
+        metrics,
+        phys_font_size,
+    });
 }
 
 /// Pixel metrics for the regular face at the given physical pixel size.
@@ -59,11 +86,10 @@ pub struct CellMetrics {
 /// `ozmux-gui::resize_terminals_to_node` and any other consumer that needs
 /// the canonical cell pitch / advance values.
 ///
-/// Initialized at `Startup` with DPR=1.0 defaults; updated every time
-/// `update_terminal_material` recomputes metrics (DPR or font-size change).
-/// Consumers reading this Resource on a frame between Startup and the first
-/// `update_terminal_material` invocation will see DPR=1.0 values; the spec
-/// documents this 1-frame jitter as an accepted Tier 1 trade-off.
+/// Inserted at `Startup` by `init_cell_metrics_from_primary_window` based
+/// on the OS-reported scale_factor of the PrimaryWindow; subsequently
+/// rewritten by `update_terminal_material` whenever DPR or font size
+/// changes (e.g. window moved to a different-DPR display).
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct TerminalCellMetricsResource {
     /// Current cell pitch and typographic measurements in physical pixels.
@@ -330,19 +356,36 @@ mod tests {
         assert!((m24.line_height_phys - m12.line_height_phys * 2.0).abs() < 0.5);
     }
 
-    /// `TerminalFontPlugin` inserts `TerminalCellMetricsResource` at Startup
-    /// with the DPR=1.0 / FONT_SIZE_PX=12 default values, so gui-side
-    /// consumers can read non-None metrics on the first frame.
+    /// `init_cell_metrics_from_primary_window` reads the PrimaryWindow's
+    /// scale_factor and inserts a DPR-aware `TerminalCellMetricsResource`.
     #[test]
-    fn font_plugin_inserts_default_cell_metrics_resource() {
+    fn init_cell_metrics_from_primary_window_uses_window_scale_factor() {
+        use bevy::window::{PrimaryWindow, Window, WindowResolution};
+
         let mut app = App::new();
+        // NOTE: PrimaryWindow must be spawned BEFORE `app.update()` — the
+        // Startup system uses `Single<&Window, With<PrimaryWindow>>` which
+        // skips the system when zero entities match. If we spawned after
+        // update, the resource would never be inserted and the assertion
+        // below would panic with "should have inserted" — a vacuous pass
+        // disguised as a failure-mode test.
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(2.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+
         app.add_plugins(TerminalFontPlugin);
         app.update();
+
         let res = app
             .world()
             .get_resource::<TerminalCellMetricsResource>()
-            .expect("TerminalCellMetricsResource should be inserted by Startup");
-        assert_eq!(res.phys_font_size, 12);
-        assert!(res.metrics.advance_phys > 7.0 && res.metrics.advance_phys < 7.5);
+            .expect("Startup system should have inserted TerminalCellMetricsResource");
+        assert_eq!(
+            res.phys_font_size, 24,
+            "phys_font_size should be FONT_SIZE_PX (12) * scale_factor (2.0) = 24"
+        );
     }
 }

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -342,8 +342,9 @@ mod tests {
     }
 
     /// `max_overflow_phys` must cover the worst face — independently
-    /// measuring BoldItalic '%' (a known wide italic glyph) must not
-    /// exceed what `cell_metrics_px` returned.
+    /// measure each of the 4 faces and verify each is ≤ the reported
+    /// `max_overflow_phys`. Catches a regression where the fold drops
+    /// any face from the per-face max computation.
     #[test]
     fn cell_metrics_px_max_overflow_covers_all_faces() {
         let fonts = TerminalFonts::default();
@@ -355,14 +356,21 @@ mod tests {
         let px_scale = 12.0_f32 * em_scale;
         let cell_w_phys_floor = m.advance_phys.floor().max(1.0);
 
-        let bi_overflow =
-            max_ascii_overflow_for_face(&fonts.bold_italic, px_scale, cell_w_phys_floor);
-        assert!(
-            bi_overflow <= m.max_overflow_phys + 0.001,
-            "BoldItalic overflow = {} exceeded reported max_overflow_phys = {}",
-            bi_overflow,
-            m.max_overflow_phys,
-        );
+        for (name, face_arc) in [
+            ("Regular", &fonts.regular),
+            ("Italic", &fonts.italic),
+            ("Bold", &fonts.bold),
+            ("BoldItalic", &fonts.bold_italic),
+        ] {
+            let face_overflow = max_ascii_overflow_for_face(face_arc, px_scale, cell_w_phys_floor);
+            assert!(
+                face_overflow <= m.max_overflow_phys + 0.001,
+                "{} face overflow = {} exceeds reported max_overflow_phys = {}",
+                name,
+                face_overflow,
+                m.max_overflow_phys,
+            );
+        }
     }
 
     /// 24 px metrics are approximately double the 12 px ones.

--- a/crates/bevy_terminal_renderer/src/glyph/font.rs
+++ b/crates/bevy_terminal_renderer/src/glyph/font.rs
@@ -400,6 +400,10 @@ mod tests {
 
     /// `init_cell_metrics_from_primary_window` reads the PrimaryWindow's
     /// scale_factor and inserts a DPR-aware `TerminalCellMetricsResource`.
+    /// Verifies BOTH (a) `phys_font_size` reflects the scale_factor and
+    /// (b) the derived metrics (advance_phys) are also DPR-scaled —
+    /// catches a regression where phys_font_size is correct but a wrong
+    /// size (e.g. FONT_SIZE_PX as u16) is fed to cell_metrics_px.
     #[test]
     fn init_cell_metrics_from_primary_window_uses_window_scale_factor() {
         use bevy::window::{PrimaryWindow, Window, WindowResolution};
@@ -425,9 +429,25 @@ mod tests {
             .world()
             .get_resource::<TerminalCellMetricsResource>()
             .expect("Startup system should have inserted TerminalCellMetricsResource");
+
+        // (a) phys_font_size reflects scale_factor.
         assert_eq!(
             res.phys_font_size, 24,
-            "phys_font_size should be FONT_SIZE_PX (12) * scale_factor (2.0) = 24"
+            "phys_font_size should be FONT_SIZE_PX * scale_factor (12 * 2.0 = 24)"
+        );
+
+        // (b) Derived metrics are ALSO scaled to DPR=2 — catches a bug
+        // where phys_font_size is right but the wrong size is fed to
+        // cell_metrics_px. Compares against DPR=1 baseline rather than
+        // hardcoding a JBM-specific advance value (~14.4 px) that would
+        // break on font updates.
+        let baseline = TerminalFonts::default();
+        let m12 = baseline.cell_metrics_px(12);
+        assert!(
+            (res.metrics.advance_phys - m12.advance_phys * 2.0).abs() < 0.5,
+            "advance_phys at DPR=2 ({:.3}) should be ~2x DPR=1's ({:.3})",
+            res.metrics.advance_phys,
+            m12.advance_phys * 2.0,
         );
     }
 }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -1,7 +1,7 @@
 use crate::{
     glyph::{
         atlas::{GlyphAtlas, GlyphRect},
-        font::{FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFonts},
+        font::{FONT_SIZE_PX, FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFonts},
     },
     material::state::TerminalMaterialState,
     schema::{Cell, SelectionKind, TerminalGrid},
@@ -14,6 +14,7 @@ use bevy::{
         storage::ShaderStorageBuffer,
     },
     shader::ShaderRef,
+    window::PrimaryWindow,
 };
 
 mod state;
@@ -297,11 +298,10 @@ fn update_terminal_material(
     )>,
     fonts: Res<TerminalFonts>,
     palette_time: Res<Time>,
-    windows: Query<&Window>,
+    windows: Query<&Window, With<PrimaryWindow>>,
     mut cell_metrics_res: ResMut<TerminalCellMetricsResource>,
 ) {
     // TODO: load font size from config.
-    const FONT_SIZE_PX: f32 = 12.0;
 
     // NOTE: This system runs unconditionally — *not* gated by
     // `Changed<TerminalGrid>`. The `mat.params = ...` write at the end is

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -322,10 +322,22 @@ fn update_terminal_material(
     // `sync_atlas_image` re-uploads pixels — the glyphs are present on GPU
     // but the shader's `textureSampleLevel` returns 0. The actual GPU upload
     // cost is bounded by `needs_rebuild` below.
-    for (handle, mut state, grid) in terminals.iter_mut() {
-        let dpr = windows.single().map(|w| w.scale_factor()).unwrap_or(1.0);
-        let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
+    // NOTE: Skip the entire system when PrimaryWindow is transiently
+    // absent (display hotplug, brief winit reconnect). Trade-off: the
+    // `mat.params = ...` write below would fire AssetEvent::Modified
+    // every frame (load-bearing for bind-group rebuild — see NOTE above);
+    // skipping for one frame means the previous frame's bind group
+    // continues to serve. This is bounded (sync_atlas_image is also
+    // ordered after this system, so atlas uploads defer in lock-step)
+    // and far less disruptive than the previous .unwrap_or(1.0) flash
+    // that would re-rasterize the entire atlas at half scale.
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    let dpr = window.scale_factor();
+    let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
 
+    for (handle, mut state, grid) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;
         let cols = grid.cols as u32;
         let rows = grid.rows as u32;

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -113,8 +113,9 @@ impl UiMaterial for TerminalUiMaterial {
 ///
 /// # Layout (std140, encase derive)
 ///
-/// Field offsets in bytes (encase auto-inserts 4 bytes of padding before
-/// `bg_padding_color` so the Vec4 lands at offset 80; total 96 bytes,
+/// Field offsets in bytes. `max_overflow_phys` fills the 4-byte padding slot
+/// at offset 76 that encase would otherwise insert before `bg_padding_color`
+/// (Vec4 needs 16-byte alignment, lands at offset 80; total 96 bytes,
 /// 16-byte aligned):
 ///
 /// | Offset | Field                       |
@@ -134,6 +135,7 @@ impl UiMaterial for TerminalUiMaterial {
 /// | 64     | `sel_kind`                  |
 /// | 68     | `underline_position_phys`   |
 /// | 72     | `underline_thickness_phys`  |
+/// | 76     | `max_overflow_phys`         |
 /// | 80     | `bg_padding_color`          |
 #[derive(Clone, Copy, ShaderType, Default, Debug)]
 struct TerminalParams {
@@ -156,6 +158,11 @@ struct TerminalParams {
     sel_kind: u32,
     underline_position_phys: f32,
     underline_thickness_phys: f32,
+    /// Worst-case ASCII rightward bbox overflow (physical px) across all four
+    /// faces. The shader uses this to extend its "rightmost column glyph"
+    /// evaluation past `grid_size.x * cell_size_px.x` into the bg_padding
+    /// strip; the host reserves the same amount from the node width.
+    max_overflow_phys: f32,
     bg_padding_color: Vec4,
 }
 
@@ -179,6 +186,7 @@ impl TerminalParams {
         time_seconds: f32,
         underline_position_phys: f32,
         underline_thickness_phys: f32,
+        max_overflow_phys: f32,
         bg_padding_color: Vec4,
     ) -> Self {
         let cols = u32::from(grid.cols);
@@ -216,6 +224,7 @@ impl TerminalParams {
             sel_kind,
             underline_position_phys,
             underline_thickness_phys,
+            max_overflow_phys,
             bg_padding_color,
         }
     }
@@ -427,6 +436,7 @@ fn update_terminal_material(
                 palette_time.elapsed_secs(),
                 metrics.underline_position_phys,
                 metrics.underline_thickness_phys.max(1.0),
+                metrics.max_overflow_phys,
                 bg_padding_color,
             );
         }

--- a/crates/bevy_terminal_renderer/src/material/state.rs
+++ b/crates/bevy_terminal_renderer/src/material/state.rs
@@ -146,6 +146,7 @@ mod tests {
                 descent_phys: 2.4,
                 underline_position_phys: -1.5,
                 underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
             }),
             initialized: true,
         };

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -1,6 +1,10 @@
 
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 
+// ============================================================================
+// Module data
+// ============================================================================
+
 struct TerminalParams {
     grid_size: vec2<u32>,
     cell_size_px: vec2<f32>,
@@ -35,6 +39,20 @@ struct Glyph {
     size_px: vec2<f32>,
 };
 
+struct CellHit {
+    valid: bool,
+    row: u32,
+    col: u32,
+    cell: Cell,
+    // Fragment position relative to the cell's top-left, in physical px.
+    in_cell_px: vec2<f32>,
+};
+
+struct CellColors {
+    fg: vec4<f32>,
+    bg: vec4<f32>,
+};
+
 @group(1) @binding(0) var<uniform> params: TerminalParams;
 @group(1) @binding(1) var<storage, read> cells: array<Cell>;
 @group(1) @binding(2) var<storage, read> glyphs: array<Glyph>;
@@ -61,145 +79,125 @@ const CURSOR_SHAPE_BAR: u32 = 2u;
 
 const GLYPH_NONE: u32 = 0xFFFFFFFFu;
 
-// -- color packing -----------------------------------------------------------
+// ============================================================================
+// Fragment entrypoint
+// ============================================================================
 
-fn unpack_rgba(p: u32) -> vec4<f32> {
-    return vec4<f32>(
-        f32(p & 0xFFu),
-        f32((p >> 8u) & 0xFFu),
-        f32((p >> 16u) & 0xFFu),
-        f32((p >> 24u) & 0xFFu),
-    ) / 255.0;
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    // Out-of-grid fragments (degenerate grid, or the right/bottom padding
+    // strip) fall back to bg_padding_color so the surrounding band blends
+    // with the terminal background instead of opaque black.
+    let fallback = params.bg_padding_color;
+    if params.grid_size.x == 0u || params.grid_size.y == 0u {
+        return fallback;
+    }
+
+    // Shader runs entirely in PHYSICAL pixels. Bevy 0.18 UiVertexOutput.size
+    // is physical px (verified in spec R1 audit), so we use it directly.
+    let p_px = in.uv * in.size;
+    let hit = locate_cell(p_px);
+    if !hit.valid {
+        return paint_right_strip(p_px, fallback);
+    }
+    return paint_grid_cell(hit, fallback);
 }
 
-// -- cell lookup -------------------------------------------------------------
+// ============================================================================
+// Top-level pipeline stages
+// ============================================================================
 
-struct CellHit {
-    valid: bool,
-    row: u32,
-    col: u32,
-    cell: Cell,
-    // Fragment position relative to the cell's top-left, in physical px.
-    in_cell_px: vec2<f32>,
-};
+// Pipeline for a fragment that lies inside the grid: background → primary
+// glyph → left-neighbor overdraw → text decorations → cursor → selection.
+fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
+    let colors = resolve_cell_colors(hit.cell);
+    var color = colors.bg;
+    color = paint_primary_glyph(hit, colors.fg, color);
+    color = paint_left_overdraw(hit, color);
+    color = paint_text_decorations(hit.cell.style_flags, hit.in_cell_px, colors.fg, color);
+    color = paint_cursor(hit.row, hit.col, hit.in_cell_px, color);
+    color = paint_selection(hit.row, hit.col, color);
+    return color;
+}
 
-// Resolves the fragment's physical-px position to a grid cell. Returns
-// `valid = false` when the fragment lies in the right/bottom padding
-// strip between `grid_size * cell_size_px` and the host UI node edge,
-// or when the cell index would overflow the `cells` storage buffer.
-fn locate_cell(p_px: vec2<f32>) -> CellHit {
-    let invalid = CellHit(false, 0u, 0u, Cell(0u, 0u, 0u, 0u), vec2<f32>(0.0, 0.0));
-    let cell_pitch = params.cell_size_px;
-    let grid_w_px = cell_pitch.x * f32(params.grid_size.x);
-    let grid_h_px = cell_pitch.y * f32(params.grid_size.y);
-    if p_px.x >= grid_w_px || p_px.y >= grid_h_px {
-        return invalid;
+// Handles fragments past the grid's right edge: when they fall within the
+// `max_overflow_phys` band reserved by the host, paint the rightmost cell's
+// bbox overflow. Falls back to `fallback` outside the band or on a miss.
+fn paint_right_strip(p_px: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
+    let grid_w_phys = params.cell_size_px.x * f32(params.grid_size.x);
+    let grid_h_phys = params.cell_size_px.y * f32(params.grid_size.y);
+    let in_right_strip = p_px.x >= grid_w_phys
+        && p_px.x < grid_w_phys + params.max_overflow_phys
+        && p_px.y < grid_h_phys;
+    if !in_right_strip {
+        return fallback;
     }
-    let col_f = p_px.x / cell_pitch.x;
-    let row_f = p_px.y / cell_pitch.y;
-    if col_f < 0.0 || row_f < 0.0 {
-        return invalid;
-    }
-    let col = u32(floor(col_f));
-    let row = u32(floor(row_f));
-    if col >= params.grid_size.x || row >= params.grid_size.y {
-        return invalid;
-    }
+
+    let col = params.grid_size.x - 1u;
+    let row = u32(floor(p_px.y / params.cell_size_px.y));
     let idx = row * params.grid_size.x + col;
     if idx >= arrayLength(&cells) {
-        return invalid;
+        return fallback;
     }
-    let cell_origin = vec2<f32>(f32(col), f32(row)) * cell_pitch;
-    return CellHit(true, row, col, cells[idx], p_px - cell_origin);
-}
 
-// -- color resolution (reverse / hidden / dim) -------------------------------
-
-struct CellColors {
-    fg: vec4<f32>,
-    bg: vec4<f32>,
-};
-
-fn resolve_cell_colors(cell: Cell) -> CellColors {
-    let style = cell.style_flags;
-    let reverse = (style & STYLE_REVERSE) != 0u;
-    let hidden = (style & STYLE_HIDDEN) != 0u;
-    let dim = (style & STYLE_DIM) != 0u;
-
-    var fg = unpack_rgba(cell.fg_packed);
-    var bg = unpack_rgba(cell.bg_packed);
-
-    if hidden {
-        fg = bg;
-    }
-    if reverse {
-        let tmp = fg;
-        fg = bg;
-        bg = tmp;
-    }
-    if dim {
-        fg = vec4<f32>(fg.rgb * 0.66, fg.a);
-    }
-    return CellColors(fg, bg);
-}
-
-// -- glyph sampling ----------------------------------------------------------
-
-// Glyph origin in cell-local PHYSICAL px, snapped to integer pixels.
-// `params.ascent_px` shifts down to the baseline; `glyph.offset_px.y`
-// then lifts back up to the bitmap top.
-fn glyph_origin_phys(glyph: Glyph) -> vec2<f32> {
-    let origin = vec2<f32>(
-        glyph.offset_px.x,
-        params.ascent_px + glyph.offset_px.y,
+    let strip_cell = cells[idx];
+    let strip_local = vec2<f32>(
+        p_px.x - f32(col) * params.cell_size_px.x,
+        p_px.y - f32(row) * params.cell_size_px.y,
     );
-    return floor(origin + vec2<f32>(0.5, 0.5));
+    let strip_fg = resolve_cell_colors(strip_cell).fg;
+    return paint_cell_glyph(strip_cell, strip_local, strip_fg, fallback);
 }
 
-// Atlas alpha coverage at `local_px` (cell-local px relative to the
-// glyph's snapped origin). Returns 0.0 when outside the glyph bitmap so
-// callers can blend unconditionally.
-//
-// NOTE: `textureSampleLevel` (explicit mip 0) instead of
-//       `textureSample` — the latter auto-computes derivatives and
-//       requires uniform control flow; WebGPU rejects it inside
-//       per-fragment branches.
-fn sample_glyph_coverage(glyph: Glyph, local_px: vec2<f32>) -> f32 {
-    if local_px.x < 0.0 || local_px.y < 0.0
-        || local_px.x >= glyph.size_px.x || local_px.y >= glyph.size_px.y {
-        return 0.0;
-    }
-    let atlas_px = mix(glyph.uv_min, glyph.uv_max, local_px / glyph.size_px);
-    let atlas_uv = atlas_px / params.atlas_size_px;
-    return textureSampleLevel(atlas_tex, atlas_sampler, atlas_uv, 0.0).a;
+// ============================================================================
+// Cell glyph stages (primary + left overdraw)
+// ============================================================================
+
+// Paints the cell's own glyph. WIDE_RIGHT_HALF cells render the LEFT half's
+// glyph anchored to the left-half origin — i.e. shifted +cell_pitch.x into
+// "this cell" coordinates — so the wide glyph spans both cells.
+fn paint_primary_glyph(hit: CellHit, fg: vec4<f32>, base: vec4<f32>) -> vec4<f32> {
+    let cur_is_wide_right = (hit.cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
+    let primary_local = select(
+        hit.in_cell_px,
+        hit.in_cell_px + vec2<f32>(params.cell_size_px.x, 0.0),
+        cur_is_wide_right,
+    );
+    return paint_cell_glyph(hit.cell, primary_local, fg, base);
 }
 
-fn blend_glyph(base: vec4<f32>, fg: vec4<f32>, coverage: f32) -> vec4<f32> {
-    return mix(base, vec4<f32>(fg.rgb, max(fg.a, coverage)), coverage);
-}
-
-// Paints `cell`'s glyph into `base`, evaluating against `local_px` (the
-// fragment's cell-local coord). Returns `base` unchanged when the cell
-// has no glyph or the index is out of range.
-fn paint_cell_glyph(
-    cell: Cell,
-    local_px: vec2<f32>,
-    fg: vec4<f32>,
-    base: vec4<f32>,
-) -> vec4<f32> {
-    if cell.glyph_index == GLYPH_NONE || cell.glyph_index >= arrayLength(&glyphs) {
+// Paints any overflow pixels from the LEFT neighbor's glyph — needed for
+// fonts where bbox.width > h_advance (e.g. JetBrains Mono `W`). Skipped when:
+//   (a) we're in column 0 (no left neighbour), or
+//   (b) the current cell is WIDE_RIGHT_HALF (already painted via primary), or
+//   (c) the left neighbour is WIDE_RIGHT_HALF (its glyph_index points to a
+//       wide glyph already painted by paint_primary_glyph on the right half;
+//       re-evaluating here would double-paint).
+fn paint_left_overdraw(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
+    if hit.col == 0u {
         return base;
     }
-    let glyph = glyphs[cell.glyph_index];
-    let glyph_local = local_px - glyph_origin_phys(glyph);
-    let coverage = sample_glyph_coverage(glyph, glyph_local);
-    return blend_glyph(base, fg, coverage);
+    let cur_is_wide_right = (hit.cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
+    if cur_is_wide_right {
+        return base;
+    }
+    let left_idx = hit.row * params.grid_size.x + (hit.col - 1u);
+    let left_cell = cells[left_idx];
+    let left_is_wide_right = (left_cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
+    if left_is_wide_right {
+        return base;
+    }
+    let left_local = hit.in_cell_px + vec2<f32>(params.cell_size_px.x, 0.0);
+    let left_fg = resolve_cell_colors(left_cell).fg;
+    return paint_cell_glyph(left_cell, left_local, left_fg, base);
 }
 
-// -- decorations (underline / strike) ----------------------------------------
+// ============================================================================
+// Overlay stages (decorations / cursor / selection)
+// ============================================================================
 
-// underline metrics come from font-derived uniforms; strike sits at
-// half the ascent and reuses the underline thickness.
+// Underline metrics come from font-derived uniforms; strike sits at half the
+// ascent and reuses the underline thickness.
 fn paint_text_decorations(
     style: u32,
     in_cell_px: vec2<f32>,
@@ -208,8 +206,8 @@ fn paint_text_decorations(
 ) -> vec4<f32> {
     var color = base;
     if (style & STYLE_UNDERLINE) != 0u {
-        // underline_position_phys is negative (below baseline). The
-        // actual y in the cell is baseline + |underline_position|.
+        // underline_position_phys is negative (below baseline). The actual
+        // y in the cell is baseline + |underline_position|.
         let y_top = params.ascent_px - params.underline_position_phys;
         let y_bot = y_top + params.underline_thickness_phys;
         if in_cell_px.y >= y_top && in_cell_px.y < y_bot {
@@ -225,8 +223,6 @@ fn paint_text_decorations(
     }
     return color;
 }
-
-// -- cursor ------------------------------------------------------------------
 
 fn paint_cursor(
     row: u32,
@@ -258,7 +254,22 @@ fn paint_cursor(
     return base;
 }
 
-// -- selection ---------------------------------------------------------------
+fn paint_selection(row: u32, col: u32, base: vec4<f32>) -> vec4<f32> {
+    if params.sel_kind == 0u {
+        return base;
+    }
+    let in_sel = is_in_selection_uniform(
+        i32(row), i32(col),
+        params.sel_kind,
+        params.sel_start_row, i32(params.sel_start_col),
+        params.sel_end_row, i32(params.sel_end_col),
+    );
+    if !in_sel {
+        return base;
+    }
+    let sel_bg = vec4<f32>(0.27, 0.50, 0.66, 0.4);
+    return mix(base, sel_bg, sel_bg.a);
+}
 
 fn is_in_selection_uniform(
     row: i32, col: i32,
@@ -281,102 +292,130 @@ fn is_in_selection_uniform(
     return true;
 }
 
-fn paint_selection(row: u32, col: u32, base: vec4<f32>) -> vec4<f32> {
-    if params.sel_kind == 0u {
-        return base;
+// ============================================================================
+// Cell lookup
+// ============================================================================
+
+// Resolves the fragment's physical-px position to a grid cell. Returns
+// `valid = false` when the fragment lies in the right/bottom padding strip
+// between `grid_size * cell_size_px` and the host UI node edge, or when the
+// cell index would overflow the `cells` storage buffer.
+fn locate_cell(p_px: vec2<f32>) -> CellHit {
+    let invalid = CellHit(false, 0u, 0u, Cell(0u, 0u, 0u, 0u), vec2<f32>(0.0, 0.0));
+    let cell_pitch = params.cell_size_px;
+    let grid_w_px = cell_pitch.x * f32(params.grid_size.x);
+    let grid_h_px = cell_pitch.y * f32(params.grid_size.y);
+    if p_px.x >= grid_w_px || p_px.y >= grid_h_px {
+        return invalid;
     }
-    let in_sel = is_in_selection_uniform(
-        i32(row), i32(col),
-        params.sel_kind,
-        params.sel_start_row, i32(params.sel_start_col),
-        params.sel_end_row, i32(params.sel_end_col),
-    );
-    if !in_sel {
-        return base;
+    let col_f = p_px.x / cell_pitch.x;
+    let row_f = p_px.y / cell_pitch.y;
+    if col_f < 0.0 || row_f < 0.0 {
+        return invalid;
     }
-    let sel_bg = vec4<f32>(0.27, 0.50, 0.66, 0.4);
-    return mix(base, sel_bg, sel_bg.a);
+    let col = u32(floor(col_f));
+    let row = u32(floor(row_f));
+    if col >= params.grid_size.x || row >= params.grid_size.y {
+        return invalid;
+    }
+    let idx = row * params.grid_size.x + col;
+    if idx >= arrayLength(&cells) {
+        return invalid;
+    }
+    let cell_origin = vec2<f32>(f32(col), f32(row)) * cell_pitch;
+    return CellHit(true, row, col, cells[idx], p_px - cell_origin);
 }
 
-// -- fragment entrypoint -----------------------------------------------------
+// ============================================================================
+// Style resolution (reverse / hidden / dim)
+// ============================================================================
 
-@fragment
-fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
-    // Out-of-grid fragments (degenerate grid or the right/bottom
-    // padding strip) are painted with the bg_padding_color uniform set
-    // by Rust-side TerminalParams::new, so the strip blends with the
-    // terminal background instead of falling back to opaque black.
-    let fallback = params.bg_padding_color;
-    if params.grid_size.x == 0u || params.grid_size.y == 0u {
-        return fallback;
+fn resolve_cell_colors(cell: Cell) -> CellColors {
+    let style = cell.style_flags;
+    let reverse = (style & STYLE_REVERSE) != 0u;
+    let hidden = (style & STYLE_HIDDEN) != 0u;
+    let dim = (style & STYLE_DIM) != 0u;
+
+    var fg = unpack_rgba(cell.fg_packed);
+    var bg = unpack_rgba(cell.bg_packed);
+
+    if hidden {
+        fg = bg;
     }
-
-    // Shader runs entirely in PHYSICAL pixels. Bevy 0.18
-    // UiVertexOutput.size is physical px (verified in spec R1 audit),
-    // so we use it directly without dpr_inv conversion.
-    let p_px = in.uv * in.size;
-    let hit = locate_cell(p_px);
-    if !hit.valid {
-        // Right-strip handler: paint the rightmost cell's bbox overflow
-        // into the bg_padding band reserved by resize_terminals_to_node.
-        // paint_cell_glyph early-rejects when the strip's local_px is past
-        // the glyph bitmap, so a miss falls through to bg_padding_color.
-        let grid_w_phys = params.cell_size_px.x * f32(params.grid_size.x);
-        let grid_h_phys = params.cell_size_px.y * f32(params.grid_size.y);
-        let in_right_strip = p_px.x >= grid_w_phys
-            && p_px.x < grid_w_phys + params.max_overflow_phys
-            && p_px.y < grid_h_phys;
-        if in_right_strip {
-            let col = params.grid_size.x - 1u;
-            let row = u32(floor(p_px.y / params.cell_size_px.y));
-            let idx = row * params.grid_size.x + col;
-            if idx < arrayLength(&cells) {
-                let strip_cell = cells[idx];
-                let strip_local = vec2<f32>(
-                    p_px.x - f32(col) * params.cell_size_px.x,
-                    p_px.y - f32(row) * params.cell_size_px.y,
-                );
-                let strip_fg = resolve_cell_colors(strip_cell).fg;
-                return paint_cell_glyph(strip_cell, strip_local, strip_fg, fallback);
-            }
-        }
-        return fallback;
+    if reverse {
+        let tmp = fg;
+        fg = bg;
+        bg = tmp;
     }
+    if dim {
+        fg = vec4<f32>(fg.rgb * 0.66, fg.a);
+    }
+    return CellColors(fg, bg);
+}
 
-    let colors = resolve_cell_colors(hit.cell);
-    var color = colors.bg;
+// ============================================================================
+// Glyph painting (low-level)
+// ============================================================================
 
-    // WIDE_RIGHT_HALF cells render the LEFT half's glyph anchored to
-    // the left-half's origin — i.e. shifted +cell_pitch.x into "this
-    // cell" coordinates — so the wide glyph spans both cells.
-    let cell_pitch = params.cell_size_px;
-    let cur_is_wide_right = (hit.cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
-    let primary_local = select(
-        hit.in_cell_px,
-        hit.in_cell_px + vec2<f32>(cell_pitch.x, 0.0),
-        cur_is_wide_right,
+// Paints `cell`'s glyph into `base`, evaluating against `local_px` (the
+// fragment's cell-local coord). Returns `base` unchanged when the cell has
+// no glyph or the index is out of range.
+fn paint_cell_glyph(
+    cell: Cell,
+    local_px: vec2<f32>,
+    fg: vec4<f32>,
+    base: vec4<f32>,
+) -> vec4<f32> {
+    if cell.glyph_index == GLYPH_NONE || cell.glyph_index >= arrayLength(&glyphs) {
+        return base;
+    }
+    let glyph = glyphs[cell.glyph_index];
+    let glyph_local = local_px - glyph_origin_phys(glyph);
+    let coverage = sample_glyph_coverage(glyph, glyph_local);
+    return blend_glyph(base, fg, coverage);
+}
+
+// Glyph origin in cell-local PHYSICAL px, snapped to integer pixels.
+// `params.ascent_px` shifts down to the baseline; `glyph.offset_px.y` then
+// lifts back up to the bitmap top.
+fn glyph_origin_phys(glyph: Glyph) -> vec2<f32> {
+    let origin = vec2<f32>(
+        glyph.offset_px.x,
+        params.ascent_px + glyph.offset_px.y,
     );
-    color = paint_cell_glyph(hit.cell, primary_local, colors.fg, color);
+    return floor(origin + vec2<f32>(0.5, 0.5));
+}
 
-    // Glyph overdraw from the LEFT neighbor — needed for fonts where
-    // bbox.width > h_advance (e.g. JetBrains Mono `W`). Skip when:
-    //   (a) the current cell is WIDE_RIGHT_HALF (handled above), or
-    //   (b) the left neighbor is WIDE_RIGHT_HALF (its glyph_index
-    //       points to a wide glyph already painted into the right
-    //       half above via primary_local; re-evaluating would double).
-    if hit.col >= 1u && !cur_is_wide_right {
-        let left_idx = hit.row * params.grid_size.x + (hit.col - 1u);
-        let left_cell = cells[left_idx];
-        let left_is_wide_right = (left_cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
-        if !left_is_wide_right {
-            let left_local = hit.in_cell_px + vec2<f32>(cell_pitch.x, 0.0);
-            let left_fg = resolve_cell_colors(left_cell).fg;
-            color = paint_cell_glyph(left_cell, left_local, left_fg, color);
-        }
+// Atlas alpha coverage at `local_px` (cell-local px relative to the glyph's
+// snapped origin). Returns 0.0 when outside the glyph bitmap so callers can
+// blend unconditionally.
+//
+// NOTE: `textureSampleLevel` (explicit mip 0) instead of `textureSample` —
+//       the latter auto-computes derivatives and requires uniform control
+//       flow; WebGPU rejects it inside per-fragment branches.
+fn sample_glyph_coverage(glyph: Glyph, local_px: vec2<f32>) -> f32 {
+    if local_px.x < 0.0 || local_px.y < 0.0
+        || local_px.x >= glyph.size_px.x || local_px.y >= glyph.size_px.y {
+        return 0.0;
     }
+    let atlas_px = mix(glyph.uv_min, glyph.uv_max, local_px / glyph.size_px);
+    let atlas_uv = atlas_px / params.atlas_size_px;
+    return textureSampleLevel(atlas_tex, atlas_sampler, atlas_uv, 0.0).a;
+}
 
-    color = paint_text_decorations(hit.cell.style_flags, hit.in_cell_px, colors.fg, color);
-    color = paint_cursor(hit.row, hit.col, hit.in_cell_px, color);
-    color = paint_selection(hit.row, hit.col, color);
-    return color;
+fn blend_glyph(base: vec4<f32>, fg: vec4<f32>, coverage: f32) -> vec4<f32> {
+    return mix(base, vec4<f32>(fg.rgb, max(fg.a, coverage)), coverage);
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+fn unpack_rgba(p: u32) -> vec4<f32> {
+    return vec4<f32>(
+        f32(p & 0xFFu),
+        f32((p >> 8u) & 0xFFu),
+        f32((p >> 16u) & 0xFFu),
+        f32((p >> 24u) & 0xFFu),
+    ) / 255.0;
 }

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -114,19 +114,24 @@ fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
     var color = colors.bg;
     color = paint_primary_glyph(hit, colors.fg, color);
     color = paint_left_overdraw(hit, color);
-    color = paint_text_decorations(hit.cell.style_flags, hit.in_cell_px, colors.fg, color);
-    color = paint_cursor(hit.row, hit.col, hit.in_cell_px, color);
-    color = paint_selection(hit.row, hit.col, color);
-    return color;
+    return paint_cell_overlays(hit, colors.fg, color);
 }
 
 // Handles fragments past the grid's right edge: when they fall within the
 // `max_overflow_phys` band reserved by the host, paint the rightmost cell's
 // bbox overflow. Falls back to `fallback` outside the band or on a miss.
 fn paint_right_strip(p_px: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
+    // Defensive guard (#10): cell_size_px is Vec2::ZERO during the
+    // ~1-frame window between MaterialNode insertion and the first
+    // update_terminal_material write. The grid_h_phys = 0 check below
+    // already prevents the strip-entry, but the explicit cell_size_px
+    // guard documents the invariant and protects against future
+    // refactors that might remove the height check.
     let grid_w_phys = params.cell_size_px.x * f32(params.grid_size.x);
     let grid_h_phys = params.cell_size_px.y * f32(params.grid_size.y);
-    let in_right_strip = p_px.x >= grid_w_phys
+    let in_right_strip = params.cell_size_px.x > 0.0
+        && params.cell_size_px.y > 0.0
+        && p_px.x >= grid_w_phys
         && p_px.x < grid_w_phys + params.max_overflow_phys
         && p_px.y < grid_h_phys;
     if !in_right_strip {
@@ -145,8 +150,17 @@ fn paint_right_strip(p_px: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
         p_px.x - f32(col) * params.cell_size_px.x,
         p_px.y - f32(row) * params.cell_size_px.y,
     );
-    let strip_fg = resolve_cell_colors(strip_cell).fg;
-    return paint_cell_glyph(strip_cell, strip_local, strip_fg, fallback);
+    let colors = resolve_cell_colors(strip_cell);
+    var color = colors.bg;
+    // NOTE: paint_cell_glyph (NOT paint_primary_glyph). strip_local.x is
+    // in [cell_pitch.x, cell_pitch.x + max_overflow_phys) — already in
+    // the right-half coordinate space of any STYLE_WIDE_RIGHT_HALF wide
+    // glyph. paint_primary_glyph would add another +cell_pitch.x, pushing
+    // past the wide bitmap (size_px.x ≈ 2*cell_pitch.x) → zero coverage.
+    // The asymmetry vs paint_grid_cell is intentional and unavoidable.
+    color = paint_cell_glyph(strip_cell, strip_local, colors.fg, color);
+    let hit = CellHit(true, row, col, strip_cell, strip_local);
+    return paint_cell_overlays(hit, colors.fg, color);
 }
 
 // ============================================================================
@@ -195,6 +209,17 @@ fn paint_left_overdraw(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
 // ============================================================================
 // Overlay stages (decorations / cursor / selection)
 // ============================================================================
+
+// Runs the three overlay stages in canonical order:
+// text decorations → cursor → selection. Used by both paint_grid_cell
+// and paint_right_strip so the strip cannot drift from the grid path
+// on overlay sequence or argument order.
+fn paint_cell_overlays(hit: CellHit, fg: vec4<f32>, base: vec4<f32>) -> vec4<f32> {
+    var color = paint_text_decorations(hit.cell.style_flags, hit.in_cell_px, fg, base);
+    color = paint_cursor(hit.row, hit.col, hit.in_cell_px, color);
+    color = paint_selection(hit.row, hit.col, color);
+    return color;
+}
 
 // Underline metrics come from font-derived uniforms; strike sits at half the
 // ascent and reuses the underline thickness.

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -17,6 +17,7 @@ struct TerminalParams {
     sel_kind: u32,
     underline_position_phys: f32,
     underline_thickness_phys: f32,
+    max_overflow_phys: f32,
     bg_padding_color: vec4<f32>,
 };
 
@@ -316,6 +317,29 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     let p_px = in.uv * in.size;
     let hit = locate_cell(p_px);
     if !hit.valid {
+        // Right-strip handler: paint the rightmost cell's bbox overflow
+        // into the bg_padding band reserved by resize_terminals_to_node.
+        // paint_cell_glyph early-rejects when the strip's local_px is past
+        // the glyph bitmap, so a miss falls through to bg_padding_color.
+        let grid_w_phys = params.cell_size_px.x * f32(params.grid_size.x);
+        let grid_h_phys = params.cell_size_px.y * f32(params.grid_size.y);
+        let in_right_strip = p_px.x >= grid_w_phys
+            && p_px.x < grid_w_phys + params.max_overflow_phys
+            && p_px.y < grid_h_phys;
+        if in_right_strip {
+            let col = params.grid_size.x - 1u;
+            let row = u32(floor(p_px.y / params.cell_size_px.y));
+            let idx = row * params.grid_size.x + col;
+            if idx < arrayLength(&cells) {
+                let strip_cell = cells[idx];
+                let strip_local = vec2<f32>(
+                    p_px.x - f32(col) * params.cell_size_px.x,
+                    p_px.y - f32(row) * params.cell_size_px.y,
+                );
+                let strip_fg = resolve_cell_colors(strip_cell).fg;
+                return paint_cell_glyph(strip_cell, strip_local, strip_fg, fallback);
+            }
+        }
         return fallback;
     }
 
@@ -346,7 +370,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
         let left_is_wide_right = (left_cell.style_flags & STYLE_WIDE_RIGHT_HALF) != 0u;
         if !left_is_wide_right {
             let left_local = hit.in_cell_px + vec2<f32>(cell_pitch.x, 0.0);
-            let left_fg = unpack_rgba(left_cell.fg_packed);
+            let left_fg = resolve_cell_colors(left_cell).fg;
             color = paint_cell_glyph(left_cell, left_local, left_fg, color);
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -297,6 +297,7 @@ mod tests {
                     descent_phys: 4.0,
                     underline_position_phys: -2.0,
                     underline_thickness_phys: 1.0,
+                    max_overflow_phys: 0.0,
                 },
                 phys_font_size: 12,
             })

--- a/src/ui/copy_mode_indicator.rs
+++ b/src/ui/copy_mode_indicator.rs
@@ -406,6 +406,7 @@ mod tests {
                     descent_phys: 3.0,
                     underline_position_phys: -1.0,
                     underline_thickness_phys: 1.0,
+                    max_overflow_phys: 0.0,
                 },
                 phys_font_size: 12,
             })

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -84,7 +84,13 @@ pub(crate) fn resize_terminals_to_node(
     for (computed, mut handle, mut pty, mut coalescer, mut grid) in terminals.iter_mut() {
         let node_phys_w = computed.size.x.max(0.0);
         let node_phys_h = computed.size.y.max(0.0);
-        let cols = ((node_phys_w / cell_w_phys).floor() as u16).max(1);
+        // NOTE: max_overflow_phys reserves space on the right for the WGSL
+        //       shader's right-strip handler to paint the rightmost cell's
+        //       bbox overflow without clipping. Height needs no analogous
+        //       reservation — line_height already accommodates descender
+        //       headroom for the bundled font.
+        let usable_w = (node_phys_w - metrics.metrics.max_overflow_phys).max(0.0);
+        let cols = ((usable_w / cell_w_phys).floor() as u16).max(1);
         let rows = ((node_phys_h / cell_h_phys).floor() as u16).max(1);
 
         let (cur_cols, cur_rows, _) = handle.read_geometry();

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -59,7 +59,7 @@ pub(crate) fn finish_terminal_setup(
 ///
 /// Always returns `(cols, rows)` ≥ `(1, 1)`; degenerate inputs collapse
 /// to a 1x1 grid rather than producing zero-sized buffers.
-pub(crate) fn compute_grid_dims(
+fn compute_grid_dims(
     node_phys_w: f32,
     node_phys_h: f32,
     cell_w_phys: f32,

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -52,6 +52,26 @@ pub(crate) fn finish_terminal_setup(
     }
 }
 
+/// Computes grid dimensions for a host node, reserving `max_overflow_phys`
+/// on the right so the WGSL right-strip handler has room to paint the
+/// rightmost cell's bbox overflow without clipping. Height is not
+/// reserved — line_height already accommodates descender headroom.
+///
+/// Always returns `(cols, rows)` ≥ `(1, 1)`; degenerate inputs collapse
+/// to a 1x1 grid rather than producing zero-sized buffers.
+pub(crate) fn compute_grid_dims(
+    node_phys_w: f32,
+    node_phys_h: f32,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    max_overflow_phys: f32,
+) -> (u16, u16) {
+    let usable_w = (node_phys_w - max_overflow_phys).max(0.0);
+    let cols = ((usable_w / cell_w_phys).floor() as u16).max(1);
+    let rows = ((node_phys_h / cell_h_phys).floor() as u16).max(1);
+    (cols, rows)
+}
+
 /// Resizes each Terminal Activity's PTY / VT grid to match its host UI
 /// node's pixel extents so the shader's `grid_size * cell_size_px` always
 /// fills the entire pane. Idempotent — no-op when cols/rows are unchanged.
@@ -82,16 +102,13 @@ pub(crate) fn resize_terminals_to_node(
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
 
     for (computed, mut handle, mut pty, mut coalescer, mut grid) in terminals.iter_mut() {
-        let node_phys_w = computed.size.x.max(0.0);
-        let node_phys_h = computed.size.y.max(0.0);
-        // NOTE: max_overflow_phys reserves space on the right for the WGSL
-        //       shader's right-strip handler to paint the rightmost cell's
-        //       bbox overflow without clipping. Height needs no analogous
-        //       reservation — line_height already accommodates descender
-        //       headroom for the bundled font.
-        let usable_w = (node_phys_w - metrics.metrics.max_overflow_phys).max(0.0);
-        let cols = ((usable_w / cell_w_phys).floor() as u16).max(1);
-        let rows = ((node_phys_h / cell_h_phys).floor() as u16).max(1);
+        let (cols, rows) = compute_grid_dims(
+            computed.size.x.max(0.0),
+            computed.size.y.max(0.0),
+            cell_w_phys,
+            cell_h_phys,
+            metrics.metrics.max_overflow_phys,
+        );
 
         let (cur_cols, cur_rows, _) = handle.read_geometry();
         if cur_cols == cols && cur_rows == rows {
@@ -132,6 +149,23 @@ mod tests {
             .init_asset::<TerminalUiMaterial>()
             .init_asset::<ShaderStorageBuffer>();
         app
+    }
+
+    #[test]
+    fn compute_grid_dims_reserves_max_overflow_for_cols() {
+        // Cell pitch 10, node width 100, overflow 4 → cols = (100−4)/10 = 9.
+        // Without the reservation: cols = 100/10 = 10. Asserting cols == 9
+        // catches both a sign-flip and a use-wrong-field regression.
+        let (cols, rows) = compute_grid_dims(100.0, 50.0, 10.0, 10.0, 4.0);
+        assert_eq!(cols, 9, "cols should be (100 − 4) / 10 = 9");
+        assert_eq!(rows, 5, "rows should be 50 / 10 = 5 (height not affected)");
+    }
+
+    #[test]
+    fn compute_grid_dims_floor_to_minimum_one() {
+        // Degenerate input: overflow exceeds node width.
+        let (cols, _) = compute_grid_dims(3.0, 20.0, 10.0, 10.0, 5.0);
+        assert_eq!(cols, 1, "cols must stay >= 1 even when usable width is 0");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Tier 1 ([previous PR](#)) restored basic visual consistency in `bevy_terminal_renderer` (font-derived `CellMetrics`, physical-px schema, wide-cell handling) but left four user-visible gaps that compounded into a poor terminal rendering experience:

- **Text rendered ~25% too small** at the documented `FONT_SIZE_PX = 12` default. `ab_glyph::PxScale::from(N)` treats `N` as `ascent + |descent|` in pixels, not the em-square — JBM at 12 px effectively rendered at ~9 px em.
- **Right-edge glyph clipping** on the rightmost column. Glyphs whose rasterized bbox extends past the floored advance (e.g. `W`, `M`, italic `f/%`) had their overflow pixels swallowed by the `bg_padding_color` fallback strip.
- **Retina startup jitter** — `TerminalCellMetricsResource` was seeded in `Plugin::build()` (before any winit Window exists), so the first frame on a 2x display used DPR=1.0 metrics, over-counted columns by 2x, and fired SIGWINCH twice.
- **Reverse/Hidden/Dim style flags ignored** during the left-neighbor glyph overdraw — reversed cells leaked the un-reversed fg into adjacent cells' overflow pixels.

A follow-up code review then surfaced two CONFIRMED visual bugs introduced by the right-edge fix, plus three test coverage gaps and two low-risk latent items.

## Solution

The branch ships three layered sub-bundles. Each is internally TDD-driven; visual changes are gated by `naga` standalone WGSL validation plus a follow-up `/code-review max` pass.

### Sub-bundle 1 — Tier 2 main (six commits, `3c12b14`..`0871f01`)

| Item | Change |
|---|---|
| A: em-square size | `cell_metrics_px` now reads `(ascender − descender) / units_per_em` from the `hhea` table and multiplies `phys_size_px` by it before constructing `PxScale`. JBM 12 px → advance ≈ 7.2 px, line_height ≈ 15.8 px (matches CSS / Terminal.app / Alacritty). Folded in an `i32` cast on the subtraction to avoid `i16` overflow for general fonts. |
| B-data: overflow tracking | New `pub max_overflow_phys: f32` on `CellMetrics`, computed via `ab_glyph::ScaleFont::outline_glyph(...).px_bounds()` (same path the atlas uses) across all four bundled faces over ASCII 0x20–0x7E. |
| B-uniform: shader plumbing | `TerminalParams` gains `max_overflow_phys: f32` at offset 76 — fills the existing std140 padding gap before `bg_padding_color` for zero-byte growth. WGSL struct mirrors the field. |
| B-WGSL: right-strip handler | When `locate_cell` returns invalid because `p_px.x` is past `grid_w_phys` but inside `[grid_w, grid_w + max_overflow_phys)`, the new strip handler paints the rightmost cell's glyph overflow into the reserved bg_padding band. |
| B-host: width reservation | `resize_terminals_to_node` subtracts `max_overflow_phys` from node width before computing cols (physical px throughout — no `/dpr` conversion). |
| C+F: Startup DPR init | `TerminalFontPlugin::build()` no longer inserts `TerminalCellMetricsResource` directly. New `init_cell_metrics_from_primary_window` Startup system uses `Single<&Window, With<PrimaryWindow>>`, reads the OS-reported scale_factor (which Bevy 0.18's winit runner writes into the Window during `resumed()`, before the first `app.update()`). Also tightens `update_terminal_material`'s window query with `With<PrimaryWindow>`. |
| D: style-aware overdraw | WGSL left-neighbor overdraw now resolves the fg through `resolve_cell_colors(left_cell).fg` so reverse/hidden/dim apply to overflow pixels. |
| B-atlas | New `TerminalFonts::px_scale_value` helper unifies the em-scaled `PxScale` value across `cell_metrics_px` AND `atlas.rs`'s glyph rasterization. Prevents the "tiny letters in oversized cells" regression where atlas glyphs were ~6.2 px wide in 7-px-wide cells. |

### Sub-bundle 2 — WGSL refactor (`84a897a`)

`terminal_ui_material.wgsl` was reorganized top-down so readers see the `@fragment` orchestrator first, then follow the pipeline stages from high-level to low-level. Four new helpers (`paint_grid_cell`, `paint_right_strip`, `paint_primary_glyph`, `paint_left_overdraw`) replaced the previous monolithic fragment body. WGSL allows module-scope forward references, so the entrypoint can sit at the top.

### Sub-bundle 3 — Bugfix bundle (six commits, `9281a2b`..`e90ed9a`)

Driven by `/code-review max` against sub-bundle 1:

| Code-review finding | Fix |
|---|---|
| **V2** — right-strip painted glyph over `fallback` (opaque black) instead of cell bg → visible black seam on themed/selection bg | Strip now uses `colors.bg` as the glyph base. New `paint_cell_overlays` helper shared between `paint_grid_cell` and `paint_right_strip`. |
| **V3** — right-strip skipped overlay stages → underline/cursor/selection truncated at `grid_w_phys` | Strip now runs the overlay pipeline via `paint_cell_overlays`. BLOCK cursor extends ~1–2 px wider on the rightmost column (intentional design choice). |
| **#4** — `max_overflow_phys` reservation in `resize_terminals_to_node` was untested (test helpers hardcoded 0.0) | Extracted cols/rows formula into `fn compute_grid_dims` + 2 unit tests covering the reservation direction and the degenerate `overflow > node_w` case. |
| **#5** — Startup test only asserted `phys_font_size == 24`, not that derived metrics scaled with DPR | Test now also asserts `advance_phys ≈ m12.advance_phys * 2.0` against a dynamic baseline. |
| **#6** — 4-face overflow test only probed BoldItalic | Test now loops over Regular/Italic/Bold/BoldItalic independently. |
| **#10** — WGSL strip divided by `cell_size_px.y` without defensive guard | Added `cell_size_px.x > 0.0 && cell_size_px.y > 0.0` to the `in_right_strip` boolean (documentary; the current code path is already unreachable). |
| **#12** — `windows.single()` called once per terminal entity + silent `unwrap_or(1.0)` → flash to half-scale atlas on transient PrimaryWindow loss | Hoisted before the loop; `let Ok(window) = ... else { return; }` skips the system instead. Previous frame's bind group continues to serve, which is bounded by PrimaryWindow recovery duration. |

The original code-review's V5 finding ("strip missing WIDE_RIGHT_HALF shift") turned out to be a false positive after spec review — `strip_local.x` is already in `[cell_pitch.x, ...)`, past the natural cell, so applying the WIDE_RIGHT_HALF +cell_pitch.x shift would over-shift past the wide bitmap. Documented in spec rev 2 and bundle commit messages.

### Affected crates

- **`crates/bevy_terminal_renderer`** (primary): `glyph/font.rs`, `glyph/atlas.rs`, `material.rs`, `material/state.rs`, `shaders/terminal_ui_material.wgsl`
- **`ozmux-gui`** (root crate): `src/ui/terminal.rs`, plus minor test-helper field additions in `src/ui.rs` / `src/ui/copy_mode_indicator.rs`

### Test status

- `cargo test -p bevy_terminal_renderer`: 9/9 pass (was 4 pre-Tier-2; +1 new font test, +1 atlas-alignment regression test, +2 strengthened existing tests = +3 net new tests)
- `cargo test -p ozmux-gui -- --test-threads=1`: 121/121 pass (was 118; +2 new `compute_grid_dims_*` tests, +1 pre-existing test that landed via the merge from main)
- `cargo clippy`: 2 pre-existing dead-code warnings unchanged (`GlyphAtlas::clear`, `Shelf::reset`)
- `cargo fmt --check`: clean
- `naga` standalone WGSL validation: `Validation successful`
- `cargo run -p ozmux-gui` manual visual verification: needs reviewer to confirm on Retina hardware (selection bg extends through right strip, underline extends into strip, no Retina startup jitter)

### Process notes

- `superpowers:brainstorming` produced the Tier 2 main spec (`docs/plans/2026-05-26-tier2-visual-quality-design.md`, rev 2 after `forte:spec-review` with Codex + Claude Code Agent).
- Same flow produced the bugfix-bundle spec (`docs/plans/2026-05-26-tier2-bugfix-bundle-design.md`, rev 2 after spec review caught the V5 false positive and other issues).
- Both specs reside under `docs/plans/` (gitignored), matching the Tier 1 design doc convention.
- Implementation executed via `superpowers:subagent-driven-development` with per-task spec + code-quality review loops.

### Breaking changes

None at the external API surface. Internal:
- `TerminalFonts::px_scale_value` (new `pub(crate)` helper) — additive, no consumer impact.
- `CellMetrics` gains `pub max_overflow_phys: f32` — additive, but any external `CellMetrics { ... }` literal would need the field. The test helpers in `src/ui.rs` and `src/ui/copy_mode_indicator.rs` were updated; no other external consumers identified in the workspace.

### Known follow-ups (out of scope)

From the bugfix-bundle code review, 6 low-severity findings remain (4 doc-clarity, 1 pre-existing latent N-times resource write, 1 WGSL boundary float-rounding defense-in-depth). None block merge. Tracked separately for future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)