### PR TITLE
feat(ui): sync browser/extension tab titles with the webview page title

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,9 +654,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e28d728ed7a5cb2d185aacaf92c12b0771b587f3ccb654af9828337483a8d05"
+version = "0.11.0-dev"
+source = "git+https://github.com/not-elm/bevy_cef?rev=d357288#d357288a01fb5145005dce1ac2166c0d8b57b7d9"
 dependencies = [
  "async-channel",
  "bevy",
@@ -671,9 +670,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86be5a2f23f825f09b7098a16135c1eb3affc484adfd7470652db7debd0468f"
+version = "0.11.0-dev"
+source = "git+https://github.com/not-elm/bevy_cef?rev=d357288#d357288a01fb5145005dce1ac2166c0d8b57b7d9"
 dependencies = [
  "async-channel",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = []
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { version = "0.10", features = ["debug"] }
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", rev = "d357288", features = ["debug"] }
 bevy_terminal_renderer = { path = "crates/bevy_terminal_renderer" }
 bevy_terminal = { path = "crates/bevy_terminal" }
 cosmic-text = "0.16"
@@ -75,7 +75,7 @@ toml = "0.8"
 dirs = "5"
 unicode-width = "0.2"
 open = "5"
-bevy_cef_core = "0.10.0"
+bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", rev = "d357288" }
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -53,4 +53,5 @@ skip-tree = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# TODO: drop once bevy_cef 0.11 (TitleChanged/WebviewTitle API) is published to crates.io.
+allow-git = ["https://github.com/not-elm/bevy_cef"]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -214,6 +214,7 @@ impl Plugin for OzmuxUiPlugin {
                 OzmuxUiRootPlugin,
                 OzmuxWorkspaceUiPlugin,
                 OzmuxTerminalUiPlugin,
+                web_title::WebTitlePlugin,
             ))
             .add_systems(
                 Update,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,6 +34,7 @@ pub mod tab_bar;
 pub(crate) mod tab_input;
 pub(crate) mod tab_label;
 pub mod terminal;
+pub(crate) mod web_title;
 pub mod workspace;
 
 /// Marker for the single root UI Node entity. Spawned once in Startup,

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -9,6 +9,7 @@ use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::surface::build_surface_host_children;
 use crate::ui::tab_bar::{TabEntry, build_pane_tab_bar};
 use crate::ui::tab_label::{LabelCtx, tab_label};
+use crate::ui::web_title::WebTitle;
 use crate::ui::{PaneDimOverlay, PaneFrame, StructuralNode, VisibleSurfaceHost, palette};
 use bevy::prelude::*;
 use bevy::ui::{FlexDirection, PositionType, UiRect, Val};
@@ -50,7 +51,7 @@ pub(crate) fn build_cell_recursive(
     inactive_host_parent: Entity,
     ui_font: &Handle<Font>,
     pane_children: &Query<&Children>,
-    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
+    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>, Option<&WebTitle>), With<SurfaceMarker>>,
     active_surfaces: &Query<&ActiveSurface, With<PaneMarker>>,
     active_pane: Entity,
     veil: Option<Color>,
@@ -177,7 +178,7 @@ fn build_pane(
     inactive_host_parent: Entity,
     ui_font: &Handle<Font>,
     pane_children: &Query<&Children>,
-    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
+    surfaces: &Query<(&SurfaceKind, &Name, Option<&Cwd>, Option<&WebTitle>), With<SurfaceMarker>>,
     active_surfaces: &Query<&ActiveSurface, With<PaneMarker>>,
     active_pane: Entity,
     veil: Option<Color>,
@@ -213,13 +214,13 @@ fn build_pane(
     let tabs: Vec<TabEntry> = surface_entities
         .iter()
         .filter_map(|&ae| {
-            let (kind, name, cwd) = surfaces.get(ae).ok()?;
+            let (kind, _name, cwd, web_title) = surfaces.get(ae).ok()?;
             Some(TabEntry {
                 entity: ae,
                 name: tab_label(
                     kind,
                     cwd,
-                    name.as_str(),
+                    web_title,
                     label_ctx.home.as_deref(),
                     label_ctx.max_chars,
                 ),
@@ -249,7 +250,7 @@ fn build_pane(
         .id();
 
     for &surface_entity in &surface_entities {
-        let Ok((kind, name, _cwd)) = surfaces.get(surface_entity) else {
+        let Ok((kind, name, _cwd, _web_title)) = surfaces.get(surface_entity) else {
             continue;
         };
         let host = registry.get_or_spawn(commands, surface_entity, kind);
@@ -270,7 +271,7 @@ fn build_pane(
     // they must NOT also get the veil — double-dimming would over-darken their
     // content. The veil is for non-terminal (e.g. webview) panes only.
     let active_is_terminal = matches!(
-        surfaces.get(active_surface).map(|(kind, _, _)| kind),
+        surfaces.get(active_surface).map(|(kind, _, _, _)| kind),
         Ok(SurfaceKind::Terminal)
     );
     if let Some(veil_color) = veil

--- a/src/ui/tab_label.rs
+++ b/src/ui/tab_label.rs
@@ -1,13 +1,17 @@
 //! Tab-title label formatting. `tab_label` renders a terminal surface's live
-//! `Cwd` (home-abbreviated, front-ellipsized) and falls back to the surface
-//! `Name` for non-terminal kinds; `LabelCtx` carries the per-rebuild inputs.
+//! `Cwd` (home-abbreviated, front-truncated) and a browser/extension surface's
+//! live `WebTitle` (sanitized, back-truncated), blank until a title arrives;
+//! `LabelCtx` carries the per-rebuild inputs.
 
+use crate::ui::web_title::WebTitle;
 use bevy_terminal::sanitize_title;
 use ozmux_multiplexer::{Cwd, SurfaceKind};
 use std::path::{Path, PathBuf};
 
 /// Placeholder shown for a terminal surface whose `Cwd` is not yet known.
 const TERMINAL_PLACEHOLDER: &str = "";
+/// Placeholder shown for a browser/extension surface with no webview title yet.
+const WEB_PLACEHOLDER: &str = "";
 
 /// Per-rebuild inputs for `tab_label`, built once in `rebuild_workspace_ui` and
 /// threaded through the cell-tree builder.
@@ -17,17 +21,26 @@ pub(crate) struct LabelCtx {
 }
 
 /// Returns the tab-title string for a surface. Terminal surfaces render their
-/// home-abbreviated, front-ellipsized `Cwd`; an unknown `Cwd` yields
-/// `TERMINAL_PLACEHOLDER`. Non-terminal kinds return `name` unchanged.
+/// home-abbreviated, front-truncated `Cwd` (`TERMINAL_PLACEHOLDER` when unknown).
+/// Browser/extension surfaces render their sanitized, back-truncated `WebTitle`
+/// (`WEB_PLACEHOLDER` when absent or empty).
 pub(crate) fn tab_label(
     kind: &SurfaceKind,
     cwd: Option<&Cwd>,
-    name: &str,
+    web_title: Option<&WebTitle>,
     home: Option<&Path>,
     max_chars: usize,
 ) -> String {
     if !matches!(kind, SurfaceKind::Terminal) {
-        return name.to_string();
+        let raw = web_title.map(|t| t.0.as_str()).unwrap_or("");
+        if raw.is_empty() {
+            return WEB_PLACEHOLDER.to_string();
+        }
+        let sanitized = sanitize_title(raw);
+        if sanitized.is_empty() {
+            return WEB_PLACEHOLDER.to_string();
+        }
+        return back_truncate(&sanitized, max_chars);
     }
     let Some(Cwd(path)) = cwd else {
         return TERMINAL_PLACEHOLDER.to_string();
@@ -35,6 +48,20 @@ pub(crate) fn tab_label(
     let abbreviated = abbreviate_home(path, home);
     let sanitized = sanitize_title(&abbreviated);
     front_truncate(&sanitized, max_chars)
+}
+
+/// Back-truncates `s` to at most `max_chars` chars, keeping the front and
+/// appending `…`. Used for web page titles (leading text is most identifying) —
+/// the mirror image of the path-oriented `front_truncate`.
+fn back_truncate(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{head}…")
 }
 
 /// Replaces a leading `home` prefix with `~` (component-aware), else returns
@@ -109,42 +136,42 @@ mod tests {
     #[test]
     fn terminal_under_home_abbreviates() {
         let cwd = Cwd(PathBuf::from("/home/u/proj"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "~/proj");
     }
 
     #[test]
     fn terminal_at_home_is_tilde() {
         let cwd = Cwd(PathBuf::from("/home/u"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "~");
     }
 
     #[test]
     fn terminal_outside_home_is_absolute() {
         let cwd = Cwd(PathBuf::from("/etc/nginx"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "/etc/nginx");
     }
 
     #[test]
     fn home_prefix_is_component_aware() {
         let cwd = Cwd(PathBuf::from("/home/u2/x"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "/home/u2/x");
     }
 
     #[test]
     fn no_home_keeps_absolute() {
         let cwd = Cwd(PathBuf::from("/home/u/proj"));
-        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        let out = tab_label(&term(), Some(&cwd), None, None, MAX);
         assert_eq!(out, "/home/u/proj");
     }
 
     #[test]
     fn long_path_front_ellipsizes() {
         let cwd = Cwd(PathBuf::from("/home/u/workspace/ozmux/wt/tab-title"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert!(out.starts_with("…/"), "got {out}");
         assert!(out.ends_with("tab-title"), "got {out}");
         assert!(
@@ -158,72 +185,108 @@ mod tests {
     fn single_long_segment_hard_cuts() {
         let seg = "a".repeat(100);
         let cwd = Cwd(PathBuf::from(format!("/{seg}")));
-        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        let out = tab_label(&term(), Some(&cwd), None, None, MAX);
         assert!(out.starts_with('…'), "got {out}");
         assert_eq!(out.chars().count(), MAX);
     }
 
-    #[test]
-    fn extension_returns_name() {
-        let kind = SurfaceKind::Extension {
+    fn browser() -> SurfaceKind {
+        use ozmux_multiplexer::BrowserProfile;
+        SurfaceKind::Browser {
+            initial_url: None,
+            profile: BrowserProfile::default(),
+        }
+    }
+
+    fn ext() -> SurfaceKind {
+        SurfaceKind::Extension {
             entry: PathBuf::from("/tmp/ext"),
-        };
-        let out = tab_label(&kind, None, "memo", None, MAX);
-        assert_eq!(out, "memo");
+        }
     }
 
     #[test]
-    fn browser_returns_name() {
-        use ozmux_multiplexer::BrowserProfile;
-        let kind = SurfaceKind::Browser {
-            initial_url: None,
-            profile: BrowserProfile::default(),
-        };
-        let cwd = Cwd(PathBuf::from("/home/u/proj"));
-        let out = tab_label(
-            &kind,
-            Some(&cwd),
-            "my-browser",
-            Some(Path::new("/home/u")),
-            MAX,
+    fn browser_renders_web_title() {
+        let wt = WebTitle("GitHub".into());
+        assert_eq!(tab_label(&browser(), None, Some(&wt), None, MAX), "GitHub");
+    }
+
+    #[test]
+    fn extension_renders_web_title() {
+        let wt = WebTitle("memo".into());
+        assert_eq!(tab_label(&ext(), None, Some(&wt), None, MAX), "memo");
+    }
+
+    #[test]
+    fn browser_blank_without_title() {
+        assert_eq!(tab_label(&browser(), None, None, None, MAX), "");
+    }
+
+    #[test]
+    fn browser_blank_on_empty_title() {
+        let wt = WebTitle(String::new());
+        assert_eq!(tab_label(&browser(), None, Some(&wt), None, MAX), "");
+    }
+
+    #[test]
+    fn web_title_back_truncates() {
+        let wt = WebTitle("A very long page title that exceeds the budget".into());
+        let out = tab_label(&browser(), None, Some(&wt), None, MAX);
+        assert!(out.starts_with("A very"), "got {out}");
+        assert!(out.ends_with('…'), "got {out}");
+        assert!(
+            out.chars().count() <= MAX,
+            "got {out} ({} chars)",
+            out.chars().count()
         );
-        assert_eq!(out, "my-browser");
+    }
+
+    #[test]
+    fn web_title_truncate_boundary() {
+        let wt = WebTitle("hello".into());
+        assert_eq!(tab_label(&browser(), None, Some(&wt), None, 1), "…");
+        assert_eq!(tab_label(&browser(), None, Some(&wt), None, 0), "");
+    }
+
+    #[test]
+    fn web_title_control_chars_stripped() {
+        let wt = WebTitle("a\u{7}b".into());
+        assert_eq!(tab_label(&ext(), None, Some(&wt), None, MAX), "ab");
     }
 
     #[test]
     fn control_chars_stripped() {
         let cwd = Cwd(PathBuf::from("/tmp/a\u{7}b"));
-        let out = tab_label(&term(), Some(&cwd), "x", None, MAX);
+        let out = tab_label(&term(), Some(&cwd), None, None, MAX);
         assert_eq!(out, "/tmp/ab");
     }
 
     #[test]
     fn tiny_max_chars_never_exceeds_budget() {
         let cwd = Cwd(PathBuf::from("/home/u/workspace"));
-        let out0 = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), 0);
+        let out0 = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), 0);
         assert_eq!(out0.chars().count(), 0, "got {out0:?}");
-        let out1 = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), 1);
+        let out1 = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), 1);
         assert_eq!(out1.chars().count(), 1, "got {out1:?}");
     }
 
     #[test]
     fn multibyte_path_abbreviates() {
         let cwd = Cwd(PathBuf::from("/home/u/プロジェクト"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert_eq!(out, "~/プロジェクト");
     }
 
     #[test]
     fn trailing_slash_does_not_leak_or_overflow() {
         let cwd = Cwd(PathBuf::from("/home/u/workspace/ozmux/wt/tab-title/"));
-        let out = tab_label(&term(), Some(&cwd), "x", Some(Path::new("/home/u")), MAX);
+        let out = tab_label(&term(), Some(&cwd), None, Some(Path::new("/home/u")), MAX);
         assert!(
             out.starts_with("…/") && out.ends_with("tab-title"),
             "got {out}"
         );
         assert!(!out.ends_with('/'), "trailing slash leaked: {out}");
         assert!(out.chars().count() <= MAX, "got {out}");
-        let tiny = tab_label(&term(), Some(&cwd), "x", None, 1);
+        let tiny = tab_label(&term(), Some(&cwd), None, None, 1);
         assert_eq!(tiny.chars().count(), 1, "got {tiny:?}");
     }
 }

--- a/src/ui/web_title.rs
+++ b/src/ui/web_title.rs
@@ -1,9 +1,78 @@
 //! Surface tab-title sync with the CEF webview page title.
 
+use crate::ui::{HostSurfaceEntity, PageWebviewOf};
 use bevy::prelude::*;
+use bevy_cef::prelude::TitleChanged;
 
 /// The live webview page title for a browser/extension surface, mirrored from
 /// bevy_cef's `WebviewTitle` onto the multiplexer Surface entity so `tab_label`
 /// and the chrome-dirty hook can read it like `Cwd`.
 #[derive(Component, Debug, Clone, Default)]
 pub(crate) struct WebTitle(pub(crate) String);
+
+/// Plugin wiring the CEF page-title → Surface `WebTitle` observer.
+pub(crate) struct WebTitlePlugin;
+
+impl Plugin for WebTitlePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_webview_title_changed);
+    }
+}
+
+/// Mirrors a CEF page-title change onto its owning Surface's `WebTitle`. The
+/// event targets the webview entity: a browser page child (resolved to its host
+/// via `PageWebviewOf`) or an extension host (which is itself the webview).
+fn on_webview_title_changed(
+    ev: On<TitleChanged>,
+    mut commands: Commands,
+    page_links: Query<&PageWebviewOf>,
+    hosts: Query<&HostSurfaceEntity>,
+) {
+    let host = page_links.get(ev.webview).map_or(ev.webview, |p| p.0);
+    if let Ok(host_surface) = hosts.get(host) {
+        // NOTE: try_insert (not insert) — a CEF title queued for a just-closed
+        // pane can target an already-despawned Surface entity; skip, don't error.
+        commands
+            .entity(host_surface.0)
+            .try_insert(WebTitle(ev.title.clone()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observer_writes_web_title_for_browser() {
+        let mut app = App::new();
+        app.add_observer(on_webview_title_changed);
+        let surface = app.world_mut().spawn_empty().id();
+        let host = app.world_mut().spawn(HostSurfaceEntity(surface)).id();
+        let page = app.world_mut().spawn(PageWebviewOf(host)).id();
+
+        app.world_mut().trigger(TitleChanged {
+            webview: page,
+            title: "GitHub".into(),
+        });
+        app.world_mut().flush();
+
+        assert_eq!(app.world().get::<WebTitle>(surface).unwrap().0, "GitHub");
+    }
+
+    #[test]
+    fn observer_writes_web_title_for_extension() {
+        let mut app = App::new();
+        app.add_observer(on_webview_title_changed);
+        let surface = app.world_mut().spawn_empty().id();
+        // Extension: the webview entity IS the host (no PageWebviewOf).
+        let host = app.world_mut().spawn(HostSurfaceEntity(surface)).id();
+
+        app.world_mut().trigger(TitleChanged {
+            webview: host,
+            title: "memo".into(),
+        });
+        app.world_mut().flush();
+
+        assert_eq!(app.world().get::<WebTitle>(surface).unwrap().0, "memo");
+    }
+}

--- a/src/ui/web_title.rs
+++ b/src/ui/web_title.rs
@@ -1,0 +1,9 @@
+//! Surface tab-title sync with the CEF webview page title.
+
+use bevy::prelude::*;
+
+/// The live webview page title for a browser/extension surface, mirrored from
+/// bevy_cef's `WebviewTitle` onto the multiplexer Surface entity so `tab_label`
+/// and the chrome-dirty hook can read it like `Cwd`.
+#[derive(Component, Debug, Clone, Default)]
+pub(crate) struct WebTitle(pub(crate) String);

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -11,6 +11,7 @@ use crate::ui::layout::build_cell_recursive;
 use crate::ui::registry::SurfaceEntityRegistry;
 use crate::ui::tab_label::LabelCtx;
 use crate::ui::terminal::resolve_pane_workspace;
+use crate::ui::web_title::WebTitle;
 use crate::ui::{
     HomeDir, HostSurfaceEntity, PaneDimOverlay, StructuralNode, SurfaceHostNode,
     TerminalSurfaceMarker, WorkspaceUiDirty, WorkspaceUiRoot,
@@ -132,7 +133,7 @@ fn rebuild_workspace_ui(
     structurals: Query<(Entity, Option<&ChildOf>), With<StructuralNode>>,
     surface_hosts: Query<(Entity, &SurfaceHostNode)>,
     children: Query<&Children>,
-    surfaces: Query<(&SurfaceKind, &Name, Option<&Cwd>), With<SurfaceMarker>>,
+    surfaces: Query<(&SurfaceKind, &Name, Option<&Cwd>, Option<&WebTitle>), With<SurfaceMarker>>,
     active_surfaces: Query<&ActiveSurface, With<PaneMarker>>,
     ui_font: Option<Res<TerminalUiFont>>,
     configs: Option<Res<OzmuxConfigsResource>>,

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -193,8 +193,9 @@ fn rebuild_workspace_ui(
 
 /// Flags a workspace `WorkspaceUiDirty` when one of its panes gains a surface
 /// (`Added<SurfaceMarker>`), switches its active surface
-/// (`Changed<ActiveSurface>`), or a surface reports a new working directory
-/// (`Changed<Cwd>`, via OSC 7) — in-pane changes that do not mutate
+/// (`Changed<ActiveSurface>`), a surface reports a new working directory
+/// (`Changed<Cwd>`, via OSC 7), or a browser/extension surface reports a new
+/// page title (`Changed<WebTitle>`) — in-pane changes that do not mutate
 /// `LayoutCells` and so would otherwise not trigger `rebuild_workspace_ui`.
 /// Covers both the `@md` control-bridge path and the in-app shortcuts via a
 /// single UI-layer hook, keeping the multiplexer crate free of UI concerns.
@@ -206,9 +207,14 @@ fn flag_chrome_dirty_on_surface_change(
     added_surfaces: Query<Entity, Added<SurfaceMarker>>,
     switched_panes: Query<Entity, (With<PaneMarker>, Changed<ActiveSurface>)>,
     changed_cwd: Query<Entity, (With<SurfaceMarker>, Changed<Cwd>)>,
+    changed_web_title: Query<Entity, (With<SurfaceMarker>, Changed<WebTitle>)>,
     child_of: Query<&ChildOf>,
 ) {
-    for surface in added_surfaces.iter() {
+    for surface in added_surfaces
+        .iter()
+        .chain(changed_cwd.iter())
+        .chain(changed_web_title.iter())
+    {
         if let Some((_pane, workspace)) = resolve_pane_workspace(surface, &child_of) {
             commands.entity(workspace).insert(WorkspaceUiDirty);
         }
@@ -218,11 +224,6 @@ fn flag_chrome_dirty_on_surface_change(
             commands
                 .entity(pane_parent.parent())
                 .insert(WorkspaceUiDirty);
-        }
-    }
-    for surface in changed_cwd.iter() {
-        if let Some((_pane, workspace)) = resolve_pane_workspace(surface, &child_of) {
-            commands.entity(workspace).insert(WorkspaceUiDirty);
         }
     }
 }
@@ -899,6 +900,41 @@ mod tests {
                 .parent(),
             bootstrap_workspace,
             "old workspace's subtree must be parked under its workspace entity",
+        );
+    }
+
+    #[test]
+    fn web_title_change_flags_workspace_dirty() {
+        use super::*;
+        let mut world = World::new();
+        let workspace = world.spawn_empty().id();
+        let pane = world.spawn(ChildOf(workspace)).id();
+        let surface = world.spawn((SurfaceMarker, ChildOf(pane))).id();
+
+        let mut sched = Schedule::default();
+        sched.add_systems(flag_chrome_dirty_on_surface_change);
+
+        // Run 1: Added<SurfaceMarker> sets the flag; clear it to isolate WebTitle.
+        sched.run(&mut world);
+        world.entity_mut(workspace).remove::<WorkspaceUiDirty>();
+
+        // Run 2: the only newly-changed input is WebTitle.
+        world.entity_mut(surface).insert(WebTitle("x".into()));
+        sched.run(&mut world);
+
+        assert!(
+            world.get::<WorkspaceUiDirty>(workspace).is_some(),
+            "Changed<WebTitle> must flag the owning workspace dirty"
+        );
+
+        // Run 3: a subsequent (changed, not added) title must re-flag, proving
+        // the arm reacts to updates — not just the first insert (Added).
+        world.entity_mut(workspace).remove::<WorkspaceUiDirty>();
+        world.entity_mut(surface).insert(WebTitle("y".into()));
+        sched.run(&mut world);
+        assert!(
+            world.get::<WorkspaceUiDirty>(workspace).is_some(),
+            "a later WebTitle change (page navigation) must re-flag the workspace"
         );
     }
 }


### PR DESCRIPTION
## Problem

Browser and extension surface tabs showed a generic placeholder name (`"surface"`) instead of the page they display. The live CEF webview page title (`document.title`) was not reflected in the tab label — a browser tab gave no hint of the open page, and the `@memo` extension tab didn't read "memo".

## Solution

Sync browser/extension tab titles with the live CEF webview page title.

- **Dependency** (`Cargo.toml`): repoint `bevy_cef`/`bevy_cef_core` to the merged title API — git rev `d357288` (`0.11.0-dev`), which adds `TitleChanged`/`WebviewTitle`. Not yet on crates.io, so this is a temporary git dependency (switch back to a published `0.11` once released).
- **`WebTitle` component** (`src/ui/web_title.rs`): a new app-side component on the multiplexer Surface entity, fed by a `TitleChanged` observer (`WebTitlePlugin`). The observer resolves the webview entity back to its surface via the existing `PageWebviewOf → HostSurfaceEntity` links (browser) or directly (extension) — mirroring the established `Cwd` / `on_terminal_current_dir` pattern.
- **`tab_label`** (`src/ui/tab_label.rs`): renders the sanitized, back-truncated `WebTitle` for browser/extension surfaces; blank until a title arrives (consistent with the terminal's CWD placeholder). Terminal tabs are unchanged.
- **Dirty hook** (`src/ui/workspace.rs`): a `Changed<WebTitle>` arm in `flag_chrome_dirty_on_surface_change` rebuilds the tab bar.

Affected: app UI (`src/ui`) and dependency wiring (`Cargo.toml`). The `ozmux_multiplexer` crate is untouched (stays UI-free).

Tested: `tab_label` unit tests (render / blank / back-truncate boundary / control-char), observer tests (browser + extension topology), and a dirty-flag test (add + update paths). `cargo fmt` / `clippy` clean.

### Notes
- **Behavior change:** browser/extension tabs that never report a page title now show **blank** (previously the generic surface `Name`) — an intentional design choice.
- **Dependency:** this makes the workspace build against an unpublished `bevy_cef` git rev (`0.11.0-dev`); building requires that rev to be reachable.
- **Unrelated:** a separate, pre-existing browser **first-render blank** (the webview renders blank until a resize/repaint) was seen during runtime testing — it reproduces on `main`, is independent of this change, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)