### PR TITLE
fix: move focus on terminal-surface click when a webview is focused

### DIFF
--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -5,7 +5,7 @@
 
 use crate::input::mouse_buttons::{cell_at_local, resolve_pane_at_phys};
 use crate::input::{InputPhase, current_modifiers};
-use crate::ui::SurfaceHostNode;
+use crate::ui::{SurfaceHostNode, VisibleSurfaceHost};
 use bevy::ecs::entity::Entity;
 use bevy::input::ButtonInput;
 use bevy::input::keyboard::{KeyCode, KeyboardInput};
@@ -104,7 +104,10 @@ fn hyperlink_hover_and_cursor(
     mut hover: ResMut<HyperlinkHoverState>,
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
     windows: Query<&Window, With<PrimaryWindow>>,
-    hosts: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<SurfaceHostNode>>,
+    hosts: Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        (With<SurfaceHostNode>, With<VisibleSurfaceHost>),
+    >,
     grids: Query<&TerminalGrid>,
     metrics: Res<TerminalCellMetricsResource>,
     keys: Res<ButtonInput<KeyCode>>,

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -9,7 +9,7 @@
 use crate::configs::OzmuxConfigsResource;
 use crate::input::hyperlink::{link_modifier_held, should_open_at, try_open_uri};
 use crate::input::{InputPhase, current_modifiers};
-use crate::ui::SurfaceHostNode;
+use crate::ui::{SurfaceHostNode, VisibleSurfaceHost};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::registry::SurfaceEntityRegistry;
 use bevy::input::ButtonState;
@@ -85,17 +85,25 @@ impl Plugin for MouseButtonsInputPlugin {
     }
 }
 
-/// Hit-tests `cursor_phys_px` against all `SurfaceHostNode` entities
-/// and returns `(entity, local_phys_px)` for the first pane that
+/// Hit-tests `cursor_phys_px` against the **visible** (`VisibleSurfaceHost`)
+/// surface hosts and returns `(entity, local_phys_px)` for the first pane that
 /// contains the cursor. `local_phys_px` is in pane-local pixels with
 /// origin at the top-left corner of the node (i.e., `(0, 0)` is the
 /// top-left, `(size.x, size.y)` is the bottom-right).
