### PR TITLE
feat: OSC 8 hyperlink support in Bevy terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,6 +3572,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4543,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4577,6 +4607,7 @@ dependencies = [
  "bevy_terminal",
  "bevy_terminal_renderer",
  "cosmic-text",
+ "open",
  "ozmux_configs",
  "ozmux_multiplexer",
  "tracing",
@@ -4698,6 +4729,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bevy = { workspace = true }
 bevy_terminal_renderer = { path = "crates/bevy_terminal_renderer" }
 bevy_terminal = { path = "crates/bevy_terminal" }
 cosmic-text = "0.16"
+open = { workspace = true }
 ozmux_configs = { path = "daemon/configs" }
 ozmux_multiplexer = { path = "daemon/multiplexer" }
 tracing = { workspace = true }
@@ -93,6 +94,7 @@ reqwest = { version = "0.13", default-features = false, features = [
   "json",
 ] }
 derive_more = { version = "2" }
+open = "5"
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/crates/bevy_terminal/src/vt/hyperlink.rs
+++ b/crates/bevy_terminal/src/vt/hyperlink.rs
@@ -26,11 +26,14 @@ pub(crate) struct HyperlinkInterner {
 }
 
 impl HyperlinkInterner {
-    /// Constructs an empty interner.
+    /// Constructs an empty interner. The first id assigned is
+    /// `HyperlinkId(1)`; `HyperlinkId(0)` is reserved as the
+    /// universal "no hyperlink" sentinel across the wire, the CPU
+    /// grid, and GPU storage.
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
-            next_id: HyperlinkId(0),
+            next_id: HyperlinkId(1),
         }
     }
 
@@ -79,9 +82,18 @@ mod tests {
         let a = interner.intern("42", "https://a.example");
         let b = interner.intern("42", "https://b.example");
         let c = interner.intern("99", "https://a.example");
-        assert_eq!(a, HyperlinkId(0));
-        assert_eq!(b, HyperlinkId(1));
-        assert_eq!(c, HyperlinkId(2));
+        assert_eq!(a, HyperlinkId(1));
+        assert_eq!(b, HyperlinkId(2));
+        assert_eq!(c, HyperlinkId(3));
+    }
+
+    #[test]
+    fn never_assigns_hyperlink_id_zero() {
+        let mut interner = HyperlinkInterner::new();
+        for i in 0..16 {
+            let id = interner.intern(&format!("{i}"), &format!("https://{i}.example"));
+            assert_ne!(id, HyperlinkId(0), "id 0 is reserved as the no-link sentinel");
+        }
     }
 
     #[test]

--- a/crates/bevy_terminal/src/vt/hyperlink.rs
+++ b/crates/bevy_terminal/src/vt/hyperlink.rs
@@ -46,7 +46,18 @@ impl HyperlinkInterner {
             }
         }
         let id = self.next_id;
