### PR TITLE
Phase 1 Step 4 — host-API bridge (window.<ns>.<method>)

### DIFF
--- a/assets/host.mjs
+++ b/assets/host.mjs
@@ -14627,6 +14627,7 @@ async function dispatchHostCall(api, frame) {
 
 // src/rpc-server.ts
 var MAX_RPC_LINE_BYTES = 8 * 1024 * 1024;
+var MAX_RPC_RESULT_BYTES = 8 * 1024 * 1024;
 async function bindHostRpcServer(sockPath, api) {
   await fs.unlink(sockPath).catch(() => {
   });
@@ -14679,8 +14680,18 @@ async function bindHostRpcServer(sockPath, api) {
       return;
     }
     const frame = { reqId, ns, method, args: args.map(decodeHostValue) };
-    dispatchHostCall(api, frame).then((result) => conn.write(`${JSON.stringify(result)}
-`)).catch((err) => {
+    dispatchHostCall(api, frame).then((result) => {
+      const resultLine = JSON.stringify(result);
+      if (Buffer.byteLength(resultLine, "utf8") > MAX_RPC_RESULT_BYTES) {
+        conn.write(
+          `${JSON.stringify({ reqId: frame.reqId, ok: false, error: "host result exceeds max size" })}
+`
+        );
+        return;
+      }
+      conn.write(`${resultLine}
+`);
+    }).catch((err) => {
       console.error("host rpc: dispatch threw", err);
       conn.write(
         `${JSON.stringify({ reqId: frame.reqId, ok: false, error: "internal host error" })}

--- a/crates/extension_host/src/lib.rs
+++ b/crates/extension_host/src/lib.rs
@@ -18,6 +18,7 @@ pub mod manifest;
 pub mod path_prefix;
 pub mod protocol;
 pub mod registry;
+pub mod rpc_client;
 pub mod scheme;
 
 pub use bridge::{
@@ -40,3 +41,4 @@ pub use manifest::{Manifest, ManifestError};
 pub use path_prefix::extension_path_prefix;
 pub use protocol::{ProtocolError, Request, Response};
 pub use registry::{RegisteredView, ViewId, ViewRegistry};
+pub use rpc_client::HostRpcClient;

--- a/crates/extension_host/src/rpc_client.rs
+++ b/crates/extension_host/src/rpc_client.rs
@@ -20,7 +20,7 @@ const WRITER_POLL: Duration = Duration::from_millis(100);
 /// via [`HostRpcClient::try_recv_response`]. The writer/reader threads are
 /// joined on drop.
 pub struct HostRpcClient {
-    outbound: Sender<String>,
+    outbound: Option<Sender<String>>,
     responses: Receiver<String>,
     shutdown: Arc<AtomicBool>,
     stream: UnixStream,
@@ -80,7 +80,7 @@ impl HostRpcClient {
         });
 
         Ok(Self {
-            outbound: out_tx,
+            outbound: Some(out_tx),
             responses: in_rx,
             shutdown,
             stream,
@@ -91,7 +91,9 @@ impl HostRpcClient {
 
     /// Queues an NDJSON request line for the host (the writer appends `\n`).
     pub fn send_line(&self, line: String) {
-        let _ = self.outbound.send(line);
+        if let Some(outbound) = self.outbound.as_ref() {
+            let _ = outbound.send(line);
+        }
     }
 
     /// Pops the next NDJSON reply line, or `None` if none is queued.
@@ -102,10 +104,13 @@ impl HostRpcClient {
 
 impl Drop for HostRpcClient {
     fn drop(&mut self) {
-        // NOTE: signal shutdown, then shut the stream so the reader's blocking
-        // read_line returns; the writer exits within one WRITER_POLL even though
-        // a sender clone may still live in the HostRpc resource.
+        // NOTE: drop the only Sender (so the writer's recv returns Disconnected at
+        // once) and shut the stream (so the reader's blocking read_line returns)
+        // BEFORE joining — otherwise the writer's join would block up to a
+        // WRITER_POLL tick and the reader's would block forever. This runs on the
+        // Bevy main thread (clear_client), so a stalled join freezes the frame loop.
         self.shutdown.store(true, Ordering::SeqCst);
+        self.outbound.take();
         let _ = self.stream.shutdown(Shutdown::Both);
         if let Some(w) = self.writer.take() {
             let _ = w.join();

--- a/crates/extension_host/src/rpc_client.rs
+++ b/crates/extension_host/src/rpc_client.rs
@@ -1,0 +1,162 @@
+//! Tokio-free NDJSON RPC client to the single Node host: a long-lived
+//! `UnixStream` with a writer thread draining outbound request lines and a
+//! reader thread pumping inbound NDJSON reply lines onto a crossbeam channel.
+
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded};
+use std::io::{BufRead, BufReader, Write};
+use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+const WRITER_POLL: Duration = Duration::from_millis(100);
+
+/// A connected NDJSON RPC client to the single Node host. Outbound
+/// `{reqId, ns, method, args}` request lines are queued via
+/// [`HostRpcClient::send_line`]; inbound `{reqId, ok, …}` reply lines are read
+/// via [`HostRpcClient::try_recv_response`]. The writer/reader threads are
+/// joined on drop.
+pub struct HostRpcClient {
+    outbound: Sender<String>,
+    responses: Receiver<String>,
+    shutdown: Arc<AtomicBool>,
+    stream: UnixStream,
+    writer: Option<JoinHandle<()>>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl HostRpcClient {
+    /// Connects to the host RPC socket and starts the writer + reader threads.
+    pub fn connect(sock: &Path) -> std::io::Result<Self> {
+        let stream = UnixStream::connect(sock)?;
+        let mut write_half = stream.try_clone()?;
+        let read_half = stream.try_clone()?;
+        let (out_tx, out_rx) = unbounded::<String>();
+        let (in_tx, in_rx) = unbounded::<String>();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let writer = {
+            let shutdown = Arc::clone(&shutdown);
+            std::thread::spawn(move || {
+                loop {
+                    match out_rx.recv_timeout(WRITER_POLL) {
+                        Ok(line) => {
+                            if write_half.write_all(line.as_bytes()).is_err()
+                                || write_half.write_all(b"\n").is_err()
+                                || write_half.flush().is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            if shutdown.load(Ordering::SeqCst) {
+                                break;
+                            }
+                        }
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+        };
+
+        let reader = std::thread::spawn(move || {
+            let mut lines = BufReader::new(read_half);
+            let mut buf = String::new();
+            loop {
+                buf.clear();
+                match lines.read_line(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        let line = buf.trim_end_matches(['\n', '\r']).to_string();
+                        if in_tx.send(line).is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            outbound: out_tx,
+            responses: in_rx,
+            shutdown,
+            stream,
+            writer: Some(writer),
+            reader: Some(reader),
+        })
+    }
+
+    /// Queues an NDJSON request line for the host (the writer appends `\n`).
+    pub fn send_line(&self, line: String) {
+        let _ = self.outbound.send(line);
+    }
+
+    /// Pops the next NDJSON reply line, or `None` if none is queued.
+    pub fn try_recv_response(&self) -> Option<String> {
+        self.responses.try_recv().ok()
+    }
+}
+
+impl Drop for HostRpcClient {
+    fn drop(&mut self) {
+        // NOTE: signal shutdown, then shut the stream so the reader's blocking
+        // read_line returns; the writer exits within one WRITER_POLL even though
+        // a sender clone may still live in the HostRpc resource.
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.stream.shutdown(Shutdown::Both);
+        if let Some(w) = self.writer.take() {
+            let _ = w.join();
+        }
+        if let Some(r) = self.reader.take() {
+            let _ = r.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::time::Duration;
+
+    #[test]
+    fn round_trips_one_ndjson_request_and_reply() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            assert!(
+                line.contains("\"reqId\":\"7\""),
+                "server saw the request line"
+            );
+            let mut w = stream;
+            w.write_all(b"{\"reqId\":\"7\",\"ok\":true,\"value\":42}\n")
+                .unwrap();
+            w.flush().unwrap();
+        });
+
+        let client = HostRpcClient::connect(&sock).unwrap();
+        client.send_line(
+            "{\"reqId\":\"7\",\"ns\":\"fs\",\"method\":\"read\",\"args\":[]}".to_string(),
+        );
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let reply = loop {
+            if let Some(line) = client.try_recv_response() {
+                break line;
+            }
+            assert!(std::time::Instant::now() < deadline, "no reply within 2s");
+            std::thread::sleep(Duration::from_millis(5));
+        };
+        assert_eq!(reply, "{\"reqId\":\"7\",\"ok\":true,\"value\":42}");
+        server.join().unwrap();
+    }
+}

--- a/docs/superpowers/plans/2026-06-12-phase1-step4-host-api-bridge.md
+++ b/docs/superpowers/plans/2026-06-12-phase1-step4-host-api-bridge.md
@@ -1,0 +1,1167 @@
+# Phase 1 Step 4: Host-API Bridge (`window.<ns>.<method>`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an OSC-mounted extension webview call `window.<ns>.<method>(...args)` and have it run `api[ns][method]` in the single Node host, gated by the surface's capabilities, with the result (incl. binary) returned to that webview's Promise.
+
+**Architecture:** Spec `docs/superpowers/specs/2026-06-11-phase1-single-host-process-design.md` §4③ (bridge-only slice; legacy stays until Step 5, memo+E2E is Step 6). A new Rust NDJSON RPC client (`HostRpcClient`, Tokio-free `UnixStream` + writer/reader threads, mirroring `host.rs`) dials the host's `OZMUX_HOST_RPC_SOCK`. A **second observer** on the existing single `Receive<OzmuxFrame>` event (NOT a second `JsEmitEventPlugin` — the raw IPC receiver is shared and `try_recv`-consumed) discriminates `kind:"host.call"` frames, gates them against the webview entity's `GrantedNamespaces` (the trusted key — never the JS payload), rewrites the page-local `reqId` to a globally-unique id (avoiding cross-webview `reqId` collisions), forwards to the host, and routes the reply back via `HostEmitEvent` on the existing `"ozmux"` channel. New-model surfaces get a new injected Proxy bridge (`host_bridge.js`) instead of the legacy `ozmux.js`; binary uses the `{__u8}` boundary tag (webview-side codec mirrors the host's vitest-tested `binary-codec.ts`).
+
+**Tech Stack:** Rust (Bevy 0.18 observers/resources, `std::os::unix::net::UnixStream`, `crossbeam-channel` internal to the host crate), TypeScript/Node host (`host/src/rpc-server.ts` + esbuild bundle), hand-written injected JS (`include_str!`, mirroring the existing `ozmux.js`).
+
+**Key facts (verified against current code):**
+- The host RPC server speaks **NDJSON** (newline-delimited JSON), reads/writes lines, caps an unframed inbound flood at 8 MiB, and has **no response-size cap** (`host/src/rpc-server.ts:7,38-44,82-93`). Result frames are `{reqId, ok:true, value}` / `{reqId, ok:false, error}` (`host/src/dispatch.ts:13-15`). Args are `{__u8}`-decoded before dispatch; results `{__u8}`-encoded after (`host/src/binary-codec.ts:20-37`).
+- Rust does **not** yet connect to the RPC socket — `HostProcess` only stores `rpc_sock_path()` (`crates/extension_host/src/host_process.rs:38,120-122`). The Tokio-free blocking-socket + crossbeam + thread-lifecycle pattern to mirror lives in `crates/extension_host/src/host.rs`.
+- `Receive<M>` is a broadcast `EntityEvent` (`#[event_target] webview: Entity`, `payload: M`) (`bevy_cef/src/common/ipc/js_emit.rs:8-12`); `HostEmitEvent` is an `EntityEvent` with `webview`/`id`/`payload: String`, built via `HostEmitEvent::new(webview, id, &impl Serialize)` (`bevy_cef/.../host_emit.rs:13-29`). There is exactly **one** `JsEmitEventPlugin::<OzmuxFrame>` and one `receive_events` that `try_recv`-consumes the shared `IpcEventRawReceiver` — adding a **second plugin** would steal messages, but a **second observer** on the produced `Receive<OzmuxFrame>` is a safe broadcast.
+- `OzmuxFrame` is `#[serde(transparent)] struct OzmuxFrame(serde_json::Value)` (`src/extension_render.rs:35-37`), so it matches any JSON object — both observers must branch on `kind`.
+- `GrantedNamespaces(pub(crate) HashSet<String>)` is stamped on the surface (== webview) entity at OSC-mount (`src/osc_webview.rs:37-43,105`), currently `#[allow(dead_code)]` with no production reader.
+- `cef.emit(arg)` serializes only its first argument (single self-describing object; no channel arg) — `src/extension_render/ozmux.js:1-4`.
+
+**Verification commands:**
+- Host-crate Rust tests: `cargo test -p ozmux_extension_host`
+- Binary (gui) Rust tests: `cargo test -p ozmux-gui --lib -- --test-threads=1` (the bridge/observer tests live here)
+- Host (Node) tests: `pnpm -C host test`
+- Full build: `cargo build`
+- Lint/format: `cargo clippy --workspace --all-targets && cargo fmt --check`
+- NOTE: a full `cargo test` has a pre-existing IME failure + a parallel-teardown SIGSEGV unrelated to this work; use the per-crate commands above as the primary signal, and `--test-threads=1` for the gui crate.
+
+---
+
+## File Structure
+
+**Create:**
+- `crates/extension_host/src/rpc_client.rs` — Tokio-free NDJSON RPC client (`HostRpcClient`): one long-lived `UnixStream`, a writer thread draining outbound request lines, a reader thread pumping inbound reply lines onto a crossbeam channel. Non-crossbeam public surface (`connect` / `send_line` / `try_recv_response`) so the binary crate never names a crossbeam type. Fully unit-testable against a fake `UnixListener`.
+- `src/extension_render/host_bridge.js` — the new injected bridge: builds one `window[ns]` Proxy per granted namespace (read from `window.__ozmuxGranted`), `cef.emit({kind:"host.call", ...})`, correlates replies on the `"ozmux"` channel, and applies the `{__u8}` codec at the argument/result boundary.
+
+**Modify:**
+- `crates/extension_host/src/lib.rs` — `pub mod rpc_client;` + `pub use rpc_client::HostRpcClient;`.
+- `host/src/rpc-server.ts` — add a response-size cap (`MAX_RPC_RESULT_BYTES`) before writing a reply; oversize → error frame. Then rebuild `assets/host.mjs`.
+- `src/extension_render.rs` — add the `HostRpc` resource, a new `on_host_call_frame` observer (capability gate + RPC forward + reqId rewrite), a `drain_host_rpc_responses` system (reply → originating webview), a `kind:"host.call"` guard on the legacy `on_ozmux_frame`, host-bridge injection in `finish_extension_setup` for surfaces carrying `GrantedNamespaces`, and inflight pruning on despawn.
+- `src/extension_manager.rs` — connect `HostRpcClient` on `LifecycleEvent::Ready`, store it into `HostRpc`; clear on `Exited`/`SpawnFailed`.
+- `src/osc_webview.rs` — remove the now-stale `#[allow(dead_code)]` on `GrantedNamespaces` (Task 3 adds the first production reader).
+
+---
+
+## Task 1: `HostRpcClient` — NDJSON RPC client to the host socket
+
+**Files:**
+- Create: `crates/extension_host/src/rpc_client.rs`
+- Modify: `crates/extension_host/src/lib.rs`
+- Test: inline `#[cfg(test)] mod tests` in `rpc_client.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/extension_host/src/rpc_client.rs` with ONLY the test module first (so the build fails on the missing type):
+
+```rust
+//! Tokio-free NDJSON RPC client to the single Node host: a long-lived
+//! `UnixStream` with a writer thread draining outbound request lines and a
+//! reader thread pumping inbound NDJSON reply lines onto a crossbeam channel.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::time::Duration;
+
+    #[test]
+    fn round_trips_one_ndjson_request_and_reply() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            assert!(line.contains("\"reqId\":\"7\""), "server saw the request line");
+            let mut w = stream;
+            w.write_all(b"{\"reqId\":\"7\",\"ok\":true,\"value\":42}\n").unwrap();
+            w.flush().unwrap();
+        });
+
+        let client = HostRpcClient::connect(&sock).unwrap();
+        client.send_line("{\"reqId\":\"7\",\"ns\":\"fs\",\"method\":\"read\",\"args\":[]}".to_string());
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let reply = loop {
+            if let Some(line) = client.try_recv_response() {
+                break line;
+            }
+            assert!(std::time::Instant::now() < deadline, "no reply within 2s");
+            std::thread::sleep(Duration::from_millis(5));
+        };
+        assert_eq!(reply, "{\"reqId\":\"7\",\"ok\":true,\"value\":42}");
+        server.join().unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ozmux_extension_host rpc_client`
+Expected: FAIL to compile — `HostRpcClient` not found (and `rpc_client` module not declared yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend the implementation ABOVE the test module in `crates/extension_host/src/rpc_client.rs`:
+
+```rust
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded};
+use std::io::{BufRead, BufReader, Write};
+use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+const WRITER_POLL: Duration = Duration::from_millis(100);
+
+/// A connected NDJSON RPC client to the single Node host. Outbound
+/// `{reqId, ns, method, args}` request lines are queued via
+/// [`HostRpcClient::send_line`]; inbound `{reqId, ok, …}` reply lines are read
+/// via [`HostRpcClient::try_recv_response`]. The writer/reader threads are
+/// joined on drop.
+pub struct HostRpcClient {
+    outbound: Sender<String>,
+    responses: Receiver<String>,
+    shutdown: Arc<AtomicBool>,
+    stream: UnixStream,
+    writer: Option<JoinHandle<()>>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl HostRpcClient {
+    /// Connects to the host RPC socket and starts the writer + reader threads.
+    pub fn connect(sock: &Path) -> std::io::Result<Self> {
+        let stream = UnixStream::connect(sock)?;
+        let mut write_half = stream.try_clone()?;
+        let read_half = stream.try_clone()?;
+        let (out_tx, out_rx) = unbounded::<String>();
+        let (in_tx, in_rx) = unbounded::<String>();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let writer = {
+            let shutdown = Arc::clone(&shutdown);
+            std::thread::spawn(move || {
+                loop {
+                    match out_rx.recv_timeout(WRITER_POLL) {
+                        Ok(line) => {
+                            if write_half.write_all(line.as_bytes()).is_err()
+                                || write_half.write_all(b"\n").is_err()
+                                || write_half.flush().is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            if shutdown.load(Ordering::SeqCst) {
+                                break;
+                            }
+                        }
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })
+        };
+
+        let reader = std::thread::spawn(move || {
+            let mut lines = BufReader::new(read_half);
+            let mut buf = String::new();
+            loop {
+                buf.clear();
+                match lines.read_line(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        let line = buf.trim_end_matches(['\n', '\r']).to_string();
+                        if in_tx.send(line).is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            outbound: out_tx,
+            responses: in_rx,
+            shutdown,
+            stream,
+            writer: Some(writer),
+            reader: Some(reader),
+        })
+    }
+
+    /// Queues an NDJSON request line for the host (the writer appends `\n`).
+    pub fn send_line(&self, line: String) {
+        let _ = self.outbound.send(line);
+    }
+
+    /// Pops the next NDJSON reply line, or `None` if none is queued.
+    pub fn try_recv_response(&self) -> Option<String> {
+        self.responses.try_recv().ok()
+    }
+}
+
+impl Drop for HostRpcClient {
+    fn drop(&mut self) {
+        // NOTE: signal shutdown, then shut the stream so the reader's blocking
+        // read_line returns; the writer exits within one WRITER_POLL even though
+        // a sender clone may still live in the HostRpc resource.
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.stream.shutdown(Shutdown::Both);
+        if let Some(w) = self.writer.take() {
+            let _ = w.join();
+        }
+        if let Some(r) = self.reader.take() {
+            let _ = r.join();
+        }
+    }
+}
+```
+
+Then declare + re-export the module. In `crates/extension_host/src/lib.rs`, add `pub mod rpc_client;` to the module list (alphabetical, after `protocol;` / before `registry;` is fine) and add to the re-export block:
+
+```rust
+pub use rpc_client::HostRpcClient;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ozmux_extension_host rpc_client`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Lint + format**
+
+Run: `cargo clippy -p ozmux_extension_host --all-targets && cargo fmt`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/extension_host/src/rpc_client.rs crates/extension_host/src/lib.rs
+git commit -m "feat(extension_host): NDJSON HostRpcClient to the single host socket"
+```
+
+---
+
+## Task 2: Response-size guard in the host RPC server
+
+**Files:**
+- Modify: `host/src/rpc-server.ts`
+- Modify (generated): `assets/host.mjs` (rebuilt)
+- Test: `host/src/rpc-server.test.ts`
+
+Rationale for the cap value: the `ozmux-ext://` asset scheme already serves large static files directly from Rust (up to 64 MiB), so the RPC channel is for dynamic/structured calls and is capped tighter at **8 MiB**, matching the existing inbound `MAX_RPC_LINE_BYTES`. Large bytes should flow over the asset scheme, not RPC.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `host/src/rpc-server.test.ts` inside the `describe('bindHostRpcServer', …)` block (the file already provides `connect()`, `rpc()`, `sockPath`, and `server` teardown):
+
+```ts
+  it('rejects an over-sized result with an error frame instead of writing it', async () => {
+    const bigApi: ApiNamespaceMap = {
+      big: { blob: async () => 'x'.repeat(9 * 1024 * 1024) },
+    };
+    server = await bindHostRpcServer(sockPath, bigApi);
+    const s = await connect();
+    const reply = await rpc(s, { reqId: '1', ns: 'big', method: 'blob', args: [] });
+    s.end();
+    expect(reply).toEqual({ reqId: '1', ok: false, error: 'host result exceeds max size' });
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C host test -- rpc-server`
+Expected: FAIL — the server currently writes the 9 MiB success frame, so `reply` is `{reqId:'1', ok:true, value:'xxxx…'}`, not the error frame.
+
+- [ ] **Step 3: Write the implementation**
+
+In `host/src/rpc-server.ts`, add the cap constant under the existing one (line 7):
+
+```ts
+const MAX_RPC_LINE_BYTES = 8 * 1024 * 1024;
+const MAX_RPC_RESULT_BYTES = 8 * 1024 * 1024;
+```
+
+Then replace the success-write arm of the `dispatchHostCall(...)` chain (currently `.then((result) => conn.write(\`${JSON.stringify(result)}\n\`))`) with a size check:
+
+```ts
+    dispatchHostCall(api, frame)
+      .then((result) => {
+        const line = JSON.stringify(result);
+        if (Buffer.byteLength(line, 'utf8') > MAX_RPC_RESULT_BYTES) {
+          // NOTE: a single oversized JSON string would choke the render process
+          // crossing the CEF IPC boundary; reject with an addressable error
+          // frame so the caller's reqId Promise settles. Big bytes belong on the
+          // ozmux-ext:// asset scheme, not RPC.
+          conn.write(
+            `${JSON.stringify({ reqId: frame.reqId, ok: false, error: 'host result exceeds max size' })}\n`,
+          );
+          return;
+        }
+        conn.write(`${line}\n`);
+      })
+      .catch((err) => {
+        // NOTE: dispatchHostCall is contracted never to reject; reply with an
+        // error frame anyway so a future regression cannot leave the caller's
+        // reqId Promise hanging forever.
+        console.error('host rpc: dispatch threw', err);
+        conn.write(
+          `${JSON.stringify({ reqId: frame.reqId, ok: false, error: 'internal host error' })}\n`,
+        );
+      });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -C host test -- rpc-server`
+Expected: PASS (all rpc-server tests, including the new one).
+
+- [ ] **Step 5: Rebuild the embedded bundle + typecheck**
+
+Run: `pnpm -C host build && pnpm -C host check-types`
+Expected: `assets/host.mjs` regenerated; types clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add host/src/rpc-server.ts host/src/rpc-server.test.ts assets/host.mjs
+git commit -m "feat(host): cap RPC result frames at 8 MiB with an error reply"
+```
+
+---
+
+## Task 3: `HostRpc` resource + capability-gated host-call observer
+
+**Files:**
+- Modify: `src/extension_render.rs`
+- Modify: `src/osc_webview.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/extension_render.rs`
+
+This adds the new path **alongside** the legacy one: a second observer on the shared `Receive<OzmuxFrame>` event, gating on the trusted `frame.webview` entity's `GrantedNamespaces`.
+
+- [ ] **Step 1: Add imports + the `HostRpc` resource**
+
+In `src/extension_render.rs` import block (top of file, no blank lines between groups), add:
+
+```rust
+use crate::osc_webview::GrantedNamespaces;
+use ozmux_extension_host::HostRpcClient;
+use serde_json::Value;
+```
+
+Add the resource + its helpers near the other resources (after `WebviewSurfaceIdMap`, before `WebviewMountUnresolved`). `HostRpc` is `pub(crate)` ONLY because `extension_manager::poll_host_lifecycle` populates it; its fields stay private:
+
+```rust
+/// The connected host RPC client plus the in-flight `globalReqId → (webview,
+/// pageReqId)` correlation. `globalReqId` is minted Rust-side (a monotonic
+/// counter) so page-local `reqId`s — which collide across webviews — are never
+/// used as a routing key. Populated by `extension_manager` on host readiness.
+#[derive(Resource, Default)]
+pub(crate) struct HostRpc {
+    client: Option<HostRpcClient>,
+    inflight: HashMap<String, (Entity, String)>,
+    next_id: u64,
+}
+
+impl HostRpc {
+    /// Installs a freshly-connected client, clearing any stale correlation /
+    /// counter from a previous host generation.
+    pub(crate) fn set_client(&mut self, client: HostRpcClient) {
+        self.client = Some(client);
+        self.inflight.clear();
+        self.next_id = 0;
+    }
+
+    /// Drops the client (host exited): subsequent calls reject `host_unavailable`.
+    pub(crate) fn clear_client(&mut self) {
+        self.client = None;
+        self.inflight.clear();
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `src/extension_render.rs`. These exercise the gate without any socket (denied / unavailable paths) and via a fake drain server (allowed path):
+
+```rust
+    use crate::osc_webview::GrantedNamespaces;
+    use bevy_cef::prelude::HostEmitEvent;
+    use std::collections::HashSet;
+
+    #[derive(Resource, Default)]
+    struct CapturedEmits(Vec<(Entity, String)>);
+
+    fn capture_emits(ev: On<HostEmitEvent>, mut cap: ResMut<CapturedEmits>) {
+        cap.0.push((ev.webview, ev.payload.clone()));
+    }
+
+    fn gate_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<HostRpc>();
+        app.init_resource::<CapturedEmits>();
+        app.add_observer(on_host_call_frame);
+        app.add_observer(capture_emits);
+        app
+    }
+
+    fn host_call(req_id: &str, ns: &str, method: &str) -> OzmuxFrame {
+        OzmuxFrame(serde_json::json!({
+            "kind": "host.call", "reqId": req_id, "ns": ns, "method": method, "args": []
+        }))
+    }
+
+    #[test]
+    fn host_call_denied_for_ungranted_namespace_is_not_forwarded() {
+        let mut app = gate_app();
+        let mut caps = HashSet::new();
+        caps.insert("clipboard".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        assert!(
+            app.world().resource::<HostRpc>().inflight.is_empty(),
+            "a denied call must NOT be forwarded (no in-flight entry)"
+        );
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1, "exactly one reject emitted");
+        assert_eq!(cap.0[0].0, webview);
+        assert!(cap.0[0].1.contains("capability_denied"), "rejected as capability_denied");
+        assert!(cap.0[0].1.contains("\"reqId\":\"h0\""), "reply carries the page-local reqId");
+    }
+
+    #[test]
+    fn host_call_trust_key_is_the_webview_entity_not_the_payload() {
+        // A granted entity exists, but the CALLER entity is not granted; a
+        // spoofed surfaceId/granted hint in the payload must not help.
+        let mut app = gate_app();
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let _granted = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+        let caller = app.world_mut().spawn(GrantedNamespaces(HashSet::new())).id();
+
+        app.world_mut().trigger(Receive {
+            webview: caller,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "host.call", "reqId": "h0", "ns": "fs", "method": "read",
+                "args": [], "surfaceId": "spoofed", "granted": ["fs"]
+            })),
+        });
+
+        assert!(app.world().resource::<HostRpc>().inflight.is_empty());
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1);
+        assert!(cap.0[0].1.contains("capability_denied"));
+    }
+
+    #[test]
+    fn host_call_rejects_when_host_unavailable() {
+        let mut app = gate_app(); // HostRpc::default → client None
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        assert!(app.world().resource::<HostRpc>().inflight.is_empty());
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1);
+        assert!(cap.0[0].1.contains("host_unavailable"));
+    }
+
+    #[test]
+    fn host_call_for_granted_namespace_is_forwarded_and_tracked() {
+        use std::io::{BufRead, BufReader};
+        use std::os::unix::net::UnixListener;
+
+        // A fake host that accepts + drains forwarded lines (never replies).
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                let mut r = BufReader::new(stream);
+                let mut line = String::new();
+                while r.read_line(&mut line).map(|n| n > 0).unwrap_or(false) {
+                    line.clear();
+                }
+            }
+        });
+
+        let mut app = gate_app();
+        let client = ozmux_extension_host::HostRpcClient::connect(&sock).unwrap();
+        app.world_mut().resource_mut::<HostRpc>().set_client(client);
+
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        let hr = app.world().resource::<HostRpc>();
+        assert_eq!(hr.inflight.len(), 1, "an allowed call is tracked in-flight");
+        let entry = hr.inflight.values().next().unwrap();
+        assert_eq!(entry.0, webview);
+        assert_eq!(entry.1.as_str(), "h0", "in-flight maps the global id back to the page-local reqId");
+        assert!(
+            app.world().resource::<CapturedEmits>().0.is_empty(),
+            "an allowed call is forwarded, not rejected"
+        );
+
+        // Drop the client so the fake server's read loop ends and the thread joins.
+        app.world_mut().resource_mut::<HostRpc>().clear_client();
+        let _ = server.join();
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 host_call`
+Expected: FAIL to compile — `on_host_call_frame` not defined.
+
+- [ ] **Step 4: Write the observer + helpers**
+
+In `src/extension_render.rs`, add the new observer (place it just after `on_ozmux_frame`, before the outbound `drain_handler_responses`). Per the parameter-ordering rule the `On<…>` trigger is fixed first, then mutable params:
+
+```rust
+/// Inbound (new-model host API): a `window.<ns>.<method>` call arrives as a
+/// `Receive<OzmuxFrame>` with `kind:"host.call"`. The trusted caller is
+/// `frame.webview` (bound per-webview by `bevy_cef`, never the JS payload); its
+/// `GrantedNamespaces` decides whether the call may proceed. Allowed calls are
+/// forwarded to the single host over a Rust-minted global `reqId`; denied or
+/// host-down calls reject the page-local Promise directly.
+///
+/// Runs as a SECOND observer on the shared `Receive<OzmuxFrame>` event (NOT a
+/// second `JsEmitEventPlugin`): observers are broadcast, so the legacy
+/// `on_ozmux_frame` still fires for the same frame and ignores `host.call`.
+fn on_host_call_frame(
+    frame: On<Receive<OzmuxFrame>>,
+    mut commands: Commands,
+    mut host_rpc: ResMut<HostRpc>,
+    granted: Query<&GrantedNamespaces>,
+) {
+    let payload = &frame.payload.0;
+    if payload.get("kind").and_then(Value::as_str) != Some("host.call") {
+        return;
+    }
+    let webview = frame.webview;
+    let req_id = payload.get("reqId").and_then(Value::as_str).unwrap_or_default();
+    let ns = payload.get("ns").and_then(Value::as_str).unwrap_or_default();
+    let method = payload.get("method").and_then(Value::as_str).unwrap_or_default();
+
+    let allowed = granted
+        .get(webview)
+        .map(|g| g.0.contains(ns))
+        .unwrap_or(false);
+    if !allowed {
+        reject_host_call(&mut commands, webview, req_id, &format!("capability_denied: {ns}"));
+        return;
+    }
+    if host_rpc.client.is_none() {
+        reject_host_call(&mut commands, webview, req_id, "host_unavailable");
+        return;
+    }
+
+    let global_id = host_rpc.next_id.to_string();
+    host_rpc.next_id += 1;
+    let args = payload.get("args").cloned().unwrap_or_else(|| Value::Array(Vec::new()));
+    let line = serde_json::json!({
+        "reqId": global_id, "ns": ns, "method": method, "args": args
+    })
+    .to_string();
+    if let Some(client) = host_rpc.client.as_ref() {
+        client.send_line(line);
+    }
+    host_rpc
+        .inflight
+        .insert(global_id, (webview, req_id.to_string()));
+}
+
+/// Emits a `{reqId, ok:false, error}` reply to a single webview on the `"ozmux"`
+/// channel (shared with the legacy outbound), settling the page-local Promise.
+fn reject_host_call(commands: &mut Commands, webview: Entity, req_id: &str, error: &str) {
+    let payload = serde_json::json!({ "reqId": req_id, "ok": false, "error": error });
+    commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
+}
+```
+
+Add the guard at the TOP of the legacy `on_ozmux_frame` body (right after `let webview = frame.webview;`), so a `host.call` frame is not mistaken for a legacy handler frame:
+
+```rust
+    let webview = frame.webview;
+    if frame.payload.0.get("kind").and_then(serde_json::Value::as_str) == Some("host.call") {
+        return;
+    }
+```
+
+Register the resource + observer in `OzmuxExtensionRenderPlugin::build` (add to the existing chain):
+
+```rust
+        app.add_plugins(JsEmitEventPlugin::<OzmuxFrame>::default())
+            .init_resource::<ExtensionHandlersBridge>()
+            .init_resource::<WebviewSurfaceIdMap>()
+            .init_resource::<HostRpc>()
+            .add_observer(on_ozmux_frame)
+            .add_observer(on_host_call_frame)
+            .add_observer(prune_webview_id_map_on_remove)
+```
+
+Finally, in `src/osc_webview.rs`, remove the now-stale dead-code suppression on `GrantedNamespaces` (Task 3 is the production reader the NOTE anticipated). Delete these lines (osc_webview.rs:38-42):
+
+```rust
+// NOTE: the production (non-test) build has no reader yet, so dead_code fires;
+// #[expect] cannot suppress it because the test binary DOES read the field
+// (the expectation would then fail under cfg(test)). Remove when the host-API
+// bridge (Step 3) adds a non-test reader.
+#[allow(dead_code)]
+```
+
+so the struct becomes:
+
+```rust
+#[derive(Component, Debug, Clone, Default)]
+pub(crate) struct GrantedNamespaces(pub(crate) HashSet<String>);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 host_call`
+Expected: PASS (4 new tests). Also run the existing suite to confirm no regression: `cargo test -p ozmux-gui --lib -- --test-threads=1 extension_render`.
+
+- [ ] **Step 6: Lint + format**
+
+Run: `cargo clippy -p ozmux-gui --all-targets && cargo fmt`
+Expected: clean (no `dead_code` warning for `GrantedNamespaces`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/extension_render.rs src/osc_webview.rs
+git commit -m "feat(extension_render): capability-gated host-call observer + HostRpc"
+```
+
+---
+
+## Task 4: Route host replies back + prune in-flight on despawn
+
+**Files:**
+- Modify: `src/extension_render.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/extension_render.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block. A fake host that replies once lets `drain_host_rpc_responses` route the reply back to the originating webview with the page-local `reqId`:
+
+```rust
+    #[test]
+    fn host_reply_routed_back_to_origin_with_page_local_req_id() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+        use std::time::Duration;
+
+        // Fake host: read one forwarded line, reply keyed on the SAME global id.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let frame: serde_json::Value = serde_json::from_str(&line).unwrap();
+            let gid = frame.get("reqId").and_then(|v| v.as_str()).unwrap().to_string();
+            let mut w = stream;
+            w.write_all(
+                format!("{{\"reqId\":\"{gid}\",\"ok\":true,\"value\":\"hi\"}}\n").as_bytes(),
+            )
+            .unwrap();
+            w.flush().unwrap();
+        });
+
+        let mut app = gate_app(); // already has on_host_call_frame + capture_emits + CapturedEmits
+        app.add_systems(Update, drain_host_rpc_responses);
+        let client = ozmux_extension_host::HostRpcClient::connect(&sock).unwrap();
+        app.world_mut().resource_mut::<HostRpc>().set_client(client);
+
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        // Forward an allowed call (server replies), then drain until routed back.
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            app.update();
+            if !app.world().resource::<CapturedEmits>().0.is_empty() {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "reply never routed back");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0[0].0, webview, "reply targets the originating webview");
+        assert!(cap.0[0].1.contains("\"reqId\":\"h0\""), "page-local reqId restored");
+        assert!(cap.0[0].1.contains("\"value\":\"hi\""), "value forwarded through");
+        assert!(
+            app.world().resource::<HostRpc>().inflight.is_empty(),
+            "the in-flight entry is consumed on reply"
+        );
+
+        app.world_mut().resource_mut::<HostRpc>().clear_client();
+        let _ = server.join();
+    }
+
+    #[test]
+    fn pruning_drops_in_flight_calls_for_a_despawned_surface() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<HostRpc>();
+        app.init_resource::<ExtensionHandlersBridge>();
+        app.init_resource::<WebviewSurfaceIdMap>();
+        app.add_observer(prune_webview_id_map_on_remove);
+
+        let surface = app.world_mut().spawn(SurfaceMarker).id();
+        app.world_mut()
+            .resource_mut::<HostRpc>()
+            .inflight
+            .insert("0".to_string(), (surface, "h0".to_string()));
+
+        app.world_mut().entity_mut(surface).despawn();
+
+        assert!(
+            app.world().resource::<HostRpc>().inflight.is_empty(),
+            "despawning a surface drops its in-flight host calls"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 host_reply pruning_drops`
+Expected: FAIL to compile — `drain_host_rpc_responses` not defined; `prune_webview_id_map_on_remove` does not yet touch `HostRpc`.
+
+- [ ] **Step 3: Write the drain system + extend pruning**
+
+Add the drain system in `src/extension_render.rs` (after `drain_handler_responses`):
+
+```rust
+/// Outbound (new-model host API): drains the host's NDJSON reply lines, maps the
+/// Rust-minted global `reqId` back to its `(webview, pageReqId)`, restores the
+/// page-local `reqId`, and re-emits each reply to the originating webview on the
+/// `"ozmux"` channel. A reply with no live in-flight entry (surface despawned)
+/// is dropped.
+fn drain_host_rpc_responses(mut commands: Commands, mut host_rpc: ResMut<HostRpc>) {
+    let mut lines = Vec::new();
+    if let Some(client) = host_rpc.client.as_ref() {
+        while let Some(line) = client.try_recv_response() {
+            lines.push(line);
+        }
+    }
+    for line in lines {
+        let Ok(mut frame) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(global_id) = frame.get("reqId").and_then(Value::as_str).map(str::to_owned) else {
+            continue;
+        };
+        let Some((webview, local_id)) = host_rpc.inflight.remove(&global_id) else {
+            continue;
+        };
+        frame["reqId"] = Value::String(local_id);
+        commands.trigger(HostEmitEvent::new(webview, "ozmux", &frame));
+    }
+}
+```
+
+Register it in `OzmuxExtensionRenderPlugin::build`'s `Update` systems tuple (add alongside `drain_handler_responses`):
+
+```rust
+            .add_systems(
+                Update,
+                (
+                    finish_extension_setup.in_set(OzmuxSystems::SetupSurface),
+                    drain_handler_responses,
+                    drain_host_rpc_responses,
+                    sync_focused_webview.after(OzmuxSystems::Input),
+                ),
+            );
+```
+
+Extend `prune_webview_id_map_on_remove` to also drop in-flight host calls for the removed entity. Update its signature (mutable params first) and body:
+
+```rust
+fn prune_webview_id_map_on_remove(
+    ev: On<Remove, SurfaceMarker>,
+    mut map: ResMut<WebviewSurfaceIdMap>,
+    mut host_rpc: ResMut<HostRpc>,
+    bridge: Res<ExtensionHandlersBridge>,
+    ids: Query<&ExtensionSurfaceId>,
+) {
+    if let Ok(id) = ids.get(ev.entity) {
+        map.0.remove(&id.0);
+        bridge.0.disconnect(&id.0);
+    }
+    host_rpc.inflight.retain(|_, (entity, _)| *entity != ev.entity);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 host_reply pruning_drops`
+Expected: PASS (2 tests). Re-run the prune regression too: `cargo test -p ozmux-gui --lib -- --test-threads=1 prune_webview_id_map_removes_entry_on_surface_despawn`.
+
+- [ ] **Step 5: Lint + format + commit**
+
+```bash
+cargo clippy -p ozmux-gui --all-targets && cargo fmt
+git add src/extension_render.rs
+git commit -m "feat(extension_render): route host replies back + prune in-flight on despawn"
+```
+
+---
+
+## Task 5: Connect the RPC client on host readiness
+
+**Files:**
+- Modify: `src/extension_manager.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/extension_manager.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `src/extension_manager.rs` a focused test of the resource's reconnect semantics (no socket needed — `clear_client` resets correlation so a host restart cannot resolve a stale global id against a new webview):
+
+```rust
+    #[test]
+    fn clearing_the_host_client_drops_stale_in_flight_correlation() {
+        use crate::extension_render::HostRpc;
+        let mut hr = HostRpc::default();
+        hr.note_in_flight_for_test("0", bevy::prelude::Entity::PLACEHOLDER, "h0");
+        assert!(hr.has_in_flight_for_test());
+        hr.clear_client();
+        assert!(!hr.has_in_flight_for_test(), "clear_client wipes stale correlation");
+    }
+```
+
+This requires tiny `pub(crate)` test seams on `HostRpc` (its fields are private). Add them to `src/extension_render.rs` under the existing `impl HostRpc` (place AFTER `set_client`/`clear_client` to keep the public-ish surface first):
+
+```rust
+    #[cfg(test)]
+    pub(crate) fn note_in_flight_for_test(&mut self, global_id: &str, webview: Entity, local: &str) {
+        self.inflight.insert(global_id.to_string(), (webview, local.to_string()));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_in_flight_for_test(&self) -> bool {
+        !self.inflight.is_empty()
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 clearing_the_host_client`
+Expected: FAIL to compile — `note_in_flight_for_test` / `has_in_flight_for_test` not defined. (This is a resource-invariant test for `clear_client`; the production wiring it accompanies — connect-on-ready — is verified by `cargo build` type-checking in Step 4 and end-to-end in Step 6, since a live `node` host is impractical to unit-test here.)
+
+- [ ] **Step 3: Wire connect-on-ready into `poll_host_lifecycle`**
+
+In `src/extension_manager.rs`, extend the host imports — add `HostRpcClient` to the `ozmux_extension_host` use list and import `HostRpc`:
+
+```rust
+use crate::extension_render::HostRpc;
+```
+
+and add `HostRpcClient` to the existing `use ozmux_extension_host::{…}` list.
+
+Replace `poll_host_lifecycle` (currently `fn poll_host_lifecycle(host: Option<Res<HostRuntime>>)`) with a version that owns the RPC lifecycle (mutable param first; `Option<ResMut<HostRpc>>` keeps manager-only tests panic-free when the render plugin is absent):
+
+```rust
+fn poll_host_lifecycle(mut host_rpc: Option<ResMut<HostRpc>>, host: Option<Res<HostRuntime>>) {
+    let Some(host) = host else {
+        return;
+    };
+    while let Ok(event) = host.host.events().try_recv() {
+        match event {
+            LifecycleEvent::Ready => match HostRpcClient::connect(host.host.rpc_sock_path()) {
+                Ok(client) => {
+                    tracing::info!("single host process ready; RPC connected");
+                    if let Some(hr) = host_rpc.as_mut() {
+                        hr.set_client(client);
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "single host ready but RPC connect failed")
+                }
+            },
+            LifecycleEvent::SpawnFailed { error } => {
+                tracing::error!(%error, "single host failed to become ready");
+                if let Some(hr) = host_rpc.as_mut() {
+                    hr.clear_client();
+                }
+            }
+            LifecycleEvent::Exited { status } => {
+                tracing::warn!(?status, "single host process exited");
+                if let Some(hr) = host_rpc.as_mut() {
+                    hr.clear_client();
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 clearing_the_host_client`
+Expected: PASS. Then `cargo build` to confirm the manager wiring type-checks.
+
+- [ ] **Step 5: Lint + format + commit**
+
+```bash
+cargo clippy --workspace --all-targets && cargo fmt
+git add src/extension_manager.rs src/extension_render.rs
+git commit -m "feat(extension_manager): connect HostRpcClient on host readiness"
+```
+
+---
+
+## Task 6: Inject the `host_bridge.js` Proxy for new-model surfaces
+
+**Files:**
+- Create: `src/extension_render/host_bridge.js`
+- Modify: `src/extension_render.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/extension_render.rs`
+
+- [ ] **Step 1: Write the bridge JS**
+
+Create `src/extension_render/host_bridge.js` (hand-written + `include_str!`d, mirroring the `ozmux.js` convention; the webview-side `{__u8}` codec mirrors the vitest-tested `host/src/binary-codec.ts` and is verified end-to-end in Step 6):
+
+```js
+// NOTE: bevy_cef contract — Rust->JS cef.listen delivers a JSON *string* (hence
+// JSON.parse); JS->Rust cef.emit serializes only its FIRST argument into one
+// global Receive<OzmuxFrame> (single self-describing object, no channel arg, a
+// second argument is dropped). New-model host-API bridge: one window[ns] Proxy
+// per granted namespace from window.__ozmuxGranted (injected as a separate
+// PreloadScript). Binary uses the {__u8} boundary tag (mirrors binary-codec.ts).
+(function () {
+  var cef = window.cef;
+  var nextId = 0;
+  var calls = new Map();
+
+  function encodeArg(a) {
+    if (a instanceof Uint8Array) {
+      var bin = '';
+      for (var i = 0; i < a.length; i++) bin += String.fromCharCode(a[i]);
+      return { __u8: btoa(bin) };
+    }
+    return a;
+  }
+
+  function decodeValue(v) {
+    if (v && typeof v === 'object' && typeof v.__u8 === 'string') {
+      var s = atob(v.__u8);
+      var out = new Uint8Array(s.length);
+      for (var i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+      return out;
+    }
+    return v;
+  }
+
+  cef.listen('ozmux', function (raw) {
+    var frame = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    var c = calls.get(frame.reqId);
+    if (!c) return;
+    calls.delete(frame.reqId);
+    if (frame.ok) c.resolve(decodeValue(frame.value));
+    else c.reject(new Error(frame.error));
+  });
+
+  function hostCall(ns, method, args) {
+    var reqId = 'h' + nextId++;
+    var encoded = args.map(encodeArg);
+    return new Promise(function (resolve, reject) {
+      calls.set(reqId, { resolve: resolve, reject: reject });
+      cef.emit({ kind: 'host.call', reqId: reqId, ns: ns, method: method, args: encoded });
+    });
+  }
+
+  var granted = window.__ozmuxGranted || [];
+  for (var g = 0; g < granted.length; g++) {
+    (function (ns) {
+      window[ns] = new Proxy(
+        {},
+        {
+          get: function (_t, method) {
+            // NOTE: a Symbol key (e.g. Symbol.toPrimitive, or `then` probing for
+            // thenable) must NOT return a callable, or `window[ns]` looks like a
+            // Promise and breaks. Only string method names dispatch a host call.
+            if (typeof method !== 'string') return undefined;
+            return function () {
+              return hostCall(ns, method, Array.prototype.slice.call(arguments));
+            };
+          },
+        },
+      );
+    })(granted[g]);
+  }
+})();
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `src/extension_render.rs`. It reuses `spawn_extension_host` (which takes an `extra` bundle) to attach `GrantedNamespaces`:
+
+```rust
+    #[test]
+    fn new_model_surface_gets_host_bridge_and_granted_list() {
+        let mut app = make_test_app();
+        app.add_systems(Update, finish_extension_setup);
+        let mut caps = std::collections::HashSet::new();
+        caps.insert("fs".to_string());
+        let (host, ..) = spawn_extension_host(
+            &mut app,
+            (laid_out_node(Vec2::new(800.0, 600.0)), GrantedNamespaces(caps)),
+        );
+        app.update();
+
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(host)
+            .expect("new-model surface must carry the host bridge as a PreloadScript");
+        assert!(
+            preload.0.iter().any(|s| s.contains("kind: 'host.call'")),
+            "the host-API bridge JS must be injected for a surface with GrantedNamespaces"
+        );
+        assert!(
+            preload.0.iter().any(|s| s.starts_with("window.__ozmuxGranted=") && s.contains("\"fs\"")),
+            "the granted-namespace list must be injected before the bridge"
+        );
+        assert!(
+            !preload.0.iter().any(|s| s == OZMUX_EXTENSION_JS),
+            "legacy ozmux.js must NOT be injected for a new-model surface"
+        );
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 new_model_surface_gets_host_bridge`
+Expected: FAIL — `finish_extension_setup` still injects `OZMUX_EXTENSION_JS` unconditionally; `HOST_BRIDGE_JS` not defined.
+
+- [ ] **Step 4: Wire the injection**
+
+In `src/extension_render.rs`, add the embedded bridge constant next to `OZMUX_EXTENSION_JS` (private — used only here):
+
+```rust
+const HOST_BRIDGE_JS: &str = include_str!("extension_render/host_bridge.js");
+```
+
+Add a `GrantedNamespaces` query to `finish_extension_setup` (immutable params, append to the signature):
+
+```rust
+    surfaces: Query<
+        (Entity, &ComputedNode),
+        (
+            With<ExtensionSurfaceMarker>,
+            Without<WebviewSource>,
+            Without<WebviewMountUnresolved>,
+        ),
+    >,
+    granted: Query<&GrantedNamespaces>,
+```
+
+Replace the `PreloadScripts::from([ctx_js, OZMUX_EXTENSION_JS.to_string()])` insertion with a branch selecting the bridge by whether the surface carries `GrantedNamespaces` (new-model) or not (legacy):
+
+```rust
+        let ctx_js = context_preload_js(workspace, pane, surface, name);
+        let preload = match granted.get(surface) {
+            Ok(g) => {
+                let list: Vec<&String> = g.0.iter().collect();
+                let granted_js = format!(
+                    "window.__ozmuxGranted={};",
+                    serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+                );
+                PreloadScripts::from([ctx_js, granted_js, HOST_BRIDGE_JS.to_string()])
+            }
+            Err(_) => PreloadScripts::from([ctx_js, OZMUX_EXTENSION_JS.to_string()]),
+        };
+        commands.entity(surface).insert((
+            WebviewSource::new(url),
+            WebviewSize(logical),
+            preload,
+            MaterialNode(materials.add(WebviewUiMaterial::default())),
+        ));
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1 new_model_surface_gets_host_bridge`
+Expected: PASS. Confirm the legacy injection test still passes (no `GrantedNamespaces` → legacy branch): `cargo test -p ozmux-gui --lib -- --test-threads=1 attaches_webview_pointed_at_memo_to_extension_host`.
+
+- [ ] **Step 6: Lint + format + commit**
+
+```bash
+cargo clippy -p ozmux-gui --all-targets && cargo fmt
+git add src/extension_render/host_bridge.js src/extension_render.rs
+git commit -m "feat(extension_render): inject host-API Proxy bridge for new-model surfaces"
+```
+
+---
+
+## Task 7: Full-workspace verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Host crate + host runtime tests**
+
+Run: `cargo test -p ozmux_extension_host && pnpm -C host test`
+Expected: all PASS.
+
+- [ ] **Step 2: GUI crate tests (serialized)**
+
+Run: `cargo test -p ozmux-gui --lib -- --test-threads=1`
+Expected: PASS for all `extension_render` / `extension_manager` tests (the known IME failure + teardown SIGSEGV are pre-existing and unrelated; if they appear, confirm they are the documented ones and not introduced here).
+
+- [ ] **Step 3: Build + lint + format gates**
+
+Run: `cargo build && cargo clippy --workspace --all-targets && cargo fmt --check && pnpm -C host check-types`
+Expected: clean.
+
+- [ ] **Step 4: Confirm the bundle is current**
+
+Run: `pnpm -C host build && git status --porcelain assets/host.mjs`
+Expected: no diff (Task 2 already rebuilt it). If a diff appears, `git add assets/host.mjs` and amend the relevant commit.
+
+- [ ] **Step 5: Final commit (only if Step 4 produced a diff)**
+
+```bash
+git add assets/host.mjs
+git commit -m "chore(host): rebuild host.mjs bundle"
+```
+
+---
+
+## Notes for the executor
+
+- **Not in this step (Step 5/6):** the legacy `window.ozmux.call/subscribe` path, the handlers bridge, the command shim, and the control plane stay untouched; `@memo` keeps working via `ozmux.js`. A real end-to-end test (a live `node` host + a real `extensions/memo` calling `window.fs.read`) lands in Step 6 with the memo migration. Step 4's new bridge is exercised by the unit/integration tests above (capability gate, RPC round-trip, reply routing) plus the host vitest suite.
+- **Deferred (recorded, not built here):** bundling `host_bridge.js` from a shared TS module via esbuild (to remove the hand-written/`binary-codec.ts` duplication); `zod` argument validation after the capability gate; MessagePack once the bevy_cef channel carries bytes (spec §5).
+- **Single-channel invariant (do not regress):** never add a second `JsEmitEventPlugin::<…>` — the raw IPC receiver is shared and `try_recv`-consumed. The host-call path is a SECOND OBSERVER on the one `Receive<OzmuxFrame>` event; both observers branch on `kind`.

--- a/docs/superpowers/specs/2026-06-11-phase1-single-host-process-design.md
+++ b/docs/superpowers/specs/2026-06-11-phase1-single-host-process-design.md
@@ -59,7 +59,7 @@ capability は **namespace 単位**。`capabilities = ["fs"]` は `window.fs.*` 
 - **host runtime はアプリ同梱**(ユーザー提供ではない)。esbuild が `host/` パッケージを `assets/host.mjs` にバンドルし、Rust バイナリへ `include_str!` で埋め込む。実行時にランタイムディレクトリへ `host.mjs` として書き出し、`node host.mjs` として spawn する。host は `<repo>/extensions/*` と `~/.config/ozmux/extensions/*` の `api.ts` を **dynamic import** して API オブジェクトを集約し、**RPC ディスパッチを担う**。**静的アセット配信は host を経由せず Rust が直接行う**(④の決定 C を参照。host はアセットソケットを持たない)。
 - **spawn 時の env:** `OZMUX_HOST_RPC_SOCK`・`OZMUX_HOST_MANIFEST`・`OZMUX_HOST_READY_PATH` の 3 つ(拡張ディレクトリは manifest の `apiPaths`/`assetRoot` が持つので env では渡さない)。ランタイムルート(ソケット置き場)は **1 つだけ**(0700 perms)。現状の per-PID / per-extension ディレクトリツリーは廃止。アセットソケットは無い(Rust 直接配信)。
 - **readiness:** host が全拡張のロード後に `.ready` を返す。ロード失敗(後述の type-stripping 制約違反を含む)は名前付きで報告 → Rust 側でログ。Rust はタイムアウト付きで待機。
-- **監視 / 障害:** Phase 1 は **自動再起動なし(YAGNI)**。host がクラッシュ / exit したら `HostProcessDown` 状態を立て、以降の host-API 呼び出しは `host_unavailable` で **グレースフルに reject**。自動再起動は将来課題。
+- **監視 / 障害:** Phase 1 は **自動再起動なし(YAGNI)**。host がクラッシュ / exit したら `HostProcessDown` 状態を立て、以降の host-API 呼び出しは `host_unavailable` で **グレースフルに reject**。**(現状の manager は host ライフサイクルを**ログするのみ**で `HostProcessDown` リソースは未実装。Step 4 でこの可用性状態を新設し、bridge がそれを参照して reject する。)** 自動再起動は将来課題。
 - **終了:** アプリ終了時に子プロセスへ SIGTERM、ランタイムルートを掃除。
 
 **Node ネイティブ TS type-stripping の制約(設計拘束):** host loader は `import('/abs/path/api.ts')` で読む。Node のネイティブ stripping は **(a) erasable な TS 構文のみ**(`enum` / parameter properties / `namespace` 不可、違反は `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`)、**(b) dynamic import 指定子に `.ts` 拡張子必須**、**(c) `tsconfig` を無視**(`paths` 不可)、**(d) `node_modules` 配下の TS は stripping 対象外**。拡張 `api.ts` は erasable TS に限定する。将来フルトランスパイルが要る場合は `tsx` / 同梱バンドル host へ切替(§5)。
@@ -76,6 +76,8 @@ capability は **namespace 単位**。`capabilities = ["fs"]` は `window.fs.*` 
 ├── ozmux.toml      # views と必要 capability の宣言(Rust が読む信頼データ)
 └── <assets>        # index.html 等。ozmux-ext://<extension>/<entry> で配信
 ```
+
+> **NOTE:** 実装済み manifest/descriptor は **複数 api パス(`api = [...]`)** を許す(`extension_manifest.rs`、`host_descriptor.rs`)。上図は最小形(単一 `api.ts`)で、1 拡張が複数の API ファイルを宣言してもよい。
 
 **`api.ts`(host が読む / コード)**
 ```ts
@@ -127,19 +129,21 @@ Approach A の心臓部。**既存の `JsEmitEventPlugin` / `HostEmitEvent` / `P
 1. `window.fs.read(p)` → `__hostCall` が `reqId` を採番し Promise を保留 → **`cef.emit({reqId, ns, method, args})`**。
    - **注意:** bevy_cef の binding は `arguments.first()` だけを直列化する(`cef_api_handler.rs`)。`cef.emit(eventName, payload)` の 2 引数形は payload を**捨てる**ため使わない。固定の `ozmux` チャネル上に **単一オブジェクト**を載せる。
 2. **Rust が capability を検査(信頼の関所)**: 信頼される発信元は **`Receive<_>.webview: Entity`**(per-webview client handler で束縛、JS payload 由来ではない)。その entity の **`GrantedNamespaces`** を読み、`ns ∉ caps` なら即 `capability_denied` で reject、**host へは転送しない**。文字列の "surfaceId" を信頼鍵にしない。
-3. 検査通過 → 単一 host ソケットへ **`{reqId, ns, method, args}`** を framed 送信(`reqId` は相関用、信頼鍵ではない)。
+3. 検査通過 → 単一 host ソケットへ **`{reqId, ns, method, args}`** を **NDJSON(改行区切り JSON)1 行**として送信(`reqId` は相関用、信頼鍵ではない)。**host の `rpc-server.ts` は NDJSON で read/write する(アセットの length-prefixed プロトコルとは別物)ので、Rust RPC クライアントも NDJSON に揃える。**
 4. host が `api[ns][method](...args)` を実行。Rust が信頼の関所なので host 側は再検査しない(単純さ優先)。
 
+> **NOTE(単一 IPC チャネル — 重要):** bevy_cef の生 IPC 受信は **`IpcEventRawReceiver` 1 本**で、`receive_events::<E>` が `try_recv()` で各メッセージを**消費**する。Step 4 で **2 つ目の `JsEmitEventPlugin` を登録してはならない**(2 つの receiver が同一チャネルを奪い合う)。加えて現行 `OzmuxFrame` は `#[serde(transparent)] struct OzmuxFrame(Value)` で**任意の JSON オブジェクトにマッチ**するため、host-call フレーム `{reqId, ns, method, args}` も既存の `on_ozmux_frame`(レガシー handlers 経路)に**サイレントに吸われる**。よって host-call は **既存の単一 `Receive<OzmuxFrame>` observer に通し、フレーム内の判別子(例 `kind: "host.call"`、レガシー `ozmux.js` は既に `kind` を出している)で分岐**するか、`OzmuxFrame` をタグ付き enum 化する。レガシーと新経路が互いのフレームをパースしないよう判別子は必須。
+
 **結果(host → Rust → webview)**
-- host は **`{reqId, ok: true, value}` / `{reqId, ok: false, error}`** を返す(discriminated union; これが実装済み `dispatch.ts` の `HostResultFrame` の正準形)。Rust は **`reqId → webview Entity` の in-flight 相関**から発信元 entity を引き、**`HostEmitEvent::new(webview, ...)`**(既存 outbound `ozmux` チャネル)で**その webview にだけ**返す。Proxy が Promise を resolve/reject。
+- host は **`{reqId, ok: true, value}` / `{reqId, ok: false, error}`** を返す(discriminated union; これが実装済み `dispatch.ts` の `HostResultFrame` の正準形)。Rust は **`reqId → webview Entity` の in-flight 相関**から発信元 entity を引き、**`HostEmitEvent::new(webview, ...)`**(既存 outbound `ozmux` チャネル)で**その webview にだけ**返す。**`reqId` は各 webview がクライアント側で採番するため webview 間で衝突しうる。in-flight マップは `(webview Entity, reqId)` でキーするか、pending を webview Entity 上の Component として持ち despawn で自動解放する(後者は別途の prune observer も不要)。** Proxy が Promise を resolve/reject。
 
 **シリアライズ**
 - 既存 CEF ブリッジは **JSON 文字列チャネル**(`HostEmitEvent` は文字列を配送)。プレーン値は JSON でそのまま。
 - バイナリ(`fs.read` の `Buffer`/`Uint8Array`)は **`{ __u8: "<base64>" }` ラッパーに符号化**。**境界タグ方式**:host が明示的に返したトップレベルの `Buffer`/`Uint8Array` をラップする(任意のネスト結果を再帰ディープウォークしない — CPU 税と `__u8` キー衝突を避ける)。webview 側 Proxy は境界でデコード。引数経路も対称。
-- **ガードレール:** `fs.read` 等で巨大ファイルが単一 JSON 文字列として render プロセスを跨ぐと詰まる。**最大レスポンスサイズ上限**を設け、超過はエラーにする(閾値は実装時に決定)。base64 は +33% のオーバーヘッドを許容(Phase 1)。専用バイナリチャネル / MessagePack は将来(§5)。
+- **ガードレール:** `fs.read` 等で巨大ファイルが単一 JSON 文字列として render プロセスを跨ぐと詰まる。**最大レスポンスサイズ上限**を設け、超過はエラーにする(閾値は実装時に決定)。**(未実装の確認:現行 `rpc-server.ts` は受信側を 8 MiB で上限する(`rpc-server.ts:7`)が、ディスパッチ結果書き込み側にレスポンスサイズ検査は無い。Step 4 で結果フレーム送信前に上限検査を追加する。)** base64 は +33% のオーバーヘッドを許容(Phase 1)。専用バイナリチャネル / MessagePack は将来(§5)。
 
 **エラー伝播**
-- host method の throw → `{err, message}` → webview の Promise が `Error` で reject。
+- host method の throw → `{reqId, ok: false, error}`(line 134 の正準形と同一。`{err, message}` ではない)→ webview の Promise が `Error` で reject。
 - `capability_denied` / 未知 ns・method / `host_unavailable`(① のクラッシュ時)も構造化 reject。
 
 **型付け**

--- a/host/src/rpc-server.test.ts
+++ b/host/src/rpc-server.test.ts
@@ -104,4 +104,15 @@ describe('bindHostRpcServer', () => {
     expect(r).toEqual({ reqId: '9', ok: true, value: 'contents:/y' });
     s.destroy();
   });
+
+  it('rejects an over-sized result with an error frame instead of writing it', async () => {
+    const bigApi: ApiNamespaceMap = {
+      big: { blob: async () => 'x'.repeat(9 * 1024 * 1024) },
+    };
+    server = await bindHostRpcServer(sockPath, bigApi);
+    const s = await connect();
+    const reply = await rpc(s, { reqId: '1', ns: 'big', method: 'blob', args: [] });
+    s.end();
+    expect(reply).toEqual({ reqId: '1', ok: false, error: 'host result exceeds max size' });
+  });
 });

--- a/host/src/rpc-server.ts
+++ b/host/src/rpc-server.ts
@@ -5,6 +5,7 @@ import { decodeHostValue } from './binary-codec.ts';
 import { dispatchHostCall, type HostCallFrame } from './dispatch.ts';
 
 const MAX_RPC_LINE_BYTES = 8 * 1024 * 1024;
+const MAX_RPC_RESULT_BYTES = 8 * 1024 * 1024;
 
 /**
  * Binds a Unix-socket NDJSON RPC server that dispatches `{reqId, ns, method, args}`
@@ -81,7 +82,19 @@ export async function bindHostRpcServer(
     }
     const frame: HostCallFrame = { reqId, ns, method, args: args.map(decodeHostValue) };
     dispatchHostCall(api, frame)
-      .then((result) => conn.write(`${JSON.stringify(result)}\n`))
+      .then((result) => {
+        const resultLine = JSON.stringify(result);
+        if (Buffer.byteLength(resultLine, 'utf8') > MAX_RPC_RESULT_BYTES) {
+          // NOTE: an oversized result would choke the render process crossing the
+          // CEF IPC boundary; reject with an addressable error frame so the
+          // caller's reqId Promise settles.
+          conn.write(
+            `${JSON.stringify({ reqId: frame.reqId, ok: false, error: 'host result exceeds max size' })}\n`,
+          );
+          return;
+        }
+        conn.write(`${resultLine}\n`);
+      })
       .catch((err) => {
         // NOTE: dispatchHostCall is contracted never to reject; reply with an
         // error frame anyway so a future regression cannot leave the caller's

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -246,6 +246,9 @@ fn poll_host_lifecycle(mut host_rpc: Option<ResMut<HostRpc>>, host: Option<Res<H
                 }
                 Err(error) => {
                     tracing::error!(%error, "single host ready but RPC connect failed");
+                    if let Some(hr) = host_rpc.as_mut() {
+                        hr.clear_client();
+                    }
                 }
             },
             LifecycleEvent::SpawnFailed { error } => {

--- a/src/extension_manager.rs
+++ b/src/extension_manager.rs
@@ -5,6 +5,7 @@
 //! renderer routes per extension off each surface's `OwningExtension`, and the
 //! control bridge drain runs across every launched extension.
 
+use crate::extension_render::HostRpc;
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use ozmux_configs::path::{SystemEnv, extensions_dir};
@@ -13,7 +14,8 @@ use ozmux_extension_host::host::{
 };
 use ozmux_extension_host::{
     BuiltHostManifest, CommandExtension, CommandExtensionConfig, ExtensionControlSet, HostProcess,
-    Manifest, RegisteredView, ViewId, ViewRegistry, apply_control_request, discover_extensions,
+    HostRpcClient, Manifest, RegisteredView, ViewId, ViewRegistry, apply_control_request,
+    discover_extensions,
 };
 use ozmux_multiplexer::MultiplexerCommands;
 use std::collections::HashSet;
@@ -229,18 +231,34 @@ fn publish_ready_endpoints(registry: Res<ExtensionRegistry>) {
     }
 }
 
-fn poll_host_lifecycle(host: Option<Res<HostRuntime>>) {
+fn poll_host_lifecycle(mut host_rpc: Option<ResMut<HostRpc>>, host: Option<Res<HostRuntime>>) {
     let Some(host) = host else {
         return;
     };
     while let Ok(event) = host.host.events().try_recv() {
         match event {
-            LifecycleEvent::Ready => tracing::info!("single host process ready"),
+            LifecycleEvent::Ready => match HostRpcClient::connect(host.host.rpc_sock_path()) {
+                Ok(client) => {
+                    tracing::info!("single host process ready; RPC connected");
+                    if let Some(hr) = host_rpc.as_mut() {
+                        hr.set_client(client);
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "single host ready but RPC connect failed");
+                }
+            },
             LifecycleEvent::SpawnFailed { error } => {
-                tracing::error!(%error, "single host failed to become ready")
+                tracing::error!(%error, "single host failed to become ready");
+                if let Some(hr) = host_rpc.as_mut() {
+                    hr.clear_client();
+                }
             }
             LifecycleEvent::Exited { status } => {
-                tracing::warn!(?status, "single host process exited")
+                tracing::warn!(?status, "single host process exited");
+                if let Some(hr) = host_rpc.as_mut() {
+                    hr.clear_client();
+                }
             }
         }
     }
@@ -415,6 +433,20 @@ mod tests {
         assert_eq!(
             found[0].config.main,
             std::ffi::OsString::from("bootstrap.ts")
+        );
+    }
+
+    #[test]
+    fn clearing_the_host_client_drops_stale_in_flight_correlation() {
+        use crate::extension_render::HostRpc;
+        let mut hr = HostRpc::default();
+        hr.note_in_flight_for_test("0", bevy::prelude::Entity::PLACEHOLDER, "h0");
+        assert_eq!(hr.count_in_flight_for_test(), 1);
+        hr.clear_client();
+        assert_eq!(
+            hr.count_in_flight_for_test(),
+            0,
+            "clear_client wipes stale correlation"
         );
     }
 }

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -5,6 +5,7 @@
 //! extension's handlers socket.
 
 use crate::extension_manager::ExtensionRegistry;
+use crate::osc_webview::GrantedNamespaces;
 use crate::osc_webview::NonInteractive;
 use crate::system_set::OzmuxSystems;
 use crate::ui::{AddressBarFocus, BrowserPageWebview, ExtensionSurfaceMarker};
@@ -12,12 +13,14 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
 use ozmux_extension_host::HandlersBridge;
+use ozmux_extension_host::HostRpcClient;
 use ozmux_extension_host::host::AssetSourceRegistry;
 use ozmux_extension_host::scheme::custom_scheme;
 use ozmux_multiplexer::{
     AttachedWorkspace, ExtensionSurfaceId, MultiplexerCommands, OwningExtension, SurfaceKind,
     SurfaceMarker, WorkspaceMarker,
 };
+use serde_json::Value;
 
 /// Builds the `ozmux-ext://<name>/<entry>` webview URL for an extension surface,
 /// where `entry` is the client's HTML path relative to the extension dir.
@@ -47,6 +50,41 @@ struct ExtensionHandlersBridge(HandlersBridge);
 /// when the owning surface is despawned.
 #[derive(Resource, Default)]
 struct WebviewSurfaceIdMap(HashMap<String, Entity>);
+
+/// The connected host RPC client plus the in-flight `globalReqId → (webview,
+/// pageReqId)` correlation. `globalReqId` is minted Rust-side (a monotonic
+/// counter) so page-local `reqId`s — which collide across webviews — are never
+/// used as a routing key. Populated by `extension_manager` on host readiness.
+#[derive(Resource, Default)]
+pub(crate) struct HostRpc {
+    client: Option<HostRpcClient>,
+    inflight: HashMap<String, (Entity, String)>,
+    next_id: u64,
+}
+
+impl HostRpc {
+    /// Installs a freshly-connected client, clearing any stale correlation /
+    /// counter from a previous host generation.
+    #[allow(
+        dead_code,
+        reason = "production caller added in Task 5: extension_manager connect-on-ready/exit wiring; tests already exercise it"
+    )]
+    pub(crate) fn set_client(&mut self, client: HostRpcClient) {
+        self.client = Some(client);
+        self.inflight.clear();
+        self.next_id = 0;
+    }
+
+    /// Drops the client (host exited): subsequent calls reject `host_unavailable`.
+    #[allow(
+        dead_code,
+        reason = "production caller added in Task 5: extension_manager connect-on-ready/exit wiring; tests already exercise it"
+    )]
+    pub(crate) fn clear_client(&mut self) {
+        self.client = None;
+        self.inflight.clear();
+    }
+}
 
 /// Marks an extension-surface host whose webview could not be mounted because
 /// its surface has no `OwningExtension`. Excluding marked hosts from the
@@ -107,7 +145,9 @@ impl Plugin for OzmuxExtensionRenderPlugin {
         app.add_plugins(JsEmitEventPlugin::<OzmuxFrame>::default())
             .init_resource::<ExtensionHandlersBridge>()
             .init_resource::<WebviewSurfaceIdMap>()
+            .init_resource::<HostRpc>()
             .add_observer(on_ozmux_frame)
+            .add_observer(on_host_call_frame)
             .add_observer(prune_webview_id_map_on_remove)
             .add_observer(log_webview_load_started)
             .add_observer(log_webview_load_finished)
@@ -345,6 +385,15 @@ fn on_ozmux_frame(
     surface_ids: Query<&ExtensionSurfaceId>,
 ) {
     let webview = frame.webview;
+    if frame
+        .payload
+        .0
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        == Some("host.call")
+    {
+        return;
+    }
     let Some(surface_id) = surface_id_for_webview(webview, &surface_ids) else {
         return;
     };
@@ -363,6 +412,85 @@ fn on_ozmux_frame(
     if let Ok(frame_json) = serde_json::to_string(&frame.payload.0) {
         bridge.0.send(&surface_id, frame_json);
     }
+}
+
+/// Inbound (new-model host API): a `window.<ns>.<method>` call arrives as a
+/// `Receive<OzmuxFrame>` with `kind:"host.call"`. The trusted caller is
+/// `frame.webview` (bound per-webview by `bevy_cef`, never the JS payload); its
+/// `GrantedNamespaces` decides whether the call may proceed. Allowed calls are
+/// forwarded to the single host over a Rust-minted global `reqId`; denied or
+/// host-down calls reject the page-local Promise directly.
+///
+/// Runs as a SECOND observer on the shared `Receive<OzmuxFrame>` event (NOT a
+/// second `JsEmitEventPlugin`): observers are broadcast, so the legacy
+/// `on_ozmux_frame` still fires for the same frame and ignores `host.call`.
+fn on_host_call_frame(
+    frame: On<Receive<OzmuxFrame>>,
+    mut commands: Commands,
+    mut host_rpc: ResMut<HostRpc>,
+    granted: Query<&GrantedNamespaces>,
+) {
+    let payload = &frame.payload.0;
+    if payload.get("kind").and_then(Value::as_str) != Some("host.call") {
+        return;
+    }
+    let webview = frame.webview;
+    let req_id = payload
+        .get("reqId")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let ns = payload
+        .get("ns")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let method = payload
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let allowed = granted
+        .get(webview)
+        .map(|g| g.0.contains(ns))
+        .unwrap_or(false);
+    if !allowed {
+        reject_host_call(
+            &mut commands,
+            webview,
+            req_id,
+            &format!("capability_denied: {ns}"),
+        );
+        return;
+    }
+    if host_rpc.client.is_none() {
+        reject_host_call(&mut commands, webview, req_id, "host_unavailable");
+        return;
+    }
+
+    let global_id = host_rpc.next_id.to_string();
+    host_rpc.next_id += 1;
+    let args = payload
+        .get("args")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let line = serde_json::json!({
+        "reqId": global_id, "ns": ns, "method": method, "args": args
+    })
+    .to_string();
+    host_rpc
+        .client
+        .as_ref()
+        .expect("client present: guarded by the is_none() check above")
+        .send_line(line);
+    host_rpc
+        .inflight
+        .insert(global_id, (webview, req_id.to_string()));
+}
+
+/// Emits a `{reqId, ok:false, error}` reply to a single webview on the `"ozmux"`
+/// channel (shared with the legacy outbound), settling the page-local Promise.
+fn reject_host_call(commands: &mut Commands, webview: Entity, req_id: &str, error: &str) {
+    let payload = serde_json::json!({ "reqId": req_id, "ok": false, "error": error });
+    commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
 }
 
 /// Outbound: drains handler responses `(surface_id, frame)` and re-emits each to the
@@ -975,5 +1103,155 @@ mod tests {
                 .contains_key("x"),
             "entry must be pruned after surface is despawned"
         );
+    }
+
+    use std::collections::HashSet;
+
+    #[derive(Resource, Default)]
+    struct CapturedEmits(Vec<(Entity, String)>);
+
+    fn capture_emits(ev: On<HostEmitEvent>, mut cap: ResMut<CapturedEmits>) {
+        cap.0.push((ev.webview, ev.payload.clone()));
+    }
+
+    fn gate_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<HostRpc>();
+        app.init_resource::<CapturedEmits>();
+        app.add_observer(on_host_call_frame);
+        app.add_observer(capture_emits);
+        app
+    }
+
+    fn host_call(req_id: &str, ns: &str, method: &str) -> OzmuxFrame {
+        OzmuxFrame(serde_json::json!({
+            "kind": "host.call", "reqId": req_id, "ns": ns, "method": method, "args": []
+        }))
+    }
+
+    #[test]
+    fn host_call_denied_for_ungranted_namespace_is_not_forwarded() {
+        let mut app = gate_app();
+        let mut caps = HashSet::new();
+        caps.insert("clipboard".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+        app.world_mut().flush();
+
+        assert!(
+            app.world().resource::<HostRpc>().inflight.is_empty(),
+            "a denied call must NOT be forwarded (no in-flight entry)"
+        );
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1, "exactly one reject emitted");
+        assert_eq!(cap.0[0].0, webview);
+        assert!(
+            cap.0[0].1.contains("capability_denied"),
+            "rejected as capability_denied"
+        );
+        assert!(
+            cap.0[0].1.contains("\"reqId\":\"h0\""),
+            "reply carries the page-local reqId"
+        );
+    }
+
+    #[test]
+    fn host_call_trust_key_is_the_webview_entity_not_the_payload() {
+        let mut app = gate_app();
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let _granted = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+        let caller = app
+            .world_mut()
+            .spawn(GrantedNamespaces(HashSet::new()))
+            .id();
+
+        app.world_mut().trigger(Receive {
+            webview: caller,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "host.call", "reqId": "h0", "ns": "fs", "method": "read",
+                "args": [], "surfaceId": "spoofed", "granted": ["fs"]
+            })),
+        });
+        app.world_mut().flush();
+
+        assert!(app.world().resource::<HostRpc>().inflight.is_empty());
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1);
+        assert!(cap.0[0].1.contains("capability_denied"));
+    }
+
+    #[test]
+    fn host_call_rejects_when_host_unavailable() {
+        let mut app = gate_app();
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+        app.world_mut().flush();
+
+        assert!(app.world().resource::<HostRpc>().inflight.is_empty());
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0.len(), 1);
+        assert!(cap.0[0].1.contains("host_unavailable"));
+    }
+
+    #[test]
+    fn host_call_for_granted_namespace_is_forwarded_and_tracked() {
+        use std::io::{BufRead, BufReader};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                let mut r = BufReader::new(stream);
+                let mut line = String::new();
+                while r.read_line(&mut line).map(|n| n > 0).unwrap_or(false) {
+                    line.clear();
+                }
+            }
+        });
+
+        let mut app = gate_app();
+        let client = ozmux_extension_host::HostRpcClient::connect(&sock).unwrap();
+        app.world_mut().resource_mut::<HostRpc>().set_client(client);
+
+        let mut caps = HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        let hr = app.world().resource::<HostRpc>();
+        assert_eq!(hr.inflight.len(), 1, "an allowed call is tracked in-flight");
+        let entry = hr.inflight.values().next().unwrap();
+        assert_eq!(entry.0, webview);
+        assert_eq!(
+            entry.1.as_str(),
+            "h0",
+            "in-flight maps the global id back to the page-local reqId"
+        );
+        app.world_mut().flush();
+        assert!(
+            app.world().resource::<CapturedEmits>().0.is_empty(),
+            "an allowed call is forwarded, not rejected"
+        );
+
+        app.world_mut().resource_mut::<HostRpc>().clear_client();
+        let _ = server.join();
     }
 }

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -65,21 +65,15 @@ pub(crate) struct HostRpc {
 impl HostRpc {
     /// Installs a freshly-connected client, clearing any stale correlation /
     /// counter from a previous host generation.
-    #[allow(
-        dead_code,
-        reason = "production caller added in Task 5: extension_manager connect-on-ready/exit wiring; tests already exercise it"
-    )]
     pub(crate) fn set_client(&mut self, client: HostRpcClient) {
         self.client = Some(client);
         self.inflight.clear();
         self.next_id = 0;
     }
 
-    /// Drops the client (host exited): subsequent calls reject `host_unavailable`.
-    #[allow(
-        dead_code,
-        reason = "production caller added in Task 5: extension_manager connect-on-ready/exit wiring; tests already exercise it"
-    )]
+    /// Drops the client and clears in-flight correlation (host exited):
+    /// subsequent calls reject `host_unavailable`. `next_id` is reset by the
+    /// following `set_client`, not here.
     pub(crate) fn clear_client(&mut self) {
         self.client = None;
         self.inflight.clear();

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -1,8 +1,10 @@
-//! CEF integration for extension surfaces: the `ozmux-ext://` asset scheme and
-//! the `window.ozmux` JS extension, the webview spawn-once system that attaches
-//! a `bevy_cef` webview to each Extension Surface host, and the handler RPC
-//! bridge (Task 9) that routes `window.ozmux` frames between the page and the
-//! extension's handlers socket.
+//! CEF integration for extension surfaces: the `ozmux-ext://` asset scheme, the
+//! webview spawn-once system that attaches a `bevy_cef` webview to each Extension
+//! Surface host, and two coexisting JS bridges injected per surface — the legacy
+//! `window.ozmux` handler RPC bridge (routing frames to the extension's handlers
+//! socket) and the new-model `window.<ns>.<method>` host-API bridge
+//! (capability-gated `host.call` frames forwarded to the single Node host via
+//! `HostRpc`, with replies routed back on the `ozmux` channel).
 
 use crate::extension_manager::ExtensionRegistry;
 use crate::osc_webview::GrantedNamespaces;
@@ -73,7 +75,10 @@ impl HostRpc {
 
     /// Drops the client and clears in-flight correlation (host exited):
     /// subsequent calls reject `host_unavailable`. `next_id` is reset by the
-    /// following `set_client`, not here.
+    /// following `set_client`, not here. In-flight calls awaiting a host reply
+    /// are dropped without settling their page Promise (Phase 1 has no per-call
+    /// timeout); the page sees a hung Promise until reload — acceptable under the
+    /// no-auto-restart scope.
     pub(crate) fn clear_client(&mut self) {
         self.client = None;
         self.inflight.clear();
@@ -107,6 +112,9 @@ struct WebviewMountUnresolved;
 /// `sdk/typescript/src/surface/ozmux-bridge.ts`.
 pub const OZMUX_EXTENSION_JS: &str = include_str!("extension_render/ozmux.js");
 
+/// JS defining the new-model `window.<ns>.<method>` host-API bridge over
+/// `cef.emit` / `cef.listen`, injected (with `window.__ozmuxGranted`) per
+/// new-model webview as a `PreloadScripts` entry instead of `OZMUX_EXTENSION_JS`.
 const HOST_BRIDGE_JS: &str = include_str!("extension_render/host_bridge.js");
 
 /// Builds the `CefPlugin` with the `ozmux-ext://` scheme bound to the shared

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -117,6 +117,11 @@ pub const OZMUX_EXTENSION_JS: &str = include_str!("extension_render/ozmux.js");
 /// new-model webview as a `PreloadScripts` entry instead of `OZMUX_EXTENSION_JS`.
 const HOST_BRIDGE_JS: &str = include_str!("extension_render/host_bridge.js");
 
+/// The `kind` discriminator that routes a `Receive<OzmuxFrame>` to the new-model
+/// host-API path (`on_host_call_frame`) instead of the legacy handler path
+/// (`on_ozmux_frame`). The page side emits the matching literal in `host_bridge.js`.
+const HOST_CALL_KIND: &str = "host.call";
+
 /// Builds the `CefPlugin` with the `ozmux-ext://` scheme bound to the shared
 /// `AssetSourceRegistry` the extension manager populates: `Static(<dir>)` for
 /// new-model extensions (served directly by Rust) and `Legacy(...)` for legacy
@@ -423,7 +428,7 @@ fn on_ozmux_frame(
         .0
         .get("kind")
         .and_then(serde_json::Value::as_str)
-        == Some("host.call")
+        == Some(HOST_CALL_KIND)
     {
         return;
     }
@@ -464,7 +469,7 @@ fn on_host_call_frame(
     granted: Query<&GrantedNamespaces>,
 ) {
     let payload = &frame.payload.0;
-    if payload.get("kind").and_then(Value::as_str) != Some("host.call") {
+    if payload.get("kind").and_then(Value::as_str) != Some(HOST_CALL_KIND) {
         return;
     }
     let webview = frame.webview;

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -84,6 +84,22 @@ impl HostRpc {
         self.client = None;
         self.inflight.clear();
     }
+
+    #[cfg(test)]
+    pub(crate) fn note_in_flight_for_test(
+        &mut self,
+        global_id: &str,
+        webview: Entity,
+        local: &str,
+    ) {
+        self.inflight
+            .insert(global_id.to_string(), (webview, local.to_string()));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn count_in_flight_for_test(&self) -> usize {
+        self.inflight.len()
+    }
 }
 
 /// Marks an extension-surface host whose webview could not be mounted because
@@ -157,6 +173,7 @@ impl Plugin for OzmuxExtensionRenderPlugin {
                 (
                     finish_extension_setup.in_set(OzmuxSystems::SetupSurface),
                     drain_handler_responses,
+                    drain_host_rpc_responses,
                     sync_focused_webview.after(OzmuxSystems::Input),
                 ),
             );
@@ -513,6 +530,37 @@ fn drain_handler_responses(
     }
 }
 
+/// Outbound (new-model host API): drains the host's NDJSON reply lines, maps the
+/// Rust-minted global `reqId` back to its `(webview, pageReqId)`, restores the
+/// page-local `reqId`, and re-emits each reply to the originating webview on the
+/// `"ozmux"` channel. A reply with no live in-flight entry (surface despawned)
+/// is dropped.
+fn drain_host_rpc_responses(mut commands: Commands, mut host_rpc: ResMut<HostRpc>) {
+    let mut lines = Vec::new();
+    if let Some(client) = host_rpc.client.as_ref() {
+        while let Some(line) = client.try_recv_response() {
+            lines.push(line);
+        }
+    }
+    for line in lines {
+        let Ok(mut frame) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(global_id) = frame
+            .get("reqId")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        else {
+            continue;
+        };
+        let Some((webview, local_id)) = host_rpc.inflight.remove(&global_id) else {
+            continue;
+        };
+        frame["reqId"] = Value::String(local_id);
+        commands.trigger(HostEmitEvent::new(webview, "ozmux", &frame));
+    }
+}
+
 /// Logs the start of a webview page load. Debug-level diagnostics: these
 /// observers fire for every `bevy_cef` webview, not only extension hosts.
 fn log_webview_load_started(load: On<LoadStarted>) {
@@ -541,12 +589,13 @@ fn log_webview_load_error(load: On<LoadError>) {
     );
 }
 
-/// Prunes the `WebviewSurfaceIdMap` entry and disconnects the handler connection
-/// for a surface that is being despawned. Runs pre-removal so `ExtensionSurfaceId`
-/// is still readable on the entity.
+/// Prunes the `WebviewSurfaceIdMap` entry, disconnects the handler connection,
+/// and drops any in-flight host RPC calls for a surface that is being despawned.
+/// Runs pre-removal so `ExtensionSurfaceId` is still readable on the entity.
 fn prune_webview_id_map_on_remove(
     ev: On<Remove, SurfaceMarker>,
     mut map: ResMut<WebviewSurfaceIdMap>,
+    mut host_rpc: ResMut<HostRpc>,
     bridge: Res<ExtensionHandlersBridge>,
     ids: Query<&ExtensionSurfaceId>,
 ) {
@@ -554,6 +603,9 @@ fn prune_webview_id_map_on_remove(
         map.0.remove(&id.0);
         bridge.0.disconnect(&id.0);
     }
+    host_rpc
+        .inflight
+        .retain(|_, (entity, _)| *entity != ev.entity);
 }
 
 #[cfg(test)]
@@ -1060,6 +1112,7 @@ mod tests {
             .add_plugins(MultiplexerPlugin);
         app.init_resource::<ExtensionHandlersBridge>();
         app.init_resource::<WebviewSurfaceIdMap>();
+        app.init_resource::<HostRpc>();
         app.add_observer(prune_webview_id_map_on_remove);
 
         let (pane, surface) = app
@@ -1253,5 +1306,105 @@ mod tests {
 
         app.world_mut().resource_mut::<HostRpc>().clear_client();
         let _ = server.join();
+    }
+
+    #[test]
+    fn host_reply_routed_back_to_origin_with_page_local_req_id() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("rpc.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let frame: serde_json::Value = serde_json::from_str(&line).unwrap();
+            let gid = frame
+                .get("reqId")
+                .and_then(|v| v.as_str())
+                .unwrap()
+                .to_string();
+            let mut w = stream;
+            w.write_all(
+                format!("{{\"reqId\":\"{gid}\",\"ok\":true,\"value\":\"hi\"}}\n").as_bytes(),
+            )
+            .unwrap();
+            w.flush().unwrap();
+        });
+
+        let mut app = gate_app();
+        app.add_systems(Update, drain_host_rpc_responses);
+        let client = ozmux_extension_host::HostRpcClient::connect(&sock).unwrap();
+        app.world_mut().resource_mut::<HostRpc>().set_client(client);
+
+        let mut caps = std::collections::HashSet::new();
+        caps.insert("fs".to_string());
+        let webview = app.world_mut().spawn(GrantedNamespaces(caps)).id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: host_call("h0", "fs", "read"),
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            app.update();
+            if !app.world().resource::<CapturedEmits>().0.is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reply never routed back"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let cap = app.world().resource::<CapturedEmits>();
+        assert_eq!(cap.0[0].0, webview, "reply targets the originating webview");
+        assert!(
+            cap.0[0].1.contains("\"reqId\":\"h0\""),
+            "page-local reqId restored"
+        );
+        assert!(
+            cap.0[0].1.contains("\"value\":\"hi\""),
+            "value forwarded through"
+        );
+        assert!(
+            app.world().resource::<HostRpc>().inflight.is_empty(),
+            "the in-flight entry is consumed on reply"
+        );
+
+        app.world_mut().resource_mut::<HostRpc>().clear_client();
+        let _ = server.join();
+    }
+
+    #[test]
+    fn pruning_drops_in_flight_calls_for_a_despawned_surface() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<HostRpc>();
+        app.init_resource::<ExtensionHandlersBridge>();
+        app.init_resource::<WebviewSurfaceIdMap>();
+        app.add_observer(prune_webview_id_map_on_remove);
+
+        let surface = app.world_mut().spawn(SurfaceMarker).id();
+        let other = app.world_mut().spawn(SurfaceMarker).id();
+        {
+            let mut hr = app.world_mut().resource_mut::<HostRpc>();
+            hr.note_in_flight_for_test("0", surface, "h0");
+            hr.note_in_flight_for_test("1", other, "h1");
+        }
+
+        app.world_mut().entity_mut(surface).despawn();
+
+        assert_eq!(
+            app.world().resource::<HostRpc>().count_in_flight_for_test(),
+            1,
+            "prune must drop ONLY the despawned surface's in-flight calls (retain, not clear)"
+        );
     }
 }

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -107,6 +107,8 @@ struct WebviewMountUnresolved;
 /// `sdk/typescript/src/surface/ozmux-bridge.ts`.
 pub const OZMUX_EXTENSION_JS: &str = include_str!("extension_render/ozmux.js");
 
+const HOST_BRIDGE_JS: &str = include_str!("extension_render/host_bridge.js");
+
 /// Builds the `CefPlugin` with the `ozmux-ext://` scheme bound to the shared
 /// `AssetSourceRegistry` the extension manager populates: `Static(<dir>)` for
 /// new-model extensions (served directly by Rust) and `Legacy(...)` for legacy
@@ -278,6 +280,7 @@ fn finish_extension_setup(
             Without<WebviewMountUnresolved>,
         ),
     >,
+    granted: Query<&GrantedNamespaces>,
 ) {
     for (surface, computed) in surfaces.iter() {
         let Some(logical) = pane_logical_size(computed.size(), computed.inverse_scale_factor())
@@ -310,10 +313,21 @@ fn finish_extension_setup(
         // entered context (and their exceptions are caught, not fatal), so
         // cef.listen registers correctly there.
         let ctx_js = context_preload_js(workspace, pane, surface, name);
+        let preload = match granted.get(surface) {
+            Ok(g) => {
+                let list: Vec<&String> = g.0.iter().collect();
+                let granted_js = format!(
+                    "window.__ozmuxGranted={};",
+                    serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+                );
+                PreloadScripts::from([ctx_js, granted_js, HOST_BRIDGE_JS.to_string()])
+            }
+            Err(_) => PreloadScripts::from([ctx_js, OZMUX_EXTENSION_JS.to_string()]),
+        };
         commands.entity(surface).insert((
             WebviewSource::new(url),
             WebviewSize(logical),
-            PreloadScripts::from([ctx_js, OZMUX_EXTENSION_JS.to_string()]),
+            preload,
             MaterialNode(materials.add(WebviewUiMaterial::default())),
         ));
     }
@@ -1374,6 +1388,42 @@ mod tests {
 
         app.world_mut().resource_mut::<HostRpc>().clear_client();
         let _ = server.join();
+    }
+
+    #[test]
+    fn new_model_surface_gets_host_bridge_and_granted_list() {
+        let mut app = make_test_app();
+        app.add_systems(Update, finish_extension_setup);
+        let mut caps = std::collections::HashSet::new();
+        caps.insert("fs".to_string());
+        let (host, ..) = spawn_extension_host(
+            &mut app,
+            (
+                laid_out_node(Vec2::new(800.0, 600.0)),
+                GrantedNamespaces(caps),
+            ),
+        );
+        app.update();
+
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(host)
+            .expect("new-model surface must carry the host bridge as a PreloadScript");
+        assert!(
+            preload.0.iter().any(|s| s == HOST_BRIDGE_JS),
+            "the host-API bridge JS must be injected for a surface with GrantedNamespaces"
+        );
+        assert!(
+            preload
+                .0
+                .iter()
+                .any(|s| s.starts_with("window.__ozmuxGranted=") && s.contains("\"fs\"")),
+            "the granted-namespace list must be injected before the bridge"
+        );
+        assert!(
+            !preload.0.iter().any(|s| s == OZMUX_EXTENSION_JS),
+            "legacy ozmux.js must NOT be injected for a new-model surface"
+        );
     }
 
     #[test]

--- a/src/extension_render/host_bridge.js
+++ b/src/extension_render/host_bridge.js
@@ -51,10 +51,11 @@
         {},
         {
           get: function (_t, method) {
-            // NOTE: a Symbol key (e.g. Symbol.toPrimitive, or `then` probing for
-            // a thenable) must NOT return a callable, or window[ns] would look
-            // like a Promise and break. Only string method names dispatch.
-            if (typeof method !== 'string') return undefined;
+            // NOTE: a Symbol key, or the string 'then', must NOT return a
+            // callable — otherwise window[ns] is detected as a thenable and
+            // `await window.fs` / Promise.resolve(window.fs) would dispatch a
+            // bogus `then` host call. Only real (string, non-'then') methods do.
+            if (typeof method !== 'string' || method === 'then') return undefined;
             return function () {
               return hostCall(ns, method, Array.prototype.slice.call(arguments));
             };

--- a/src/extension_render/host_bridge.js
+++ b/src/extension_render/host_bridge.js
@@ -1,0 +1,66 @@
+// NOTE: bevy_cef contract — Rust->JS cef.listen delivers a JSON *string* (hence
+// JSON.parse); JS->Rust cef.emit serializes only its FIRST argument into one
+// global Receive<OzmuxFrame> (single self-describing object, no channel arg, a
+// second argument is dropped). The {__u8} base64 tag mirrors binary-codec.ts.
+(function () {
+  var cef = window.cef;
+  var nextId = 0;
+  var calls = new Map();
+
+  function encodeArg(a) {
+    if (a instanceof Uint8Array) {
+      var bin = '';
+      for (var i = 0; i < a.length; i++) bin += String.fromCharCode(a[i]);
+      return { __u8: btoa(bin) };
+    }
+    return a;
+  }
+
+  function decodeValue(v) {
+    if (v && typeof v === 'object' && typeof v.__u8 === 'string') {
+      var s = atob(v.__u8);
+      var out = new Uint8Array(s.length);
+      for (var i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+      return out;
+    }
+    return v;
+  }
+
+  cef.listen('ozmux', function (raw) {
+    var frame = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    var c = calls.get(frame.reqId);
+    if (!c) return;
+    calls.delete(frame.reqId);
+    if (frame.ok) c.resolve(decodeValue(frame.value));
+    else c.reject(new Error(frame.error));
+  });
+
+  function hostCall(ns, method, args) {
+    var reqId = 'h' + nextId++;
+    var encoded = args.map(encodeArg);
+    return new Promise(function (resolve, reject) {
+      calls.set(reqId, { resolve: resolve, reject: reject });
+      cef.emit({ kind: 'host.call', reqId: reqId, ns: ns, method: method, args: encoded });
+    });
+  }
+
+  var granted = window.__ozmuxGranted || [];
+  for (var g = 0; g < granted.length; g++) {
+    (function (ns) {
+      window[ns] = new Proxy(
+        {},
+        {
+          get: function (_t, method) {
+            // NOTE: a Symbol key (e.g. Symbol.toPrimitive, or `then` probing for
+            // a thenable) must NOT return a callable, or window[ns] would look
+            // like a Promise and break. Only string method names dispatch.
+            if (typeof method !== 'string') return undefined;
+            return function () {
+              return hostCall(ns, method, Array.prototype.slice.call(arguments));
+            };
+          },
+        },
+      );
+    })(granted[g]);
+  }
+})();

--- a/src/osc_webview.rs
+++ b/src/osc_webview.rs
@@ -35,11 +35,6 @@ pub(crate) struct NonInteractive;
 /// (Step 3) reads this as the per-surface capability grant; it is the in-ECS
 /// trust record, never derived from webview-supplied data.
 #[derive(Component, Debug, Clone, Default)]
-// NOTE: the production (non-test) build has no reader yet, so dead_code fires;
-// #[expect] cannot suppress it because the test binary DOES read the field
-// (the expectation would then fail under cfg(test)). Remove when the host-API
-// bridge (Step 3) adds a non-test reader.
-#[allow(dead_code)]
 pub(crate) struct GrantedNamespaces(pub(crate) HashSet<String>);
 
 /// Wires the OSC-webview mount/unmount observer and the config-driven gate.


### PR DESCRIPTION
## Summary
Implements **Step 4** of the Phase 1 single-host migration: the host-API bridge that lets an OSC-mounted extension webview call `window.<ns>.<method>(...)` and run `api[ns][method]` in the single Node host, capability-gated, with the (possibly binary) result returned to the page's Promise. **Bridge-only scope** — the legacy `window.ozmux.call/subscribe` + handlers + command shim stay untouched (Step 5), and the real `extensions/memo` E2E is Step 6. Stacked on `phase1-single-host`, not `main`.

- **`HostRpcClient`** — Tokio-free NDJSON `UnixStream` client (writer/reader threads, crossbeam-internal, `Drop`-joined) to the host RPC socket.
- **Capability gate** — `on_host_call_frame` is a *second observer* on the single `Receive<OzmuxFrame>` event (not a 2nd `JsEmitEventPlugin`); it gates on the trusted `frame.webview` Entity's `GrantedNamespaces` (never the JS payload), mints a Rust-side global `reqId` (page-local ids collide across webviews), and forwards over NDJSON.
- **Reply path** — `drain_host_rpc_responses` maps the global id back to `(webview, pageReqId)` and re-emits via `HostEmitEvent` on the `ozmux` channel; in-flight calls are pruned on surface despawn.
- **Lifecycle** — `poll_host_lifecycle` connects the client on host `Ready`, clears on exit (graceful `host_unavailable` reject thereafter).
- **Injection** — `host_bridge.js` builds one `window[ns]` Proxy per granted namespace (with a `{__u8}` base64 boundary codec); legacy surfaces keep `ozmux.js`.
- **Host** — `rpc-server.ts` caps result frames at 8 MiB.

Built subagent-driven (per-task spec + code review), an opus whole-branch final review (PR-ready, 0 Critical/Important), and a `/code-review max` pass whose findings were applied (Drop main-thread stall, Proxy thenable guard, shared `kind` const, stale-client clear).

## Test Plan
- [x] `cargo test -p ozmux_extension_host` → 86 passed
- [x] `pnpm -C host test` (vitest) → 37 passed
- [x] `cargo test -p ozmux-gui --bin ozmux-gui -- --test-threads=1` → 318 passed
- [x] `cargo build` + `cargo clippy --workspace --all-targets` + `cargo fmt --check` → clean
- [x] `assets/host.mjs` bundle current; `pnpm -C host check-types` clean
- [ ] Manual webview E2E lands with the memo migration in Step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)