### PR TITLE
feat: focus an activity by clicking its tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ use multiplexer::log::OzmuxLayoutLogPlugin;
 use ozmux_extension_host::host::EndpointRegistry;
 use ozmux_multiplexer::MultiplexerPlugin;
 use ui::ime_overlay::ImeOverlayPlugin;
-use ui::{OzmuxUiPlugin, copy_mode::CopyModePlugin, copy_mode_indicator::CopyModeIndicatorPlugin};
+use ui::{
+    OzmuxUiPlugin, copy_mode::CopyModePlugin, copy_mode_indicator::CopyModeIndicatorPlugin,
+    tab_input::TabInteractionPlugin,
+};
 
 fn main() {
     let endpoints = EndpointRegistry::default();
@@ -62,6 +65,7 @@ fn main() {
             OzmuxBrowserRenderPlugin,
             CopyModePlugin,
             CopyModeIndicatorPlugin,
+            TabInteractionPlugin,
         ))
         .add_plugins((
             MouseWheelInputPlugin,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -881,6 +881,23 @@ mod tests {
     }
 
     #[test]
+    fn rebuilt_tabs_carry_tab_button() {
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let tab_count = world
+            .query_filtered::<Entity, With<TabButton>>()
+            .iter(world)
+            .count();
+        assert_eq!(
+            tab_count, 1,
+            "the bootstrap pane has one activity, so its tab bar has one TabButton-tagged tab",
+        );
+    }
+
+    #[test]
     fn status_bar_chips_appear_in_session_creation_order_after_cmd_r() {
         use crate::ui::status_bar_sync::StatusBarRoot;
         use bevy::ecs::system::RunSystemOnce;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,6 +31,7 @@ pub mod status_bar_sync;
 #[cfg(test)]
 pub(crate) mod stress_test;
 pub mod tab_bar;
+pub(crate) mod tab_input;
 pub mod terminal;
 
 /// Marker for the single root UI Node entity. Spawned once in Startup,
@@ -125,6 +126,14 @@ pub(crate) enum NavAction {
 pub(crate) struct BrowserNavButton {
     pub(crate) host: Entity,
     pub(crate) action: NavAction,
+}
+
+/// On a tab-bar Node: marks it clickable and records which Activity (in which
+/// Pane) selecting it activates. Read by `drive_tab_clicks` / `tab_hover_cursor`.
+#[derive(Component, Clone, Copy)]
+pub(crate) struct TabButton {
+    pub(crate) pane: Entity,
+    pub(crate) activity: Entity,
 }
 
 /// The browser activity host whose address bar currently owns the keyboard, or

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -220,7 +220,7 @@ fn build_pane(
     // multi-session tab indicator would require knowing the session-level
     // active pane, which is not threaded here yet. Safe default: treat
     // every pane as the active one (solid accent indicator).
-    build_pane_tab_bar(commands, pane_frame, &tabs, true, ui_font);
+    build_pane_tab_bar(commands, pane_frame, pane_entity, &tabs, true, ui_font);
 
     let activity_slot = commands
         .spawn((

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -3,7 +3,7 @@
 //! the (background, indicator, text) color triple for a single tab.
 
 use crate::theme;
-use crate::ui::StructuralNode;
+use crate::ui::{StructuralNode, TabButton};
 use crate::ui::palette;
 use bevy::color::Color;
 use bevy::prelude::*;
@@ -45,12 +45,8 @@ fn tab_colors(is_active: bool, is_active_pane: bool) -> TabColors {
 
 /// A single tab's display data, derived from ECS components by the caller.
 pub(crate) struct TabEntry {
-    /// Activity entity. Not read by the tab bar builder today, but load-bearing
-    /// for future tab interactivity (click-to-switch) and equality checks.
-    #[expect(
-        dead_code,
-        reason = "reserved for future tab interactivity; do not remove"
-    )]
+    /// Activity entity this tab selects. Attached to the tab Node as
+    /// `TabButton.activity` so `drive_tab_clicks` can focus it.
     pub entity: Entity,
     /// Display name of the activity.
     pub name: String,
@@ -61,9 +57,10 @@ pub(crate) struct TabEntry {
 /// Spawn the per-pane tab bar (one tab per Activity) as a child of `parent`.
 /// Every spawned Entity carries `StructuralNode`. `is_active_pane` drives
 /// the indicator accent (accent vs border).
-pub fn build_pane_tab_bar(
+pub(crate) fn build_pane_tab_bar(
     commands: &mut Commands,
     parent: Entity,
+    pane: Entity,
     tabs: &[TabEntry],
     is_active_pane: bool,
     ui_font: &Handle<Font>,
@@ -84,13 +81,14 @@ pub fn build_pane_tab_bar(
         .id();
 
     for tab in tabs {
-        build_tab(commands, bar, tab, is_active_pane, ui_font);
+        build_tab(commands, bar, pane, tab, is_active_pane, ui_font);
     }
 }
 
 fn build_tab(
     commands: &mut Commands,
     parent: Entity,
+    pane: Entity,
     tab: &TabEntry,
     is_active_pane: bool,
     ui_font: &Handle<Font>,
@@ -100,6 +98,11 @@ fn build_tab(
     let tab_entity = commands
         .spawn((
             Name::new("Tab"),
+            Button,
+            TabButton {
+                pane,
+                activity: tab.entity,
+            },
             Node {
                 padding: UiRect::axes(Val::Px(theme::TAB_PADDING_X_PX), Val::Px(4.0)),
                 border: UiRect {

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -3,8 +3,8 @@
 //! the (background, indicator, text) color triple for a single tab.
 
 use crate::theme;
-use crate::ui::{StructuralNode, TabButton};
 use crate::ui::palette;
+use crate::ui::{StructuralNode, TabButton};
 use bevy::color::Color;
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, BorderRadius, FlexDirection, JustifyContent, UiRect, Val};

--- a/src/ui/tab_input.rs
+++ b/src/ui/tab_input.rs
@@ -2,9 +2,28 @@
 //! activity, plus a pointer cursor while hovering a tab. Mirrors the browser
 //! toolbar's `Interaction`-driven pattern in `crate::browser_render`.
 
+use crate::input::InputPhase;
 use crate::ui::TabButton;
 use bevy::prelude::*;
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
 use ozmux_multiplexer::{AttachedSession, MultiplexerCommands, SessionMarker};
+
+/// Wires tab interactivity: `drive_tab_clicks` (click → focus pane + switch
+/// activity) and `tab_hover_cursor` (pointer cursor on hover, after the hover
+/// phase so it wins over the hyperlink system's `Text` write).
+pub(crate) struct TabInteractionPlugin;
+
+impl Plugin for TabInteractionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                drive_tab_clicks,
+                tab_hover_cursor.after(InputPhase::Hover),
+            ),
+        );
+    }
+}
 
 /// Routes a left-press on a tab to a focus + activity switch: focuses the tab's
 /// pane (`set_active_pane`) and makes the tab's activity active
@@ -30,6 +49,28 @@ fn drive_tab_clicks(
         if let Err(e) = mux.set_active_activity(tab.pane, tab.activity) {
             tracing::warn!(target: "ozmux_gui::ui", ?e, "tab click: set_active_activity failed");
         }
+    }
+}
+
+/// Shows a pointer cursor while the mouse hovers any tab, so tabs read as
+/// clickable. Runs after `InputPhase::Hover` so it wins over the hyperlink
+/// system's per-frame `Text` write; leaving a tab reverts to `Text` when that
+/// system re-asserts. Mirrors `crate::browser_render::nav_button_hover_cursor`.
+fn tab_hover_cursor(
+    tabs: Query<&Interaction, With<TabButton>>,
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+) {
+    let hovering = tabs
+        .iter()
+        .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
+    if !hovering {
+        return;
+    }
+    let Ok(mut icon) = cursor_icons.single_mut() else {
+        return;
+    };
+    if !matches!(&*icon, CursorIcon::System(e) if *e == SystemCursorIcon::Pointer) {
+        *icon = CursorIcon::System(SystemCursorIcon::Pointer);
     }
 }
 
@@ -138,6 +179,45 @@ mod tests {
             app.world().get::<ActivePane>(session).map(|a| a.0),
             Some(pane),
             "a hovered (not pressed) tab must not change the active pane",
+        );
+    }
+
+    #[test]
+    fn tab_hover_sets_pointer_cursor() {
+        let mut world = World::new();
+        let window = world
+            .spawn((PrimaryWindow, CursorIcon::System(SystemCursorIcon::Text)))
+            .id();
+        let tab = world
+            .spawn((
+                TabButton {
+                    pane: Entity::PLACEHOLDER,
+                    activity: Entity::PLACEHOLDER,
+                },
+                Interaction::Hovered,
+            ))
+            .id();
+
+        world.run_system_once(tab_hover_cursor).unwrap();
+        assert!(
+            matches!(
+                world.get::<CursorIcon>(window),
+                Some(CursorIcon::System(SystemCursorIcon::Pointer))
+            ),
+            "hovering a tab sets the pointer cursor",
+        );
+
+        // Not hovering: the system no-ops, leaving the cursor as the hover phase
+        // set it (Text).
+        *world.get_mut::<Interaction>(tab).unwrap() = Interaction::None;
+        *world.get_mut::<CursorIcon>(window).unwrap() = CursorIcon::System(SystemCursorIcon::Text);
+        world.run_system_once(tab_hover_cursor).unwrap();
+        assert!(
+            matches!(
+                world.get::<CursorIcon>(window),
+                Some(CursorIcon::System(SystemCursorIcon::Text))
+            ),
+            "no hovered tab leaves the cursor unchanged",
         );
     }
 }

--- a/src/ui/tab_input.rs
+++ b/src/ui/tab_input.rs
@@ -17,7 +17,17 @@ impl Plugin for TabInteractionPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (drive_tab_clicks, tab_hover_cursor.after(InputPhase::Hover)),
+            (
+                // NOTE: drive_tab_clicks mutates `Session::active_pane`, which
+                // dispatch_focused_key (InputPhase::FocusedKey) reads to route
+                // keystrokes, and which the chrome-rebuild / dim systems (run
+                // after OzmuxSystems::Input) react to. It MUST live in
+                // InputPhase::Dispatch so that focus change is visible the same
+                // frame — see the OzmuxSystems::Input invariant in system_set.rs
+                // and the matching placement of dispatch_mouse_buttons.
+                drive_tab_clicks.in_set(InputPhase::Dispatch),
+                tab_hover_cursor.after(InputPhase::Hover),
+            ),
         );
     }
 }
@@ -30,11 +40,12 @@ fn drive_tab_clicks(
     tabs: Query<(&Interaction, &TabButton), Changed<Interaction>>,
     attached: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
 ) {
+    let attached_session = attached.single().ok();
     for (interaction, tab) in tabs.iter() {
         if *interaction != Interaction::Pressed {
             continue;
         }
-        if let Ok(session) = attached.single()
+        if let Some(session) = attached_session
             && let Err(e) = mux.set_active_pane(session, tab.pane)
         {
             tracing::warn!(target: "ozmux_gui::ui", ?e, "tab click: set_active_pane failed");
@@ -80,8 +91,11 @@ mod tests {
         MultiplexerPlugin, Side, SplitOrientation,
     };
 
-    #[test]
-    fn tab_press_focuses_pane_and_switches_activity() {
+    /// Builds an app running `drive_tab_clicks`, with one attached session whose
+    /// single pane has two activities — the first active, the second added but
+    /// not activated. Returns `(app, session, pane, first_activity,
+    /// second_activity)`.
+    fn app_with_two_activities() -> (App, Entity, Entity, Entity, Entity) {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(MultiplexerPlugin);
@@ -96,8 +110,8 @@ mod tests {
             .unwrap();
         app.world_mut().flush();
 
-        // A second activity to switch to. `add_activity` does NOT activate it,
-        // so `first` stays the active activity.
+        // `add_activity` does NOT activate the new activity, so `first` stays
+        // the active one.
         let second = app
             .world_mut()
             .run_system_once(move |mut mux: MultiplexerCommands| {
@@ -107,14 +121,20 @@ mod tests {
         app.world_mut().flush();
 
         app.world_mut().entity_mut(session).insert(AttachedSession);
+        (app, session, pane, first, second)
+    }
+
+    #[test]
+    fn tab_press_focuses_pane_and_switches_activity() {
+        let (mut app, session, pane, first, second) = app_with_two_activities();
         assert_eq!(
             app.world().get::<ActiveActivity>(pane).map(|a| a.0),
             Some(first),
             "precondition: the first activity is active before the click",
         );
 
-        // Spawn a tab for `second`, already pressed. A freshly-added
-        // Interaction::Pressed satisfies the Changed<Interaction> filter.
+        // A freshly-added Interaction::Pressed satisfies the Changed<Interaction>
+        // filter.
         app.world_mut().spawn((
             TabButton {
                 pane,
@@ -138,27 +158,7 @@ mod tests {
 
     #[test]
     fn tab_hovered_not_pressed_does_not_switch() {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(MultiplexerPlugin);
-        app.add_systems(Update, drive_tab_clicks);
-
-        let (session, pane, first) = app
-            .world_mut()
-            .run_system_once(|mut mux: MultiplexerCommands| {
-                let o = mux.create_session(Some("test".into()));
-                (o.session, o.pane, o.activity)
-            })
-            .unwrap();
-        app.world_mut().flush();
-        let second = app
-            .world_mut()
-            .run_system_once(move |mut mux: MultiplexerCommands| {
-                mux.add_activity(pane, ActivityKind::Terminal)
-            })
-            .unwrap();
-        app.world_mut().flush();
-        app.world_mut().entity_mut(session).insert(AttachedSession);
+        let (mut app, session, pane, first, second) = app_with_two_activities();
 
         app.world_mut().spawn((
             TabButton {

--- a/src/ui/tab_input.rs
+++ b/src/ui/tab_input.rs
@@ -1,0 +1,143 @@
+//! Tab interactivity: left-click a tab to focus its pane and switch to its
+//! activity, plus a pointer cursor while hovering a tab. Mirrors the browser
+//! toolbar's `Interaction`-driven pattern in `crate::browser_render`.
+
+use crate::ui::TabButton;
+use bevy::prelude::*;
+use ozmux_multiplexer::{AttachedSession, MultiplexerCommands, SessionMarker};
+
+/// Routes a left-press on a tab to a focus + activity switch: focuses the tab's
+/// pane (`set_active_pane`) and makes the tab's activity active
+/// (`set_active_activity`). Mirrors `crate::browser_render::drive_nav_buttons`.
+fn drive_tab_clicks(
+    mut mux: MultiplexerCommands,
+    tabs: Query<(&Interaction, &TabButton), Changed<Interaction>>,
+    attached: Query<Entity, (With<SessionMarker>, With<AttachedSession>)>,
+) {
+    for (interaction, tab) in tabs.iter() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        if let Ok(session) = attached.single()
+            && let Err(e) = mux.set_active_pane(session, tab.pane)
+        {
+            tracing::warn!(target: "ozmux_gui::ui", ?e, "tab click: set_active_pane failed");
+        }
+        // NOTE: the activity switch is intentionally unconditional — a tab click
+        // still selects its activity even if no session is attached (the pane
+        // entity fully targets the switch); only the pane-focus step needs a
+        // session. Do not gate this on `attached`.
+        if let Err(e) = mux.set_active_activity(tab.pane, tab.activity) {
+            tracing::warn!(target: "ozmux_gui::ui", ?e, "tab click: set_active_activity failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+    use ozmux_multiplexer::{
+        ActiveActivity, ActivePane, ActivityKind, AttachedSession, MultiplexerCommands,
+        MultiplexerPlugin,
+    };
+
+    #[test]
+    fn tab_press_focuses_pane_and_switches_activity() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.add_systems(Update, drive_tab_clicks);
+
+        let (session, pane, first) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_session(Some("test".into()));
+                (o.session, o.pane, o.activity)
+            })
+            .unwrap();
+        app.world_mut().flush();
+
+        // A second activity to switch to. `add_activity` does NOT activate it,
+        // so `first` stays the active activity.
+        let second = app
+            .world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                mux.add_activity(pane, ActivityKind::Terminal)
+            })
+            .unwrap();
+        app.world_mut().flush();
+
+        app.world_mut().entity_mut(session).insert(AttachedSession);
+        assert_eq!(
+            app.world().get::<ActiveActivity>(pane).map(|a| a.0),
+            Some(first),
+            "precondition: the first activity is active before the click",
+        );
+
+        // Spawn a tab for `second`, already pressed. A freshly-added
+        // Interaction::Pressed satisfies the Changed<Interaction> filter.
+        app.world_mut().spawn((
+            TabButton {
+                pane,
+                activity: second,
+            },
+            Interaction::Pressed,
+        ));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<ActiveActivity>(pane).map(|a| a.0),
+            Some(second),
+            "pressing a tab switches the pane's active activity",
+        );
+        assert_eq!(
+            app.world().get::<ActivePane>(session).map(|a| a.0),
+            Some(pane),
+            "pressing a tab focuses its pane",
+        );
+    }
+
+    #[test]
+    fn tab_hovered_not_pressed_does_not_switch() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.add_systems(Update, drive_tab_clicks);
+
+        let (session, pane, first) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_session(Some("test".into()));
+                (o.session, o.pane, o.activity)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        let second = app
+            .world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                mux.add_activity(pane, ActivityKind::Terminal)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut().entity_mut(session).insert(AttachedSession);
+
+        app.world_mut().spawn((
+            TabButton {
+                pane,
+                activity: second,
+            },
+            Interaction::Hovered,
+        ));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<ActiveActivity>(pane).map(|a| a.0),
+            Some(first),
+            "a hovered (not pressed) tab must not switch the active activity",
+        );
+        assert_eq!(
+            app.world().get::<ActivePane>(session).map(|a| a.0),
+            Some(pane),
+            "a hovered (not pressed) tab must not change the active pane",
+        );
+    }
+}

--- a/src/ui/tab_input.rs
+++ b/src/ui/tab_input.rs
@@ -77,7 +77,7 @@ mod tests {
     use bevy::ecs::system::RunSystemOnce;
     use ozmux_multiplexer::{
         ActiveActivity, ActivePane, ActivityKind, AttachedSession, MultiplexerCommands,
-        MultiplexerPlugin,
+        MultiplexerPlugin, Side, SplitOrientation,
     };
 
     #[test]
@@ -178,6 +178,68 @@ mod tests {
             app.world().get::<ActivePane>(session).map(|a| a.0),
             Some(pane),
             "a hovered (not pressed) tab must not change the active pane",
+        );
+    }
+
+    #[test]
+    fn tab_press_in_unfocused_pane_focuses_that_pane() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.add_systems(Update, drive_tab_clicks);
+
+        let (session, original_pane) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_session(Some("test".into()));
+                (o.session, o.pane)
+            })
+            .unwrap();
+        app.world_mut().flush();
+
+        // Split into a second pane, then re-focus the original so the new pane is
+        // the unfocused one (`split_pane` promotes the new pane to active).
+        let other_pane = app
+            .world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                let p = mux
+                    .split_pane(original_pane, Side::After, SplitOrientation::Horizontal)
+                    .expect("split");
+                mux.set_active_pane(session, original_pane)
+                    .expect("refocus original");
+                p
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut().entity_mut(session).insert(AttachedSession);
+
+        let other_activity = app
+            .world_mut()
+            .run_system_once(move |mux: MultiplexerCommands| mux.panes_active_activity(other_pane))
+            .unwrap()
+            .expect("the split pane has an active activity");
+
+        assert_eq!(
+            app.world().get::<ActivePane>(session).map(|a| a.0),
+            Some(original_pane),
+            "precondition: the original pane is focused, the split pane is not",
+        );
+
+        // Click the already-active tab of the unfocused pane: the activity switch
+        // is a no-op, but the pane focus must move to it in one click.
+        app.world_mut().spawn((
+            TabButton {
+                pane: other_pane,
+                activity: other_activity,
+            },
+            Interaction::Pressed,
+        ));
+        app.update();
+
+        assert_eq!(
+            app.world().get::<ActivePane>(session).map(|a| a.0),
+            Some(other_pane),
+            "clicking a tab in an unfocused pane focuses that pane",
         );
     }
 

--- a/src/ui/tab_input.rs
+++ b/src/ui/tab_input.rs
@@ -17,10 +17,7 @@ impl Plugin for TabInteractionPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            (
-                drive_tab_clicks,
-                tab_hover_cursor.after(InputPhase::Hover),
-            ),
+            (drive_tab_clicks, tab_hover_cursor.after(InputPhase::Hover)),
         );
     }
 }
@@ -86,7 +83,8 @@ mod tests {
     #[test]
     fn tab_press_focuses_pane_and_switches_activity() {
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
         app.add_systems(Update, drive_tab_clicks);
 
         let (session, pane, first) = app
@@ -141,7 +139,8 @@ mod tests {
     #[test]
     fn tab_hovered_not_pressed_does_not_switch() {
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins).add_plugins(MultiplexerPlugin);
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
         app.add_systems(Update, drive_tab_clicks);
 
         let (session, pane, first) = app


### PR DESCRIPTION
## Problem

Activity tabs in a pane's tab bar were purely visual — clicking one did nothing. The only way to change a pane's active activity was keyboard cycling (`FocusActivityEvent`); there was no way to focus an activity, or its pane, by clicking its tab. `TabEntry.entity` even carried an `#[expect(dead_code, reason = "reserved for future tab interactivity")]` placeholder for exactly this.

## Solution

Left-click a tab now **focuses its pane and switches that pane to the clicked activity in a single click** — including tabs on a pane that isn't currently focused — and **hovering a tab shows a pointer cursor**.

The approach reuses the browser toolbar's existing clickable-widget pattern (`src/browser_render.rs`) rather than inventing new input machinery:

- Tabs are tagged with Bevy's `Button` + a `TabButton { pane, activity }` component (`src/ui.rs`, `src/ui/tab_bar.rs`), with `pane` threaded through from `src/ui/layout.rs`.
- `drive_tab_clicks` reads `Changed<Interaction>` and, on `Interaction::Pressed`, calls `set_active_pane` + `set_active_activity` (both `set_if_neq`, so re-clicking the active tab is a no-op). It runs in `InputPhase::Dispatch` so the focus change is visible to keystroke routing (`dispatch_focused_key`) and to the chrome-rebuild / dim systems the same frame, per the `OzmuxSystems::Input` invariant in `system_set.rs`.
- `tab_hover_cursor` mirrors `nav_button_hover_cursor`, setting the pointer cursor `.after(InputPhase::Hover)` (last-writer-wins over the hyperlink system's `Text` write).
- `TabInteractionPlugin` wires both systems; registered in `src/main.rs`.

Downstream rendering reactions are reused unchanged: `Changed<ActiveActivity>` → `SessionUiDirty` rebuild (active-tab highlight + content), `Changed<ActivePane>` → dim/veil repaint.

**Affected:** engine UI (`src/ui.rs`, `src/ui/tab_bar.rs`, `src/ui/layout.rs`, `src/ui/tab_input.rs`, `src/main.rs`). No breaking changes.

**Tests:** 5 new unit/integration tests — click switches activity + focuses pane; hover is a no-op; clicking a tab in an unfocused pane focuses it; hover → pointer cursor; rebuilt tabs carry `TabButton`. Full suite passes (272 tests, `--test-threads=1`); `cargo build` / `clippy` / `rustfmt` clean.

<details><summary>Screenshots</summary>

Not captured — this is a native Bevy/CEF GUI and the change was developed/verified headlessly (unit + integration tests). Behavior should be confirmed interactively: hover a tab (pointer cursor), click an inactive tab (its content + highlight switch), and click a tab in an unfocused split pane (that pane focuses + switches in one click).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