-        self.next_id = HyperlinkId(self.next_id.0.wrapping_add(1));
+        // NOTE: `checked_add` (not `wrapping_add`) preserves the
+        //       `HyperlinkId(0)` reservation — wrapping past
+        //       `u32::MAX` would silently emit the sentinel and break
+        //       the GPU "no link" branch. The panic is reachable only
+        //       after ~4 billion distinct hyperlinks in one session,
+        //       far beyond any realistic budget.
+        self.next_id = HyperlinkId(
+            self.next_id
+                .0
+                .checked_add(1)
+                .expect("hyperlink id space exhausted"),
+        );
         self.entries.push((
             (
                 AlacrittyHyperlinkId(alac_id.to_owned()),

--- a/crates/bevy_terminal/src/vt/hyperlink.rs
+++ b/crates/bevy_terminal/src/vt/hyperlink.rs
@@ -46,12 +46,6 @@ impl HyperlinkInterner {
             }
         }
         let id = self.next_id;
-        // NOTE: `checked_add` (not `wrapping_add`) preserves the
-        //       `HyperlinkId(0)` reservation — wrapping past
-        //       `u32::MAX` would silently emit the sentinel and break
-        //       the GPU "no link" branch. The panic is reachable only
-        //       after ~4 billion distinct hyperlinks in one session,
-        //       far beyond any realistic budget.
         self.next_id = HyperlinkId(
             self.next_id
                 .0
@@ -103,7 +97,11 @@ mod tests {
         let mut interner = HyperlinkInterner::new();
         for i in 0..16 {
             let id = interner.intern(&format!("{i}"), &format!("https://{i}.example"));
-            assert_ne!(id, HyperlinkId(0), "id 0 is reserved as the no-link sentinel");
+            assert_ne!(
+                id,
+                HyperlinkId(0),
+                "id 0 is reserved as the no-link sentinel"
+            );
         }
     }
 

--- a/crates/bevy_terminal_renderer/src/grid.rs
+++ b/crates/bevy_terminal_renderer/src/grid.rs
@@ -107,10 +107,7 @@ mod tests {
         app.add_observer(apply_snapshot);
         let entity = app
             .world_mut()
-            .spawn(grid_with(vec![(
-                HyperlinkId(99),
-                HyperlinkUri::new("old"),
-            )]))
+            .spawn(grid_with(vec![(HyperlinkId(99), HyperlinkUri::new("old"))]))
             .id();
         app.world_mut().trigger(FrameSnapshot {
             entity,

--- a/crates/bevy_terminal_renderer/src/grid.rs
+++ b/crates/bevy_terminal_renderer/src/grid.rs
@@ -27,6 +27,9 @@ fn apply_snapshot(snap: On<FrameSnapshot>, mut terminals: Query<&mut TerminalGri
     grid.history_size = snap.history_size;
     grid.last_seq = snap.seq;
     grid.modes = snap.modes.clone();
+    grid.hyperlinks.clear();
+    grid.hyperlinks
+        .extend(snap.hyperlinks.iter().map(|h| (h.id, h.uri.clone())));
     grid.vi_cursor = snap.vi_cursor;
     grid.selection = snap.selection;
     grid.cells = snap
@@ -45,6 +48,11 @@ fn apply_delta(delta: On<FrameDelta>, mut terminals: Query<&mut TerminalGrid>) {
     grid.last_seq = delta.seq;
     grid.vi_cursor = delta.vi_cursor;
     grid.selection = delta.selection;
+    for h in &delta.hyperlinks {
+        if !grid.hyperlinks.iter().any(|(id, _)| *id == h.id) {
+            grid.hyperlinks.push((h.id, h.uri.clone()));
+        }
+    }
     for dirty in &delta.dirty_rows {
         let row_idx = dirty.row as usize;
         if row_idx < grid.cells.len() {
@@ -76,4 +84,93 @@ fn runs_to_cells(runs: &[Run]) -> Vec<Cell> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{Hyperlink, HyperlinkId, HyperlinkUri, Row};
+
+    fn grid_with(seed: Vec<(HyperlinkId, HyperlinkUri)>) -> TerminalGrid {
+        TerminalGrid {
+            cols: 1,
+            rows: 1,
+            cells: vec![vec![]],
+            hyperlinks: seed,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_snapshot_clears_and_extends_hyperlinks() {
+        let mut app = App::new();
+        app.add_observer(apply_snapshot);
+        let entity = app
+            .world_mut()
+            .spawn(grid_with(vec![(
+                HyperlinkId(99),
+                HyperlinkUri::new("old"),
+            )]))
+            .id();
+        app.world_mut().trigger(FrameSnapshot {
+            entity,
+            seq: 1,
+            cols: 1,
+            rows: 1,
+            cursor: Default::default(),
+            rows_data: vec![Row { runs: vec![] }],
+            reason: Default::default(),
+            modes: vec![],
+            hyperlinks: vec![Hyperlink {
+                id: HyperlinkId(1),
+                uri: HyperlinkUri::new("https://new"),
+            }],
+            display_offset: 0,
+            history_size: 0,
+            vi_cursor: None,
+            selection: None,
+        });
+        app.update();
+        let grid = app.world().get::<TerminalGrid>(entity).unwrap();
+        assert_eq!(grid.hyperlinks.len(), 1);
+        assert_eq!(grid.hyperlinks[0].0, HyperlinkId(1));
+        assert_eq!(grid.hyperlinks[0].1.as_str(), "https://new");
+    }
+
+    #[test]
+    fn apply_delta_merges_hyperlinks_without_overwrite() {
+        let mut app = App::new();
+        app.add_observer(apply_delta);
+        let entity = app
+            .world_mut()
+            .spawn(grid_with(vec![(
+                HyperlinkId(1),
+                HyperlinkUri::new("https://old"),
+            )]))
+            .id();
+        app.world_mut().trigger(FrameDelta {
+            entity,
+            seq: 2,
+            cursor: Default::default(),
+            dirty_rows: vec![],
+            hyperlinks: vec![
+                Hyperlink {
+                    id: HyperlinkId(1),
+                    uri: HyperlinkUri::new("https://CHANGED"),
+                },
+                Hyperlink {
+                    id: HyperlinkId(2),
+                    uri: HyperlinkUri::new("https://new"),
+                },
+            ],
+            display_offset: 0,
+            vi_cursor: None,
+            selection: None,
+        });
+        app.update();
+        let grid = app.world().get::<TerminalGrid>(entity).unwrap();
+        assert_eq!(grid.hyperlinks.len(), 2);
+        assert_eq!(grid.hyperlinks[0].1.as_str(), "https://old");
+        assert_eq!(grid.hyperlinks[1].1.as_str(), "https://new");
+    }
 }

--- a/crates/bevy_terminal_renderer/src/lib.rs
+++ b/crates/bevy_terminal_renderer/src/lib.rs
@@ -1,8 +1,8 @@
-use bevy::prelude::*;
-
 use crate::{
     glyph::TerminalGlyphPlugin, grid::TerminalGridPlugin, material::TerminalMaterialPlugin,
+    schema::HyperlinkHoverState,
 };
+use bevy::prelude::*;
 
 mod bundle;
 pub mod bundled;
@@ -26,11 +26,10 @@ pub struct TerminalRendererPlugin;
 
 impl Plugin for TerminalRendererPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<crate::schema::HyperlinkHoverState>()
-            .add_plugins((
-                TerminalGridPlugin,
-                TerminalMaterialPlugin,
-                TerminalGlyphPlugin,
-            ));
+        app.init_resource::<HyperlinkHoverState>().add_plugins((
+            TerminalGridPlugin,
+            TerminalMaterialPlugin,
+            TerminalGlyphPlugin,
+        ));
     }
 }

--- a/crates/bevy_terminal_renderer/src/lib.rs
+++ b/crates/bevy_terminal_renderer/src/lib.rs
@@ -26,10 +26,11 @@ pub struct TerminalRendererPlugin;
 
 impl Plugin for TerminalRendererPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((
-            TerminalGridPlugin,
-            TerminalMaterialPlugin,
-            TerminalGlyphPlugin,
-        ));
+        app.init_resource::<crate::schema::HyperlinkHoverState>()
+            .add_plugins((
+                TerminalGridPlugin,
+                TerminalMaterialPlugin,
+                TerminalGlyphPlugin,
+            ));
     }
 }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -4,7 +4,7 @@ use crate::{
         font::{FONT_SIZE_PX, FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFonts},
     },
     material::state::TerminalMaterialState,
-    schema::{Cell, SelectionKind, TerminalGrid},
+    schema::{Cell, HyperlinkHoverState, SelectionKind, TerminalGrid},
 };
 use bevy::{
     asset::{load_internal_asset, uuid_handle},
@@ -319,6 +319,7 @@ fn update_terminal_material(
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
     mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
     mut terminals: Query<(
+        Entity,
         &MaterialNode<TerminalUiMaterial>,
         &mut TerminalMaterialState,
         &TerminalGrid,
@@ -327,6 +328,7 @@ fn update_terminal_material(
     palette_time: Res<Time>,
     windows: Query<&Window, With<PrimaryWindow>>,
     mut cell_metrics_res: ResMut<TerminalCellMetricsResource>,
+    hover: Res<HyperlinkHoverState>,
 ) {
     // TODO: load font size from config.
 
@@ -355,7 +357,7 @@ fn update_terminal_material(
     let dpr = window.scale_factor();
     let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
 
-    for (handle, mut state, grid) in terminals.iter_mut() {
+    for (entity, handle, mut state, grid) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;
         let cols = grid.cols as u32;
         let rows = grid.rows as u32;
@@ -456,6 +458,11 @@ fn update_terminal_material(
         // TODO: source from a theme / TerminalGrid::default_bg instead of opaque black.
         let bg_padding_color = Vec4::new(0.0, 0.0, 0.0, 1.0);
 
+        let (hover_hyperlink_id, hover_active) = match (hover.entity, hover.hyperlink_id) {
+            (Some(e), Some(id)) if e == entity => (id.0, if hover.modifier_held { 1 } else { 0 }),
+            _ => (0, 0),
+        };
+
         if let Some(mat) = materials.get_mut(&handle.0) {
             mat.params = TerminalParams::new(
                 grid,
@@ -468,8 +475,8 @@ fn update_terminal_material(
                 metrics.underline_thickness_phys.max(1.0),
                 metrics.max_overflow_phys,
                 bg_padding_color,
-                0,
-                0,
+                hover_hyperlink_id,
+                hover_active,
             );
         }
     }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -138,6 +138,8 @@ impl UiMaterial for TerminalUiMaterial {
 /// | 72     | `underline_thickness_phys`  |
 /// | 76     | `max_overflow_phys`         |
 /// | 80     | `bg_padding_color`          |
+/// | 96     | `hover_hyperlink_id`        |
+/// | 100    | `hover_active`              |
 #[derive(Clone, Copy, ShaderType, Default, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -165,6 +167,13 @@ struct TerminalParams {
     /// strip; the host reserves the same amount from the node width.
     max_overflow_phys: f32,
     bg_padding_color: Vec4,
+    /// Wire id of the hovered link (across all panes); `0` = nothing
+    /// hovered, or hovered cell is unlinked.
+    hover_hyperlink_id: u32,
+    /// `1` when the activation modifier is held AND the hovered link
+    /// is in this entity's pane; else `0`. Drives the accent-underline
+    /// path in the shader.
+    hover_active: u32,
 }
 
 impl TerminalParams {
@@ -189,6 +198,8 @@ impl TerminalParams {
         underline_thickness_phys: f32,
         max_overflow_phys: f32,
         bg_padding_color: Vec4,
+        hover_hyperlink_id: u32,
+        hover_active: u32,
     ) -> Self {
         let cols = u32::from(grid.cols);
         let rows = u32::from(grid.rows);
@@ -227,6 +238,8 @@ impl TerminalParams {
             underline_thickness_phys,
             max_overflow_phys,
             bg_padding_color,
+            hover_hyperlink_id,
+            hover_active,
         }
     }
 }
@@ -455,6 +468,8 @@ fn update_terminal_material(
                 metrics.underline_thickness_phys.max(1.0),
                 metrics.max_overflow_phys,
                 bg_padding_color,
+                0,
+                0,
             );
         }
     }
@@ -661,5 +676,12 @@ mod tests {
 
         assert_eq!(state.cpu_cells[0].hyperlink_id, 7);
         assert_eq!(state.cpu_cells[1].hyperlink_id, 0);
+    }
+
+    #[test]
+    fn terminal_params_default_hyperlink_uniforms_are_zero() {
+        let params = TerminalParams::default();
+        assert_eq!(params.hover_hyperlink_id, 0);
+        assert_eq!(params.hover_active, 0);
     }
 }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -19,17 +19,6 @@ use bevy::{
 
 mod state;
 
-/// Schema version of the `GpuGlyph` / `TerminalParams` layout. Bumped when
-/// the meaning of fields changes incompatibly so `TerminalMaterialState`
-/// can force a full LUT rebuild on the first frame after upgrade.
-///
-/// History: 0 = pre-Tier1 (logical-px `GpuGlyph`, hardcoded 8x16 cell,
-/// shader stretches `cell_pitch`); 1 = Tier 1 (physical-px schema,
-/// font-derived cell metrics, shader uses `params.cell_size_px` directly,
-/// `bg_padding_color` fallback, `STYLE_WIDE_RIGHT_HALF` cells); 2 = OSC 8
-/// hyperlink support (`GpuCell.hyperlink_id`, `TerminalParams.hover_*`).
-const SCHEMA_VERSION_TIER1: u32 = 2;
-
 /// Render-side public SystemSet anchor for `update_terminal_material`.
 ///
 /// `sync_atlas_image` in `glyph.rs` is ordered with
@@ -364,19 +353,16 @@ fn update_terminal_material(
         let dims_changed = (grid.cols, grid.rows) != state.last_grid_dims;
         let grid_changed = grid.last_seq != state.last_grid_seq;
         let phys_size_changed = phys_font_size != state.last_phys_font_size;
-        let schema_changed = state.last_schema_version != SCHEMA_VERSION_TIER1;
 
         let needs_rebuild = !state.initialized
             || grid_changed
             || atlas_invalidated
             || dims_changed
-            || phys_size_changed
-            || schema_changed;
+            || phys_size_changed;
 
-        if phys_size_changed || schema_changed {
+        if phys_size_changed {
             state.invalidate_all();
             state.last_phys_font_size = phys_font_size;
-            state.last_schema_version = SCHEMA_VERSION_TIER1;
         }
 
         // NOTE: atlas.generation can advance during this very system (via
@@ -633,11 +619,6 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_bumped_to_two() {
-        assert_eq!(SCHEMA_VERSION_TIER1, 2);
-    }
-
-    #[test]
     fn rebuild_cells_writes_hyperlink_id_when_present() {
         use crate::schema::HyperlinkId;
         use bevy::platform::collections::HashMap;
@@ -672,7 +653,6 @@ mod tests {
             last_grid_seq: 0,
             last_grid_dims: (0, 0),
             last_phys_font_size: 0,
-            last_schema_version: 0,
             cached_metrics: None,
             initialized: false,
         };

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -495,7 +495,7 @@ fn rebuild_cells(
                     fg_packed: fg,
                     bg_packed: bg,
                     style_flags,
-                    hyperlink_id: 0,
+                    hyperlink_id: cell.hyperlink_id.map_or(0, |h| h.0),
                 };
             }
 
@@ -516,7 +516,7 @@ fn rebuild_cells(
                         fg_packed: fg,
                         bg_packed: bg,
                         style_flags: style_flags | STYLE_WIDE_RIGHT_HALF,
-                        hyperlink_id: 0,
+                        hyperlink_id: cell.hyperlink_id.map_or(0, |h| h.0),
                     };
                 }
             }
@@ -613,5 +613,53 @@ mod tests {
     #[test]
     fn schema_version_bumped_to_two() {
         assert_eq!(SCHEMA_VERSION_TIER1, 2);
+    }
+
+    #[test]
+    fn rebuild_cells_writes_hyperlink_id_when_present() {
+        use crate::schema::HyperlinkId;
+        use bevy::platform::collections::HashMap;
+
+        let linked = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(7)),
+        };
+        let unlinked = Cell {
+            text: "y".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: None,
+        };
+        let grid = TerminalGrid {
+            cols: 2,
+            rows: 1,
+            cells: vec![vec![linked, unlinked]],
+            ..Default::default()
+        };
+        let mut state = TerminalMaterialState {
+            glyph_index_map: HashMap::new(),
+            cpu_cells: vec![GpuCell::default(); 2],
+            cpu_glyphs: Vec::new(),
+            last_atlas_generation: 0,
+            last_grid_seq: 0,
+            last_grid_dims: (0, 0),
+            last_phys_font_size: 0,
+            last_schema_version: 0,
+            cached_metrics: None,
+            initialized: false,
+        };
+        let mut atlas = GlyphAtlas::default();
+        let fonts = TerminalFonts::default();
+
+        rebuild_cells(&grid, &mut state, &fonts, &mut atlas, 16, 2);
+
+        assert_eq!(state.cpu_cells[0].hyperlink_id, 7);
+        assert_eq!(state.cpu_cells[1].hyperlink_id, 0);
     }
 }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -26,8 +26,9 @@ mod state;
 /// History: 0 = pre-Tier1 (logical-px `GpuGlyph`, hardcoded 8x16 cell,
 /// shader stretches `cell_pitch`); 1 = Tier 1 (physical-px schema,
 /// font-derived cell metrics, shader uses `params.cell_size_px` directly,
-/// `bg_padding_color` fallback, `STYLE_WIDE_RIGHT_HALF` cells).
-const SCHEMA_VERSION_TIER1: u32 = 1;
+/// `bg_padding_color` fallback, `STYLE_WIDE_RIGHT_HALF` cells); 2 = OSC 8
+/// hyperlink support (`GpuCell.hyperlink_id`, `TerminalParams.hover_*`).
+const SCHEMA_VERSION_TIER1: u32 = 2;
 
 /// Render-side public SystemSet anchor for `update_terminal_material`.
 ///
@@ -230,7 +231,7 @@ impl TerminalParams {
     }
 }
 
-/// One GPU-side cell — 16 bytes, indexed `row * cols + col` in the storage buffer.
+/// One GPU-side cell — 20 bytes, indexed `row * cols + col` in the storage buffer.
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct GpuCell {
     /// Index into the glyph LUT, or `u32::MAX` for an empty cell (space / blank).
@@ -241,6 +242,9 @@ struct GpuCell {
     bg_packed: u32,
     /// Mirror of `ozmux_terminal_protocol::style::*` bit flags.
     style_flags: u32,
+    /// OSC 8 wire id of this cell, or `0` for "no link". Safe because
+    /// `HyperlinkInterner` reserves `HyperlinkId(0)`.
+    hyperlink_id: u32,
 }
 
 /// Set on the right-half cell of a width=2 (CJK / wide) grapheme so the
@@ -266,6 +270,7 @@ impl Default for GpuCell {
             fg_packed: 0,
             bg_packed: 0,
             style_flags: 0,
+            hyperlink_id: 0,
         }
     }
 }
@@ -490,6 +495,7 @@ fn rebuild_cells(
                     fg_packed: fg,
                     bg_packed: bg,
                     style_flags,
+                    hyperlink_id: 0,
                 };
             }
 
@@ -510,6 +516,7 @@ fn rebuild_cells(
                         fg_packed: fg,
                         bg_packed: bg,
                         style_flags: style_flags | STYLE_WIDE_RIGHT_HALF,
+                        hyperlink_id: 0,
                     };
                 }
             }
@@ -585,4 +592,26 @@ fn resolve_glyph_index(
     state.cpu_glyphs.push(GpuGlyph::new(rect));
     state.glyph_index_map.insert(key, idx);
     idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn gpu_cell_is_twenty_bytes() {
+        assert_eq!(size_of::<GpuCell>(), 20);
+    }
+
+    #[test]
+    fn gpu_cell_default_has_zero_hyperlink_id() {
+        let cell = GpuCell::default();
+        assert_eq!(cell.hyperlink_id, 0);
+    }
+
+    #[test]
+    fn schema_version_bumped_to_two() {
+        assert_eq!(SCHEMA_VERSION_TIER1, 2);
+    }
 }

--- a/crates/bevy_terminal_renderer/src/material/state.rs
+++ b/crates/bevy_terminal_renderer/src/material/state.rs
@@ -40,11 +40,6 @@ pub(crate) struct TerminalMaterialState {
     /// the entity sees `phys_size_changed == true` and triggers
     /// `invalidate_all()`.
     pub last_phys_font_size: u16,
-    /// Schema version of the cells/glyphs SSBO data. `SCHEMA_VERSION_TIER1`
-    /// is bumped whenever the renderer changes the meaning of `GpuGlyph`
-    /// fields (e.g. logical-px → physical-px in this Tier 1 fix), forcing
-    /// a one-time rebuild on first frame after upgrade.
-    pub last_schema_version: u32,
     /// Cached output of `TerminalFonts::cell_metrics_px(last_phys_font_size)`
     /// to avoid re-parsing the `post` table on every frame.
     pub cached_metrics: Option<CellMetrics>,
@@ -54,13 +49,11 @@ pub(crate) struct TerminalMaterialState {
 impl TerminalMaterialState {
     /// Resets all glyph-cache state so the next `update_terminal_material`
     /// invocation fully reuploads the atlas LUT, glyph rects, and atlas
-    /// generation marker. Called on DPR change (`phys_font_size` changed)
-    /// or schema upgrade (`last_schema_version != SCHEMA_VERSION_TIER1`).
+    /// generation marker. Called on DPR change (`phys_font_size` changed).
     ///
     /// Deliberately does NOT touch:
-    /// - `last_phys_font_size` / `last_schema_version` — the caller writes
-    ///   those after invalidation so the next frame's diff detection still
-    ///   works.
+    /// - `last_phys_font_size` — the caller writes it after invalidation
+    ///   so the next frame's diff detection still works.
     /// - `cpu_cells` — re-populated wholesale by `rebuild_cells` on the
     ///   next rebuild (forced here by `last_grid_seq = 0`).
     /// - `initialized` — stays `true`; the rebuild path is re-entered via
@@ -118,7 +111,6 @@ fn on_add_material_node(mut world: DeferredWorld, ctx: HookContext) {
             last_grid_seq: 0,
             last_grid_dims: (0, 0),
             last_phys_font_size: 0,
-            last_schema_version: 0,
             cached_metrics: None,
             initialized: false,
         });
@@ -138,7 +130,6 @@ mod tests {
             last_grid_seq: 99,
             last_grid_dims: (80, 24),
             last_phys_font_size: 24,
-            last_schema_version: 1,
             cached_metrics: Some(CellMetrics {
                 advance_phys: 5.5,
                 line_height_phys: 14.4,
@@ -173,11 +164,10 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_all_preserves_phys_font_size_and_schema_version() {
+    fn invalidate_all_preserves_phys_font_size() {
         let mut state = populated_state();
         state.invalidate_all();
         assert_eq!(state.last_phys_font_size, 24);
-        assert_eq!(state.last_schema_version, 1);
         assert!(state.initialized);
     }
 }

--- a/crates/bevy_terminal_renderer/src/schema.rs
+++ b/crates/bevy_terminal_renderer/src/schema.rs
@@ -1,9 +1,11 @@
 mod cursor;
 mod frame;
 mod grid;
+mod hover;
 mod hyperlink;
 
 pub use cursor::*;
 pub use frame::*;
 pub use grid::*;
+pub use hover::*;
 pub use hyperlink::*;

--- a/crates/bevy_terminal_renderer/src/schema/grid.rs
+++ b/crates/bevy_terminal_renderer/src/schema/grid.rs
@@ -44,21 +44,39 @@ pub struct TerminalGrid {
 }
 
 impl TerminalGrid {
-    /// Resolves `(row, col)` to the hyperlink at that grapheme cell,
-    /// if any. Returns `None` for out-of-bounds, width-0 trailers,
-    /// unlinked cells, or when the id is present on the cell but
-    /// absent from the map.
+    /// Resolves `(row, col)` to the hyperlink at that visible cell, if
+    /// any. `col` is a column coordinate, not a grapheme index — wide
+    /// cells (width=2) match both of their columns, and width-0
+    /// trailers are skipped without consuming a column. Returns
+    /// `None` for out-of-bounds, unlinked cells, or when the id is
+    /// present on the cell but absent from the map.
+    //
+    // NOTE: `self.cells[row]` is grapheme-indexed (one entry per
+    //       cluster from `runs_to_cells`), so a column-to-cell walk
+    //       is required — direct `cells[row][col]` indexing would
+    //       desynchronize after any wide char or width-0 trailer.
+    //       Must mirror the column-advance logic in
+    //       `material::rebuild_cells`.
     pub fn hyperlink_at(&self, row: u16, col: u16) -> Option<(HyperlinkId, &HyperlinkUri)> {
         let row_cells = self.cells.get(row as usize)?;
-        let cell = row_cells.get(col as usize)?;
-        if cell.width == 0 {
-            return None;
+        let mut current_col: u32 = 0;
+        let target = u32::from(col);
+        for cell in row_cells {
+            if cell.width == 0 {
+                continue;
+            }
+            let cell_end = current_col.saturating_add(u32::from(cell.width));
+            if target >= current_col && target < cell_end {
+                let id = cell.hyperlink_id?;
+                return self
+                    .hyperlinks
+                    .iter()
+                    .find(|(stored_id, _)| *stored_id == id)
+                    .map(|(stored_id, uri)| (*stored_id, uri));
+            }
+            current_col = cell_end;
         }
-        let id = cell.hyperlink_id?;
-        self.hyperlinks
-            .iter()
-            .find(|(stored_id, _)| *stored_id == id)
-            .map(|(stored_id, uri)| (*stored_id, uri))
+        None
     }
 
     pub fn current_cursor_pos_and_style(&self) -> (UVec2, u32) {
@@ -323,5 +341,88 @@ mod tests {
             ..Default::default()
         };
         assert!(grid.hyperlink_at(0, 0).is_none());
+    }
+
+    #[test]
+    fn hyperlink_at_resolves_both_halves_of_wide_char() {
+        // Wide CJK grapheme occupies 2 columns but only 1 cell entry.
+        // Both halves must resolve to the same hyperlink.
+        let wide_linked = Cell {
+            text: "あ".to_string(),
+            width: 2,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(7)),
+        };
+        let trailing = Cell {
+            text: "b".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: None,
+        };
+        let grid = TerminalGrid {
+            cols: 3,
+            rows: 1,
+            cells: vec![vec![wide_linked, trailing]],
+            hyperlinks: vec![(HyperlinkId(7), HyperlinkUri::new("https://example"))],
+            ..Default::default()
+        };
+        // Column 0: left half of the wide char → linked.
+        let (id, uri) = grid.hyperlink_at(0, 0).expect("left half should resolve");
+        assert_eq!(id, HyperlinkId(7));
+        assert_eq!(uri.as_str(), "https://example");
+        // Column 1: right half of the wide char → SAME link.
+        let (id, uri) = grid.hyperlink_at(0, 1).expect("right half should resolve");
+        assert_eq!(id, HyperlinkId(7));
+        assert_eq!(uri.as_str(), "https://example");
+        // Column 2: trailing ASCII char → unlinked.
+        assert!(grid.hyperlink_at(0, 2).is_none());
+    }
+
+    #[test]
+    fn hyperlink_at_skips_width_zero_trailer_in_column_walk() {
+        // Width-0 trailer (e.g., a combining mark emitted as its own
+        // wire cell) consumes a grapheme slot but no columns. The
+        // following cell must still be reachable at its column.
+        let base = Cell {
+            text: "a".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: None,
+        };
+        let trailer = Cell {
+            text: "\u{0301}".to_string(),
+            width: 0,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: None,
+        };
+        let linked = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(9)),
+        };
+        let grid = TerminalGrid {
+            cols: 2,
+            rows: 1,
+            cells: vec![vec![base, trailer, linked]],
+            hyperlinks: vec![(HyperlinkId(9), HyperlinkUri::new("https://x"))],
+            ..Default::default()
+        };
+        // Column 0: 'a' (unlinked).
+        assert!(grid.hyperlink_at(0, 0).is_none());
+        // Column 1: the linked cell — the width-0 trailer must not
+        // displace its column.
+        let (id, _uri) = grid.hyperlink_at(0, 1).expect("linked cell at col 1");
+        assert_eq!(id, HyperlinkId(9));
     }
 }

--- a/crates/bevy_terminal_renderer/src/schema/grid.rs
+++ b/crates/bevy_terminal_renderer/src/schema/grid.rs
@@ -251,10 +251,7 @@ mod tests {
         let grid = TerminalGrid {
             cols: 4,
             rows: 2,
-            cells: vec![
-                vec![],
-                vec![],
-            ],
+            cells: vec![vec![], vec![]],
             ..Default::default()
         };
         assert!(grid.hyperlink_at(99, 0).is_none());

--- a/crates/bevy_terminal_renderer/src/schema/grid.rs
+++ b/crates/bevy_terminal_renderer/src/schema/grid.rs
@@ -1,4 +1,4 @@
-use crate::schema::{CURSOR_VISIBLE_BIT, Cursor, CursorShape, HyperlinkId, ViCursor};
+use crate::schema::{CURSOR_VISIBLE_BIT, Cursor, CursorShape, HyperlinkId, HyperlinkUri, ViCursor};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -35,9 +35,32 @@ pub struct TerminalGrid {
     /// IME composition) to non-destructively hide the cursor without
     /// clobbering terminal-controlled state.
     pub suppress_cursor: bool,
+    /// OSC 8 hyperlinks indexed by wire id. Populated cumulatively from
+    /// `FrameSnapshot.hyperlinks` / `FrameDelta.hyperlinks`. Replaced on
+    /// snapshot, merged on delta. Linear scan — realistic sessions
+    /// carry ≤100 distinct hyperlinks (mirroring the server-side
+    /// interner rationale).
+    pub hyperlinks: Vec<(HyperlinkId, HyperlinkUri)>,
 }
 
 impl TerminalGrid {
+    /// Resolves `(row, col)` to the hyperlink at that grapheme cell,
+    /// if any. Returns `None` for out-of-bounds, width-0 trailers,
+    /// unlinked cells, or when the id is present on the cell but
+    /// absent from the map.
+    pub fn hyperlink_at(&self, row: u16, col: u16) -> Option<(HyperlinkId, &HyperlinkUri)> {
+        let row_cells = self.cells.get(row as usize)?;
+        let cell = row_cells.get(col as usize)?;
+        if cell.width == 0 {
+            return None;
+        }
+        let id = cell.hyperlink_id?;
+        self.hyperlinks
+            .iter()
+            .find(|(stored_id, _)| *stored_id == id)
+            .map(|(stored_id, uri)| (*stored_id, uri))
+    }
+
     pub fn current_cursor_pos_and_style(&self) -> (UVec2, u32) {
         let mut cursor_pos = UVec2::ZERO;
         let mut cursor_style = 0;
@@ -203,5 +226,82 @@ mod tests {
         let (pos, style) = grid.current_cursor_pos_and_style();
         assert_eq!(pos, UVec2::new(7, 2));
         assert_eq!(style & CURSOR_VISIBLE_BIT, 0);
+    }
+
+    #[test]
+    fn hyperlink_at_returns_none_when_out_of_bounds() {
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 2,
+            cells: vec![
+                vec![],
+                vec![],
+            ],
+            ..Default::default()
+        };
+        assert!(grid.hyperlink_at(99, 0).is_none());
+        assert!(grid.hyperlink_at(0, 99).is_none());
+    }
+
+    #[test]
+    fn hyperlink_at_returns_none_for_width_zero_trailer() {
+        let cell = Cell {
+            text: "\u{0301}".to_string(),
+            width: 0,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(5)),
+        };
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 1,
+            cells: vec![vec![cell]],
+            hyperlinks: vec![(HyperlinkId(5), HyperlinkUri::new("https://example"))],
+            ..Default::default()
+        };
+        assert!(grid.hyperlink_at(0, 0).is_none());
+    }
+
+    #[test]
+    fn hyperlink_at_returns_none_when_map_missing_id() {
+        let cell = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(7)),
+        };
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 1,
+            cells: vec![vec![cell]],
+            hyperlinks: vec![],
+            ..Default::default()
+        };
+        assert!(grid.hyperlink_at(0, 0).is_none());
+    }
+
+    #[test]
+    fn hyperlink_at_returns_id_and_uri_for_linked_cell() {
+        let cell = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(HyperlinkId(7)),
+        };
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 1,
+            cells: vec![vec![cell]],
+            hyperlinks: vec![(HyperlinkId(7), HyperlinkUri::new("https://example"))],
+            ..Default::default()
+        };
+        let (id, uri) = grid.hyperlink_at(0, 0).expect("hyperlink present");
+        assert_eq!(id, HyperlinkId(7));
+        assert_eq!(uri.as_str(), "https://example");
     }
 }

--- a/crates/bevy_terminal_renderer/src/schema/grid.rs
+++ b/crates/bevy_terminal_renderer/src/schema/grid.rs
@@ -304,4 +304,24 @@ mod tests {
         assert_eq!(id, HyperlinkId(7));
         assert_eq!(uri.as_str(), "https://example");
     }
+
+    #[test]
+    fn hyperlink_at_returns_none_for_unlinked_cell() {
+        let cell = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: None,
+        };
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 1,
+            cells: vec![vec![cell]],
+            hyperlinks: vec![(HyperlinkId(7), HyperlinkUri::new("https://example"))],
+            ..Default::default()
+        };
+        assert!(grid.hyperlink_at(0, 0).is_none());
+    }
 }

