### PR TITLE
feat: @md Markdown preview extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Logs go through `tracing-subscriber`; override the filter with `RUST_LOG`.
 | Run all vitest suites   | `pnpm -r test`                                         |
 | Typecheck every package | `pnpm check-types`                                     |
 | Lint (biome)            | `pnpm lint` / `pnpm lint:fix` / `pnpm lint:ci`         |
+| Build extension clients | `pnpm build` (required before `cargo run` for extensions with a Vite client, e.g. `md`) |
 
 Biome (`biome.json`) scans `sdk/**` and `extensions/**` — it is the JS/TS lint+format tool for this repo.
 

--- a/extensions/md/bootstrap.ts
+++ b/extensions/md/bootstrap.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url';
+import { bootstrap } from '@ozmux/sdk/server';
+import { mdCommand } from './server/command.ts';
+import { makeContentChannel } from './server/content.ts';
+
+const distIndexPath = fileURLToPath(new URL('./dist/index.html', import.meta.url));
+
+bootstrap({
+  commands: {
+    '@md': (ctx) => mdCommand(ctx, { distIndexPath, makeChannel: makeContentChannel }),
+  },
+});

--- a/extensions/md/content-event.ts
+++ b/extensions/md/content-event.ts
@@ -1,0 +1,5 @@
+/** A single preview update streamed from the server `content` channel to the client. */
+export type ContentEvent =
+  | { kind: 'content'; markdown: string }
+  | { kind: 'missing' }
+  | { kind: 'too-large'; bytes: number };

