### PR TITLE
feat: browser activity via `@browser open` with a native CEF toolbar

### DIFF
--- a/crates/configs/src/browser.rs
+++ b/crates/configs/src/browser.rs
@@ -1,6 +1,7 @@
-//! Browser activity configuration: search-engine template for the toolbar
-//! URL bar's Chrome-style omnibox behavior, plus the omnibox classifier
-//! used by both the toolbar (via the TS port) and the `ozmux browser` CLI.
+//! Browser activity configuration: the search-engine template for the address
+//! bar's Chrome-style omnibox behavior, plus the `resolve_omnibox_input`
+//! classifier the browser renderer uses for the initial load and toolbar
+//! navigations.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/extension_host/src/bridge.rs
+++ b/crates/extension_host/src/bridge.rs
@@ -260,11 +260,15 @@ mod tests {
                     other => panic!("expected Browser kind, got {other:?}"),
                 }
                 assert!(
-                    world.get::<ozmux_multiplexer::ExtensionActivityAid>(new_act).is_none(),
+                    world
+                        .get::<ozmux_multiplexer::ExtensionActivityAid>(new_act)
+                        .is_none(),
                     "browser activity must not get an ExtensionActivityAid"
                 );
                 assert!(
-                    world.get::<ozmux_multiplexer::OwningExtension>(new_act).is_none(),
+                    world
+                        .get::<ozmux_multiplexer::OwningExtension>(new_act)
+                        .is_none(),
                     "browser activity must not get an OwningExtension"
                 );
             }

--- a/crates/extension_host/src/bridge.rs
+++ b/crates/extension_host/src/bridge.rs
@@ -10,7 +10,7 @@ use crate::control::{
 use crate::path_prefix::extension_path_prefix;
 use bevy::prelude::*;
 use ozmux_multiplexer::{
-    ActivityKind, ExtensionActivityAid, MultiplexerCommands, OwningExtension, Side,
+    ActivityKind, BrowserProfile, ExtensionActivityAid, MultiplexerCommands, OwningExtension, Side,
     SplitOrientation,
 };
 use std::path::PathBuf;
@@ -140,13 +140,6 @@ fn resolve_and_split(
         })?;
     let ControlOp::Split(p) = req.op;
     let activity_id = p.activity.activity_id.clone();
-    let ActivityKindSpec::Extension {
-        entry,
-        extension_name,
-    } = p.activity.kind;
-    let kind = ActivityKind::Extension {
-        entry: PathBuf::from(entry),
-    };
     let side = match p.side {
         ControlSide::Before => Side::Before,
         ControlSide::After => Side::After,
@@ -155,15 +148,38 @@ fn resolve_and_split(
         ControlOrientation::Horizontal => SplitOrientation::Horizontal,
         ControlOrientation::Vertical => SplitOrientation::Vertical,
     };
+    let (kind, extension_name, is_extension): (ActivityKind, Option<String>, bool) =
+        match p.activity.kind {
+            ActivityKindSpec::Extension {
+                entry,
+                extension_name,
+            } => (
+                ActivityKind::Extension {
+                    entry: PathBuf::from(entry),
+                },
+                extension_name,
+                true,
+            ),
+            ActivityKindSpec::Browser { url } => (
+                ActivityKind::Browser {
+                    initial_url: Some(url),
+                    profile: BrowserProfile::default(),
+                },
+                None,
+                false,
+            ),
+        };
     let outcome = mux
         .split_pane_with_activity(pane, side, orientation, kind)
         .map_err(|e| ControlError {
             code: "internal".into(),
             message: e.to_string(),
         })?;
-    mux.insert_on(outcome.activity, ExtensionActivityAid(activity_id));
-    if let Some(name) = extension_name {
-        mux.insert_on(outcome.activity, OwningExtension(name));
+    if is_extension {
+        mux.insert_on(outcome.activity, ExtensionActivityAid(activity_id));
+        if let Some(name) = extension_name {
+            mux.insert_on(outcome.activity, OwningExtension(name));
+        }
     }
     Ok(SplitReply {
         new_pane_id: outcome.pane.to_bits(),
@@ -193,6 +209,66 @@ mod tests {
                     activity_id: "aid-xyz".into(),
                 },
             }),
+        }
+    }
+
+    fn browser_split_request(pane_bits: u64) -> ControlRequest {
+        ControlRequest {
+            pane_bits,
+            op: ControlOp::Split(crate::control::SplitParams {
+                side: ControlSide::After,
+                orientation: ControlOrientation::Vertical,
+                activity: crate::control::ActivitySpec {
+                    kind: ActivityKindSpec::Browser {
+                        url: "github.com".into(),
+                    },
+                    name: None,
+                    activity_id: "aid-b".into(),
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn handles_split_and_creates_browser_pane_without_extension_components() {
+        let mut world = World::new();
+        let created = world
+            .run_system_once(|mut mux: MultiplexerCommands| mux.create_session(None))
+            .unwrap();
+        let pane_bits = created.pane.to_bits();
+
+        let (resp_tx, resp_rx) = bounded(1);
+        let mut resp_tx = Some(resp_tx);
+        world
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                apply_control_request(
+                    &mut mux,
+                    browser_split_request(pane_bits),
+                    resp_tx.take().unwrap(),
+                );
+            })
+            .unwrap();
+        world.flush();
+
+        match resp_rx.try_recv().unwrap() {
+            ControlResponse::Ok(reply) => {
+                let new_act = Entity::try_from_bits(reply.new_activity_id).unwrap();
+                match world.get::<ActivityKind>(new_act) {
+                    Some(ActivityKind::Browser { initial_url, .. }) => {
+                        assert_eq!(initial_url.as_deref(), Some("github.com"));
+                    }
+                    other => panic!("expected Browser kind, got {other:?}"),
+                }
+                assert!(
+                    world.get::<ozmux_multiplexer::ExtensionActivityAid>(new_act).is_none(),
+                    "browser activity must not get an ExtensionActivityAid"
+                );
+                assert!(
+                    world.get::<ozmux_multiplexer::OwningExtension>(new_act).is_none(),
+                    "browser activity must not get an OwningExtension"
+                );
+            }
+            ControlResponse::Err(e) => panic!("expected Ok, got {}", e.code),
         }
     }
 

--- a/crates/extension_host/src/control.rs
+++ b/crates/extension_host/src/control.rs
@@ -65,7 +65,7 @@ pub struct ActivitySpec {
     pub activity_id: String,
 }
 
-/// Protocol-side activity kind. #2 supports only `extension`.
+/// Protocol-side activity kind.
 #[derive(Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ActivityKindSpec {
@@ -79,6 +79,12 @@ pub enum ActivityKindSpec {
         /// for back-compat; absent on older SDK payloads.
         #[serde(default)]
         extension_name: Option<String>,
+    },
+    /// An embedded browser activity. `url` is the raw `@browser open` input
+    /// (a URL or search words), passed through verbatim for the host to resolve.
+    Browser {
+        /// Raw user input (a URL or search words).
+        url: String,
     },
 }
 
@@ -200,7 +206,10 @@ mod tests {
         let ActivityKindSpec::Extension {
             entry,
             extension_name,
-        } = p.activity.kind;
+        } = p.activity.kind
+        else {
+            panic!("expected Extension kind");
+        };
         assert_eq!(entry, "index.html");
         assert_eq!(extension_name.as_deref(), Some("memo"));
     }
@@ -214,7 +223,10 @@ mod tests {
         let ActivityKindSpec::Extension {
             entry,
             extension_name,
-        } = p.activity.kind;
+        } = p.activity.kind
+        else {
+            panic!("expected Extension kind");
+        };
         assert_eq!(entry, "index.html");
         assert_eq!(extension_name, None);
     }
@@ -235,6 +247,19 @@ mod tests {
             parse_call(line),
             Err(ControlParseError::BadRequest(_))
         ));
+    }
+
+    #[test]
+    fn parses_browser_split_call() {
+        let line = r#"{"kind":"call","id":"b1","op":"split","pane":"1","params":{"side":"after","orientation":"vertical","activity":{"kind":"browser","url":"github.com","name":null,"activity_id":"aid-b"}}}"#;
+        let (id, req) = parse_call(line).expect("parse");
+        assert_eq!(id, "b1");
+        let ControlOp::Split(p) = req.op;
+        assert_eq!(p.activity.activity_id, "aid-b");
+        let ActivityKindSpec::Browser { url } = p.activity.kind else {
+            panic!("expected Browser kind");
+        };
+        assert_eq!(url, "github.com");
     }
 
     #[test]

--- a/extensions/browser/bootstrap.ts
+++ b/extensions/browser/bootstrap.ts
@@ -1,0 +1,26 @@
+import { bootstrap } from '@ozmux/sdk/server';
+
+bootstrap({
+  commands: {
+    '@browser': async (ctx) => {
+      const [subcommand, ...rest] = ctx.argv;
+      if (subcommand !== 'open') {
+        ctx.stderr.write('usage: @browser open <url-or-search-words>\n');
+        return 1;
+      }
+      const input = rest.join(' ').trim();
+      if (input.length === 0) {
+        ctx.stderr.write('usage: @browser open <url-or-search-words>\n');
+        return 1;
+      }
+
+      await ctx.pane.split({
+        orientation: 'vertical',
+        side: 'after',
+        activity: { kind: 'browser', url: input },
+      });
+
+      return 0;
+    },
+  },
+});

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "browser",
+  "main": "bootstrap.ts",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.30.2",
+  "dependencies": {
+    "@ozmux/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/extensions/browser/tsconfig.json
+++ b/extensions/browser/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["bootstrap.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,19 @@ importers:
         specifier: 'catalog:'
         version: 24.12.2
 
+  extensions/browser:
+    dependencies:
+      '@ozmux/sdk':
+        specifier: workspace:*
+        version: link:../../sdk/typescript
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   extensions/memo:
     dependencies:
       '@ozmux/sdk':

--- a/sdk/typescript/src/server/control-client.ts
+++ b/sdk/typescript/src/server/control-client.ts
@@ -4,7 +4,9 @@ import * as net from 'node:net';
 export interface SplitControlParams {
   side: 'before' | 'after';
   orientation: 'horizontal' | 'vertical';
-  activity: { kind: 'extension'; entry: string; name?: string | null; activity_id: string };
+  activity:
+    | { kind: 'extension'; entry: string; name?: string | null; activity_id: string }
+    | { kind: 'browser'; url: string; name?: string | null; activity_id: string };
 }
 
 /** The host's reply to a successful split. */

--- a/sdk/typescript/src/server/pane.test.ts
+++ b/sdk/typescript/src/server/pane.test.ts
@@ -242,6 +242,31 @@ describe('Pane.split', () => {
       }),
     ).resolves.toBeDefined();
   });