--- a/crates/bevy_terminal_renderer/src/schema/hover.rs
+++ b/crates/bevy_terminal_renderer/src/schema/hover.rs
@@ -1,0 +1,26 @@
+//! Global hover state shared between the ozmux input layer (writer) and
+//! the renderer's `update_terminal_material` (reader). Lives in the
+//! renderer crate so the renderer does not depend on the application
+//! crate.
+
+use crate::schema::HyperlinkId;
+use bevy::ecs::entity::Entity;
+use bevy::ecs::resource::Resource;
+
+/// Pointer hover state used to drive the hyperlink underline-accent and
+/// the OS cursor icon. Exactly one cell can be hovered at a time across
+/// all panes, so this is a global Resource rather than per-pane
+/// component.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct HyperlinkHoverState {
+    /// Activity-host entity the cursor is currently over, or `None`
+    /// when the cursor is outside every pane.
+    pub entity: Option<Entity>,
+    /// Hovered wire id; meaningful only when `entity` is `Some`. `None`
+    /// when the cursor is over an unlinked cell.
+    pub hyperlink_id: Option<HyperlinkId>,
+    /// Activation modifier (Cmd on macOS, Ctrl elsewhere) is currently
+    /// held. Drives both the cursor icon flip and the shader's
+    /// `hover_active` uniform.
+    pub modifier_held: bool,
+}

