### PR TITLE
feat(ui): dim inactive panes — webview veil + terminal content dimming

### DIFF
--- a/crates/bevy_terminal_renderer/src/lib.rs
+++ b/crates/bevy_terminal_renderer/src/lib.rs
@@ -19,6 +19,7 @@ pub use crate::glyph::font::{
 pub mod prelude {
     pub use crate::TerminalRendererPlugin;
     pub use crate::bundle::TerminalRenderBundle;
+    pub use crate::material::PaneDim;
     pub use crate::schema::*;
 }
 

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -83,6 +83,19 @@ impl UiMaterial for TerminalUiMaterial {
     }
 }
 
+/// Per-pane brightness multiplier for the terminal renderer. The consumer
+/// (e.g. ozmux-gui) sets this on a terminal host from its active-pane state;
+/// [`update_terminal_material`] bakes it into the material's `dim` uniform
+/// each frame. An absent component is treated as `1.0` (full-bright / active).
+#[derive(Component, Clone, Copy, Debug)]
+pub struct PaneDim(pub f32);
+
+impl Default for PaneDim {
+    fn default() -> Self {
+        Self(1.0)
+    }
+}
+
 /// Uniform block uploaded once per frame alongside the storage buffers.
 ///
 /// # Invariants
@@ -129,7 +142,8 @@ impl UiMaterial for TerminalUiMaterial {
 /// | 80     | `bg_padding_color`          |
 /// | 96     | `hover_hyperlink_id`        |
 /// | 100    | `hover_active`              |
-#[derive(Clone, Copy, ShaderType, Default, Debug)]
+/// | 104    | `dim`                       |
+#[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
     cell_size_px: Vec2,
@@ -163,6 +177,38 @@ struct TerminalParams {
     /// is in this entity's pane; else `0`. Drives the accent-underline
     /// path in the shader.
     hover_active: u32,
+    /// Pane brightness multiplier applied to the final fragment RGB.
+    /// `1.0` = active / full-bright; `< 1.0` dims an inactive pane. The
+    /// hand-written `Default` below sets this to `1.0` so an un-updated
+    /// material never renders dark (a derived `Default` would give `0.0`).
+    dim: f32,
+}
+
+impl Default for TerminalParams {
+    fn default() -> Self {
+        Self {
+            grid_size: UVec2::ZERO,
+            cell_size_px: Vec2::ZERO,
+            atlas_size_px: Vec2::ZERO,
+            ascent_px: 0.0,
+            dpr: 0.0,
+            cursor_pos: UVec2::ZERO,
+            cursor_style: 0,
+            time_seconds: 0.0,
+            sel_start_row: 0,
+            sel_start_col: 0,
+            sel_end_row: 0,
+            sel_end_col: 0,
+            sel_kind: 0,
+            underline_position_phys: 0.0,
+            underline_thickness_phys: 0.0,
+            max_overflow_phys: 0.0,
+            bg_padding_color: Vec4::ZERO,
+            hover_hyperlink_id: 0,
+            hover_active: 0,
+            dim: 1.0,
+        }
+    }
 }
 
 impl TerminalParams {
@@ -189,6 +235,7 @@ impl TerminalParams {
         bg_padding_color: Vec4,
         hover_hyperlink_id: u32,
         hover_active: u32,
+        dim: f32,
     ) -> Self {
         let cols = u32::from(grid.cols);
         let rows = u32::from(grid.rows);
@@ -229,6 +276,7 @@ impl TerminalParams {
             bg_padding_color,
             hover_hyperlink_id,
             hover_active,
+            dim,
         }
     }
 }
@@ -312,6 +360,7 @@ fn update_terminal_material(
         &MaterialNode<TerminalUiMaterial>,
         &mut TerminalMaterialState,
         &TerminalGrid,
+        Option<&PaneDim>,
     )>,
     fonts: Res<TerminalFonts>,
     palette_time: Res<Time>,
@@ -346,7 +395,7 @@ fn update_terminal_material(
     let dpr = window.scale_factor();
     let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
 
-    for (entity, handle, mut state, grid) in terminals.iter_mut() {
+    for (entity, handle, mut state, grid, pane_dim) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;
         let cols = grid.cols as u32;
         let rows = grid.rows as u32;
@@ -449,6 +498,7 @@ fn update_terminal_material(
             _ => (0, 0),
         };
 
+        let dim = pane_dim.map_or(1.0, |d| d.0).clamp(0.0, 1.0);
         if let Some(mat) = materials.get_mut(&handle.0) {
             mat.params = TerminalParams::new(
                 grid,
@@ -463,6 +513,7 @@ fn update_terminal_material(
                 bg_padding_color,
                 hover_hyperlink_id,
                 hover_active,
+                dim,
             );
         }
     }
@@ -670,5 +721,15 @@ mod tests {
         let params = TerminalParams::default();
         assert_eq!(params.hover_hyperlink_id, 0);
         assert_eq!(params.hover_active, 0);
+    }
+
+    #[test]
+    fn terminal_params_default_dim_is_one() {
+        assert_eq!(TerminalParams::default().dim, 1.0);
+    }
+
+    #[test]
+    fn terminal_params_uniform_size_is_112() {
+        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 112);
     }
 }

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -25,6 +25,7 @@ struct TerminalParams {
     bg_padding_color: vec4<f32>,
     hover_hyperlink_id: u32,
     hover_active: u32,
+    dim: f32,
 };
 
 struct Cell {
@@ -96,18 +97,28 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // strip) fall back to bg_padding_color so the surrounding band blends
     // with the terminal background instead of opaque black.
     let fallback = params.bg_padding_color;
+
+    var color: vec4<f32>;
     if params.grid_size.x == 0u || params.grid_size.y == 0u {
-        return fallback;
+        color = fallback;
+    } else {
+        // Shader runs entirely in PHYSICAL pixels. Bevy 0.18
+        // UiVertexOutput.size is physical px (verified in spec R1 audit), so
+        // we use it directly.
+        let p_px = in.uv * in.size;
+        let hit = locate_cell(p_px);
+        if !hit.valid {
+            color = paint_right_strip(p_px, fallback);
+        } else {
+            color = paint_grid_cell(hit, fallback);
+        }
     }
 
-    // Shader runs entirely in PHYSICAL pixels. Bevy 0.18 UiVertexOutput.size
-    // is physical px (verified in spec R1 audit), so we use it directly.
-    let p_px = in.uv * in.size;
-    let hit = locate_cell(p_px);
-    if !hit.valid {
-        return paint_right_strip(p_px, fallback);
-    }
-    return paint_grid_cell(hit, fallback);
+    // Pane-level dim: active pane => params.dim == 1.0 (no-op); inactive pane
+    // => params.dim < 1.0. RGB only; alpha is preserved so blending and the
+    // opaque-padding contract are unchanged. Composes with the per-cell SGR
+    // STYLE_DIM independently.
+    return vec4<f32>(color.rgb * params.dim, color.a);
 }
 
 // ============================================================================

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -12,7 +12,8 @@ pub struct InactivePaneConfig {
     /// Veil alpha in `0.0..=1.0`. Higher = darker inactive panes.
     pub opacity: f32,
     /// Veil color as a `#RRGGBB` hex string. Alpha comes from `opacity`,
-    /// not from this string.
+    /// not from this string. Hex is case-insensitive on input and stored
+    /// normalized to lowercase.
     pub color: String,
 }
 
@@ -54,7 +55,7 @@ impl InactivePaneConfigPatch {
         if let Some(v) = self.color
             && parse_hex_rgb(&v).is_some()
         {
-            base.color = v;
+            base.color = v.to_ascii_lowercase();
         }
         base
     }
@@ -142,6 +143,17 @@ mod tests {
         assert_eq!(patch.enabled, Some(false));
         assert_eq!(patch.opacity, Some(0.6));
         assert_eq!(patch.color.as_deref(), Some("#112233"));
+    }
+
+    #[test]
+    fn uppercase_color_is_normalized_and_parsed() {
+        let merged = InactivePaneConfigPatch {
+            color: Some("#FF00AB".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.color, "#ff00ab");
+        assert_eq!(merged.rgb(), (0xff, 0x00, 0xab));
     }
 
     #[test]

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -13,16 +13,23 @@ pub struct InactivePaneConfig {
     pub opacity: f32,
     /// Veil color as a `#RRGGBB` hex string. Alpha comes from `opacity`,
     /// not from this string. Hex is case-insensitive on input and stored
-    /// normalized to lowercase.
+    /// normalized to lowercase. `opacity`/`color` dim non-terminal panes
+    /// (e.g. the webview); terminal panes use `dim`.
     pub color: String,
+    /// Inactive-terminal brightness multiplier in `0.0..=1.0`. The terminal
+    /// renderer multiplies an inactive pane's rendered content by this
+    /// (lower = dimmer); `1.0` leaves it full-bright. Separate from `opacity`
+    /// because a darkening veil is invisible on a black terminal background.
+    pub dim: f32,
 }
 
 impl Default for InactivePaneConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            opacity: 0.45,
+            opacity: 0.5,
             color: "#000000".to_string(),
+            dim: 0.5,
         }
     }
 }