+///
+/// Only the active surface's host is hit-tested. Inactive hosts are parked
+/// outside layout and keep stale, often window-sized `ComputedNode` geometry;
+/// including them lets a click resolve to a parked host of an already-active
+/// pane, so focus never moves (see `VisibleSurfaceHost`).
 ///
 /// `cursor_phys_px` is in physical (DPR-scaled) pixels — the caller
 /// must convert from `Window::cursor_position()` (logical) by
 /// multiplying by `Window::scale_factor()` first.
 pub(crate) fn resolve_pane_at_phys(
-    hosts: &Query<(Entity, &ComputedNode, &UiGlobalTransform), With<SurfaceHostNode>>,
+    hosts: &Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        (With<SurfaceHostNode>, With<VisibleSurfaceHost>),
+    >,
     cursor_phys_px: Vec2,
 ) -> Option<(Entity, Vec2)> {
     for (entity, node, transform) in hosts.iter() {
@@ -387,7 +395,10 @@ fn dispatch_mouse_buttons(
     )>,
     keys: Res<ButtonInput<KeyCode>>,
     configs: Res<OzmuxConfigsResource>,
-    hosts: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<SurfaceHostNode>>,
+    hosts: Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        (With<SurfaceHostNode>, With<VisibleSurfaceHost>),
+    >,
     grids: Query<&bevy_terminal_renderer::schema::TerminalGrid>,
     copy_modes: Query<(), With<CopyModeState>>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
@@ -771,6 +782,57 @@ fn apply_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_pane_at_phys_ignores_parked_hosts() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        // Both hosts' geometry covers (400, 300), but only one is the active
+        // (slotted) `VisibleSurfaceHost`. The parked host retains stale,
+        // oversized `ComputedNode` geometry after being unslotted; the hit-test
+        // must ignore it and return the visible host. Regression: a
+        // terminal-surface click resolving to a parked host of an
+        // already-active pane left keyboard focus stuck on a webview.
+        let mut app = App::new();
+        app.world_mut().spawn((
+            SurfaceHostNode,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+        ));
+        let visible = app
+            .world_mut()
+            .spawn((
+                SurfaceHostNode,
+                VisibleSurfaceHost,
+                ComputedNode {
+                    size: Vec2::new(800.0, 600.0),
+                    ..ComputedNode::DEFAULT
+                },
+                UiGlobalTransform::from_xy(400.0, 300.0),
+            ))
+            .id();
+
+        let resolved = app
+            .world_mut()
+            .run_system_once(
+                |hosts: Query<
+                    (Entity, &ComputedNode, &UiGlobalTransform),
+                    (With<SurfaceHostNode>, With<VisibleSurfaceHost>),
+                >| {
+                    resolve_pane_at_phys(&hosts, Vec2::new(400.0, 300.0)).map(|(e, _)| e)
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            resolved,
+            Some(visible),
+            "the hit-test must ignore parked (non-VisibleSurfaceHost) hosts",
+        );
+    }
 
     #[test]
     fn plugin_registers_state_resource() {
@@ -1527,11 +1589,13 @@ mod tests {
         app.world_mut().entity_mut(session).insert(AttachedSession);
 
         // The clicked pane's host: SurfaceHostNode + a laid-out node under the
-        // cursor, but NO TerminalHandle (a webview host).
+        // cursor, but NO TerminalHandle (a webview host). `VisibleSurfaceHost`
+        // marks it as the active (slotted) host so the hit-test considers it.
         let ext_host = app
             .world_mut()
             .spawn((
                 SurfaceHostNode,
+                VisibleSurfaceHost,
                 ComputedNode {
                     size: Vec2::new(800.0, 600.0),
                     ..ComputedNode::DEFAULT

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -60,6 +60,19 @@ pub struct StructuralNode;
 #[derive(Component)]
 pub struct SurfaceHostNode;
 
+/// Marks the surface host currently slotted into its pane's visible
+/// `surface_slot` (i.e. the active surface). Inactive hosts are parked under a
+/// non-`Node` parent and keep this marker removed.
+///
+/// # Invariants
+///
+/// Geometric hit-tests (`resolve_pane_at_phys`) MUST filter on this marker:
+/// a parked host is excluded from layout, so its `ComputedNode` retains stale,
+/// often window-sized geometry. Without this filter a click resolves to a
+/// parked host of an already-active pane and focus never moves.
+#[derive(Component)]
+pub struct VisibleSurfaceHost;
+
 /// Marks a Surface Host whose `kind` is `Terminal`. `finish_terminal_setup`
 /// queries for `With<TerminalSurfaceMarker>` to find hosts that need a
 /// `TerminalBundle` + `TerminalRenderBundle` attached.

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -8,7 +8,7 @@ use crate::theme;
 use crate::ui::surface::build_surface_host_children;
 use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::tab_bar::{TabEntry, build_pane_tab_bar};
-use crate::ui::{PaneDimOverlay, PaneFrame, StructuralNode, palette};
+use crate::ui::{PaneDimOverlay, PaneFrame, StructuralNode, VisibleSurfaceHost, palette};
 use bevy::prelude::*;
 use bevy::ui::{FlexDirection, PositionType, UiRect, Val};
 use ozmux_multiplexer::{
@@ -243,9 +243,14 @@ fn build_pane(
         let host = registry.get_or_spawn(commands, surface_entity, kind);
         build_surface_host_children(commands, host, kind, name);
         if surface_entity == active_surface {
-            commands.entity(host).insert(ChildOf(surface_slot));
+            commands
+                .entity(host)
+                .insert((ChildOf(surface_slot), VisibleSurfaceHost));
         } else {
-            commands.entity(host).insert(ChildOf(inactive_host_parent));
+            commands
+                .entity(host)
+                .insert(ChildOf(inactive_host_parent))
+                .remove::<VisibleSurfaceHost>();
         }
     }
 


### PR DESCRIPTION
## Problem

When an extension webview surface is focused (e.g. `@md memo.md`), clicking a terminal's rendered **surface** (content area) did not move keyboard focus to it — keystrokes stayed routed to the webview. Clicking the terminal's **tab** worked, which is what made the bug confusing.

Repro: `@md memo.md` → `Cmd+O` (split a new pane) → click the WebView → click the terminal surface → focus does not move.

## Solution

**Root cause (confirmed by a runtime trace).** A pane with multiple surfaces keeps one `SurfaceHostNode` per surface. The active surface's host is parented into the visible `surface_slot`; the inactive one is parented under a non-`Node` parent and excluded from layout. Bevy never re-lays-out a parked node, so its `ComputedNode` keeps **stale, often window-sized geometry** from when it was last visible. `resolve_pane_at_phys` hit-tested **all** `SurfaceHostNode`s and returned the first match in arbitrary query order — so a click could resolve to the parked host of an already-active pane. `try_click_to_focus` then no-ops (pane already active), `ActivePane` never moves, and `sync_focused_webview` keeps `FocusedWebview = Some(webview)`. Tab clicks were immune because tab buttons are distinct picking targets, never overlapped by a stale host.

The trace showed `match_count = 2` on every click and the identical pixel resolving to the parked host one frame and the active host the next.

**Fix (engine):**
- Add a `VisibleSurfaceHost` marker, inserted on the slotted (active) host and removed from parked hosts (`src/ui.rs`, `src/ui/layout.rs`).
- Filter the geometry hit-test to `With<VisibleSurfaceHost>` so only the active surface of each pane is hit-tested — `resolve_pane_at_phys` and its callers in `dispatch_mouse_buttons` and hyperlink hover (`src/input/mouse_buttons.rs`, `src/input/hyperlink.rs`).
- Regression test `resolve_pane_at_phys_ignores_parked_hosts` covering the previously-untested direction (a parked host overlapping the cursor must be ignored).

**Companion change (separate repo).** The complete fix also requires a `bevy_cef` change so keyboard/IME is delivered only to the focused webview (when `FocusedWebview` is `None`, no webview receives input). `bevy_cef`'s `send_key_event`/`ime_event` previously broadcast to all browsers with a focused CEF frame, and CEF's `focused_frame()` survives `set_focus(false)`, so a blurred webview kept receiving input. That fix lands in the `bevy_cef` path dependency; this PR is the ozmux-side half.

Affected: engine only (UI layout + input hit-testing). No public API or breaking changes.
