### PR TITLE
feat(server): wire VT/PTY data plane into OzmuxServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4082,10 +4082,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "crossbeam-channel",
  "futures-util",
  "interprocess",
  "ozmux_mux",
  "ozmux_proto",
+ "ozmux_vt",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/daemon/ozmux_mux/src/mux.rs
+++ b/daemon/ozmux_mux/src/mux.rs
@@ -544,10 +544,11 @@ impl MultiPlexer {
     }
 
     /// Creates a workspace in the active session, seeding one terminal pane and
-    /// surface. Makes the new workspace active.
+    /// surface. Makes the new workspace active. `name` overrides the default
+    /// monotonic name when `Some`, applied atomically at creation.
     ///
     /// Returns `[WorkspaceCreated, PaneCreated, WorkspaceSelected, ActivePaneChanged]`.
-    pub fn new_workspace(&mut self) -> MuxResult<Vec<MuxEvent>> {
+    pub fn new_workspace(&mut self, name: Option<String>) -> MuxResult<Vec<MuxEvent>> {
         let session = self.active_session;
         let surface = self.surfaces.insert(Surface {
             kind: SurfaceKind::Terminal,
@@ -560,10 +561,11 @@ impl MultiPlexer {
         });
         let created_at = self.name_counter;
         self.name_counter += 1;
+        let name = name.unwrap_or_else(|| format!("{created_at}"));
         let workspace = self.workspaces.insert(Workspace {
             root: NodeId::Pane(pane),
             active_pane: pane,
-            name: format!("{created_at}"),
+            name: name.clone(),
             created_at,
             size: None,
         });
@@ -573,7 +575,7 @@ impl MultiPlexer {
             MuxEvent::WorkspaceCreated {
                 session,
                 workspace,
-                name: format!("{created_at}"),
+                name,
             },
             MuxEvent::PaneCreated {
                 pane,
@@ -678,7 +680,7 @@ impl MultiPlexer {
         } else {
             // NOTE: The session must always have at least one workspace; auto-create
             // when the last one is closed to keep the invariant without erroring.
-            let mut replacement = self.new_workspace()?;
+            let mut replacement = self.new_workspace(None)?;
             replacement.append(&mut events);
             return Ok(replacement);
         }
@@ -2282,7 +2284,7 @@ mod tests {
     #[test]
     fn create_workspace_spawns_root_pane_surface_tree() {
         let mut mux = MultiPlexer::new();
-        let events = mux.new_workspace().unwrap();
+        let events = mux.new_workspace(None).unwrap();
 
         let (session, workspace) = match events[0] {
             MuxEvent::WorkspaceCreated {
@@ -2343,7 +2345,7 @@ mod tests {
     fn close_workspace_despawns_workspace_and_descendants() {
         let mut mux = MultiPlexer::new();
         let first_ws = mux.active_workspace();
-        let evs = mux.new_workspace().unwrap();
+        let evs = mux.new_workspace(None).unwrap();
         let second_ws = match evs[0] {
             MuxEvent::WorkspaceCreated { workspace, .. } => workspace,
             _ => panic!("WorkspaceCreated expected"),
@@ -2380,7 +2382,7 @@ mod tests {
     #[test]
     fn close_workspace_frees_interior_splits() {
         let mut mux = MultiPlexer::new();
-        mux.new_workspace().unwrap();
+        mux.new_workspace(None).unwrap();
         let ws1 = mux.active_workspace();
         let p1 = mux.active_pane(ws1).unwrap();
         // Build SplitA(SplitB(p1, p1b), SplitC(p2, p2b)) — SplitA is interior
@@ -2430,7 +2432,7 @@ mod tests {
     fn select_workspace_changes_active_and_is_changed_only() {
         let mut mux = MultiPlexer::new();
         let first_ws = mux.active_workspace();
-        let evs = mux.new_workspace().unwrap();
+        let evs = mux.new_workspace(None).unwrap();
         let second_ws = match evs[0] {
             MuxEvent::WorkspaceCreated { workspace, .. } => workspace,
             _ => panic!("WorkspaceCreated expected"),
@@ -2821,7 +2823,9 @@ mod tests {
         let mut mux = MultiPlexer::new();
         let ws = mux.active_workspace();
         let pane = mux.active_pane(ws).unwrap();
-        let spawn = mux.spawn_surface(pane, SurfaceKind::Terminal, None).unwrap();
+        let spawn = mux
+            .spawn_surface(pane, SurfaceKind::Terminal, None)
+            .unwrap();
         let new_surface = match spawn[0] {
             MuxEvent::SurfaceSpawned { surface, .. } => surface,
             _ => panic!("first event must be SurfaceSpawned"),
@@ -2829,7 +2833,10 @@ mod tests {
         let events = mux.set_active_surface_by_surface(new_surface).unwrap();
         assert_eq!(
             events,
-            vec![MuxEvent::ActiveSurfaceChanged { pane, surface: new_surface }]
+            vec![MuxEvent::ActiveSurfaceChanged {
+                pane,
+                surface: new_surface
+            }]
         );
         assert_eq!(mux.active_surface(pane).unwrap(), new_surface);
     }

--- a/daemon/ozmux_mux/src/mux.rs
+++ b/daemon/ozmux_mux/src/mux.rs
@@ -272,17 +272,8 @@ impl MultiPlexer {
         self.set_node_parent(sibling, grandparent);
         self.rewrite_child_pointer(workspace, grandparent, NodeId::Split(split_id), sibling);
 
-        let removed_surfaces = self.panes[pane].surfaces.clone();
-        for surface in &removed_surfaces {
-            self.surfaces.remove(*surface);
-        }
-        self.panes.remove(pane);
         self.splits.remove(split_id);
-
-        let mut events = vec![MuxEvent::PaneClosed { pane }];
-        for surface in removed_surfaces {
-            events.push(MuxEvent::SurfaceClosed { surface });
-        }
+        let mut events = self.destroy_pane(pane);
 
         let reached_root = grandparent.is_none();
         if reached_root {
@@ -628,63 +619,34 @@ impl MultiPlexer {
     /// `WorkspaceSelected` is appended. If a replacement was auto-created, a
     /// full `new_workspace` event sequence is prepended.
     pub fn close_workspace(&mut self, workspace: WorkspaceId) -> MuxResult<Vec<MuxEvent>> {
-        self.workspace(workspace)?;
-        let session = self.active_session;
-
-        // Walk the whole subtree (intact) to remove EVERY split, pane, and
-        // surface. Removing only each leaf's parent split (its parent) would
-        // leak interior splits whose two children are both splits.
         let root = self.workspace(workspace)?.root;
-        let mut events: Vec<MuxEvent> = Vec::new();
-        let mut split_ids: Vec<SplitId> = Vec::new();
-        let mut stack = vec![root];
-        while let Some(node) = stack.pop() {
-            match node {
-                NodeId::Split(s) => {
-                    let split = &self.splits[s];
-                    stack.push(split.second);
-                    stack.push(split.first);
-                    split_ids.push(s);
-                }
-                NodeId::Pane(p) => {
-                    let surfaces = self.panes[p].surfaces.clone();
-                    events.push(MuxEvent::PaneClosed { pane: p });
-                    for surface in surfaces {
-                        events.push(MuxEvent::SurfaceClosed { surface });
-                        self.surfaces.remove(surface);
-                    }
-                    self.panes.remove(p);
-                }
-            }
-        }
-        for s in split_ids {
-            self.splits.remove(s);
-        }
-        self.workspaces.remove(workspace);
-        let sess = &mut self.sessions[session];
-        sess.workspaces.retain(|w| *w != workspace);
+        let session = self.active_session;
+        let was_active = self.sessions[session].active == workspace;
 
+        let mut events = self.cascade_destroy_subtree(root);
+        self.workspaces.remove(workspace);
+        self.sessions[session].workspaces.retain(|w| *w != workspace);
         events.push(MuxEvent::WorkspaceDestroyed { workspace });
 
-        let was_active = sess.active == workspace;
         if !was_active {
             return Ok(events);
         }
 
+        // The active workspace was destroyed: re-point the session to the
+        // previous workspace, or auto-create a replacement so the session is
+        // never left empty (the always-one-workspace invariant).
         if let Some(&remaining) = self.sessions[session].workspaces.last() {
             self.sessions[session].active = remaining;
             events.push(MuxEvent::WorkspaceSelected {
                 session,
                 workspace: remaining,
             });
+            Ok(events)
         } else {
-            // NOTE: The session must always have at least one workspace; auto-create
-            // when the last one is closed to keep the invariant without erroring.
             let mut replacement = self.new_workspace(None)?;
             replacement.append(&mut events);
-            return Ok(replacement);
+            Ok(replacement)
         }
-        Ok(events)
     }
 
     /// Adds a surface to a pane without changing the active surface.
@@ -1167,6 +1129,47 @@ impl MultiPlexer {
                 NodeId::Split(s) => cur = self.splits[s].first,
             }
         }
+    }
+
+    /// Removes `pane` and all of its surfaces from the arena, returning
+    /// `[PaneClosed, SurfaceClosed*]`. Does NOT touch the layout tree (splits)
+    /// or the owning workspace — callers handle the structural relinking.
+    fn destroy_pane(&mut self, pane: PaneId) -> Vec<MuxEvent> {
+        let mut events = vec![MuxEvent::PaneClosed { pane }];
+        for surface in self.panes[pane].surfaces.clone() {
+            events.push(MuxEvent::SurfaceClosed { surface });
+            self.surfaces.remove(surface);
+        }
+        self.panes.remove(pane);
+        events
+    }
+
+    /// Destroys every split, pane, and surface in the subtree rooted at `root`,
+    /// returning `[PaneClosed, SurfaceClosed*]` per pane in DFS (left-first)
+    /// order.
+    ///
+    /// Walking the whole subtree (not just each leaf's parent split) is
+    /// required: removing only leaf parents would leak interior splits whose
+    /// two children are both splits.
+    fn cascade_destroy_subtree(&mut self, root: NodeId) -> Vec<MuxEvent> {
+        let mut events = Vec::new();
+        let mut split_ids = Vec::new();
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            match node {
+                NodeId::Split(s) => {
+                    let split = &self.splits[s];
+                    stack.push(split.second);
+                    stack.push(split.first);
+                    split_ids.push(s);
+                }
+                NodeId::Pane(p) => events.extend(self.destroy_pane(p)),
+            }
+        }
+        for s in split_ids {
+            self.splits.remove(s);
+        }
+        events
     }
 
     fn node_cell_extent(&self, node: NodeId) -> (u16, u16) {

--- a/daemon/ozmux_proto/src/mirror.rs
+++ b/daemon/ozmux_proto/src/mirror.rs
@@ -509,7 +509,7 @@ mod tests {
         let mut delta_events: Vec<MuxEvent> = Vec::new();
 
         // new_workspace → creates ws1.
-        let nw_evs = mux.new_workspace().unwrap();
+        let nw_evs = mux.new_workspace(None).unwrap();
         let ws1 = match &nw_evs[0] {
             MuxEvent::WorkspaceCreated { workspace, .. } => *workspace,
             _ => panic!("expected WorkspaceCreated"),
@@ -654,7 +654,7 @@ mod tests {
         let mut delta_events: Vec<MuxEvent> = Vec::new();
 
         // Fix 1: new_workspace creates ws1 post-snapshot.
-        let nw_evs = mux.new_workspace().unwrap();
+        let nw_evs = mux.new_workspace(None).unwrap();
         let ws1 = match &nw_evs[0] {
             MuxEvent::WorkspaceCreated { workspace, .. } => *workspace,
             _ => panic!("expected WorkspaceCreated"),

--- a/daemon/ozmux_server/Cargo.toml
+++ b/daemon/ozmux_server/Cargo.toml
@@ -18,6 +18,8 @@ tracing = { workspace = true }
 serde_json = { workspace = true }
 ozmux_proto = { path = "../ozmux_proto/" }
 ozmux_mux = { path = "../ozmux_mux" }
+ozmux_vt = { path = "../ozmux_vt", features = ["pty"] }
+crossbeam-channel = "0.5"
 
 [lints]
 workspace = true

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -27,6 +27,16 @@ const EVENT_CHANNEL_CAPACITY: usize = 1024;
 /// than allowed to block its own command path (including `Shutdown`).
 const CLIENT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Default terminal size for a surface spawned before any client has reported a
+/// viewport (startup / zero clients); the first `PaneResized` reflows it.
+const DEFAULT_TERMINAL_SIZE: (u16, u16) = (80, 24);
+
+/// Max time to wait for a driver thread to answer a reply request (cold-attach
+/// snapshot, copy-selection text). A live driver answers well under this; a
+/// driver wedged on a blocking PTY write (or already gone) is bounded out so it
+/// cannot hang the client.
+const DRIVER_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 struct ServerState {
     multiplexer: Mutex<MultiPlexer>,
     events_tx: broadcast::Sender<ServerMessage>,
@@ -94,6 +104,19 @@ async fn write_server_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// Writes `msg` to a client bounded by `CLIENT_WRITE_TIMEOUT`. Returns
+/// `Ok(false)` when the write stalls (a non-draining reader) so the caller can
+/// drop the connection — mirrors the lag-drop policy. Real I/O errors propagate.
+async fn write_to_client<W: AsyncWrite + Unpin>(
+    framed_write: &mut FramedWrite<W, LengthDelimitedCodec>,
+    msg: &ServerMessage,
+) -> anyhow::Result<bool> {
+    match tokio::time::timeout(CLIENT_WRITE_TIMEOUT, write_server_message(framed_write, msg)).await {
+        Ok(result) => result.map(|()| true),
+        Err(_elapsed) => Ok(false),
+    }
+}
+
 async fn handle_client(
     stream: interprocess::local_socket::tokio::Stream,
     state: Arc<ServerState>,
@@ -109,7 +132,9 @@ async fn handle_client(
         let term_surfaces = terminal_surfaces(&snapshot);
         (events_rx, ServerMessage::Welcome { snapshot }, term_surfaces)
     };
-    write_server_message(&mut framed_write, &welcome).await?;
+    if !write_to_client(&mut framed_write, &welcome).await? {
+        return Ok(());
+    }
 
     // NOTE: subscribe (above, inside the lock) happens BEFORE these snapshot
     // requests, so every delta with seq >= the snapshot's seq is already
@@ -123,21 +148,17 @@ async fn handle_client(
         }
     }
     for (surface, rx) in snap_reqs {
-        // NOTE: a driver whose child exited but whose surface is still open
-        // (v1 does not auto-close on exit) has left its registry slot behind
-        // with no thread to answer; bound the wait so a dead surface cannot
-        // hang the attach. A live driver answers in well under this budget.
-        if let Ok(Ok(snapshot)) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), rx).await
-        {
-            write_server_message(
-                &mut framed_write,
-                &ServerMessage::Frame {
-                    surface,
-                    frame: ozmux_vt::frame::Frame::Snapshot(snapshot),
-                },
-            )
-            .await?;
+        // NOTE: a driver wedged on a blocking PTY write (or already gone) never
+        // answers; bound the wait so it cannot hang the attach. A live driver
+        // answers in well under this budget.
+        if let Ok(Ok(snapshot)) = tokio::time::timeout(DRIVER_REPLY_TIMEOUT, rx).await {
+            let frame = ServerMessage::Frame {
+                surface,
+                frame: ozmux_vt::frame::Frame::Snapshot(snapshot),
+            };
+            if !write_to_client(&mut framed_write, &frame).await? {
+                return Ok(());
+            }
         }
     }
 
@@ -166,19 +187,11 @@ async fn handle_client(
             event = events_rx.recv() => {
                 match event {
                     Ok(server_msg) => {
-                        match tokio::time::timeout(
-                            CLIENT_WRITE_TIMEOUT,
-                            write_server_message(&mut framed_write, &server_msg),
-                        )
-                        .await
-                        {
-                            Ok(result) => result?,
-                            Err(_elapsed) => {
-                                tracing::warn!(
-                                    "client write stalled past the timeout; dropping connection (client must re-attach)"
-                                );
-                                break;
-                            }
+                        if !write_to_client(&mut framed_write, &server_msg).await? {
+                            tracing::warn!(
+                                "client write stalled past the timeout; dropping connection (client must re-attach)"
+                            );
+                            break;
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -275,10 +288,8 @@ async fn dispatch<W: AsyncWrite + Unpin>(
                     .terminals
                     .route(surface, DriverCommand::CopyMode { op, reply: Some(tx) })
                 {
-                    // NOTE: bound the wait — a dead-but-registered driver never replies.
-                    if let Ok(Ok(text)) =
-                        tokio::time::timeout(std::time::Duration::from_secs(2), rx).await
-                    {
+                    // NOTE: bound the wait — a wedged or already-gone driver never replies.
+                    if let Ok(Ok(text)) = tokio::time::timeout(DRIVER_REPLY_TIMEOUT, rx).await {
                         write_server_message(
                             framed_write,
                             &ServerMessage::SelectionCopied { surface, text },
@@ -309,7 +320,7 @@ fn reconcile_before_broadcast(
     for event in events {
         match event {
             MuxEvent::PaneCreated { pane, surfaces, .. } => {
-                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or((80, 24));
+                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or(DEFAULT_TERMINAL_SIZE);
                 for entry in surfaces {
                     if entry.kind == SurfaceKind::Terminal
                         && let Some(seed) =
@@ -322,7 +333,7 @@ fn reconcile_before_broadcast(
             MuxEvent::SurfaceSpawned { pane, surface, kind, cwd }
                 if *kind == SurfaceKind::Terminal =>
             {
-                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or((80, 24));
+                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or(DEFAULT_TERMINAL_SIZE);
                 if let Some(seed) = state.terminals.reserve(*surface, cols, rows, cwd.clone()) {
                     seeds.push(seed);
                 }
@@ -353,7 +364,7 @@ async fn seed_initial_terminals(state: &Arc<ServerState>) {
     let mut seeds = Vec::new();
     for ws in &snapshot.workspaces {
         for pane in &ws.panes {
-            let (cols, rows) = mux.resolved_pane_size(pane.pane).unwrap_or((80, 24));
+            let (cols, rows) = mux.resolved_pane_size(pane.pane).unwrap_or(DEFAULT_TERMINAL_SIZE);
             for surf in &pane.surfaces {
                 if surf.kind == SurfaceKind::Terminal
                     && let Some(seed) =

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -195,7 +195,7 @@ async fn dispatch<W: AsyncWrite + Unpin>(
             .await
         }
         ClientMessage::CreateWorkspace { name } => {
-            apply(framed_write, state, |m| create_workspace(m, name)).await
+            apply(framed_write, state, |m| m.new_workspace(name)).await
         }
         ClientMessage::Health => Ok(()),
         // NOTE: Shutdown is intercepted in handle_client before dispatch runs;
@@ -246,21 +246,4 @@ where
         write_server_message(framed_write, &ServerMessage::Error { message }).await?;
     }
     Ok(())
-}
-
-fn create_workspace(mux: &mut MultiPlexer, name: Option<String>) -> MuxResult<Vec<MuxEvent>> {
-    let mut events = mux.new_workspace()?;
-    // NOTE: the workspace already exists after `new_workspace`; the rename is
-    // best-effort so a rename failure can never discard the `new_workspace`
-    // events (which would advance mux state without ever broadcasting it).
-    if let Some(name) = name
-        && let Some(workspace) = events.iter().find_map(|event| match event {
-            MuxEvent::WorkspaceCreated { workspace, .. } => Some(*workspace),
-            _ => None,
-        })
-        && let Ok(rename_events) = mux.rename_workspace(workspace, name)
-    {
-        events.extend(rename_events);
-    }
-    Ok(events)
 }

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -21,6 +21,12 @@ mod terminal;
 /// re-attach for a fresh snapshot (see `handle_client`).
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 
+/// Max time to spend writing one broadcast message to a client before treating
+/// the client as a stalled reader and dropping it (it must re-attach). Mirrors
+/// the lag-drop policy: a client that cannot keep up is disconnected rather
+/// than allowed to block its own command path (including `Shutdown`).
+const CLIENT_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 struct ServerState {
     multiplexer: Mutex<MultiPlexer>,
     events_tx: broadcast::Sender<ServerMessage>,
@@ -137,6 +143,7 @@ async fn handle_client(
 
     loop {
         tokio::select! {
+            biased;
             inbound = framed_read.next() => {
                 let Some(frame) = inbound else { break };
                 let bytes = match frame {
@@ -158,7 +165,22 @@ async fn handle_client(
             }
             event = events_rx.recv() => {
                 match event {
-                    Ok(server_msg) => write_server_message(&mut framed_write, &server_msg).await?,
+                    Ok(server_msg) => {
+                        match tokio::time::timeout(
+                            CLIENT_WRITE_TIMEOUT,
+                            write_server_message(&mut framed_write, &server_msg),
+                        )
+                        .await
+                        {
+                            Ok(result) => result?,
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    "client write stalled past the timeout; dropping connection (client must re-attach)"
+                                );
+                                break;
+                            }
+                        }
+                    }
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
                         tracing::warn!(
                             skipped,

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -96,13 +96,44 @@ async fn handle_client(
     let mut framed_read = FramedRead::new(read_half, codec());
     let mut framed_write = FramedWrite::new(write_half, codec());
 
-    let (mut events_rx, welcome) = {
+    let (mut events_rx, welcome, term_surfaces) = {
         let mux = state.multiplexer.lock().await;
         let events_rx = state.events_tx.subscribe();
         let snapshot = mux.snapshot(mux.active_session())?;
-        (events_rx, ServerMessage::Welcome { snapshot })
+        let term_surfaces = terminal_surfaces(&snapshot);
+        (events_rx, ServerMessage::Welcome { snapshot }, term_surfaces)
     };
     write_server_message(&mut framed_write, &welcome).await?;
+
+    // NOTE: subscribe (above, inside the lock) happens BEFORE these snapshot
+    // requests, so every delta with seq >= the snapshot's seq is already
+    // buffered in `events_rx`; the client reconciles by seq, so socket arrival
+    // order does not matter. Send each snapshot ONLY to this client.
+    let mut snap_reqs = Vec::new();
+    for surface in term_surfaces {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if state.terminals.route(surface, DriverCommand::Snapshot(tx)) {
+            snap_reqs.push((surface, rx));
+        }
+    }
+    for (surface, rx) in snap_reqs {
+        // NOTE: a driver whose child exited but whose surface is still open
+        // (v1 does not auto-close on exit) has left its registry slot behind
+        // with no thread to answer; bound the wait so a dead surface cannot
+        // hang the attach. A live driver answers in well under this budget.
+        if let Ok(Ok(snapshot)) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), rx).await
+        {
+            write_server_message(
+                &mut framed_write,
+                &ServerMessage::Frame {
+                    surface,
+                    frame: ozmux_vt::frame::Frame::Snapshot(snapshot),
+                },
+            )
+            .await?;
+        }
+    }
 
     loop {
         tokio::select! {
@@ -221,13 +252,17 @@ async fn dispatch<W: AsyncWrite + Unpin>(
                 if state
                     .terminals
                     .route(surface, DriverCommand::CopyMode { op, reply: Some(tx) })
-                    && let Ok(text) = rx.await
                 {
-                    write_server_message(
-                        framed_write,
-                        &ServerMessage::SelectionCopied { surface, text },
-                    )
-                    .await?;
+                    // NOTE: bound the wait — a dead-but-registered driver never replies.
+                    if let Ok(Ok(text)) =
+                        tokio::time::timeout(std::time::Duration::from_secs(2), rx).await
+                    {
+                        write_server_message(
+                            framed_write,
+                            &ServerMessage::SelectionCopied { surface, text },
+                        )
+                        .await?;
+                    }
                 }
                 Ok(())
             } else {
@@ -310,6 +345,22 @@ async fn seed_initial_terminals(state: &Arc<ServerState>) {
     for seed in seeds {
         state.terminals.spawn(seed, state.events_tx.clone());
     }
+}
+
+/// Collects the Terminal-kind surfaces from a session snapshot (the surfaces
+/// that have a driver and thus a frame to resnapshot on cold-attach).
+fn terminal_surfaces(snapshot: &ozmux_mux::SessionSnapshot) -> Vec<ozmux_mux::SurfaceId> {
+    let mut out = Vec::new();
+    for ws in &snapshot.workspaces {
+        for pane in &ws.panes {
+            for surf in &pane.surfaces {
+                if surf.kind == SurfaceKind::Terminal {
+                    out.push(surf.surface);
+                }
+            }
+        }
+    }
+    out
 }
 
 async fn apply<W, F>(

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -3,11 +3,12 @@
 //! UDS/NamedPipe wire. One task per connection.
 
 use bytes::Bytes;
+use crate::terminal::{DriverCommand, TerminalRegistry};
 use futures_util::{SinkExt, StreamExt};
 use interprocess::local_socket::tokio::Listener;
 use interprocess::local_socket::traits::tokio::{Listener as _, Stream as _};
 use interprocess::local_socket::{GenericNamespaced, ListenerOptions, ToNsName};
-use ozmux_mux::{MultiPlexer, MuxEvent, MuxResult};
+use ozmux_mux::{MultiPlexer, MuxEvent, MuxResult, SurfaceKind};
 use ozmux_proto::{ClientMessage, MAX_MESSAGE_BYTES, ServerMessage};
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
@@ -24,6 +25,7 @@ struct ServerState {
     multiplexer: Mutex<MultiPlexer>,
     events_tx: broadcast::Sender<ServerMessage>,
     shutdown: Notify,
+    terminals: TerminalRegistry,
 }
 
 /// A control-plane ozmux daemon: accepts client connections on a local socket,
@@ -44,6 +46,7 @@ impl OzmuxServer {
             multiplexer: Mutex::new(MultiPlexer::default()),
             events_tx,
             shutdown: Notify::new(),
+            terminals: TerminalRegistry::new(),
         });
         Ok(Self { listener, state })
     }
@@ -51,6 +54,7 @@ impl OzmuxServer {
     /// Accepts connections until a client sends `Shutdown`, spawning one task per
     /// connection.
     pub async fn start(&self) -> anyhow::Result<()> {
+        seed_initial_terminals(&self.state).await;
         loop {
             tokio::select! {
                 conn = self.listener.accept() => {
@@ -219,6 +223,78 @@ async fn dispatch<W: AsyncWrite + Unpin>(
     }
 }
 
+/// Reserves routing slots for Terminal surfaces created by `events`, returning
+/// the seeds to spawn AFTER the structural broadcast. Tears down closed
+/// surfaces and resizes panes (order-independent; done before the broadcast).
+fn reconcile_before_broadcast(
+    state: &ServerState,
+    mux: &MultiPlexer,
+    events: &[MuxEvent],
+) -> Vec<crate::terminal::DriverSeed> {
+    let mut seeds = Vec::new();
+    for event in events {
+        match event {
+            MuxEvent::PaneCreated { pane, surfaces, .. } => {
+                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or((80, 24));
+                for entry in surfaces {
+                    if entry.kind == SurfaceKind::Terminal
+                        && let Some(seed) =
+                            state.terminals.reserve(entry.surface, cols, rows, entry.cwd.clone())
+                    {
+                        seeds.push(seed);
+                    }
+                }
+            }
+            MuxEvent::SurfaceSpawned { pane, surface, kind, cwd }
+                if *kind == SurfaceKind::Terminal =>
+            {
+                let (cols, rows) = mux.resolved_pane_size(*pane).unwrap_or((80, 24));
+                if let Some(seed) = state.terminals.reserve(*surface, cols, rows, cwd.clone()) {
+                    seeds.push(seed);
+                }
+            }
+            MuxEvent::SurfaceClosed { surface } => state.terminals.remove(*surface),
+            MuxEvent::PaneResized { pane, cols, rows } => {
+                if let Ok(surfaces) = mux.surfaces(*pane) {
+                    for surface in surfaces {
+                        state
+                            .terminals
+                            .route(surface, DriverCommand::Resize { cols: *cols, rows: *rows });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    seeds
+}
+
+/// Spawns drivers for the Terminal surfaces present in the seeded multiplexer
+/// (startup / no clients). No broadcast-ordering concern: no client is attached.
+async fn seed_initial_terminals(state: &Arc<ServerState>) {
+    let mux = state.multiplexer.lock().await;
+    let Ok(snapshot) = mux.snapshot(mux.active_session()) else {
+        return;
+    };
+    let mut seeds = Vec::new();
+    for ws in &snapshot.workspaces {
+        for pane in &ws.panes {
+            let (cols, rows) = mux.resolved_pane_size(pane.pane).unwrap_or((80, 24));
+            for surf in &pane.surfaces {
+                if surf.kind == SurfaceKind::Terminal
+                    && let Some(seed) =
+                        state.terminals.reserve(surf.surface, cols, rows, surf.cwd.clone())
+                {
+                    seeds.push(seed);
+                }
+            }
+        }
+    }
+    for seed in seeds {
+        state.terminals.spawn(seed, state.events_tx.clone());
+    }
+}
+
 async fn apply<W, F>(
     framed_write: &mut FramedWrite<W, LengthDelimitedCodec>,
     state: &ServerState,
@@ -237,7 +313,14 @@ where
         match op(&mut mux) {
             Ok(events) => {
                 if !events.is_empty() {
+                    // NOTE: reserve routing slots + teardown/resize BEFORE the broadcast so a
+                    // client that sees a new surface can immediately route to it; spawn driver
+                    // threads AFTER so their first frame follows the structural event.
+                    let seeds = reconcile_before_broadcast(state, &mux, &events);
                     let _ = state.events_tx.send(ServerMessage::Events(events));
+                    for seed in seeds {
+                        state.terminals.spawn(seed, state.events_tx.clone());
+                    }
                 }
                 None
             }

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -14,6 +14,8 @@ use tokio::io::AsyncWrite;
 use tokio::sync::{Mutex, Notify, broadcast};
 use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
+mod terminal;
+
 /// Broadcast ring capacity; a client that lags beyond this is dropped and must
 /// re-attach for a fresh snapshot (see `handle_client`).
 const EVENT_CHANNEL_CAPACITY: usize = 1024;

--- a/daemon/ozmux_server/src/lib.rs
+++ b/daemon/ozmux_server/src/lib.rs
@@ -9,7 +9,7 @@ use interprocess::local_socket::tokio::Listener;
 use interprocess::local_socket::traits::tokio::{Listener as _, Stream as _};
 use interprocess::local_socket::{GenericNamespaced, ListenerOptions, ToNsName};
 use ozmux_mux::{MultiPlexer, MuxEvent, MuxResult, SurfaceKind};
-use ozmux_proto::{ClientMessage, MAX_MESSAGE_BYTES, ServerMessage};
+use ozmux_proto::{ClientMessage, CopyModeOp, MAX_MESSAGE_BYTES, ServerMessage};
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
 use tokio::sync::{Mutex, Notify, broadcast};
@@ -207,18 +207,35 @@ async fn dispatch<W: AsyncWrite + Unpin>(
         // NOTE: Shutdown is intercepted in handle_client before dispatch runs;
         // this arm only keeps the match exhaustive.
         ClientMessage::Shutdown => Ok(()),
-        ClientMessage::Input { .. }
-        | ClientMessage::Scroll { .. }
-        | ClientMessage::CopyMode { .. } => {
-            // TODO: data plane (Input/Scroll/CopyMode) needs an ozmux_vt frame
-            // source; this server is control-plane only.
-            write_server_message(
-                framed_write,
-                &ServerMessage::Error {
-                    message: "control-plane only; needs ozmux_vt".to_string(),
-                },
-            )
-            .await
+        ClientMessage::Input { surface, bytes } => {
+            state.terminals.route(surface, DriverCommand::Input(bytes));
+            Ok(())
+        }
+        ClientMessage::Scroll { surface, delta } => {
+            state.terminals.route(surface, DriverCommand::Scroll(delta));
+            Ok(())
+        }
+        ClientMessage::CopyMode { surface, op } => {
+            if matches!(op, CopyModeOp::CopySelection) {
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                if state
+                    .terminals
+                    .route(surface, DriverCommand::CopyMode { op, reply: Some(tx) })
+                    && let Ok(text) = rx.await
+                {
+                    write_server_message(
+                        framed_write,
+                        &ServerMessage::SelectionCopied { surface, text },
+                    )
+                    .await?;
+                }
+                Ok(())
+            } else {
+                state
+                    .terminals
+                    .route(surface, DriverCommand::CopyMode { op, reply: None });
+                Ok(())
+            }
         }
     }
 }

--- a/daemon/ozmux_server/src/terminal.rs
+++ b/daemon/ozmux_server/src/terminal.rs
@@ -1,0 +1,4 @@
+//! Server-side data plane: per-surface terminal drivers and the registry that
+//! routes client commands to them.
+
+mod driver;

--- a/daemon/ozmux_server/src/terminal.rs
+++ b/daemon/ozmux_server/src/terminal.rs
@@ -12,7 +12,6 @@ use ozmux_vt::vt::{Vt, VtMotion, VtSelection};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use std::thread::JoinHandle;
 use tokio::sync::{broadcast, oneshot};
 
 /// A command sent from an async client task to a surface's driver thread.
@@ -41,7 +40,6 @@ pub(crate) struct DriverSeed {
 
 struct SurfaceHandle {
     cmd_tx: Sender<DriverCommand>,
-    join: Option<JoinHandle<()>>,
 }
 
 /// Maps a proto `CopyModeOp` onto the `Vt`'s alacritty-free API. Returns the
@@ -136,21 +134,24 @@ impl TerminalRegistry {
             return None;
         }
         let (cmd_tx, cmd_rx) = unbounded();
-        map.insert(surface, SurfaceHandle { cmd_tx, join: None });
+        map.insert(surface, SurfaceHandle { cmd_tx });
         let cwd = if cwd.as_os_str().is_empty() { None } else { Some(cwd) };
         Some(DriverSeed { surface, cols, rows, cwd, cmd_rx })
     }
 
-    /// Spawns the driver OS thread for a reserved seed and attaches its join
-    /// handle. Must run AFTER the structural broadcast so the driver's first
-    /// frame follows the `PaneCreated`/`SurfaceSpawned` event.
+    /// Spawns the (detached) driver thread for a reserved seed. Must run AFTER
+    /// the structural broadcast so the driver's first frame follows the
+    /// `PaneCreated`/`SurfaceSpawned` event.
+    ///
+    /// The thread is intentionally not joined. It self-terminates when its
+    /// command channel disconnects — `remove`, or the whole registry being
+    /// dropped (the default `HashMap` drop drops every `cmd_tx`) — or when the
+    /// child exits, and the OS reaps it on process exit. We do NOT block-join:
+    /// a driver wedged on a blocking `pty.write_all` (child not draining its
+    /// input) is not in `Select`, so dropping `cmd_tx` cannot wake it, and a
+    /// join would hang shutdown.
     pub(crate) fn spawn(&self, seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
-        let surface = seed.surface;
-        let join = SurfaceDriver::spawn(seed, events_tx);
-        let mut map = self.map.lock().unwrap();
-        if let Some(handle) = map.get_mut(&surface) {
-            handle.join = Some(join);
-        }
+        SurfaceDriver::spawn(seed, events_tx);
     }
 
     /// Removes `surface`'s driver: dropping `cmd_tx` disconnects the driver's
@@ -158,29 +159,6 @@ impl TerminalRegistry {
     pub(crate) fn remove(&self, surface: SurfaceId) {
         let mut map = self.map.lock().unwrap();
         map.remove(&surface);
-    }
-}
-
-impl Drop for TerminalRegistry {
-    fn drop(&mut self) {
-        // NOTE: Disconnect every driver's command channel first (so each `Select`
-        // returns and the thread heads for the exit), then join. Dropping
-        // `cmd_tx` is what unblocks the driver loop; `Pty::Drop` then SIGHUPs
-        // the child as each thread unwinds.
-        let mut map = self.map.lock().unwrap_or_else(|e| e.into_inner());
-        let joins: Vec<_> = map
-            .drain()
-            .filter_map(|(_, handle)| {
-                drop(handle.cmd_tx);
-                handle.join
-            })
-            .collect();
-        // NOTE: Drop the lock before joining so a driver thread that happens to touch
-        // the registry on its way out cannot deadlock against us.
-        drop(map);
-        for join in joins {
-            let _ = join.join();
-        }
     }
 }
 

--- a/daemon/ozmux_server/src/terminal.rs
+++ b/daemon/ozmux_server/src/terminal.rs
@@ -159,10 +159,28 @@ impl TerminalRegistry {
         let mut map = self.map.lock().unwrap();
         map.remove(&surface);
     }
+}
 
-    /// True when `surface` has a registered driver.
-    pub(crate) fn contains(&self, surface: SurfaceId) -> bool {
-        self.map.lock().unwrap().contains_key(&surface)
+impl Drop for TerminalRegistry {
+    fn drop(&mut self) {
+        // NOTE: Disconnect every driver's command channel first (so each `Select`
+        // returns and the thread heads for the exit), then join. Dropping
+        // `cmd_tx` is what unblocks the driver loop; `Pty::Drop` then SIGHUPs
+        // the child as each thread unwinds.
+        let mut map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+        let joins: Vec<_> = map
+            .drain()
+            .filter_map(|(_, handle)| {
+                drop(handle.cmd_tx);
+                handle.join
+            })
+            .collect();
+        // NOTE: Drop the lock before joining so a driver thread that happens to touch
+        // the registry on its way out cannot deadlock against us.
+        drop(map);
+        for join in joins {
+            let _ = join.join();
+        }
     }
 }
 
@@ -204,7 +222,6 @@ mod tests {
             reg.reserve(s, 80, 24, PathBuf::new()).is_none(),
             "second reserve must be skipped"
         );
-        assert!(reg.contains(s));
     }
 
     #[test]

--- a/daemon/ozmux_server/src/terminal.rs
+++ b/daemon/ozmux_server/src/terminal.rs
@@ -105,13 +105,13 @@ pub(crate) struct TerminalRegistry {
 
 impl TerminalRegistry {
     /// Creates an empty registry.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self { map: Mutex::new(HashMap::new()) }
     }
 
     /// Sends `cmd` to `surface`'s driver. Returns `false` when no driver is
     /// registered (already-closed surface); the caller drops the command.
-    pub(crate) fn route(&self, surface: SurfaceId, cmd: DriverCommand) -> bool {
+    pub fn route(&self, surface: SurfaceId, cmd: DriverCommand) -> bool {
         let map = self.map.lock().unwrap();
         match map.get(&surface) {
             Some(handle) => handle.cmd_tx.send(cmd).is_ok(),
@@ -122,7 +122,7 @@ impl TerminalRegistry {
     /// Reserves a routing slot for `surface` and returns the seed used to spawn
     /// the driver thread AFTER the structural broadcast. Empty `cwd` -> `None`.
     /// Returns `None` (skips) when `surface` is already registered (idempotent).
-    pub(crate) fn reserve(
+    pub fn reserve(
         &self,
         surface: SurfaceId,
         cols: u16,
@@ -150,13 +150,13 @@ impl TerminalRegistry {
     /// a driver wedged on a blocking `pty.write_all` (child not draining its
     /// input) is not in `Select`, so dropping `cmd_tx` cannot wake it, and a
     /// join would hang shutdown.
-    pub(crate) fn spawn(&self, seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
+    pub fn spawn(&self, seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
         SurfaceDriver::spawn(seed, events_tx);
     }
 
     /// Removes `surface`'s driver: dropping `cmd_tx` disconnects the driver's
     /// command receiver, so its `Select` returns and the thread exits.
-    pub(crate) fn remove(&self, surface: SurfaceId) {
+    pub fn remove(&self, surface: SurfaceId) {
         let mut map = self.map.lock().unwrap();
         map.remove(&surface);
     }

--- a/daemon/ozmux_server/src/terminal.rs
+++ b/daemon/ozmux_server/src/terminal.rs
@@ -2,3 +2,214 @@
 //! routes client commands to them.
 
 mod driver;
+
+use crate::terminal::driver::SurfaceDriver;
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use ozmux_mux::SurfaceId;
+use ozmux_proto::{CellSide, CopyModeOp, SelectionKind, ServerMessage, ViMotionKind};
+use ozmux_vt::frame::FrameSnapshot;
+use ozmux_vt::vt::{Vt, VtMotion, VtSelection};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::thread::JoinHandle;
+use tokio::sync::{broadcast, oneshot};
+
+/// A command sent from an async client task to a surface's driver thread.
+pub(crate) enum DriverCommand {
+    /// Pre-encoded input bytes to write to the PTY.
+    Input(Vec<u8>),
+    /// Scroll the host viewport by `delta` rows (positive = into history).
+    Scroll(i32),
+    /// Resize the PTY and the VT grid.
+    Resize { cols: u16, rows: u16 },
+    /// A copy-mode op; `reply` is `Some` only for `CopySelection`.
+    CopyMode { op: CopyModeOp, reply: Option<oneshot::Sender<String>> },
+    /// Cold-attach: reply with a fresh full snapshot.
+    Snapshot(oneshot::Sender<FrameSnapshot>),
+}
+
+/// A reserved-but-not-yet-spawned driver: its routing slot exists in the
+/// registry; the OS thread is started after the structural broadcast.
+pub(crate) struct DriverSeed {
+    pub(crate) surface: SurfaceId,
+    pub(crate) cols: u16,
+    pub(crate) rows: u16,
+    pub(crate) cwd: Option<PathBuf>,
+    pub(crate) cmd_rx: Receiver<DriverCommand>,
+}
+
+struct SurfaceHandle {
+    cmd_tx: Sender<DriverCommand>,
+    join: Option<JoinHandle<()>>,
+}
+
+/// Maps a proto `CopyModeOp` onto the `Vt`'s alacritty-free API. Returns the
+/// selection text only for `CopySelection`; otherwise `None`.
+pub(crate) fn apply_copy_mode(vt: &mut Vt, op: &CopyModeOp) -> Option<String> {
+    match op {
+        CopyModeOp::Enter => vt.enter_vi_mode(),
+        CopyModeOp::Exit => vt.exit_vi_mode(),
+        CopyModeOp::ViMotion(k) => vt.vi_motion_kind(motion_to_vt(*k)),
+        CopyModeOp::ViGoto { point } => vt.vi_goto_view(point.line, point.col),
+        CopyModeOp::ScrollPageUp => vt.scroll_page_up(),
+        CopyModeOp::ScrollPageDown => vt.scroll_page_down(),
+        CopyModeOp::SelectionStartAt { point, side, ty } => {
+            vt.selection_start_at_view(point.line, point.col, is_right(*side), sel_to_vt(*ty))
+        }
+        CopyModeOp::SelectionUpdateTo { point, side } => {
+            vt.selection_update_to_view(point.line, point.col, is_right(*side))
+        }
+        CopyModeOp::SelectionStart { ty } => vt.selection_start_kind(sel_to_vt(*ty)),
+        CopyModeOp::SelectionClear => vt.selection_clear(),
+        CopyModeOp::SelectionChangeType { ty } => {
+            vt.selection_change_type_kind(sel_to_vt(*ty));
+        }
+        CopyModeOp::CopySelection => return vt.selection_to_string(),
+    }
+    None
+}
+
+fn is_right(side: CellSide) -> bool {
+    matches!(side, CellSide::Right)
+}
+
+fn motion_to_vt(k: ViMotionKind) -> VtMotion {
+    match k {
+        ViMotionKind::Left => VtMotion::Left,
+        ViMotionKind::Right => VtMotion::Right,
+        ViMotionKind::Up => VtMotion::Up,
+        ViMotionKind::Down => VtMotion::Down,
+        ViMotionKind::First => VtMotion::First,
+        ViMotionKind::Last => VtMotion::Last,
+        ViMotionKind::FirstOccupied => VtMotion::FirstOccupied,
+        ViMotionKind::High => VtMotion::High,
+        ViMotionKind::Low => VtMotion::Low,
+        ViMotionKind::WordRight => VtMotion::WordRight,
+        ViMotionKind::WordLeft => VtMotion::WordLeft,
+        ViMotionKind::WordRightEnd => VtMotion::WordRightEnd,
+    }
+}
+
+fn sel_to_vt(k: SelectionKind) -> VtSelection {
+    match k {
+        SelectionKind::Simple => VtSelection::Simple,
+        SelectionKind::Block => VtSelection::Block,
+        SelectionKind::Lines => VtSelection::Lines,
+        SelectionKind::Semantic => VtSelection::Semantic,
+    }
+}
+
+/// Routes client commands to per-surface driver threads.
+pub(crate) struct TerminalRegistry {
+    map: Mutex<HashMap<SurfaceId, SurfaceHandle>>,
+}
+
+impl TerminalRegistry {
+    /// Creates an empty registry.
+    pub(crate) fn new() -> Self {
+        Self { map: Mutex::new(HashMap::new()) }
+    }
+
+    /// Sends `cmd` to `surface`'s driver. Returns `false` when no driver is
+    /// registered (already-closed surface); the caller drops the command.
+    pub(crate) fn route(&self, surface: SurfaceId, cmd: DriverCommand) -> bool {
+        let map = self.map.lock().unwrap();
+        match map.get(&surface) {
+            Some(handle) => handle.cmd_tx.send(cmd).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Reserves a routing slot for `surface` and returns the seed used to spawn
+    /// the driver thread AFTER the structural broadcast. Empty `cwd` -> `None`.
+    /// Returns `None` (skips) when `surface` is already registered (idempotent).
+    pub(crate) fn reserve(
+        &self,
+        surface: SurfaceId,
+        cols: u16,
+        rows: u16,
+        cwd: PathBuf,
+    ) -> Option<DriverSeed> {
+        let mut map = self.map.lock().unwrap();
+        if map.contains_key(&surface) {
+            return None;
+        }
+        let (cmd_tx, cmd_rx) = unbounded();
+        map.insert(surface, SurfaceHandle { cmd_tx, join: None });
+        let cwd = if cwd.as_os_str().is_empty() { None } else { Some(cwd) };
+        Some(DriverSeed { surface, cols, rows, cwd, cmd_rx })
+    }
+
+    /// Spawns the driver OS thread for a reserved seed and attaches its join
+    /// handle. Must run AFTER the structural broadcast so the driver's first
+    /// frame follows the `PaneCreated`/`SurfaceSpawned` event.
+    pub(crate) fn spawn(&self, seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
+        let surface = seed.surface;
+        let join = SurfaceDriver::spawn(seed, events_tx);
+        let mut map = self.map.lock().unwrap();
+        if let Some(handle) = map.get_mut(&surface) {
+            handle.join = Some(join);
+        }
+    }
+
+    /// Removes `surface`'s driver: dropping `cmd_tx` disconnects the driver's
+    /// command receiver, so its `Select` returns and the thread exits.
+    pub(crate) fn remove(&self, surface: SurfaceId) {
+        let mut map = self.map.lock().unwrap();
+        map.remove(&surface);
+    }
+
+    /// True when `surface` has a registered driver.
+    pub(crate) fn contains(&self, surface: SurfaceId) -> bool {
+        self.map.lock().unwrap().contains_key(&surface)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn apply_copy_mode_enter_and_exit_return_none() {
+        let mut vt = Vt::new(10, 5);
+        let out = apply_copy_mode(&mut vt, &CopyModeOp::Enter);
+        assert!(out.is_none());
+        // Behavioral check: exit should succeed (round-trip) without panicking,
+        // confirming Enter armed vi mode.
+        let out2 = apply_copy_mode(&mut vt, &CopyModeOp::Exit);
+        assert!(out2.is_none());
+    }
+
+    #[test]
+    fn apply_copy_mode_copyselection_returns_text() {
+        let mut vt = Vt::new(10, 3);
+        vt.on_output(b"X", Instant::now());
+        vt.enter_vi_mode();
+        // Move the vi cursor to column 0 (where 'X' was written) before
+        // anchoring the selection.
+        apply_copy_mode(&mut vt, &CopyModeOp::ViMotion(ViMotionKind::First));
+        apply_copy_mode(&mut vt, &CopyModeOp::SelectionStart { ty: SelectionKind::Simple });
+        let text = apply_copy_mode(&mut vt, &CopyModeOp::CopySelection);
+        assert!(text.unwrap_or_default().contains('X'));
+    }
+
+    #[test]
+    fn reserve_is_idempotent_for_same_surface() {
+        let reg = TerminalRegistry::new();
+        let s = SurfaceId::default();
+        assert!(reg.reserve(s, 80, 24, PathBuf::new()).is_some());
+        assert!(
+            reg.reserve(s, 80, 24, PathBuf::new()).is_none(),
+            "second reserve must be skipped"
+        );
+        assert!(reg.contains(s));
+    }
+
+    #[test]
+    fn route_to_unknown_surface_returns_false() {
+        let reg = TerminalRegistry::new();
+        assert!(!reg.route(SurfaceId::default(), DriverCommand::Scroll(1)));
+    }
+}

--- a/daemon/ozmux_server/src/terminal/driver.rs
+++ b/daemon/ozmux_server/src/terminal/driver.rs
@@ -11,7 +11,7 @@ use ozmux_vt::frame::{Frame, SnapshotReason};
 use ozmux_vt::pty::Pty;
 use ozmux_vt::vt::{OutputAction, Vt};
 use std::path::Path;
-use std::thread::{self, JoinHandle};
+use std::thread;
 use std::time::Instant;
 use tokio::sync::broadcast;
 
@@ -25,13 +25,10 @@ pub(crate) struct SurfaceDriver {
 }
 
 impl SurfaceDriver {
-    /// Spawns the PTY + VT engine for `seed` and starts the driver thread. On a
+    /// Spawns the PTY + VT engine for `seed` on a detached driver thread. On a
     /// PTY spawn failure, logs and broadcasts `ChildExit { code: None }` so the
-    /// client can mark the surface dead; the thread exits immediately.
-    pub(crate) fn spawn(
-        seed: DriverSeed,
-        events_tx: broadcast::Sender<ServerMessage>,
-    ) -> JoinHandle<()> {
+    /// client can mark the surface dead, and no thread is started.
+    pub(crate) fn spawn(seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
         let DriverSeed { surface, cols, rows, cwd, cmd_rx } = seed;
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let env = vec![("TERM".to_string(), "xterm-256color".to_string())];
@@ -40,15 +37,16 @@ impl SurfaceDriver {
             Ok(pty) => {
                 let vt = Vt::new(cols, rows);
                 let driver = SurfaceDriver { surface, pty, vt, cmd_rx, events_tx };
-                thread::spawn(move || driver.run())
+                thread::spawn(move || driver.run());
             }
             Err(error) => {
                 tracing::error!(?error, ?surface, "PTY spawn failed");
+                // NOTE: `cmd_rx` drops here, disconnecting the channel, so a later
+                // `route` to this surface fails fast instead of queueing undrained.
                 let _ = events_tx.send(ServerMessage::SurfaceEvent {
                     surface,
                     event: VtEvent::ChildExit { code: None },
                 });
-                thread::spawn(|| {})
             }
         }
     }
@@ -58,15 +56,15 @@ impl SurfaceDriver {
         // shell. The Select loop blocks forever on `deadline == None` until
         // output, so the bootstrap rescue must be primed here.
         self.pump(Instant::now());
+        // NOTE: clone the receivers once: each iteration's `Select` borrows
+        // these locals (not `self`), so the `&mut self` calls in the loop are
+        // unblocked. `crossbeam` receivers are ref-counted clones of the same
+        // channel, so they receive identically to the originals.
+        let chunk_rx = self.pty.chunk_receiver().clone();
+        let exit_rx = self.pty.exit_receiver().clone();
+        let cmd_rx = self.cmd_rx.clone();
         loop {
             let deadline = self.vt.next_deadline();
-            // NOTE: receivers are cloned out of `self` so `sel` does not hold a
-            // borrow on `self` past the `select`/`select_deadline` call.
-            // `crossbeam_channel::Receiver` is `Clone` (ref-counted), so this
-            // is allocation-free.
-            let chunk_rx = self.pty.chunk_receiver().clone();
-            let exit_rx = self.pty.exit_receiver().clone();
-            let cmd_rx = self.cmd_rx.clone();
 
             let mut sel = Select::new();
             let chunk_idx = sel.recv(&chunk_rx);
@@ -199,13 +197,14 @@ mod tests {
             cwd: None,
             cmd_rx,
         };
-        let join = SurfaceDriver::spawn(seed, events_tx);
+        SurfaceDriver::spawn(seed, events_tx);
         assert!(
             recv_until_frame(&mut rx),
             "quiet shell must still emit an Initial snapshot via startup pump"
         );
+        // Detached thread: dropping cmd_tx disconnects its command channel, so
+        // the driver's Select returns and the thread exits on its own.
         drop(cmd_tx);
-        let _ = join.join();
     }
 
     #[test]
@@ -219,11 +218,12 @@ mod tests {
             cwd: None,
             cmd_rx,
         };
-        let join = SurfaceDriver::spawn(seed, events_tx);
+        SurfaceDriver::spawn(seed, events_tx);
         assert!(recv_until_frame(&mut rx), "initial frame");
         cmd_tx.send(DriverCommand::Input(b"printf hello\n".to_vec())).unwrap();
         assert!(recv_until_frame(&mut rx), "input must drive a subsequent frame");
+        // Detached thread: dropping cmd_tx disconnects its command channel, so
+        // the driver's Select returns and the thread exits on its own.
         drop(cmd_tx);
-        let _ = join.join();
     }
 }

--- a/daemon/ozmux_server/src/terminal/driver.rs
+++ b/daemon/ozmux_server/src/terminal/driver.rs
@@ -1,0 +1,3 @@
+//! Per-surface VT/PTY driver: owns one terminal's `(Pty, Vt)` on a dedicated
+//! OS thread and multiplexes PTY output, child exit, client commands, and the
+//! coalescer deadline via `crossbeam::Select`.

--- a/daemon/ozmux_server/src/terminal/driver.rs
+++ b/daemon/ozmux_server/src/terminal/driver.rs
@@ -1,3 +1,229 @@
 //! Per-surface VT/PTY driver: owns one terminal's `(Pty, Vt)` on a dedicated
 //! OS thread and multiplexes PTY output, child exit, client commands, and the
 //! coalescer deadline via `crossbeam::Select`.
+
+use crate::terminal::{DriverCommand, DriverSeed, apply_copy_mode};
+use crossbeam_channel::{Receiver, Select};
+use ozmux_mux::SurfaceId;
+use ozmux_proto::ServerMessage;
+use ozmux_vt::event::VtEvent;
+use ozmux_vt::frame::{Frame, SnapshotReason};
+use ozmux_vt::pty::Pty;
+use ozmux_vt::vt::{OutputAction, Vt};
+use std::path::Path;
+use std::thread::{self, JoinHandle};
+use std::time::Instant;
+use tokio::sync::broadcast;
+
+/// Owns one terminal's `(Pty, Vt)` on a dedicated OS thread.
+pub(crate) struct SurfaceDriver {
+    surface: SurfaceId,
+    pty: Pty,
+    vt: Vt,
+    cmd_rx: Receiver<DriverCommand>,
+    events_tx: broadcast::Sender<ServerMessage>,
+}
+
+impl SurfaceDriver {
+    /// Spawns the PTY + VT engine for `seed` and starts the driver thread. On a
+    /// PTY spawn failure, logs and broadcasts `ChildExit { code: None }` so the
+    /// client can mark the surface dead; the thread exits immediately.
+    pub(crate) fn spawn(
+        seed: DriverSeed,
+        events_tx: broadcast::Sender<ServerMessage>,
+    ) -> JoinHandle<()> {
+        let DriverSeed { surface, cols, rows, cwd, cmd_rx } = seed;
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let env = vec![("TERM".to_string(), "xterm-256color".to_string())];
+        let cwd_ref: Option<&Path> = cwd.as_deref();
+        match Pty::spawn(cols, rows, &shell, cwd_ref, &env) {
+            Ok(pty) => {
+                let vt = Vt::new(cols, rows);
+                let driver = SurfaceDriver { surface, pty, vt, cmd_rx, events_tx };
+                thread::spawn(move || driver.run())
+            }
+            Err(error) => {
+                tracing::error!(?error, ?surface, "PTY spawn failed");
+                let _ = events_tx.send(ServerMessage::SurfaceEvent {
+                    surface,
+                    event: VtEvent::ChildExit { code: None },
+                });
+                thread::spawn(|| {})
+            }
+        }
+    }
+
+    fn run(mut self) {
+        // NOTE: Startup bootstrap: emit the Initial snapshot even for a quiet
+        // shell. The Select loop blocks forever on `deadline == None` until
+        // output, so the bootstrap rescue must be primed here.
+        self.pump(Instant::now());
+        loop {
+            let deadline = self.vt.next_deadline();
+            // NOTE: receivers are cloned out of `self` so `sel` does not hold a
+            // borrow on `self` past the `select`/`select_deadline` call.
+            // `crossbeam_channel::Receiver` is `Clone` (ref-counted), so this
+            // is allocation-free.
+            let chunk_rx = self.pty.chunk_receiver().clone();
+            let exit_rx = self.pty.exit_receiver().clone();
+            let cmd_rx = self.cmd_rx.clone();
+
+            let mut sel = Select::new();
+            let chunk_idx = sel.recv(&chunk_rx);
+            let exit_idx = sel.recv(&exit_rx);
+            let cmd_idx = sel.recv(&cmd_rx);
+
+            let picked = match deadline {
+                Some(d) => sel.select_deadline(d),
+                None => Ok(sel.select()),
+            };
+
+            // NOTE: capture `now` AFTER waking; using the pre-block timestamp
+            // would make a deadline-elapsed `tick` see `now < deadline` and skip
+            // the flush for a full extra loop.
+            let now = Instant::now();
+
+            // NOTE: Drop `sel` before any `&mut self` call: it borrows the
+            // cloned receivers and, if a `SelectedOperation` from `select` were
+            // left live, dropping it without a `recv`/`complete` would panic.
+            drop(sel);
+
+            match picked {
+                Err(_) => self.pump(now),
+                Ok(op) => {
+                    let i = op.index();
+                    if i == chunk_idx {
+                        match op.recv(&chunk_rx) {
+                            Ok(chunk) => {
+                                if self.vt.on_output(&chunk, now) == OutputAction::EmitNow
+                                    && let Some(frame) = self.vt.emit()
+                                {
+                                    self.send_frame(frame);
+                                }
+                                self.pump(now);
+                            }
+                            Err(_) => break,
+                        }
+                    } else if i == exit_idx {
+                        let code = op.recv(&exit_rx).ok().flatten();
+                        self.send_event(VtEvent::ChildExit { code });
+                        break;
+                    } else if i == cmd_idx {
+                        match op.recv(&cmd_rx) {
+                            Ok(cmd) => {
+                                self.handle_cmd(cmd);
+                                self.pump(now);
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_cmd(&mut self, cmd: DriverCommand) {
+        match cmd {
+            DriverCommand::Input(bytes) => {
+                // NOTE: set the user-input flag BEFORE the PTY write so the echo
+                // chunk flushes immediately. Input and chunk handling share this
+                // thread, so no racing emit can observe the flag mid-write.
+                self.vt.note_user_input();
+                let _ = self.pty.write_all(&bytes);
+            }
+            DriverCommand::Scroll(delta) => self.vt.scroll(delta),
+            DriverCommand::Resize { cols, rows } => {
+                let _ = self.pty.resize(cols, rows);
+                self.vt.resize(cols, rows);
+            }
+            DriverCommand::CopyMode { op, reply } => {
+                let text = apply_copy_mode(&mut self.vt, &op);
+                if let Some(tx) = reply {
+                    let _ = tx.send(text.unwrap_or_default());
+                }
+            }
+            DriverCommand::Snapshot(tx) => {
+                let _ = tx.send(self.vt.force_snapshot(SnapshotReason::Reconnect));
+            }
+        }
+    }
+
+    fn pump(&mut self, now: Instant) {
+        let replies = self.vt.drain_replies();
+        if !replies.is_empty() {
+            let _ = self.pty.write_all(&replies);
+        }
+        for ev in self.vt.drain_events() {
+            self.send_event(ev);
+        }
+        if let Some(frame) = self.vt.tick(now) {
+            self.send_frame(frame);
+        }
+    }
+
+    fn send_frame(&self, frame: Frame) {
+        let _ = self.events_tx.send(ServerMessage::Frame { surface: self.surface, frame });
+    }
+
+    fn send_event(&self, event: VtEvent) {
+        let _ = self
+            .events_tx
+            .send(ServerMessage::SurfaceEvent { surface: self.surface, event });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn recv_until_frame(rx: &mut broadcast::Receiver<ServerMessage>) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            if let Ok(ServerMessage::Frame { .. }) = rx.try_recv() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    #[test]
+    fn driver_emits_initial_snapshot_for_quiet_shell() {
+        let (events_tx, mut rx) = broadcast::channel(256);
+        let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded();
+        let seed = DriverSeed {
+            surface: SurfaceId::default(),
+            cols: 80,
+            rows: 24,
+            cwd: None,
+            cmd_rx,
+        };
+        let join = SurfaceDriver::spawn(seed, events_tx);
+        assert!(
+            recv_until_frame(&mut rx),
+            "quiet shell must still emit an Initial snapshot via startup pump"
+        );
+        drop(cmd_tx);
+        let _ = join.join();
+    }
+
+    #[test]
+    fn driver_input_produces_a_frame() {
+        let (events_tx, mut rx) = broadcast::channel(256);
+        let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded();
+        let seed = DriverSeed {
+            surface: SurfaceId::default(),
+            cols: 80,
+            rows: 24,
+            cwd: None,
+            cmd_rx,
+        };
+        let join = SurfaceDriver::spawn(seed, events_tx);
+        assert!(recv_until_frame(&mut rx), "initial frame");
+        cmd_tx.send(DriverCommand::Input(b"printf hello\n".to_vec())).unwrap();
+        assert!(recv_until_frame(&mut rx), "input must drive a subsequent frame");
+        drop(cmd_tx);
+        let _ = join.join();
+    }
+}

--- a/daemon/ozmux_server/src/terminal/driver.rs
+++ b/daemon/ozmux_server/src/terminal/driver.rs
@@ -28,7 +28,7 @@ impl SurfaceDriver {
     /// Spawns the PTY + VT engine for `seed` on a detached driver thread. On a
     /// PTY spawn failure, logs and broadcasts `ChildExit { code: None }` so the
     /// client can mark the surface dead, and no thread is started.
-    pub(crate) fn spawn(seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
+    pub fn spawn(seed: DriverSeed, events_tx: broadcast::Sender<ServerMessage>) {
         let DriverSeed { surface, cols, rows, cwd, cmd_rx } = seed;
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
         let env = vec![("TERM".to_string(), "xterm-256color".to_string())];

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -220,7 +220,7 @@ async fn input_is_rejected_with_error() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn create_workspace_broadcasts_created_and_renamed() {
+async fn create_workspace_broadcasts_created_with_name() {
     let (name, _server) = spawn_server();
     let (mut reader, mut writer) = connect_client(&name).await;
     let _welcome = recv(&mut reader).await;
@@ -234,14 +234,16 @@ async fn create_workspace_broadcasts_created_and_renamed() {
     match recv(&mut reader).await {
         ServerMessage::Events(events) => {
             assert!(
-                events
-                    .iter()
-                    .any(|e| matches!(e, MuxEvent::WorkspaceCreated { .. }))
+                events.iter().any(
+                    |e| matches!(e, MuxEvent::WorkspaceCreated { name, .. } if name == "proj")
+                ),
+                "the requested name arrives atomically on WorkspaceCreated"
             );
             assert!(
-                events.iter().any(
-                    |e| matches!(e, MuxEvent::WorkspaceRenamed { name, .. } if name == "proj")
-                )
+                !events
+                    .iter()
+                    .any(|e| matches!(e, MuxEvent::WorkspaceRenamed { .. })),
+                "naming is atomic at creation; no separate rename event"
             );
         }
         other => panic!("expected Events, got {other:?}"),

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -252,14 +252,8 @@ async fn spawn_surface_emits_initial_frame() {
     let pane = active_pane_of(&welcome);
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
     send(&mut writer, ClientMessage::SpawnSurface { pane, kind: SurfaceKind::Terminal, cwd: None }).await;
-    let timed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-        loop {
-            if let ServerMessage::Frame { .. } = recv(&mut reader).await {
-                return;
-            }
-        }
-    })
-    .await;
+    let timed =
+        tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
     assert!(timed.is_ok(), "a newly spawned terminal surface must emit an Initial frame");
 }
 

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -59,6 +59,16 @@ async fn recv(reader: &mut ClientReader) -> ServerMessage {
     serde_json::from_slice(&frame).unwrap()
 }
 
+async fn recv_events(reader: &mut ClientReader) -> Vec<MuxEvent> {
+    loop {
+        match recv(reader).await {
+            ServerMessage::Events(events) => return events,
+            ServerMessage::Frame { .. } | ServerMessage::SurfaceEvent { .. } => continue,
+            other => panic!("expected Events, got {other:?}"),
+        }
+    }
+}
+
 fn active_pane_of(welcome: &ServerMessage) -> PaneId {
     match welcome {
         ServerMessage::Welcome { snapshot } => {
@@ -120,26 +130,22 @@ async fn split_broadcasts_events_to_sender() {
         },
     )
     .await;
-    match recv(&mut reader).await {
-        ServerMessage::Events(events) => {
-            assert!(
-                events
-                    .iter()
-                    .any(|e| matches!(e, MuxEvent::PaneCreated { .. }))
-            );
-            assert!(
-                events
-                    .iter()
-                    .any(|e| matches!(e, MuxEvent::LayoutChanged { .. }))
-            );
-            assert!(
-                events
-                    .iter()
-                    .any(|e| matches!(e, MuxEvent::ActivePaneChanged { .. }))
-            );
-        }
-        other => panic!("expected Events, got {other:?}"),
-    }
+    let events = recv_events(&mut reader).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, MuxEvent::PaneCreated { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, MuxEvent::LayoutChanged { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, MuxEvent::ActivePaneChanged { .. }))
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -162,16 +168,12 @@ async fn split_is_broadcast_to_all_clients() {
     )
     .await;
     for reader in [&mut reader_a, &mut reader_b] {
-        match recv(reader).await {
-            ServerMessage::Events(events) => {
-                assert!(
-                    events
-                        .iter()
-                        .any(|e| matches!(e, MuxEvent::PaneCreated { .. }))
-                );
-            }
-            other => panic!("expected Events, got {other:?}"),
-        }
+        let events = recv_events(reader).await;
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MuxEvent::PaneCreated { .. }))
+        );
     }
 }
 
@@ -188,12 +190,16 @@ async fn closing_last_pane_errors_only_to_sender() {
         ServerMessage::Error { .. } => {}
         other => panic!("expected Error, got {other:?}"),
     }
-    let quiet =
-        tokio::time::timeout(std::time::Duration::from_millis(300), recv(&mut reader_b)).await;
-    assert!(
-        quiet.is_err(),
-        "an error must not broadcast to other clients"
-    );
+    // NOTE: terminal drivers broadcast Frame/SurfaceEvent messages continuously;
+    // drain those and assert no Error arrives within the window.
+    let deadline = std::time::Duration::from_millis(300);
+    loop {
+        match tokio::time::timeout(deadline, recv(&mut reader_b)).await {
+            Err(_) => break,
+            Ok(ServerMessage::Frame { .. } | ServerMessage::SurfaceEvent { .. }) => continue,
+            Ok(other) => panic!("an error must not broadcast to other clients; got {other:?}"),
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -231,21 +237,17 @@ async fn create_workspace_broadcasts_created_with_name() {
         },
     )
     .await;
-    match recv(&mut reader).await {
-        ServerMessage::Events(events) => {
-            assert!(
-                events.iter().any(
-                    |e| matches!(e, MuxEvent::WorkspaceCreated { name, .. } if name == "proj")
-                ),
-                "the requested name arrives atomically on WorkspaceCreated"
-            );
-            assert!(
-                !events
-                    .iter()
-                    .any(|e| matches!(e, MuxEvent::WorkspaceRenamed { .. })),
-                "naming is atomic at creation; no separate rename event"
-            );
-        }
-        other => panic!("expected Events, got {other:?}"),
-    }
+    let events = recv_events(&mut reader).await;
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, MuxEvent::WorkspaceCreated { name, .. } if name == "proj")),
+        "the requested name arrives atomically on WorkspaceCreated"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, MuxEvent::WorkspaceRenamed { .. })),
+        "naming is atomic at creation; no separate rename event"
+    );
 }

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -202,6 +202,7 @@ async fn closing_last_pane_errors_only_to_sender() {
     }
 }
 
+#[ignore = "replaced by data-plane input test in Unit 7"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn input_is_rejected_with_error() {
     let (name, _server) = spawn_server();

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -5,8 +5,8 @@ use futures_util::{SinkExt, StreamExt};
 use interprocess::local_socket::tokio::Stream;
 use interprocess::local_socket::tokio::prelude::*;
 use interprocess::local_socket::{GenericNamespaced, ToNsName};
-use ozmux_mux::{MuxEvent, PaneId, Side, SplitOrientation, SurfaceKind};
-use ozmux_proto::{ClientMessage, MAX_MESSAGE_BYTES, ServerMessage};
+use ozmux_mux::{MuxEvent, PaneId, Side, SplitOrientation, SurfaceId, SurfaceKind};
+use ozmux_proto::{ClientMessage, CopyModeOp, MAX_MESSAGE_BYTES, SelectionKind, ServerMessage};
 use ozmux_server::OzmuxServer;
 use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::task::JoinHandle;
@@ -75,6 +75,15 @@ async fn recv_error(reader: &mut ClientReader) {
             ServerMessage::Error { .. } => return,
             ServerMessage::Frame { .. } | ServerMessage::SurfaceEvent { .. } => continue,
             other => panic!("expected Error, got {other:?}"),
+        }
+    }
+}
+
+async fn recv_until_frame(reader: &mut ClientReader) -> SurfaceId {
+    loop {
+        match recv(reader).await {
+            ServerMessage::Frame { surface, .. } => return surface,
+            _ => continue,
         }
     }
 }
@@ -209,9 +218,18 @@ async fn closing_last_pane_errors_only_to_sender() {
     }
 }
 
-#[ignore = "replaced by data-plane input test in Unit 7"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn input_is_rejected_with_error() {
+async fn cold_attach_receives_frame_snapshot_for_seed_surface() {
+    let (name, _server) = spawn_server();
+    let (mut reader, _writer) = connect_client(&name).await;
+    let _welcome = recv(&mut reader).await;
+    let timed =
+        tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
+    assert!(timed.is_ok(), "cold-attach must deliver a Frame snapshot for the seed surface");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn input_produces_a_frame() {
     let (name, _server) = spawn_server();
     let (mut reader, mut writer) = connect_client(&name).await;
     let welcome = recv(&mut reader).await;
@@ -219,18 +237,56 @@ async fn input_is_rejected_with_error() {
         ServerMessage::Welcome { snapshot } => snapshot.workspaces[0].panes[0].active_surface,
         other => panic!("expected Welcome, got {other:?}"),
     };
-    send(
-        &mut writer,
-        ClientMessage::Input {
-            surface,
-            bytes: vec![b'x'],
-        },
-    )
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
+    send(&mut writer, ClientMessage::Input { surface, bytes: b"printf hi\n".to_vec() }).await;
+    let timed =
+        tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
+    assert!(timed.is_ok(), "input must drive a subsequent frame");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn_surface_emits_initial_frame() {
+    let (name, _server) = spawn_server();
+    let (mut reader, mut writer) = connect_client(&name).await;
+    let welcome = recv(&mut reader).await;
+    let pane = active_pane_of(&welcome);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
+    send(&mut writer, ClientMessage::SpawnSurface { pane, kind: SurfaceKind::Terminal, cwd: None }).await;
+    let timed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let ServerMessage::Frame { .. } = recv(&mut reader).await {
+                return;
+            }
+        }
+    })
     .await;
-    match recv(&mut reader).await {
-        ServerMessage::Error { message } => assert!(message.contains("control-plane")),
-        other => panic!("expected Error, got {other:?}"),
-    }
+    assert!(timed.is_ok(), "a newly spawned terminal surface must emit an Initial frame");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn copy_selection_replies_to_origin_only() {
+    let (name, _server) = spawn_server();
+    let (mut reader, mut writer) = connect_client(&name).await;
+    let welcome = recv(&mut reader).await;
+    let surface = match &welcome {
+        ServerMessage::Welcome { snapshot } => snapshot.workspaces[0].panes[0].active_surface,
+        other => panic!("expected Welcome, got {other:?}"),
+    };
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), recv_until_frame(&mut reader)).await;
+    send(&mut writer, ClientMessage::Input { surface, bytes: b"X".to_vec() }).await;
+    send(&mut writer, ClientMessage::CopyMode { surface, op: CopyModeOp::Enter }).await;
+    send(&mut writer, ClientMessage::CopyMode { surface, op: CopyModeOp::SelectionStart { ty: SelectionKind::Simple } }).await;
+    send(&mut writer, ClientMessage::CopyMode { surface, op: CopyModeOp::CopySelection }).await;
+    let timed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let ServerMessage::SelectionCopied { surface: s, .. } = recv(&mut reader).await {
+                return s;
+            }
+        }
+    })
+    .await;
+    let s = timed.expect("CopySelection must reply with SelectionCopied");
+    assert_eq!(s, surface);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/daemon/ozmux_server/tests/control_plane.rs
+++ b/daemon/ozmux_server/tests/control_plane.rs
@@ -69,6 +69,16 @@ async fn recv_events(reader: &mut ClientReader) -> Vec<MuxEvent> {
     }
 }
 
+async fn recv_error(reader: &mut ClientReader) {
+    loop {
+        match recv(reader).await {
+            ServerMessage::Error { .. } => return,
+            ServerMessage::Frame { .. } | ServerMessage::SurfaceEvent { .. } => continue,
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+}
+
 fn active_pane_of(welcome: &ServerMessage) -> PaneId {
     match welcome {
         ServerMessage::Welcome { snapshot } => {
@@ -186,10 +196,7 @@ async fn closing_last_pane_errors_only_to_sender() {
     let _welcome_b = recv(&mut reader_b).await;
     let pane = active_pane_of(&welcome_a);
     send(&mut writer_a, ClientMessage::Close { pane }).await;
-    match recv(&mut reader_a).await {
-        ServerMessage::Error { .. } => {}
-        other => panic!("expected Error, got {other:?}"),
-    }
+    recv_error(&mut reader_a).await;
     // NOTE: terminal drivers broadcast Frame/SurfaceEvent messages continuously;
     // drain those and assert no Error arrives within the window.
     let deadline = std::time::Duration::from_millis(300);

--- a/daemon/ozmux_vt/src/pty.rs
+++ b/daemon/ozmux_vt/src/pty.rs
@@ -78,7 +78,8 @@ impl Pty {
             pixel_height: 0,
         };
         self.master
-            .get_mut()?
+            .get_mut()
+            .unwrap_or_else(|e| e.into_inner())
             .resize(size)
             .map_err(|e| anyhow::anyhow!("PTY resize failed: {e}"))?;
         Ok(())
@@ -86,7 +87,10 @@ impl Pty {
 
     /// Writes bytes to the PTY master.
     pub fn write_all(&mut self, bytes: &[u8]) -> std::io::Result<()> {
-        self.writer.get_mut()?.write_all(bytes)
+        self.writer
+            .get_mut()
+            .unwrap_or_else(|e| e.into_inner())
+            .write_all(bytes)
     }
 
     /// Non-blocking poll for the next PTY chunk from the reader thread.

--- a/daemon/ozmux_vt/src/vt.rs
+++ b/daemon/ozmux_vt/src/vt.rs
@@ -61,6 +61,49 @@ pub struct ViIndicatorSnapshot {
     pub history_size: usize,
 }
 
+/// Alacritty-free vi-motion selector for cross-crate callers (the daemon's
+/// copy-mode adapter), mirroring the subset the GUI emits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VtMotion {
+    /// Move left one cell.
+    Left,
+    /// Move right one cell.
+    Right,
+    /// Move up one line.
+    Up,
+    /// Move down one line.
+    Down,
+    /// Jump to the first column of the (logical) line.
+    First,
+    /// Jump to the last occupied column of the (logical) line.
+    Last,
+    /// Jump to the first non-empty cell of the line.
+    FirstOccupied,
+    /// Move to the top visible row.
+    High,
+    /// Move to the bottom visible row.
+    Low,
+    /// Move to the start of the next whitespace-separated word.
+    WordRight,
+    /// Move to the start of the previous whitespace-separated word.
+    WordLeft,
+    /// Move to the end of the current whitespace-separated word.
+    WordRightEnd,
+}
+
+/// Alacritty-free selection-type selector for cross-crate callers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VtSelection {
+    /// Character-granularity selection.
+    Simple,
+    /// Rectangular block selection.
+    Block,
+    /// Full-line selection.
+    Lines,
+    /// Semantically-separated word selection.
+    Semantic,
+}
+
 /// Inner `Dimensions` impl exposed to `Term::new` / `Term::resize`.
 ///
 /// Alacritty's own `TermSize` is `pub(crate)` so we provide a minimal
@@ -509,6 +552,61 @@ impl Vt {
         true
     }
 
+    /// Drives `vi_motion` from an alacritty-free selector.
+    pub fn vi_motion_kind(&mut self, motion: VtMotion) {
+        use alacritty_terminal::vi_mode::ViMotion as M;
+        let m = match motion {
+            VtMotion::Left => M::Left,
+            VtMotion::Right => M::Right,
+            VtMotion::Up => M::Up,
+            VtMotion::Down => M::Down,
+            VtMotion::First => M::First,
+            VtMotion::Last => M::Last,
+            VtMotion::FirstOccupied => M::FirstOccupied,
+            VtMotion::High => M::High,
+            VtMotion::Low => M::Low,
+            VtMotion::WordRight => M::WordRight,
+            VtMotion::WordLeft => M::WordLeft,
+            VtMotion::WordRightEnd => M::WordRightEnd,
+        };
+        self.vi_motion(m);
+    }
+
+    /// Places the vi cursor at a viewport point (0-based row/col) without
+    /// exposing alacritty's `Point` to callers.
+    pub fn vi_goto_view(&mut self, line: i32, col: usize) {
+        use alacritty_terminal::index::{Column, Line, Point};
+        self.vi_goto(Point::new(Line(line), Column(col)));
+    }
+
+    /// Starts a selection of `ty` at a viewport point; `side_right` chooses
+    /// the right half of the cell.
+    pub fn selection_start_at_view(&mut self, line: i32, col: usize, side_right: bool, ty: VtSelection) {
+        use alacritty_terminal::index::{Column, Line, Point, Side};
+        let point = Point::new(Line(line), Column(col));
+        let side = if side_right { Side::Right } else { Side::Left };
+        self.selection_start_at(point, side, vt_selection_to_alacritty(ty));
+    }
+
+    /// Extends the active selection to a viewport point.
+    pub fn selection_update_to_view(&mut self, line: i32, col: usize, side_right: bool) {
+        use alacritty_terminal::index::{Column, Line, Point, Side};
+        let point = Point::new(Line(line), Column(col));
+        let side = if side_right { Side::Right } else { Side::Left };
+        self.selection_update_to(point, side);
+    }
+
+    /// Starts a selection of `ty` at the current vi cursor.
+    pub fn selection_start_kind(&mut self, ty: VtSelection) {
+        self.selection_start(vt_selection_to_alacritty(ty));
+    }
+
+    /// Switches the active selection's type, preserving the anchor. Returns
+    /// `false` when no selection is active.
+    pub fn selection_change_type_kind(&mut self, ty: VtSelection) -> bool {
+        self.selection_change_type(vt_selection_to_alacritty(ty))
+    }
+
     /// Reads the current cols / rows / cursor.
     pub fn read_geometry(&self) -> (u16, u16, Cursor) {
         let cols = self.term.columns() as u16;
@@ -829,6 +927,16 @@ fn hash_row<T>(term: &Term<T>, line: Line, cursor: &Cursor, viewport_y: u16) -> 
         cursor.blinking.hash(&mut h);
     }
     h.finish()
+}
+
+fn vt_selection_to_alacritty(ty: VtSelection) -> alacritty_terminal::selection::SelectionType {
+    use alacritty_terminal::selection::SelectionType as S;
+    match ty {
+        VtSelection::Simple => S::Simple,
+        VtSelection::Block => S::Block,
+        VtSelection::Lines => S::Lines,
+        VtSelection::Semantic => S::Semantic,
+    }
 }
 
 fn hash_acolor(c: &AColor, h: &mut DefaultHasher) {
@@ -1295,6 +1403,35 @@ mod tests {
             matches!(f, Frame::Delta(_)),
             "force_snapshot must leave the delta base intact, got a {f:?}"
         );
+    }
+
+    #[test]
+    fn vi_motion_kind_down_advances_like_alacritty_down() {
+        let mut vt = Vt::new(10, 5);
+        vt.enter_vi_mode();
+        let before = vt.term.vi_mode_cursor.point.line.0;
+        vt.vi_motion_kind(VtMotion::Down);
+        let after = vt.term.vi_mode_cursor.point.line.0;
+        assert_eq!(after, before + 1, "VtMotion::Down must advance one line");
+    }
+
+    #[test]
+    fn selection_start_at_view_creates_selection_via_neutral_api() {
+        let mut vt = Vt::new(80, 24);
+        vt.selection_start_at_view(5, 10, false, VtSelection::Simple);
+        assert_eq!(vt.selection_type(), Some(alacritty_terminal::selection::SelectionType::Simple));
+        assert!(vt.selection_to_string().is_some());
+    }
+
+    #[test]
+    fn selection_start_kind_lines_sets_lines_type() {
+        let mut vt = Vt::new(10, 3);
+        vt.enter_vi_mode();
+        vt.selection_start_kind(VtSelection::Lines);
+        assert!(matches!(
+            vt.selection_type(),
+            Some(alacritty_terminal::selection::SelectionType::Lines)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Wire the **VT/PTY data plane** into `OzmuxServer` (previously control-plane only). Each terminal surface gets a dedicated OS-thread `SurfaceDriver` owning `(Pty, Vt)`, multiplexing PTY output / child-exit / client commands / coalescer-deadline via `crossbeam::Select`, and publishing `Frame`/`SurfaceEvent` into the existing tokio `broadcast` (sync send — no async bridge).
- **Routing & lifecycle:** `Input`/`Scroll`/`CopyMode` route to drivers via a `TerminalRegistry`; driver lifecycle (spawn / teardown / resize) is reconciled from mux events, reserving routing slots *before* the structural broadcast and spawning threads *after*; `CopySelection` replies (`SelectionCopied`) go only to the originating client.
- **Cold-attach:** a newly attached client gets a per-surface `force_snapshot` frame after `Welcome` (subscribe-before-snapshot; seq-reconciled), sent only to that client.
- **`ozmux_vt`:** added alacritty-free copy-mode wrappers (`VtMotion`/`VtSelection` + neutral methods) so `ozmux_server` does not depend on `alacritty_terminal`.
- **Robustness fixes found during review:** fixed a stalled-reader **deadlock** in the per-client loop (`biased` select so commands incl. `Shutdown` are serviced first + bounded client writes); **detached** driver threads (a blocking-join could hang shutdown if a child wedged its PTY write); bounded every client write and driver-reply await with named timeouts.
- Also includes a small earlier refactor: atomic workspace naming in `MultiPlexer::new_workspace`.

## Test Plan
- [x] Daemon crates green: `ozmux_vt` 137, `ozmux_mux` 60, `ozmux_proto` 22, `ozmux_server` 6 lib + 10 integration.
- [x] `cargo clippy -p ozmux_server -p ozmux_vt --tests` clean.
- [x] `shutdown_stops_the_server` 10/10 (was a flaky deadlock before the fix); `control_plane` suite stable across 5 runs.
- [x] New end-to-end integration tests: cold-attach frame snapshot, input→frame echo, spawn-surface→initial frame, `CopySelection`→origin-only reply.
- [ ] Reviewer: confirm client-side frame-mirror (seq gate) contract is tracked separately (server-side responsibility ends at the wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)