+
+  it('sends a browser split carrying the raw url, no extension_name', async () => {
+    const sock = tmpSock();
+    const { server, frames } = await startFakeSplitServer(sock, {
+      new_pane_id: 'p7',
+      new_activity_id: 'a7',
+    });
+    process.env.OZMUX_CONTROL_SOCK_PATH = sock;
+
+    const pane = new Pane({ id: 'p1', windowId: 'w1' });
+    await pane.split({
+      side: 'after',
+      orientation: 'vertical',
+      activity: { kind: 'browser', url: 'github.com' },
+    });
+
+    const params = frames[0].params as {
+      activity: { kind: string; url: string; activity_id: string; extension_name?: string };
+    };
+    expect(params.activity.kind).toBe('browser');
+    expect(params.activity.url).toBe('github.com');
+    expect(params.activity.extension_name).toBeUndefined();
+    expect(typeof params.activity.activity_id).toBe('string');
+    server.close();
+  });
 });
 
 describe('Pane.addActivity', () => {

--- a/sdk/typescript/src/server/pane.ts
+++ b/sdk/typescript/src/server/pane.ts
@@ -32,7 +32,8 @@ export type Orientation = 'horizontal' | 'vertical';
 /**
  * What the caller hands to `Pane.split()` / `Pane.addActivity()`. The
  * terminal variant just creates a shell; the extension variant takes an HTML
- * entry path plus optional handlers/channels.
+ * entry path plus optional handlers/channels; the browser variant opens a URL
+ * directly in the embedded webview without binding to any extension.
  */
 export type ActivitySpecInput =
   | { kind: 'terminal'; name?: string }
@@ -42,7 +43,8 @@ export type ActivitySpecInput =
       name?: string;
       handlers?: HandlerMap;
       channels?: ChannelMap;
-    };
+    }
+  | { kind: 'browser'; url: string; name?: string };
 
 export interface SplitArgs {
   side: Side;
@@ -148,19 +150,19 @@ function rollbackActivityRegistries(activityId: ActivityId, spec: ActivitySpecIn
 
 function activityKindForSpec(spec: ActivitySpecInput): ActivityKind {
   if (spec.kind === 'terminal') return { type: 'terminal' };
+  if (spec.kind === 'browser') return { type: 'browser', initial_url: spec.url };
   return { type: 'extension', entry: toEntry(spec.html) };
 }
 
 function controlActivity(
   activityId: ActivityId,
   spec: ActivitySpecInput,
-): {
-  kind: 'extension';
-  entry: string;
-  name?: string;
-  activity_id: string;
-  extension_name?: string;
-} {
+):
+  | { kind: 'extension'; entry: string; name?: string; activity_id: string; extension_name?: string }
+  | { kind: 'browser'; url: string; name?: string; activity_id: string } {
+  if (spec.kind === 'browser') {
+    return { kind: 'browser', url: spec.url, name: spec.name, activity_id: activityId };
+  }
   // TODO: terminal splits over the control socket are not supported in #2/#3; a future op should carry a terminal kind instead of this extension fallback.
   if (spec.kind !== 'extension') {
     return { kind: 'extension', entry: '', name: spec.name, activity_id: activityId };
@@ -182,6 +184,8 @@ function buildActivityPayload(
   if (spec.name !== undefined) base.name = spec.name;
   if (spec.kind === 'terminal') {
     base.kind = { type: 'terminal' };
+  } else if (spec.kind === 'browser') {
+    base.kind = { type: 'browser', initial_url: spec.url };
   } else {
     // `extension_name` lets the daemon populate its ExtensionRegistry so
     // the in-CEF extension client can resolve the owning extension's UDS.

--- a/sdk/typescript/src/server/pane.ts
+++ b/sdk/typescript/src/server/pane.ts
@@ -158,7 +158,13 @@ function controlActivity(
   activityId: ActivityId,
   spec: ActivitySpecInput,
 ):
-  | { kind: 'extension'; entry: string; name?: string; activity_id: string; extension_name?: string }
+  | {
+      kind: 'extension';
+      entry: string;
+      name?: string;
+      activity_id: string;
+      extension_name?: string;
+    }
   | { kind: 'browser'; url: string; name?: string; activity_id: string } {
   if (spec.kind === 'browser') {
     return { kind: 'browser', url: spec.url, name: spec.name, activity_id: activityId };

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -6,6 +6,7 @@
 
 use crate::clipboard::Clipboard;
 use crate::configs::OzmuxConfigsResource;
+use crate::system_set::OzmuxSystems;
 use crate::ui::{
     AddrBarText, AddressBarFocus, AddressEdit, BrowserActivityMarker, BrowserNavButton,
     BrowserPageWebview, BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
@@ -19,6 +20,29 @@ use ozmux_configs::browser::resolve_omnibox_input;
 use ozmux_multiplexer::{ActivityKind, AttachedSession, MultiplexerCommands, SessionMarker};
 
 const TOOLBAR_HEIGHT_PX: f32 = 32.0;
+
+/// Wires the browser activity renderer: two-phase mount, toolbar render +
+/// navigation, address-bar editor + focus, and navigation-state observers.
+pub(crate) struct OzmuxBrowserRenderPlugin;
+
+impl Plugin for OzmuxBrowserRenderPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::ui::AddressBarFocus>()
+            .add_observer(on_address_changed)
+            .add_observer(on_loading_state_changed)
+            .add_systems(
+                Update,
+                (
+                    build_browser_chrome.in_set(OzmuxSystems::SetupActivity),
+                    attach_browser_webview.in_set(OzmuxSystems::SetupActivity),
+                    render_address_text,
+                    drive_nav_buttons,
+                    focus_address_bar_on_cmd_l.before(crate::input::dispatch_focused_key),
+                    browser_address_editor.after(crate::input::dispatch_focused_key),
+                ),
+            );
+    }
+}
 
 /// Builds the toolbar + empty page-webview children for each laid-out browser
 /// host that has not been built yet (no `BrowserPageWebview` pointer).
@@ -255,6 +279,10 @@ fn browser_address_editor(
                     insert_str(&mut edit, &one_line);
                 }
             }
+            continue;
+        }
+        let ctrl = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
+        if cmd || ctrl {
             continue;
         }
         match &ev.logical_key {
@@ -680,6 +708,36 @@ mod tests {
 
     #[derive(bevy::ecs::resource::Resource, Default)]
     struct Navigated(Vec<(Entity, String)>);
+
+    #[test]
+    fn editor_ignores_text_when_cmd_held() {
+        let mut app = make_test_app();
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.init_resource::<ButtonInput<KeyCode>>();
+        app.add_message::<KeyboardInput>();
+        app.add_systems(Update, build_browser_chrome);
+        app.add_systems(Update, browser_address_editor.after(build_browser_chrome));
+        let window = app.world_mut().spawn_empty().id();
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update();
+        app.world_mut().resource_mut::<crate::ui::AddressBarFocus>().0 = Some(host);
+
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::SuperLeft);
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<KeyboardInput>>()
+            .write(key_press(window, Key::Character("l".into())));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<AddressEdit>(host).unwrap().buffer, "",
+            "Cmd+<key> must not type into the address bar"
+        );
+    }
 
     #[test]
     fn enter_resolves_and_navigates_then_clears_focus() {

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -7,6 +7,7 @@
 use crate::clipboard::Clipboard;
 use crate::configs::OzmuxConfigsResource;
 use crate::system_set::OzmuxSystems;
+use crate::ui::palette;
 use crate::ui::{
     AddrBarText, AddressBarFocus, AddressEdit, BrowserActivityMarker, BrowserNavButton,
     BrowserPageWebview, BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
@@ -252,12 +253,16 @@ fn drive_nav_buttons(
     }
 }
 
-/// Dims the back/forward buttons when navigation in that direction is unavailable.
+/// Distinguishes enabled vs disabled back/forward buttons: an enabled button
+/// shows a bright `FOREGROUND` glyph on a lighter `TAB_ACTIVE_BG` background; a
+/// disabled one is dimmed to `MUTED` on a transparent background. Mirrors the
+/// tab bar's active/inactive treatment so the states read consistently.
 fn sync_nav_button_enabled(
     states: Query<&BrowserToolbarState>,
-    mut buttons: Query<(&BrowserNavButton, &mut BackgroundColor)>,
+    mut buttons: Query<(&BrowserNavButton, &mut BackgroundColor, &Children)>,
+    mut text_colors: Query<&mut TextColor>,
 ) {
-    for (button, mut bg) in buttons.iter_mut() {
+    for (button, mut bg, children) in buttons.iter_mut() {
         let enabled = match button.action {
             NavAction::Back => states
                 .get(button.host)
@@ -269,13 +274,20 @@ fn sync_nav_button_enabled(
                 .unwrap_or(false),
             NavAction::Reload => true,
         };
-        let color = if enabled {
-            Color::srgb(0.3, 0.3, 0.3)
+        let (background, glyph) = if enabled {
+            (palette::TAB_ACTIVE_BG, palette::FOREGROUND)
         } else {
-            Color::srgb(0.15, 0.15, 0.15)
+            (Color::NONE, palette::MUTED)
         };
-        if bg.0 != color {
-            bg.0 = color;
+        if bg.0 != background {
+            bg.0 = background;
+        }
+        for child in children.iter() {
+            if let Ok(mut tc) = text_colors.get_mut(child)
+                && tc.0 != glyph
+            {
+                tc.0 = glyph;
+            }
         }
     }
 }
@@ -296,11 +308,11 @@ fn spawn_nav_button(
                 justify_content: JustifyContent::Center,
                 ..default()
             },
-            BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+            BackgroundColor(Color::NONE),
             BrowserNavButton { host, action },
         ))
         .with_children(|p| {
-            p.spawn(Text::new(label.to_string()));
+            p.spawn((Text::new(label.to_string()), TextColor(palette::MUTED)));
         })
         .id()
 }
@@ -735,6 +747,63 @@ mod tests {
             captured.0,
             vec![page],
             "RequestGoBack must fire with the page webview"
+        );
+    }
+
+    #[test]
+    fn nav_button_glyph_dims_when_disabled() {
+        let mut app = make_test_app();
+        app.add_systems(
+            Update,
+            (build_browser_chrome, sync_nav_button_enabled).chain(),
+        );
+        let host = app
+            .world_mut()
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
+            .id();
+        app.update(); // build chrome
+        {
+            let mut state = app
+                .world_mut()
+                .get_mut::<BrowserToolbarState>(host)
+                .unwrap();
+            state.can_go_back = true;
+            state.can_go_forward = false;
+        }
+        app.update(); // sync drives the button colors
+
+        let glyph = |app: &mut App, action: NavAction| -> Color {
+            let btn = {
+                let mut q = app.world_mut().query::<(Entity, &BrowserNavButton)>();
+                q.iter(app.world())
+                    .find(|(_, b)| b.action == action && b.host == host)
+                    .map(|(e, _)| e)
+                    .expect("button must exist")
+            };
+            let children: Vec<Entity> = app
+                .world()
+                .get::<Children>(btn)
+                .expect("button has a label child")
+                .iter()
+                .collect();
+            children
+                .into_iter()
+                .find_map(|c| app.world().get::<TextColor>(c).map(|tc| tc.0))
+                .expect("label has a TextColor")
+        };
+
+        assert_eq!(
+            glyph(&mut app, NavAction::Back),
+            palette::FOREGROUND,
+            "enabled back glyph is bright (FOREGROUND)"
+        );
+        assert_eq!(
+            glyph(&mut app, NavAction::Forward),
+            palette::MUTED,
+            "disabled forward glyph is muted (MUTED)"
         );
     }
 

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -104,6 +104,40 @@ fn attach_browser_webview(
     }
 }
 
+/// Mirrors a page webview's `AddressChanged` onto its host's `BrowserToolbarState`.
+fn on_address_changed(
+    ev: On<AddressChanged>,
+    owners: Query<&PageWebviewOf>,
+    mut states: Query<&mut BrowserToolbarState>,
+) {
+    let Ok(owner) = owners.get(ev.webview) else {
+        return;
+    };
+    let Ok(mut state) = states.get_mut(owner.0) else {
+        return;
+    };
+    state.url = ev.url.clone();
+    state.can_go_back = ev.can_go_back;
+    state.can_go_forward = ev.can_go_forward;
+}
+
+/// Mirrors a page webview's `LoadingStateChanged` onto its host's `BrowserToolbarState`.
+fn on_loading_state_changed(
+    ev: On<LoadingStateChanged>,
+    owners: Query<&PageWebviewOf>,
+    mut states: Query<&mut BrowserToolbarState>,
+) {
+    let Ok(owner) = owners.get(ev.webview) else {
+        return;
+    };
+    let Ok(mut state) = states.get_mut(owner.0) else {
+        return;
+    };
+    state.is_loading = ev.is_loading;
+    state.can_go_back = ev.can_go_back;
+    state.can_go_forward = ev.can_go_forward;
+}
+
 fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, label: &str) -> Entity {
     commands
         .spawn((
@@ -203,6 +237,58 @@ mod tests {
             Some(Vec2::new(800.0, 568.0)),
             "webview seeded at the CHILD's laid-out size, not the host's"
         );
+    }
+
+    #[test]
+    fn address_changed_updates_host_toolbar_state() {
+        let mut app = make_test_app();
+        app.add_systems(Update, build_browser_chrome);
+        app.add_observer(on_address_changed);
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update();
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+
+        app.world_mut().trigger(AddressChanged {
+            webview: page,
+            url: "https://example.com/x".into(),
+            can_go_back: true,
+            can_go_forward: false,
+        });
+        app.world_mut().flush();
+
+        let state = app.world().get::<BrowserToolbarState>(host).unwrap();
+        assert_eq!(state.url, "https://example.com/x");
+        assert!(state.can_go_back);
+        assert!(!state.can_go_forward);
+    }
+
+    #[test]
+    fn loading_state_changed_updates_host_toolbar_state() {
+        let mut app = make_test_app();
+        app.add_systems(Update, build_browser_chrome);
+        app.add_observer(on_loading_state_changed);
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update();
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+
+        app.world_mut().trigger(LoadingStateChanged {
+            webview: page,
+            is_loading: true,
+            can_go_back: false,
+            can_go_forward: true,
+        });
+        app.world_mut().flush();
+
+        let state = app.world().get::<BrowserToolbarState>(host).unwrap();
+        assert!(state.is_loading);
+        assert!(!state.can_go_back);
+        assert!(state.can_go_forward);
     }
 
     #[test]

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -43,6 +43,10 @@ impl Plugin for OzmuxBrowserRenderPlugin {
                     nav_button_hover_cursor.after(crate::input::InputPhase::Hover),
                     focus_address_bar_on_click,
                     focus_address_bar_on_cmd_l.before(crate::input::dispatch_focused_key),
+                    blur_address_bar_on_focus_leave
+                        .after(crate::input::InputPhase::Dispatch)
+                        .before(crate::input::dispatch_focused_key)
+                        .run_if(address_bar_is_focused),
                     browser_address_editor.after(crate::input::dispatch_focused_key),
                 ),
             );
@@ -470,6 +474,37 @@ fn focus_address_bar_on_cmd_l(
     focus.0 = Some(host);
 }
 
+/// Run condition gating `blur_address_bar_on_focus_leave`: only poll while the
+/// address bar actually owns focus, so its heavy params (`MultiplexerCommands`,
+/// queries) are not fetched on the common unfocused path.
+fn address_bar_is_focused(focus: Res<AddressBarFocus>) -> bool {
+    focus.0.is_some()
+}
+
+/// Clears `AddressBarFocus` when focus leaves the bar — when the active pane is
+/// no longer the focused browser host, or a left-click lands outside any address
+/// bar. Without this the bar stays focused after the user moves to a terminal,
+/// and `dispatch_focused_key`'s guard then suppresses all keyboard input.
+fn blur_address_bar_on_focus_leave(
+    mut focus: ResMut<AddressBarFocus>,
+    mux: MultiplexerCommands,
+    attached: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
+    registry: Res<crate::ui::registry::ActivityEntityRegistry>,
+    mouse: Res<ButtonInput<MouseButton>>,
+    addr_bars: Query<&Interaction, With<AddrBarText>>,
+) {
+    let Some(focused_host) = focus.0 else {
+        return;
+    };
+    let active_host = crate::input::resolve_focused_terminal(&mux, &attached, &registry);
+    let pane_left = active_host != Some(focused_host);
+    let clicked_outside = mouse.just_pressed(MouseButton::Left)
+        && !addr_bars.iter().any(|i| *i == Interaction::Pressed);
+    if pane_left || clicked_outside {
+        focus.0 = None;
+    }
+}
+
 /// Returns the byte offset in `e.buffer` for the character at `idx`.
 fn char_byte(e: &AddressEdit, idx: usize) -> usize {
     e.buffer
@@ -869,6 +904,117 @@ mod tests {
                 Some(CursorIcon::System(SystemCursorIcon::Text))
             ),
             "no hovered button leaves the cursor unchanged"
+        );
+    }
+
+    /// Builds an app with one attached session whose active activity maps (in the
+    /// registry) to `host`, and the address bar focused on that same `host` — so
+    /// `blur_address_bar_on_focus_leave`'s pane-left condition is false by default.
+    fn focused_app_on_active_host() -> (App, Entity) {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.init_resource::<crate::ui::registry::ActivityEntityRegistry>();
+        app.init_resource::<ButtonInput<MouseButton>>();
+
+        let (session, _pane, activity) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_session(Some("t".into()));
+                (o.session, o.pane, o.activity)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut().entity_mut(session).insert(AttachedSession);
+
+        let host = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .resource_mut::<crate::ui::registry::ActivityEntityRegistry>()
+            .insert_for_test(activity, host);
+        app.world_mut()
+            .resource_mut::<crate::ui::AddressBarFocus>()
+            .0 = Some(host);
+        (app, host)
+    }
+
+    #[test]
+    fn blur_clears_focus_when_active_pane_is_not_the_focused_host() {
+        use bevy::ecs::system::RunSystemOnce;
+        let (mut app, _active_host) = focused_app_on_active_host();
+        // Focus a DIFFERENT host than the active pane's host.
+        let other_host = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .resource_mut::<crate::ui::AddressBarFocus>()
+            .0 = Some(other_host);
+
+        app.world_mut()
+            .run_system_once(blur_address_bar_on_focus_leave)
+            .unwrap();
+
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            None,
+            "the bar blurs when the active pane is not the focused host"
+        );
+    }
+
+    #[test]
+    fn blur_clears_focus_on_left_click_outside_bar() {
+        use bevy::ecs::system::RunSystemOnce;
+        let (mut app, _host) = focused_app_on_active_host();
+        app.world_mut()
+            .resource_mut::<ButtonInput<MouseButton>>()
+            .press(MouseButton::Left);
+
+        app.world_mut()
+            .run_system_once(blur_address_bar_on_focus_leave)
+            .unwrap();
+
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            None,
+            "a left-click outside any address bar blurs the bar"
+        );
+    }
+
+    #[test]
+    fn blur_keeps_focus_when_clicking_the_bar() {
+        use bevy::ecs::system::RunSystemOnce;
+        let (mut app, host) = focused_app_on_active_host();
+        app.world_mut()
+            .spawn((crate::ui::AddrBarText(host), Interaction::Pressed));
+        app.world_mut()
+            .resource_mut::<ButtonInput<MouseButton>>()
+            .press(MouseButton::Left);
+
+        app.world_mut()
+            .run_system_once(blur_address_bar_on_focus_leave)
+            .unwrap();
+
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            Some(host),
+            "clicking the address bar itself does not blur it"
+        );
+    }
+
+    #[test]
+    fn blur_keeps_focus_when_staying_on_focused_pane() {
+        use bevy::ecs::system::RunSystemOnce;
+        let (mut app, host) = focused_app_on_active_host();
+
+        app.world_mut()
+            .run_system_once(blur_address_bar_on_focus_leave)
+            .unwrap();
+
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            Some(host),
+            "staying on the focused browser pane keeps the bar focused"
         );
     }
 

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -4,12 +4,16 @@
 //! page-webview node — and (in a later phase) a CEF webview attached to the
 //! laid-out page child after host-side omnibox resolution.
 