--- a/crates/bevy_terminal_renderer/src/schema/hyperlink.rs
+++ b/crates/bevy_terminal_renderer/src/schema/hyperlink.rs
@@ -1,3 +1,5 @@
+//! Wire types for OSC 8 hyperlinks.
+
 use serde::{Deserialize, Serialize};
 
 /// OSC 8 hyperlink: server-assigned wire id → URI mapping.
@@ -12,16 +14,16 @@ pub struct Hyperlink {
     pub uri: HyperlinkUri,
 }
 /// Wire-level monotonic hyperlink id.
+///
+/// # Invariants
+///
+/// Callers outside `HyperlinkInterner` MUST NOT construct `HyperlinkId(0)`;
+/// it is the universal "no hyperlink" sentinel used by `GpuCell.hyperlink_id`
+/// and the shader's `hyperlink_id != 0u` branch. The interner reserves it
+/// (see `crate::vt::hyperlink::HyperlinkInterner::new`).
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct HyperlinkId(pub u32);
-
-impl HyperlinkId {
-    /// Returns the underlying `u32`.
-    pub fn get(self) -> u32 {
-        self.0
-    }
-}
 
 /// OSC 8 hyperlink target URI.  
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -23,6 +23,8 @@ struct TerminalParams {
     underline_thickness_phys: f32,
     max_overflow_phys: f32,
     bg_padding_color: vec4<f32>,
+    hover_hyperlink_id: u32,
+    hover_active: u32,
 };
 
 struct Cell {
@@ -30,6 +32,7 @@ struct Cell {
     fg_packed: u32,
     bg_packed: u32,
     style_flags: u32,
+    hyperlink_id: u32,
 };
 
 struct Glyph {
@@ -62,6 +65,10 @@ struct CellColors {
 // NOTE: Must stay in sync with `ozmux_terminal_protocol::style::*`. The
 //       Rust-side test `style_bits_match_protocol_constants` asserts the
 //       literal values here against the canonical Rust constants.
+// Hyperlink accent color when the activation modifier is held and the
+// cell shares the hovered link's id. Hardcoded for v1.
+const ACCENT_LINK_COLOR: vec4<f32> = vec4<f32>(0.4, 0.7, 1.0, 1.0);
+
 const STYLE_UNDERLINE: u32 = 4u;
 const STYLE_STRIKE: u32 = 8u;
 const STYLE_REVERSE: u32 = 16u;
@@ -215,7 +222,13 @@ fn paint_left_overdraw(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
 // and paint_right_strip so the strip cannot drift from the grid path
 // on overlay sequence or argument order.
 fn paint_cell_overlays(hit: CellHit, fg: vec4<f32>, base: vec4<f32>) -> vec4<f32> {
-    var color = paint_text_decorations(hit.cell.style_flags, hit.in_cell_px, fg, base);
+    var color = paint_text_decorations(
+        hit.cell.style_flags,
+        hit.in_cell_px,
+        fg,
+        base,
+        hit.cell.hyperlink_id,
+    );
     color = paint_cursor(hit.row, hit.col, hit.in_cell_px, color);
     color = paint_selection(hit.row, hit.col, color);
     return color;
@@ -228,9 +241,23 @@ fn paint_text_decorations(
     in_cell_px: vec2<f32>,
     fg: vec4<f32>,
     base: vec4<f32>,
+    cell_hyperlink_id: u32,
 ) -> vec4<f32> {
     var color = base;
-    if (style & STYLE_UNDERLINE) != 0u {
+    var underline_painted = false;
+    if cell_hyperlink_id != 0u {
+        let is_hovered =
+            params.hover_active != 0u &&
+            cell_hyperlink_id == params.hover_hyperlink_id;
+        let underline_color = select(fg, ACCENT_LINK_COLOR, is_hovered);
+        let y_top = params.ascent_px - params.underline_position_phys;
+        let y_bot = y_top + params.underline_thickness_phys;
+        if in_cell_px.y >= y_top && in_cell_px.y < y_bot {
+            color = vec4<f32>(underline_color.rgb, max(color.a, underline_color.a));
+        }
+        underline_painted = true;
+    }
+    if (style & STYLE_UNDERLINE) != 0u && !underline_painted {
         // underline_position_phys is negative (below baseline). The actual
         // y in the cell is baseline + |underline_position|.
         let y_top = params.ascent_px - params.underline_position_phys;
@@ -326,7 +353,7 @@ fn is_in_selection_uniform(
 // between `grid_size * cell_size_px` and the host UI node edge, or when the
 // cell index would overflow the `cells` storage buffer.
 fn locate_cell(p_px: vec2<f32>) -> CellHit {
-    let invalid = CellHit(false, 0u, 0u, Cell(0u, 0u, 0u, 0u), vec2<f32>(0.0, 0.0));
+    let invalid = CellHit(false, 0u, 0u, Cell(0u, 0u, 0u, 0u, 0u), vec2<f32>(0.0, 0.0));
     let cell_pitch = params.cell_size_px;
     let grid_w_px = cell_pitch.x * f32(params.grid_size.x);
     let grid_h_px = cell_pitch.y * f32(params.grid_size.y);

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -4,6 +4,7 @@
 
 use crate::multiplexer::{AttachedSession, Multiplexer, SessionEntityId, SessionUiSubtree};
 use bevy::prelude::*;
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
 
 /// Bevy Plugin that registers the `bootstrap` system in the `Startup`
 /// schedule.
@@ -11,7 +12,7 @@ pub struct OzmuxBootstrapPlugin;
 
 impl Plugin for OzmuxBootstrapPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, bootstrap);
+        app.add_systems(Startup, (bootstrap, insert_initial_cursor_icon));
     }
 }
 
@@ -46,6 +47,20 @@ pub(crate) fn bootstrap(mut commands: Commands, mut mux: ResMut<Multiplexer>) {
         .insert(ChildOf(session_entity));
 
     mux.bump_epoch(&sid);
+}
+
+/// Inserts an initial `CursorIcon::System(SystemCursorIcon::Text)` on
+/// the primary window so the hover system in `src/input/hyperlink.rs`
+/// can mutate the component without first having to insert it.
+fn insert_initial_cursor_icon(
+    mut commands: Commands,
+    windows: Query<Entity, (With<PrimaryWindow>, Without<CursorIcon>)>,
+) {
+    for window in windows.iter() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Text));
+    }
 }
 
 #[cfg(test)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -30,15 +30,36 @@ pub(crate) fn resolve_focused_terminal(
     registry.get(&pane.active_activity)
 }
 
+/// Sub-phases of `OzmuxSystems::Input`. Runs in the order:
+/// `Hover` (cursor / hyperlink hover detection) → `Dispatch`
+/// (mouse / wheel button routing) → `FocusedKey` (keyboard
+/// shortcut + key forwarding).
+#[derive(SystemSet, Hash, PartialEq, Eq, Debug, Clone)]
+pub(crate) enum InputPhase {
+    Hover,
+    Dispatch,
+    FocusedKey,
+}
+
 /// Bevy Plugin that registers the keyboard shortcut handling pipeline.
 pub struct OzmuxShortcutPlugin;
 
 impl Plugin for OzmuxShortcutPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.configure_sets(
+            Update,
+            (
+                InputPhase::Hover,
+                InputPhase::Dispatch,
+                InputPhase::FocusedKey,
+            )
+                .chain()
+                .in_set(crate::system_set::OzmuxSystems::Input),
+        )
+        .add_systems(
             Update,
             dispatch_focused_key
-                .in_set(crate::system_set::OzmuxSystems::Input)
+                .in_set(InputPhase::FocusedKey)
                 .after(read_ime_events),
         );
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@
 //! table comes from the loaded `OzmuxConfigsResource`; this module owns
 //! no chord data.
 
+pub(crate) mod hyperlink;
 pub(crate) mod ime;
 pub(crate) mod mouse_buttons;
 pub(crate) mod mouse_wheel;

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -35,6 +35,65 @@ pub(crate) fn link_modifier_held(mods: &Modifiers) -> bool {
     }
 }
 
+/// Validates `uri` against the scheme allowlist and hands it to the
+/// OS default opener via `open::that_detached`. Disallowed URIs are
+/// dropped with a debug log; opener errors are warned.
+pub(crate) fn try_open_uri(uri: &str) {
+    if !is_allowed(uri) {
+        debug!("hyperlink: dropping disallowed uri {}", uri);
+        return;
+    }
+    if let Err(e) = open::that_detached(uri) {
+        warn!("hyperlink: failed to open {}: {}", uri, e);
+    }
+}
+
+/// Pure predicate: returns the URI of the cell at `(row, col)` when
+/// a `Press + Left + modifier_held` event arrives on a linked cell;
+/// otherwise `None`. Centralizes the interception decision so
+/// `dispatch_mouse_buttons` only has to check the return value.
+pub(crate) fn should_open_at(
+    grid: &bevy_terminal_renderer::schema::TerminalGrid,
+    row: u16,
+    col: u16,
+    button: bevy_terminal::MouseButtonKind,
+    kind: bevy_terminal::ButtonEventKind,
+    modifier_held: bool,
+) -> Option<bevy_terminal_renderer::schema::HyperlinkUri> {
+    if !modifier_held || button != bevy_terminal::MouseButtonKind::Left {
+        return None;
+    }
+    if !matches!(kind, bevy_terminal::ButtonEventKind::Press) {
+        return None;
+    }
+    grid.hyperlink_at(row, col).map(|(_id, uri)| uri.clone())
+}
+
+const ALLOWED_SCHEMES: &[&str] = &["http", "https", "mailto", "ftp"];
+
+/// Parses an RFC 3986 scheme: first byte ALPHA, continuation
+/// ALPHA / DIGIT / `+` / `-` / `.`. Returns `None` for malformed input.
+fn scheme_of(uri: &str) -> Option<&str> {
+    let (scheme, _) = uri.split_once(':')?;
+    let mut bytes = scheme.bytes();
+    let first = bytes.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if !bytes.all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.') {
+        return None;
+    }
+    Some(scheme)
+}
+
+/// Returns `true` when `uri` carries a scheme on the v1 allowlist
+/// (`http`, `https`, `mailto`, `ftp`), case-insensitive.
+fn is_allowed(uri: &str) -> bool {
+    scheme_of(uri)
+        .map(|s| s.to_ascii_lowercase())
+        .is_some_and(|s| ALLOWED_SCHEMES.contains(&s.as_str()))
+}
+
 fn hyperlink_hover_and_cursor(
     mut hover: ResMut<HyperlinkHoverState>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -160,5 +219,147 @@ mod tests {
         assert!(!link_modifier_held(&mods));
         mods.ctrl = true;
         assert!(link_modifier_held(&mods));
+    }
+
+    use bevy::prelude::Color;
+    use bevy_terminal::{ButtonEventKind, MouseButtonKind};
+    use bevy_terminal_renderer::schema::{Cell, HyperlinkId, HyperlinkUri};
+
+    #[test]
+    fn scheme_of_rejects_leading_digit() {
+        assert_eq!(scheme_of("1abc:foo"), None);
+    }
+
+    #[test]
+    fn scheme_of_rejects_empty_scheme() {
+        assert_eq!(scheme_of(":foo"), None);
+        assert_eq!(scheme_of("no-colon"), None);
+    }
+
+    #[test]
+    fn scheme_of_rejects_disallowed_punctuation() {
+        assert_eq!(scheme_of("my_scheme:foo"), None);
+    }
+
+    #[test]
+    fn scheme_of_accepts_canonical_schemes() {
+        assert_eq!(scheme_of("http:foo"), Some("http"));
+        assert_eq!(scheme_of("https:foo"), Some("https"));
+        assert_eq!(scheme_of("git+ssh:foo"), Some("git+ssh"));
+        assert_eq!(scheme_of("a-b.c:foo"), Some("a-b.c"));
+    }
+
+    #[test]
+    fn is_allowed_accepts_canonical_schemes_case_insensitive() {
+        assert!(is_allowed("http://example.com"));
+        assert!(is_allowed("HTTPS://example.com"));
+        assert!(is_allowed("Mailto:foo@example"));
+        assert!(is_allowed("ftp://example.com"));
+    }
+
+    #[test]
+    fn is_allowed_rejects_dangerous_or_unknown_schemes() {
+        assert!(!is_allowed("javascript:alert(1)"));
+        assert!(!is_allowed("file:///etc/passwd"));
+        assert!(!is_allowed("data:text/html,<script>"));
+        assert!(!is_allowed("vscode://"));
+        assert!(!is_allowed(""));
+        assert!(!is_allowed("no-colon-here"));
+    }
+
+    fn make_grid_with_link(
+        row: usize,
+        col: usize,
+        id: HyperlinkId,
+    ) -> bevy_terminal_renderer::schema::TerminalGrid {
+        let cell = Cell {
+            text: "x".to_string(),
+            width: 1,
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            style: 0,
+            hyperlink_id: Some(id),
+        };
+        let mut cells = vec![
+            vec![
+                Cell {
+                    text: " ".to_string(),
+                    width: 1,
+                    fg: Color::WHITE,
+                    bg: Color::BLACK,
+                    style: 0,
+                    hyperlink_id: None,
+                };
+                col + 1
+            ];
+            row + 1
+        ];
+        cells[row][col] = cell;
+        bevy_terminal_renderer::schema::TerminalGrid {
+            cols: (col as u16) + 1,
+            rows: (row as u16) + 1,
+            cells,
+            hyperlinks: vec![(id, HyperlinkUri::new("https://example.com"))],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn should_open_at_returns_none_without_modifier() {
+        let grid = make_grid_with_link(0, 0, HyperlinkId(1));
+        let result = should_open_at(
+            &grid,
+            0,
+            0,
+            MouseButtonKind::Left,
+            ButtonEventKind::Press,
+            false,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn should_open_at_returns_none_for_non_left_button() {
+        let grid = make_grid_with_link(0, 0, HyperlinkId(1));
+        for button in [MouseButtonKind::Middle, MouseButtonKind::Right] {
+            let result = should_open_at(
+                &grid,
+                0,
+                0,
+                button,
+                ButtonEventKind::Press,
+                true,
+            );
+            assert!(result.is_none(), "button={:?}", button);
+        }
+    }
+
+    #[test]
+    fn should_open_at_returns_none_for_release_event() {
+        let grid = make_grid_with_link(0, 0, HyperlinkId(1));
+        let result = should_open_at(
+            &grid,
+            0,
+            0,
+            MouseButtonKind::Left,
+            ButtonEventKind::Release,
+            true,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn should_open_at_returns_uri_for_press_left_modifier_on_link() {
+        let grid = make_grid_with_link(0, 0, HyperlinkId(1));
+        let uri = should_open_at(
+            &grid,
+            0,
+            0,
+            MouseButtonKind::Left,
+            ButtonEventKind::Press,
+            true,
+        )
+        .expect("hyperlink present");
+        assert_eq!(uri.as_str(), "https://example.com");
     }
 }

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -3,7 +3,27 @@
 //! also re-exports the pure predicates the mouse-buttons system calls
 //! during interception.
 
+use bevy::ecs::entity::Entity;
+use bevy::input::ButtonInput;
+use bevy::input::keyboard::KeyCode;
+use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
+use bevy_terminal_renderer::TerminalCellMetricsResource;
+use bevy_terminal_renderer::schema::{HyperlinkHoverState, TerminalGrid};
 use ozmux_configs::shortcuts::Modifiers;
+
+/// Plugin: registers `hyperlink_hover_and_cursor` in `InputPhase::Hover`.
+pub(crate) struct HyperlinkInputPlugin;
+
+impl Plugin for HyperlinkInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            hyperlink_hover_and_cursor.in_set(crate::input::InputPhase::Hover),
+        );
+    }
+}
 
 /// Returns `true` when the platform's hyperlink-activation modifier is
 /// currently held: Cmd (`meta`) on macOS, Ctrl elsewhere.
@@ -12,6 +32,100 @@ pub(crate) fn link_modifier_held(mods: &Modifiers) -> bool {
         mods.meta
     } else {
         mods.ctrl
+    }
+}
+
+fn hyperlink_hover_and_cursor(
+    mut hover: ResMut<HyperlinkHoverState>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    hosts: Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        With<crate::ui::ActivityHostNode>,
+    >,
+    grids: Query<&TerminalGrid>,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+) {
+    let Ok(window) = windows.single() else {
+        clear_hover(&mut hover, &mut cursor_icons);
+        return;
+    };
+    let scale = window.scale_factor();
+    let Some(cursor_logical) = window.cursor_position() else {
+        clear_hover(&mut hover, &mut cursor_icons);
+        return;
+    };
+    let cursor_phys = cursor_logical * scale;
+    let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
+
+    let mods = crate::input::current_modifiers(&keys);
+    hover.modifier_held = link_modifier_held(&mods);
+
+    let Some((entity, local)) =
+        crate::input::mouse_buttons::resolve_pane_at_phys(&hosts, cursor_phys)
+    else {
+        hover.entity = None;
+        hover.hyperlink_id = None;
+        write_cursor_icon(&mut cursor_icons, SystemCursorIcon::Text);
+        return;
+    };
+    let Ok(grid) = grids.get(entity) else {
+        hover.entity = None;
+        hover.hyperlink_id = None;
+        write_cursor_icon(&mut cursor_icons, SystemCursorIcon::Text);
+        return;
+    };
+    let (col, row, _side) = crate::input::mouse_buttons::cell_at_local(
+        local,
+        cell_w_phys,
+        cell_h_phys,
+        grid.cols,
+        grid.rows,
+    );
+    // NOTE: cell_at_local returns 1-indexed coords; convert to 0-indexed
+    //       for the grid lookup. Overlooking this misaligns hover by one cell.
+    let id = grid
+        .hyperlink_at(row.saturating_sub(1) as u16, col.saturating_sub(1) as u16)
+        .map(|(id, _uri)| id);
+    hover.entity = Some(entity);
+    hover.hyperlink_id = id;
+
+    let desired = if id.is_some() && hover.modifier_held {
+        SystemCursorIcon::Pointer
+    } else {
+        SystemCursorIcon::Text
+    };
+    write_cursor_icon(&mut cursor_icons, desired);
+}
+
+fn clear_hover(
+    hover: &mut HyperlinkHoverState,
+    cursor_icons: &mut Query<&mut CursorIcon, With<PrimaryWindow>>,
+) {
+    hover.entity = None;
+    hover.hyperlink_id = None;
+    hover.modifier_held = false;
+    write_cursor_icon(cursor_icons, SystemCursorIcon::Text);
+}
+
+fn write_cursor_icon(
+    cursor_icons: &mut Query<&mut CursorIcon, With<PrimaryWindow>>,
+    desired: SystemCursorIcon,
+) {
+    let Ok(mut icon) = cursor_icons.single_mut() else {
+        return;
+    };
+    // NOTE: idempotent write — only mutate when the desired value differs
+    // from the current one so winit's `update_cursors` does not fire
+    // `Changed<CursorIcon>` every frame.
+    let already = match &*icon {
+        CursorIcon::System(existing) => *existing == desired,
+        _ => false,
+    };
+    if !already {
+        *icon = CursorIcon::System(desired);
     }
 }
 

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -3,18 +3,19 @@
 //! also re-exports the pure predicates the mouse-buttons system calls
 //! during interception.
 
+use crate::input::mouse_buttons::{cell_at_local, resolve_pane_at_phys};
+use crate::input::{InputPhase, current_modifiers};
+use crate::ui::ActivityHostNode;
 use bevy::ecs::entity::Entity;
 use bevy::input::ButtonInput;
-use bevy::input::keyboard::KeyCode;
+use bevy::input::keyboard::{KeyCode, KeyboardInput};
+use bevy::input::mouse::MouseMotion;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
 use bevy_terminal_renderer::TerminalCellMetricsResource;
 use bevy_terminal_renderer::schema::{HyperlinkHoverState, TerminalGrid};
 use ozmux_configs::shortcuts::Modifiers;
-
-use crate::input::mouse_buttons::{cell_at_local, resolve_pane_at_phys};
-use crate::ui::ActivityHostNode;
 
 /// Plugin: registers `hyperlink_hover_and_cursor` in `InputPhase::Hover`.
 pub(crate) struct HyperlinkInputPlugin;
@@ -23,7 +24,9 @@ impl Plugin for HyperlinkInputPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            hyperlink_hover_and_cursor.in_set(crate::input::InputPhase::Hover),
+            hyperlink_hover_and_cursor
+                .run_if(on_message::<MouseMotion>.or(on_message::<KeyboardInput>))
+                .in_set(InputPhase::Hover),
         );
     }
 }