--- a/extensions/md/index.html
+++ b/extensions/md/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>md</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/extensions/md/package.json
+++ b/extensions/md/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "md",
+  "main": "bootstrap.ts",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "check-types": "tsc -p tsconfig.json && tsc -p tsconfig.client.json",
+    "test": "vitest run"
+  },
+  "packageManager": "pnpm@10.30.2",
+  "dependencies": {
+    "@ozmux/sdk": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-markdown": "catalog:",
+    "remark-gfm": "catalog:",
+    "rehype-highlight": "catalog:",
+    "highlight.js": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/extensions/md/server/args.test.ts
+++ b/extensions/md/server/args.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseMdArgs } from './args.ts';
+
+describe('parseMdArgs', () => {
+  it('parses a bare file path', () => {
+    expect(parseMdArgs(['foo.md'])).toEqual({ ok: true, rawPath: 'foo.md', split: undefined });
+  });
+
+  it('parses -s vertical with a path', () => {
+    expect(parseMdArgs(['-s', 'vertical', 'foo.md'])).toEqual({
+      ok: true,
+      rawPath: 'foo.md',
+      split: 'vertical',
+    });
+  });
+
+  it('parses --split=horizontal with a path', () => {
+    expect(parseMdArgs(['--split=horizontal', 'a.md'])).toEqual({
+      ok: true,
+      rawPath: 'a.md',
+      split: 'horizontal',
+    });
+  });
+
+  it('rejects zero positionals with code 2', () => {
+    const r = parseMdArgs([]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe(2);
+  });
+
+  it('rejects more than one positional with code 2', () => {
+    const r = parseMdArgs(['a.md', 'b.md']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe(2);
+  });
+
+  it('rejects an invalid orientation with code 2', () => {
+    const r = parseMdArgs(['-s', 'sideways', 'a.md']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe(2);
+      expect(r.message).toContain('sideways');
+    }
+  });
+
+  it('rejects an unknown flag with code 2', () => {
+    const r = parseMdArgs(['--nope', 'a.md']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe(2);
+  });
+});

--- a/extensions/md/server/args.test.ts
+++ b/extensions/md/server/args.test.ts
@@ -48,4 +48,10 @@ describe('parseMdArgs', () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe(2);
   });
+
+  it('rejects --split with no value with code 2', () => {
+    const r = parseMdArgs(['--split']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe(2);
+  });
 });

--- a/extensions/md/server/args.ts
+++ b/extensions/md/server/args.ts
@@ -1,0 +1,37 @@
+import { parseArgs } from 'node:util';
+
+/** Pane split orientation accepted by `-s` / `--split`. */
+export type Orientation = 'horizontal' | 'vertical';
+
+/** Result of parsing `@md` argv: either the validated inputs or an exit code + message. */
+export type ParsedMdArgs =
+  | { ok: true; rawPath: string; split: Orientation | undefined }
+  | { ok: false; code: number; message: string };
+
+const USAGE = 'usage: @md [-s|--split <horizontal|vertical>] <file>';
+
+/** Parses `@md` arguments (command name already stripped) into a validated result. */
+export function parseMdArgs(argv: string[]): ParsedMdArgs {
+  let values: { split?: string };
+  let positionals: string[];
+  try {
+    ({ values, positionals } = parseArgs({
+      args: argv,
+      options: { split: { type: 'string', short: 's' } },
+      allowPositionals: true,
+    }) as { values: { split?: string }; positionals: string[] });
+  } catch (err) {
+    return { ok: false, code: 2, message: `${(err as Error).message}\n${USAGE}` };
+  }
+
+  if (positionals.length !== 1) {
+    return { ok: false, code: 2, message: USAGE };
+  }
+
+  const split = values.split;
+  if (split !== undefined && split !== 'horizontal' && split !== 'vertical') {
+    return { ok: false, code: 2, message: `invalid orientation: ${split}\n${USAGE}` };
+  }
+
+  return { ok: true, rawPath: positionals[0], split };
+}

--- a/extensions/md/server/command.test.ts
+++ b/extensions/md/server/command.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import type { CommandContext, SplitArgs } from '@ozmux/sdk/server';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { mdCommand, type MdDeps } from './command.ts';
+
+const dir = await mkdtemp(path.join(tmpdir(), 'md-cmd-'));
+afterAll(async () => import('node:fs/promises').then((fs) => fs.rm(dir, { recursive: true, force: true })));
+
+function fakeCtx(argv: string[]) {
+  const errs: string[] = [];
+  const activate = vi.fn(async () => {});
+  const split = vi.fn((_args: SplitArgs) => Promise.resolve({}));
+  const addActivity = vi.fn(async () => ({ activate }));
+  const ctx = {
+    argv,
+    cwd: dir,
+    stderr: { write: (s: string) => (errs.push(s), true) },
+    pane: { split, addActivity },
+  } as unknown as CommandContext;
+  return { ctx, errs, split, addActivity, activate };
+}
+
+async function deps(): Promise<MdDeps> {
+  const distIndexPath = path.join(dir, 'dist-index.html');
+  await writeFile(distIndexPath, '<!doctype html>');
+  return {
+    distIndexPath,
+    makeChannel: () => async function* () {},
+  };
+}
+
+describe('mdCommand', () => {
+  it('returns 2 and prints usage when no file is given', async () => {
+    const { ctx, errs } = fakeCtx([]);
+    expect(await mdCommand(ctx, await deps())).toBe(2);
+    expect(errs.join('')).toContain('usage:');
+  });
+
+  it('returns 1 when the file is missing', async () => {
+    const { ctx, errs } = fakeCtx(['missing.md']);
+    expect(await mdCommand(ctx, await deps())).toBe(1);
+    expect(errs.join('')).toContain('no such file');
+  });
+
+  it('returns 1 with a build hint when dist/index.html is absent', async () => {
+    await writeFile(path.join(dir, 'present.md'), '# x');
+    const { ctx, errs } = fakeCtx(['present.md']);
+    const badDeps: MdDeps = { distIndexPath: path.join(dir, 'nope.html'), makeChannel: () => async function* () {} };
+    expect(await mdCommand(ctx, badDeps)).toBe(1);
+    expect(errs.join('')).toContain('client not built');
+  });
+
+  it('splits the pane when -s is given', async () => {
+    await writeFile(path.join(dir, 's.md'), '# x');
+    const { ctx, split, addActivity } = fakeCtx(['-s', 'vertical', 's.md']);
+    expect(await mdCommand(ctx, await deps())).toBe(0);
+    expect(addActivity).not.toHaveBeenCalled();
+    expect(split).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/style/noNonNullAssertion: guarded by the toHaveBeenCalledTimes(1) assertion above
+    const arg = split.mock.calls[0]![0]!;
+    expect(arg.orientation).toBe('vertical');
+    expect(arg.side).toBe('after');
+    expect(arg.activity.kind).toBe('extension');
+    expect(arg.activity.name).toBe('s.md');
+  });
+
+  it('adds + activates an in-pane activity when no flag is given', async () => {
+    await writeFile(path.join(dir, 'inpane.md'), '# x');
+    const { ctx, split, addActivity, activate } = fakeCtx(['inpane.md']);
+    expect(await mdCommand(ctx, await deps())).toBe(0);
+    expect(split).not.toHaveBeenCalled();
+    expect(addActivity).toHaveBeenCalledTimes(1);
+    expect(activate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/md/server/command.test.ts
+++ b/extensions/md/server/command.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import type { CommandContext, SplitArgs } from '@ozmux/sdk/server';
+import type { ActivitySpecInput, CommandContext, SplitArgs } from '@ozmux/sdk/server';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { type MdDeps, mdCommand } from './command.ts';
 
@@ -14,7 +14,7 @@ function fakeCtx(argv: string[]) {
   const errs: string[] = [];
   const activate = vi.fn(async () => {});
   const split = vi.fn((_args: SplitArgs) => Promise.resolve({}));
-  const addActivity = vi.fn(async () => ({ activate }));
+  const addActivity = vi.fn((_spec: ActivitySpecInput) => Promise.resolve({ activate }));
   const ctx = {
     argv,
     cwd: dir,
@@ -74,14 +74,23 @@ describe('mdCommand', () => {
     expect(arg.side).toBe('after');
     expect(arg.activity.kind).toBe('extension');
     expect(arg.activity.name).toBe('s.md');
+    if (arg.activity.kind === 'extension') {
+      expect(typeof arg.activity.channels?.content).toBe('function');
+    }
   });
 
-  it('adds + activates an in-pane activity when no flag is given', async () => {
+  it('adds + activates an in-pane activity (with its content channel) when no flag is given', async () => {
     await writeFile(path.join(dir, 'inpane.md'), '# x');
     const { ctx, split, addActivity, activate } = fakeCtx(['inpane.md']);
     expect(await mdCommand(ctx, await deps())).toBe(0);
     expect(split).not.toHaveBeenCalled();
     expect(addActivity).toHaveBeenCalledTimes(1);
     expect(activate).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/style/noNonNullAssertion: guarded by the toHaveBeenCalledTimes(1) assertion above
+    const spec = addActivity.mock.calls[0]![0]!;
+    expect(spec.kind).toBe('extension');
+    if (spec.kind === 'extension') {
+      expect(typeof spec.channels?.content).toBe('function');
+    }
   });
 });

--- a/extensions/md/server/command.test.ts
+++ b/extensions/md/server/command.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import type { CommandContext, SplitArgs } from '@ozmux/sdk/server';
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mdCommand, type MdDeps } from './command.ts';
+import { type MdDeps, mdCommand } from './command.ts';
 
 const dir = await mkdtemp(path.join(tmpdir(), 'md-cmd-'));
-afterAll(async () => import('node:fs/promises').then((fs) => fs.rm(dir, { recursive: true, force: true })));
+afterAll(async () =>
+  import('node:fs/promises').then((fs) => fs.rm(dir, { recursive: true, force: true })),
+);
 
 function fakeCtx(argv: string[]) {
   const errs: string[] = [];
@@ -16,7 +18,12 @@ function fakeCtx(argv: string[]) {
   const ctx = {
     argv,
     cwd: dir,
-    stderr: { write: (s: string) => (errs.push(s), true) },
+    stderr: {
+      write: (s: string) => {
+        errs.push(s);
+        return true;
+      },
+    },
     pane: { split, addActivity },
   } as unknown as CommandContext;
   return { ctx, errs, split, addActivity, activate };
@@ -47,7 +54,10 @@ describe('mdCommand', () => {
   it('returns 1 with a build hint when dist/index.html is absent', async () => {
     await writeFile(path.join(dir, 'present.md'), '# x');
     const { ctx, errs } = fakeCtx(['present.md']);
-    const badDeps: MdDeps = { distIndexPath: path.join(dir, 'nope.html'), makeChannel: () => async function* () {} };
+    const badDeps: MdDeps = {
+      distIndexPath: path.join(dir, 'nope.html'),
+      makeChannel: () => async function* () {},
+    };
     expect(await mdCommand(ctx, badDeps)).toBe(1);
     expect(errs.join('')).toContain('client not built');
   });

--- a/extensions/md/server/command.ts
+++ b/extensions/md/server/command.ts
@@ -1,0 +1,46 @@
+import * as path from 'node:path';
+import type { ActivitySpecInput, ChannelGenerator, CommandContext } from '@ozmux/sdk/server';
+import { parseMdArgs } from './args.ts';
+import { resolveTarget, statOrNull } from './target.ts';
+
+/** Host-supplied bits the command needs: the built client entry, and the channel factory. */
+export interface MdDeps {
+  distIndexPath: string;
+  // biome-ignore lint/suspicious/noExplicitAny: channel map values are typed as ChannelGenerator<any,any>; using any here avoids a variance error when callers supply a narrower generator
+  makeChannel: (filePath: string) => ChannelGenerator<any, any>;
+}
+
+/** Runs the `@md` command: parse → gate → build-guard → open the preview activity. */
+export async function mdCommand(ctx: CommandContext, deps: MdDeps): Promise<number> {
+  const parsed = parseMdArgs(ctx.argv);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return parsed.code;
+  }
+
+  const target = await resolveTarget(ctx.cwd, parsed.rawPath);
+  if (!target.ok) {
+    ctx.stderr.write(`${target.message}\n`);
+    return target.code;
+  }
+
+  if (!(await statOrNull(deps.distIndexPath))?.isFile()) {
+    ctx.stderr.write('@md: client not built — run `pnpm build` (missing dist/index.html)\n');
+    return 1;
+  }
+
+  const activity: ActivitySpecInput = {
+    kind: 'extension',
+    name: path.basename(target.filePath),
+    html: deps.distIndexPath,
+    channels: { content: deps.makeChannel(target.filePath) },
+  };
+
+  if (parsed.split) {
+    await ctx.pane.split({ orientation: parsed.split, side: 'after', activity });
+  } else {
+    const created = await ctx.pane.addActivity(activity);
+    await created.activate();
+  }
+  return 0;
+}

--- a/extensions/md/server/command.ts
+++ b/extensions/md/server/command.ts
@@ -1,27 +1,22 @@
 import * as path from 'node:path';
 import type { ActivitySpecInput, ChannelGenerator, CommandContext } from '@ozmux/sdk/server';
+import type { ContentEvent } from '../content-event.ts';
 import { parseMdArgs } from './args.ts';
 import { resolveTarget, statOrNull } from './target.ts';
 
 /** Host-supplied bits the command needs: the built client entry, and the channel factory. */
 export interface MdDeps {
   distIndexPath: string;
-  makeChannel: (filePath: string) => ChannelGenerator<Record<string, never>, unknown>;
+  makeChannel: (filePath: string) => ChannelGenerator<Record<string, never>, ContentEvent>;
 }
 
 /** Runs the `@md` command: parse → gate → build-guard → open the preview activity. */
 export async function mdCommand(ctx: CommandContext, deps: MdDeps): Promise<number> {
   const parsed = parseMdArgs(ctx.argv);
-  if (!parsed.ok) {
-    ctx.stderr.write(`${parsed.message}\n`);
-    return parsed.code;
-  }
+  if (!parsed.ok) return fail(ctx, parsed);
 
   const target = await resolveTarget(ctx.cwd, parsed.rawPath);
-  if (!target.ok) {
-    ctx.stderr.write(`${target.message}\n`);
-    return target.code;
-  }
+  if (!target.ok) return fail(ctx, target);
 
   if (!(await statOrNull(deps.distIndexPath))?.isFile()) {
     ctx.stderr.write('@md: client not built — run `pnpm build` (missing dist/index.html)\n');
@@ -42,4 +37,10 @@ export async function mdCommand(ctx: CommandContext, deps: MdDeps): Promise<numb
     await created.activate();
   }
   return 0;
+}
+
+/** Writes a gate failure's message to stderr and returns its exit code. */
+function fail(ctx: CommandContext, result: { message: string; code: number }): number {
+  ctx.stderr.write(`${result.message}\n`);
+  return result.code;
 }

--- a/extensions/md/server/command.ts
+++ b/extensions/md/server/command.ts
@@ -6,8 +6,7 @@ import { resolveTarget, statOrNull } from './target.ts';
 /** Host-supplied bits the command needs: the built client entry, and the channel factory. */
 export interface MdDeps {
   distIndexPath: string;
-  // biome-ignore lint/suspicious/noExplicitAny: channel map values are typed as ChannelGenerator<any,any>; using any here avoids a variance error when callers supply a narrower generator
-  makeChannel: (filePath: string) => ChannelGenerator<any, any>;
+  makeChannel: (filePath: string) => ChannelGenerator<Record<string, never>, unknown>;
 }
 
 /** Runs the `@md` command: parse → gate → build-guard → open the preview activity. */

--- a/extensions/md/server/content.test.ts
+++ b/extensions/md/server/content.test.ts
@@ -136,3 +136,36 @@ describe('makeContentChannel', () => {
     expect(events[1]).toEqual({ kind: 'missing' });
   });
 });
+
+/** Polls `pred` until true or the timeout elapses (for real-fs.watch timing). */
+async function waitUntil(pred: () => boolean, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitUntil timed out');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('watchFile (real fs.watch via the default source)', () => {
+  it('re-yields after a real edit and terminates the consumer on abort', async () => {
+    const f = path.join(dir, 'real-watch.md');
+    await writeFile(f, 'first');
+    const ac = new AbortController();
+    const events: ContentEvent[] = [];
+
+    const channel = makeContentChannel(f); // default source = real watchFile
+    const consumer = (async () => {
+      for await (const ev of channel({}, { signal: ac.signal })) events.push(ev);
+    })();
+
+    await waitUntil(() => events.length >= 1, 3000);
+    expect(events[0]).toEqual({ kind: 'content', markdown: 'first' });
+
+    await writeFile(f, 'second');
+    await waitUntil(() => events.length >= 2, 3000);
+    expect(events[1]).toEqual({ kind: 'content', markdown: 'second' });
+
+    ac.abort();
+    await consumer; // resolves (no hang) because watchFile observes the abort and closes the watcher
+  });
+});

--- a/extensions/md/server/content.test.ts
+++ b/extensions/md/server/content.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import type { ContentEvent } from '../content-event.ts';
+import { MAX_BYTES, makeContentChannel, readContent, signatureOf } from './content.ts';
+
+const dir = await mkdtemp(path.join(tmpdir(), 'md-content-'));
+afterAll(async () => rm(dir, { recursive: true, force: true }));
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 15));
+
+describe('readContent', () => {
+  it('returns the UTF-8 text for a normal file', async () => {
+    const f = path.join(dir, 'a.md');
+    await writeFile(f, '# hi');
+    expect(await readContent(f)).toEqual({ kind: 'content', markdown: '# hi' });
+  });
+
+  it('returns missing for a non-existent file', async () => {
+    expect(await readContent(path.join(dir, 'nope.md'))).toEqual({ kind: 'missing' });
+  });
+
+  it('returns too-large above the cap', async () => {
+    const f = path.join(dir, 'big.md');
+    await writeFile(f, 'x'.repeat(MAX_BYTES + 1));
+    const ev = await readContent(f);
+    expect(ev.kind).toBe('too-large');
+    if (ev.kind === 'too-large') expect(ev.bytes).toBe(MAX_BYTES + 1);
+  });
+});
+
+describe('signatureOf', () => {
+  it('changes when the file content changes', async () => {
+    const f = path.join(dir, 'sig.md');
+    await writeFile(f, 'one');
+    const a = await signatureOf(f);
+    await writeFile(f, 'one and two');
+    const b = await signatureOf(f);
+    expect(a).not.toBe(b);
+  });
+
+  it('returns empty string for a missing file', async () => {
+    expect(await signatureOf(path.join(dir, 'gone.md'))).toBe('');
+  });
+});
+
+/** A manually-driven {@link ChangeSource}: `push()` emits one tick. */
+function createPushSource() {
+  const buf: undefined[] = [];
+  let wake: (() => void) | null = null;
+  const source = async function* (
+    _dir: string,
+    _base: string,
+    { signal }: { signal: AbortSignal },
+  ): AsyncGenerator<void, void, undefined> {
+    while (!signal.aborted) {
+      if (buf.length === 0) {
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      if (signal.aborted) return;
+      buf.shift();
+      yield;
+    }
+  };
+  const push = () => {
+    buf.push(undefined);
+    const w = wake;
+    wake = null;
+    w?.();
+  };
+  return { source, push };
+}
+
+describe('makeContentChannel', () => {
+  it('yields initial content, re-yields on real change, dedupes no-op ticks, and stops on abort', async () => {
+    const f = path.join(dir, 'live.md');
+    await writeFile(f, 'one');
+    const ac = new AbortController();
+    const ps = createPushSource();
+    const events: ContentEvent[] = [];
+
+    const channel = makeContentChannel(f, ps.source);
+    const consumer = (async () => {
+      for await (const ev of channel({}, { signal: ac.signal })) events.push(ev);
+    })();
+
+    await flush();
+
+    await writeFile(f, 'two');
+    ps.push();
+    await flush();
+
+    ps.push();
+    await flush();
+
+    await writeFile(f, 'three');
+    ps.push();
+    await flush();
+
+    ac.abort();
+    ps.push();
+    await consumer;
+
+    expect(events).toEqual([
+      { kind: 'content', markdown: 'one' },
+      { kind: 'content', markdown: 'two' },
+      { kind: 'content', markdown: 'three' },
+    ]);
+  });
+
+  it('yields a missing event when the file is deleted', async () => {
+    const f = path.join(dir, 'del.md');
+    await writeFile(f, 'here');
+    const ac = new AbortController();
+    const ps = createPushSource();
+    const events: ContentEvent[] = [];
+
+    const channel = makeContentChannel(f, ps.source);
+    const consumer = (async () => {
+      for await (const ev of channel({}, { signal: ac.signal })) events.push(ev);
+    })();
+
+    await flush();
+    await rm(f);
+    ps.push();
+    await flush();
+
+    ac.abort();
+    ps.push();
+    await consumer;
+
+    expect(events[0]).toEqual({ kind: 'content', markdown: 'here' });
+    expect(events[1]).toEqual({ kind: 'missing' });
+  });
+});

--- a/extensions/md/server/content.test.ts
+++ b/extensions/md/server/content.test.ts
@@ -1,30 +1,36 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, stat as statFs, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 import type { ContentEvent } from '../content-event.ts';
-import { MAX_BYTES, makeContentChannel, readContent, signatureOf } from './content.ts';
+import {
+  type ChangeSource,
+  MAX_BYTES,
+  makeContentChannel,
+  readContent,
+  signatureOf,
+} from './content.ts';
 
 const dir = await mkdtemp(path.join(tmpdir(), 'md-content-'));
 afterAll(async () => rm(dir, { recursive: true, force: true }));
 
-const flush = () => new Promise<void>((r) => setTimeout(r, 15));
+const flush = () => new Promise<void>((r) => setTimeout(r, 30));
 
 describe('readContent', () => {
   it('returns the UTF-8 text for a normal file', async () => {
     const f = path.join(dir, 'a.md');
     await writeFile(f, '# hi');
-    expect(await readContent(f)).toEqual({ kind: 'content', markdown: '# hi' });
+    expect(await readContent(f, await statFs(f))).toEqual({ kind: 'content', markdown: '# hi' });
   });
 
-  it('returns missing for a non-existent file', async () => {
-    expect(await readContent(path.join(dir, 'nope.md'))).toEqual({ kind: 'missing' });
+  it('returns missing for a null stat', async () => {
+    expect(await readContent(path.join(dir, 'nope.md'), null)).toEqual({ kind: 'missing' });
   });
 
   it('returns too-large above the cap', async () => {
     const f = path.join(dir, 'big.md');
     await writeFile(f, 'x'.repeat(MAX_BYTES + 1));
-    const ev = await readContent(f);
+    const ev = await readContent(f, await statFs(f));
     expect(ev.kind).toBe('too-large');
     if (ev.kind === 'too-large') expect(ev.bytes).toBe(MAX_BYTES + 1);
   });
@@ -34,44 +40,34 @@ describe('signatureOf', () => {
   it('changes when the file content changes', async () => {
     const f = path.join(dir, 'sig.md');
     await writeFile(f, 'one');
-    const a = await signatureOf(f);
+    const a = signatureOf(await statFs(f));
     await writeFile(f, 'one and two');
-    const b = await signatureOf(f);
+    const b = signatureOf(await statFs(f));
     expect(a).not.toBe(b);
   });
 
-  it('returns empty string for a missing file', async () => {
-    expect(await signatureOf(path.join(dir, 'gone.md'))).toBe('');
+  it('returns empty string for a null stat', () => {
+    expect(signatureOf(null)).toBe('');
   });
 });
 
-/** A manually-driven {@link ChangeSource}: `push()` emits one tick. */
+/** A manually-driven {@link ChangeSource}: `push()` fires one debounced change; `fail()` an error. */
 function createPushSource() {
-  const buf: undefined[] = [];
-  let wake: (() => void) | null = null;
-  const source = async function* (
-    _dir: string,
-    _base: string,
-    { signal }: { signal: AbortSignal },
-  ): AsyncGenerator<void, void, undefined> {
-    while (!signal.aborted) {
-      if (buf.length === 0) {
-        await new Promise<void>((resolve) => {
-          wake = resolve;
-        });
-      }
-      if (signal.aborted) return;
-      buf.shift();
-      yield;
-    }
+  let onChange: (() => void) | null = null;
+  let onError: ((err: unknown) => void) | null = null;
+  const source: ChangeSource = (_dir, _base, opts) => {
+    onChange = opts.onChange;
+    onError = opts.onError;
+    return () => {
+      onChange = null;
+      onError = null;
+    };
   };
-  const push = () => {
-    buf.push(undefined);
-    const w = wake;
-    wake = null;
-    w?.();
+  return {
+    source,
+    push: () => onChange?.(),
+    fail: (err: unknown) => onError?.(err),
   };
-  return { source, push };
 }
 
 describe('makeContentChannel', () => {
@@ -93,7 +89,7 @@ describe('makeContentChannel', () => {
     ps.push();
     await flush();
 
-    ps.push();
+    ps.push(); // no file change → deduped, no event
     await flush();
 
     await writeFile(f, 'three');
@@ -101,7 +97,6 @@ describe('makeContentChannel', () => {
     await flush();
 
     ac.abort();
-    ps.push();
     await consumer;
 
     expect(events).toEqual([
@@ -129,11 +124,29 @@ describe('makeContentChannel', () => {
     await flush();
 
     ac.abort();
-    ps.push();
     await consumer;
 
     expect(events[0]).toEqual({ kind: 'content', markdown: 'here' });
     expect(events[1]).toEqual({ kind: 'missing' });
+  });
+
+  it('throws (surfaces) when the watcher reports an error', async () => {
+    const f = path.join(dir, 'err.md');
+    await writeFile(f, 'ok');
+    const ac = new AbortController();
+    const ps = createPushSource();
+    const events: ContentEvent[] = [];
+
+    const channel = makeContentChannel(f, ps.source);
+    const consumer = (async () => {
+      for await (const ev of channel({}, { signal: ac.signal })) events.push(ev);
+    })();
+
+    await flush();
+    ps.fail(new Error('watch exploded'));
+
+    await expect(consumer).rejects.toThrow('watch exploded');
+    expect(events[0]).toEqual({ kind: 'content', markdown: 'ok' });
   });
 });
 
@@ -166,6 +179,6 @@ describe('watchFile (real fs.watch via the default source)', () => {
     expect(events[1]).toEqual({ kind: 'content', markdown: 'second' });
 
     ac.abort();
-    await consumer; // resolves (no hang) because watchFile observes the abort and closes the watcher
+    await consumer; // resolves (no hang) because abort wakes the loop and closes the watcher
   });
 });

--- a/extensions/md/server/content.ts
+++ b/extensions/md/server/content.ts
@@ -1,0 +1,116 @@
+import { watch } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import * as path from 'node:path';
+import type { ChannelGenerator } from '@ozmux/sdk/server';
+import type { ContentEvent } from '../content-event.ts';
+
+/** Maximum file size streamed to the preview; larger files report `too-large`. */
+export const MAX_BYTES = 2 * 1024 * 1024;
+
+/** Reads the file as UTF-8, or reports `missing` / `too-large` without throwing. */
+export async function readContent(filePath: string): Promise<ContentEvent> {
+  let s;
+  try {
+    s = await stat(filePath);
+  } catch {
+    return { kind: 'missing' };
+  }
+  if (s.size > MAX_BYTES) return { kind: 'too-large', bytes: s.size };
+  try {
+    return { kind: 'content', markdown: await readFile(filePath, 'utf8') };
+  } catch {
+    return { kind: 'missing' };
+  }
+}
+
+/** A `${mtimeMs}:${size}` fingerprint, or `''` if the file is gone. Used to skip no-op re-renders. */
+export async function signatureOf(filePath: string): Promise<string> {
+  try {
+    const s = await stat(filePath);
+    return `${s.mtimeMs}:${s.size}`;
+  } catch {
+    return '';
+  }
+}
+
+/** Emits a tick whenever `basename` in `dir` changes; debounced and abort-aware. */
+export type ChangeSource = (
+  dir: string,
+  basename: string,
+  opts: { signal: AbortSignal; debounceMs: number },
+) => AsyncGenerator<void, void, undefined>;
+
+/** Default {@link ChangeSource}: watches the parent dir so editor temp+rename saves are caught. */
+export async function* watchFile(
+  dir: string,
+  basename: string,
+  opts: { signal: AbortSignal; debounceMs: number },
+): AsyncGenerator<void, void, undefined> {
+  const { signal, debounceMs } = opts;
+  if (signal.aborted) return;
+
+  let pending = false;
+  let wake: (() => void) | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const fire = () => {
+    pending = true;
+    const w = wake;
+    wake = null;
+    w?.();
+  };
+
+  const watcher = watch(dir, (_event, filename) => {
+    if (filename !== basename) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(fire, debounceMs);
+  });
+
+  const onAbort = () => {
+    const w = wake;
+    wake = null;
+    w?.();
+  };
+  signal.addEventListener('abort', onAbort, { once: true });
+
+  try {
+    while (!signal.aborted) {
+      if (!pending) {
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      if (signal.aborted) return;
+      pending = false;
+      yield;
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    watcher.close();
+    signal.removeEventListener('abort', onAbort);
+  }
+}
+
+/**
+ * Builds the `content` channel for one preview: yields the file's content on
+ * subscribe, then re-yields on every real change. `source` is injectable for tests.
+ */
+export function makeContentChannel(
+  filePath: string,
+  source: ChangeSource = watchFile,
+): ChannelGenerator {
+  return async function* (_params, { signal }) {
+    yield await readContent(filePath);
+    let lastSig = await signatureOf(filePath);
+    for await (const _tick of source(path.dirname(filePath), path.basename(filePath), {
+      signal,
+      debounceMs: 50,
+    })) {
+      if (signal.aborted) return;
+      const sig = await signatureOf(filePath);
+      if (sig === lastSig) continue;
+      lastSig = sig;
+      yield await readContent(filePath);
+    }
+  };
+}

--- a/extensions/md/server/content.ts
+++ b/extensions/md/server/content.ts
@@ -1,5 +1,6 @@
+import type { Stats } from 'node:fs';
 import { watch } from 'node:fs';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import type { ChannelGenerator } from '@ozmux/sdk/server';
 import type { ContentEvent } from '../content-event.ts';
@@ -8,11 +9,15 @@ import { statOrNull } from './target.ts';
 /** Maximum file size streamed to the preview; larger files report `too-large`. */
 export const MAX_BYTES = 2 * 1024 * 1024;
 
-/** Reads the file as UTF-8, or reports `missing` / `too-large` without throwing. */
-export async function readContent(filePath: string): Promise<ContentEvent> {
-  const s = await statOrNull(filePath);
-  if (!s) return { kind: 'missing' };
-  if (s.size > MAX_BYTES) return { kind: 'too-large', bytes: s.size };
+/** A `${mtimeMs}:${size}` change fingerprint, or `''` when the file is absent. */
+export function signatureOf(stat: Stats | null): string {
+  return stat ? `${stat.mtimeMs}:${stat.size}` : '';
+}
+
+/** Reads the file as UTF-8 using an already-obtained `stat`, or reports missing/too-large. */
+export async function readContent(filePath: string, stat: Stats | null): Promise<ContentEvent> {
+  if (!stat) return { kind: 'missing' };
+  if (stat.size > MAX_BYTES) return { kind: 'too-large', bytes: stat.size };
   try {
     return { kind: 'content', markdown: await readFile(filePath, 'utf8') };
   } catch {
@@ -20,94 +25,109 @@ export async function readContent(filePath: string): Promise<ContentEvent> {
   }
 }
 
-/** A `${mtimeMs}:${size}` fingerprint, or `''` if the file is gone. Used to skip no-op re-renders. */
-export async function signatureOf(filePath: string): Promise<string> {
-  try {
-    const s = await stat(filePath);
-    return `${s.mtimeMs}:${s.size}`;
-  } catch {
-    return '';
-  }
-}
-
-/** Emits a tick whenever `basename` in `dir` changes; debounced and abort-aware. */
-export type ChangeSource = (
-  dir: string,
-  basename: string,
-  opts: { signal: AbortSignal; debounceMs: number },
-) => AsyncGenerator<void, void, undefined>;
-
-/** Default {@link ChangeSource}: watches the parent dir so editor temp+rename saves are caught. */
-export async function* watchFile(
-  dir: string,
-  basename: string,
-  opts: { signal: AbortSignal; debounceMs: number },
-): AsyncGenerator<void, void, undefined> {
-  const { signal, debounceMs } = opts;
-  if (signal.aborted) return;
-
-  let pending = false;
-  let wake: (() => void) | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
-
-  const fire = () => {
-    pending = true;
-    const w = wake;
-    wake = null;
-    w?.();
-  };
-
-  const watcher = watch(dir, (_event, filename) => {
-    if (filename !== basename) return;
-    if (timer) clearTimeout(timer);
-    timer = setTimeout(fire, debounceMs);
-  });
-
-  const onAbort = () => {
-    const w = wake;
-    wake = null;
-    w?.();
-  };
-  signal.addEventListener('abort', onAbort, { once: true });
-
-  try {
-    while (!signal.aborted) {
-      if (!pending) {
-        await new Promise<void>((resolve) => {
-          wake = resolve;
-        });
-      }
-      if (signal.aborted) return;
-      pending = false;
-      yield;
-    }
-  } finally {
-    if (timer) clearTimeout(timer);
-    watcher.close();
-    signal.removeEventListener('abort', onAbort);
-  }
+/** Callbacks a {@link ChangeSource} drives over its lifetime. */
+export interface WatchCallbacks {
+  /** Invoked (debounced) when the watched file may have changed. */
+  onChange: () => void;
+  /** Invoked when the underlying watcher fails irrecoverably. */
+  onError: (err: unknown) => void;
 }
 
 /**
- * Builds the `content` channel for one preview: yields the file's content on
- * subscribe, then re-yields on every real change. `source` is injectable for tests.
+ * Watches `basename` within `dir` and reports debounced changes, returning a
+ * disposer that stops watching. Injectable so the channel can be tested without
+ * real filesystem events.
+ */
+export type ChangeSource = (
+  dir: string,
+  basename: string,
+  opts: { debounceMs: number } & WatchCallbacks,
+) => () => void;
+
+/** Default {@link ChangeSource}: parent-dir `fs.watch`, debounced, surviving editor temp+rename saves. */
+export const watchFile: ChangeSource = (dir, basename, { debounceMs, onChange, onError }) => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const watcher = watch(dir, (_event, filename) => {
+      // NOTE: `filename` is null on some platforms/events; treat null as "maybe
+      // ours" (the re-stat + signature dedupe decides) rather than dropping it.
+      if (filename !== null && filename !== basename) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(onChange, debounceMs);
+    });
+    // NOTE: an unhandled FSWatcher 'error' event crashes the process; route it to
+    // onError so the channel terminates cleanly (e.g. when the dir is removed).
+    watcher.on('error', onError);
+    return () => {
+      if (timer) clearTimeout(timer);
+      watcher.close();
+    };
+  } catch (err) {
+    onError(err);
+    return () => {};
+  }
+};
+
+/**
+ * Builds the `content` channel for one preview: arms the watcher first, then
+ * yields the file's content and re-yields on every real change (deduped via a
+ * single stat per tick). `source` is injectable for tests.
  */
 export function makeContentChannel(
   filePath: string,
   source: ChangeSource = watchFile,
 ): ChannelGenerator<Record<string, never>, ContentEvent> {
   return async function* (_params, { signal }) {
-    yield await readContent(filePath);
-    let lastSig = await signatureOf(filePath);
-    for await (const _tick of source(path.dirname(filePath), path.basename(filePath), {
-      signal,
+    let notify: (() => void) | null = null;
+    let pending = false;
+    let failure: unknown = null;
+    const wake = () => {
+      const n = notify;
+      notify = null;
+      n?.();
+    };
+    const onAbort = () => wake();
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    // Arm the watcher BEFORE the initial read so a write during startup is observed.
+    const dispose = source(path.dirname(filePath), path.basename(filePath), {
       debounceMs: 50,
-    })) {
-      if (signal.aborted) return;
-      const sig = await signatureOf(filePath);
-      if (sig === lastSig) continue;
-      lastSig = sig;
-      yield await readContent(filePath);
+      onChange: () => {
+        pending = true;
+        wake();
+      },
+      onError: (err) => {
+        failure = err;
+        wake();
+      },
+    });
+
+    try {
+      let stat = await statOrNull(filePath);
+      let lastSig = signatureOf(stat);
+      yield await readContent(filePath, stat);
+
+      while (!signal.aborted) {
+        if (!pending && failure === null) {
+          await new Promise<void>((resolve) => {
+            notify = resolve;
+          });
+        }
+        if (signal.aborted) return;
+        if (failure !== null) {
+          throw failure instanceof Error ? failure : new Error(String(failure));
+        }
+        pending = false;
+        stat = await statOrNull(filePath);
+        const sig = signatureOf(stat);
+        if (sig === lastSig) continue;
+        lastSig = sig;
+        if (signal.aborted) return;
+        yield await readContent(filePath, stat);
+      }
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+      dispose();
     }
   };
 }

--- a/extensions/md/server/content.ts
+++ b/extensions/md/server/content.ts
@@ -3,18 +3,15 @@ import { readFile, stat } from 'node:fs/promises';
 import * as path from 'node:path';
 import type { ChannelGenerator } from '@ozmux/sdk/server';
 import type { ContentEvent } from '../content-event.ts';
+import { statOrNull } from './target.ts';
 
 /** Maximum file size streamed to the preview; larger files report `too-large`. */
 export const MAX_BYTES = 2 * 1024 * 1024;
 
 /** Reads the file as UTF-8, or reports `missing` / `too-large` without throwing. */
 export async function readContent(filePath: string): Promise<ContentEvent> {
-  let s;
-  try {
-    s = await stat(filePath);
-  } catch {
-    return { kind: 'missing' };
-  }
+  const s = await statOrNull(filePath);
+  if (!s) return { kind: 'missing' };
   if (s.size > MAX_BYTES) return { kind: 'too-large', bytes: s.size };
   try {
     return { kind: 'content', markdown: await readFile(filePath, 'utf8') };

--- a/extensions/md/server/content.ts
+++ b/extensions/md/server/content.ts
@@ -98,7 +98,7 @@ export async function* watchFile(
 export function makeContentChannel(
   filePath: string,
   source: ChangeSource = watchFile,
-): ChannelGenerator {
+): ChannelGenerator<Record<string, never>, ContentEvent> {
   return async function* (_params, { signal }) {
     yield await readContent(filePath);
     let lastSig = await signatureOf(filePath);

--- a/extensions/md/server/target.test.ts
+++ b/extensions/md/server/target.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { resolveTarget, statOrNull } from './target.ts';
+
+const dir = await mkdtemp(path.join(tmpdir(), 'md-target-'));
+
+afterAll(async () => {
+  await import('node:fs/promises').then((fs) => fs.rm(dir, { recursive: true, force: true }));
+});
+
+describe('statOrNull', () => {
+  it('returns null for a missing path', async () => {
+    expect(await statOrNull(path.join(dir, 'nope'))).toBeNull();
+  });
+});
+
+describe('resolveTarget', () => {
+  it('resolves a relative path against cwd and accepts a regular file', async () => {
+    const file = path.join(dir, 'a.md');
+    await writeFile(file, '# hi');
+    const r = await resolveTarget(dir, 'a.md');
+    expect(r).toEqual({ ok: true, filePath: file });
+  });
+
+  it('rejects a missing file with code 1', async () => {
+    const r = await resolveTarget(dir, 'missing.md');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe(1);
+      expect(r.message).toContain('no such file');
+    }
+  });
+
+  it('rejects a directory with code 1', async () => {
+    const r = await resolveTarget(dir, '.');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe(1);
+      expect(r.message).toContain('not a regular file');
+    }
+  });
+});

--- a/extensions/md/server/target.ts
+++ b/extensions/md/server/target.ts
@@ -1,0 +1,26 @@
+import type { Stats } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import * as path from 'node:path';
+
+/** Returns the file's `Stats`, or `null` if it cannot be stat'd (missing, no access). */
+export async function statOrNull(filePath: string): Promise<Stats | null> {
+  try {
+    return await stat(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/** Resolved target file, or an exit code + message when the gate rejects it. */
+export type ResolveResult =
+  | { ok: true; filePath: string }
+  | { ok: false; code: number; message: string };
+
+/** Resolves `rawPath` against `cwd` and requires it to be an existing regular file. */
+export async function resolveTarget(cwd: string, rawPath: string): Promise<ResolveResult> {
+  const filePath = path.resolve(cwd, rawPath);
+  const s = await statOrNull(filePath);
+  if (!s) return { ok: false, code: 1, message: `@md: no such file: ${rawPath}` };
+  if (!s.isFile()) return { ok: false, code: 1, message: `@md: not a regular file: ${rawPath}` };
+  return { ok: true, filePath };
+}

--- a/extensions/md/src/App.tsx
+++ b/extensions/md/src/App.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ContentEvent } from '../content-event.ts';
+import { Preview } from './Preview.tsx';
+
+/** Subscribes to the `content` channel and renders the current preview state. */
+export function App() {
+  const client = useMemo(() => window.ozmux.createClient(), []);
+  const [event, setEvent] = useState<ContentEvent | undefined>(undefined);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    void (async () => {
+      try {
+        for await (const ev of client.subscribe<Record<string, never>, ContentEvent>(
+          'content',
+          {},
+          { signal: ac.signal },
+        )) {
+          setEvent(ev);
+        }
+      } catch {
+        // NOTE: a thrown abort is the normal unsubscribe path; nothing to surface.
+      }
+    })();
+    return () => ac.abort();
+  }, [client]);
+
+  if (event === undefined) return <div className="md-status">Loading…</div>;
+  if (event.kind === 'missing') return <div className="md-status">file not found</div>;
+  if (event.kind === 'too-large') {
+    return <div className="md-status">file too large to preview ({event.bytes} bytes)</div>;
+  }
+  return <Preview markdown={event.markdown} />;
+}

--- a/extensions/md/src/App.tsx
+++ b/extensions/md/src/App.tsx
@@ -6,6 +6,7 @@ import { Preview } from './Preview.tsx';
 export function App() {
   const client = useMemo(() => window.ozmux.createClient(), []);
   const [event, setEvent] = useState<ContentEvent | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const ac = new AbortController();
@@ -18,13 +19,16 @@ export function App() {
         )) {
           setEvent(ev);
         }
-      } catch {
-        // NOTE: a thrown abort is the normal unsubscribe path; nothing to surface.
+      } catch (e) {
+        // NOTE: aborting resolves the iterator cleanly (no throw), so reaching here
+        // means a real channel error — surface it rather than freezing on stale content.
+        if (!ac.signal.aborted) setError(e instanceof Error ? e.message : String(e));
       }
     })();
     return () => ac.abort();
   }, [client]);
 
+  if (error !== null) return <div className="md-status">preview error: {error}</div>;
   if (event === undefined) return <div className="md-status">Loading…</div>;
   if (event.kind === 'missing') return <div className="md-status">file not found</div>;
   if (event.kind === 'too-large') {

--- a/extensions/md/src/Preview.tsx
+++ b/extensions/md/src/Preview.tsx
@@ -7,12 +7,16 @@ import { handleKey, type KeyState } from './navigation.ts';
 /** Renders Markdown and binds the vim-style scroll keys to its scroll container. */
 export function Preview({ markdown }: { markdown: string }) {
   const ref = useRef<HTMLDivElement>(null);
-  const keyState = useRef<KeyState>({ lastGAt: 0 });
+  const keyState = useRef<KeyState>({ lastGAt: Number.NEGATIVE_INFINITY });
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    el.focus();
+    // Focus for keyboard nav, but don't steal focus if the user already has
+    // something focused (e.g. on a remount while they're working elsewhere).
+    if (document.activeElement === null || document.activeElement === document.body) {
+      el.focus();
+    }
     const onKey = (e: KeyboardEvent) => {
       const target = handleKey(
         { key: e.key, ctrlKey: e.ctrlKey },

--- a/extensions/md/src/Preview.tsx
+++ b/extensions/md/src/Preview.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import { handleKey, type KeyState } from './navigation.ts';
+
+/** Renders Markdown and binds the vim-style scroll keys to its scroll container. */
+export function Preview({ markdown }: { markdown: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const keyState = useRef<KeyState>({ lastGAt: 0 });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.focus();
+    const onKey = (e: KeyboardEvent) => {
+      const target = handleKey(
+        { key: e.key, ctrlKey: e.ctrlKey },
+        { scrollTop: el.scrollTop, scrollLeft: el.scrollLeft, clientHeight: el.clientHeight },
+        keyState.current,
+        performance.now(),
+        el.scrollHeight - el.clientHeight,
+      );
+      if (!target) return;
+      e.preventDefault();
+      if (target.top !== undefined) el.scrollTop = target.top;
+      if (target.left !== undefined) el.scrollLeft = target.left;
+    };
+    el.addEventListener('keydown', onKey);
+    return () => el.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    // biome-ignore lint/a11y/noNoninteractiveTabindex: scroll container requires keyboard focus for vim-style navigation keys
+    <div ref={ref} className="md-scroll" tabIndex={0}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/extensions/md/src/main.tsx
+++ b/extensions/md/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App.tsx';
+import './styles.css';
+
+const root = document.getElementById('root');
+if (root) {
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/extensions/md/src/navigation.test.ts
+++ b/extensions/md/src/navigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { COL_STEP, handleKey, type KeyState, LINE_STEP, type ScrollMetrics } from './navigation.ts';
+
+const m: ScrollMetrics = { scrollTop: 100, scrollLeft: 50, clientHeight: 200 };
+const fresh = (): KeyState => ({ lastGAt: 0 });
+const k = (key: string, ctrlKey = false) => ({ key, ctrlKey });
+
+describe('handleKey', () => {
+  it('j scrolls down one line, k scrolls up', () => {
+    expect(handleKey(k('j'), m, fresh(), 1000, 1000)).toEqual({ top: 100 + LINE_STEP });
+    expect(handleKey(k('k'), m, fresh(), 1000, 1000)).toEqual({ top: 100 - LINE_STEP });
+  });
+
+  it('h/l scroll left/right', () => {
+    expect(handleKey(k('l'), m, fresh(), 1000, 1000)).toEqual({ left: 50 + COL_STEP });
+    expect(handleKey(k('h'), m, fresh(), 1000, 1000)).toEqual({ left: 50 - COL_STEP });
+  });
+
+  it('Ctrl-d / Ctrl-u scroll half a page', () => {
+    expect(handleKey(k('d', true), m, fresh(), 1000, 1000)).toEqual({ top: 100 + 100 });
+    expect(handleKey(k('u', true), m, fresh(), 1000, 1000)).toEqual({ top: 100 - 100 });
+  });
+
+  it('G jumps to the bottom (maxTop)', () => {
+    expect(handleKey(k('G'), m, fresh(), 1000, 777)).toEqual({ top: 777 });
+  });
+
+  it('clamps to [0, maxTop]', () => {
+    const atTop: ScrollMetrics = { scrollTop: 10, scrollLeft: 0, clientHeight: 200 };
+    expect(handleKey(k('k'), atTop, fresh(), 1000, 1000)).toEqual({ top: 0 });
+    const atBottom: ScrollMetrics = { scrollTop: 990, scrollLeft: 0, clientHeight: 200 };
+    expect(handleKey(k('j'), atBottom, fresh(), 1000, 1000)).toEqual({ top: 1000 });
+  });
+
+  it('gg (two g within the window) jumps to top; a single g does nothing', () => {
+    const st = fresh();
+    expect(handleKey(k('g'), m, st, 1000, 1000)).toBeNull();
+    expect(handleKey(k('g'), m, st, 1100, 1000)).toEqual({ top: 0 });
+  });
+
+  it('g then a non-g resets the gg sequence', () => {
+    const st = fresh();
+    expect(handleKey(k('g'), m, st, 1000, 1000)).toBeNull();
+    handleKey(k('x'), m, st, 1050, 1000);
+    expect(handleKey(k('g'), m, st, 1100, 1000)).toBeNull();
+  });
+
+  it('returns null for unhandled keys', () => {
+    expect(handleKey(k('z'), m, fresh(), 1000, 1000)).toBeNull();
+  });
+});

--- a/extensions/md/src/navigation.test.ts
+++ b/extensions/md/src/navigation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { COL_STEP, handleKey, type KeyState, LINE_STEP, type ScrollMetrics } from './navigation.ts';
 
 const m: ScrollMetrics = { scrollTop: 100, scrollLeft: 50, clientHeight: 200 };
-const fresh = (): KeyState => ({ lastGAt: 0 });
+const fresh = (): KeyState => ({ lastGAt: Number.NEGATIVE_INFINITY });
 const k = (key: string, ctrlKey = false) => ({ key, ctrlKey });
 
 describe('handleKey', () => {
@@ -43,6 +43,11 @@ describe('handleKey', () => {
     expect(handleKey(k('g'), m, st, 1000, 1000)).toBeNull();
     handleKey(k('x'), m, st, 1050, 1000);
     expect(handleKey(k('g'), m, st, 1100, 1000)).toBeNull();
+  });
+
+  it('a single g shortly after load (small now, fresh state) does not jump to top', () => {
+    const st: KeyState = { lastGAt: Number.NEGATIVE_INFINITY };
+    expect(handleKey(k('g'), m, st, 100, 1000)).toBeNull();
   });
 
   it('returns null for unhandled keys', () => {

--- a/extensions/md/src/navigation.ts
+++ b/extensions/md/src/navigation.ts
@@ -31,7 +31,12 @@ const GG_WINDOW_MS = 400;
 /**
  * Maps a keydown to a scroll target, or `null` when the key is unhandled. Pure:
  * the caller supplies geometry, `now`, and `maxTop` (= scrollHeight - clientHeight),
- * and owns applying the result. Mutates `state.lastGAt` to track `gg`.
+ * and owns applying the result. `gg` is detected by reading `state.lastGAt`; the
+ * state is reset up front and only a first lone `g` re-arms it.
+ *
+ * `state.lastGAt` should start at `Number.NEGATIVE_INFINITY` (no prior `g`) so a
+ * single `g` pressed soon after load — when `now` is small — does not satisfy the
+ * window and jump to the top.
  */
 export function handleKey(
   e: KeyLike,
@@ -40,8 +45,10 @@ export function handleKey(
   now: number,
   maxTop: number,
 ): ScrollTarget | null {
+  const recentG = now - state.lastGAt < GG_WINDOW_MS;
+  state.lastGAt = Number.NEGATIVE_INFINITY;
+
   if (e.ctrlKey && (e.key === 'd' || e.key === 'u')) {
-    state.lastGAt = 0;
     const half = Math.floor(m.clientHeight / 2);
     const top = e.key === 'd' ? m.scrollTop + half : m.scrollTop - half;
     return { top: clamp(top, 0, maxTop) };
@@ -49,29 +56,20 @@ export function handleKey(
 
   switch (e.key) {
     case 'j':
-      state.lastGAt = 0;
       return { top: clamp(m.scrollTop + LINE_STEP, 0, maxTop) };
     case 'k':
-      state.lastGAt = 0;
       return { top: clamp(m.scrollTop - LINE_STEP, 0, maxTop) };
     case 'h':
-      state.lastGAt = 0;
       return { left: m.scrollLeft - COL_STEP };
     case 'l':
-      state.lastGAt = 0;
       return { left: m.scrollLeft + COL_STEP };
     case 'G':
-      state.lastGAt = 0;
       return { top: maxTop };
     case 'g':
-      if (now - state.lastGAt < GG_WINDOW_MS) {
-        state.lastGAt = 0;
-        return { top: 0 };
-      }
+      if (recentG) return { top: 0 };
       state.lastGAt = now;
       return null;
     default:
-      state.lastGAt = 0;
       return null;
   }
 }

--- a/extensions/md/src/navigation.ts
+++ b/extensions/md/src/navigation.ts
@@ -1,0 +1,81 @@
+/** Per-axis scroll geometry the key handler reads (plain numbers; no DOM). */
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollLeft: number;
+  clientHeight: number;
+}
+
+/** Mutable state threaded across keystrokes to detect the `gg` sequence. */
+export interface KeyState {
+  lastGAt: number;
+}
+
+/** The scroll position to apply; absent axis means "leave unchanged". */
+export interface ScrollTarget {
+  top?: number;
+  left?: number;
+}
+
+/** Minimal keyboard-event shape the handler needs. */
+export interface KeyLike {
+  key: string;
+  ctrlKey: boolean;
+}
+
+/** Pixels scrolled per j/k line step. */
+export const LINE_STEP = 40;
+/** Pixels scrolled per h/l column step. */
+export const COL_STEP = 40;
+const GG_WINDOW_MS = 400;
+
+/**
+ * Maps a keydown to a scroll target, or `null` when the key is unhandled. Pure:
+ * the caller supplies geometry, `now`, and `maxTop` (= scrollHeight - clientHeight),
+ * and owns applying the result. Mutates `state.lastGAt` to track `gg`.
+ */
+export function handleKey(
+  e: KeyLike,
+  m: ScrollMetrics,
+  state: KeyState,
+  now: number,
+  maxTop: number,
+): ScrollTarget | null {
+  if (e.ctrlKey && (e.key === 'd' || e.key === 'u')) {
+    state.lastGAt = 0;
+    const half = Math.floor(m.clientHeight / 2);
+    const top = e.key === 'd' ? m.scrollTop + half : m.scrollTop - half;
+    return { top: clamp(top, 0, maxTop) };
+  }
+
+  switch (e.key) {
+    case 'j':
+      state.lastGAt = 0;
+      return { top: clamp(m.scrollTop + LINE_STEP, 0, maxTop) };
+    case 'k':
+      state.lastGAt = 0;
+      return { top: clamp(m.scrollTop - LINE_STEP, 0, maxTop) };
+    case 'h':
+      state.lastGAt = 0;
+      return { left: m.scrollLeft - COL_STEP };
+    case 'l':
+      state.lastGAt = 0;
+      return { left: m.scrollLeft + COL_STEP };
+    case 'G':
+      state.lastGAt = 0;
+      return { top: maxTop };
+    case 'g':
+      if (now - state.lastGAt < GG_WINDOW_MS) {
+        state.lastGAt = 0;
+        return { top: 0 };
+      }
+      state.lastGAt = now;
+      return null;
+    default:
+      state.lastGAt = 0;
+      return null;
+  }
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value));
+}

--- a/extensions/md/src/styles.css
+++ b/extensions/md/src/styles.css
@@ -1,0 +1,65 @@
+@import "highlight.js/styles/github-dark.css";
+
+:root {
+  color-scheme: dark;
+}
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  background: #1a1b26;
+  color: #c0caf5;
+}
+.md-status {
+  padding: 1rem;
+  opacity: 0.7;
+}
+.md-scroll {
+  box-sizing: border-box;
+  height: 100vh;
+  overflow: auto;
+  padding: 1rem 1.25rem;
+  outline: none;
+}
+.md-scroll h1,
+.md-scroll h2,
+.md-scroll h3 {
+  border-bottom: 1px solid #2a2e42;
+  padding-bottom: 0.2em;
+}
+.md-scroll a {
+  color: #7aa2f7;
+}
+.md-scroll code {
+  background: #292e42;
+  border-radius: 3px;
+  padding: 0.1em 0.3em;
+}
+.md-scroll pre {
+  background: #16161e;
+  border-radius: 6px;
+  overflow: auto;
+  padding: 0.8rem;
+}
+.md-scroll pre code {
+  background: none;
+  padding: 0;
+}
+.md-scroll table {
+  border-collapse: collapse;
+}
+.md-scroll th,
+.md-scroll td {
+  border: 1px solid #2a2e42;
+  padding: 0.3em 0.6em;
+}
+.md-scroll blockquote {
+  border-left: 3px solid #414868;
+  color: #9aa5ce;
+  margin: 0;
+  padding-left: 1em;
+}

--- a/extensions/md/tsconfig.client.json
+++ b/extensions/md/tsconfig.client.json
@@ -5,7 +5,7 @@
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["@ozmux/sdk/ozmux-global"],
+    "types": ["@ozmux/sdk/ozmux-global", "vite/client"],
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,

--- a/extensions/md/tsconfig.client.json
+++ b/extensions/md/tsconfig.client.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.client.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@ozmux/sdk/ozmux-global"],
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "content-event.ts"]
+}

--- a/extensions/md/tsconfig.json
+++ b/extensions/md/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["bootstrap.ts", "server/**/*.ts", "content-event.ts"]
+}

--- a/extensions/md/vite.config.ts
+++ b/extensions/md/vite.config.ts
@@ -1,0 +1,8 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+  plugins: [react()],
+  build: { outDir: 'dist', emptyOutDir: true },
+});

--- a/extensions/md/vitest.config.ts
+++ b/extensions/md/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { include: ['server/**/*.test.ts', 'src/**/*.test.ts'] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,39 @@ catalogs:
     '@types/node':
       specifier: ^24.12.2
       version: 24.12.2
+    '@types/react':
+      specifier: ^19.0.0
+      version: 19.2.15
+    '@types/react-dom':
+      specifier: ^19.0.0
+      version: 19.2.3
+    '@vitejs/plugin-react':
+      specifier: ^6.0.0
+      version: 6.0.2
+    highlight.js:
+      specifier: ^11.0.0
+      version: 11.11.1
+    react:
+      specifier: ^19.0.0
+      version: 19.2.6
+    react-dom:
+      specifier: ^19.0.0
+      version: 19.2.6
+    react-markdown:
+      specifier: ^10.0.0
+      version: 10.1.0
+    rehype-highlight:
+      specifier: ^7.0.0
+      version: 7.0.2
+    remark-gfm:
+      specifier: ^4.0.0
+      version: 4.0.1
     typescript:
       specifier: ~6.0.3
       version: 6.0.3
+    vite:
+      specifier: ^8.0.0
+      version: 8.0.10
     vitest:
       specifier: ^4.1.5
       version: 4.1.5
@@ -29,6 +59,52 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
+
+  extensions/md:
+    dependencies:
+      '@ozmux/sdk':
+        specifier: workspace:*
+        version: link:../../sdk/typescript
+      highlight.js:
+        specifier: 'catalog:'
+        version: 11.11.1
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      react-markdown:
+        specifier: 'catalog:'
+        version: 10.1.0(@types/react@19.2.15)(react@19.2.6)
+      rehype-highlight:
+        specifier: 'catalog:'
+        version: 7.0.2
+      remark-gfm:
+        specifier: 'catalog:'
+        version: 4.0.1
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   extensions/memo:
     dependencies:
@@ -460,6 +536,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -469,14 +548,59 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitejs/plugin-react@6.0.2':
+    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -516,12 +640,33 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -530,16 +675,38 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -553,12 +720,22 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -583,9 +760,47 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -677,6 +892,12 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
@@ -684,12 +905,147 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -698,6 +1054,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -716,9 +1075,42 @@ packages:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -736,6 +1128,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -747,11 +1142,23 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -790,6 +1197,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -809,6 +1222,33 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -924,6 +1364,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1183,6 +1626,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1195,13 +1640,50 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
+
+  '@vitejs/plugin-react@6.0.2(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1258,12 +1740,26 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bail@2.0.2: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
     optional: true
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1273,6 +1769,8 @@ snapshots:
       source-map-js: 1.2.1
     optional: true
 
+  csstype@3.2.3: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -1281,10 +1779,24 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js@10.6.0:
     optional: true
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   entities@8.0.0:
     optional: true
@@ -1321,11 +1833,17 @@ snapshots:
       '@esbuild/win32-x64': 0.27.7
     optional: true
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -1345,12 +1863,66 @@ snapshots:
       resolve-pkg-maps: 1.0.0
     optional: true
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
+
+  html-url-attributes@3.0.1: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1:
     optional: true
@@ -1434,6 +2006,14 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
+
   lru-cache@11.3.6:
     optional: true
 
@@ -1441,15 +2021,373 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1:
     optional: true
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mrmime@2.0.1:
     optional: true
 
+  ms@2.1.3: {}
+
   nanoid@3.3.12: {}
 
   obug@2.1.1: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -1468,8 +2406,77 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1:
     optional: true
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-markdown@10.1.0(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.15
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.6
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react@19.2.6: {}
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2:
     optional: true
@@ -1503,6 +2510,8 @@ snapshots:
       xmlchars: 2.2.0
     optional: true
 
+  scheduler@0.27.0: {}
+
   siginfo@2.0.0: {}
 
   sirv@3.0.2:
@@ -1514,9 +2523,24 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   symbol-tree@3.2.4:
     optional: true
@@ -1553,6 +2577,10 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -1570,6 +2598,54 @@ snapshots:
 
   undici@7.25.0:
     optional: true
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
@@ -1646,3 +2722,5 @@ snapshots:
     optional: true
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,15 @@ catalog:
   typescript: ~6.0.3
   vitest: ^4.1.5
   zod: ^4.4.3
+  react: ^19.0.0
+  react-dom: ^19.0.0
+  '@types/react': ^19.0.0
+  '@types/react-dom': ^19.0.0
+  vite: ^8.0.0
+  '@vitejs/plugin-react': ^6.0.0
+  react-markdown: ^10.0.0
+  remark-gfm: ^4.0.0
+  rehype-highlight: ^7.0.0
+  highlight.js: ^11.0.0
 
 catalogMode: strict

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     title: "ozmux".to_string(),
+                    ime_enabled: true,
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
## Problem

ozmux has no way to preview a Markdown file — there's no built-in command to render a `.md` and watch it refresh as you edit.

## Solution

Adds the `@md` Node extension (`extensions/md/`) — a live Markdown preview rendered in an embedded CEF webview.

**Command:** `@md [-s | --split <horizontal|vertical>] <FILE>`
- `-s <orientation>` opens the preview in a split pane (`side: after`).
- The file-existence gate and the client build-guard both run **before** any activity is created (missing file → stderr + exit 1, no pane).

**Server** (`bootstrap.ts` + `server/*`, run via Node type-stripping):
- arg parsing via `node:util` `parseArgs`; path resolution + existence gate;
- a `content` channel that streams the file over the SDK channel protocol, backed by a **parent-directory** `fs.watch` — debounced (50 ms), deduped by `mtime:size` (single `stat` per tick), 2 MB read cap, surfaces watcher errors instead of crashing, and emits a `missing` event on delete.

**Client** (`src/*.tsx`, bundled by Vite, loaded over `ozmux-ext://md/dist/...`):
- a React app rendering with `react-markdown` + `remark-gfm` + `rehype-highlight` (raw HTML off → no XSS from the file);
- vim-style navigation: `j`/`k` (line), `Ctrl-d`/`Ctrl-u` (half-page), `gg`/`G` (top/bottom), `h`/`l` (horizontal).

**Affected areas:** new `extensions/md/`; `pnpm-workspace.yaml` (adds the React/Vite/Markdown toolchain to the strict `catalog:`); `CLAUDE.md` (documents the `pnpm build` prerequisite for Vite-client extensions). **No Rust/engine changes** — the extension is auto-discovered from its `package.json`.

**Testing:** 35 vitest tests (server arg/gate/content-channel/command + pure client navigation, incl. real-`fs.watch`, watcher-error, dedupe, and abort paths). `pnpm check-types`, `pnpm build`, and `pnpm lint:ci` all pass.

### Known limitation (deferred to a follow-up PR)

The **no-flag in-pane** invocation (`@md <FILE>` without `-s`) currently no-ops: the SDK's `addActivity`/`activate` route through the removed daemon/HTTP transport, and the live control protocol only implements `split`. Wiring an `add_activity` control op (host + SDK) plus a UI rebuild on `ActiveActivity` change is deferred. **Use `@md -s vertical <FILE>` for now** (the split path is fully wired).

Runtime/GUI behavior has not yet been verified end-to-end in the running app (needs `cargo run` + CEF); the change is verified at the code/tooling level.

<details><summary>Screenshots</summary>Pending in-app runtime verification.</details>

> Note: this branch also carries one pre-existing, unrelated commit — `update: enable ime` (53b2491) — which predates the `@md` work.
