### PR TITLE
feat(ui): terminal tab title shows the working directory (CWD)

### DIFF
--- a/crates/bevy_terminal/src/lib.rs
+++ b/crates/bevy_terminal/src/lib.rs
@@ -32,5 +32,5 @@ pub use handle::{TerminalHandle, ViIndicatorSnapshot};
 pub use mouse_encode::ProtocolModifiers;
 pub use plugin::TerminalHandlePlugin;
 pub use pty::PtyHandle;
-pub use title::TerminalTitle;
+pub use title::{TerminalTitle, sanitize_title};
 pub use wheel::{CellCoord, WheelAction, WheelConfig, WheelDir, WheelModifiers};

--- a/crates/bevy_terminal/src/title.rs
+++ b/crates/bevy_terminal/src/title.rs
@@ -16,7 +16,7 @@ pub struct TerminalTitle(pub Option<String>);
 const MAX_LEN: usize = 256;
 
 /// Returns a display-safe copy of an OSC terminal title.
-pub(crate) fn sanitize_title(raw: &str) -> String {
+pub fn sanitize_title(raw: &str) -> String {
     let cleaned: String = raw.chars().filter(|c| !is_disallowed(*c)).collect();
     if cleaned.chars().count() > MAX_LEN {
         cleaned

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -44,6 +44,11 @@ pub const TAB_BORDER_RADIUS_PX: f32 = 4.0;
 /// Top indicator thickness on the active pane tab.
 pub const TAB_INDICATOR_PX: f32 = 2.0;
 pub const BORDER_PX: f32 = 1.0;
+/// Maximum width of a single pane tab. Long CWD paths are front-ellipsized
+/// to fit and hard-clipped at this width so a tab never spans the bar.
+pub const TAB_MAX_WIDTH_PX: f32 = 220.0;
+/// Character budget for a terminal tab's CWD label before front-ellipsis.
+pub const TAB_LABEL_MAX_CHARS: usize = 28;
 
 /// Background color of the copy-mode indicator chip. tmux-style bright
 /// yellow so the chip reads as a deliberate HUD element on top of the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -242,7 +242,7 @@ mod tests {
     use ozmux_multiplexer::{AttachedSession, MultiplexerPlugin};
 
     /// Collects the rendered text of every tab (the `Text` child of each
-    /// `TabButton` node), in tab order.
+    /// `TabButton` node). Order is unspecified — fine for single-tab assertions.
     fn tab_texts(world: &mut World) -> Vec<String> {
         let tabs: Vec<Entity> = world
             .query_filtered::<Entity, With<TabButton>>()
@@ -1059,6 +1059,7 @@ mod tests {
         use bevy_terminal::TerminalCurrentDir;
 
         let (mut app, _guard) = make_test_app();
+        app.insert_resource(HomeDir(None));
         app.update();
         app.update();
 
@@ -1097,6 +1098,7 @@ mod tests {
         use ozmux_multiplexer::{Cwd, SurfaceMarker};
 
         let (mut app, _guard) = make_test_app();
+        app.insert_resource(HomeDir(None));
         app.update();
         app.update();
 
@@ -1119,6 +1121,7 @@ mod tests {
         use ozmux_multiplexer::{Cwd, LayoutCells, SessionMarker, SurfaceMarker};
 
         let (mut app, _guard) = make_test_app();
+        app.insert_resource(HomeDir(None));
         app.update();
         app.update();
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,8 +15,8 @@ use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::root::OzmuxUiRootPlugin;
 use crate::ui::session::OzmuxSessionUiPlugin;
 use crate::ui::terminal::OzmuxTerminalUiPlugin;
-use std::path::PathBuf;
 use bevy::prelude::*;
+use std::path::PathBuf;
 
 pub mod copy_mode;
 pub mod copy_mode_indicator;
@@ -32,8 +32,8 @@ pub mod status_bar_sync;
 pub(crate) mod stress_test;
 pub(crate) mod surface;
 pub mod tab_bar;
-pub(crate) mod tab_label;
 pub(crate) mod tab_input;
+pub(crate) mod tab_label;
 pub mod terminal;
 
 /// Marker for the single root UI Node entity. Spawned once in Startup,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1036,6 +1036,25 @@ mod tests {
     }
 
     #[test]
+    fn terminal_tab_node_is_width_capped() {
+        use bevy::ui::OverflowAxis;
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let world = app.world_mut();
+        let tab = world
+            .query_filtered::<Entity, With<TabButton>>()
+            .iter(world)
+            .next()
+            .expect("one tab after bootstrap");
+        let node = world.get::<Node>(tab).expect("tab has a Node");
+        assert_eq!(node.max_width, Val::Px(crate::theme::TAB_MAX_WIDTH_PX));
+        assert_eq!(node.overflow.x, OverflowAxis::Clip);
+    }
+
+    #[test]
     fn osc7_current_dir_updates_tab() {
         use bevy_terminal::TerminalCurrentDir;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1036,6 +1036,31 @@ mod tests {
     }
 
     #[test]
+    fn osc7_current_dir_updates_tab() {
+        use bevy_terminal::TerminalCurrentDir;
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let host = app
+            .world_mut()
+            .query_filtered::<Entity, With<HostSurfaceEntity>>()
+            .iter(app.world())
+            .next()
+            .expect("a surface host exists after rebuild");
+        app.world_mut().trigger(TerminalCurrentDir {
+            entity: host,
+            path: "/tmp/proj".into(),
+        });
+        for _ in 0..3 {
+            app.update();
+        }
+
+        assert_eq!(tab_texts(app.world_mut()), vec!["/tmp/proj".to_string()]);
+    }
+
+    #[test]
     fn terminal_tab_without_cwd_shows_placeholder() {
         let (mut app, _guard) = make_test_app();
         app.update();
@@ -1046,6 +1071,28 @@ mod tests {
             vec!["terminal".to_string()],
             "bootstrap terminal surface has no Cwd yet → placeholder",
         );
+    }
+
+    #[test]
+    fn cwd_change_refreshes_tab_without_layout_change() {
+        use ozmux_multiplexer::{Cwd, SurfaceMarker};
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let surface = app
+            .world_mut()
+            .query_filtered::<Entity, With<SurfaceMarker>>()
+            .single(app.world())
+            .expect("one bootstrap surface");
+        app.world_mut()
+            .entity_mut(surface)
+            .insert(Cwd("/tmp/proj".into()));
+        app.update();
+        app.update();
+
+        assert_eq!(tab_texts(app.world_mut()), vec!["/tmp/proj".to_string()]);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,6 +31,7 @@ pub mod status_bar_sync;
 pub(crate) mod stress_test;
 pub(crate) mod surface;
 pub mod tab_bar;
+pub(crate) mod tab_label;
 pub(crate) mod tab_input;
 pub mod terminal;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -241,6 +241,28 @@ mod tests {
     use bevy_terminal_renderer::{CellMetrics, TerminalCellMetricsResource};
     use ozmux_multiplexer::{AttachedSession, MultiplexerPlugin};
 
+    /// Collects the rendered text of every tab (the `Text` child of each
+    /// `TabButton` node), in tab order.
+    fn tab_texts(world: &mut World) -> Vec<String> {
+        let tabs: Vec<Entity> = world
+            .query_filtered::<Entity, With<TabButton>>()
+            .iter(world)
+            .collect();
+        let mut out = Vec::new();
+        for tab in tabs {
+            let kids: Vec<Entity> = world
+                .get::<Children>(tab)
+                .map(|c| c.iter().collect())
+                .unwrap_or_default();
+            for k in kids {
+                if let Some(text) = world.get::<bevy::ui::widget::Text>(k) {
+                    out.push(text.0.clone());
+                }
+            }
+        }
+        out
+    }
+
     fn make_test_app() -> (App, std::sync::MutexGuard<'static, ()>) {
         let guard = crate::configs::env_guard();
         // SAFETY: env mutations are serialized by env_guard() for this crate's tests.
@@ -1011,5 +1033,46 @@ mod tests {
             vec!["session1".to_string(), "session2".to_string()],
             "status bar must show session1 leftmost, session2 to its right",
         );
+    }
+
+    #[test]
+    fn terminal_tab_without_cwd_shows_placeholder() {
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        assert_eq!(
+            tab_texts(app.world_mut()),
+            vec!["terminal".to_string()],
+            "bootstrap terminal surface has no Cwd yet → placeholder",
+        );
+    }
+
+    #[test]
+    fn terminal_tab_renders_cwd_after_rebuild() {
+        use ozmux_multiplexer::{Cwd, LayoutCells, SessionMarker, SurfaceMarker};
+
+        let (mut app, _guard) = make_test_app();
+        app.update();
+        app.update();
+
+        let surface = app
+            .world_mut()
+            .query_filtered::<Entity, With<SurfaceMarker>>()
+            .single(app.world())
+            .expect("one bootstrap surface");
+        app.world_mut()
+            .entity_mut(surface)
+            .insert(Cwd("/tmp/proj".into()));
+        {
+            let world = app.world_mut();
+            let mut q = world.query_filtered::<&mut LayoutCells, With<SessionMarker>>();
+            for mut lc in q.iter_mut(world) {
+                lc.set_changed();
+            }
+        }
+        app.update();
+
+        assert_eq!(tab_texts(app.world_mut()), vec!["/tmp/proj".to_string()]);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::root::OzmuxUiRootPlugin;
 use crate::ui::session::OzmuxSessionUiPlugin;
 use crate::ui::terminal::OzmuxTerminalUiPlugin;
+use std::path::PathBuf;
 use bevy::prelude::*;
 
 pub mod copy_mode;
@@ -195,12 +196,19 @@ pub(crate) struct PaneDimOverlay {
 #[derive(Component)]
 pub(crate) struct SessionUiDirty;
 
+/// Resolved `$HOME` at startup (`None` if unset). Read by `rebuild_session_ui`
+/// to home-abbreviate terminal tab paths; the value matches the terminal
+/// spawner's `$HOME` fallback so the tab agrees with where the shell started.
+#[derive(Resource)]
+pub(crate) struct HomeDir(pub(crate) Option<PathBuf>);
+
 /// Bevy Plugin wiring the native Bevy UI rebuild pipeline.
 pub struct OzmuxUiPlugin;
 
 impl Plugin for OzmuxUiPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SurfaceEntityRegistry>()
+            .insert_resource(HomeDir(std::env::var_os("HOME").map(PathBuf::from)))
             .add_plugins((
                 OzmuxUiRootPlugin,
                 OzmuxSessionUiPlugin,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -8,11 +8,12 @@ use crate::theme;
 use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::surface::build_surface_host_children;
 use crate::ui::tab_bar::{TabEntry, build_pane_tab_bar};
+use crate::ui::tab_label::{LabelCtx, tab_label};
 use crate::ui::{PaneDimOverlay, PaneFrame, StructuralNode, VisibleSurfaceHost, palette};
 use bevy::prelude::*;
 use bevy::ui::{FlexDirection, PositionType, UiRect, Val};
 use ozmux_multiplexer::{
-    ActiveSurface, Cell, CellId, LayoutCellState, PaneMarker, SplitOrientation, SurfaceKind,
+    ActiveSurface, Cell, CellId, Cwd, LayoutCellState, PaneMarker, SplitOrientation, SurfaceKind,
     SurfaceMarker,
 };
 
@@ -49,10 +50,11 @@ pub(crate) fn build_cell_recursive(
     inactive_host_parent: Entity,
     ui_font: &Handle<Font>,
     pane_children: &Query<&Children>,
-    surfaces: &Query<(&SurfaceKind, &Name), With<SurfaceMarker>>,
+    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
     active_surfaces: &Query<&ActiveSurface, With<PaneMarker>>,
     active_pane: Entity,
     veil: Option<Color>,
+    label_ctx: &LabelCtx,
 ) {
     let cell = match cells.cell(cell_id) {
         Ok(c) => c,
@@ -87,6 +89,7 @@ pub(crate) fn build_cell_recursive(
             active_surfaces,
             active_pane,
             veil,
+            label_ctx,
         ),
         Cell::Split(s) => {
             let (lhs_grow, rhs_grow) = split_ratio_to_flex_grows(s.lhs_weight, s.rhs_weight);
@@ -132,6 +135,7 @@ pub(crate) fn build_cell_recursive(
                 active_surfaces,
                 active_pane,
                 veil,
+                label_ctx,
             );
 
             let rhs = commands
@@ -158,6 +162,7 @@ pub(crate) fn build_cell_recursive(
                 active_surfaces,
                 active_pane,
                 veil,
+                label_ctx,
             );
         }
     }
@@ -172,10 +177,11 @@ fn build_pane(
     inactive_host_parent: Entity,
     ui_font: &Handle<Font>,
     pane_children: &Query<&Children>,
-    surfaces: &Query<(&SurfaceKind, &Name), With<SurfaceMarker>>,
+    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
     active_surfaces: &Query<&ActiveSurface, With<PaneMarker>>,
     active_pane: Entity,
     veil: Option<Color>,
+    label_ctx: &LabelCtx,
 ) {
     let active_surface = active_surfaces
         .get(pane_entity)
@@ -207,10 +213,16 @@ fn build_pane(
     let tabs: Vec<TabEntry> = surface_entities
         .iter()
         .filter_map(|&ae| {
-            let (_, name) = surfaces.get(ae).ok()?;
+            let (kind, name, cwd) = surfaces.get(ae).ok()?;
             Some(TabEntry {
                 entity: ae,
-                name: name.as_str().to_string(),
+                name: tab_label(
+                    kind,
+                    cwd,
+                    name.as_str(),
+                    label_ctx.home.as_deref(),
+                    label_ctx.max_chars,
+                ),
                 is_active: ae == active_surface,
             })
         })
@@ -237,7 +249,7 @@ fn build_pane(
         .id();
 
     for &surface_entity in &surface_entities {
-        let Ok((kind, name)) = surfaces.get(surface_entity) else {
+        let Ok((kind, name, _cwd)) = surfaces.get(surface_entity) else {
             continue;
         };
         let host = registry.get_or_spawn(commands, surface_entity, kind);
@@ -258,7 +270,7 @@ fn build_pane(
     // they must NOT also get the veil — double-dimming would over-darken their
     // content. The veil is for non-terminal (e.g. webview) panes only.
     let active_is_terminal = matches!(
-        surfaces.get(active_surface).map(|(kind, _)| kind),
+        surfaces.get(active_surface).map(|(kind, _, _)| kind),
         Ok(SurfaceKind::Terminal)
     );
     if let Some(veil_color) = veil

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -6,11 +6,11 @@
 use crate::configs::OzmuxConfigsResource;
 use crate::font::TerminalUiFont;
 use crate::system_set::OzmuxSystems;
+use crate::theme;
 use crate::ui::layout::build_cell_recursive;
 use crate::ui::registry::SurfaceEntityRegistry;
-use crate::ui::terminal::resolve_pane_session;
-use crate::theme;
 use crate::ui::tab_label::LabelCtx;
+use crate::ui::terminal::resolve_pane_session;
 use crate::ui::{
     HomeDir, HostSurfaceEntity, PaneDimOverlay, SessionUiDirty, SessionUiRoot, StructuralNode,
     SurfaceHostNode, TerminalSurfaceMarker,

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -198,6 +198,7 @@ fn flag_chrome_dirty_on_surface_change(
     mut commands: Commands,
     added_surfaces: Query<Entity, Added<SurfaceMarker>>,
     switched_panes: Query<Entity, (With<PaneMarker>, Changed<ActiveSurface>)>,
+    changed_cwd: Query<Entity, (With<SurfaceMarker>, Changed<Cwd>)>,
     child_of: Query<&ChildOf>,
 ) {
     for surface in added_surfaces.iter() {
@@ -208,6 +209,11 @@ fn flag_chrome_dirty_on_surface_change(
     for pane in switched_panes.iter() {
         if let Ok(pane_parent) = child_of.get(pane) {
             commands.entity(pane_parent.parent()).insert(SessionUiDirty);
+        }
+    }
+    for surface in changed_cwd.iter() {
+        if let Some((_pane, session)) = resolve_pane_session(surface, &child_of) {
+            commands.entity(session).insert(SessionUiDirty);
         }
     }
 }

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -186,8 +186,9 @@ fn rebuild_session_ui(
 }
 
 /// Flags a session `SessionUiDirty` when one of its panes gains a surface
-/// (`Added<SurfaceMarker>`) or switches its active surface
-/// (`Changed<ActiveSurface>`) — in-pane changes that do not mutate
+/// (`Added<SurfaceMarker>`), switches its active surface
+/// (`Changed<ActiveSurface>`), or a surface reports a new working directory
+/// (`Changed<Cwd>`, via OSC 7) — in-pane changes that do not mutate
 /// `LayoutCells` and so would otherwise not trigger `rebuild_session_ui`.
 /// Covers both the `@md` control-bridge path and the in-app shortcuts via a
 /// single UI-layer hook, keeping the multiplexer crate free of UI concerns.

--- a/src/ui/session.rs
+++ b/src/ui/session.rs
@@ -9,8 +9,10 @@ use crate::system_set::OzmuxSystems;
 use crate::ui::layout::build_cell_recursive;
 use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::terminal::resolve_pane_session;
+use crate::theme;
+use crate::ui::tab_label::LabelCtx;
 use crate::ui::{
-    HostSurfaceEntity, PaneDimOverlay, SessionUiDirty, SessionUiRoot, StructuralNode,
+    HomeDir, HostSurfaceEntity, PaneDimOverlay, SessionUiDirty, SessionUiRoot, StructuralNode,
     SurfaceHostNode, TerminalSurfaceMarker,
 };
 use bevy::prelude::*;
@@ -18,7 +20,7 @@ use bevy::ui::UiSystems;
 use bevy_terminal_renderer::material::{PaneDim, TerminalUiMaterial};
 use ozmux_extension_host::ExtensionControlSet;
 use ozmux_multiplexer::{
-    ActivePane, ActiveSurface, AttachedSession, Cell, LayoutCells, PaneMarker, SessionMarker,
+    ActivePane, ActiveSurface, AttachedSession, Cell, Cwd, LayoutCells, PaneMarker, SessionMarker,
     SessionUiSubtree, SurfaceKind, SurfaceMarker,
 };
 
@@ -127,10 +129,11 @@ fn rebuild_session_ui(
     structurals: Query<(Entity, Option<&ChildOf>), With<StructuralNode>>,
     surface_hosts: Query<(Entity, &SurfaceHostNode)>,
     children: Query<&Children>,
-    surfaces: Query<(&SurfaceKind, &Name), With<SurfaceMarker>>,
+    surfaces: Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
     active_surfaces: Query<&ActiveSurface, With<PaneMarker>>,
     ui_font: Option<Res<TerminalUiFont>>,
     configs: Option<Res<OzmuxConfigsResource>>,
+    home_dir: Option<Res<HomeDir>>,
 ) {
     let ui_font_handle = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
 
@@ -140,6 +143,10 @@ fn rebuild_session_ui(
             Some(Color::srgb_u8(r, g, b).with_alpha(cfg.inactive_pane.opacity))
         }
         _ => None,
+    };
+    let label_ctx = LabelCtx {
+        home: home_dir.and_then(|h| h.0.clone()),
+        max_chars: theme::TAB_LABEL_MAX_CHARS,
     };
 
     for (session_entity, layout, subtree, active_pane, _is_attached) in sessions.iter() {
@@ -165,6 +172,7 @@ fn rebuild_session_ui(
                     &active_surfaces,
                     active_pane,
                     session_veil,
+                    &label_ctx,
                 );
             }
             Ok(_) => tracing::warn!(target: "ozmux_gui::ui", "root_cell is not Cell::Root"),

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -7,8 +7,8 @@ use crate::ui::palette;
 use crate::ui::{StructuralNode, TabButton};
 use bevy::color::Color;
 use bevy::prelude::*;
-use bevy::ui::{AlignItems, BorderRadius, FlexDirection, JustifyContent, Overflow, UiRect, Val};
 use bevy::text::{LineBreak, TextLayout};
+use bevy::ui::{AlignItems, BorderRadius, FlexDirection, JustifyContent, Overflow, UiRect, Val};
 
 /// Color triple for one tab.
 struct TabColors {

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -7,7 +7,8 @@ use crate::ui::palette;
 use crate::ui::{StructuralNode, TabButton};
 use bevy::color::Color;
 use bevy::prelude::*;
-use bevy::ui::{AlignItems, BorderRadius, FlexDirection, JustifyContent, UiRect, Val};
+use bevy::ui::{AlignItems, BorderRadius, FlexDirection, JustifyContent, Overflow, UiRect, Val};
+use bevy::text::{LineBreak, TextLayout};
 
 /// Color triple for one tab.
 struct TabColors {
@@ -119,6 +120,8 @@ fn build_tab(
                 },
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
+                max_width: Val::Px(theme::TAB_MAX_WIDTH_PX),
+                overflow: Overflow::clip_x(),
                 ..default()
             },
             BackgroundColor(colors.bg),
@@ -139,6 +142,10 @@ fn build_tab(
         TextFont {
             font: ui_font.clone(),
             font_size: 12.0,
+            ..default()
+        },
+        TextLayout {
+            linebreak: LineBreak::NoWrap,
             ..default()
         },
         StructuralNode,

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -7,7 +7,7 @@ use ozmux_multiplexer::{Cwd, SurfaceKind};
 use std::path::{Path, PathBuf};
 
 /// Placeholder shown for a terminal surface whose `Cwd` is not yet known.
-const TERMINAL_PLACEHOLDER: &str = "terminal";
+const TERMINAL_PLACEHOLDER: &str = "";
 
 /// Per-rebuild inputs for `tab_label`, built once in `rebuild_session_ui` and
 /// threaded through the cell-tree builder.

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -7,7 +7,7 @@ use ozmux_multiplexer::{Cwd, SurfaceKind};
 use std::path::{Path, PathBuf};
 
 /// Placeholder shown for a terminal surface whose `Cwd` is not yet known.
-pub(crate) const TERMINAL_PLACEHOLDER: &str = "terminal";
+const TERMINAL_PLACEHOLDER: &str = "terminal";
 
 /// Per-rebuild inputs for `tab_label`, built once in `rebuild_session_ui` and
 /// threaded through the cell-tree builder.
@@ -172,6 +172,24 @@ mod tests {
         };
         let out = tab_label(&kind, None, "memo", None, MAX);
         assert_eq!(out, "memo");
+    }
+
+    #[test]
+    fn browser_returns_name() {
+        use ozmux_multiplexer::BrowserProfile;
+        let kind = SurfaceKind::Browser {
+            initial_url: None,
+            profile: BrowserProfile::default(),
+        };
+        let cwd = Cwd(PathBuf::from("/home/u/proj"));
+        let out = tab_label(
+            &kind,
+            Some(&cwd),
+            "my-browser",
+            Some(Path::new("/home/u")),
+            MAX,
+        );
+        assert_eq!(out, "my-browser");
     }
 
     #[test]

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -69,7 +69,11 @@ fn front_truncate(s: &str, max_chars: usize) -> String {
     let mut used = 0usize;
     for seg in segments.iter().rev() {
         let seg_len = seg.chars().count();
-        let extra = if kept.is_empty() { seg_len } else { seg_len + 1 };
+        let extra = if kept.is_empty() {
+            seg_len
+        } else {
+            seg_len + 1
+        };
         if used + extra > budget {
             break;
         }

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -38,7 +38,7 @@ pub(crate) fn tab_label(
 }
 
 /// Replaces a leading `home` prefix with `~` (component-aware), else returns
-/// the lossy absolute path.
+/// the lossy path string.
 fn abbreviate_home(path: &Path, home: Option<&Path>) -> String {
     if let Some(home) = home
         && let Ok(rest) = path.strip_prefix(home)
@@ -57,6 +57,9 @@ fn abbreviate_home(path: &Path, home: Option<&Path>) -> String {
 /// segments and prepending `…/`. A single over-long trailing segment is
 /// hard-cut with a leading `…`.
 fn front_truncate(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
     if s.chars().count() <= max_chars {
         return s.to_string();
     }
@@ -172,5 +175,21 @@ mod tests {
         let cwd = Cwd(PathBuf::from("/tmp/a\u{7}b"));
         let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
         assert_eq!(out, "/tmp/ab");
+    }
+
+    #[test]
+    fn tiny_max_chars_never_exceeds_budget() {
+        let cwd = Cwd(PathBuf::from("/home/u/workspace"));
+        let out0 = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), 0);
+        assert_eq!(out0.chars().count(), 0, "got {out0:?}");
+        let out1 = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), 1);
+        assert_eq!(out1.chars().count(), 1, "got {out1:?}");
+    }
+
+    #[test]
+    fn multibyte_path_abbreviates() {
+        let cwd = Cwd(PathBuf::from("/home/u/プロジェクト"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert_eq!(out, "~/プロジェクト");
     }
 }

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -1,0 +1,176 @@
+//! Tab-title label formatting. `tab_label` renders a terminal surface's live
+//! `Cwd` (home-abbreviated, front-ellipsized) and falls back to the surface
+//! `Name` for non-terminal kinds; `LabelCtx` carries the per-rebuild inputs.
+
+use bevy_terminal::sanitize_title;
+use ozmux_multiplexer::{Cwd, SurfaceKind};
+use std::path::{Path, PathBuf};
+
+/// Placeholder shown for a terminal surface whose `Cwd` is not yet known.
+pub(crate) const TERMINAL_PLACEHOLDER: &str = "terminal";
+
+/// Per-rebuild inputs for `tab_label`, built once in `rebuild_session_ui` and
+/// threaded through the cell-tree builder.
+pub(crate) struct LabelCtx {
+    pub(crate) home: Option<PathBuf>,
+    pub(crate) max_chars: usize,
+}
+
+/// Returns the tab-title string for a surface. Terminal surfaces render their
+/// home-abbreviated, front-ellipsized `Cwd`; an unknown `Cwd` yields
+/// `TERMINAL_PLACEHOLDER`. Non-terminal kinds return `name` unchanged.
+pub(crate) fn tab_label(
+    kind: &SurfaceKind,
+    cwd: Option<&Cwd>,
+    name: &str,
+    home: Option<&Path>,
+    max_chars: usize,
+) -> String {
+    if !matches!(kind, SurfaceKind::Terminal) {
+        return name.to_string();
+    }
+    let Some(Cwd(path)) = cwd else {
+        return TERMINAL_PLACEHOLDER.to_string();
+    };
+    let abbreviated = abbreviate_home(path, home);
+    let sanitized = sanitize_title(&abbreviated);
+    front_truncate(&sanitized, max_chars)
+}
+
+/// Replaces a leading `home` prefix with `~` (component-aware), else returns
+/// the lossy absolute path.
+fn abbreviate_home(path: &Path, home: Option<&Path>) -> String {
+    if let Some(home) = home
+        && let Ok(rest) = path.strip_prefix(home)
+    {
+        let rest = rest.to_string_lossy();
+        return if rest.is_empty() {
+            "~".to_string()
+        } else {
+            format!("~/{rest}")
+        };
+    }
+    path.to_string_lossy().into_owned()
+}
+
+/// Front-truncates `s` to at most `max_chars` chars, dropping leading path
+/// segments and prepending `…/`. A single over-long trailing segment is
+/// hard-cut with a leading `…`.
+fn front_truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let budget = max_chars.saturating_sub(2);
+    let segments: Vec<&str> = s.split('/').collect();
+    let mut kept: Vec<&str> = Vec::new();
+    let mut used = 0usize;
+    for seg in segments.iter().rev() {
+        let seg_len = seg.chars().count();
+        let extra = if kept.is_empty() { seg_len } else { seg_len + 1 };
+        if used + extra > budget {
+            break;
+        }
+        used += extra;
+        kept.push(seg);
+    }
+    if kept.is_empty() {
+        let last = segments.last().copied().unwrap_or("");
+        let chars: Vec<char> = last.chars().collect();
+        let take = max_chars.saturating_sub(1);
+        let start = chars.len().saturating_sub(take);
+        let tail: String = chars[start..].iter().collect();
+        return format!("…{tail}");
+    }
+    kept.reverse();
+    format!("…/{}", kept.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX: usize = 28;
+
+    fn term() -> SurfaceKind {
+        SurfaceKind::Terminal
+    }
+
+    #[test]
+    fn terminal_under_home_abbreviates() {
+        let cwd = Cwd(PathBuf::from("/home/u/proj"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert_eq!(out, "~/proj");
+    }
+
+    #[test]
+    fn terminal_at_home_is_tilde() {
+        let cwd = Cwd(PathBuf::from("/home/u"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert_eq!(out, "~");
+    }
+
+    #[test]
+    fn terminal_outside_home_is_absolute() {
+        let cwd = Cwd(PathBuf::from("/etc/nginx"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert_eq!(out, "/etc/nginx");
+    }
+
+    #[test]
+    fn home_prefix_is_component_aware() {
+        let cwd = Cwd(PathBuf::from("/home/u2/x"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert_eq!(out, "/home/u2/x");
+    }
+
+    #[test]
+    fn no_home_keeps_absolute() {
+        let cwd = Cwd(PathBuf::from("/home/u/proj"));
+        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        assert_eq!(out, "/home/u/proj");
+    }
+
+    #[test]
+    fn long_path_front_ellipsizes() {
+        let cwd = Cwd(PathBuf::from("/home/u/workspace/ozmux/wt/tab-title"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert!(out.starts_with("…/"), "got {out}");
+        assert!(out.ends_with("tab-title"), "got {out}");
+        assert!(
+            out.chars().count() <= MAX,
+            "got {out} ({} chars)",
+            out.chars().count()
+        );
+    }
+
+    #[test]
+    fn single_long_segment_hard_cuts() {
+        let seg = "a".repeat(100);
+        let cwd = Cwd(PathBuf::from(format!("/{seg}")));
+        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        assert!(out.starts_with('…'), "got {out}");
+        assert_eq!(out.chars().count(), MAX);
+    }
+
+    #[test]
+    fn no_cwd_is_placeholder() {
+        let out = tab_label(&term(), None, "ignored", None, MAX);
+        assert_eq!(out, "terminal");
+    }
+
+    #[test]
+    fn extension_returns_name() {
+        let kind = SurfaceKind::Extension {
+            entry: PathBuf::from("/tmp/ext"),
+        };
+        let out = tab_label(&kind, None, "memo", None, MAX);
+        assert_eq!(out, "memo");
+    }
+
+    #[test]
+    fn control_chars_stripped() {
+        let cwd = Cwd(PathBuf::from("/tmp/a\u{7}b"));
+        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        assert_eq!(out, "/tmp/ab");
+    }
+}

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -64,7 +64,11 @@ fn front_truncate(s: &str, max_chars: usize) -> String {
         return s.to_string();
     }
     let budget = max_chars.saturating_sub(2);
-    let segments: Vec<&str> = s.split('/').collect();
+    // NOTE: empty segments must be filtered — an OSC 7 trailing slash makes
+    // `split('/')` yield a 0-length segment whose `extra` is always 0, so it
+    // would slip into `kept` and leak a stray separator (or overflow a tiny
+    // budget).
+    let segments: Vec<&str> = s.split('/').filter(|seg| !seg.is_empty()).collect();
     let mut kept: Vec<&str> = Vec::new();
     let mut used = 0usize;
     for seg in segments.iter().rev() {
@@ -213,5 +217,19 @@ mod tests {
         let cwd = Cwd(PathBuf::from("/home/u/プロジェクト"));
         let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "~/プロジェクト");
+    }
+
+    #[test]
+    fn trailing_slash_does_not_leak_or_overflow() {
+        let cwd = Cwd(PathBuf::from("/home/u/workspace/ozmux/wt/tab-title/"));
+        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        assert!(
+            out.starts_with("…/") && out.ends_with("tab-title"),
+            "got {out}"
+        );
+        assert!(!out.ends_with('/'), "trailing slash leaked: {out}");
+        assert!(out.chars().count() <= MAX, "got {out}");
+        let tiny = tab_label(&term(), Some(&cwd), "x", None, 1);
+        assert_eq!(tiny.chars().count(), 1, "got {tiny:?}");
     }
 }


### PR DESCRIPTION
## Problem

For terminal surfaces, the per-pane tab title showed a generic `surface` name — it gave no hint of which directory each terminal was in, so tabs were indistinguishable at a glance.

## Solution

Terminal tabs now display the surface's **live working directory**, kept current via OSC 7:

- **Format:** home-abbreviated (`~/workspace/ozmux/wt/tab-title`), front-ellipsized on segment boundaries when too long (`…/wt/tab-title`), hard-capped to a fixed tab width.
- **Fallback:** a `terminal` placeholder until the first OSC 7 report (or for shells that never emit it).
- **Scope:** only terminal surfaces change; Browser/Extension surfaces keep their existing `Name`.
- **Refresh:** a `Changed<Cwd>` arm on the existing `flag_chrome_dirty_on_surface_change` repaints the tab on every `cd`, reusing the established full-subtree rebuild (chrome only — surface/terminal hosts are preserved).

Affected areas (UI layer + one cross-crate export):

- `src/ui/tab_label.rs` *(new)* — pure, ECS-free formatter: `abbreviate_home` (component-aware `strip_prefix`) → `sanitize_title` → front-ellipsis.
- `src/ui/layout.rs`, `src/ui/session.rs` — thread the live `Cwd` + a `HomeDir` resource into the rebuild.
- `src/ui/tab_bar.rs` — `max_width` + `Overflow::clip_x()` + `LineBreak::NoWrap`.
- `src/theme.rs` — tab-width / label-length constants.
- `crates/bevy_terminal` — export `sanitize_title` for reuse (anti-spoofing of percent-decoded OSC 7 paths).

Notes:

- `$HOME` is resolved via `var_os("HOME")` to match the terminal spawner's own fallback, so the tab agrees with where the shell started.
- Same-frame repaint isn't guaranteed (the OSC 7 → `Cwd` path has deferred-command hops); the tab repaints within 1–2 frames, which is visually fine.

### Tests

- 14 unit tests for the pure formatter (home-abbrev, component-aware prefix, front-ellipsis, single-segment hard-cut, trailing slash, multibyte, control-char stripping, placeholder, non-terminal kinds, tiny budgets).
- 5 ECS integration tests (placeholder, render-after-rebuild, `Changed<Cwd>` refresh, the **real OSC-7 trigger path**, width cap).
- `cargo clippy --all-targets -D warnings` clean; `cargo fmt` clean.

<details><summary>Screenshots</summary>

UI change is text-only in the tab bar — active terminal tab, before → after:

```
before:  [ surface ]
after:   [ ~/workspace/ozmux/wt/tab-title ]      # …/-ellipsized + width-capped when long
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)