@@ -119,7 +122,7 @@ fn hyperlink_hover_and_cursor(
     let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
 
-    let mods = crate::input::current_modifiers(&keys);
+    let mods = current_modifiers(&keys);
     hover.modifier_held = link_modifier_held(&mods);
 
     let Some((entity, local)) = resolve_pane_at_phys(&hosts, cursor_phys) else {

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -1,0 +1,50 @@
+//! OSC 8 hyperlink hover detection, cursor-icon control, scheme
+//! allowlist, and Cmd+click activation. The plugin registered here
+//! also re-exports the pure predicates the mouse-buttons system calls
+//! during interception.
+
+use ozmux_configs::shortcuts::Modifiers;
+
+/// Returns `true` when the platform's hyperlink-activation modifier is
+/// currently held: Cmd (`meta`) on macOS, Ctrl elsewhere.
+pub(crate) fn link_modifier_held(mods: &Modifiers) -> bool {
+    if cfg!(target_os = "macos") {
+        mods.meta
+    } else {
+        mods.ctrl
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty() -> Modifiers {
+        Modifiers::default()
+    }
+
+    #[test]
+    fn link_modifier_held_returns_false_when_no_modifier() {
+        assert!(!link_modifier_held(&empty()));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn link_modifier_held_macos_requires_meta() {
+        let mut mods = empty();
+        mods.ctrl = true;
+        assert!(!link_modifier_held(&mods));
+        mods.meta = true;
+        assert!(link_modifier_held(&mods));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn link_modifier_held_non_macos_requires_ctrl() {
+        let mut mods = empty();
+        mods.meta = true;
+        assert!(!link_modifier_held(&mods));
+        mods.ctrl = true;
+        assert!(link_modifier_held(&mods));
+    }
+}

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -125,15 +125,11 @@ fn hyperlink_hover_and_cursor(
     let Some((entity, local)) =
         crate::input::mouse_buttons::resolve_pane_at_phys(&hosts, cursor_phys)
     else {
-        hover.entity = None;
-        hover.hyperlink_id = None;
-        write_cursor_icon(&mut cursor_icons, SystemCursorIcon::Text);
+        clear_target(&mut hover, &mut cursor_icons);
         return;
     };
     let Ok(grid) = grids.get(entity) else {
-        hover.entity = None;
-        hover.hyperlink_id = None;
-        write_cursor_icon(&mut cursor_icons, SystemCursorIcon::Text);
+        clear_target(&mut hover, &mut cursor_icons);
         return;
     };
     let (col, row, _side) = crate::input::mouse_buttons::cell_at_local(
@@ -159,6 +155,9 @@ fn hyperlink_hover_and_cursor(
     write_cursor_icon(&mut cursor_icons, desired);
 }
 
+/// Resets every field of the hover state and forces the I-beam cursor.
+/// Used when the window or cursor is unobservable — modifier state
+/// cannot be trusted because the system bailed before reading keys.
 fn clear_hover(
     hover: &mut HyperlinkHoverState,
     cursor_icons: &mut Query<&mut CursorIcon, With<PrimaryWindow>>,
@@ -166,6 +165,19 @@ fn clear_hover(
     hover.entity = None;
     hover.hyperlink_id = None;
     hover.modifier_held = false;
+    write_cursor_icon(cursor_icons, SystemCursorIcon::Text);
+}
+
+/// Resets only the per-cursor fields (entity + hyperlink_id) and the
+/// cursor icon, preserving `modifier_held` set earlier this frame. Used
+/// when the cursor is observable but lands outside any pane or the
+/// hovered entity has no `TerminalGrid` — modifier state remains valid.
+fn clear_target(
+    hover: &mut HyperlinkHoverState,
+    cursor_icons: &mut Query<&mut CursorIcon, With<PrimaryWindow>>,
+) {
+    hover.entity = None;
+    hover.hyperlink_id = None;
     write_cursor_icon(cursor_icons, SystemCursorIcon::Text);
 }
 

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -13,6 +13,9 @@ use bevy_terminal_renderer::TerminalCellMetricsResource;
 use bevy_terminal_renderer::schema::{HyperlinkHoverState, TerminalGrid};
 use ozmux_configs::shortcuts::Modifiers;
 
+use crate::input::mouse_buttons::{cell_at_local, resolve_pane_at_phys};
+use crate::ui::ActivityHostNode;
+
 /// Plugin: registers `hyperlink_hover_and_cursor` in `InputPhase::Hover`.
 pub(crate) struct HyperlinkInputPlugin;
 
@@ -96,12 +99,9 @@ fn is_allowed(uri: &str) -> bool {
 
 fn hyperlink_hover_and_cursor(
     mut hover: ResMut<HyperlinkHoverState>,
-    windows: Query<&Window, With<PrimaryWindow>>,
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
-    hosts: Query<
-        (Entity, &ComputedNode, &UiGlobalTransform),
-        With<crate::ui::ActivityHostNode>,
-    >,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    hosts: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<ActivityHostNode>>,
     grids: Query<&TerminalGrid>,
     metrics: Res<TerminalCellMetricsResource>,
     keys: Res<ButtonInput<KeyCode>>,
@@ -122,9 +122,7 @@ fn hyperlink_hover_and_cursor(
     let mods = crate::input::current_modifiers(&keys);
     hover.modifier_held = link_modifier_held(&mods);
 
-    let Some((entity, local)) =
-        crate::input::mouse_buttons::resolve_pane_at_phys(&hosts, cursor_phys)
-    else {
+    let Some((entity, local)) = resolve_pane_at_phys(&hosts, cursor_phys) else {
         clear_target(&mut hover, &mut cursor_icons);
         return;
     };
@@ -132,15 +130,7 @@ fn hyperlink_hover_and_cursor(
         clear_target(&mut hover, &mut cursor_icons);
         return;
     };
-    let (col, row, _side) = crate::input::mouse_buttons::cell_at_local(
-        local,
-        cell_w_phys,
-        cell_h_phys,
-        grid.cols,
-        grid.rows,
-    );
-    // NOTE: cell_at_local returns 1-indexed coords; convert to 0-indexed
-    //       for the grid lookup. Overlooking this misaligns hover by one cell.
+    let (col, row, _side) = cell_at_local(local, cell_w_phys, cell_h_phys, grid.cols, grid.rows);
     let id = grid
         .hyperlink_at(row.saturating_sub(1) as u16, col.saturating_sub(1) as u16)
         .map(|(id, _uri)| id);
@@ -334,14 +324,7 @@ mod tests {
     fn should_open_at_returns_none_for_non_left_button() {
         let grid = make_grid_with_link(0, 0, HyperlinkId(1));
         for button in [MouseButtonKind::Middle, MouseButtonKind::Right] {
-            let result = should_open_at(
-                &grid,
-                0,
-                0,
-                button,
-                ButtonEventKind::Press,
-                true,
-            );
+            let result = should_open_at(&grid, 0, 0, button, ButtonEventKind::Press, true);
             assert!(result.is_none(), "button={:?}", button);
         }
     }

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -496,8 +496,8 @@ fn dispatch_mouse_buttons(
         //       call above is preserved so the pane still focuses.
         if matches!(bevy_button, bevy_terminal::MouseButtonKind::Left) {
             let modifier_held = crate::input::hyperlink::link_modifier_held(&mods);
-            if modifier_held {
-                if let Ok(grid) = grids_q.get(entity) {
+            if modifier_held
+                && let Ok(grid) = grids_q.get(entity) {
                     if let Some(uri) = crate::input::hyperlink::should_open_at(
                         grid,
                         row.saturating_sub(1) as u16,
@@ -520,7 +520,6 @@ fn dispatch_mouse_buttons(
                         continue;
                     }
                 }
-            }
         }
 
         let evt = bevy_terminal::ButtonEvent {

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -7,7 +7,7 @@
 //! §6.
 
 use bevy::prelude::*;
-use bevy_terminal::{CellCoord, Column, Line, Point, SelectionType, Side};
+use bevy_terminal::{ButtonAction, CellCoord, Column, Line, Point, SelectionType, Side};
 use std::time::Instant;
 
 /// Per-frame state for the mouse-selection system.
@@ -385,6 +385,11 @@ fn dispatch_mouse_buttons(
     mut mux: ResMut<crate::multiplexer::Multiplexer>,
     mut buttons_msg: MessageReader<bevy::input::mouse::MouseButtonInput>,
     mut cursor_msg: MessageReader<bevy::window::CursorMoved>,
+    mut handles: Query<(
+        &mut bevy_terminal::TerminalHandle,
+        &mut bevy_terminal::PtyHandle,
+        &mut bevy_terminal::Coalescer,
+    )>,
     keys: Res<ButtonInput<KeyCode>>,
     configs: Res<crate::configs::OzmuxConfigsResource>,
     hosts_q: Query<
@@ -395,11 +400,6 @@ fn dispatch_mouse_buttons(
         ),
         With<crate::ui::ActivityHostNode>,
     >,
-    mut handles: Query<(
-        &mut bevy_terminal::TerminalHandle,
-        &mut bevy_terminal::PtyHandle,
-        &mut bevy_terminal::Coalescer,
-    )>,
     grids_q: Query<&bevy_terminal_renderer::schema::TerminalGrid>,
     copy_mode_q: Query<(), With<crate::ui::copy_mode::CopyModeState>>,
     windows_q: Query<&Window, With<bevy::window::PrimaryWindow>>,
@@ -675,7 +675,6 @@ fn apply_action(
     )>,
     copy_mode_q: &Query<(), With<crate::ui::copy_mode::CopyModeState>>,
 ) {
-    use bevy_terminal::ButtonAction as A;
     let Ok((mut handle, mut pty, mut coalescer)) = handles.get_mut(entity) else {
         return;
     };
@@ -698,19 +697,19 @@ fn apply_action(
     let in_copy_mode = copy_mode_q.get(entity).is_ok();
 
     match action {
-        A::Noop => {}
-        A::WriteToPty(bytes) => {
+        ButtonAction::Noop => {}
+        ButtonAction::WriteToPty(bytes) => {
             if let Err(e) = handle.write(&mut pty, &bytes) {
                 tracing::warn!(?e, ?entity, "mouse-button PTY write failed");
             }
         }
-        A::ClearAndWriteToPty(bytes) => {
+        ButtonAction::ClearAndWriteToPty(bytes) => {
             handle.selection_clear(&mut coalescer);
             if let Err(e) = handle.write(&mut pty, &bytes) {
                 tracing::warn!(?e, ?entity, "mouse-button forwarded press PTY write failed");
             }
         }
-        A::ArmDrag { ty, cell, side } => {
+        ButtonAction::ArmDrag { ty, cell, side } => {
             // Clear any prior selection on the focused pane so the
             // click does not leave a stale highlight visible (spec §2,
             // brainstorm Q5).
@@ -725,7 +724,7 @@ fn apply_action(
                 },
             });
         }
-        A::StartLocalSelection { ty, cell, side } => {
+        ButtonAction::StartLocalSelection { ty, cell, side } => {
             let pt = to_viewport_point(cell);
             if in_copy_mode {
                 handle.vi_goto(&mut coalescer, pt);
@@ -741,7 +740,7 @@ fn apply_action(
                 phase: DragPhase::Active,
             });
         }
-        A::UpdateLocalSelection { cell, side } => {
+        ButtonAction::UpdateLocalSelection { cell, side } => {
             let pt = to_viewport_point(cell);
             if let Some(drag) = state.drag.as_mut().filter(|d| d.entity == entity) {
                 // Materialize the selection now if the drag is still
@@ -772,7 +771,7 @@ fn apply_action(
             // reaching this arm without a drag would be a logic bug
             // elsewhere.
         }
-        A::ClearLocalSelection => {
+        ButtonAction::ClearLocalSelection => {
             handle.selection_clear(&mut coalescer);
         }
     }

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -101,10 +101,6 @@ pub(crate) fn resolve_pane_at_phys(
         if !node.contains_point(*transform, cursor_phys_px) {
             continue;
         }
-        // NOTE: normalize_point returns None if the affine transform is
-        // degenerate (zero-size node or non-invertible). contains_point
-        // returning true normally implies Some here, but skip defensively
-        // to avoid an unwrap on the degenerate case.
         let Some(normalized) = node.normalize_point(*transform, cursor_phys_px) else {
             continue;
         };
@@ -513,12 +509,6 @@ fn dispatch_mouse_buttons(
                         crate::input::hyperlink::try_open_uri(uri.as_str());
                         continue;
                     }
-                    // NOTE: While the modifier is still held at Release time,
-                    //       skip routing so the PTY does not get a stray release
-                    //       it cannot pair with a press. If the user lifts the
-                    //       modifier between Press and Release, this guard fails
-                    //       and the PTY may see an orphan release — accepted per
-                    //       spec §4 (matches Safari Cmd+click semantics).
                     if matches!(kind, bevy_terminal::ButtonEventKind::Release)
                         && grid
                             .hyperlink_at(

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -404,6 +404,7 @@ fn dispatch_mouse_buttons(
         &mut bevy_terminal::PtyHandle,
         &mut bevy_terminal::Coalescer,
     )>,
+    grids_q: Query<&bevy_terminal_renderer::schema::TerminalGrid>,
     copy_mode_q: Query<(), With<crate::ui::copy_mode::CopyModeState>>,
     windows_q: Query<&Window, With<bevy::window::PrimaryWindow>>,
     metrics: Res<bevy_terminal_renderer::TerminalCellMetricsResource>,
@@ -490,6 +491,46 @@ fn dispatch_mouse_buttons(
                 continue;
             };
             try_click_to_focus(&mut mux, &registry, attached_sid.0, entity);
+        }
+
+        // NOTE: OSC 8 hyperlink interception — Cmd+Left (or Ctrl+Left) on
+        //       a linked cell. Press opens the URI and skips PTY routing;
+        //       Release also skips so the PTY does not see a release
+        //       without a matching press. The existing try_click_to_focus
+        //       call above is preserved so the pane still focuses.
+        if matches!(bevy_button, bevy_terminal::MouseButtonKind::Left) {
+            let modifier_held = crate::input::hyperlink::link_modifier_held(&mods);
+            if modifier_held {
+                if let Ok(grid) = grids_q.get(entity) {
+                    if let Some(uri) = crate::input::hyperlink::should_open_at(
+                        grid,
+                        row.saturating_sub(1) as u16,
+                        col.saturating_sub(1) as u16,
+                        bevy_button,
+                        kind,
+                        modifier_held,
+                    ) {
+                        crate::input::hyperlink::try_open_uri(uri.as_str());
+                        continue;
+                    }
+                    // NOTE: While the modifier is still held at Release time,
+                    //       skip routing so the PTY does not get a stray release
+                    //       it cannot pair with a press. If the user lifts the
+                    //       modifier between Press and Release, this guard fails
+                    //       and the PTY may see an orphan release — accepted per
+                    //       spec §4 (matches Safari Cmd+click semantics).
+                    if matches!(kind, bevy_terminal::ButtonEventKind::Release)
+                        && grid
+                            .hyperlink_at(
+                                row.saturating_sub(1) as u16,
+                                col.saturating_sub(1) as u16,
+                            )
+                            .is_some()
+                    {
+                        continue;
+                    }
+                }
+            }
         }
 
         let evt = bevy_terminal::ButtonEvent {

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -72,9 +72,7 @@ impl Plugin for MouseButtonsInputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MouseSelectionState>().add_systems(
             Update,
-            dispatch_mouse_buttons
-                .in_set(crate::system_set::OzmuxSystems::Input)
-                .before(crate::input::dispatch_focused_key),
+            dispatch_mouse_buttons.in_set(crate::input::InputPhase::Dispatch),
         );
     }
 }

--- a/src/input/mouse_wheel.rs
+++ b/src/input/mouse_wheel.rs
@@ -50,7 +50,7 @@ impl Plugin for MouseWheelInputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WheelAccumulator>().add_systems(
             Update,
-            dispatch_mouse_wheel.in_set(crate::system_set::OzmuxSystems::Input),
+            dispatch_mouse_wheel.in_set(crate::input::InputPhase::Dispatch),
         );
     }
 }

--- a/src/input/mouse_wheel.rs
+++ b/src/input/mouse_wheel.rs
@@ -33,6 +33,10 @@ use bevy_terminal::{
 use bevy_terminal_renderer::TerminalCellMetricsResource;
 use ozmux_configs::mouse::FineModifier;
 
+use crate::configs::OzmuxConfigsResource;
+use crate::input::InputPhase;
+use crate::ui::registry::ActivityEntityRegistry;
+
 /// Per-frame accumulator that carries fractional Pixel deltas across
 /// frames and tracks the entity the residual was earned on (so a focus
 /// change clears stale momentum).
@@ -48,10 +52,8 @@ pub(crate) struct MouseWheelInputPlugin;
 
 impl Plugin for MouseWheelInputPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<WheelAccumulator>().add_systems(
-            Update,
-            dispatch_mouse_wheel.in_set(crate::input::InputPhase::Dispatch),
-        );
+        app.init_resource::<WheelAccumulator>()
+            .add_systems(Update, dispatch_mouse_wheel.in_set(InputPhase::Dispatch));
     }
 }
 
@@ -60,8 +62,8 @@ fn dispatch_mouse_wheel(
     mut accumulator: ResMut<WheelAccumulator>,
     mut handles: Query<(&mut TerminalHandle, &mut PtyHandle, &mut Coalescer)>,
     keys: Res<ButtonInput<KeyCode>>,
-    configs: Res<crate::configs::OzmuxConfigsResource>,
-    registry: Res<crate::ui::registry::ActivityEntityRegistry>,
+    configs: Res<OzmuxConfigsResource>,
+    registry: Res<ActivityEntityRegistry>,
     mux: Res<crate::multiplexer::Multiplexer>,
     copy_mode_q: Query<(), With<crate::ui::copy_mode::CopyModeState>>,
     attached_sid_q: Query<

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,11 @@ fn main() {
             OzmuxUiPlugin,
             CopyModePlugin,
             CopyModeIndicatorPlugin,
+        ))
+        .add_plugins((
             crate::input::mouse_wheel::MouseWheelInputPlugin,
             crate::input::mouse_buttons::MouseButtonsInputPlugin,
+            crate::input::hyperlink::HyperlinkInputPlugin,
             ImePlugin,
             ImeOverlayPlugin,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod system_set;
 mod theme;
 mod ui;
 
+use crate::input::hyperlink::HyperlinkInputPlugin;
+use crate::input::mouse_buttons::MouseButtonsInputPlugin;
+use crate::input::mouse_wheel::MouseWheelInputPlugin;
 use bevy::prelude::*;
 use bevy_terminal::TerminalHandlePlugin;
 use bevy_terminal_renderer::TerminalRendererPlugin;
@@ -41,9 +44,9 @@ fn main() {
             CopyModeIndicatorPlugin,
         ))
         .add_plugins((
-            crate::input::mouse_wheel::MouseWheelInputPlugin,
-            crate::input::mouse_buttons::MouseButtonsInputPlugin,
-            crate::input::hyperlink::HyperlinkInputPlugin,
+            MouseWheelInputPlugin,
+            MouseButtonsInputPlugin,
+            HyperlinkInputPlugin,
             ImePlugin,
             ImeOverlayPlugin,
         ))

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -7,9 +7,10 @@ pub enum OzmuxSystems {
     SessionUi,
     /// The phase that setup activities.
     SetupActivity,
-    /// Per-frame input handling — keyboard and mouse. Members are
-    /// ordered: `dispatch_mouse_buttons` runs `.before(dispatch_focused_key)`
-    /// so click-to-focus mutates `Session::active_pane` before the
-    /// keyboard chord dispatcher reads it in the same frame.
+    /// Per-frame input handling — keyboard and mouse. Members run in
+    /// `crate::input::InputPhase` order: `Hover` → `Dispatch` →
+    /// `FocusedKey`. The chain ensures click-to-focus (Dispatch)
+    /// mutates `Session::active_pane` before the keyboard chord
+    /// dispatcher (FocusedKey) reads it in the same frame.
     Input,
 }

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -284,8 +284,8 @@ pub(crate) fn position_ime_overlay(
     let clause_x_logical = pos.x + begin_cells * cell_w_logical;
     let clause_w_logical = (end_cells - begin_cells) * cell_w_logical;
 
-    if has_beam {
-        if let Some(b) = bar.as_mut() {
+    if has_beam
+        && let Some(b) = bar.as_mut() {
             // Caret bar is a top-level UI entity (not a child of the
             // Text root), so its position is in window-absolute coords:
             // overlay origin + per-character horizontal offset.
@@ -294,10 +294,9 @@ pub(crate) fn position_ime_overlay(
             b.top = Val::Px(pos.y);
             b.height = Val::Px(line_h_logical);
         }
-    }
 
-    if has_clause {
-        if let Some(c) = clause.as_mut() {
+    if has_clause
+        && let Some(c) = clause.as_mut() {
             // Hollow block over the macOS-IME clause-selection range.
             // Positioned in window-absolute coords for the same
             // leaf-Text-no-children reason as ImeCaretBar.
@@ -307,7 +306,6 @@ pub(crate) fn position_ime_overlay(
             c.width = Val::Px(clause_w_logical);
             c.height = Val::Px(line_h_logical);
         }
-    }
 }
 
 /// Sets `TerminalGrid.suppress_cursor = true` on the currently-focused


### PR DESCRIPTION
## Problem

OSC 8 hyperlinks emitted by modern tools (`ls --hyperlink=auto`, `gcc`/`clang` diagnostics, recent shells) were captured server-side and transported over the wire, but the Bevy-rendered terminal never made them clickable. Linked cells looked indistinguishable from plain text, and Cmd-click did nothing.

## Solution

End-to-end OSC 8 hyperlink rendering and activation in `ozmux-gui`.

**What's user-visible:**
- Linked cells now carry an always-on underline (fg color).
- Holding the activation modifier (Cmd on macOS, Ctrl on Linux/Windows) while hovering a linked cell switches the OS cursor to a hand and the underline to an accent color.
- Cmd-click opens the URI in the OS default opener — restricted to a `http` / `https` / `mailto` / `ftp` allowlist (other schemes silently dropped with a debug log).

**Architecture (renderer-first, no reverse deps):**
- `crates/bevy_terminal_renderer` — `TerminalGrid` gains a `hyperlinks: Vec<(HyperlinkId, HyperlinkUri)>` map (replaced on snapshot, merged on delta) and a `hyperlink_at(row, col)` column-tracking helper. `GpuCell` grows a `hyperlink_id: u32` field; `TerminalParams` grows `hover_hyperlink_id` + `hover_active` uniforms. Schema version bumped 1 → 2 so the LUT rebuilds on upgrade. New `HyperlinkHoverState` resource lives in this crate so the renderer can read it without a reverse-dependency on the app crate. WGSL shader paints the underline; accent color is a hardcoded const for v1.
- `crates/bevy_terminal` — `HyperlinkInterner::new()` now starts at `HyperlinkId(1)`, reserving `0` as the universal "no link" sentinel across wire → CPU → GPU.
- `src/` — new `src/input/hyperlink.rs` with `hyperlink_hover_and_cursor` system (hit-tests cursor, updates resource + window `CursorIcon` Component idempotently), the scheme allowlist, the pure `should_open_at` predicate, and `try_open_uri` (uses the `open` crate v5, `that_detached` variant — handles WSL/macOS/Linux/Windows correctly). New `InputPhase` SystemSet inside `OzmuxSystems::Input` chains `Hover → Dispatch → FocusedKey` so the new system can order before `dispatch_mouse_buttons` without bumping its visibility. `dispatch_mouse_buttons` intercepts Cmd+Left Press on linked cells, calls `try_open_uri`, and skips `ButtonAction::route` so the PTY never sees a phantom press.

**Process notes:**
- Driven from a spec (`docs/superpowers/specs/2026-05-28-hyperlink-support-design.md`) and a 16-task plan, executed task-by-task with TDD and per-task spec + code-quality review.
- A final max-effort code review caught one critical bug: `hyperlink_at` was indexing `cells[row][col]` treating `col` as a grapheme index, but `cells[row]` is grapheme-indexed (one entry per cluster). Wide CJK chars and width-0 trailers desynchronized the two — hover/click on the right half of a wide-char hyperlink resolved to the wrong grapheme. Fixed in `28c7b33` with a column-tracking walk that mirrors `material::rebuild_cells`, plus two new tests (`hyperlink_at_resolves_both_halves_of_wide_char`, `hyperlink_at_skips_width_zero_trailer_in_column_walk`).
- Same fix commit also switches the interner's `wrapping_add` to `checked_add` to preserve the `HyperlinkId(0)` sentinel under overflow.

**Tests:** 211 ozmux-gui + 32 renderer (was 30) + 154 bevy_terminal tests, all green. `cargo build` clean (the two pre-existing `dead_code` warnings in `glyph/atlas.rs` are unrelated).

**Non-goals (deferred):**
- Auto URL detection in plain text (Alacritty's `RegexSearch` is the natural follow-up).
- Right-click context menu / "Copy link".
- Tooltip on hover.
- Configurable allowlist or accent color.
- Keyboard-only link activation.

## Test plan

- [ ] `make dev-e2e` and verify the golden path:
      `printf '\e]8;;https://example.com\e\\Click me\e]8;;\e\\\n'` → underlined; hold Cmd → hand cursor + accent underline; Cmd+click → browser opens.
- [ ] Disallowed scheme dropped silently:
      `printf '\e]8;;javascript:alert(1)\e\\Nope\e]8;;\e\\\n'` → underlined; Cmd+click logs `hyperlink: dropping disallowed uri javascript:alert(1)` and does not spawn the opener.
- [ ] Wide-char hyperlink right half (regression test for the critical fix):
      `printf '\e]8;;https://example.com\e\\日本\e]8;;\e\\\n'` → hovering the right half of '日' or '本' still shows the link affordance; Cmd+click on either half opens https://example.com.
- [ ] Selection preservation: drag-select text, Cmd+click a hyperlink elsewhere → selection persists, browser opens.
- [ ] Copy mode: enter copy mode, Cmd+click a hyperlink → browser opens, copy-mode state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)