+use crate::configs::OzmuxConfigsResource;
 use crate::ui::{
     AddrBarText, AddressEdit, BrowserActivityMarker, BrowserNavButton, BrowserPageWebview,
-    BrowserToolbarState, NavAction, PageWebviewOf,
+    BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
 };
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
+use bevy_cef::prelude::*;
+use ozmux_configs::browser::resolve_omnibox_input;
+use ozmux_multiplexer::ActivityKind;
 
 const TOOLBAR_HEIGHT_PX: f32 = 32.0;
 
@@ -65,6 +69,41 @@ fn build_browser_chrome(
     }
 }
 
+/// Attaches the CEF page webview to a laid-out page-webview child once its own
+/// `ComputedNode` is real, seeding `WebviewSize` from the child (not the host)
+/// so CEF is created at the final page size — no mid-load resize.
+fn attach_browser_webview(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<WebviewUiMaterial>>,
+    configs: Res<OzmuxConfigsResource>,
+    pages: Query<(Entity, &ComputedNode, &PageWebviewOf), Without<WebviewSource>>,
+    hosts: Query<&HostActivityEntity>,
+    kinds: Query<&ActivityKind>,
+) {
+    for (page, computed, owner) in pages.iter() {
+        let size = computed.size() * computed.inverse_scale_factor();
+        if size.x < 1.0 || size.y < 1.0 {
+            continue;
+        }
+        let Ok(host_activity) = hosts.get(owner.0) else {
+            continue;
+        };
+        let Ok(ActivityKind::Browser { initial_url, .. }) = kinds.get(host_activity.0) else {
+            continue;
+        };
+        let raw = initial_url.as_deref().unwrap_or("");
+        let resolved = resolve_omnibox_input(raw, &configs.browser.search_template);
+        if resolved.is_empty() {
+            continue;
+        }
+        commands.entity(page).insert((
+            WebviewSource::new(resolved),
+            WebviewSize(size),
+            MaterialNode(materials.add(WebviewUiMaterial::default())),
+        ));
+    }
+}
+
 fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, label: &str) -> Entity {
     commands
         .spawn((
@@ -89,7 +128,6 @@ mod tests {
     use super::*;
     use bevy::asset::AssetPlugin;
     use bevy::image::ImagePlugin;
-    use bevy_cef::prelude::*;
     use ozmux_multiplexer::MultiplexerPlugin;
 
     fn make_test_app() -> App {
@@ -98,7 +136,8 @@ mod tests {
             .add_plugins(AssetPlugin::default())
             .add_plugins(ImagePlugin::default())
             .add_plugins(MultiplexerPlugin)
-            .init_asset::<WebviewUiMaterial>();
+            .init_asset::<WebviewUiMaterial>()
+            .insert_resource(crate::configs::OzmuxConfigsResource(ozmux_configs::OzmuxConfigs::default()));
         app
     }
 
@@ -130,5 +169,63 @@ mod tests {
         app.update();
         let second = app.world().get::<BrowserPageWebview>(host).unwrap().0;
         assert_eq!(first, second, "chrome built exactly once");
+    }
+
+    #[test]
+    fn attach_resolves_omnibox_and_seeds_child_size() {
+        use crate::ui::HostActivityEntity;
+        use ozmux_multiplexer::ActivityKind;
+        let mut app = make_test_app();
+        app.add_systems(Update, (build_browser_chrome, attach_browser_webview).chain());
+
+        let activity = app
+            .world_mut()
+            .spawn(ActivityKind::Browser { initial_url: Some("github.com".into()), profile: Default::default() })
+            .id();
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, HostActivityEntity(activity), laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        // NOTE: first tick builds chrome; attach is a no-op until the page child is laid out.
+        app.update();
+
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+        app.world_mut().entity_mut(page).insert(laid_out_node(Vec2::new(800.0, 568.0)));
+        // NOTE: page child now has a ComputedNode, so attach fires this tick.
+        app.update();
+
+        match app.world().get::<WebviewSource>(page) {
+            Some(WebviewSource::Url(url)) => assert_eq!(url, "https://github.com"),
+            other => panic!("expected resolved Url, got {other:?}"),
+        }
+        assert_eq!(
+            app.world().get::<WebviewSize>(page).map(|s| s.0),
+            Some(Vec2::new(800.0, 568.0)),
+            "webview seeded at the CHILD's laid-out size, not the host's"
+        );
+    }
+
+    #[test]
+    fn attach_skips_empty_input() {
+        use crate::ui::HostActivityEntity;
+        use ozmux_multiplexer::ActivityKind;
+        let mut app = make_test_app();
+        app.add_systems(Update, (build_browser_chrome, attach_browser_webview).chain());
+        let activity = app
+            .world_mut()
+            .spawn(ActivityKind::Browser { initial_url: None, profile: Default::default() })
+            .id();
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, HostActivityEntity(activity), laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update();
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+        app.world_mut().entity_mut(page).insert(laid_out_node(Vec2::new(800.0, 568.0)));
+        app.update();
+        assert!(
+            app.world().get::<WebviewSource>(page).is_none(),
+            "empty initial_url resolves to empty; no webview attached"
+        );
     }
 }

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -16,7 +16,7 @@ use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
-use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
+use bevy::window::{CursorIcon, Ime, PrimaryWindow, SystemCursorIcon};
 use bevy_cef::prelude::*;
 use ozmux_configs::browser::resolve_omnibox_input;
 use ozmux_multiplexer::{ActivityKind, AttachedSession, MultiplexerCommands, SessionMarker};
@@ -48,6 +48,7 @@ impl Plugin for OzmuxBrowserRenderPlugin {
                         .before(crate::input::dispatch_focused_key)
                         .run_if(address_bar_is_focused),
                     browser_address_editor.after(crate::input::dispatch_focused_key),
+                    apply_ime_to_address_bar,
                 ),
             );
     }
@@ -129,6 +130,7 @@ fn attach_browser_webview(
     pages: Query<(Entity, &ComputedNode, &PageWebviewOf), Without<WebviewSource>>,
     hosts: Query<&HostActivityEntity>,
     kinds: Query<&ActivityKind>,
+    mut states: Query<&mut BrowserToolbarState>,
 ) {
     for (page, computed, owner) in pages.iter() {
         let size = computed.size() * computed.inverse_scale_factor();
@@ -145,6 +147,13 @@ fn attach_browser_webview(
         let resolved = resolve_omnibox_input(raw, &configs.browser.search_template);
         if resolved.is_empty() {
             continue;
+        }
+        // Seed the toolbar URL so the bar isn't blank (or caret-only on early
+        // focus) until CEF fires its first AddressChanged.
+        if let Ok(mut state) = states.get_mut(owner.0)
+            && state.url.is_empty()
+        {
+            state.url = resolved.clone();
         }
         commands.entity(page).insert((
             WebviewSource::new(resolved),
@@ -354,6 +363,7 @@ fn browser_address_editor(
     mut events: MessageReader<KeyboardInput>,
     configs: Res<OzmuxConfigsResource>,
     keys: Res<ButtonInput<KeyCode>>,
+    ime_state: Res<crate::input::ime::ImeState>,
     mut clipboard: Option<ResMut<Clipboard>>,
     mut hosts: Query<(&mut AddressEdit, &BrowserPageWebview)>,
 ) {
@@ -370,8 +380,26 @@ fn browser_address_editor(
         if ev.state != ButtonState::Pressed {
             continue;
         }
+        // NOTE: while an IME composition is active the OS owns the keystrokes;
+        // the committed text arrives via `apply_ime_to_address_bar`. Skipping
+        // raw keys here prevents inserting pre-composition ASCII on platforms
+        // that still deliver `KeyboardInput` during composition.
+        if ime_state.is_composing() {
+            continue;
+        }
         let cmd = keys.pressed(KeyCode::SuperLeft) || keys.pressed(KeyCode::SuperRight);
-        if cmd && matches!(&ev.logical_key, Key::Character(s) if s.eq_ignore_ascii_case("v")) {
+        let ctrl = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
+        let shift = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+        let alt = keys.pressed(KeyCode::AltLeft) || keys.pressed(KeyCode::AltRight);
+        // NOTE: strict Cmd+v paste (lowercase, no other modifiers), matching the
+        // terminal's `is_paste_chord` — Shift+Cmd+V is not a paste shortcut, so
+        // the same chord must not diverge between the address bar and a terminal.
+        if cmd
+            && !ctrl
+            && !shift
+            && !alt
+            && matches!(&ev.logical_key, Key::Character(s) if s.as_str() == "v")
+        {
             if let Some(clip) = clipboard.as_mut()
                 && let Some(text) = clip.read()
             {
@@ -380,7 +408,6 @@ fn browser_address_editor(
             }
             continue;
         }
-        let ctrl = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
         if cmd || ctrl {
             continue;
         }
@@ -413,6 +440,31 @@ fn browser_address_editor(
                 }
             }
             _ => {}
+        }
+    }
+}
+
+/// Routes IME-committed text (`Ime::Commit`) into the focused address bar's edit
+/// buffer. The OS candidate window shows the preedit (anchored by
+/// `ime_policy_system`); on commit the text is inserted here. CJK input into the
+/// URL/search bar would otherwise be lost, since `read_ime_events` forwards
+/// commits to the active terminal, which a browser pane has none of.
+fn apply_ime_to_address_bar(
+    mut events: MessageReader<Ime>,
+    focus: Res<AddressBarFocus>,
+    mut edits: Query<&mut AddressEdit>,
+) {
+    let Some(host) = focus.0 else {
+        events.clear();
+        return;
+    };
+    let Ok(mut edit) = edits.get_mut(host) else {
+        events.clear();
+        return;
+    };
+    for ev in events.read() {
+        if let Ime::Commit { value, .. } = ev {
+            insert_str(&mut edit, value);
         }
     }
 }
@@ -1019,6 +1071,35 @@ mod tests {
     }
 
     #[test]
+    fn ime_commit_inserts_into_focused_address_bar() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let mut app = App::new();
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.add_message::<Ime>();
+        let host = app.world_mut().spawn(AddressEdit::default()).id();
+        app.world_mut()
+            .resource_mut::<crate::ui::AddressBarFocus>()
+            .0 = Some(host);
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .write(Ime::Commit {
+                window: Entity::PLACEHOLDER,
+                value: "こんにちは".into(),
+            });
+
+        app.world_mut()
+            .run_system_once(apply_ime_to_address_bar)
+            .unwrap();
+
+        assert_eq!(
+            app.world().get::<AddressEdit>(host).unwrap().buffer,
+            "こんにちは",
+            "Ime::Commit must be inserted into the focused address bar's buffer"
+        );
+    }
+
+    #[test]
     fn address_text_follows_toolbar_state_when_unfocused() {
         let mut app = make_test_app();
         app.init_resource::<crate::ui::AddressBarFocus>();
@@ -1157,6 +1238,7 @@ mod tests {
     fn editor_ignores_text_when_cmd_held() {
         let mut app = make_test_app();
         app.init_resource::<crate::ui::AddressBarFocus>();
+        app.init_resource::<crate::input::ime::ImeState>();
         app.init_resource::<ButtonInput<KeyCode>>();
         app.add_message::<KeyboardInput>();
         app.add_systems(Update, build_browser_chrome);
@@ -1193,6 +1275,7 @@ mod tests {
     fn enter_resolves_and_navigates_then_clears_focus() {
         let mut app = make_test_app();
         app.init_resource::<crate::ui::AddressBarFocus>();
+        app.init_resource::<crate::input::ime::ImeState>();
         app.insert_resource(bevy::input::ButtonInput::<bevy::input::keyboard::KeyCode>::default());
         app.add_message::<KeyboardInput>();
         app.add_systems(Update, build_browser_chrome);

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -1,0 +1,134 @@
+//! Browser activity rendering: a native back/forward/reload + address-bar
+//! toolbar over a `bevy_cef` page webview. The activity host (a column) gets
+//! two persistent, non-`StructuralNode` children built once — a toolbar and a
+//! page-webview node — and (in a later phase) a CEF webview attached to the
+//! laid-out page child after host-side omnibox resolution.
+
+use crate::ui::{
+    AddrBarText, AddressEdit, BrowserActivityMarker, BrowserNavButton, BrowserPageWebview,
+    BrowserToolbarState, NavAction, PageWebviewOf,
+};
+use bevy::prelude::*;
+use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
+
+const TOOLBAR_HEIGHT_PX: f32 = 32.0;
+
+/// Builds the toolbar + empty page-webview children for each laid-out browser
+/// host that has not been built yet (no `BrowserPageWebview` pointer).
+fn build_browser_chrome(
+    mut commands: Commands,
+    hosts: Query<
+        (Entity, &ComputedNode),
+        (With<BrowserActivityMarker>, Without<BrowserPageWebview>),
+    >,
+) {
+    for (host, computed) in hosts.iter() {
+        if computed.size().x < 1.0 || computed.size().y < 1.0 {
+            continue;
+        }
+
+        let back = spawn_nav_button(&mut commands, host, NavAction::Back, "<");
+        let forward = spawn_nav_button(&mut commands, host, NavAction::Forward, ">");
+        let reload = spawn_nav_button(&mut commands, host, NavAction::Reload, "R");
+        let addr = commands
+            .spawn((Text::new(""), AddrBarText, Node { flex_grow: 1.0, ..default() }))
+            .id();
+
+        let toolbar = commands
+            .spawn((
+                Node {
+                    width: Val::Percent(100.0),
+                    height: Val::Px(TOOLBAR_HEIGHT_PX),
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::FlexStart,
+                    ..default()
+                },
+                ChildOf(host),
+            ))
+            .id();
+        commands.entity(toolbar).add_children(&[back, forward, reload, addr]);
+
+        let page = commands
+            .spawn((
+                Node { flex_grow: 1.0, width: Val::Percent(100.0), ..default() },
+                PageWebviewOf(host),
+                ChildOf(host),
+            ))
+            .id();
+
+        commands.entity(host).insert((
+            BrowserPageWebview(page),
+            BrowserToolbarState::default(),
+            AddressEdit::default(),
+        ));
+    }
+}
+
+fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, label: &str) -> Entity {
+    commands
+        .spawn((
+            Button,
+            Node {
+                width: Val::Px(28.0),
+                height: Val::Px(28.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
+            BrowserNavButton { host, action },
+        ))
+        .with_children(|p| {
+            p.spawn(Text::new(label.to_string()));
+        })
+        .id()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::asset::AssetPlugin;
+    use bevy::image::ImagePlugin;
+    use bevy_cef::prelude::*;
+    use ozmux_multiplexer::MultiplexerPlugin;
+
+    fn make_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(AssetPlugin::default())
+            .add_plugins(ImagePlugin::default())
+            .add_plugins(MultiplexerPlugin)
+            .init_asset::<WebviewUiMaterial>();
+        app
+    }
+
+    fn laid_out_node(size: Vec2) -> ComputedNode {
+        ComputedNode { size, inverse_scale_factor: 1.0, ..ComputedNode::DEFAULT }
+    }
+
+    #[test]
+    fn build_chrome_spawns_toolbar_and_empty_page_child() {
+        let mut app = make_test_app();
+        app.add_systems(Update, build_browser_chrome);
+        let host = app.world_mut().spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0)))).id();
+        app.update();
+
+        let page = app.world().get::<BrowserPageWebview>(host).expect("host gets BrowserPageWebview").0;
+        assert!(app.world().get::<WebviewSource>(page).is_none(), "page child must be an empty Node (no webview yet)");
+        assert_eq!(app.world().get::<PageWebviewOf>(page).map(|p| p.0), Some(host), "page child points back to host");
+        assert!(app.world().get::<BrowserToolbarState>(host).is_some());
+        assert!(app.world().get::<AddressEdit>(host).is_some());
+    }
+
+    #[test]
+    fn build_chrome_is_idempotent() {
+        let mut app = make_test_app();
+        app.add_systems(Update, build_browser_chrome);
+        let host = app.world_mut().spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0)))).id();
+        app.update();
+        let first = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+        app.update();
+        let second = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+        assert_eq!(first, second, "chrome built exactly once");
+    }
+}

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -37,6 +37,8 @@ impl Plugin for OzmuxBrowserRenderPlugin {
                     attach_browser_webview.in_set(OzmuxSystems::SetupActivity),
                     render_address_text,
                     drive_nav_buttons,
+                    sync_nav_button_enabled,
+                    focus_address_bar_on_click,
                     focus_address_bar_on_cmd_l.before(crate::input::dispatch_focused_key),
                     browser_address_editor.after(crate::input::dispatch_focused_key),
                 ),
@@ -63,8 +65,9 @@ fn build_browser_chrome(
         let reload = spawn_nav_button(&mut commands, host, NavAction::Reload, "R");
         let addr = commands
             .spawn((
+                Button,
                 Text::new(""),
-                AddrBarText,
+                AddrBarText(host),
                 Node {
                     flex_grow: 1.0,
                     ..default()
@@ -182,34 +185,59 @@ fn on_loading_state_changed(
 /// owns address-bar focus) or its toolbar-state URL (when unfocused).
 fn render_address_text(
     focus: Res<AddressBarFocus>,
-    hosts: Query<(Entity, &BrowserToolbarState, &AddressEdit), With<BrowserActivityMarker>>,
-    children: Query<&Children>,
-    mut texts: Query<&mut Text, With<AddrBarText>>,
+    hosts: Query<(&BrowserToolbarState, &AddressEdit)>,
+    mut texts: Query<(&AddrBarText, &mut Text)>,
 ) {
-    for (host, state, edit) in hosts.iter() {
+    for (addr, mut text) in texts.iter_mut() {
+        let host = addr.0;
+        let Ok((state, edit)) = hosts.get(host) else {
+            continue;
+        };
         let display = if focus.0 == Some(host) {
-            edit.buffer.clone()
+            render_with_caret(&edit.buffer, edit.caret)
         } else {
             state.url.clone()
         };
-        for descendant in descendants(host, &children) {
-            if let Ok(mut text) = texts.get_mut(descendant)
-                && text.0 != display
-            {
-                text.0 = display.clone();
-            }
+        if text.0 != display {
+            text.0 = display;
         }
     }
 }
 
-/// Routes toolbar button presses to `bevy_cef` navigation requests.
+/// Renders the edit buffer with a `|` caret inserted at the char index `caret`.
+fn render_with_caret(buffer: &str, caret: usize) -> String {
+    let chars: Vec<char> = buffer.chars().collect();
+    let at = caret.min(chars.len());
+    let mut s: String = chars[..at].iter().collect();
+    s.push('|');
+    s.extend(chars[at..].iter());
+    s
+}
+
+/// Routes toolbar button presses to `bevy_cef` navigation requests, skipping
+/// Back/Forward when the host state indicates they are unavailable.
 fn drive_nav_buttons(
     mut commands: Commands,
     buttons: Query<(&Interaction, &BrowserNavButton), Changed<Interaction>>,
     pages: Query<&BrowserPageWebview>,
+    states: Query<&BrowserToolbarState>,
 ) {
     for (interaction, button) in buttons.iter() {
         if *interaction != Interaction::Pressed {
+            continue;
+        }
+        let enabled = match button.action {
+            NavAction::Back => states
+                .get(button.host)
+                .map(|s| s.can_go_back)
+                .unwrap_or(false),
+            NavAction::Forward => states
+                .get(button.host)
+                .map(|s| s.can_go_forward)
+                .unwrap_or(false),
+            NavAction::Reload => true,
+        };
+        if !enabled {
             continue;
         }
         let Ok(page) = pages.get(button.host) else {
@@ -224,20 +252,32 @@ fn drive_nav_buttons(
     }
 }
 
-/// Depth-first descendants of `root` (excluding `root`).
-fn descendants(root: Entity, children: &Query<&Children>) -> Vec<Entity> {
-    let mut out = Vec::new();
-    let mut stack: Vec<Entity> = children
-        .get(root)
-        .map(|c| c.iter().collect())
-        .unwrap_or_default();
-    while let Some(e) = stack.pop() {
-        out.push(e);
-        if let Ok(c) = children.get(e) {
-            stack.extend(c.iter());
+/// Dims the back/forward buttons when navigation in that direction is unavailable.
+fn sync_nav_button_enabled(
+    states: Query<&BrowserToolbarState>,
+    mut buttons: Query<(&BrowserNavButton, &mut BackgroundColor)>,
+) {
+    for (button, mut bg) in buttons.iter_mut() {
+        let enabled = match button.action {
+            NavAction::Back => states
+                .get(button.host)
+                .map(|s| s.can_go_back)
+                .unwrap_or(false),
+            NavAction::Forward => states
+                .get(button.host)
+                .map(|s| s.can_go_forward)
+                .unwrap_or(false),
+            NavAction::Reload => true,
+        };
+        let color = if enabled {
+            Color::srgb(0.3, 0.3, 0.3)
+        } else {
+            Color::srgb(0.15, 0.15, 0.15)
+        };
+        if bg.0 != color {
+            bg.0 = color;
         }
     }
-    out
 }
 
 fn spawn_nav_button(
@@ -256,6 +296,7 @@ fn spawn_nav_button(
                 justify_content: JustifyContent::Center,
                 ..default()
             },
+            BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
             BrowserNavButton { host, action },
         ))
         .with_children(|p| {
@@ -333,6 +374,26 @@ fn browser_address_editor(
             }
             _ => {}
         }
+    }
+}
+
+/// Clicking the address bar focuses it (seeding the buffer from the current URL).
+fn focus_address_bar_on_click(
+    mut focus: ResMut<AddressBarFocus>,
+    clicked: Query<(&Interaction, &AddrBarText), Changed<Interaction>>,
+    mut edits: Query<(&mut AddressEdit, &BrowserToolbarState)>,
+) {
+    for (interaction, addr) in clicked.iter() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        let host = addr.0;
+        let Ok((mut edit, state)) = edits.get_mut(host) else {
+            continue;
+        };
+        edit.buffer = state.url.clone();
+        edit.caret = edit.buffer.chars().count();
+        focus.0 = Some(host);
     }
 }
 
@@ -648,6 +709,12 @@ mod tests {
 
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
 
+        // Enable back navigation so drive_nav_buttons permits the press.
+        app.world_mut()
+            .get_mut::<BrowserToolbarState>(host)
+            .unwrap()
+            .can_go_back = true;
+
         // Find the Back button entity.
         let back_btn: Entity = {
             let mut q = app.world_mut().query::<(Entity, &BrowserNavButton)>();
@@ -893,6 +960,118 @@ mod tests {
             app.world().resource::<crate::ui::AddressBarFocus>().0,
             None,
             "Enter clears focus"
+        );
+    }
+
+    #[test]
+    fn render_with_caret_inserts_pipe_at_position() {
+        assert_eq!(super::render_with_caret("abc", 1), "a|bc");
+        assert_eq!(super::render_with_caret("abc", 3), "abc|");
+        assert_eq!(super::render_with_caret("", 0), "|");
+    }
+
+    #[test]
+    fn click_address_bar_focuses_and_seeds_buffer() {
+        let mut app = make_test_app();
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.add_systems(
+            Update,
+            (build_browser_chrome, focus_address_bar_on_click).chain(),
+        );
+
+        let host = app
+            .world_mut()
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
+            .id();
+        app.update(); // build chrome
+
+        app.world_mut()
+            .get_mut::<BrowserToolbarState>(host)
+            .unwrap()
+            .url = "https://x.com".into();
+
+        let addr_btn: Entity = {
+            let mut q = app.world_mut().query::<(Entity, &AddrBarText)>();
+            q.iter(app.world())
+                .find(|(_, a)| a.0 == host)
+                .map(|(e, _)| e)
+                .expect("AddrBarText button must exist for host")
+        };
+
+        app.world_mut()
+            .entity_mut(addr_btn)
+            .insert(Interaction::Pressed);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            Some(host),
+            "clicking address bar must set focus to the host"
+        );
+        assert_eq!(
+            app.world().get::<AddressEdit>(host).unwrap().buffer,
+            "https://x.com",
+            "buffer must be seeded from toolbar state URL"
+        );
+    }
+
+    #[test]
+    fn back_button_disabled_when_cannot_go_back() {
+        let mut app = make_test_app();
+        app.init_resource::<Captured>();
+        app.add_systems(Update, (build_browser_chrome, drive_nav_buttons).chain());
+        app.add_observer(|ev: On<RequestGoBack>, mut r: ResMut<Captured>| {
+            r.0.push(ev.webview);
+        });
+
+        let host = app
+            .world_mut()
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
+            .id();
+        app.update(); // build chrome
+
+        // can_go_back is false by default; verify no event fires on press.
+        let back_btn: Entity = {
+            let mut q = app.world_mut().query::<(Entity, &BrowserNavButton)>();
+            q.iter(app.world())
+                .find(|(_, b)| b.action == NavAction::Back && b.host == host)
+                .map(|(e, _)| e)
+                .expect("back button must exist")
+        };
+
+        app.world_mut()
+            .entity_mut(back_btn)
+            .insert(Interaction::Pressed);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Captured>().0,
+            vec![],
+            "RequestGoBack must NOT fire when can_go_back is false"
+        );
+
+        // Now enable back navigation and verify the event fires.
+        app.world_mut()
+            .get_mut::<BrowserToolbarState>(host)
+            .unwrap()
+            .can_go_back = true;
+
+        app.world_mut()
+            .entity_mut(back_btn)
+            .insert(Interaction::Pressed);
+        app.update();
+
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+        assert_eq!(
+            app.world().resource::<Captured>().0,
+            vec![page],
+            "RequestGoBack must fire when can_go_back is true"
         );
     }
 }

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -6,8 +6,8 @@
 
 use crate::configs::OzmuxConfigsResource;
 use crate::ui::{
-    AddrBarText, AddressEdit, BrowserActivityMarker, BrowserNavButton, BrowserPageWebview,
-    BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
+    AddrBarText, AddressBarFocus, AddressEdit, BrowserActivityMarker, BrowserNavButton,
+    BrowserPageWebview, BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
 };
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
@@ -136,6 +136,68 @@ fn on_loading_state_changed(
     state.is_loading = ev.is_loading;
     state.can_go_back = ev.can_go_back;
     state.can_go_forward = ev.can_go_forward;
+}
+
+/// Renders each address-bar `Text` from its host's edit buffer (when that host
+/// owns address-bar focus) or its toolbar-state URL (when unfocused).
+fn render_address_text(
+    focus: Res<AddressBarFocus>,
+    hosts: Query<(Entity, &BrowserToolbarState, &AddressEdit), With<BrowserActivityMarker>>,
+    children: Query<&Children>,
+    mut texts: Query<&mut Text, With<AddrBarText>>,
+) {
+    for (host, state, edit) in hosts.iter() {
+        let display = if focus.0 == Some(host) {
+            edit.buffer.clone()
+        } else {
+            state.url.clone()
+        };
+        for descendant in descendants(host, &children) {
+            if let Ok(mut text) = texts.get_mut(descendant) {
+                if text.0 != display {
+                    text.0 = display.clone();
+                }
+            }
+        }
+    }
+}
+
+/// Routes toolbar button presses to `bevy_cef` navigation requests.
+fn drive_nav_buttons(
+    mut commands: Commands,
+    buttons: Query<(&Interaction, &BrowserNavButton), Changed<Interaction>>,
+    pages: Query<&BrowserPageWebview>,
+) {
+    for (interaction, button) in buttons.iter() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        let Ok(page) = pages.get(button.host) else {
+            continue;
+        };
+        let webview = page.0;
+        match button.action {
+            NavAction::Back => commands.trigger(RequestGoBack { webview }),
+            NavAction::Forward => commands.trigger(RequestGoForward { webview }),
+            NavAction::Reload => commands.trigger(RequestReload { webview }),
+        }
+    }
+}
+
+/// Depth-first descendants of `root` (excluding `root`).
+fn descendants(root: Entity, children: &Query<&Children>) -> Vec<Entity> {
+    let mut out = Vec::new();
+    let mut stack: Vec<Entity> = children
+        .get(root)
+        .map(|c| c.iter().collect())
+        .unwrap_or_default();
+    while let Some(e) = stack.pop() {
+        out.push(e);
+        if let Ok(c) = children.get(e) {
+            stack.extend(c.iter());
+        }
+    }
+    out
 }
 
 fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, label: &str) -> Entity {
@@ -289,6 +351,67 @@ mod tests {
         assert!(state.is_loading);
         assert!(!state.can_go_back);
         assert!(state.can_go_forward);
+    }
+
+    #[derive(Resource, Default)]
+    struct Captured(Vec<Entity>);
+
+    #[test]
+    fn back_button_press_triggers_request_go_back() {
+        let mut app = make_test_app();
+        app.init_resource::<Captured>();
+        app.add_systems(Update, (build_browser_chrome, drive_nav_buttons).chain());
+        app.add_observer(|ev: On<RequestGoBack>, mut r: ResMut<Captured>| {
+            r.0.push(ev.webview);
+        });
+
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update(); // build chrome
+
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+
+        // Find the Back button entity.
+        let back_btn: Entity = {
+            let mut q = app.world_mut().query::<(Entity, &BrowserNavButton)>();
+            q.iter(app.world())
+                .find(|(_, b)| b.action == NavAction::Back && b.host == host)
+                .map(|(e, _)| e)
+                .expect("back button must exist")
+        };
+
+        // Simulate a press by inserting Interaction::Pressed.
+        app.world_mut().entity_mut(back_btn).insert(Interaction::Pressed);
+        app.update();
+
+        let captured = app.world().resource::<Captured>();
+        assert_eq!(captured.0, vec![page], "RequestGoBack must fire with the page webview");
+    }
+
+    #[test]
+    fn address_text_follows_toolbar_state_when_unfocused() {
+        let mut app = make_test_app();
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.add_systems(Update, (build_browser_chrome, render_address_text).chain());
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update(); // build chrome + render (empty url)
+        app.world_mut().get_mut::<BrowserToolbarState>(host).unwrap().url =
+            "https://example.com".into();
+        app.update(); // render picks up the new url
+
+        let mut found: Option<String> = None;
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Text, With<crate::ui::AddrBarText>>();
+        for text in q.iter(app.world()) {
+            found = Some(text.0.clone());
+        }
+        assert_eq!(found.as_deref(), Some("https://example.com"));
     }
 
     #[test]

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -16,6 +16,7 @@ use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
 use bevy_cef::prelude::*;
 use ozmux_configs::browser::resolve_omnibox_input;
 use ozmux_multiplexer::{ActivityKind, AttachedSession, MultiplexerCommands, SessionMarker};
@@ -39,6 +40,7 @@ impl Plugin for OzmuxBrowserRenderPlugin {
                     render_address_text,
                     drive_nav_buttons,
                     sync_nav_button_enabled,
+                    nav_button_hover_cursor.after(crate::input::InputPhase::Hover),
                     focus_address_bar_on_click,
                     focus_address_bar_on_cmd_l.before(crate::input::dispatch_focused_key),
                     browser_address_editor.after(crate::input::dispatch_focused_key),
@@ -289,6 +291,28 @@ fn sync_nav_button_enabled(
                 tc.0 = glyph;
             }
         }
+    }
+}
+
+/// Shows a pointer cursor while the mouse hovers any nav button, so the
+/// back/forward/reload buttons read as clickable. Runs after `InputPhase::Hover`
+/// so it wins over the hyperlink system's per-frame `Text` write over the
+/// browser pane; leaving a button reverts to `Text` when that system re-asserts.
+fn nav_button_hover_cursor(
+    buttons: Query<&Interaction, With<BrowserNavButton>>,
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+) {
+    let hovering = buttons
+        .iter()
+        .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
+    if !hovering {
+        return;
+    }
+    let Ok(mut icon) = cursor_icons.single_mut() else {
+        return;
+    };
+    if !matches!(&*icon, CursorIcon::System(e) if *e == SystemCursorIcon::Pointer) {
+        *icon = CursorIcon::System(SystemCursorIcon::Pointer);
     }
 }
 
@@ -804,6 +828,47 @@ mod tests {
             glyph(&mut app, NavAction::Forward),
             palette::MUTED,
             "disabled forward glyph is muted (MUTED)"
+        );
+    }
+
+    #[test]
+    fn nav_button_hover_sets_pointer_cursor() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let mut world = World::new();
+        let window = world
+            .spawn((PrimaryWindow, CursorIcon::System(SystemCursorIcon::Text)))
+            .id();
+        let host = world.spawn_empty().id();
+        let button = world
+            .spawn((
+                BrowserNavButton {
+                    host,
+                    action: NavAction::Back,
+                },
+                Interaction::Hovered,
+            ))
+            .id();
+
+        world.run_system_once(nav_button_hover_cursor).unwrap();
+        assert!(
+            matches!(
+                world.get::<CursorIcon>(window),
+                Some(CursorIcon::System(SystemCursorIcon::Pointer))
+            ),
+            "hovering a nav button sets the pointer cursor"
+        );
+
+        // Not hovering: the system no-ops, leaving the cursor as the hover phase set it.
+        *world.get_mut::<Interaction>(button).unwrap() = Interaction::None;
+        *world.get_mut::<CursorIcon>(window).unwrap() = CursorIcon::System(SystemCursorIcon::Text);
+        world.run_system_once(nav_button_hover_cursor).unwrap();
+        assert!(
+            matches!(
+                world.get::<CursorIcon>(window),
+                Some(CursorIcon::System(SystemCursorIcon::Text))
+            ),
+            "no hovered button leaves the cursor unchanged"
         );
     }
 

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -4,16 +4,19 @@
 //! page-webview node — and (in a later phase) a CEF webview attached to the
 //! laid-out page child after host-side omnibox resolution.
 
+use crate::clipboard::Clipboard;
 use crate::configs::OzmuxConfigsResource;
 use crate::ui::{
     AddrBarText, AddressBarFocus, AddressEdit, BrowserActivityMarker, BrowserNavButton,
     BrowserPageWebview, BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
 };
+use bevy::input::ButtonState;
+use bevy::input::keyboard::{Key, KeyboardInput, KeyCode};
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
 use bevy_cef::prelude::*;
 use ozmux_configs::browser::resolve_omnibox_input;
-use ozmux_multiplexer::ActivityKind;
+use ozmux_multiplexer::{ActivityKind, AttachedSession, MultiplexerCommands, SessionMarker};
 
 const TOOLBAR_HEIGHT_PX: f32 = 32.0;
 
@@ -219,6 +222,108 @@ fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, la
         .id()
 }
 
+/// Applies keyboard input to the focused browser host's address-bar buffer.
+/// Enter resolves the omnibox and navigates the page webview, then blurs; Esc
+/// blurs without navigating.
+fn browser_address_editor(
+    mut commands: Commands,
+    mut focus: ResMut<AddressBarFocus>,
+    mut events: MessageReader<KeyboardInput>,
+    configs: Res<OzmuxConfigsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    mut clipboard: Option<ResMut<Clipboard>>,
+    mut hosts: Query<(&mut AddressEdit, &BrowserPageWebview)>,
+) {
+    let Some(host) = focus.0 else {
+        events.clear();
+        return;
+    };
+    let Ok((mut edit, page)) = hosts.get_mut(host) else {
+        focus.0 = None;
+        events.clear();
+        return;
+    };
+    for ev in events.read() {
+        if ev.state != ButtonState::Pressed {
+            continue;
+        }
+        let cmd = keys.pressed(KeyCode::SuperLeft) || keys.pressed(KeyCode::SuperRight);
+        if cmd && matches!(&ev.logical_key, Key::Character(s) if s.eq_ignore_ascii_case("v")) {
+            if let Some(clip) = clipboard.as_mut() {
+                if let Some(text) = clip.read() {
+                    let one_line: String = text.split(['\n', '\r']).collect();
+                    insert_str(&mut edit, &one_line);
+                }
+            }
+            continue;
+        }
+        match &ev.logical_key {
+            Key::Enter => {
+                let url = resolve_omnibox_input(&edit.buffer, &configs.browser.search_template);
+                if !url.is_empty() {
+                    commands.trigger(RequestNavigate { webview: page.0, url });
+                }
+                focus.0 = None;
+                return;
+            }
+            Key::Escape => {
+                focus.0 = None;
+                return;
+            }
+            Key::Backspace => backspace(&mut edit),
+            Key::Delete => delete(&mut edit),
+            Key::ArrowLeft => caret_left(&mut edit),
+            Key::ArrowRight => caret_right(&mut edit),
+            Key::Home => caret_home(&mut edit),
+            Key::End => caret_end(&mut edit),
+            Key::Space => insert_char(&mut edit, ' '),
+            Key::Character(s) => {
+                for c in s.chars() {
+                    insert_char(&mut edit, c);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// `Cmd+L` focuses the active browser pane's address bar (browser convention).
+fn focus_address_bar_on_cmd_l(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut focus: ResMut<AddressBarFocus>,
+    mux: MultiplexerCommands,
+    attached: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
+    registry: Res<crate::ui::registry::ActivityEntityRegistry>,
+    browser_hosts: Query<(), With<BrowserActivityMarker>>,
+    mut edits: Query<(&mut AddressEdit, &BrowserToolbarState)>,
+) {
+    let cmd = keys.pressed(KeyCode::SuperLeft) || keys.pressed(KeyCode::SuperRight);
+    if !(cmd && keys.just_pressed(KeyCode::KeyL)) {
+        return;
+    }
+    let Some(session) = attached.iter().next() else {
+        return;
+    };
+    let Some(pane) = mux.sessions_active_pane(session) else {
+        return;
+    };
+    let Some(activity) = mux.panes_active_activity(pane) else {
+        return;
+    };
+    let Some(host) = registry.get(activity) else {
+        return;
+    };
+    if !browser_hosts.contains(host) {
+        return;
+    }
+    let Ok((mut edit, state)) = edits.get_mut(host) else {
+        return;
+    };
+    edit.buffer = state.url.clone();
+    edit.caret = edit.buffer.chars().count();
+    focus.0 = Some(host);
+}
+
 /// Returns the byte offset in `e.buffer` for the character at `idx`.
 fn char_byte(e: &AddressEdit, idx: usize) -> usize {
     e.buffer
@@ -293,6 +398,8 @@ mod tests {
     use super::*;
     use bevy::asset::AssetPlugin;
     use bevy::image::ImagePlugin;
+    use bevy::input::ButtonState;
+    use bevy::input::keyboard::{Key, KeyboardInput, NativeKeyCode};
     use ozmux_multiplexer::MultiplexerPlugin;
 
     fn make_test_app() -> App {
@@ -558,5 +665,65 @@ mod tests {
         assert_eq!(e.caret, 3);
         super::backspace(&mut e); // removes 'b'
         assert_eq!(e.buffer, "aあc");
+    }
+
+    fn key_press(window: Entity, logical: Key) -> KeyboardInput {
+        KeyboardInput {
+            key_code: bevy::input::keyboard::KeyCode::Unidentified(NativeKeyCode::Unidentified),
+            logical_key: logical,
+            state: ButtonState::Pressed,
+            repeat: false,
+            window,
+            text: None,
+        }
+    }
+
+    #[derive(bevy::ecs::resource::Resource, Default)]
+    struct Navigated(Vec<(Entity, String)>);
+
+    #[test]
+    fn enter_resolves_and_navigates_then_clears_focus() {
+        let mut app = make_test_app();
+        app.init_resource::<crate::ui::AddressBarFocus>();
+        app.insert_resource(bevy::input::ButtonInput::<bevy::input::keyboard::KeyCode>::default());
+        app.add_message::<KeyboardInput>();
+        app.add_systems(Update, build_browser_chrome);
+        app.add_systems(Update, browser_address_editor.after(build_browser_chrome));
+
+        let window = app.world_mut().spawn_empty().id();
+        let host = app
+            .world_mut()
+            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .id();
+        app.update();
+        let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
+
+        app.world_mut().resource_mut::<crate::ui::AddressBarFocus>().0 = Some(host);
+        for c in "github.com".chars() {
+            app.world_mut()
+                .resource_mut::<bevy::ecs::message::Messages<KeyboardInput>>()
+                .write(key_press(window, Key::Character(c.to_string().into())));
+        }
+        app.update();
+        assert_eq!(app.world().get::<AddressEdit>(host).unwrap().buffer, "github.com");
+
+        app.init_resource::<Navigated>();
+        app.add_observer(|ev: On<RequestNavigate>, mut n: ResMut<Navigated>| {
+            n.0.push((ev.webview, ev.url.clone()));
+        });
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<KeyboardInput>>()
+            .write(key_press(window, Key::Enter));
+        app.update();
+        app.world_mut().flush();
+
+        let nav = app.world().resource::<Navigated>();
+        assert_eq!(nav.0, vec![(page, "https://github.com".to_string())]);
+        assert_eq!(
+            app.world().resource::<crate::ui::AddressBarFocus>().0,
+            None,
+            "Enter clears focus"
+        );
     }
 }

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -12,7 +12,7 @@ use crate::ui::{
     BrowserPageWebview, BrowserToolbarState, HostActivityEntity, NavAction, PageWebviewOf,
 };
 use bevy::input::ButtonState;
-use bevy::input::keyboard::{Key, KeyboardInput, KeyCode};
+use bevy::input::keyboard::{Key, KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, JustifyContent, Val};
 use bevy_cef::prelude::*;
@@ -62,7 +62,14 @@ fn build_browser_chrome(
         let forward = spawn_nav_button(&mut commands, host, NavAction::Forward, ">");
         let reload = spawn_nav_button(&mut commands, host, NavAction::Reload, "R");
         let addr = commands
-            .spawn((Text::new(""), AddrBarText, Node { flex_grow: 1.0, ..default() }))
+            .spawn((
+                Text::new(""),
+                AddrBarText,
+                Node {
+                    flex_grow: 1.0,
+                    ..default()
+                },
+            ))
             .id();
 
         let toolbar = commands
@@ -78,11 +85,17 @@ fn build_browser_chrome(
                 ChildOf(host),
             ))
             .id();
-        commands.entity(toolbar).add_children(&[back, forward, reload, addr]);
+        commands
+            .entity(toolbar)
+            .add_children(&[back, forward, reload, addr]);
 
         let page = commands
             .spawn((
-                Node { flex_grow: 1.0, width: Val::Percent(100.0), ..default() },
+                Node {
+                    flex_grow: 1.0,
+                    width: Val::Percent(100.0),
+                    ..default()
+                },
                 PageWebviewOf(host),
                 ChildOf(host),
             ))
@@ -180,10 +193,10 @@ fn render_address_text(
             state.url.clone()
         };
         for descendant in descendants(host, &children) {
-            if let Ok(mut text) = texts.get_mut(descendant) {
-                if text.0 != display {
-                    text.0 = display.clone();
-                }
+            if let Ok(mut text) = texts.get_mut(descendant)
+                && text.0 != display
+            {
+                text.0 = display.clone();
             }
         }
     }
@@ -227,7 +240,12 @@ fn descendants(root: Entity, children: &Query<&Children>) -> Vec<Entity> {
     out
 }
 
-fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, label: &str) -> Entity {
+fn spawn_nav_button(
+    commands: &mut Commands,
+    host: Entity,
+    action: NavAction,
+    label: &str,
+) -> Entity {
     commands
         .spawn((
             Button,
@@ -273,11 +291,11 @@ fn browser_address_editor(
         }
         let cmd = keys.pressed(KeyCode::SuperLeft) || keys.pressed(KeyCode::SuperRight);
         if cmd && matches!(&ev.logical_key, Key::Character(s) if s.eq_ignore_ascii_case("v")) {
-            if let Some(clip) = clipboard.as_mut() {
-                if let Some(text) = clip.read() {
-                    let one_line: String = text.split(['\n', '\r']).collect();
-                    insert_str(&mut edit, &one_line);
-                }
+            if let Some(clip) = clipboard.as_mut()
+                && let Some(text) = clip.read()
+            {
+                let one_line: String = text.split(['\n', '\r']).collect();
+                insert_str(&mut edit, &one_line);
             }
             continue;
         }
@@ -289,7 +307,10 @@ fn browser_address_editor(
             Key::Enter => {
                 let url = resolve_omnibox_input(&edit.buffer, &configs.browser.search_template);
                 if !url.is_empty() {
-                    commands.trigger(RequestNavigate { webview: page.0, url });
+                    commands.trigger(RequestNavigate {
+                        webview: page.0,
+                        url,
+                    });
                 }
                 focus.0 = None;
                 return;
@@ -437,24 +458,47 @@ mod tests {
             .add_plugins(ImagePlugin::default())
             .add_plugins(MultiplexerPlugin)
             .init_asset::<WebviewUiMaterial>()
-            .insert_resource(crate::configs::OzmuxConfigsResource(ozmux_configs::OzmuxConfigs::default()));
+            .insert_resource(crate::configs::OzmuxConfigsResource(
+                ozmux_configs::OzmuxConfigs::default(),
+            ));
         app
     }
 
     fn laid_out_node(size: Vec2) -> ComputedNode {
-        ComputedNode { size, inverse_scale_factor: 1.0, ..ComputedNode::DEFAULT }
+        ComputedNode {
+            size,
+            inverse_scale_factor: 1.0,
+            ..ComputedNode::DEFAULT
+        }
     }
 
     #[test]
     fn build_chrome_spawns_toolbar_and_empty_page_child() {
         let mut app = make_test_app();
         app.add_systems(Update, build_browser_chrome);
-        let host = app.world_mut().spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0)))).id();
+        let host = app
+            .world_mut()
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
+            .id();
         app.update();
 
-        let page = app.world().get::<BrowserPageWebview>(host).expect("host gets BrowserPageWebview").0;
-        assert!(app.world().get::<WebviewSource>(page).is_none(), "page child must be an empty Node (no webview yet)");
-        assert_eq!(app.world().get::<PageWebviewOf>(page).map(|p| p.0), Some(host), "page child points back to host");
+        let page = app
+            .world()
+            .get::<BrowserPageWebview>(host)
+            .expect("host gets BrowserPageWebview")
+            .0;
+        assert!(
+            app.world().get::<WebviewSource>(page).is_none(),
+            "page child must be an empty Node (no webview yet)"
+        );
+        assert_eq!(
+            app.world().get::<PageWebviewOf>(page).map(|p| p.0),
+            Some(host),
+            "page child points back to host"
+        );
         assert!(app.world().get::<BrowserToolbarState>(host).is_some());
         assert!(app.world().get::<AddressEdit>(host).is_some());
     }
@@ -463,7 +507,13 @@ mod tests {
     fn build_chrome_is_idempotent() {
         let mut app = make_test_app();
         app.add_systems(Update, build_browser_chrome);
-        let host = app.world_mut().spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0)))).id();
+        let host = app
+            .world_mut()
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
+            .id();
         app.update();
         let first = app.world().get::<BrowserPageWebview>(host).unwrap().0;
         app.update();
@@ -476,21 +526,33 @@ mod tests {
         use crate::ui::HostActivityEntity;
         use ozmux_multiplexer::ActivityKind;
         let mut app = make_test_app();
-        app.add_systems(Update, (build_browser_chrome, attach_browser_webview).chain());
+        app.add_systems(
+            Update,
+            (build_browser_chrome, attach_browser_webview).chain(),
+        );
 
         let activity = app
             .world_mut()
-            .spawn(ActivityKind::Browser { initial_url: Some("github.com".into()), profile: Default::default() })
+            .spawn(ActivityKind::Browser {
+                initial_url: Some("github.com".into()),
+                profile: Default::default(),
+            })
             .id();
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, HostActivityEntity(activity), laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                HostActivityEntity(activity),
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         // NOTE: first tick builds chrome; attach is a no-op until the page child is laid out.
         app.update();
 
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
-        app.world_mut().entity_mut(page).insert(laid_out_node(Vec2::new(800.0, 568.0)));
+        app.world_mut()
+            .entity_mut(page)
+            .insert(laid_out_node(Vec2::new(800.0, 568.0)));
         // NOTE: page child now has a ComputedNode, so attach fires this tick.
         app.update();
 
@@ -512,7 +574,10 @@ mod tests {
         app.add_observer(on_address_changed);
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update();
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
@@ -538,7 +603,10 @@ mod tests {
         app.add_observer(on_loading_state_changed);
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update();
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
@@ -571,7 +639,10 @@ mod tests {
 
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update(); // build chrome
 
@@ -587,11 +658,17 @@ mod tests {
         };
 
         // Simulate a press by inserting Interaction::Pressed.
-        app.world_mut().entity_mut(back_btn).insert(Interaction::Pressed);
+        app.world_mut()
+            .entity_mut(back_btn)
+            .insert(Interaction::Pressed);
         app.update();
 
         let captured = app.world().resource::<Captured>();
-        assert_eq!(captured.0, vec![page], "RequestGoBack must fire with the page webview");
+        assert_eq!(
+            captured.0,
+            vec![page],
+            "RequestGoBack must fire with the page webview"
+        );
     }
 
     #[test]
@@ -601,11 +678,16 @@ mod tests {
         app.add_systems(Update, (build_browser_chrome, render_address_text).chain());
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update(); // build chrome + render (empty url)
-        app.world_mut().get_mut::<BrowserToolbarState>(host).unwrap().url =
-            "https://example.com".into();
+        app.world_mut()
+            .get_mut::<BrowserToolbarState>(host)
+            .unwrap()
+            .url = "https://example.com".into();
         app.update(); // render picks up the new url
 
         let mut found: Option<String> = None;
@@ -623,18 +705,30 @@ mod tests {
         use crate::ui::HostActivityEntity;
         use ozmux_multiplexer::ActivityKind;
         let mut app = make_test_app();
-        app.add_systems(Update, (build_browser_chrome, attach_browser_webview).chain());
+        app.add_systems(
+            Update,
+            (build_browser_chrome, attach_browser_webview).chain(),
+        );
         let activity = app
             .world_mut()
-            .spawn(ActivityKind::Browser { initial_url: None, profile: Default::default() })
+            .spawn(ActivityKind::Browser {
+                initial_url: None,
+                profile: Default::default(),
+            })
             .id();
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, HostActivityEntity(activity), laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                HostActivityEntity(activity),
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update();
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
-        app.world_mut().entity_mut(page).insert(laid_out_node(Vec2::new(800.0, 568.0)));
+        app.world_mut()
+            .entity_mut(page)
+            .insert(laid_out_node(Vec2::new(800.0, 568.0)));
         app.update();
         assert!(
             app.world().get::<WebviewSource>(page).is_none(),
@@ -645,7 +739,10 @@ mod tests {
     use crate::ui::AddressEdit as AE;
 
     fn edit(s: &str, caret: usize) -> AE {
-        AE { buffer: s.into(), caret }
+        AE {
+            buffer: s.into(),
+            caret,
+        }
     }
 
     #[test]
@@ -720,10 +817,15 @@ mod tests {
         let window = app.world_mut().spawn_empty().id();
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update();
-        app.world_mut().resource_mut::<crate::ui::AddressBarFocus>().0 = Some(host);
+        app.world_mut()
+            .resource_mut::<crate::ui::AddressBarFocus>()
+            .0 = Some(host);
 
         app.world_mut()
             .resource_mut::<ButtonInput<KeyCode>>()
@@ -734,7 +836,8 @@ mod tests {
         app.update();
 
         assert_eq!(
-            app.world().get::<AddressEdit>(host).unwrap().buffer, "",
+            app.world().get::<AddressEdit>(host).unwrap().buffer,
+            "",
             "Cmd+<key> must not type into the address bar"
         );
     }
@@ -751,19 +854,27 @@ mod tests {
         let window = app.world_mut().spawn_empty().id();
         let host = app
             .world_mut()
-            .spawn((BrowserActivityMarker, laid_out_node(Vec2::new(800.0, 600.0))))
+            .spawn((
+                BrowserActivityMarker,
+                laid_out_node(Vec2::new(800.0, 600.0)),
+            ))
             .id();
         app.update();
         let page = app.world().get::<BrowserPageWebview>(host).unwrap().0;
 
-        app.world_mut().resource_mut::<crate::ui::AddressBarFocus>().0 = Some(host);
+        app.world_mut()
+            .resource_mut::<crate::ui::AddressBarFocus>()
+            .0 = Some(host);
         for c in "github.com".chars() {
             app.world_mut()
                 .resource_mut::<bevy::ecs::message::Messages<KeyboardInput>>()
                 .write(key_press(window, Key::Character(c.to_string().into())));
         }
         app.update();
-        assert_eq!(app.world().get::<AddressEdit>(host).unwrap().buffer, "github.com");
+        assert_eq!(
+            app.world().get::<AddressEdit>(host).unwrap().buffer,
+            "github.com"
+        );
 
         app.init_resource::<Navigated>();
         app.add_observer(|ev: On<RequestNavigate>, mut n: ResMut<Navigated>| {

--- a/src/browser_render.rs
+++ b/src/browser_render.rs
@@ -219,6 +219,75 @@ fn spawn_nav_button(commands: &mut Commands, host: Entity, action: NavAction, la
         .id()
 }
 
+/// Returns the byte offset in `e.buffer` for the character at `idx`.
+fn char_byte(e: &AddressEdit, idx: usize) -> usize {
+    e.buffer
+        .char_indices()
+        .nth(idx)
+        .map(|(b, _)| b)
+        .unwrap_or(e.buffer.len())
+}
+
+/// Returns the number of Unicode scalar values in `e.buffer`.
+fn char_count(e: &AddressEdit) -> usize {
+    e.buffer.chars().count()
+}
+
+/// Inserts `c` at the caret position and advances the caret by one.
+fn insert_char(e: &mut AddressEdit, c: char) {
+    let at = char_byte(e, e.caret);
+    e.buffer.insert(at, c);
+    e.caret += 1;
+}
+
+/// Inserts `s` at the caret position and advances the caret by `s.chars().count()`.
+fn insert_str(e: &mut AddressEdit, s: &str) {
+    let at = char_byte(e, e.caret);
+    e.buffer.insert_str(at, s);
+    e.caret += s.chars().count();
+}
+
+/// Removes the character immediately before the caret and moves the caret left by one.
+fn backspace(e: &mut AddressEdit) {
+    if e.caret == 0 {
+        return;
+    }
+    let start = char_byte(e, e.caret - 1);
+    let end = char_byte(e, e.caret);
+    e.buffer.replace_range(start..end, "");
+    e.caret -= 1;
+}
+
+/// Removes the character immediately at (after) the caret; the caret does not move.
+fn delete(e: &mut AddressEdit) {
+    if e.caret >= char_count(e) {
+        return;
+    }
+    let start = char_byte(e, e.caret);
+    let end = char_byte(e, e.caret + 1);
+    e.buffer.replace_range(start..end, "");
+}
+
+/// Moves the caret one character to the left, clamped at 0.
+fn caret_left(e: &mut AddressEdit) {
+    e.caret = e.caret.saturating_sub(1);
+}
+
+/// Moves the caret one character to the right, clamped at `char_count`.
+fn caret_right(e: &mut AddressEdit) {
+    e.caret = (e.caret + 1).min(char_count(e));
+}
+
+/// Moves the caret to the start of the buffer.
+fn caret_home(e: &mut AddressEdit) {
+    e.caret = 0;
+}
+
+/// Moves the caret to the end of the buffer.
+fn caret_end(e: &mut AddressEdit) {
+    e.caret = char_count(e);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,5 +505,58 @@ mod tests {
             app.world().get::<WebviewSource>(page).is_none(),
             "empty initial_url resolves to empty; no webview attached"
         );
+    }
+
+    use crate::ui::AddressEdit as AE;
+
+    fn edit(s: &str, caret: usize) -> AE {
+        AE { buffer: s.into(), caret }
+    }
+
+    #[test]
+    fn address_edit_insert_at_caret() {
+        let mut e = edit("ac", 1);
+        super::insert_char(&mut e, 'b');
+        assert_eq!(e.buffer, "abc");
+        assert_eq!(e.caret, 2);
+    }
+
+    #[test]
+    fn address_edit_backspace_and_delete() {
+        let mut e = edit("abc", 2);
+        super::backspace(&mut e);
+        assert_eq!((e.buffer.as_str(), e.caret), ("ac", 1));
+        super::delete(&mut e);
+        assert_eq!((e.buffer.as_str(), e.caret), ("a", 1));
+    }
+
+    #[test]
+    fn address_edit_caret_motion_clamps() {
+        let mut e = edit("abc", 0);
+        super::caret_left(&mut e);
+        assert_eq!(e.caret, 0);
+        super::caret_right(&mut e);
+        assert_eq!(e.caret, 1);
+        super::caret_end(&mut e);
+        assert_eq!(e.caret, 3);
+        super::caret_home(&mut e);
+        assert_eq!(e.caret, 0);
+    }
+
+    #[test]
+    fn address_edit_insert_str_paste() {
+        let mut e = edit("ab", 1);
+        super::insert_str(&mut e, "XY");
+        assert_eq!((e.buffer.as_str(), e.caret), ("aXYb", 3));
+    }
+
+    #[test]
+    fn address_edit_utf8_safe() {
+        let mut e = edit("aあc", 2); // caret between あ and c
+        super::insert_char(&mut e, 'b');
+        assert_eq!(e.buffer, "aあbc");
+        assert_eq!(e.caret, 3);
+        super::backspace(&mut e); // removes 'b'
+        assert_eq!(e.buffer, "aあc");
     }
 }

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -7,7 +7,7 @@
 use crate::extension_manager::ExtensionRegistry;
 use crate::system_set::OzmuxSystems;
 use crate::ui::registry::ActivityEntityRegistry;
-use crate::ui::{ExtensionActivityMarker, HostActivityEntity};
+use crate::ui::{AddressBarFocus, BrowserPageWebview, ExtensionActivityMarker, HostActivityEntity};
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
@@ -130,32 +130,62 @@ impl Plugin for OzmuxExtensionRenderPlugin {
 /// from the active pane fixes both — keyboard follows the focused pane, and CEF
 /// blurs the webview on focus-leave (`bevy_cef`'s `apply_webview_focus` releases
 /// CEF focus when `FocusedWebview` becomes `None`).
+///
+/// For browser activities the webview lives on a child entity pointed to by
+/// `BrowserPageWebview`; `active_webview` resolves through that indirection.
+/// When `AddressBarFocus` names the active host, CEF focus is released so the
+/// address bar can own the keyboard.
 fn sync_focused_webview(
     mut focused: ResMut<FocusedWebview>,
     mux: MultiplexerCommands,
     attached_session: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
     registry: Res<ActivityEntityRegistry>,
     webviews: Query<(), With<WebviewSource>>,
+    browser_hosts: Query<&BrowserPageWebview>,
+    address_focus: Option<Res<AddressBarFocus>>,
 ) {
-    let active = active_webview(&mux, &attached_session, &registry, &webviews);
+    let bar_focused_host = address_focus.as_ref().and_then(|f| f.0);
+    let active = active_webview(
+        &mux,
+        &attached_session,
+        &registry,
+        &webviews,
+        &browser_hosts,
+        bar_focused_host,
+    );
     if focused.0 != active {
         focused.0 = active;
     }
 }
 
-/// The active pane's webview host entity, or `None` when the active activity is
-/// not a webview (e.g. a terminal pane).
+/// The active pane's focused webview entity, or `None` when the active activity
+/// is not a webview (e.g. a terminal pane) or when the address bar owns input.
+///
+/// For extension activities the webview is on the host itself (`WebviewSource`).
+/// For browser activities the webview is on the `BrowserPageWebview` child;
+/// when `bar_focused_host` matches the host, returns `None` to release CEF focus.
 fn active_webview(
     mux: &MultiplexerCommands,
     attached_session: &Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
     registry: &ActivityEntityRegistry,
     webviews: &Query<(), With<WebviewSource>>,
+    browser_hosts: &Query<&BrowserPageWebview>,
+    bar_focused_host: Option<Entity>,
 ) -> Option<Entity> {
     let session = attached_session.iter().next()?;
     let pane = mux.sessions_active_pane(session)?;
     let activity = mux.panes_active_activity(pane)?;
     let host = registry.get(activity)?;
-    webviews.contains(host).then_some(host)
+    if webviews.contains(host) {
+        return Some(host);
+    }
+    if let Ok(page) = browser_hosts.get(host) {
+        if bar_focused_host == Some(host) {
+            return None;
+        }
+        return Some(page.0);
+    }
+    None
 }
 
 /// Attaches a `bevy_cef` webview to each Extension Activity host once its pane
@@ -781,6 +811,52 @@ mod tests {
         assert_eq!(
             resolved, None,
             "an unstamped activity (no ExtensionActivityAid) must resolve to no aid"
+        );
+    }
+
+    #[test]
+    fn focused_webview_resolves_browser_child_and_respects_address_focus() {
+        use bevy::ecs::system::RunSystemOnce;
+        use crate::ui::{AddressBarFocus, BrowserPageWebview};
+        use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.init_resource::<ActivityEntityRegistry>();
+        app.init_resource::<FocusedWebview>();
+        app.init_resource::<AddressBarFocus>();
+        app.add_systems(Update, sync_focused_webview);
+
+        let (session, _pane, activity) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_session(Some("t".into()));
+                (o.session, o.pane, o.activity)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut().entity_mut(session).insert(AttachedSession);
+
+        let child = app.world_mut().spawn(WebviewSource::new("https://example.com")).id();
+        let host = app.world_mut().spawn(BrowserPageWebview(child)).id();
+        {
+            let mut reg = app.world_mut().resource_mut::<ActivityEntityRegistry>();
+            reg.insert_for_test(activity, host);
+        }
+
+        app.update();
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "active browser pane focuses its page-webview child"
+        );
+
+        app.world_mut().resource_mut::<AddressBarFocus>().0 = Some(host);
+        app.update();
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "address-bar focus releases CEF focus"
         );
     }
 }

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -816,12 +816,13 @@ mod tests {
 
     #[test]
     fn focused_webview_resolves_browser_child_and_respects_address_focus() {
-        use bevy::ecs::system::RunSystemOnce;
         use crate::ui::{AddressBarFocus, BrowserPageWebview};
+        use bevy::ecs::system::RunSystemOnce;
         use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
 
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
         app.init_resource::<ActivityEntityRegistry>();
         app.init_resource::<FocusedWebview>();
         app.init_resource::<AddressBarFocus>();
@@ -837,7 +838,10 @@ mod tests {
         app.world_mut().flush();
         app.world_mut().entity_mut(session).insert(AttachedSession);
 
-        let child = app.world_mut().spawn(WebviewSource::new("https://example.com")).id();
+        let child = app
+            .world_mut()
+            .spawn(WebviewSource::new("https://example.com"))
+            .id();
         let host = app.world_mut().spawn(BrowserPageWebview(child)).id();
         {
             let mut reg = app.world_mut().resource_mut::<ActivityEntityRegistry>();

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,16 +98,13 @@ pub(crate) fn dispatch_focused_key(
     registry: Res<ActivityEntityRegistry>,
     copy_modes: Query<(), With<CopyModeState>>,
     ime_state: Res<ImeState>,
-    address_bar_focus: Option<Res<crate::ui::AddressBarFocus>>,
 ) {
-    // NOTE: while the browser address bar owns the keyboard, suppress chord
-    // lookup + terminal forwarding here; browser_address_editor consumes the
-    // keys instead. Drain our own reader cursor so these keys are not
-    // re-read (and leaked to the terminal) on the tick the bar blurs.
-    if address_bar_focus.as_ref().is_some_and(|f| f.0.is_some()) {
-        events.clear();
-        return;
-    }
+    // NOTE: when the browser address bar owns focus, the active pane is always a
+    // browser host (no `TerminalHandle`), so every terminal action below
+    // (forward/paste/copy/scroll) no-ops on it and `browser_address_editor`
+    // (ordered after this) consumes the bar's typed keys. App-global chords are
+    // intentionally NOT suppressed — they keep working in the bar, as in a real
+    // browser omnibox.
     let bindings = &configs.shortcuts.bindings;
     // NOTE: ButtonInput<KeyCode> is updated in PreUpdate; every Update-tick event
     // sees the same modifier snapshot. Read once outside the loop.

--- a/src/input.rs
+++ b/src/input.rs
@@ -98,7 +98,16 @@ pub(crate) fn dispatch_focused_key(
     registry: Res<ActivityEntityRegistry>,
     copy_modes: Query<(), With<CopyModeState>>,
     ime_state: Res<ImeState>,
+    address_bar_focus: Option<Res<crate::ui::AddressBarFocus>>,
 ) {
+    // NOTE: while the browser address bar owns the keyboard, suppress chord
+    // lookup + terminal forwarding here; browser_address_editor consumes the
+    // keys instead. Drain our own reader cursor so these keys are not
+    // re-read (and leaked to the terminal) on the tick the bar blurs.
+    if address_bar_focus.as_ref().is_some_and(|f| f.0.is_some()) {
+        events.clear();
+        return;
+    }
     let bindings = &configs.shortcuts.bindings;
     // NOTE: ButtonInput<KeyCode> is updated in PreUpdate; every Update-tick event
     // sees the same modifier snapshot. Read once outside the loop.

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -6,6 +6,7 @@
 //! the attached terminal), and `ime_policy_system` (toggles
 //! `Window::ime_enabled` and `.ime_position`).
 
+use crate::ui::AddressBarFocus;
 use crate::ui::TerminalActivityMarker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::registry::ActivityEntityRegistry;
@@ -155,6 +156,7 @@ pub(crate) fn ime_policy_system(
     anchors: Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     metrics: Res<TerminalCellMetricsResource>,
     focused_webview: Res<FocusedWebview>,
+    address_bar_focus: Res<AddressBarFocus>,
     webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
 ) {
@@ -166,12 +168,14 @@ pub(crate) fn ime_policy_system(
     // `Ime` → CEF bridge. ozmux MUST keep `ime_enabled` true here, or
     // bevy_winit calls winit `set_ime_allowed(false)` and the OS delivers
     // no `Ime` events at all — starving that bridge so webview IME silently
-    // breaks. Removing this branch reintroduces that bug.
-    if let Some(webview) = focused_webview.0 {
+    // breaks. Removing this branch reintroduces that bug. The browser address
+    // bar (a native Bevy text input) releases CEF focus, so it appears here
+    // instead: keep IME on and route commits via `apply_ime_to_address_bar`.
+    if let Some(target) = focused_webview.0.or(address_bar_focus.0) {
         if !window.ime_enabled {
             window.ime_enabled = true;
         }
-        if let Ok((node, ui_xform)) = webview_anchors.get(webview) {
+        if let Ok((node, ui_xform)) = webview_anchors.get(target) {
             let scale = window.resolution.scale_factor();
             let top_left_phys = ui_xform.translation - 0.5 * node.size();
             let pos = top_left_phys / scale;
@@ -526,6 +530,7 @@ mod tests {
             .add_plugins(MultiplexerPlugin);
         app.init_resource::<ActivityEntityRegistry>();
         app.init_resource::<FocusedWebview>();
+        app.init_resource::<AddressBarFocus>();
         app.insert_resource(TerminalCellMetricsResource {
             metrics: CellMetrics {
                 advance_phys: 8.0,
@@ -563,6 +568,55 @@ mod tests {
         assert!(
             enabled,
             "IME must stay enabled while a CEF webview owns focus, or bevy_cef's IME bridge is starved"
+        );
+    }
+
+    #[test]
+    fn ime_stays_enabled_for_focused_address_bar() {
+        use bevy_terminal_renderer::CellMetrics;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<ActivityEntityRegistry>();
+        app.init_resource::<FocusedWebview>();
+        app.init_resource::<AddressBarFocus>();
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+
+        // The address bar owns focus; FocusedWebview is released (None).
+        let host = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<AddressBarFocus>().0 = Some(host);
+
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ime_enabled: false,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+
+        app.world_mut().run_system_once(ime_policy_system).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>();
+        let enabled = q.single(app.world()).expect("primary window").ime_enabled;
+        assert!(
+            enabled,
+            "IME must stay enabled while the browser address bar owns focus"
         );
     }
 

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -19,6 +19,7 @@ use bevy::math::Vec2;
 use bevy::prelude::Entity;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{Ime, PrimaryWindow, Window};
+use bevy_cef::prelude::FocusedWebview;
 use bevy_terminal::{TerminalKey, TerminalModifiers};
 use bevy_terminal_renderer::TerminalCellMetricsResource;
 use bevy_terminal_renderer::prelude::TerminalGrid;
@@ -137,8 +138,9 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 /// Derives whether IME should be on this tick and writes
 /// `PrimaryWindow.ime_enabled` and `.ime_position`.
 ///
-/// `ime_enabled` is `true` iff (a) the attached activity carries
-/// `TerminalActivityMarker`, and (b) it does NOT have `CopyModeState`.
+/// `ime_enabled` is `true` iff a CEF webview owns focus (it drives its own
+/// IME through bevy_cef's `Ime` → CEF bridge), OR the attached activity
+/// carries `TerminalActivityMarker` and does NOT have `CopyModeState`.
 ///
 /// `ime_position` is the logical-pixel anchor for the OS candidate
 /// window — computed from the attached terminal's `UiGlobalTransform`
@@ -152,11 +154,33 @@ pub(crate) fn ime_policy_system(
     copy_modes: Query<(), With<CopyModeState>>,
     anchors: Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     metrics: Res<TerminalCellMetricsResource>,
+    focused_webview: Res<FocusedWebview>,
+    webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
 ) {
     let Ok(mut window) = primary_window.single_mut() else {
         return;
     };
+
+    // NOTE: a focused CEF webview drives its own IME through bevy_cef's
+    // `Ime` → CEF bridge. ozmux MUST keep `ime_enabled` true here, or
+    // bevy_winit calls winit `set_ime_allowed(false)` and the OS delivers
+    // no `Ime` events at all — starving that bridge so webview IME silently
+    // breaks. Removing this branch reintroduces that bug.
+    if let Some(webview) = focused_webview.0 {
+        if !window.ime_enabled {
+            window.ime_enabled = true;
+        }
+        if let Ok((node, ui_xform)) = webview_anchors.get(webview) {
+            let scale = window.resolution.scale_factor();
+            let top_left_phys = ui_xform.translation - 0.5 * node.size();
+            let pos = top_left_phys / scale;
+            if window.ime_position != pos {
+                window.ime_position = pos;
+            }
+        }
+        return;
+    }
 
     let Some(entity) = super::resolve_focused_terminal(&mux, &attached_session, &registry) else {
         if window.ime_enabled {
@@ -491,6 +515,55 @@ mod tests {
         });
 
         (app, term_entity)
+    }
+
+    #[test]
+    fn ime_stays_enabled_for_focused_webview() {
+        use bevy_terminal_renderer::CellMetrics;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<ActivityEntityRegistry>();
+        app.init_resource::<FocusedWebview>();
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+
+        // A CEF webview owns focus; no terminal is active.
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+
+        // Window starts with IME OFF — the policy must turn it back ON.
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ime_enabled: false,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+
+        app.world_mut().run_system_once(ime_policy_system).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>();
+        let enabled = q.single(app.world()).expect("primary window").ime_enabled;
+        assert!(
+            enabled,
+            "IME must stay enabled while a CEF webview owns focus, or bevy_cef's IME bridge is starved"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ mod system_set;
 mod theme;
 mod ui;
 
-use crate::extension_manager::ExtensionManagerPlugin;
 use crate::browser_render::OzmuxBrowserRenderPlugin;
+use crate::extension_manager::ExtensionManagerPlugin;
 use crate::extension_render::{OzmuxExtensionRenderPlugin, cef_plugin};
 use crate::input::hyperlink::HyperlinkInputPlugin;
 use crate::input::mouse_buttons::MouseButtonsInputPlugin;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod theme;
 mod ui;
 
 use crate::extension_manager::ExtensionManagerPlugin;
+use crate::browser_render::OzmuxBrowserRenderPlugin;
 use crate::extension_render::{OzmuxExtensionRenderPlugin, cef_plugin};
 use crate::input::hyperlink::HyperlinkInputPlugin;
 use crate::input::mouse_buttons::MouseButtonsInputPlugin;
@@ -57,6 +58,7 @@ fn main() {
             OzmuxShortcutPlugin,
             OzmuxUiPlugin,
             OzmuxExtensionRenderPlugin,
+            OzmuxBrowserRenderPlugin,
             CopyModePlugin,
             CopyModeIndicatorPlugin,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! ozmux Bevy GUI entry point.
 
 mod bootstrap;
+mod browser_render;
 mod clipboard;
 mod configs;
 mod extension_manager;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,6 +72,33 @@ pub struct TerminalActivityMarker;
 #[derive(Component)]
 pub(crate) struct ExtensionActivityMarker;
 
+/// Marks an Activity Host whose `kind` is `Browser`. The browser renderer
+/// (`crate::browser_render`) queries `With<BrowserActivityMarker>` to find hosts
+/// that need a native toolbar + a `bevy_cef` page webview attached.
+#[derive(Component)]
+pub(crate) struct BrowserActivityMarker;
+
+/// On a browser activity host: points to its page-webview child entity. Its
+/// presence also marks the host's chrome as already built (mount-once gate).
+#[derive(Component)]
+pub(crate) struct BrowserPageWebview(pub(crate) Entity);
+
+/// On a browser page-webview child: points back to its owning activity host.
+/// Lets navigation observers (which fire on the webview entity) reach the host.
+#[derive(Component)]
+pub(crate) struct PageWebviewOf(pub(crate) Entity);
+
+/// On a browser activity host: the latest navigation state, written by the
+/// `AddressChanged` / `LoadingStateChanged` observers and read by the toolbar
+/// render + button-enablement systems.
+#[derive(Component, Default, Clone)]
+pub(crate) struct BrowserToolbarState {
+    pub(crate) url: String,
+    pub(crate) is_loading: bool,
+    pub(crate) can_go_back: bool,
+    pub(crate) can_go_forward: bool,
+}
+
 /// Back-pointer from a stable Activity host entity to its owning
 /// multiplexer Activity entity. Stamped by
 /// `ActivityEntityRegistry::get_or_spawn`. `finish_terminal_setup` reads

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -99,6 +99,33 @@ pub(crate) struct BrowserToolbarState {
     pub(crate) can_go_forward: bool,
 }
 
+/// On a browser activity host: the address-bar edit buffer + caret. Pure edit
+/// logic lives in `crate::browser_render`.
+#[derive(Component, Default, Clone)]
+pub(crate) struct AddressEdit {
+    pub(crate) buffer: String,
+    pub(crate) caret: usize,
+}
+
+/// Marker on the address-bar `Text` node inside a browser toolbar.
+#[derive(Component)]
+pub(crate) struct AddrBarText;
+
+/// A toolbar navigation action a `BrowserNavButton` performs.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum NavAction {
+    Back,
+    Forward,
+    Reload,
+}
+
+/// On a toolbar button: its owning host + the action it triggers.
+#[derive(Component)]
+pub(crate) struct BrowserNavButton {
+    pub(crate) host: Entity,
+    pub(crate) action: NavAction,
+}
+
 /// Back-pointer from a stable Activity host entity to its owning
 /// multiplexer Activity entity. Stamped by
 /// `ActivityEntityRegistry::get_or_spawn`. `finish_terminal_setup` reads

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -107,9 +107,10 @@ pub(crate) struct AddressEdit {
     pub(crate) caret: usize,
 }
 
-/// Marker on the address-bar `Text` node inside a browser toolbar.
+/// On the address-bar node inside a browser toolbar: marks it and points to
+/// its owning host. The node is a `Button` so it can be clicked to focus.
 #[derive(Component)]
-pub(crate) struct AddrBarText;
+pub(crate) struct AddrBarText(pub(crate) Entity);
 
 /// A toolbar navigation action a `BrowserNavButton` performs.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -127,7 +128,7 @@ pub(crate) struct BrowserNavButton {
 }
 
 /// The browser activity host whose address bar currently owns the keyboard, or
-/// `None`. Read by the browser editor + `dispatch_focused_key` (later task).
+/// `None`. Read by the browser editor + `dispatch_focused_key`.
 #[derive(Resource, Default)]
 pub(crate) struct AddressBarFocus(pub(crate) Option<Entity>);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -126,6 +126,11 @@ pub(crate) struct BrowserNavButton {
     pub(crate) action: NavAction,
 }
 
+/// The browser activity host whose address bar currently owns the keyboard, or
+/// `None`. Read by the browser editor + `dispatch_focused_key` (later task).
+#[derive(Resource, Default)]
+pub(crate) struct AddressBarFocus(pub(crate) Option<Entity>);
+
 /// Back-pointer from a stable Activity host entity to its owning
 /// multiplexer Activity entity. Stamped by
 /// `ActivityEntityRegistry::get_or_spawn`. `finish_terminal_setup` reads

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -654,7 +654,7 @@ mod tests {
                 let ext = mux.add_activity(
                     pane,
                     ActivityKind::Extension {
-                        html_root: "/tmp".into(),
+                        entry: "/tmp".into(),
                     },
                 );
                 mux.set_active_activity(pane, ext).unwrap();

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -31,21 +31,38 @@ fn kind_color(kind: &ActivityKind) -> Color {
 /// For `ActivityKind::Terminal` and `ActivityKind::Extension` the
 /// placeholder children are skipped because a full-size `MaterialNode`
 /// (`TerminalUiMaterial` / `WebviewUiMaterial`) covers the host node
-/// entirely. The kind-colored `BackgroundColor` still shows briefly
-/// between activity creation and material readiness.
+/// entirely. For `ActivityKind::Browser` the host is a `FlexDirection::Column`
+/// so the browser renderer can stack a toolbar above a page webview; the
+/// placeholder children are also skipped (the browser renderer spawns the
+/// real toolbar + webview children). The kind-colored `BackgroundColor` still
+/// shows briefly between activity creation and renderer readiness.
 pub(crate) fn build_activity_host_children(
     commands: &mut Commands,
     host: Entity,
     kind: &ActivityKind,
     name: &Name,
 ) {
+    let is_browser = matches!(kind, ActivityKind::Browser { .. });
     commands.entity(host).insert((
         Node {
             flex_grow: 1.0,
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
-            justify_content: JustifyContent::Center,
-            align_items: AlignItems::Center,
+            flex_direction: if is_browser {
+                FlexDirection::Column
+            } else {
+                FlexDirection::Row
+            },
+            justify_content: if is_browser {
+                JustifyContent::FlexStart
+            } else {
+                JustifyContent::Center
+            },
+            align_items: if is_browser {
+                AlignItems::Stretch
+            } else {
+                AlignItems::Center
+            },
             ..default()
         },
         BackgroundColor(kind_color(kind)),
@@ -53,7 +70,7 @@ pub(crate) fn build_activity_host_children(
 
     if matches!(
         kind,
-        ActivityKind::Terminal | ActivityKind::Extension { .. }
+        ActivityKind::Terminal | ActivityKind::Extension { .. } | ActivityKind::Browser { .. }
     ) {
         return;
     }
@@ -80,6 +97,7 @@ pub(crate) fn build_activity_host_children(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::ecs::world::CommandQueue;
     use ozmux_multiplexer::BrowserProfile;
 
     #[test]
@@ -97,5 +115,60 @@ mod tests {
             profile: BrowserProfile::default(),
         };
         assert_eq!(kind_color(&kind), palette::ACTIVITY_BROWSER);
+    }
+
+    #[test]
+    fn browser_host_is_column_and_skips_placeholder() {
+        let mut world = World::new();
+        let host = world.spawn_empty().id();
+
+        let mut queue = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue, &world);
+            build_activity_host_children(
+                &mut commands,
+                host,
+                &ActivityKind::Browser {
+                    initial_url: Some("https://example.com".into()),
+                    profile: BrowserProfile::default(),
+                },
+                &Name::new("browser"),
+            );
+        }
+        queue.apply(&mut world);
+
+        let node = world.get::<Node>(host).expect("host must have a Node");
+        assert_eq!(
+            node.flex_direction,
+            FlexDirection::Column,
+            "browser host must use FlexDirection::Column"
+        );
+        assert!(
+            world.get::<Children>(host).is_none(),
+            "browser host must not spawn placeholder children"
+        );
+    }
+
+    #[test]
+    fn terminal_host_skips_placeholder_children() {
+        let mut world = World::new();
+        let host = world.spawn_empty().id();
+
+        let mut queue = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue, &world);
+            build_activity_host_children(
+                &mut commands,
+                host,
+                &ActivityKind::Terminal,
+                &Name::new("terminal"),
+            );
+        }
+        queue.apply(&mut world);
+
+        assert!(
+            world.get::<Children>(host).is_none(),
+            "terminal host must not spawn placeholder children"
+        );
     }
 }

--- a/src/ui/registry.rs
+++ b/src/ui/registry.rs
@@ -6,7 +6,8 @@
 //! split/focus changes.
 
 use crate::ui::{
-    ActivityHostNode, ExtensionActivityMarker, HostActivityEntity, TerminalActivityMarker,
+    ActivityHostNode, BrowserActivityMarker, ExtensionActivityMarker, HostActivityEntity,
+    TerminalActivityMarker,
 };
 use bevy::prelude::*;
 use ozmux_multiplexer::{ActivityKind, ActivityMarker};
@@ -41,6 +42,9 @@ impl ActivityEntityRegistry {
         }
         if matches!(kind, ActivityKind::Extension { .. }) {
             spawn.insert(ExtensionActivityMarker);
+        }
+        if matches!(kind, ActivityKind::Browser { .. }) {
+            spawn.insert(BrowserActivityMarker);
         }
         let host = spawn.id();
         self.hosts.insert(activity, host);
@@ -246,6 +250,32 @@ mod tests {
                 .get::<TerminalActivityMarker>()
                 .is_none(),
             "Browser kind must NOT carry TerminalActivityMarker"
+        );
+    }
+
+    #[test]
+    fn get_or_spawn_tags_browser_host_with_browser_marker() {
+        use crate::ui::BrowserActivityMarker;
+        use ozmux_multiplexer::BrowserProfile;
+        let mut world = World::new();
+        world.insert_resource(ActivityEntityRegistry::default());
+        let activity = world.spawn_empty().id();
+        let kind = ActivityKind::Browser {
+            initial_url: Some("https://example.com".into()),
+            profile: BrowserProfile::default(),
+        };
+
+        let mut host = None;
+        drive(&mut world, |commands, registry| {
+            host = Some(registry.get_or_spawn(commands, activity, &kind));
+        });
+
+        assert!(
+            world
+                .entity(host.unwrap())
+                .get::<BrowserActivityMarker>()
+                .is_some(),
+            "a Browser kind host must carry BrowserActivityMarker"
         );
     }
 }


### PR DESCRIPTION
## Problem

ozmux had no way to open a web page from a pane — there was only scaffolding (`ActivityKind::Browser`, the omnibox classifier in `crates/configs`) that nothing wired up. You couldn't view docs / search results / a localhost server without leaving the multiplexer.

## Solution

Implements the browser activity end-to-end: typing `@browser open {URL or search words}` in any pane splits the pane and renders the target in an embedded `bevy_cef` webview with a native back / forward / reload + editable address-bar toolbar. The flow mirrors the proven `@memo` extension path (shell shim → command server → control-socket `split` → host creates the activity → CEF renders it).

**Affected areas:**

- **engine (`src/`, `crates/`)**
  - `crates/extension_host` — new `Browser` variant in the control protocol + bridge; creates a native `ActivityKind::Browser` (no handlers bridge / aid / owning-extension, unlike extension activities).
  - `src/browser_render.rs` (new) — two-phase CEF mount (omnibox resolved **host-side** via the existing `resolve_omnibox_input`; `WebviewSize` seeded from the laid-out page **child**, not the host, to avoid the mid-load resize that wedges CEF's OSR widget), the native toolbar, the address-bar editor + focus, and navigation-state observers.
  - `src/ui/*`, `src/extension_render.rs`, `src/input.rs`, `src/main.rs` — `BrowserActivityMarker` + column host, single `FocusedWebview` writer generalized to the browser page-webview child (and released while the address bar is focused), the keyboard-ownership guard, and plugin wiring.
- **packages (`sdk/`, `extensions/`)**
  - `@ozmux/sdk` — `browser` split spec over the control socket.
  - `extensions/browser` (new) — the `@browser open` command extension (auto-discovered, like `@memo`).

**Follow-ups included in this branch:**
- Disabled back/forward buttons are grayed out (glyph dimmed to `MUTED`), reusing the tab-bar active/inactive convention.
- Pointer cursor while hovering the nav buttons.
- Fix: the address bar stayed focused after focus moved to another pane, which (via the global keyboard guard) left the terminal completely keyboard-dead. It now blurs on focus-leave (pane switch or left-click outside the bar), gated with `run_if` so its heavy params aren't fetched on the common path.

**Verification:** `cargo test --test-threads=1` (all green), `cargo clippy` / `cargo fmt` clean, `pnpm check-types` / `pnpm -r test` / `pnpm lint` clean.

### Notes
- **Deferred** (spec non-goals): named profiles / incognito, in-bar text selection / IME, "open as a new tab".
- **Pre-existing, unrelated:** the `ozmux-gui` test suite SIGSEGVs under the default-parallel `cargo test` (reproduced on the `main` baseline before any of this work) — run with `--test-threads=1`.

<details><summary>Screenshots</summary>

_UI change — to be captured from a local CEF-provisioned run (`@browser open github.com`: toolbar, omnibox, disabled vs enabled nav buttons)._

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)