@@ -42,6 +49,7 @@ pub(crate) struct InactivePaneConfigPatch {
     pub(crate) enabled: Option<bool>,
     pub(crate) opacity: Option<f32>,
     pub(crate) color: Option<String>,
+    pub(crate) dim: Option<f32>,
 }
 
 impl InactivePaneConfigPatch {
@@ -58,6 +66,11 @@ impl InactivePaneConfigPatch {
             && parse_hex_rgb(&v).is_some()
         {
             base.color = v.to_ascii_lowercase();
+        }
+        if let Some(v) = self.dim
+            && !v.is_nan()
+        {
+            base.dim = v.clamp(0.0, 1.0);
         }
         base
     }
@@ -87,9 +100,10 @@ mod tests {
     fn defaults_match_expected_values() {
         let cfg = InactivePaneConfig::default();
         assert!(cfg.enabled);
-        assert_eq!(cfg.opacity, 0.45);
+        assert_eq!(cfg.opacity, 0.5);
         assert_eq!(cfg.color, "#000000");
         assert_eq!(cfg.rgb(), (0, 0, 0));
+        assert_eq!(cfg.dim, 0.5);
     }
 
     #[test]
@@ -98,6 +112,7 @@ mod tests {
             enabled: true,
             opacity: 0.5,
             color: "#1a2b3c".to_string(),
+            dim: 0.5,
         };
         assert_eq!(cfg.rgb(), (0x1a, 0x2b, 0x3c));
     }
@@ -144,10 +159,12 @@ mod tests {
     #[test]
     fn patch_parses_from_toml() {
         let patch: InactivePaneConfigPatch =
-            toml::from_str("enabled = false\nopacity = 0.6\ncolor = \"#112233\"").unwrap();
+            toml::from_str("enabled = false\nopacity = 0.6\ncolor = \"#112233\"\ndim = 0.3")
+                .unwrap();
         assert_eq!(patch.enabled, Some(false));
         assert_eq!(patch.opacity, Some(0.6));
         assert_eq!(patch.color.as_deref(), Some("#112233"));
+        assert_eq!(patch.dim, Some(0.3));
     }
 
     #[test]
@@ -186,6 +203,7 @@ mod tests {
             enabled: true,
             opacity: 0.5,
             color: "#中文".to_string(),
+            dim: 0.5,
         };
         assert_eq!(
             cfg.rgb(),
@@ -198,7 +216,7 @@ mod tests {
     fn nan_opacity_is_rejected_and_keeps_base() {
         let patch: InactivePaneConfigPatch = toml::from_str("opacity = nan").unwrap();
         let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.opacity, 0.45, "NaN opacity must fall back to base");
+        assert_eq!(merged.opacity, 0.5, "NaN opacity must fall back to base");
         assert!(merged.opacity.is_finite(), "stored opacity must be finite");
     }
 
@@ -210,5 +228,30 @@ mod tests {
         }
         .apply_to(InactivePaneConfig::default());
         assert_eq!(merged.opacity, 1.0, "+inf opacity clamps to 1.0");
+    }
+
+    #[test]
+    fn dim_clamps_into_unit_range() {
+        let high = InactivePaneConfigPatch {
+            dim: Some(4.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(high.dim, 1.0);
+
+        let low = InactivePaneConfigPatch {
+            dim: Some(-1.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(low.dim, 0.0);
+    }
+
+    #[test]
+    fn nan_dim_is_rejected_and_keeps_base() {
+        let patch: InactivePaneConfigPatch = toml::from_str("dim = nan").unwrap();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.dim, 0.5, "NaN dim must fall back to base");
+        assert!(merged.dim.is_finite());
     }
 }

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -49,7 +49,9 @@ impl InactivePaneConfigPatch {
         if let Some(v) = self.enabled {
             base.enabled = v;
         }
-        if let Some(v) = self.opacity {
+        if let Some(v) = self.opacity
+            && !v.is_nan()
+        {
             base.opacity = v.clamp(0.0, 1.0);
         }
         if let Some(v) = self.color
@@ -65,7 +67,10 @@ impl InactivePaneConfigPatch {
 /// any other shape (missing `#`, wrong length, non-hex digits).
 fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
     let hex = s.strip_prefix('#')?;
-    if hex.len() != 6 {
+    // NOTE: `!hex.is_ascii()` is load-bearing — the byte-index slices below
+    // panic on a 6-BYTE non-ASCII string (e.g. "#中文") whose offsets 2/4
+    // fall on a non-char-boundary. Drop this and config loading crashes.
+    if hex.len() != 6 || !hex.is_ascii() {
         return None;
     }
     let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
@@ -161,5 +166,49 @@ mod tests {
         let patch = InactivePaneConfigPatch::default();
         let merged = patch.apply_to(InactivePaneConfig::default());
         assert_eq!(merged, InactivePaneConfig::default());
+    }
+
+    #[test]
+    fn non_ascii_six_byte_color_is_rejected_without_panic() {
+        // "中文" is 6 UTF-8 bytes; byte-slicing it would panic at a
+        // non-char-boundary if parse_hex_rgb did not guard on is_ascii.
+        let merged = InactivePaneConfigPatch {
+            color: Some("#中文".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(
+            merged.color, "#000000",
+            "non-ASCII color must fall back to base"
+        );
+
+        let cfg = InactivePaneConfig {
+            enabled: true,
+            opacity: 0.5,
+            color: "#中文".to_string(),
+        };
+        assert_eq!(
+            cfg.rgb(),
+            (0, 0, 0),
+            "rgb() must not panic on a non-ASCII color"
+        );
+    }
+
+    #[test]
+    fn nan_opacity_is_rejected_and_keeps_base() {
+        let patch: InactivePaneConfigPatch = toml::from_str("opacity = nan").unwrap();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.opacity, 0.45, "NaN opacity must fall back to base");
+        assert!(merged.opacity.is_finite(), "stored opacity must be finite");
+    }
+
+    #[test]
+    fn infinite_opacity_clamps_to_unit_range() {
+        let merged = InactivePaneConfigPatch {
+            opacity: Some(f32::INFINITY),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.opacity, 1.0, "+inf opacity clamps to 1.0");
     }
 }

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -1,0 +1,153 @@
+//! Inactive-pane dimming configuration: the translucent veil drawn over
+//! every pane that is not its session's active pane.
+
+use serde::{Deserialize, Serialize};
+
+/// Fully-resolved `[inactive_pane]` config block. The UI layer draws a
+/// veil over each inactive pane using `color` (RGB) at `opacity` (alpha).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct InactivePaneConfig {
+    /// Whether inactive panes are dimmed at all.
+    pub enabled: bool,
+    /// Veil alpha in `0.0..=1.0`. Higher = darker inactive panes.
+    pub opacity: f32,
+    /// Veil color as a `#RRGGBB` hex string. Alpha comes from `opacity`,
+    /// not from this string.
+    pub color: String,
+}
+
+impl Default for InactivePaneConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            opacity: 0.45,
+            color: "#000000".to_string(),
+        }
+    }
+}
+
+impl InactivePaneConfig {
+    /// Returns the veil color's `(r, g, b)` byte components parsed from the
+    /// `#RRGGBB` `color` string, falling back to black on a malformed value.
+    pub fn rgb(&self) -> (u8, u8, u8) {
+        parse_hex_rgb(&self.color).unwrap_or((0, 0, 0))
+    }
+}
+
+/// Per-field-optional patch produced by parsing `[inactive_pane]` from
+/// `config.toml`. Missing keys fall through to the defaults.
+#[derive(Deserialize, Default)]
+pub(crate) struct InactivePaneConfigPatch {
+    pub(crate) enabled: Option<bool>,
+    pub(crate) opacity: Option<f32>,
+    pub(crate) color: Option<String>,
+}
+
+impl InactivePaneConfigPatch {
+    pub(crate) fn apply_to(self, mut base: InactivePaneConfig) -> InactivePaneConfig {
+        if let Some(v) = self.enabled {
+            base.enabled = v;
+        }
+        if let Some(v) = self.opacity {
+            base.opacity = v.clamp(0.0, 1.0);
+        }
+        if let Some(v) = self.color
+            && parse_hex_rgb(&v).is_some()
+        {
+            base.color = v;
+        }
+        base
+    }
+}
+
+/// Parses a `#RRGGBB` hex string into `(r, g, b)` bytes; returns `None` for
+/// any other shape (missing `#`, wrong length, non-hex digits).
+fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
+    let hex = s.strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some((r, g, b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_expected_values() {
+        let cfg = InactivePaneConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.opacity, 0.45);
+        assert_eq!(cfg.color, "#000000");
+        assert_eq!(cfg.rgb(), (0, 0, 0));
+    }
+
+    #[test]
+    fn rgb_parses_hex() {
+        let cfg = InactivePaneConfig {
+            enabled: true,
+            opacity: 0.5,
+            color: "#1a2b3c".to_string(),
+        };
+        assert_eq!(cfg.rgb(), (0x1a, 0x2b, 0x3c));
+    }
+
+    #[test]
+    fn patch_overrides_only_present_fields() {
+        let patch = InactivePaneConfigPatch {
+            opacity: Some(0.8),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.opacity, 0.8);
+        assert!(merged.enabled);
+        assert_eq!(merged.color, "#000000");
+    }
+
+    #[test]
+    fn opacity_clamps_into_unit_range() {
+        let high = InactivePaneConfigPatch {
+            opacity: Some(5.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(high.opacity, 1.0);
+
+        let low = InactivePaneConfigPatch {
+            opacity: Some(-2.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(low.opacity, 0.0);
+    }
+
+    #[test]
+    fn invalid_color_falls_back_to_base() {
+        let merged = InactivePaneConfigPatch {
+            color: Some("not-a-color".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.color, "#000000");
+    }
+
+    #[test]
+    fn patch_parses_from_toml() {
+        let patch: InactivePaneConfigPatch =
+            toml::from_str("enabled = false\nopacity = 0.6\ncolor = \"#112233\"").unwrap();
+        assert_eq!(patch.enabled, Some(false));
+        assert_eq!(patch.opacity, Some(0.6));
+        assert_eq!(patch.color.as_deref(), Some("#112233"));
+    }
+
+    #[test]
+    fn empty_patch_leaves_base_unchanged() {
+        let patch = InactivePaneConfigPatch::default();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged, InactivePaneConfig::default());
+    }
+}

--- a/crates/configs/src/lib.rs
+++ b/crates/configs/src/lib.rs
@@ -6,6 +6,7 @@
 
 use crate::browser::BrowserConfig;
 use crate::font::FontConfig;
+use crate::inactive_pane::InactivePaneConfig;
 use crate::shortcuts::Shortcuts;
 use crate::theme::Theme;
 pub use error::{OzmuxConfigsError, OzmuxConfigsResult};
@@ -14,6 +15,7 @@ use std::path::Path;
 pub mod browser;
 pub mod error;
 pub mod font;
+pub mod inactive_pane;
 pub mod mouse;
 pub mod path;
 mod raw;
@@ -33,6 +35,8 @@ pub struct OzmuxConfigs {
     pub browser: BrowserConfig,
     /// Mouse-input configuration.
     pub mouse: mouse::MouseConfig,
+    /// Inactive-pane dimming configuration.
+    pub inactive_pane: InactivePaneConfig,
 }
 
 impl OzmuxConfigs {

--- a/crates/configs/src/raw.rs
+++ b/crates/configs/src/raw.rs
@@ -6,6 +6,7 @@ use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
 use crate::browser::BrowserPatch;
 use crate::font::FontPatch;
+use crate::inactive_pane::InactivePaneConfigPatch;
 use crate::mouse::MousePatch;
 use crate::shortcuts::Shortcuts;
 use crate::theme::ThemePatch;
@@ -21,13 +22,14 @@ pub(crate) struct RawConfigs {
     pub(crate) font: Option<FontPatch>,
     pub(crate) browser: Option<BrowserPatch>,
     pub(crate) mouse: Option<MousePatch>,
+    pub(crate) inactive_pane: Option<InactivePaneConfigPatch>,
 }
 
 impl RawConfigs {
     /// Applies any populated fields onto `base` and returns the merged result.
     /// Within the `shortcuts` section, `bindings` is full-replace when present.
-    /// The `theme`, `font`, `browser`, and `mouse` sections use their respective
-    /// `Patch::apply_to` for per-field merge.
+    /// The `theme`, `font`, `browser`, `mouse`, and `inactive_pane` sections use
+    /// their respective `Patch::apply_to` for per-field merge.
     pub(crate) fn apply_to(self, mut base: OzmuxConfigs) -> OzmuxConfigs {
         if let Some(shortcuts) = self.shortcuts {
             base.shortcuts = shortcuts;
@@ -43,6 +45,9 @@ impl RawConfigs {
         }
         if let Some(patch) = self.mouse {
             base.mouse = patch.apply_to(base.mouse);
+        }
+        if let Some(patch) = self.inactive_pane {
+            base.inactive_pane = patch.apply_to(base.inactive_pane);
         }
         base
     }
@@ -128,6 +133,30 @@ resize-pane-down = "Cmd+Shift+J"
         assert!(
             msg.contains("resize-pane-down") || msg.contains("unknown field"),
             "error message should mention the unknown field; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn inactive_pane_section_merges_and_clamps() {
+        let toml_str = r#"
+[inactive_pane]
+enabled = false
+opacity = 2.0
+"#;
+        let raw: RawConfigs = toml::from_str(toml_str).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert!(!merged.inactive_pane.enabled);
+        assert_eq!(merged.inactive_pane.opacity, 1.0, "opacity clamps to 1.0");
+        assert_eq!(merged.inactive_pane.color, "#000000", "color keeps default");
+    }
+
+    #[test]
+    fn missing_inactive_pane_section_uses_defaults() {
+        let raw: RawConfigs = toml::from_str("").unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(
+            merged.inactive_pane,
+            crate::inactive_pane::InactivePaneConfig::default()
         );
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -98,8 +98,6 @@ pub struct PaneFrame;
 /// `Visibility` on focus changes.
 #[derive(Component)]
 pub(crate) struct PaneDimOverlay {
-    // TODO: remove this allow once sync_pane_dim (Task 3) reads this field in production code
-    #[allow(dead_code)]
     pub(crate) pane: Entity,
 }
 
@@ -665,6 +663,79 @@ mod tests {
         let world = app.world_mut();
         let count = world.query::<&PaneDimOverlay>().iter(world).count();
         assert_eq!(count, 0, "no overlays spawned when dimming is disabled");
+    }
+
+    #[test]
+    fn focus_change_moves_dim_to_newly_inactive_pane() {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{MultiplexerCommands, SessionMarker, Side, SplitOrientation};
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let original_pane = app
+            .world_mut()
+            .run_system_once(
+                |mut mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().expect("session");
+                    let pane = mux.sessions_active_pane(session).expect("active pane");
+                    mux.split_pane(pane, Side::After, SplitOrientation::Horizontal)
+                        .expect("split_pane");
+                    pane
+                },
+            )
+            .unwrap();
+        app.update();
+
+        let (session, target_pane) = app
+            .world_mut()
+            .run_system_once(
+                |mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().unwrap();
+                    let active = mux.sessions_active_pane(session).unwrap();
+                    let target = mux
+                        .panes_of_session(session)
+                        .find(|p| *p != active)
+                        .expect("a non-active pane exists after split");
+                    (session, target)
+                },
+            )
+            .unwrap();
+        let _ = original_pane;
+
+        app.world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                mux.set_active_pane(session, target_pane)
+                    .expect("set_active_pane");
+            })
+            .unwrap();
+        app.update();
+
+        let world = app.world_mut();
+        let overlays: Vec<(Entity, Visibility)> = world
+            .query::<(&PaneDimOverlay, &Visibility)>()
+            .iter(world)
+            .map(|(o, v)| (o.pane, *v))
+            .collect();
+        assert_eq!(overlays.len(), 2);
+        for (pane, vis) in overlays {
+            if pane == target_pane {
+                assert_eq!(
+                    vis,
+                    Visibility::Hidden,
+                    "newly-focused pane's veil is hidden"
+                );
+            } else {
+                assert_eq!(
+                    vis,
+                    Visibility::Visible,
+                    "newly-inactive pane's veil is visible"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -533,14 +533,33 @@ mod tests {
         assert_eq!(count, 1, "exactly one AttachedSession after bootstrap");
     }
 
+    /// Collects `(pane, PaneDim.0)` for every terminal host that
+    /// `sync_terminal_dim` has assigned a `PaneDim`.
+    fn terminal_host_pane_dims(world: &mut World) -> Vec<(Entity, f32)> {
+        use bevy_terminal_renderer::material::PaneDim;
+        let hosts: Vec<(Entity, f32)> = world
+            .query_filtered::<(&HostActivityEntity, &PaneDim), With<TerminalActivityMarker>>()
+            .iter(world)
+            .map(|(h, d)| (h.0, d.0))
+            .collect();
+        hosts
+            .into_iter()
+            .filter_map(|(activity, dim)| {
+                let pane = world.get::<ChildOf>(activity)?.parent();
+                Some((pane, dim))
+            })
+            .collect()
+    }
+
     #[test]
-    fn split_panes_get_dim_overlays_with_active_hidden() {
+    fn split_dims_inactive_terminal_keeps_active_bright() {
         use bevy::ecs::system::RunSystemOnce;
         use ozmux_multiplexer::{MultiplexerCommands, SessionMarker, Side, SplitOrientation};
 
         let (mut app, _guard) = make_test_app();
-        app.update();
-        app.update();
+        for _ in 0..3 {
+            app.update();
+        }
 
         app.world_mut()
             .run_system_once(
@@ -553,7 +572,9 @@ mod tests {
                 },
             )
             .unwrap();
-        app.update();
+        for _ in 0..4 {
+            app.update();
+        }
 
         let active_pane = app
             .world_mut()
@@ -566,113 +587,127 @@ mod tests {
             )
             .unwrap();
 
-        let world = app.world_mut();
-        let overlays: Vec<(Entity, Visibility)> = world
-            .query::<(&PaneDimOverlay, &Visibility)>()
-            .iter(world)
-            .map(|(o, v)| (o.pane, *v))
-            .collect();
-        assert_eq!(overlays.len(), 2, "exactly one dim overlay per pane");
-        for (pane, vis) in overlays {
+        {
+            let world = app.world_mut();
+            let overlay_count = world.query::<&PaneDimOverlay>().iter(world).count();
+            assert_eq!(overlay_count, 0, "terminal panes get no veil overlay");
+        }
+
+        let dims = terminal_host_pane_dims(app.world_mut());
+        assert_eq!(dims.len(), 2, "two terminal hosts after split");
+        for (pane, dim) in dims {
             if pane == active_pane {
-                assert_eq!(vis, Visibility::Hidden, "active pane's veil is hidden");
+                assert_eq!(dim, 1.0, "active terminal is full-bright");
             } else {
-                assert_eq!(vis, Visibility::Visible, "inactive pane's veil is visible");
+                assert_eq!(dim, 0.5, "inactive terminal dimmed to default factor");
             }
         }
     }
 
     #[test]
-    fn lone_bootstrap_pane_veil_is_hidden() {
+    fn lone_terminal_pane_is_full_bright_and_unveiled() {
+        use bevy_terminal_renderer::material::PaneDim;
+
         let (mut app, _guard) = make_test_app();
-        app.update();
-        app.update();
+        for _ in 0..4 {
+            app.update();
+        }
 
         let world = app.world_mut();
-        let visibilities: Vec<Visibility> = world
-            .query::<(&PaneDimOverlay, &Visibility)>()
+        let overlay_count = world.query::<&PaneDimOverlay>().iter(world).count();
+        assert_eq!(
+            overlay_count, 0,
+            "terminal panes must not get a veil overlay"
+        );
+
+        let dims: Vec<f32> = world
+            .query_filtered::<&PaneDim, With<TerminalActivityMarker>>()
             .iter(world)
-            .map(|(_, v)| *v)
+            .map(|d| d.0)
             .collect();
-        assert_eq!(
-            visibilities.len(),
-            1,
-            "exactly one overlay for the lone pane"
-        );
-        assert_eq!(
-            visibilities[0],
-            Visibility::Hidden,
-            "lone active pane is not dimmed"
-        );
+        assert_eq!(dims.len(), 1, "exactly one terminal host after bootstrap");
+        assert_eq!(dims[0], 1.0, "lone active terminal is full-bright");
     }
 
     #[test]
-    fn dim_overlay_is_not_pickable() {
+    fn extension_pane_keeps_pickable_ignore_veil() {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{ActivityKind, LayoutCells, MultiplexerCommands, SessionMarker};
+
         let (mut app, _guard) = make_test_app();
-        app.update();
-        app.update();
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let pane = app
+            .world_mut()
+            .run_system_once(
+                |mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().unwrap();
+                    mux.sessions_active_pane(session).unwrap()
+                },
+            )
+            .unwrap();
+        app.world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                let ext = mux.add_activity(
+                    pane,
+                    ActivityKind::Extension {
+                        html_root: "/tmp".into(),
+                    },
+                );
+                mux.set_active_activity(pane, ext).unwrap();
+            })
+            .unwrap();
+        // An activity switch reparents hosts via a rebuild; force it in the harness.
+        app.world_mut()
+            .run_system_once(
+                |mut sessions: Query<&mut LayoutCells, With<SessionMarker>>| {
+                    for mut lc in sessions.iter_mut() {
+                        lc.set_changed();
+                    }
+                },
+            )
+            .unwrap();
+        for _ in 0..2 {
+            app.update();
+        }
 
         let world = app.world_mut();
         let overlay = world
             .query_filtered::<Entity, With<PaneDimOverlay>>()
             .iter(world)
             .next()
-            .expect("one overlay after bootstrap");
+            .expect("extension pane must have a veil overlay");
         let pickable = world
             .get::<Pickable>(overlay)
-            .expect("overlay must carry Pickable");
-        assert!(
-            !pickable.should_block_lower,
-            "veil must not block picks below it"
-        );
+            .expect("veil must carry Pickable");
+        assert!(!pickable.should_block_lower, "veil must not block lower");
         assert!(!pickable.is_hoverable, "veil must not be hoverable");
     }
 
     #[test]
-    fn disabled_config_spawns_no_dim_overlays() {
-        use ozmux_multiplexer::{LayoutCells, SessionMarker};
-
-        let (mut app, _guard) = make_test_app();
-        app.update();
-        app.update();
-
-        let custom = ozmux_configs::OzmuxConfigs {
-            inactive_pane: ozmux_configs::inactive_pane::InactivePaneConfig {
-                enabled: false,
-                opacity: 0.45,
-                color: "#000000".to_string(),
-            },
-            ..Default::default()
-        };
-        app.insert_resource(crate::configs::OzmuxConfigsResource(custom));
-
-        {
-            let world = app.world_mut();
-            let session = world
-                .query_filtered::<Entity, (With<SessionMarker>, With<AttachedSession>)>()
-                .single(world)
-                .expect("attached session");
-            world
-                .entity_mut(session)
-                .get_mut::<LayoutCells>()
-                .expect("LayoutCells")
-                .set_changed();
-        }
-        app.update();
-
-        let world = app.world_mut();
-        let count = world.query::<&PaneDimOverlay>().iter(world).count();
-        assert_eq!(count, 0, "no overlays spawned when dimming is disabled");
-    }
-
-    #[test]
-    fn focus_change_moves_dim_to_newly_inactive_pane() {
+    fn disabled_config_dims_nothing() {
         use bevy::ecs::system::RunSystemOnce;
         use ozmux_multiplexer::{MultiplexerCommands, SessionMarker, Side, SplitOrientation};
 
         let (mut app, _guard) = make_test_app();
-        app.update();
-        app.update();
+        // Override to disabled BEFORE hosts mount, so the first PaneDim
+        // assignment and the veil decision both see enabled = false.
+        let custom = ozmux_configs::OzmuxConfigs {
+            inactive_pane: ozmux_configs::inactive_pane::InactivePaneConfig {
+                enabled: false,
+                opacity: 0.5,
+                color: "#000000".to_string(),
+                dim: 0.3,
+            },
+            ..Default::default()
+        };
+        app.insert_resource(crate::configs::OzmuxConfigsResource(custom));
+        for _ in 0..3 {
+            app.update();
+        }
 
         app.world_mut()
             .run_system_once(
@@ -685,7 +720,48 @@ mod tests {
                 },
             )
             .unwrap();
-        app.update();
+        for _ in 0..4 {
+            app.update();
+        }
+
+        let world = app.world_mut();
+        let overlay_count = world.query::<&PaneDimOverlay>().iter(world).count();
+        assert_eq!(
+            overlay_count, 0,
+            "no veil overlays when dimming is disabled"
+        );
+        let dims = terminal_host_pane_dims(world);
+        assert_eq!(dims.len(), 2, "two terminal hosts after split");
+        assert!(
+            dims.iter().all(|(_, d)| *d == 1.0),
+            "disabled dimming leaves every terminal full-bright (got {dims:?})"
+        );
+    }
+
+    #[test]
+    fn focus_change_moves_terminal_dim() {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{MultiplexerCommands, SessionMarker, Side, SplitOrientation};
+
+        let (mut app, _guard) = make_test_app();
+        for _ in 0..3 {
+            app.update();
+        }
+
+        app.world_mut()
+            .run_system_once(
+                |mut mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().expect("session");
+                    let pane = mux.sessions_active_pane(session).expect("active pane");
+                    mux.split_pane(pane, Side::After, SplitOrientation::Horizontal)
+                        .expect("split_pane");
+                },
+            )
+            .unwrap();
+        for _ in 0..4 {
+            app.update();
+        }
 
         let (session, target_pane) = app
             .world_mut()
@@ -709,32 +785,17 @@ mod tests {
                     .expect("set_active_pane");
             })
             .unwrap();
-        app.update();
+        for _ in 0..2 {
+            app.update();
+        }
 
-        let world = app.world_mut();
-        let overlays: Vec<(Entity, Visibility)> = world
-            .query::<(&PaneDimOverlay, &Visibility)>()
-            .iter(world)
-            .map(|(o, v)| (o.pane, *v))
-            .collect();
-        assert_eq!(
-            overlays.len(),
-            2,
-            "two overlays after split and focus change"
-        );
-        for (pane, vis) in overlays {
+        let dims = terminal_host_pane_dims(app.world_mut());
+        assert_eq!(dims.len(), 2, "two terminal hosts");
+        for (pane, dim) in dims {
             if pane == target_pane {
-                assert_eq!(
-                    vis,
-                    Visibility::Hidden,
-                    "newly-focused pane's veil is hidden"
-                );
+                assert_eq!(dim, 1.0, "newly-focused terminal is full-bright");
             } else {
-                assert_eq!(
-                    vis,
-                    Visibility::Visible,
-                    "newly-inactive pane's veil is visible"
-                );
+                assert_eq!(dim, 0.5, "newly-inactive terminal is dimmed");
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -674,8 +674,7 @@ mod tests {
         app.update();
         app.update();
 
-        let original_pane = app
-            .world_mut()
+        app.world_mut()
             .run_system_once(
                 |mut mux: MultiplexerCommands,
                  sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
@@ -683,7 +682,6 @@ mod tests {
                     let pane = mux.sessions_active_pane(session).expect("active pane");
                     mux.split_pane(pane, Side::After, SplitOrientation::Horizontal)
                         .expect("split_pane");
-                    pane
                 },
             )
             .unwrap();
@@ -704,7 +702,6 @@ mod tests {
                 },
             )
             .unwrap();
-        let _ = original_pane;
 
         app.world_mut()
             .run_system_once(move |mut mux: MultiplexerCommands| {
@@ -720,7 +717,11 @@ mod tests {
             .iter(world)
             .map(|(o, v)| (o.pane, *v))
             .collect();
-        assert_eq!(overlays.len(), 2);
+        assert_eq!(
+            overlays.len(),
+            2,
+            "two overlays after split and focus change"
+        );
         for (pane, vis) in overlays {
             if pane == target_pane {
                 assert_eq!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -91,6 +91,18 @@ pub struct TerminalSpawnFailed;
 #[derive(Component)]
 pub struct PaneFrame;
 
+/// Marks the per-pane dim veil — a translucent overlay node, last child of
+/// the pane frame, drawn over both terminal and webview content when the
+/// pane is NOT its session's active pane. `pane` is the multiplexer Pane
+/// entity this veil belongs to; `sync_pane_dim` reads it to toggle
+/// `Visibility` on focus changes.
+#[derive(Component)]
+pub(crate) struct PaneDimOverlay {
+    // TODO: remove this allow once sync_pane_dim (Task 3) reads this field in production code
+    #[allow(dead_code)]
+    pub(crate) pane: Entity,
+}
+
 /// Bevy Plugin wiring the native Bevy UI rebuild pipeline.
 pub struct OzmuxUiPlugin;
 
@@ -521,6 +533,138 @@ mod tests {
             .iter(app.world())
             .count();
         assert_eq!(count, 1, "exactly one AttachedSession after bootstrap");
+    }
+
+    #[test]
+    fn split_panes_get_dim_overlays_with_active_hidden() {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{MultiplexerCommands, SessionMarker, Side, SplitOrientation};
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        app.world_mut()
+            .run_system_once(
+                |mut mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().expect("session");
+                    let pane = mux.sessions_active_pane(session).expect("active pane");
+                    mux.split_pane(pane, Side::After, SplitOrientation::Horizontal)
+                        .expect("split_pane");
+                },
+            )
+            .unwrap();
+        app.update();
+
+        let active_pane = app
+            .world_mut()
+            .run_system_once(
+                |mux: MultiplexerCommands,
+                 sessions: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>| {
+                    let session = sessions.iter().next().unwrap();
+                    mux.sessions_active_pane(session).unwrap()
+                },
+            )
+            .unwrap();
+
+        let world = app.world_mut();
+        let overlays: Vec<(Entity, Visibility)> = world
+            .query::<(&PaneDimOverlay, &Visibility)>()
+            .iter(world)
+            .map(|(o, v)| (o.pane, *v))
+            .collect();
+        assert_eq!(overlays.len(), 2, "exactly one dim overlay per pane");
+        for (pane, vis) in overlays {
+            if pane == active_pane {
+                assert_eq!(vis, Visibility::Hidden, "active pane's veil is hidden");
+            } else {
+                assert_eq!(vis, Visibility::Visible, "inactive pane's veil is visible");
+            }
+        }
+    }
+
+    #[test]
+    fn lone_bootstrap_pane_veil_is_hidden() {
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let visibilities: Vec<Visibility> = world
+            .query::<(&PaneDimOverlay, &Visibility)>()
+            .iter(world)
+            .map(|(_, v)| *v)
+            .collect();
+        assert_eq!(
+            visibilities.len(),
+            1,
+            "exactly one overlay for the lone pane"
+        );
+        assert_eq!(
+            visibilities[0],
+            Visibility::Hidden,
+            "lone active pane is not dimmed"
+        );
+    }
+
+    #[test]
+    fn dim_overlay_is_not_pickable() {
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let overlay = world
+            .query_filtered::<Entity, With<PaneDimOverlay>>()
+            .iter(world)
+            .next()
+            .expect("one overlay after bootstrap");
+        let pickable = world
+            .get::<Pickable>(overlay)
+            .expect("overlay must carry Pickable");
+        assert!(
+            !pickable.should_block_lower,
+            "veil must not block picks below it"
+        );
+        assert!(!pickable.is_hoverable, "veil must not be hoverable");
+    }
+
+    #[test]
+    fn disabled_config_spawns_no_dim_overlays() {
+        use ozmux_multiplexer::{LayoutCells, SessionMarker};
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let custom = ozmux_configs::OzmuxConfigs {
+            inactive_pane: ozmux_configs::inactive_pane::InactivePaneConfig {
+                enabled: false,
+                opacity: 0.45,
+                color: "#000000".to_string(),
+            },
+            ..Default::default()
+        };
+        app.insert_resource(crate::configs::OzmuxConfigsResource(custom));
+
+        {
+            let world = app.world_mut();
+            let session = world
+                .query_filtered::<Entity, (With<SessionMarker>, With<AttachedSession>)>()
+                .single(world)
+                .expect("attached session");
+            world
+                .entity_mut(session)
+                .get_mut::<LayoutCells>()
+                .expect("LayoutCells")
+                .set_changed();
+        }
+        app.update();
+
+        let world = app.world_mut();
+        let count = world.query::<&PaneDimOverlay>().iter(world).count();
+        assert_eq!(count, 0, "no overlays spawned when dimming is disabled");
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -259,10 +259,10 @@ fn build_pane(
             Name::new(format!("PaneDim({pane_entity:?})")),
             Node {
                 position_type: PositionType::Absolute,
-                left: Val::Px(0.0),
-                right: Val::Px(0.0),
                 top: Val::Px(0.0),
-                bottom: Val::Px(0.0),
+                left: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
                 ..default()
             },
             BackgroundColor(veil_color),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -249,7 +249,16 @@ fn build_pane(
         }
     }
 
-    if let Some(veil_color) = veil {
+    // NOTE: terminal panes are dimmed at the renderer (PaneDim uniform), so
+    // they must NOT also get the veil — double-dimming would over-darken their
+    // content. The veil is for non-terminal (e.g. webview) panes only.
+    let active_is_terminal = matches!(
+        activities.get(active_activity).map(|(kind, _)| kind),
+        Ok(ActivityKind::Terminal)
+    );
+    if let Some(veil_color) = veil
+        && !active_is_terminal
+    {
         let visibility = if pane_entity == active_pane {
             Visibility::Hidden
         } else {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -8,9 +8,9 @@ use crate::theme;
 use crate::ui::activity::build_activity_host_children;
 use crate::ui::registry::ActivityEntityRegistry;
 use crate::ui::tab_bar::{TabEntry, build_pane_tab_bar};
-use crate::ui::{PaneFrame, StructuralNode, palette};
+use crate::ui::{PaneDimOverlay, PaneFrame, StructuralNode, palette};
 use bevy::prelude::*;
-use bevy::ui::{FlexDirection, UiRect, Val};
+use bevy::ui::{FlexDirection, PositionType, UiRect, Val};
 use ozmux_multiplexer::{
     ActiveActivity, ActivityKind, ActivityMarker, Cell, CellId, LayoutCellState, PaneMarker,
     SplitOrientation,
@@ -51,6 +51,8 @@ pub(crate) fn build_cell_recursive(
     pane_children: &Query<&Children>,
     activities: &Query<(&ActivityKind, &Name), With<ActivityMarker>>,
     active_activities: &Query<&ActiveActivity, With<PaneMarker>>,
+    active_pane: Entity,
+    veil: Option<Color>,
 ) {
     let cell = match cells.cell(cell_id) {
         Ok(c) => c,
@@ -83,6 +85,8 @@ pub(crate) fn build_cell_recursive(
             pane_children,
             activities,
             active_activities,
+            active_pane,
+            veil,
         ),
         Cell::Split(s) => {
             let (lhs_grow, rhs_grow) = split_ratio_to_flex_grows(s.lhs_weight, s.rhs_weight);
@@ -126,6 +130,8 @@ pub(crate) fn build_cell_recursive(
                 pane_children,
                 activities,
                 active_activities,
+                active_pane,
+                veil,
             );
 
             let rhs = commands
@@ -150,6 +156,8 @@ pub(crate) fn build_cell_recursive(
                 pane_children,
                 activities,
                 active_activities,
+                active_pane,
+                veil,
             );
         }
     }
@@ -166,6 +174,8 @@ fn build_pane(
     pane_children: &Query<&Children>,
     activities: &Query<(&ActivityKind, &Name), With<ActivityMarker>>,
     active_activities: &Query<&ActiveActivity, With<PaneMarker>>,
+    active_pane: Entity,
+    veil: Option<Color>,
 ) {
     let active_activity = active_activities
         .get(pane_entity)
@@ -237,6 +247,31 @@ fn build_pane(
         } else {
             commands.entity(host).insert(ChildOf(inactive_host_parent));
         }
+    }
+
+    if let Some(veil_color) = veil {
+        let visibility = if pane_entity == active_pane {
+            Visibility::Hidden
+        } else {
+            Visibility::Visible
+        };
+        commands.spawn((
+            Name::new(format!("PaneDim({pane_entity:?})")),
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                top: Val::Px(0.0),
+                bottom: Val::Px(0.0),
+                ..default()
+            },
+            BackgroundColor(veil_color),
+            visibility,
+            Pickable::IGNORE,
+            StructuralNode,
+            PaneDimOverlay { pane: pane_entity },
+            ChildOf(pane_frame),
+        ));
     }
 }
 

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -211,9 +211,9 @@ fn descend_and_despawn_structural(
 /// Pane→session is resolved via `ChildOf`; using `MultiplexerCommands` here
 /// would conflict on its `&mut ActivePane`.
 fn sync_pane_dim(
+    mut overlays: Query<(&PaneDimOverlay, &mut Visibility)>,
     changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
     panes: Query<&ChildOf, With<PaneMarker>>,
-    mut overlays: Query<(&PaneDimOverlay, &mut Visibility)>,
 ) {
     for (session, active) in changed_sessions.iter() {
         for (overlay, mut visibility) in overlays.iter_mut() {

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -154,35 +154,6 @@ fn rebuild_session_ui(
     }
 }
 
-/// Flips each pane's dim veil when its session's `ActivePane` changes
-/// (focus moves between panes without a layout rebuild). For every session
-/// whose `ActivePane` changed, sets each `PaneDimOverlay` belonging to that
-/// session to `Hidden` iff its pane is the new active pane, else `Visible`.
-/// Pane→session is resolved via `ChildOf`; using `MultiplexerCommands` here
-/// would conflict on its `&mut ActivePane`.
-fn sync_pane_dim(
-    changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
-    panes: Query<&ChildOf, With<PaneMarker>>,
-    mut overlays: Query<(&PaneDimOverlay, &mut Visibility)>,
-) {
-    for (session, active) in changed_sessions.iter() {
-        for (overlay, mut visibility) in overlays.iter_mut() {
-            let Ok(child_of) = panes.get(overlay.pane) else {
-                continue;
-            };
-            if child_of.parent() != session {
-                continue;
-            }
-            let want = if overlay.pane == active.0 {
-                Visibility::Hidden
-            } else {
-                Visibility::Visible
-            };
-            visibility.set_if_neq(want);
-        }
-    }
-}
-
 fn descend_and_detach_hosts(
     commands: &mut Commands,
     root: Entity,
@@ -223,6 +194,35 @@ fn descend_and_despawn_structural(
     }
     for e in to_despawn {
         commands.entity(e).try_despawn();
+    }
+}
+
+/// Flips each pane's dim veil when its session's `ActivePane` changes
+/// (focus moves between panes without a layout rebuild). For every session
+/// whose `ActivePane` changed, sets each `PaneDimOverlay` belonging to that
+/// session to `Hidden` iff its pane is the new active pane, else `Visible`.
+/// Pane→session is resolved via `ChildOf`; using `MultiplexerCommands` here
+/// would conflict on its `&mut ActivePane`.
+fn sync_pane_dim(
+    changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
+    panes: Query<&ChildOf, With<PaneMarker>>,
+    mut overlays: Query<(&PaneDimOverlay, &mut Visibility)>,
+) {
+    for (session, active) in changed_sessions.iter() {
+        for (overlay, mut visibility) in overlays.iter_mut() {
+            let Ok(child_of) = panes.get(overlay.pane) else {
+                continue;
+            };
+            if child_of.parent() != session {
+                continue;
+            }
+            let want = if overlay.pane == active.0 {
+                Visibility::Hidden
+            } else {
+                Visibility::Visible
+            };
+            visibility.set_if_neq(want);
+        }
     }
 }
 

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -113,20 +113,16 @@ fn rebuild_session_ui(
 
     let veil: Option<Color> = match configs.as_deref() {
         Some(cfg) if cfg.inactive_pane.enabled => {
-            let ip = &cfg.inactive_pane;
-            let (r, g, b) = ip.rgb();
-            Some(Color::srgba(
-                r as f32 / 255.0,
-                g as f32 / 255.0,
-                b as f32 / 255.0,
-                ip.opacity,
-            ))
+            let (r, g, b) = cfg.inactive_pane.rgb();
+            Some(Color::srgb_u8(r, g, b).with_alpha(cfg.inactive_pane.opacity))
         }
         _ => None,
     };
 
     for (session_entity, layout, subtree, active_pane, _is_attached) in sessions.iter() {
-        let active_pane = active_pane.map(|a| a.0).unwrap_or(Entity::PLACEHOLDER);
+        let active_pane = active_pane.map(|a| a.0);
+        let session_veil = if active_pane.is_some() { veil } else { None };
+        let active_pane = active_pane.unwrap_or(Entity::PLACEHOLDER);
         descend_and_detach_hosts(&mut commands, subtree.0, &children, &activity_hosts);
         descend_and_despawn_structural(&mut commands, subtree.0, &children, &structurals);
 
@@ -145,7 +141,7 @@ fn rebuild_session_ui(
                     &activities,
                     &active_activities,
                     active_pane,
-                    veil,
+                    session_veil,
                 );
             }
             Ok(_) => tracing::warn!(target: "ozmux_gui::ui", "root_cell is not Cell::Root"),

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -8,9 +8,14 @@ use crate::font::TerminalUiFont;
 use crate::system_set::OzmuxSystems;
 use crate::ui::layout::build_cell_recursive;
 use crate::ui::registry::ActivityEntityRegistry;
-use crate::ui::{ActivityHostNode, PaneDimOverlay, SessionUiRoot, StructuralNode};
+use crate::ui::terminal::resolve_pane_session;
+use crate::ui::{
+    ActivityHostNode, HostActivityEntity, PaneDimOverlay, SessionUiRoot, StructuralNode,
+    TerminalActivityMarker,
+};
 use bevy::prelude::*;
 use bevy::ui::UiSystems;
+use bevy_terminal_renderer::material::{PaneDim, TerminalUiMaterial};
 use ozmux_extension_host::ExtensionControlSet;
 use ozmux_multiplexer::{
     ActiveActivity, ActivePane, ActivityKind, ActivityMarker, AttachedSession, Cell, LayoutCells,
@@ -24,6 +29,12 @@ impl Plugin for OzmuxSessionUiPlugin {
         order_activity_pipeline(app);
         app.add_systems(Update, rebuild_session_ui.in_set(OzmuxSystems::SessionUi))
             .add_systems(Update, sync_pane_dim.after(OzmuxSystems::Input))
+            .add_systems(
+                Update,
+                sync_terminal_dim
+                    .after(OzmuxSystems::Input)
+                    .after(OzmuxSystems::SetupActivity),
+            )
             .add_systems(PostUpdate, sync_active_session.before(UiSystems::Prepare));
     }
 }
@@ -219,6 +230,66 @@ fn sync_pane_dim(
             };
             visibility.set_if_neq(want);
         }
+    }
+}
+
+/// Sets each terminal host's [`PaneDim`] from its session's `ActivePane` so
+/// the renderer dims inactive terminals (a darkening veil is invisible on a
+/// black terminal, so terminals are dimmed at the renderer instead). Reacts
+/// to focus changes (`Changed<ActivePane>`) and to terminal hosts whose
+/// material was just mounted (`Added<MaterialNode<..>>`, since hosts attach
+/// lazily after a rebuild). Pane→session is resolved via `ChildOf`;
+/// `MultiplexerCommands` can't be used here (it holds `&mut ActivePane`).
+fn sync_terminal_dim(
+    mut commands: Commands,
+    changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
+    hosts: Query<
+        (Entity, &HostActivityEntity),
+        (
+            With<TerminalActivityMarker>,
+            With<MaterialNode<TerminalUiMaterial>>,
+        ),
+    >,
+    newly_mounted: Query<
+        (Entity, &HostActivityEntity),
+        (
+            With<TerminalActivityMarker>,
+            Added<MaterialNode<TerminalUiMaterial>>,
+        ),
+    >,
+    active_panes: Query<&ActivePane>,
+    child_of: Query<&ChildOf>,
+    configs: Option<Res<OzmuxConfigsResource>>,
+) {
+    let dim_factor = match configs.as_deref() {
+        Some(cfg) if cfg.inactive_pane.enabled => cfg.inactive_pane.dim,
+        _ => 1.0,
+    };
+
+    for (session, active) in changed_sessions.iter() {
+        for (host, host_activity) in hosts.iter() {
+            let Some((pane, host_session)) = resolve_pane_session(host_activity.0, &child_of)
+            else {
+                continue;
+            };
+            if host_session != session {
+                continue;
+            }
+            let want = if pane == active.0 { 1.0 } else { dim_factor };
+            commands.entity(host).insert(PaneDim(want));
+        }
+    }
+
+    for (host, host_activity) in newly_mounted.iter() {
+        let Some((pane, session)) = resolve_pane_session(host_activity.0, &child_of) else {
+            continue;
+        };
+        let is_active = active_panes
+            .get(session)
+            .map(|a| a.0 == pane)
+            .unwrap_or(true);
+        let want = if is_active { 1.0 } else { dim_factor };
+        commands.entity(host).insert(PaneDim(want));
     }
 }
 

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -8,7 +8,7 @@ use crate::font::TerminalUiFont;
 use crate::system_set::OzmuxSystems;
 use crate::ui::layout::build_cell_recursive;
 use crate::ui::registry::ActivityEntityRegistry;
-use crate::ui::{ActivityHostNode, SessionUiRoot, StructuralNode};
+use crate::ui::{ActivityHostNode, PaneDimOverlay, SessionUiRoot, StructuralNode};
 use bevy::prelude::*;
 use bevy::ui::UiSystems;
 use ozmux_extension_host::ExtensionControlSet;
@@ -23,6 +23,7 @@ impl Plugin for OzmuxSessionUiPlugin {
     fn build(&self, app: &mut App) {
         order_activity_pipeline(app);
         app.add_systems(Update, rebuild_session_ui.in_set(OzmuxSystems::SessionUi))
+            .add_systems(Update, sync_pane_dim.after(OzmuxSystems::Input))
             .add_systems(PostUpdate, sync_active_session.before(UiSystems::Prepare));
     }
 }
@@ -149,6 +150,35 @@ fn rebuild_session_ui(
             }
             Ok(_) => tracing::warn!(target: "ozmux_gui::ui", "root_cell is not Cell::Root"),
             Err(err) => tracing::warn!(target: "ozmux_gui::ui", ?err, "root_cell missing"),
+        }
+    }
+}
+
+/// Flips each pane's dim veil when its session's `ActivePane` changes
+/// (focus moves between panes without a layout rebuild). For every session
+/// whose `ActivePane` changed, sets each `PaneDimOverlay` belonging to that
+/// session to `Hidden` iff its pane is the new active pane, else `Visible`.
+/// Pane→session is resolved via `ChildOf`; using `MultiplexerCommands` here
+/// would conflict on its `&mut ActivePane`.
+fn sync_pane_dim(
+    changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
+    panes: Query<&ChildOf, With<PaneMarker>>,
+    mut overlays: Query<(&PaneDimOverlay, &mut Visibility)>,
+) {
+    for (session, active) in changed_sessions.iter() {
+        for (overlay, mut visibility) in overlays.iter_mut() {
+            let Ok(child_of) = panes.get(overlay.pane) else {
+                continue;
+            };
+            if child_of.parent() != session {
+                continue;
+            }
+            let want = if overlay.pane == active.0 {
+                Visibility::Hidden
+            } else {
+                Visibility::Visible
+            };
+            visibility.set_if_neq(want);
         }
     }
 }

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -3,6 +3,7 @@
 //! Session entity is non-`Node`, so a parked subtree is skipped by Bevy's
 //! UI walker — no layout, no `ComputedNode` updates, no resize-pass work.
 
+use crate::configs::OzmuxConfigsResource;
 use crate::font::TerminalUiFont;
 use crate::system_set::OzmuxSystems;
 use crate::ui::layout::build_cell_recursive;
@@ -12,8 +13,8 @@ use bevy::prelude::*;
 use bevy::ui::UiSystems;
 use ozmux_extension_host::ExtensionControlSet;
 use ozmux_multiplexer::{
-    ActiveActivity, ActivityKind, ActivityMarker, AttachedSession, Cell, LayoutCells, PaneMarker,
-    SessionMarker, SessionUiSubtree,
+    ActiveActivity, ActivePane, ActivityKind, ActivityMarker, AttachedSession, Cell, LayoutCells,
+    PaneMarker, SessionMarker, SessionUiSubtree,
 };
 
 pub struct OzmuxSessionUiPlugin;
@@ -94,6 +95,7 @@ fn rebuild_session_ui(
             Entity,
             &LayoutCells,
             &SessionUiSubtree,
+            Option<&ActivePane>,
             Has<AttachedSession>,
         ),
         (With<SessionMarker>, Changed<LayoutCells>),
@@ -104,10 +106,26 @@ fn rebuild_session_ui(
     activities: Query<(&ActivityKind, &Name), With<ActivityMarker>>,
     active_activities: Query<&ActiveActivity, With<PaneMarker>>,
     ui_font: Option<Res<TerminalUiFont>>,
+    configs: Option<Res<OzmuxConfigsResource>>,
 ) {
     let ui_font_handle = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
 
-    for (session_entity, layout, subtree, _is_attached) in sessions.iter() {
+    let veil: Option<Color> = match configs.as_deref() {
+        Some(cfg) if cfg.inactive_pane.enabled => {
+            let ip = &cfg.inactive_pane;
+            let (r, g, b) = ip.rgb();
+            Some(Color::srgba(
+                r as f32 / 255.0,
+                g as f32 / 255.0,
+                b as f32 / 255.0,
+                ip.opacity,
+            ))
+        }
+        _ => None,
+    };
+
+    for (session_entity, layout, subtree, active_pane, _is_attached) in sessions.iter() {
+        let active_pane = active_pane.map(|a| a.0).unwrap_or(Entity::PLACEHOLDER);
         descend_and_detach_hosts(&mut commands, subtree.0, &children, &activity_hosts);
         descend_and_despawn_structural(&mut commands, subtree.0, &children, &structurals);
 
@@ -125,6 +143,8 @@ fn rebuild_session_ui(
                     &children,
                     &activities,
                     &active_activities,
+                    active_pane,
+                    veil,
                 );
             }
             Ok(_) => tracing::warn!(target: "ozmux_gui::ui", "root_cell is not Cell::Root"),

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -31,9 +31,11 @@ impl Plugin for OzmuxSessionUiPlugin {
             .add_systems(Update, sync_pane_dim.after(OzmuxSystems::Input))
             .add_systems(
                 Update,
-                sync_terminal_dim
-                    .after(OzmuxSystems::Input)
-                    .after(OzmuxSystems::SetupActivity),
+                sync_terminal_dim_on_focus.after(OzmuxSystems::Input),
+            )
+            .add_systems(
+                Update,
+                sync_terminal_dim_on_mount.after(OzmuxSystems::SetupActivity),
             )
             .add_systems(PostUpdate, sync_active_session.before(UiSystems::Prepare));
     }
@@ -233,14 +235,21 @@ fn sync_pane_dim(
     }
 }
 
-/// Sets each terminal host's [`PaneDim`] from its session's `ActivePane` so
-/// the renderer dims inactive terminals (a darkening veil is invisible on a
-/// black terminal, so terminals are dimmed at the renderer instead). Reacts
-/// to focus changes (`Changed<ActivePane>`) and to terminal hosts whose
-/// material was just mounted (`Added<MaterialNode<..>>`, since hosts attach
-/// lazily after a rebuild). Pane→session is resolved via `ChildOf`;
+/// Inactive-terminal brightness multiplier from config: `inactive_pane.dim`
+/// when dimming is enabled, else `1.0` (disabled or absent config = no dim).
+fn inactive_dim_factor(configs: Option<&OzmuxConfigsResource>) -> f32 {
+    match configs {
+        Some(cfg) if cfg.inactive_pane.enabled => cfg.inactive_pane.dim,
+        _ => 1.0,
+    }
+}
+
+/// On focus change, sets each terminal host's [`PaneDim`] in the changed
+/// session: `1.0` for the active pane's terminal, the configured dim factor
+/// otherwise. A darkening veil is invisible on a black terminal, so terminals
+/// are dimmed at the renderer instead. Pane→session is resolved via `ChildOf`;
 /// `MultiplexerCommands` can't be used here (it holds `&mut ActivePane`).
-fn sync_terminal_dim(
+fn sync_terminal_dim_on_focus(
     mut commands: Commands,
     changed_sessions: Query<(Entity, &ActivePane), Changed<ActivePane>>,
     hosts: Query<
@@ -250,22 +259,10 @@ fn sync_terminal_dim(
             With<MaterialNode<TerminalUiMaterial>>,
         ),
     >,
-    newly_mounted: Query<
-        (Entity, &HostActivityEntity),
-        (
-            With<TerminalActivityMarker>,
-            Added<MaterialNode<TerminalUiMaterial>>,
-        ),
-    >,
-    active_panes: Query<&ActivePane>,
     child_of: Query<&ChildOf>,
     configs: Option<Res<OzmuxConfigsResource>>,
 ) {
-    let dim_factor = match configs.as_deref() {
-        Some(cfg) if cfg.inactive_pane.enabled => cfg.inactive_pane.dim,
-        _ => 1.0,
-    };
-
+    let dim_factor = inactive_dim_factor(configs.as_deref());
     for (session, active) in changed_sessions.iter() {
         for (host, host_activity) in hosts.iter() {
             let Some((pane, host_session)) = resolve_pane_session(host_activity.0, &child_of)
@@ -279,7 +276,27 @@ fn sync_terminal_dim(
             commands.entity(host).insert(PaneDim(want));
         }
     }
+}
 
+/// Sets the initial [`PaneDim`] on a terminal host the frame its material is
+/// mounted. Hosts attach lazily after a rebuild — possibly a frame after the
+/// focus change `sync_terminal_dim_on_focus` reacts to — so this reads the
+/// host's session `ActivePane` directly, dimming a freshly-split inactive
+/// terminal without waiting for the next focus change.
+fn sync_terminal_dim_on_mount(
+    mut commands: Commands,
+    newly_mounted: Query<
+        (Entity, &HostActivityEntity),
+        (
+            With<TerminalActivityMarker>,
+            Added<MaterialNode<TerminalUiMaterial>>,
+        ),
+    >,
+    active_panes: Query<&ActivePane>,
+    child_of: Query<&ChildOf>,
+    configs: Option<Res<OzmuxConfigsResource>>,
+) {
+    let dim_factor = inactive_dim_factor(configs.as_deref());
     for (host, host_activity) in newly_mounted.iter() {
         let Some((pane, session)) = resolve_pane_session(host_activity.0, &child_of) else {
             continue;

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -95,7 +95,10 @@ fn finish_terminal_setup(
 /// Session). Returns `None` when either link is missing — mirrors
 /// `MultiplexerCommands::pane_of_activity` + `session_of_pane` without
 /// borrowing the full mutation SystemParam.
-fn resolve_pane_session(activity: Entity, child_of: &Query<&ChildOf>) -> Option<(Entity, Entity)> {
+pub(crate) fn resolve_pane_session(
+    activity: Entity,
+    child_of: &Query<&ChildOf>,
+) -> Option<(Entity, Entity)> {
     let pane = child_of.get(activity).ok()?.parent();
     let session = child_of.get(pane).ok()?.parent();
     Some((pane, session))


### PR DESCRIPTION
## Problem

In a split layout, inactive panes were visually indistinguishable from the active one — there was no focus cue. A naive "darken the inactive pane" overlay works for the webview/extension pane (light background) but is **invisible on a terminal pane**: the terminal background is near-black, and darkening black yields black.

## Solution

Two complementary mechanisms, because one approach doesn't fit both pane types:

- **Non-terminal panes (webview / `@memo` extension):** a configurable translucent veil overlay (`PaneDimOverlay`), spawned as the last child of the pane frame and toggled on focus change (`sync_pane_dim`, reacting to `Changed<ActivePane>`). Non-pickable (`Pickable::IGNORE`) so it doesn't intercept the webview's pointer routing.
- **Terminal panes:** a per-pane brightness multiplier (`PaneDim`) baked into the terminal renderer's uniform; the WGSL shader multiplies the final fragment color by it, so the rendered **content** dims — visible on a black background, unlike a darkening overlay. `sync_terminal_dim` sets it from `ActivePane`. Terminal panes deliberately get no veil (it would double-dim).
- **Config:** new `[inactive_pane]` section — `enabled`, `opacity`, `color` (webview veil) and `dim` (terminal brightness multiplier, default `0.5`).

Affected areas:
- `crates/configs` — the `[inactive_pane]` config section + per-field merge/validation.
- `crates/bevy_terminal_renderer` — `dim` field on the `TerminalParams` uniform, the `PaneDim` component, and the fragment shader.
- `src/ui` — pane build/layout, the two focus-sync systems, and veil gating by active-activity kind.

Tests: config (parse / clamp / NaN-reject), renderer (uniform-layout lock + `dim` default), and `ui` integration (PaneDim active vs. inactive and flip-on-focus; terminal panes have no veil; extension panes keep a non-pickable veil; disabled config dims nothing). `cargo test --workspace`, `cargo clippy --workspace --all-targets`, and `cargo fmt --check` all pass.

### Breaking Changes

None.

<details><summary>Screenshots</summary>

The "before" state (inactive vs. active terminal were indistinguishable — the veil is a no-op on the black terminal background) and the Cmux reference live in the working tree (`ozmux.png`, `ozmux2.png`, `cmux.png`). Please drag in a fresh capture showing the inactive terminal dimmed after this change — GPU rendering isn't capturable from CI/headless.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)