### PR TITLE
feat: インライン WebView 表示（OSC 5379・in-shader 合成・複数インスタンス）

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -305,4 +305,4 @@ If you add a tool or script that detects any of these, move the corresponding en
 
 ## Existing legitimate exceptions
 
-- (None recorded yet — append entries here as they are discovered, with a brief justification.)
+- `frame_builder.rs` builder signatures keep `interner: &mut HyperlinkInterner` as the LAST parameter despite the mutable-params-first rule: the interner is an output-cache argument by convention across ~17 call sites, and reordering would churn them all for no readability gain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
 [[package]]
 name = "bevy_cef"
 version = "0.11.0-dev"
+source = "git+https://github.com/not-elm/bevy_cef?branch=headless-gpu#e6c7b44820d3c68d75eb057ebe3439d2644ae1b7"
 dependencies = [
  "async-channel",
  "bevy",
@@ -670,6 +671,7 @@ dependencies = [
 [[package]]
 name = "bevy_cef_core"
 version = "0.11.0-dev"
+source = "git+https://github.com/not-elm/bevy_cef?branch=headless-gpu#e6c7b44820d3c68d75eb057ebe3439d2644ae1b7"
 dependencies = [
  "async-channel",
  "bevy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4630,6 +4630,7 @@ dependencies = [
  "arboard",
  "bevy",
  "bevy_cef",
+ "bevy_cef_core",
  "bevy_terminal",
  "bevy_terminal_renderer",
  "cosmic-text",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,6 @@ dependencies = [
 [[package]]
 name = "bevy_cef"
 version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=poc%2Fmacos-accelerated-paint-iosurface#7f99a9d600ea40f2206732ed37ad94e2e65d64d6"
 dependencies = [
  "async-channel",
  "bevy",
@@ -671,7 +670,6 @@ dependencies = [
 [[package]]
 name = "bevy_cef_core"
 version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=poc%2Fmacos-accelerated-paint-iosurface#7f99a9d600ea40f2206732ed37ad94e2e65d64d6"
 dependencies = [
  "async-channel",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = []
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "poc/macos-accelerated-paint-iosurface", features = ["debug"] }
+bevy_cef = { path = "/Users/watanabe/workspace/bevy_cef/wt/headless-gpu", features = ["debug"] }
 bevy_terminal_renderer = { path = "crates/bevy_terminal_renderer" }
 bevy_terminal = { path = "crates/bevy_terminal" }
 cosmic-text = "0.16"
@@ -75,7 +75,7 @@ toml = "0.8"
 dirs = "5"
 unicode-width = "0.2"
 open = "5"
-bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "poc/macos-accelerated-paint-iosurface"}
+bevy_cef_core = { path = "/Users/watanabe/workspace/bevy_cef/wt/headless-gpu/crates/bevy_cef_core" }
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = []
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { path = "/Users/watanabe/workspace/bevy_cef/wt/headless-gpu", features = ["debug"] }
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "headless-gpu", features = ["debug"] }
 bevy_cef_core = { workspace = true }
 bevy_terminal_renderer = { path = "crates/bevy_terminal_renderer" }
 bevy_terminal = { path = "crates/bevy_terminal" }
@@ -76,7 +76,7 @@ toml = "0.8"
 dirs = "5"
 unicode-width = "0.2"
 open = "5"
-bevy_cef_core = { path = "/Users/watanabe/workspace/bevy_cef/wt/headless-gpu/crates/bevy_cef_core" }
+bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "headless-gpu" }
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
 bevy_cef = { path = "/Users/watanabe/workspace/bevy_cef/wt/headless-gpu", features = ["debug"] }
+bevy_cef_core = { workspace = true }
 bevy_terminal_renderer = { path = "crates/bevy_terminal_renderer" }
 bevy_terminal = { path = "crates/bevy_terminal" }
 cosmic-text = "0.16"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ cargo run               # or: make run
 - `sdk/typescript` — `@ozmux/sdk` (consumed by extensions)
 - `extensions/memo` — the `@memo` Node extension
 
+## Inline webviews
+
+A registered extension view can render **inline in the terminal text flow** (a
+live CEF webview composited in the terminal shader, scrolling with the text).
+A program in the shell mounts one by writing an OSC 5379 sequence; the
+`@ozmux/sdk/inline` helper builds it:
+
+```ts
+import { mountInline } from '@ozmux/sdk/inline';
+process.stdout.write('memo:\n');
+process.stdout.write(mountInline('memo.main', { rows: 12, cols: 48 }));
+```
+
+Try the bundled sample inside an ozmux terminal (macOS, `cargo run --features
+debug`): `node extensions/memo/mount.ts`. Click the view to focus it; keys,
+wheel, and IME then route to the page; `Ctrl+Shift+Escape` returns focus to the
+terminal. Full protocol, focus model, and limits: [`docs/inline-webview.md`](docs/inline-webview.md).
+
 ## Development
 
 See `CLAUDE.md` for architecture and `.claude/rules/` for coding conventions.

--- a/crates/bevy_terminal/src/events.rs
+++ b/crates/bevy_terminal/src/events.rs
@@ -73,7 +73,7 @@ pub struct TerminalCurrentDir {
 pub struct OscWebviewRequest {
     #[event_target]
     pub entity: Entity,
-    /// The verb (mount or unmount) parsed from the OSC 5379 payload.
+    /// The verb (tab or inline mount/unmount) parsed from the OSC 5379 payload.
     pub verb: OscWebviewVerb,
     /// Anchor metadata for `MountInline` (absolute line + column + frame seq);
     /// `None` for every other verb.

--- a/crates/bevy_terminal/src/events.rs
+++ b/crates/bevy_terminal/src/events.rs
@@ -10,7 +10,7 @@
 //! `#[event_target] entity` field routes the trigger to the
 //! correct observer.
 
-use crate::vt::listener::OscWebviewVerb;
+use crate::vt::listener::{InlineAnchor, OscWebviewVerb};
 use bevy::ecs::entity::Entity;
 use bevy::ecs::event::EntityEvent;
 use std::path::PathBuf;
@@ -75,6 +75,9 @@ pub struct OscWebviewRequest {
     pub entity: Entity,
     /// The verb (mount or unmount) parsed from the OSC 5379 payload.
     pub verb: OscWebviewVerb,
+    /// Anchor metadata for `MountInline` (absolute line + column + frame seq);
+    /// `None` for every other verb.
+    pub anchor: Option<InlineAnchor>,
 }
 
 /// Subset of keys the terminal input codec understands. Keeps the public

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -1002,7 +1002,10 @@ impl TerminalHandle {
     /// the saturation first-arrival rule.
     fn send_synthetic_unmount_all(&mut self) {
         let frame = ControlFrame::OscWebview {
-            verb: OscWebviewVerb::UnmountInline { view_id: None },
+            verb: OscWebviewVerb::UnmountInline {
+                view_id: None,
+                instance_id: None,
+            },
             anchor: None,
         };
         if let Err(e) = self.control_tx.send(frame) {
@@ -2031,7 +2034,10 @@ mod tests {
         assert_eq!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                verb: OscWebviewVerb::UnmountInline {
+                    view_id: None,
+                    instance_id: None,
+                },
                 anchor: None,
             }
         );
@@ -2049,7 +2055,10 @@ mod tests {
         assert!(matches!(
             first,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                verb: OscWebviewVerb::UnmountInline {
+                    view_id: None,
+                    instance_id: None,
+                },
                 ..
             }
         ));
@@ -2092,7 +2101,10 @@ mod tests {
         assert!(matches!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                verb: OscWebviewVerb::UnmountInline {
+                    view_id: None,
+                    instance_id: None,
+                },
                 ..
             }
         ));
@@ -2148,7 +2160,10 @@ mod tests {
         assert!(matches!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                verb: OscWebviewVerb::UnmountInline {
+                    view_id: None,
+                    instance_id: None,
+                },
                 ..
             }
         ));
@@ -2166,7 +2181,10 @@ mod tests {
         assert!(matches!(
             fold,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                verb: OscWebviewVerb::UnmountInline {
+                    view_id: None,
+                    instance_id: None,
+                },
                 ..
             }
         ));
@@ -2359,6 +2377,7 @@ mod tests {
                     view_id: "memo".into(),
                     rows: 3,
                     cols: 10,
+                    instance_id: None,
                 },
                 anchor: Some(InlineAnchor {
                     line: 42,
@@ -2390,7 +2409,8 @@ mod tests {
                 OscWebviewVerb::MountInline {
                     ref view_id,
                     rows: 3,
-                    cols: 10
+                    cols: 10,
+                    instance_id: None,
                 } if view_id == "memo"
             ),
             "verb must be MountInline{{memo, 3, 10}}, got {:?}",

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -167,15 +167,6 @@ impl TerminalHandle {
             .advance(&mut self.osc_webview, chunk);
     }
 
-    /// Drains the buffered OSC 5379 verb left by the last `advance` call,
-    /// if any. Returns `None` when no OSC 5379 sequence was parsed or the
-    /// gate was off.
-    pub(crate) fn take_pending_osc_webview(
-        &mut self,
-    ) -> Option<crate::vt::listener::OscWebviewVerb> {
-        self.osc_webview.take_pending()
-    }
-
     /// Returns true if the current `Term` cursor differs from the most
     /// recently emitted cursor (`prev_cursor`).
     pub fn cursor_changed(&self) -> bool {
@@ -1752,41 +1743,6 @@ mod tests {
         assert_eq!(
             app.world().resource::<Seen>().0,
             vec![PathBuf::from("/tmp")]
-        );
-    }
-
-    #[test]
-    fn advance_osc_webview_buffers_pending_verb() {
-        use crate::vt::listener::{ControlFrame, OscWebviewVerb, TermListener};
-        use crossbeam_channel::unbounded;
-
-        let (reply_tx, reply_rx) = unbounded::<Vec<u8>>();
-        let (control_tx, control_rx) = unbounded::<ControlFrame>();
-        let listener = TermListener {
-            reply_tx,
-            control_tx: control_tx.clone(),
-        };
-        let mut handle = TerminalHandle::new(
-            80,
-            24,
-            listener,
-            reply_rx,
-            control_rx,
-            control_tx,
-            Arc::new(AtomicBool::new(true)),
-        );
-        handle.advance(b"\x1b]5379;mount;dash\x07");
-
-        assert_eq!(
-            handle.take_pending_osc_webview(),
-            Some(OscWebviewVerb::Mount {
-                view_id: "dash".into()
-            }),
-            "advance must buffer the parsed OSC 5379 verb in osc_webview"
-        );
-        assert!(
-            handle.take_pending_osc_webview().is_none(),
-            "second take must return None"
         );
     }
 }

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -15,7 +15,7 @@ use crate::vt::frame_builder::{
     viewport_row_to_line,
 };
 use crate::vt::hyperlink::HyperlinkInterner;
-use crate::vt::listener::{ControlFrame, TermListener};
+use crate::vt::listener::{ControlFrame, InlineAnchor, OscWebviewVerb, TermListener};
 use crate::vt::mode_diff::diff_mode;
 use alacritty_terminal::Term;
 use alacritty_terminal::grid::{Dimensions, Scroll};
@@ -100,10 +100,24 @@ pub struct TerminalHandle {
     row_hashes: HashMap<i32, u64>,
     window_open_mode: Option<TermMode>,
     frame_seq: u32,
+    history_base: u64,
     #[expect(
         dead_code,
-        reason = "stamped frames are wired in the follow-up advance-loop task"
+        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
     )]
+    frozen_history: usize,
+    #[expect(
+        dead_code,
+        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
+    )]
+    frozen_valid: bool,
+    saturated: bool,
+    force_next_emit: bool,
+    #[expect(
+        dead_code,
+        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
+    )]
+    scroll_cap: usize,
     control_tx: Sender<ControlFrame>,
     reply_rx: Receiver<Vec<u8>>,
     control_rx: Receiver<ControlFrame>,
@@ -126,7 +140,9 @@ impl TerminalHandle {
         gate: Arc<AtomicBool>,
     ) -> Self {
         let size = LocalDim::new(cols, rows);
-        let term = Term::new(Config::default(), &size, listener);
+        let config = Config::default();
+        let scroll_cap = config.scrolling_history;
+        let term = Term::new(config, &size, listener);
         let osc7 = Osc7Capture::new(
             control_tx.clone(),
             gethostname::gethostname().to_string_lossy().into_owned(),
@@ -146,6 +162,12 @@ impl TerminalHandle {
             row_hashes: HashMap::new(),
             window_open_mode: None,
             frame_seq: 0,
+            history_base: 0,
+            frozen_history: 0,
+            frozen_valid: true,
+            saturated: false,
+            force_next_emit: false,
+            scroll_cap,
             control_tx,
             reply_rx,
             control_rx,
@@ -156,15 +178,34 @@ impl TerminalHandle {
         }
     }
 
-    /// Feeds a chunk of PTY bytes through the vte parser into `Term`.
+    /// Feeds a chunk of PTY bytes through the vte parsers into `Term`.
+    ///
+    /// The webview sibling parser LEADS via `advance_until_terminated`:
+    /// it stops right after each OSC 5379 sequence so the main parser can
+    /// be advanced exactly to that byte and the cursor sampled there
+    /// (spec §3). For ST-terminated sequences the stop offset lands
+    /// between ESC and `\`; the leftover `\` is consumed harmlessly by
+    /// the next segment.
     pub fn advance(&mut self, chunk: &[u8]) {
         if chunk.is_empty() {
             return;
         }
-        self.parser.advance(&mut self.term, chunk);
-        self.osc7_parser.advance(&mut self.osc7, chunk);
-        self.osc_webview_parser
-            .advance(&mut self.osc_webview, chunk);
+        let mut rest = chunk;
+        loop {
+            let k = self
+                .osc_webview_parser
+                .advance_until_terminated(&mut self.osc_webview, rest);
+            self.parser.advance(&mut self.term, &rest[..k]);
+            self.osc7_parser.advance(&mut self.osc7, &rest[..k]);
+            match self.osc_webview.take_pending() {
+                Some(verb) => self.handle_webview_verb(verb),
+                None => self.run_history_maintenance(),
+            }
+            if k == rest.len() {
+                break;
+            }
+            rest = &rest[k..];
+        }
     }
 
     /// Returns true if the current `Term` cursor differs from the most
@@ -855,6 +896,46 @@ impl TerminalHandle {
         self.term.reset_damage();
         coalescer.disarm();
     }
+
+    /// Stamps the anchor / applies state gates for a buffered OSC 5379 verb
+    /// at an `advance_until_terminated` stop point, then forwards the frame.
+    fn handle_webview_verb(&mut self, verb: OscWebviewVerb) {
+        if self.parser.sync_bytes_count() > 0 {
+            self.parser.stop_sync(&mut self.term);
+        }
+        self.run_history_maintenance();
+        let anchor = if matches!(verb, OscWebviewVerb::MountInline { .. }) {
+            if self.term.mode().contains(TermMode::ALT_SCREEN) {
+                tracing::debug!("mount-inline rejected: alternate screen active");
+                return;
+            }
+            if self.saturated {
+                tracing::debug!("mount-inline rejected: scrollback saturated");
+                return;
+            }
+            let cursor = self.term.grid().cursor.point;
+            self.force_next_emit = true;
+            Some(InlineAnchor {
+                line: self.history_base
+                    + self.term.history_size() as u64
+                    + cursor.line.0.max(0) as u64,
+                col: cursor.column.0 as u16,
+                frame_seq: self.frame_seq,
+            })
+        } else {
+            None
+        };
+        if let Err(e) = self
+            .control_tx
+            .send(ControlFrame::OscWebview { verb, anchor })
+        {
+            tracing::warn!(?e, "control_tx send(OscWebview) failed");
+        }
+    }
+
+    /// Per-segment history_base maintenance (spec §3). Fleshed out in a
+    /// follow-up task; the call sites are already final.
+    fn run_history_maintenance(&mut self) {}
 }
 
 /// Classification used by `decide_frame_kind` to select snapshot vs
@@ -1744,6 +1825,108 @@ mod tests {
             app.world().resource::<Seen>().0,
             vec![PathBuf::from("/tmp")]
         );
+    }
+
+    fn handle_with_gate_on(
+        cols: u16,
+        rows: u16,
+    ) -> (TerminalHandle, crossbeam_channel::Receiver<ControlFrame>) {
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) = crossbeam_channel::unbounded::<ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let h = TerminalHandle::new(
+            cols,
+            rows,
+            listener,
+            reply_rx,
+            crossbeam_channel::unbounded::<ControlFrame>().1,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(true)),
+        );
+        (h, ctrl_rx)
+    }
+
+    #[test]
+    fn mount_inline_anchor_is_cursor_at_osc_byte_position_not_chunk_end() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        let mut payload = b"\x1b]5379;mount-inline;memo;3;10\x1b\\".to_vec();
+        payload.extend_from_slice(b"\r\n\r\n\r\n");
+        h.advance(&payload);
+        let frame = rx.try_recv().expect("MountInline frame");
+        let ControlFrame::OscWebview { verb, anchor } = frame else {
+            panic!("expected OscWebview, got {frame:?}");
+        };
+        assert!(matches!(verb, OscWebviewVerb::MountInline { .. }));
+        let anchor = anchor.expect("MountInline carries an anchor");
+        assert_eq!(
+            anchor.line, 0,
+            "anchor = cursor at the OSC byte, before the newlines"
+        );
+        assert_eq!(anchor.col, 0);
+    }
+
+    #[test]
+    fn mount_inline_anchor_accounts_for_prior_output_in_same_chunk() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        let mut payload = b"\r\n\r\n".to_vec();
+        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x07");
+        payload.extend_from_slice(b"\r\n\r\n");
+        h.advance(&payload);
+        let ControlFrame::OscWebview { anchor, .. } = rx.try_recv().expect("frame") else {
+            panic!("expected OscWebview");
+        };
+        assert_eq!(anchor.expect("anchor").line, 2);
+    }
+
+    #[test]
+    fn legacy_mount_still_arrives_without_anchor() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x1b]5379;mount;dash\x1b\\");
+        let ControlFrame::OscWebview { verb, anchor } = rx.try_recv().expect("frame") else {
+            panic!("expected OscWebview");
+        };
+        assert_eq!(
+            verb,
+            OscWebviewVerb::Mount {
+                view_id: "dash".into()
+            }
+        );
+        assert!(anchor.is_none());
+    }
+
+    #[test]
+    fn osc_split_across_two_chunks_still_anchors_correctly() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        let full = b"\x1b]5379;mount-inline;memo;3;10\x1b\\";
+        let (a, b) = full.split_at(10);
+        h.advance(a);
+        h.advance(b);
+        let ControlFrame::OscWebview { anchor, .. } = rx.try_recv().expect("frame") else {
+            panic!("expected OscWebview");
+        };
+        assert_eq!(anchor.expect("anchor").line, 0);
+    }
+
+    #[test]
+    fn two_mounts_in_one_chunk_each_get_their_own_anchor() {
+        let (mut h, rx) = handle_with_gate_on(20, 6);
+        let mut payload = b"\x1b]5379;mount-inline;a1;2;10\x1b\\".to_vec();
+        payload.extend_from_slice(b"\r\n\r\n");
+        payload.extend_from_slice(b"\x1b]5379;mount-inline;b2;2;10\x1b\\");
+        h.advance(&payload);
+        let first = rx.try_recv().expect("first frame");
+        let second = rx.try_recv().expect("second frame");
+        let get = |f: ControlFrame| match f {
+            ControlFrame::OscWebview {
+                anchor: Some(a), ..
+            } => a.line,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_eq!(get(first), 0);
+        assert_eq!(get(second), 2);
     }
 }
 

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -597,8 +597,12 @@ impl TerminalHandle {
                 ControlFrame::CurrentDir(path) => {
                     commands.trigger(TerminalCurrentDir { entity, path });
                 }
-                ControlFrame::OscWebview(verb) => {
-                    commands.trigger(OscWebviewRequest { entity, verb });
+                ControlFrame::OscWebview { verb, anchor } => {
+                    commands.trigger(OscWebviewRequest {
+                        entity,
+                        verb,
+                        anchor,
+                    });
                 }
             }
         }

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -107,7 +107,7 @@ pub struct TerminalHandle {
     force_next_emit: bool,
     #[expect(
         dead_code,
-        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
+        reason = "read by the saturation gate in the follow-up task"
     )]
     scroll_cap: usize,
     control_tx: Sender<ControlFrame>,
@@ -241,10 +241,7 @@ impl TerminalHandle {
         cols: u16,
         rows: u16,
     ) -> anyhow::Result<()> {
-        let dim = LocalDim::new(cols, rows);
-        self.term.resize(dim);
-        self.row_hashes.clear();
-        self.frozen_valid = false;
+        self.resize_grid(cols, rows);
         pty.resize(cols, rows)?;
         self.stage_full_damage_and_arm(coalescer);
         Ok(())
@@ -896,6 +893,9 @@ impl TerminalHandle {
         if self.parser.sync_bytes_count() > 0 {
             self.parser.stop_sync(&mut self.term);
         }
+        // NOTE: maintenance (fold) must run BEFORE the anchor is stamped —
+        // same-chunk "CSI 3 J then mount-inline" depends on this order
+        // (spec §3).
         self.run_history_maintenance();
         let anchor = if matches!(verb, OscWebviewVerb::MountInline { .. }) {
             if self.term.mode().contains(TermMode::ALT_SCREEN) {
@@ -926,19 +926,29 @@ impl TerminalHandle {
         }
     }
 
+    /// Resizes the alacritty grid and invalidates the resize-sensitive
+    /// caches: `row_hashes` (post-resize rows must not be hash-filtered
+    /// against pre-resize hashes) and the frozen history baseline
+    /// (reflow changes `history_size`; the next primary-screen
+    /// observation skips the fold and re-baselines, spec §3).
+    fn resize_grid(&mut self, cols: u16, rows: u16) {
+        let dim = LocalDim::new(cols, rows);
+        self.term.resize(dim);
+        self.row_hashes.clear();
+        self.frozen_valid = false;
+    }
+
     /// Per-segment `history_base` maintenance (spec §3):
     /// fold `history_size` decreases into `history_base`, synthesize an
     /// unmount-all on every fold, keep a frozen baseline across alt screen,
-    /// and track saturation (handled in `update_saturation`).
+    /// and track saturation (handled in `update_saturation`). Callers that
+    /// stamp anchors must run this first (see `handle_webview_verb`).
     fn run_history_maintenance(&mut self) {
         if self.term.mode().contains(TermMode::ALT_SCREEN) {
             return;
         }
         let h = self.term.history_size();
         if self.frozen_valid && h < self.frozen_history {
-            // NOTE: fold BEFORE any anchor is stamped at this stop point —
-            // the same-chunk "CSI 3 J then mount-inline" case is only
-            // correct in this order (spec §3).
             self.history_base += (self.frozen_history - h) as u64;
             self.send_synthetic_unmount_all();
         }
@@ -2039,6 +2049,18 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn resize_invalidates_baseline_and_next_segment_rebaselines_without_fold() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        seed_scrollback(&mut h, 30);
+        h.resize_grid(20, 8);
+        h.advance(b"x");
+        assert!(
+            rx.try_recv().is_err(),
+            "re-baseline after resize must not fold/unmount"
+        );
     }
 
     #[test]

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -2310,6 +2310,104 @@ mod tests {
         );
         assert!(!reached(u32::MAX - 1, 2));
     }
+
+    #[test]
+    fn drain_forwards_mount_inline_anchor_to_request() {
+        use crate::events::OscWebviewRequest;
+        use crate::title::TerminalTitle;
+        use crate::vt::listener::{ControlFrame, InlineAnchor, OscWebviewVerb};
+        use bevy::ecs::system::RunSystemOnce;
+        use bevy::prelude::*;
+
+        #[derive(Resource, Default)]
+        struct Seen(Vec<OscWebviewRequest>);
+
+        let mut app = App::new();
+        app.init_resource::<Seen>();
+        app.add_observer(|ev: On<OscWebviewRequest>, mut seen: ResMut<Seen>| {
+            seen.0.push(ev.event().clone());
+        });
+
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (inject_tx, inject_rx) = crossbeam_channel::unbounded::<ControlFrame>();
+        let (ctrl_tx, _ctrl_rx) = crossbeam_channel::unbounded::<ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let handle = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            inject_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        inject_tx
+            .send(ControlFrame::OscWebview {
+                verb: OscWebviewVerb::MountInline {
+                    view_id: "memo".into(),
+                    rows: 3,
+                    cols: 10,
+                },
+                anchor: Some(InlineAnchor {
+                    line: 42,
+                    col: 7,
+                    frame_seq: 9,
+                }),
+            })
+            .unwrap();
+
+        app.world_mut().spawn((handle, TerminalTitle::default()));
+        app.world_mut()
+            .run_system_once(
+                |mut commands: Commands,
+                 q: Query<(Entity, &TerminalHandle, &mut TerminalTitle)>| {
+                    for (entity, handle, mut title) in q {
+                        handle.drain_control_events(&mut commands, entity, &mut title);
+                    }
+                },
+            )
+            .unwrap();
+        app.world_mut().flush();
+
+        let seen = app.world().resource::<Seen>();
+        assert_eq!(seen.0.len(), 1, "exactly one OscWebviewRequest triggered");
+        let req = &seen.0[0];
+        assert!(
+            matches!(
+                req.verb,
+                OscWebviewVerb::MountInline {
+                    ref view_id,
+                    rows: 3,
+                    cols: 10
+                } if view_id == "memo"
+            ),
+            "verb must be MountInline{{memo, 3, 10}}, got {:?}",
+            req.verb
+        );
+        assert_eq!(
+            req.anchor,
+            Some(InlineAnchor {
+                line: 42,
+                col: 7,
+                frame_seq: 9
+            }),
+            "anchor must cross the drain boundary unchanged"
+        );
+    }
+
+    #[test]
+    fn c1_osc_introducer_is_rejected_not_parsed() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x9d5379;mount-inline;memo;3;10\x9c");
+        assert!(
+            rx.try_recv().is_err(),
+            "8-bit C1 OSC introducer must not reach the capture (spec section 2: 7-bit ESC ] only)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -906,7 +906,12 @@ impl TerminalHandle {
     /// Stamps the anchor / applies state gates for a buffered OSC 5379 verb
     /// at an `advance_until_terminated` stop point, then forwards the frame.
     fn handle_webview_verb(&mut self, verb: OscWebviewVerb) {
-        if self.parser.sync_bytes_count() > 0 {
+        // NOTE: only MountInline samples the cursor, so only it needs the
+        // synchronized-update (CSI ?2026) buffer flushed before the anchor is
+        // read. Flushing for the other verbs would force-end an in-flight
+        // synchronized update and tear a partial frame for no benefit.
+        if matches!(verb, OscWebviewVerb::MountInline { .. }) && self.parser.sync_bytes_count() > 0
+        {
             self.parser.stop_sync(&mut self.term);
         }
         // NOTE: maintenance (fold) must run BEFORE the anchor is stamped —
@@ -977,9 +982,12 @@ impl TerminalHandle {
     /// scrollback cap, trims become unobservable, so all inline webviews
     /// are unmounted once and further mounts are rejected until the
     /// history shrinks below the cap again (e.g. CSI 3 J).
-    // TODO: decide scroll_cap == 0 semantics when config-driven scrollback lands (0 >= 0 saturates immediately).
+    ///
+    /// `scroll_cap == 0` means "no scrollback limit configured" and never
+    /// saturates — without the guard `0 >= 0` would saturate on the first
+    /// segment and reject every inline mount permanently.
     fn update_saturation(&mut self, history_size: usize) {
-        if history_size >= self.scroll_cap {
+        if self.scroll_cap > 0 && history_size >= self.scroll_cap {
             if !self.saturated {
                 self.saturated = true;
                 tracing::debug!("scrollback saturated: unmounting all inline webviews");

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -100,6 +100,11 @@ pub struct TerminalHandle {
     row_hashes: HashMap<i32, u64>,
     window_open_mode: Option<TermMode>,
     frame_seq: u32,
+    #[expect(
+        dead_code,
+        reason = "stamped frames are wired in the follow-up advance-loop task"
+    )]
+    control_tx: Sender<ControlFrame>,
     reply_rx: Receiver<Vec<u8>>,
     control_rx: Receiver<ControlFrame>,
     osc7_parser: Parser,
@@ -122,7 +127,10 @@ impl TerminalHandle {
     ) -> Self {
         let size = LocalDim::new(cols, rows);
         let term = Term::new(Config::default(), &size, listener);
-        let control_tx2 = control_tx.clone();
+        let osc7 = Osc7Capture::new(
+            control_tx.clone(),
+            gethostname::gethostname().to_string_lossy().into_owned(),
+        );
         Self {
             term,
             parser: Processor::new(),
@@ -138,15 +146,13 @@ impl TerminalHandle {
             row_hashes: HashMap::new(),
             window_open_mode: None,
             frame_seq: 0,
+            control_tx,
             reply_rx,
             control_rx,
             osc7_parser: Parser::new(),
-            osc7: Osc7Capture::new(
-                control_tx,
-                gethostname::gethostname().to_string_lossy().into_owned(),
-            ),
+            osc7,
             osc_webview_parser: Parser::new(),
-            osc_webview: OscWebviewCapture::new(control_tx2, gate),
+            osc_webview: OscWebviewCapture::new(gate),
         }
     }
 
@@ -159,6 +165,15 @@ impl TerminalHandle {
         self.osc7_parser.advance(&mut self.osc7, chunk);
         self.osc_webview_parser
             .advance(&mut self.osc_webview, chunk);
+    }
+
+    /// Drains the buffered OSC 5379 verb left by the last `advance` call,
+    /// if any. Returns `None` when no OSC 5379 sequence was parsed or the
+    /// gate was off.
+    pub(crate) fn take_pending_osc_webview(
+        &mut self,
+    ) -> Option<crate::vt::listener::OscWebviewVerb> {
+        self.osc_webview.take_pending()
     }
 
     /// Returns true if the current `Term` cursor differs from the most
@@ -1741,22 +1756,9 @@ mod tests {
     }
 
     #[test]
-    fn advance_osc_webview_then_drain_triggers_request() {
-        use crate::events::OscWebviewRequest;
-        use crate::title::TerminalTitle;
-        use crate::vt::listener::{ControlFrame, TermListener};
-        use bevy::ecs::system::RunSystemOnce;
-        use bevy::prelude::*;
+    fn advance_osc_webview_buffers_pending_verb() {
+        use crate::vt::listener::{ControlFrame, OscWebviewVerb, TermListener};
         use crossbeam_channel::unbounded;
-
-        #[derive(Resource, Default)]
-        struct Seen(Vec<crate::vt::listener::OscWebviewVerb>);
-
-        let mut app = App::new();
-        app.init_resource::<Seen>();
-        app.add_observer(|ev: On<OscWebviewRequest>, mut seen: ResMut<Seen>| {
-            seen.0.push(ev.event().verb.clone());
-        });
 
         let (reply_tx, reply_rx) = unbounded::<Vec<u8>>();
         let (control_tx, control_rx) = unbounded::<ControlFrame>();
@@ -1775,24 +1777,16 @@ mod tests {
         );
         handle.advance(b"\x1b]5379;mount;dash\x07");
 
-        app.world_mut().spawn((handle, TerminalTitle::default()));
-        app.world_mut()
-            .run_system_once(
-                |mut commands: Commands,
-                 q: Query<(Entity, &TerminalHandle, &mut TerminalTitle)>| {
-                    for (entity, handle, mut title) in q {
-                        handle.drain_control_events(&mut commands, entity, &mut title);
-                    }
-                },
-            )
-            .unwrap();
-        app.world_mut().flush();
-
         assert_eq!(
-            app.world().resource::<Seen>().0,
-            vec![crate::vt::listener::OscWebviewVerb::Mount {
+            handle.take_pending_osc_webview(),
+            Some(OscWebviewVerb::Mount {
                 view_id: "dash".into()
-            }]
+            }),
+            "advance must buffer the parsed OSC 5379 verb in osc_webview"
+        );
+        assert!(
+            handle.take_pending_osc_webview().is_none(),
+            "second take must return None"
         );
     }
 }

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -70,10 +70,9 @@ impl Dimensions for LocalDim {
 /// Snapshot of the data the copy-mode indicator needs.
 ///
 /// Reading `Term` directly (rather than the renderer-side `TerminalGrid`
-/// component) is deliberate: `FrameDelta` does not carry `history_size`,
-/// so a `TerminalGrid` mirror would be stale between snapshots and the
-/// indicator would briefly display the wrong `total` under sustained
-/// PTY output.
+/// component) keeps the indicator exact under sustained PTY output:
+/// frames are coalesced, so the mirror may lag by up to one coalesce
+/// window even though `FrameDelta` now carries `history_size`.
 #[derive(Debug, Clone, Copy)]
 pub struct ViIndicatorSnapshot {
     /// 0-based scroll offset from the live tail (0 = bottom).
@@ -843,7 +842,14 @@ impl TerminalHandle {
         seq: u32,
         reason: SnapshotReason,
     ) {
-        let snap = build_snapshot(&self.term, entity, seq, reason, &mut self.hyperlinks);
+        let snap = build_snapshot(
+            &self.term,
+            entity,
+            seq,
+            self.history_base,
+            reason,
+            &mut self.hyperlinks,
+        );
         commands.trigger(snap);
         self.rebuild_full_row_hashes();
     }
@@ -874,7 +880,14 @@ impl TerminalHandle {
         rows: Vec<u16>,
         kept_hashes: Vec<(i32, u64)>,
     ) {
-        let delta = build_delta(&self.term, entity, seq, &rows, &mut self.hyperlinks);
+        let delta = build_delta(
+            &self.term,
+            entity,
+            seq,
+            self.history_base,
+            &rows,
+            &mut self.hyperlinks,
+        );
         self.scratch_dirty = rows;
         commands.trigger(delta);
         for (line_i32, h) in kept_hashes {
@@ -2255,6 +2268,31 @@ mod tests {
             h.test_frame_seq(),
             1,
             "with the flag consumed, an identical staged-noop emit must not advance seq"
+        );
+    }
+
+    #[test]
+    fn force_flag_survives_a_no_damage_abort() {
+        use bevy::ecs::world::{CommandQueue, World};
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        let _ = rx.try_recv().expect("mount frame");
+        assert!(h.test_force_next_emit());
+
+        h.pending_damage = None;
+        let mut world = World::new();
+        let entity = world.spawn_empty().id();
+        let mut coalescer = Coalescer::default();
+        let mut queue = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue, &world);
+            h.emit(&mut commands, entity, &mut coalescer);
+        }
+        queue.apply(&mut world);
+
+        assert!(
+            h.test_force_next_emit(),
+            "a no-damage abort must DEFER the forced frame, not discard it — hoisting the mem::take above the pending_damage guard wedges the GUI's first-projection hold"
         );
     }
 

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -670,14 +670,21 @@ impl TerminalHandle {
         let curr_vi_cursor = extract_vi_cursor(&self.term);
         let curr_selection = extract_selection_range(&self.term);
 
-        if self.is_noop_emit(
-            &dirty,
-            &curr_cursor,
-            prev_mode,
-            curr_mode,
-            curr_vi_cursor,
-            curr_selection,
-        ) {
+        // NOTE: force_next_emit guarantees a grid frame with the stamped seq
+        // reaches the renderer even for an OSC-only chunk (no damage, no
+        // cursor move) — without it the GUI's first-projection hold (spec §5)
+        // would never release for clients that violate the newline contract.
+        let force = std::mem::take(&mut self.force_next_emit);
+        if !force
+            && self.is_noop_emit(
+                &dirty,
+                &curr_cursor,
+                prev_mode,
+                curr_mode,
+                curr_vi_cursor,
+                curr_selection,
+            )
+        {
             self.finalize_emit(coalescer);
             return;
         }
@@ -957,6 +964,7 @@ impl TerminalHandle {
     /// scrollback cap, trims become unobservable, so all inline webviews
     /// are unmounted once and further mounts are rejected until the
     /// history shrinks below the cap again (e.g. CSI 3 J).
+    // TODO: decide scroll_cap == 0 semantics when config-driven scrollback lands (0 >= 0 saturates immediately).
     fn update_saturation(&mut self, history_size: usize) {
         if history_size >= self.scroll_cap {
             if !self.saturated {
@@ -979,6 +987,16 @@ impl TerminalHandle {
         if let Err(e) = self.control_tx.send(frame) {
             tracing::warn!(?e, "control_tx send(synthetic UnmountInline) failed");
         }
+    }
+
+    #[cfg(test)]
+    fn test_force_next_emit(&self) -> bool {
+        self.force_next_emit
+    }
+
+    #[cfg(test)]
+    fn test_frame_seq(&self) -> u32 {
+        self.frame_seq
     }
 }
 
@@ -2098,8 +2116,8 @@ mod tests {
     #[test]
     fn saturation_first_arrival_unmounts_all_and_rejects_mounts() {
         let (mut h, rx) = handle_with_gate_on(10, 3);
-        let mut payload = Vec::with_capacity(64 * 1024);
-        for _ in 0..10_010 {
+        let mut payload = Vec::new();
+        for _ in 0..h.scroll_cap + 10 {
             payload.extend_from_slice(b"x\r\n");
         }
         h.advance(&payload);
@@ -2123,7 +2141,14 @@ mod tests {
             "mount-inline rejected while saturated"
         );
         h.advance(b"\x1b[3J");
-        let _fold = rx.try_recv().expect("fold unmount on clear");
+        let fold = rx.try_recv().expect("fold unmount on clear");
+        assert!(matches!(
+            fold,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                ..
+            }
+        ));
         h.advance(b"\x1b]5379;mount-inline;memo;2;5\x1b\\");
         let frame = rx.try_recv().expect("mount accepted after clear");
         assert!(matches!(
@@ -2146,10 +2171,106 @@ mod tests {
         );
         h.advance(b"\x1b[?1049l");
         h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
-        assert!(
-            rx.try_recv().is_ok(),
-            "accepted again after returning to primary"
+        let frame = rx
+            .try_recv()
+            .expect("accepted again after returning to primary");
+        assert!(matches!(
+            frame,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::MountInline { .. },
+                anchor: Some(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn mount_inside_synchronized_update_samples_flushed_state() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        let mut payload = b"\x1b[?2026h\r\n\r\n".to_vec();
+        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(&payload);
+        let ControlFrame::OscWebview {
+            anchor: Some(anchor),
+            ..
+        } = rx.try_recv().expect("mount frame")
+        else {
+            panic!("expected mount with anchor");
+        };
+        assert_eq!(
+            anchor.line, 2,
+            "stop_sync must flush the BSU buffer before sampling"
         );
+    }
+
+    #[test]
+    fn mount_stamps_next_emit_seq_and_force_flag_bypasses_noop() {
+        use bevy::ecs::world::{CommandQueue, World};
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        let ControlFrame::OscWebview {
+            anchor: Some(anchor),
+            ..
+        } = rx.try_recv().expect("mount frame")
+        else {
+            panic!("expected mount with anchor");
+        };
+        assert_eq!(
+            anchor.frame_seq, 0,
+            "stamped seq = value the NEXT emit carries"
+        );
+        assert!(
+            h.test_force_next_emit(),
+            "accepted mount must arm the force flag"
+        );
+
+        h.first_emit = false;
+        h.prev_cursor = Some(extract_cursor(&h.term));
+        h.pending_damage = Some(crate::vt::damage::DirtyRows::Rows(Vec::new()));
+
+        let mut world = World::new();
+        let entity = world.spawn_empty().id();
+        let mut coalescer = Coalescer::default();
+        let mut queue = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue, &world);
+            h.emit(&mut commands, entity, &mut coalescer);
+        }
+        queue.apply(&mut world);
+
+        assert_eq!(
+            h.test_frame_seq(),
+            1,
+            "forced emit must consume seq 0 (a frame was emitted despite no observable change)"
+        );
+        assert!(!h.test_force_next_emit(), "force flag is one-shot");
+
+        h.pending_damage = Some(crate::vt::damage::DirtyRows::Rows(Vec::new()));
+        let mut queue = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue, &world);
+            h.emit(&mut commands, entity, &mut coalescer);
+        }
+        queue.apply(&mut world);
+        assert_eq!(
+            h.test_frame_seq(),
+            1,
+            "with the flag consumed, an identical staged-noop emit must not advance seq"
+        );
+    }
+
+    #[test]
+    fn seq_wrap_comparison_is_serial_number_arithmetic() {
+        fn reached(last_seq: u32, stamped: u32) -> bool {
+            last_seq.wrapping_sub(stamped) as i32 >= 0
+        }
+        assert!(reached(5, 5));
+        assert!(reached(6, 5));
+        assert!(!reached(4, 5));
+        assert!(
+            reached(2, u32::MAX - 1),
+            "wrap: last_seq passed the boundary"
+        );
+        assert!(!reached(u32::MAX - 1, 2));
     }
 }
 

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -101,15 +101,7 @@ pub struct TerminalHandle {
     window_open_mode: Option<TermMode>,
     frame_seq: u32,
     history_base: u64,
-    #[expect(
-        dead_code,
-        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
-    )]
     frozen_history: usize,
-    #[expect(
-        dead_code,
-        reason = "read once run_history_maintenance is fleshed out in the follow-up task"
-    )]
     frozen_valid: bool,
     saturated: bool,
     force_next_emit: bool,
@@ -252,6 +244,7 @@ impl TerminalHandle {
         let dim = LocalDim::new(cols, rows);
         self.term.resize(dim);
         self.row_hashes.clear();
+        self.frozen_valid = false;
         pty.resize(cols, rows)?;
         self.stage_full_damage_and_arm(coalescer);
         Ok(())
@@ -933,9 +926,42 @@ impl TerminalHandle {
         }
     }
 
-    /// Per-segment history_base maintenance (spec §3). Fleshed out in a
-    /// follow-up task; the call sites are already final.
-    fn run_history_maintenance(&mut self) {}
+    /// Per-segment `history_base` maintenance (spec §3):
+    /// fold `history_size` decreases into `history_base`, synthesize an
+    /// unmount-all on every fold, keep a frozen baseline across alt screen,
+    /// and track saturation (handled in `update_saturation`).
+    fn run_history_maintenance(&mut self) {
+        if self.term.mode().contains(TermMode::ALT_SCREEN) {
+            return;
+        }
+        let h = self.term.history_size();
+        if self.frozen_valid && h < self.frozen_history {
+            // NOTE: fold BEFORE any anchor is stamped at this stop point —
+            // the same-chunk "CSI 3 J then mount-inline" case is only
+            // correct in this order (spec §3).
+            self.history_base += (self.frozen_history - h) as u64;
+            self.send_synthetic_unmount_all();
+        }
+        self.frozen_history = h;
+        self.frozen_valid = true;
+        self.update_saturation(h);
+    }
+
+    /// Saturation gate state (spec §3). Fleshed out in the next task;
+    /// the call site is already final.
+    fn update_saturation(&mut self, _history_size: usize) {}
+
+    /// Sends the VT-synthesized unmount-all used by both the fold rule and
+    /// the saturation first-arrival rule.
+    fn send_synthetic_unmount_all(&mut self) {
+        let frame = ControlFrame::OscWebview {
+            verb: OscWebviewVerb::UnmountInline { view_id: None },
+            anchor: None,
+        };
+        if let Err(e) = self.control_tx.send(frame) {
+            tracing::warn!(?e, "control_tx send(synthetic UnmountInline) failed");
+        }
+    }
 }
 
 /// Classification used by `decide_frame_kind` to select snapshot vs
@@ -1927,6 +1953,116 @@ mod tests {
         };
         assert_eq!(get(first), 0);
         assert_eq!(get(second), 2);
+    }
+
+    fn seed_scrollback(h: &mut TerminalHandle, lines: usize) {
+        let mut payload = Vec::new();
+        for i in 0..lines {
+            payload.extend_from_slice(format!("l{i}\r\n").as_bytes());
+        }
+        h.advance(&payload);
+    }
+
+    #[test]
+    fn clear_scrollback_folds_into_history_base_and_unmounts_all() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        seed_scrollback(&mut h, 30);
+        let hist_before = h.vi_indicator_snapshot().history_size;
+        assert!(hist_before > 0, "precondition: scrollback non-empty");
+        h.advance(b"\x1b[3J");
+        let frame = rx.try_recv().expect("synthesized UnmountInline");
+        assert_eq!(
+            frame,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                anchor: None,
+            }
+        );
+    }
+
+    #[test]
+    fn clear_then_mount_in_same_chunk_anchors_after_fold() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        seed_scrollback(&mut h, 30);
+        let hist = h.vi_indicator_snapshot().history_size as u64;
+        let mut payload = b"\x1b[3J".to_vec();
+        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(&payload);
+        let first = rx.try_recv().expect("fold unmount first");
+        assert!(matches!(
+            first,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                ..
+            }
+        ));
+        let ControlFrame::OscWebview {
+            anchor: Some(anchor),
+            ..
+        } = rx.try_recv().expect("mount second")
+        else {
+            panic!("expected mount frame with anchor");
+        };
+        // NOTE: the invariant is anchor = history_base(=hist)
+        // + history_size(0 after 3J) + live cursor row. cursor.y from
+        // read_geometry is the viewport row, which equals the live-grid
+        // row because display_offset is 0 at the live tail.
+        let (_, _, cursor) = h.read_geometry();
+        assert_eq!(anchor.line, hist + cursor.y as u64);
+    }
+
+    #[test]
+    fn alt_screen_roundtrip_does_not_fold() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        seed_scrollback(&mut h, 30);
+        h.advance(b"\x1b[?1049h");
+        h.advance(b"\x1b[?1049l");
+        assert!(
+            rx.try_recv().is_err(),
+            "no synthesized frames on alt roundtrip"
+        );
+    }
+
+    #[test]
+    fn alt_exit_plus_clear_in_one_chunk_still_folds() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        seed_scrollback(&mut h, 30);
+        h.advance(b"\x1b[?1049h");
+        h.advance(b"\x1b[?1049l\x1b[3J");
+        let frame = rx
+            .try_recv()
+            .expect("fold must be detected against the frozen baseline");
+        assert!(matches!(
+            frame,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bel_terminated_mount_at_exact_chunk_end_is_drained_in_same_call() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x07");
+        assert!(
+            matches!(rx.try_recv(), Ok(ControlFrame::OscWebview { .. })),
+            "verb must be drained in the same advance call even when the chunk ends at BEL"
+        );
+    }
+
+    #[test]
+    fn mount_anchor_col_reflects_text_before_osc_on_same_row() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"ab\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        let ControlFrame::OscWebview {
+            anchor: Some(a), ..
+        } = rx.try_recv().expect("frame")
+        else {
+            panic!("expected mount frame");
+        };
+        assert_eq!(a.col, 2, "cursor column after printing 'ab' is 2");
+        assert_eq!(a.line, 0);
     }
 }
 

--- a/crates/bevy_terminal/src/handle.rs
+++ b/crates/bevy_terminal/src/handle.rs
@@ -105,10 +105,6 @@ pub struct TerminalHandle {
     frozen_valid: bool,
     saturated: bool,
     force_next_emit: bool,
-    #[expect(
-        dead_code,
-        reason = "read by the saturation gate in the follow-up task"
-    )]
     scroll_cap: usize,
     control_tx: Sender<ControlFrame>,
     reply_rx: Receiver<Vec<u8>>,
@@ -957,9 +953,21 @@ impl TerminalHandle {
         self.update_saturation(h);
     }
 
-    /// Saturation gate state (spec §3). Fleshed out in the next task;
-    /// the call site is already final.
-    fn update_saturation(&mut self, _history_size: usize) {}
+    /// Saturation policy (spec §3): once `history_size` reaches the
+    /// scrollback cap, trims become unobservable, so all inline webviews
+    /// are unmounted once and further mounts are rejected until the
+    /// history shrinks below the cap again (e.g. CSI 3 J).
+    fn update_saturation(&mut self, history_size: usize) {
+        if history_size >= self.scroll_cap {
+            if !self.saturated {
+                self.saturated = true;
+                tracing::debug!("scrollback saturated: unmounting all inline webviews");
+                self.send_synthetic_unmount_all();
+            }
+        } else {
+            self.saturated = false;
+        }
+    }
 
     /// Sends the VT-synthesized unmount-all used by both the fold rule and
     /// the saturation first-arrival rule.
@@ -2085,6 +2093,63 @@ mod tests {
         };
         assert_eq!(a.col, 2, "cursor column after printing 'ab' is 2");
         assert_eq!(a.line, 0);
+    }
+
+    #[test]
+    fn saturation_first_arrival_unmounts_all_and_rejects_mounts() {
+        let (mut h, rx) = handle_with_gate_on(10, 3);
+        let mut payload = Vec::with_capacity(64 * 1024);
+        for _ in 0..10_010 {
+            payload.extend_from_slice(b"x\r\n");
+        }
+        h.advance(&payload);
+        let frame = rx
+            .try_recv()
+            .expect("saturation first-arrival synthesizes unmount-all");
+        assert!(matches!(
+            frame,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::UnmountInline { view_id: None },
+                ..
+            }
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "unmount-all fires exactly once while saturated"
+        );
+        h.advance(b"\x1b]5379;mount-inline;memo;2;5\x1b\\");
+        assert!(
+            rx.try_recv().is_err(),
+            "mount-inline rejected while saturated"
+        );
+        h.advance(b"\x1b[3J");
+        let _fold = rx.try_recv().expect("fold unmount on clear");
+        h.advance(b"\x1b]5379;mount-inline;memo;2;5\x1b\\");
+        let frame = rx.try_recv().expect("mount accepted after clear");
+        assert!(matches!(
+            frame,
+            ControlFrame::OscWebview {
+                verb: OscWebviewVerb::MountInline { .. },
+                anchor: Some(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn alt_screen_mount_rejected() {
+        let (mut h, rx) = handle_with_gate_on(20, 5);
+        h.advance(b"\x1b[?1049h");
+        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        assert!(
+            rx.try_recv().is_err(),
+            "mount-inline rejected on alt screen"
+        );
+        h.advance(b"\x1b[?1049l");
+        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        assert!(
+            rx.try_recv().is_ok(),
+            "accepted again after returning to primary"
+        );
     }
 }
 

--- a/crates/bevy_terminal/src/lib.rs
+++ b/crates/bevy_terminal/src/lib.rs
@@ -34,5 +34,5 @@ pub use mouse_encode::ProtocolModifiers;
 pub use plugin::TerminalHandlePlugin;
 pub use pty::PtyHandle;
 pub use title::{TerminalTitle, sanitize_title};
-pub use vt::listener::OscWebviewVerb;
+pub use vt::listener::{InlineAnchor, OscWebviewVerb};
 pub use wheel::{CellCoord, WheelAction, WheelConfig, WheelDir, WheelModifiers};

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -100,11 +100,18 @@ impl Perform for OscWebviewCapture {
                 let Some(cols) = parse_dim(params.get(4).copied(), MAX_COLS) else {
                     return;
                 };
+                let instance_id = match params.get(5).copied() {
+                    Some(raw) => match valid_view_id(raw) {
+                        Some(v) => Some(v),
+                        None => return,
+                    },
+                    None => None,
+                };
                 OscWebviewVerb::MountInline {
                     view_id,
                     rows,
                     cols,
-                    instance_id: None,
+                    instance_id,
                 }
             }
             Some(b"unmount-inline") => {
@@ -304,6 +311,82 @@ mod tests {
         let mut c = cap(true);
         c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3"], true);
         assert!(c.take_pending().is_none());
+    }
+
+    #[test]
+    fn mount_inline_parses_instance_id() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[
+                OSC_WEBVIEW_CODE,
+                b"mount-inline",
+                b"memo",
+                b"3",
+                b"20",
+                b"a",
+            ],
+            true,
+        );
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 3,
+                cols: 20,
+                instance_id: Some("a".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn mount_inline_absent_instance_id_is_none() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            true,
+        );
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 3,
+                cols: 20,
+                instance_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_inline_trailing_empty_instance_id_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20", b""],
+            true,
+        );
+        assert!(
+            c.take_pending().is_none(),
+            "a trailing empty instance id (mount-inline;memo;3;20;) is malformed"
+        );
+    }
+
+    #[test]
+    fn mount_inline_bad_instance_id_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[
+                OSC_WEBVIEW_CODE,
+                b"mount-inline",
+                b"memo",
+                b"3",
+                b"20",
+                b"../etc",
+            ],
+            true,
+        );
+        assert!(
+            c.take_pending().is_none(),
+            "an out-of-charset instance id is malformed"
+        );
     }
 
     #[test]

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -1,9 +1,9 @@
-//! Sibling `vte::Perform` that captures the ozmux private OSC for webview
-//! mount/unmount and forwards it as a `ControlFrame::OscWebview` — but only when
-//! the shared default-off gate is enabled.
+//! Sibling `vte::Perform` that captures OSC 5379 payloads and buffers one
+//! parsed verb per sequence for `TerminalHandle::advance` to drain at the
+//! `advance_until_terminated` stop point — where the inline anchor is stamped.
+//! Never sends frames itself.
 
-use crate::vt::listener::{ControlFrame, OscWebviewVerb};
-use crossbeam_channel::Sender;
+use crate::vt::listener::OscWebviewVerb;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use vte::Perform;
@@ -13,18 +13,32 @@ use vte::Perform;
 pub(crate) const OSC_WEBVIEW_CODE: &[u8] = b"5379";
 
 const MAX_VIEW_ID: usize = 128;
+const MAX_ROWS: u16 = 200;
+const MAX_COLS: u16 = 400;
 
-/// A `vte::Perform` that captures OSC 5379 payloads and emits
-/// `ControlFrame::OscWebview` on the control channel when the gate is on.
+/// A `vte::Perform` that parses OSC 5379 payloads and buffers ONE verb for
+/// `TerminalHandle::advance` to drain at the `advance_until_terminated`
+/// stop point (where the anchor is stamped). It never sends frames itself.
 pub(crate) struct OscWebviewCapture {
-    control_tx: Sender<ControlFrame>,
     gate: Arc<AtomicBool>,
+    pending: Option<OscWebviewVerb>,
 }
 
 impl OscWebviewCapture {
-    /// Builds a capture that sends frames on `control_tx` only when `gate` is `true`.
-    pub(crate) fn new(control_tx: Sender<ControlFrame>, gate: Arc<AtomicBool>) -> Self {
-        Self { control_tx, gate }
+    /// Builds a capture that buffers verbs only while `gate` is `true`.
+    pub(crate) fn new(gate: Arc<AtomicBool>) -> Self {
+        Self {
+            gate,
+            pending: None,
+        }
+    }
+
+    /// Takes the buffered verb, clearing `terminated()`.
+    // NOTE: the caller MUST take the pending verb after every
+    // advance_until_terminated stop; a stuck pending makes the next call
+    // return 0 forever (infinite loop in TerminalHandle::advance).
+    pub(crate) fn take_pending(&mut self) -> Option<OscWebviewVerb> {
+        self.pending.take()
     }
 }
 
@@ -39,6 +53,12 @@ fn valid_view_id(s: &[u8]) -> Option<String> {
         return None;
     }
     Some(String::from_utf8_lossy(s).into_owned())
+}
+
+fn parse_dim(raw: Option<&[u8]>, max: u16) -> Option<u16> {
+    let s = std::str::from_utf8(raw?).ok()?;
+    let v: u16 = s.parse().ok()?;
+    (1..=max).contains(&v).then_some(v)
 }
 
 impl Perform for OscWebviewCapture {
@@ -67,100 +87,181 @@ impl Perform for OscWebviewCapture {
                 };
                 OscWebviewVerb::Unmount { view_id }
             }
+            Some(b"mount-inline") => {
+                let Some(view_id) = params.get(2).copied().and_then(valid_view_id) else {
+                    return;
+                };
+                let Some(rows) = parse_dim(params.get(3).copied(), MAX_ROWS) else {
+                    return;
+                };
+                let Some(cols) = parse_dim(params.get(4).copied(), MAX_COLS) else {
+                    return;
+                };
+                OscWebviewVerb::MountInline {
+                    view_id,
+                    rows,
+                    cols,
+                }
+            }
+            Some(b"unmount-inline") => {
+                let view_id = match params.get(2).copied() {
+                    Some(raw) => match valid_view_id(raw) {
+                        Some(v) => Some(v),
+                        None => return,
+                    },
+                    None => None,
+                };
+                OscWebviewVerb::UnmountInline { view_id }
+            }
             _ => return,
         };
-        if let Err(e) = self
-            .control_tx
-            .send(ControlFrame::OscWebview { verb, anchor: None })
-        {
-            tracing::warn!(?e, "control_tx send(OscWebview) failed");
-        }
+        self.pending = Some(verb);
+    }
+
+    fn terminated(&self) -> bool {
+        self.pending.is_some()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossbeam_channel::unbounded;
 
-    #[test]
-    fn gate_off_drops_sequence() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(false)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
-        assert!(rx.try_recv().is_err());
+    fn cap(gate_on: bool) -> OscWebviewCapture {
+        OscWebviewCapture::new(Arc::new(AtomicBool::new(gate_on)))
     }
 
     #[test]
-    fn gate_on_emits_mount() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
+    fn gate_off_drops_sequence() {
+        let mut c = cap(false);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
+        assert!(c.take_pending().is_none());
+    }
+
+    #[test]
+    fn gate_on_buffers_mount_and_terminated_reflects_pending() {
+        let mut c = cap(true);
+        assert!(!Perform::terminated(&c));
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
+        assert!(Perform::terminated(&c), "pending verb must set terminated");
         assert_eq!(
-            rx.try_recv(),
-            Ok(ControlFrame::OscWebview {
-                verb: OscWebviewVerb::Mount {
-                    view_id: "dash".into()
-                },
-                anchor: None,
+            c.take_pending(),
+            Some(OscWebviewVerb::Mount {
+                view_id: "dash".into()
             })
+        );
+        assert!(
+            !Perform::terminated(&c),
+            "take_pending must clear terminated or advance_until_terminated loops forever"
         );
     }
 
     #[test]
     fn other_osc_code_ignored() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[b"7", b"file://localhost/tmp"], true);
-        assert!(rx.try_recv().is_err());
+        let mut c = cap(true);
+        c.osc_dispatch(&[b"7", b"file://localhost/tmp"], true);
+        assert!(c.take_pending().is_none());
     }
 
     #[test]
     fn bad_view_id_rejected() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"../etc/passwd"], true);
-        assert!(rx.try_recv().is_err());
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"../etc/passwd"], true);
+        assert!(c.take_pending().is_none());
     }
 
     #[test]
     fn unmount_without_view_id_targets_any() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount"], true);
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount"], true);
         assert_eq!(
-            rx.try_recv(),
-            Ok(ControlFrame::OscWebview {
-                verb: OscWebviewVerb::Unmount { view_id: None },
-                anchor: None,
-            })
-        );
-    }
-
-    #[test]
-    fn unmount_with_valid_view_id_targets_it() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"dash"], true);
-        assert_eq!(
-            rx.try_recv(),
-            Ok(ControlFrame::OscWebview {
-                verb: OscWebviewVerb::Unmount {
-                    view_id: Some("dash".into())
-                },
-                anchor: None,
-            })
+            c.take_pending(),
+            Some(OscWebviewVerb::Unmount { view_id: None })
         );
     }
 
     #[test]
     fn unmount_with_invalid_view_id_dropped() {
-        let (tx, rx) = unbounded();
-        let mut cap = OscWebviewCapture::new(tx, Arc::new(AtomicBool::new(true)));
-        cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"../etc/passwd"], true);
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"../etc/passwd"], true);
+        assert!(c.take_pending().is_none());
+    }
+
+    #[test]
+    fn mount_inline_parses_rows_cols() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            true,
+        );
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 3,
+                cols: 20,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_inline_out_of_range_dims_dropped() {
+        for (r, w) in [
+            ("0", "20"),
+            ("201", "20"),
+            ("3", "0"),
+            ("3", "401"),
+            ("x", "20"),
+        ] {
+            let mut c = cap(true);
+            c.osc_dispatch(
+                &[
+                    OSC_WEBVIEW_CODE,
+                    b"mount-inline",
+                    b"memo",
+                    r.as_bytes(),
+                    w.as_bytes(),
+                ],
+                true,
+            );
+            assert!(
+                c.take_pending().is_none(),
+                "rows={r} cols={w} must be malformed"
+            );
+        }
+    }
+
+    #[test]
+    fn mount_inline_missing_dims_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount-inline", b"memo"], true);
+        assert!(c.take_pending().is_none());
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3"], true);
+        assert!(c.take_pending().is_none());
+    }
+
+    #[test]
+    fn unmount_inline_absent_param_is_all_but_empty_param_is_malformed() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline"], true);
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::UnmountInline { view_id: None })
+        );
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b""], true);
         assert!(
-            rx.try_recv().is_err(),
-            "a present-but-invalid unmount view-id must drop, not unmount-any"
+            c.take_pending().is_none(),
+            "empty third param is malformed, not unmount-all"
+        );
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo"], true);
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::UnmountInline {
+                view_id: Some("memo".into())
+            })
         );
     }
 }

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -69,7 +69,10 @@ impl Perform for OscWebviewCapture {
             }
             _ => return,
         };
-        if let Err(e) = self.control_tx.send(ControlFrame::OscWebview(verb)) {
+        if let Err(e) = self
+            .control_tx
+            .send(ControlFrame::OscWebview { verb, anchor: None })
+        {
             tracing::warn!(?e, "control_tx send(OscWebview) failed");
         }
     }
@@ -95,9 +98,12 @@ mod tests {
         cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
         assert_eq!(
             rx.try_recv(),
-            Ok(ControlFrame::OscWebview(OscWebviewVerb::Mount {
-                view_id: "dash".into()
-            }))
+            Ok(ControlFrame::OscWebview {
+                verb: OscWebviewVerb::Mount {
+                    view_id: "dash".into()
+                },
+                anchor: None,
+            })
         );
     }
 
@@ -124,9 +130,10 @@ mod tests {
         cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount"], true);
         assert_eq!(
             rx.try_recv(),
-            Ok(ControlFrame::OscWebview(OscWebviewVerb::Unmount {
-                view_id: None
-            }))
+            Ok(ControlFrame::OscWebview {
+                verb: OscWebviewVerb::Unmount { view_id: None },
+                anchor: None,
+            })
         );
     }
 
@@ -137,9 +144,12 @@ mod tests {
         cap.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"dash"], true);
         assert_eq!(
             rx.try_recv(),
-            Ok(ControlFrame::OscWebview(OscWebviewVerb::Unmount {
-                view_id: Some("dash".into())
-            }))
+            Ok(ControlFrame::OscWebview {
+                verb: OscWebviewVerb::Unmount {
+                    view_id: Some("dash".into())
+                },
+                anchor: None,
+            })
         );
     }
 

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -104,6 +104,7 @@ impl Perform for OscWebviewCapture {
                     view_id,
                     rows,
                     cols,
+                    instance_id: None,
                 }
             }
             Some(b"unmount-inline") => {
@@ -114,7 +115,10 @@ impl Perform for OscWebviewCapture {
                     },
                     None => None,
                 };
-                OscWebviewVerb::UnmountInline { view_id }
+                OscWebviewVerb::UnmountInline {
+                    view_id,
+                    instance_id: None,
+                }
             }
             _ => return,
         };
@@ -203,6 +207,7 @@ mod tests {
                 view_id: "memo".into(),
                 rows: 3,
                 cols: 20,
+                instance_id: None,
             })
         );
     }
@@ -247,6 +252,7 @@ mod tests {
                 view_id: "memo".into(),
                 rows: 1,
                 cols: 1,
+                instance_id: None,
             })
         );
     }
@@ -264,6 +270,7 @@ mod tests {
                 view_id: "memo".into(),
                 rows: 200,
                 cols: 400,
+                instance_id: None,
             })
         );
     }
@@ -305,7 +312,10 @@ mod tests {
         c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline"], true);
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::UnmountInline { view_id: None })
+            Some(OscWebviewVerb::UnmountInline {
+                view_id: None,
+                instance_id: None,
+            })
         );
         let mut c = cap(true);
         c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b""], true);
@@ -318,7 +328,8 @@ mod tests {
         assert_eq!(
             c.take_pending(),
             Some(OscWebviewVerb::UnmountInline {
-                view_id: Some("memo".into())
+                view_id: Some("memo".into()),
+                instance_id: None,
             })
         );
     }

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -37,6 +37,12 @@ impl OscWebviewCapture {
     // NOTE: the caller MUST take the pending verb after every
     // advance_until_terminated stop; a stuck pending makes the next call
     // return 0 forever (infinite loop in TerminalHandle::advance).
+    // NOTE: cfg_attr(not(test)) because the tests below call this method —
+    // a bare #[expect] would be unfulfilled in test builds and warn.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "drain point for the follow-up advance-loop task")
+    )]
     pub(crate) fn take_pending(&mut self) -> Option<OscWebviewVerb> {
         self.pending.take()
     }

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -37,12 +37,6 @@ impl OscWebviewCapture {
     // NOTE: the caller MUST take the pending verb after every
     // advance_until_terminated stop; a stuck pending makes the next call
     // return 0 forever (infinite loop in TerminalHandle::advance).
-    // NOTE: cfg_attr(not(test)) because the tests below call this method —
-    // a bare #[expect] would be unfulfilled in test builds and warn.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "drain point for the follow-up advance-loop task")
-    )]
     pub(crate) fn take_pending(&mut self) -> Option<OscWebviewVerb> {
         self.pending.take()
     }
@@ -63,6 +57,9 @@ fn valid_view_id(s: &[u8]) -> Option<String> {
 
 fn parse_dim(raw: Option<&[u8]>, max: u16) -> Option<u16> {
     let s = std::str::from_utf8(raw?).ok()?;
+    if !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
     let v: u16 = s.parse().ok()?;
     (1..=max).contains(&v).then_some(v)
 }
@@ -233,6 +230,61 @@ mod tests {
             assert!(
                 c.take_pending().is_none(),
                 "rows={r} cols={w} must be malformed"
+            );
+        }
+    }
+
+    #[test]
+    fn mount_inline_minimum_dims_accepted() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"1", b"1"],
+            true,
+        );
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 1,
+                cols: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_inline_maximum_dims_accepted() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"200", b"400"],
+            true,
+        );
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 200,
+                cols: 400,
+            })
+        );
+    }
+
+    #[test]
+    fn mount_inline_non_digit_dims_dropped() {
+        for (r, w) in [("3", "y"), ("+3", "20"), ("3", "+20")] {
+            let mut c = cap(true);
+            c.osc_dispatch(
+                &[
+                    OSC_WEBVIEW_CODE,
+                    b"mount-inline",
+                    b"memo",
+                    r.as_bytes(),
+                    w.as_bytes(),
+                ],
+                true,
+            );
+            assert!(
+                c.take_pending().is_none(),
+                "rows={r} cols={w} must be malformed (digits only)"
             );
         }
     }

--- a/crates/bevy_terminal/src/osc_webview.rs
+++ b/crates/bevy_terminal/src/osc_webview.rs
@@ -115,7 +115,24 @@ impl Perform for OscWebviewCapture {
                 }
             }
             Some(b"unmount-inline") => {
+                // NOTE: a present-but-invalid view id is malformed, not "unmount
+                // any"; only an ABSENT third param means "all inline on this
+                // terminal". An empty third param (`unmount-inline ; ;`) is
+                // rejected by valid_view_id.
                 let view_id = match params.get(2).copied() {
+                    Some(raw) => match valid_view_id(raw) {
+                        Some(v) => Some(v),
+                        None => return,
+                    },
+                    None => None,
+                };
+                // NOTE: an instance id is addressable only alongside a view id
+                // (Kitty placement model); the empty-view-id case is already
+                // dropped above, so reaching here with `view_id == None` and a
+                // present fourth param is impossible, but the guard keeps the
+                // `view_id == None ⟹ instance_id == None` invariant explicit.
+                let instance_id = match params.get(3).copied() {
+                    Some(_) if view_id.is_none() => return,
                     Some(raw) => match valid_view_id(raw) {
                         Some(v) => Some(v),
                         None => return,
@@ -124,7 +141,7 @@ impl Perform for OscWebviewCapture {
                 };
                 OscWebviewVerb::UnmountInline {
                     view_id,
-                    instance_id: None,
+                    instance_id,
                 }
             }
             _ => return,
@@ -414,6 +431,65 @@ mod tests {
                 view_id: Some("memo".into()),
                 instance_id: None,
             })
+        );
+    }
+
+    #[test]
+    fn unmount_inline_parses_view_and_instance() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b"a"], true);
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::UnmountInline {
+                view_id: Some("memo".into()),
+                instance_id: Some("a".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn unmount_inline_view_only_has_no_instance() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo"], true);
+        assert_eq!(
+            c.take_pending(),
+            Some(OscWebviewVerb::UnmountInline {
+                view_id: Some("memo".into()),
+                instance_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn unmount_inline_trailing_empty_instance_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b""], true);
+        assert!(
+            c.take_pending().is_none(),
+            "unmount-inline;memo; (empty instance) is malformed"
+        );
+    }
+
+    #[test]
+    fn unmount_inline_empty_view_with_instance_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"", b"a"], true);
+        assert!(
+            c.take_pending().is_none(),
+            "unmount-inline;;a (empty view id + instance) is malformed"
+        );
+    }
+
+    #[test]
+    fn unmount_inline_bad_instance_dropped() {
+        let mut c = cap(true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b"../x"],
+            true,
+        );
+        assert!(
+            c.take_pending().is_none(),
+            "an out-of-charset instance id is malformed"
         );
     }
 }

--- a/crates/bevy_terminal/src/vt/frame_builder.rs
+++ b/crates/bevy_terminal/src/vt/frame_builder.rs
@@ -41,6 +41,7 @@ pub(crate) fn build_snapshot<T>(
     term: &Term<T>,
     entity: Entity,
     seq: u32,
+    history_base: u64,
     reason: SnapshotReason,
     interner: &mut HyperlinkInterner,
 ) -> FrameSnapshot {
@@ -68,6 +69,7 @@ pub(crate) fn build_snapshot<T>(
             .collect(),
         display_offset: term.grid().display_offset() as u32,
         history_size: term.history_size() as u32,
+        history_base,
         vi_cursor: extract_vi_cursor(term),
         selection: extract_selection_range(term),
     }
@@ -81,6 +83,7 @@ pub(crate) fn build_delta<T>(
     term: &Term<T>,
     entity: Entity,
     seq: u32,
+    history_base: u64,
     rows: &[u16],
     interner: &mut HyperlinkInterner,
 ) -> FrameDelta {
@@ -103,6 +106,8 @@ pub(crate) fn build_delta<T>(
             .map(|(id, uri)| Hyperlink { id, uri })
             .collect(),
         display_offset: term.grid().display_offset() as u32,
+        history_size: term.history_size() as u32,
+        history_base,
         vi_cursor: extract_vi_cursor(term),
         selection: extract_selection_range(term),
     }
@@ -456,6 +461,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             5,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -484,6 +490,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -501,6 +508,7 @@ mod tests {
         let snap = build_snapshot(
             &term,
             Entity::PLACEHOLDER,
+            0,
             0,
             SnapshotReason::Initial,
             &mut interner,
@@ -521,6 +529,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -539,6 +548,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -552,7 +562,7 @@ mod tests {
         let mut term = make_term(10, 3);
         install_text(&mut term, "xyz");
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 9, &[0u16], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 9, 0, &[0u16], &mut interner);
         assert_eq!(delta.seq, 9);
         assert_eq!(delta.dirty_rows.len(), 1);
         assert_eq!(delta.dirty_rows[0].row, 0);
@@ -569,7 +579,7 @@ mod tests {
         let mut term = make_term(10, 3);
         install_text(&mut term, "aaa\r\nbbb\r\nccc");
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, &[0, 2], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, 0, &[0, 2], &mut interner);
         assert_eq!(delta.dirty_rows.len(), 2);
         assert_eq!(delta.dirty_rows[0].row, 0);
         assert_eq!(delta.dirty_rows[1].row, 2);
@@ -579,7 +589,7 @@ mod tests {
     fn delta_empty_rows_slice_yields_empty_dirty_rows() {
         let term = make_term(10, 3);
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 100, &[], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 100, 0, &[], &mut interner);
         assert_eq!(delta.seq, 100);
         assert!(delta.dirty_rows.is_empty());
     }
@@ -589,7 +599,7 @@ mod tests {
         let mut term = make_term(10, 3);
         install_text(&mut term, "abc");
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 1, &[0], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 1, 0, &[0], &mut interner);
         assert_eq!(delta.cursor.x, 3);
         assert_eq!(delta.cursor.y, 0);
         assert!(delta.cursor.visible);
@@ -654,11 +664,13 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            4,
             SnapshotReason::Initial,
             &mut interner,
         );
         assert_eq!(snap.display_offset, 2);
         assert!(snap.history_size >= 2, "history_size={}", snap.history_size);
+        assert_eq!(snap.history_base, 4);
     }
 
     #[test]
@@ -754,6 +766,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -781,7 +794,7 @@ mod tests {
         }
         term.scroll_display(Scroll::Top);
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, &[0u16], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, 4, &[0u16], &mut interner);
         let row0: String = delta.dirty_rows[0]
             .runs
             .iter()
@@ -791,6 +804,11 @@ mod tests {
             row0.starts_with("alpha"),
             "delta row 0 after Scroll::Top should be oldest history line; got {row0:?}",
         );
+        assert!(
+            delta.history_size > 0,
+            "delta must mirror Term::history_size"
+        );
+        assert_eq!(delta.history_base, 4);
     }
 
     #[test]
@@ -944,6 +962,7 @@ mod tests {
             &term,
             Entity::PLACEHOLDER,
             0,
+            0,
             SnapshotReason::Initial,
             &mut interner,
         );
@@ -967,7 +986,7 @@ mod tests {
         sel.update(p, Side::Right);
         term.selection = Some(sel);
         let mut interner = HyperlinkInterner::new();
-        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, &[0u16], &mut interner);
+        let delta = build_delta(&term, Entity::PLACEHOLDER, 0, 0, &[0u16], &mut interner);
         assert!(
             delta.selection.is_some(),
             "selection present → delta must carry it"

--- a/crates/bevy_terminal/src/vt/listener.rs
+++ b/crates/bevy_terminal/src/vt/listener.rs
@@ -22,9 +22,20 @@ pub enum OscWebviewVerb {
         view_id: String,
         rows: u16,
         cols: u16,
+        /// Client-assigned instance id (Kitty placement model); `None` is the
+        /// implicit default instance. `(view_id, instance_id)` is the address.
+        instance_id: Option<String>,
     },
-    /// Unmount inline webview(s): a specific view id, or all for this terminal.
-    UnmountInline { view_id: Option<String> },
+    /// Unmount inline webview(s): a specific `(view_id, instance_id)`, all
+    /// instances of a `view_id`, or all for this terminal.
+    ///
+    /// # Invariants
+    /// `view_id == None` implies `instance_id == None` (an instance is
+    /// addressable only alongside its view id; enforced at the capture stage).
+    UnmountInline {
+        view_id: Option<String>,
+        instance_id: Option<String>,
+    },
 }
 
 /// Anchor stamped by the VT thread at the exact byte position of a

--- a/crates/bevy_terminal/src/vt/listener.rs
+++ b/crates/bevy_terminal/src/vt/listener.rs
@@ -17,6 +17,28 @@ pub enum OscWebviewVerb {
     Mount { view_id: String },
     /// Unmount the active webview, optionally scoped to a specific view id.
     Unmount { view_id: Option<String> },
+    /// Mount a registered webview INLINE at the cursor anchor, sized in cells.
+    MountInline {
+        view_id: String,
+        rows: u16,
+        cols: u16,
+    },
+    /// Unmount inline webview(s): a specific view id, or all for this terminal.
+    UnmountInline { view_id: Option<String> },
+}
+
+/// Anchor stamped by the VT thread at the exact byte position of a
+/// `mount-inline` OSC: absolute scrollback line (top of the rect),
+/// column, and the `frame_seq` the next grid emit will carry (used by
+/// the GUI to defer first projection until the grid catches up).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InlineAnchor {
+    /// Absolute line = history_base + history_size + live-grid cursor row.
+    pub line: u64,
+    /// Cursor column at the OSC byte position.
+    pub col: u16,
+    /// The seq value the next emitted frame will carry (wrap-aware compare).
+    pub frame_seq: u32,
 }
 
 /// Best-effort control frames forwarded from `TermListener`. The
@@ -35,7 +57,11 @@ pub(crate) enum ControlFrame {
     /// A new current working directory reported via OSC 7.
     CurrentDir(PathBuf),
     /// An OSC-driven webview mount/unmount request from the PTY.
-    OscWebview(OscWebviewVerb),
+    /// `anchor` is `Some` only for `MountInline` (stamped in `handle.rs`).
+    OscWebview {
+        verb: OscWebviewVerb,
+        anchor: Option<InlineAnchor>,
+    },
 }
 
 /// Reply-required reply bytes (currently just `PtyWrite`). The
@@ -97,6 +123,17 @@ mod tests {
     use super::*;
     use alacritty_terminal::event::{Event, EventListener};
     use crossbeam_channel::unbounded;
+
+    #[test]
+    fn inline_anchor_is_copy_and_eq() {
+        let a = InlineAnchor {
+            line: 42,
+            col: 7,
+            frame_seq: 3,
+        };
+        let b = a;
+        assert_eq!(a, b);
+    }
 
     #[test]
     fn pty_write_event_is_forwarded() {

--- a/crates/bevy_terminal/src/vt/listener.rs
+++ b/crates/bevy_terminal/src/vt/listener.rs
@@ -58,10 +58,6 @@ pub(crate) enum ControlFrame {
     CurrentDir(PathBuf),
     /// An OSC-driven webview mount/unmount request from the PTY.
     /// `anchor` is `Some` only for `MountInline` (stamped in `handle.rs`).
-    #[expect(
-        dead_code,
-        reason = "construction moves to advance-loop stamping in the follow-up task"
-    )]
     OscWebview {
         verb: OscWebviewVerb,
         anchor: Option<InlineAnchor>,

--- a/crates/bevy_terminal/src/vt/listener.rs
+++ b/crates/bevy_terminal/src/vt/listener.rs
@@ -58,6 +58,10 @@ pub(crate) enum ControlFrame {
     CurrentDir(PathBuf),
     /// An OSC-driven webview mount/unmount request from the PTY.
     /// `anchor` is `Some` only for `MountInline` (stamped in `handle.rs`).
+    #[expect(
+        dead_code,
+        reason = "construction moves to advance-loop stamping in the follow-up task"
+    )]
     OscWebview {
         verb: OscWebviewVerb,
         anchor: Option<InlineAnchor>,

--- a/crates/bevy_terminal/src/vt/listener.rs
+++ b/crates/bevy_terminal/src/vt/listener.rs
@@ -10,7 +10,7 @@
 use crossbeam_channel::Sender;
 use std::path::PathBuf;
 
-/// Verb carried by `ControlFrame::OscWebview`: mount a registered view by id, or unmount.
+/// Verb carried by `ControlFrame::OscWebview`: tab mount/unmount or inline mount/unmount of a registered view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OscWebviewVerb {
     /// Mount a registered webview by its unique identifier.

--- a/crates/bevy_terminal_renderer/src/grid.rs
+++ b/crates/bevy_terminal_renderer/src/grid.rs
@@ -25,6 +25,7 @@ fn apply_snapshot(snap: On<FrameSnapshot>, mut terminals: Query<&mut TerminalGri
     grid.cursor = Some(snap.cursor.clone());
     grid.display_offset = snap.display_offset;
     grid.history_size = snap.history_size;
+    grid.history_base = snap.history_base;
     grid.last_seq = snap.seq;
     grid.modes = snap.modes.clone();
     grid.hyperlinks.clear();
@@ -45,6 +46,8 @@ fn apply_delta(delta: On<FrameDelta>, mut terminals: Query<&mut TerminalGrid>) {
     };
     grid.cursor = Some(delta.cursor.clone());
     grid.display_offset = delta.display_offset;
+    grid.history_size = delta.history_size;
+    grid.history_base = delta.history_base;
     grid.last_seq = delta.seq;
     grid.vi_cursor = delta.vi_cursor;
     grid.selection = delta.selection;
@@ -124,6 +127,7 @@ mod tests {
             }],
             display_offset: 0,
             history_size: 0,
+            history_base: 0,
             vi_cursor: None,
             selection: None,
         });
@@ -132,6 +136,49 @@ mod tests {
         assert_eq!(grid.hyperlinks.len(), 1);
         assert_eq!(grid.hyperlinks[0].0, HyperlinkId(1));
         assert_eq!(grid.hyperlinks[0].1.as_str(), "https://new");
+    }
+
+    #[test]
+    fn apply_delta_mirrors_history_fields() {
+        let mut app = App::new();
+        app.add_observer(apply_snapshot).add_observer(apply_delta);
+        let entity = app.world_mut().spawn(grid_with(vec![])).id();
+        app.world_mut().trigger(FrameSnapshot {
+            entity,
+            seq: 1,
+            cols: 1,
+            rows: 1,
+            cursor: Default::default(),
+            rows_data: vec![Row { runs: vec![] }],
+            reason: Default::default(),
+            modes: vec![],
+            hyperlinks: vec![],
+            display_offset: 0,
+            history_size: 7,
+            history_base: 3,
+            vi_cursor: None,
+            selection: None,
+        });
+        app.update();
+        let grid = app.world().get::<TerminalGrid>(entity).unwrap();
+        assert_eq!(grid.history_size, 7);
+        assert_eq!(grid.history_base, 3);
+        app.world_mut().trigger(FrameDelta {
+            entity,
+            seq: 2,
+            cursor: Default::default(),
+            dirty_rows: vec![],
+            hyperlinks: vec![],
+            display_offset: 0,
+            history_size: 9,
+            history_base: 5,
+            vi_cursor: None,
+            selection: None,
+        });
+        app.update();
+        let grid = app.world().get::<TerminalGrid>(entity).unwrap();
+        assert_eq!(grid.history_size, 9);
+        assert_eq!(grid.history_base, 5);
     }
 
     #[test]
@@ -161,6 +208,8 @@ mod tests {
                 },
             ],
             display_offset: 0,
+            history_size: 0,
+            history_base: 0,
             vi_cursor: None,
             selection: None,
         });

--- a/crates/bevy_terminal_renderer/src/lib.rs
+++ b/crates/bevy_terminal_renderer/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::glyph::font::{
 pub mod prelude {
     pub use crate::TerminalRendererPlugin;
     pub use crate::bundle::TerminalRenderBundle;
-    pub use crate::material::PaneDim;
+    pub use crate::material::{OVERLAY_SLOTS, PaneDim, TerminalOverlays};
     pub use crate::schema::*;
 }
 

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -75,11 +75,34 @@ pub struct TerminalUiMaterial {
     #[texture(3)]
     #[sampler(4)]
     atlas: Handle<Image>,
+    #[texture(5)]
+    #[sampler(6)]
+    overlay0: Option<Handle<Image>>,
+    #[texture(7)]
+    #[sampler(8)]
+    overlay1: Option<Handle<Image>>,
+    #[texture(9)]
+    #[sampler(10)]
+    overlay2: Option<Handle<Image>>,
+    #[texture(11)]
+    #[sampler(12)]
+    overlay3: Option<Handle<Image>>,
 }
 
 impl UiMaterial for TerminalUiMaterial {
     fn fragment_shader() -> ShaderRef {
         TERMINAL_SHADER_HANDLE.into()
+    }
+}
+
+impl TerminalUiMaterial {
+    /// Copies the slot-indexed overlay handles onto the per-slot material
+    /// fields. The ONLY place that maps slot index -> `overlay<i>` field.
+    fn set_overlays(&mut self, textures: &[Option<Handle<Image>>; OVERLAY_SLOTS]) {
+        self.overlay0 = textures[0].clone();
+        self.overlay1 = textures[1].clone();
+        self.overlay2 = textures[2].clone();
+        self.overlay3 = textures[3].clone();
     }
 }
 
@@ -93,6 +116,43 @@ pub struct PaneDim(pub f32);
 impl Default for PaneDim {
     fn default() -> Self {
         Self(1.0)
+    }
+}
+
+/// Number of inline-overlay texture slots on `TerminalUiMaterial`.
+///
+/// Slot index = array index = `overlay<i>` field order (NOT the WGSL binding
+/// number). Hard upper bound per terminal surface (spec §6.1).
+pub const OVERLAY_SLOTS: usize = 4;
+
+/// Per-terminal overlay placements + textures, derived every frame by the
+/// consumer (e.g. ozmux-gui's inline-webview projection) and consumed by
+/// `update_terminal_material` — the only material mutation site. The renderer
+/// knows nothing about what the textures contain.
+///
+/// # Invariants
+///
+/// - `rects[i]` is `(row, col, rows, cols)` in CELL coordinates; `row` may be
+///   negative (rect partially above the viewport). `rows == 0` is the
+///   inactive-slot sentinel — the shader skips the slot and
+///   `update_terminal_material` ignores `textures[i]`.
+/// - Consumers must rebuild this component from live state every frame
+///   (all-sentinel start), so stale texture handles cannot outlive their
+///   producers (spec §5).
+#[derive(Component, Clone, Debug)]
+pub struct TerminalOverlays {
+    /// Placement rects, slot-indexed: `(row, col, rows, cols)` in cells.
+    pub rects: [IVec4; OVERLAY_SLOTS],
+    /// Texture handles, slot-indexed; `None` for inactive slots.
+    pub textures: [Option<Handle<Image>>; OVERLAY_SLOTS],
+}
+
+impl Default for TerminalOverlays {
+    fn default() -> Self {
+        Self {
+            rects: [IVec4::ZERO; OVERLAY_SLOTS],
+            textures: [const { None }; OVERLAY_SLOTS],
+        }
     }
 }
 
@@ -118,7 +178,9 @@ impl Default for PaneDim {
 ///
 /// Field offsets in bytes. `max_overflow_phys` fills the 4-byte padding slot
 /// at offset 76 that encase would otherwise insert before `bg_padding_color`
-/// (Vec4 needs 16-byte alignment, lands at offset 80; total 96 bytes,
+/// (Vec4 needs 16-byte alignment, lands at offset 80). `overlay_rects`
+/// (`array<vec4<i32>, 4>`) also needs 16-byte alignment, so encase pads
+/// 4 bytes after `dim` and lands it at offset 112 (total 176 bytes,
 /// 16-byte aligned):
 ///
 /// | Offset | Field                       |
@@ -143,6 +205,7 @@ impl Default for PaneDim {
 /// | 96     | `hover_hyperlink_id`        |
 /// | 100    | `hover_active`              |
 /// | 104    | `dim`                       |
+/// | 112    | `overlay_rects`             |
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -182,6 +245,9 @@ struct TerminalParams {
     /// hand-written `Default` below sets this to `1.0` so an un-updated
     /// material never renders dark (a derived `Default` would give `0.0`).
     dim: f32,
+    /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell
+    /// coords; `row` may be negative; `rows == 0` = inactive slot sentinel.
+    overlay_rects: [IVec4; OVERLAY_SLOTS],
 }
 
 impl Default for TerminalParams {
@@ -207,6 +273,7 @@ impl Default for TerminalParams {
             hover_hyperlink_id: 0,
             hover_active: 0,
             dim: 1.0,
+            overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
 }
@@ -277,6 +344,7 @@ impl TerminalParams {
             hover_hyperlink_id,
             hover_active,
             dim,
+            overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
 }
@@ -361,6 +429,7 @@ fn update_terminal_material(
         &mut TerminalMaterialState,
         &TerminalGrid,
         Option<&PaneDim>,
+        Option<&TerminalOverlays>,
     )>,
     fonts: Res<TerminalFonts>,
     palette_time: Res<Time>,
@@ -395,7 +464,7 @@ fn update_terminal_material(
     let dpr = window.scale_factor();
     let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
 
-    for (entity, handle, mut state, grid, pane_dim) in terminals.iter_mut() {
+    for (entity, handle, mut state, grid, pane_dim, overlays) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;
         let cols = grid.cols as u32;
         let rows = grid.rows as u32;
@@ -500,7 +569,7 @@ fn update_terminal_material(
 
         let dim = pane_dim.map_or(1.0, |d| d.0).clamp(0.0, 1.0);
         if let Some(mat) = materials.get_mut(&handle.0) {
-            mat.params = TerminalParams::new(
+            let mut params = TerminalParams::new(
                 grid,
                 cell_size_phys,
                 Vec2::new(atlas.width() as f32, atlas.height() as f32),
@@ -515,6 +584,16 @@ fn update_terminal_material(
                 hover_active,
                 dim,
             );
+            match overlays {
+                Some(o) => {
+                    params.overlay_rects = o.rects;
+                    mat.set_overlays(&o.textures);
+                }
+                None => {
+                    mat.set_overlays(&[const { None }; OVERLAY_SLOTS]);
+                }
+            }
+            mat.params = params;
         }
     }
 }
@@ -729,7 +808,29 @@ mod tests {
     }
 
     #[test]
-    fn terminal_params_uniform_size_is_112() {
-        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 112);
+    fn terminal_overlays_default_is_all_sentinel() {
+        let o = TerminalOverlays::default();
+        assert!(
+            o.rects.iter().all(|r| r.z == 0),
+            "rows == 0 sentinel on every slot"
+        );
+        assert!(o.textures.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn set_overlays_maps_slot_index_to_field_order() {
+        let mut mat = TerminalUiMaterial::default();
+        let h0 = Handle::<Image>::default();
+        let textures = [Some(h0.clone()), None, Some(h0.clone()), None];
+        mat.set_overlays(&textures);
+        assert!(mat.overlay0.is_some());
+        assert!(mat.overlay1.is_none());
+        assert!(mat.overlay2.is_some());
+        assert!(mat.overlay3.is_none());
+    }
+
+    #[test]
+    fn terminal_params_uniform_size_includes_overlay_rects() {
+        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 176);
     }
 }

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -449,7 +449,10 @@ fn update_terminal_material(
     // reference to the initial (empty) atlas texture even after
     // `sync_atlas_image` re-uploads pixels — the glyphs are present on GPU
     // but the shader's `textureSampleLevel` returns 0. The actual GPU upload
-    // cost is bounded by `needs_rebuild` below.
+    // cost is bounded by `needs_rebuild` below. The same every-frame Modified
+    // is also the overlay-texture rebind lifeline: a bevy_cef headless target
+    // re-creates its GPU texture on resize, and only this rebuild repoints
+    // the bind group at it (spec §4).
     // NOTE: Skip the entire system when PrimaryWindow is transiently
     // absent (display hotplug, brief winit reconnect). Trade-off: the
     // `mat.params = ...` write below would fire AssetEvent::Modified

--- a/crates/bevy_terminal_renderer/src/material.rs
+++ b/crates/bevy_terminal_renderer/src/material.rs
@@ -134,8 +134,9 @@ pub const OVERLAY_SLOTS: usize = 4;
 ///
 /// - `rects[i]` is `(row, col, rows, cols)` in CELL coordinates; `row` may be
 ///   negative (rect partially above the viewport). `rows == 0` is the
-///   inactive-slot sentinel — the shader skips the slot and
-///   `update_terminal_material` ignores `textures[i]`.
+///   inactive-slot sentinel — the shader skips the slot; the renderer binds
+///   `textures[i]` regardless, so consumers should set freed slots to `None`
+///   (the rebuild-every-frame contract below does this naturally).
 /// - Consumers must rebuild this component from live state every frame
 ///   (all-sentinel start), so stale texture handles cannot outlive their
 ///   producers (spec §5).
@@ -819,14 +820,15 @@ mod tests {
 
     #[test]
     fn set_overlays_maps_slot_index_to_field_order() {
+        const H_A: Handle<Image> = uuid_handle!("c0fee000-0000-4000-8000-000000000001");
+        const H_B: Handle<Image> = uuid_handle!("c0fee000-0000-4000-8000-000000000002");
         let mut mat = TerminalUiMaterial::default();
-        let h0 = Handle::<Image>::default();
-        let textures = [Some(h0.clone()), None, Some(h0.clone()), None];
+        let textures = [Some(H_A), None, Some(H_B), None];
         mat.set_overlays(&textures);
-        assert!(mat.overlay0.is_some());
-        assert!(mat.overlay1.is_none());
-        assert!(mat.overlay2.is_some());
-        assert!(mat.overlay3.is_none());
+        assert_eq!(mat.overlay0, Some(H_A));
+        assert_eq!(mat.overlay1, None);
+        assert_eq!(mat.overlay2, Some(H_B));
+        assert_eq!(mat.overlay3, None);
     }
 
     #[test]

--- a/crates/bevy_terminal_renderer/src/schema/frame.rs
+++ b/crates/bevy_terminal_renderer/src/schema/frame.rs
@@ -31,6 +31,10 @@ pub struct FrameSnapshot {
     /// Total scrollback history line count (upper bound for display_offset).
     #[serde(default)]
     pub history_size: u32,
+    /// Cumulative lines trimmed from the top of scrollback (monotonic;
+    /// advances only on history-destroying folds — spec §3).
+    #[serde(default)]
+    pub history_base: u64,
     /// Vi-mode cursor (active only in copy mode). Absent in normal mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vi_cursor: Option<ViCursor>,
@@ -58,6 +62,12 @@ pub struct FrameDelta {
     /// Lines scrolled back from the live tail. `0` = at live tail.
     #[serde(default)]
     pub display_offset: u32,
+    /// Total scrollback history line count (upper bound for display_offset).
+    #[serde(default)]
+    pub history_size: u32,
+    /// Cumulative lines trimmed from the top of scrollback (monotonic).
+    #[serde(default)]
+    pub history_base: u64,
     /// Vi-mode cursor (active only in copy mode). Absent in normal mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vi_cursor: Option<ViCursor>,

--- a/crates/bevy_terminal_renderer/src/schema/frame.rs
+++ b/crates/bevy_terminal_renderer/src/schema/frame.rs
@@ -65,7 +65,8 @@ pub struct FrameDelta {
     /// Total scrollback history line count (upper bound for display_offset).
     #[serde(default)]
     pub history_size: u32,
-    /// Cumulative lines trimmed from the top of scrollback (monotonic).
+    /// Cumulative lines trimmed from the top of scrollback (monotonic;
+    /// advances only on history-destroying folds — spec §3).
     #[serde(default)]
     pub history_base: u64,
     /// Vi-mode cursor (active only in copy mode). Absent in normal mode.

--- a/crates/bevy_terminal_renderer/src/schema/grid.rs
+++ b/crates/bevy_terminal_renderer/src/schema/grid.rs
@@ -18,6 +18,8 @@ pub struct TerminalGrid {
     pub display_offset: u32,
     /// Total scrollback history line count.
     pub history_size: u32,
+    /// Cumulative trimmed-lines counter mirrored from the latest frame.
+    pub history_base: u64,
     /// Monotonic sequence number of the last applied frame.
     pub last_seq: u32,
     /// Active terminal modes from the last snapshot (e.g. "mouse-sgr-1006").

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -26,6 +26,7 @@ struct TerminalParams {
     hover_hyperlink_id: u32,
     hover_active: u32,
     dim: f32,
+    overlay_rects: array<vec4<i32>, 4>,
 };
 
 struct Cell {
@@ -62,6 +63,14 @@ struct CellColors {
 @group(1) @binding(2) var<storage, read> glyphs: array<Glyph>;
 @group(1) @binding(3) var atlas_tex: texture_2d<f32>;
 @group(1) @binding(4) var atlas_sampler: sampler;
+@group(1) @binding(5) var overlay0_tex: texture_2d<f32>;
+@group(1) @binding(6) var overlay0_samp: sampler;
+@group(1) @binding(7) var overlay1_tex: texture_2d<f32>;
+@group(1) @binding(8) var overlay1_samp: sampler;
+@group(1) @binding(9) var overlay2_tex: texture_2d<f32>;
+@group(1) @binding(10) var overlay2_samp: sampler;
+@group(1) @binding(11) var overlay3_tex: texture_2d<f32>;
+@group(1) @binding(12) var overlay3_samp: sampler;
 
 // NOTE: Must stay in sync with `ozmux_terminal_protocol::style::*`. The
 //       Rust-side test `style_bits_match_protocol_constants` asserts the
@@ -125,11 +134,13 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 // Top-level pipeline stages
 // ============================================================================
 
-// Pipeline for a fragment that lies inside the grid: background → primary
-// glyph → left-neighbor overdraw → text decorations → cursor → selection.
+// Pipeline for a fragment that lies inside the grid: background → inline
+// overlays → primary glyph → left-neighbor overdraw → text decorations →
+// cursor → selection.
 fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
     let colors = resolve_cell_colors(hit.cell);
     var color = colors.bg;
+    color = composite_inline_overlays(hit, color);
     color = paint_primary_glyph(hit, colors.fg, color);
     color = paint_left_overdraw(hit, color);
     return paint_cell_overlays(hit, colors.fg, color);
@@ -353,6 +364,85 @@ fn is_in_selection_uniform(
     if row == lo_r && col < lo_c { return false; }
     if row == hi_r && col > hi_c { return false; }
     return true;
+}
+
+// ============================================================================
+// Inline-overlay compositing (webview textures)
+// ============================================================================
+
+// Inline-overlay compositing (spec §6.2): samples each ACTIVE overlay slot
+// whose cell-rect contains this fragment and composites it OVER the cell
+// background. Source is premultiplied alpha (CEF convention, spec §6.3);
+// the sRGB texture view linearizes on read, so values mix in linear space
+// with no manual conversion. Glyphs paint AFTER overlays, so terminal text
+// sits on top of an inline webview.
+//
+// uv derives from the UNCLIPPED rect (rect.x may be negative when the rect
+// is partially scrolled above the viewport), so partial visibility never
+// distorts the image; grid-edge clipping is inherent because only in-grid
+// fragments reach paint_grid_cell.
+fn composite_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
+    var color = base;
+    let p_px = vec2<f32>(f32(hit.col), f32(hit.row)) * params.cell_size_px + hit.in_cell_px;
+    // NOTE: bindings cannot be dynamically indexed in core WGSL — the four
+    // slots are unrolled by hand; keep slot order identical to the Rust
+    // `set_overlays` field order or textures swap silently.
+    {
+        let uv = overlay_uv(params.overlay_rects[0], p_px, hit);
+        if uv.x >= 0.0 {
+            let s = textureSampleLevel(overlay0_tex, overlay0_samp, uv, 0.0);
+            color = blend_premultiplied_over(color, s);
+        }
+    }
+    {
+        let uv = overlay_uv(params.overlay_rects[1], p_px, hit);
+        if uv.x >= 0.0 {
+            let s = textureSampleLevel(overlay1_tex, overlay1_samp, uv, 0.0);
+            color = blend_premultiplied_over(color, s);
+        }
+    }
+    {
+        let uv = overlay_uv(params.overlay_rects[2], p_px, hit);
+        if uv.x >= 0.0 {
+            let s = textureSampleLevel(overlay2_tex, overlay2_samp, uv, 0.0);
+            color = blend_premultiplied_over(color, s);
+        }
+    }
+    {
+        let uv = overlay_uv(params.overlay_rects[3], p_px, hit);
+        if uv.x >= 0.0 {
+            let s = textureSampleLevel(overlay3_tex, overlay3_samp, uv, 0.0);
+            color = blend_premultiplied_over(color, s);
+        }
+    }
+    return color;
+}
+
+// Returns the overlay-local uv for `rect = (row, col, rows, cols)` at the
+// fragment's grid position, or vec2(-1.0) when the slot is inactive
+// (rows == 0) or the fragment's CELL lies outside the rect. The hit test is
+// cell-quantized (placeholder-cell semantics); the uv itself is pixel-exact
+// against the unclipped rect.
+fn overlay_uv(rect: vec4<i32>, p_px: vec2<f32>, hit: CellHit) -> vec2<f32> {
+    let miss = vec2<f32>(-1.0, -1.0);
+    if rect.z == 0 {
+        return miss;
+    }
+    let row = i32(hit.row);
+    let col = i32(hit.col);
+    if row < rect.x || row >= rect.x + rect.z || col < rect.y || col >= rect.y + rect.w {
+        return miss;
+    }
+    let origin_px = vec2<f32>(f32(rect.y), f32(rect.x)) * params.cell_size_px;
+    let size_px = vec2<f32>(f32(rect.w), f32(rect.z)) * params.cell_size_px;
+    return (p_px - origin_px) / size_px;
+}
+
+// Premultiplied-alpha OVER in linear space (src premultiplied per CEF; dst is
+// the terminal cell background, opaque in practice).
+fn blend_premultiplied_over(dst: vec4<f32>, src: vec4<f32>) -> vec4<f32> {
+    let inv = 1.0 - src.a;
+    return vec4<f32>(src.rgb + dst.rgb * inv, src.a + dst.a * inv);
 }
 
 // ============================================================================

--- a/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/bevy_terminal_renderer/src/shaders/terminal_ui_material.wgsl
@@ -140,7 +140,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
     let colors = resolve_cell_colors(hit.cell);
     var color = colors.bg;
-    color = composite_inline_overlays(hit, color);
+    color = paint_inline_overlays(hit, color);
     color = paint_primary_glyph(hit, colors.fg, color);
     color = paint_left_overdraw(hit, color);
     return paint_cell_overlays(hit, colors.fg, color);
@@ -367,7 +367,7 @@ fn is_in_selection_uniform(
 }
 
 // ============================================================================
-// Inline-overlay compositing (webview textures)
+// Inline-overlay compositing
 // ============================================================================
 
 // Inline-overlay compositing (spec §6.2): samples each ACTIVE overlay slot
@@ -381,7 +381,7 @@ fn is_in_selection_uniform(
 // is partially scrolled above the viewport), so partial visibility never
 // distorts the image; grid-edge clipping is inherent because only in-grid
 // fragments reach paint_grid_cell.
-fn composite_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
+fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     var color = base;
     let p_px = vec2<f32>(f32(hit.col), f32(hit.row)) * params.cell_size_px + hit.in_cell_px;
     // NOTE: bindings cannot be dynamically indexed in core WGSL — the four

--- a/crates/configs/src/shortcuts.rs
+++ b/crates/configs/src/shortcuts.rs
@@ -301,7 +301,7 @@ pub struct Shortcuts {
 /// TOML reads the `[shortcuts.bindings]` table; the `kebab-case` serde
 /// rename maps each `close-pane = "Cmd+Shift+D"` line to the matching
 /// field. `#[serde(default)]` at struct level seeds missing fields from
-/// `Bindings::default()` (the 19 defaults). `deny_unknown_fields` rejects
+/// `Bindings::default()` (the 20 defaults). `deny_unknown_fields` rejects
 /// typos and unimplemented-action keys at load time.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
@@ -363,6 +363,9 @@ pub struct Bindings {
     /// Paste the system clipboard into the active terminal.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
     pub paste: Option<KeyChord>,
+    /// Releases keyboard focus from a focused inline webview back to the terminal.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub release_inline_focus: Option<KeyChord>,
 }
 
 fn parse_default_chord(s: &str) -> KeyChord {
@@ -391,6 +394,7 @@ impl Default for Bindings {
             focus_workspace_next: Some(parse_default_chord("Cmd+Shift+]")),
             copy: Some(parse_default_chord("Cmd+C")),
             paste: Some(parse_default_chord("Cmd+V")),
+            release_inline_focus: Some(parse_default_chord("Ctrl+Shift+Escape")),
         }
     }
 }
@@ -511,11 +515,16 @@ impl Bindings {
             ),
             ("copy", &self.copy, ShortcutAction::Copy),
             ("paste", &self.paste, ShortcutAction::Paste),
+            (
+                "release-inline-focus",
+                &self.release_inline_focus,
+                ShortcutAction::ReleaseInlineFocus,
+            ),
         ]
         .into_iter()
     }
 
-    /// KeyChord -> Action reverse lookup. Linear scan of 19 entries.
+    /// KeyChord -> Action reverse lookup. Linear scan of 20 entries.
     /// Hot path; cheap given the fixed size. HashMap caching deferred per spec.
     pub fn lookup(&self, chord: &KeyChord) -> Option<ShortcutAction> {
         self.iter().find_map(|(_, bound, action)| {
@@ -620,6 +629,8 @@ pub enum ShortcutAction {
     Copy,
     /// Paste the system clipboard into the active terminal.
     Paste,
+    /// Releases keyboard focus from a focused inline webview back to the terminal.
+    ReleaseInlineFocus,
 }
 
 /// Layout direction shared by `FocusPane` and `ResizePane`.
@@ -888,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn bindings_default_has_all_19_fields_some() {
+    fn bindings_default_has_all_20_fields_some() {
         let b = Bindings::default();
         assert!(b.close_pane.is_some());
         assert!(b.focus_pane_left.is_some());
@@ -909,6 +920,7 @@ mod tests {
         assert!(b.focus_workspace_next.is_some());
         assert!(b.copy.is_some());
         assert!(b.paste.is_some());
+        assert!(b.release_inline_focus.is_some());
     }
 
     #[test]
@@ -976,9 +988,9 @@ mod tests {
     }
 
     #[test]
-    fn iter_yields_19_entries() {
+    fn iter_yields_20_entries() {
         let b = Bindings::default();
-        assert_eq!(b.iter().count(), 19);
+        assert_eq!(b.iter().count(), 20);
     }
 
     #[test]
@@ -986,7 +998,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         // The Bindings struct serializes its fields in declaration order.
         // The kebab-case rename applies. Any change to defaults updates this string.
-        let expected = r#"{"bindings":{"close-pane":{"key":"d","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"focus-pane-left":{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-down":{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-up":{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-right":{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"split-pane-vertical":{"key":"i","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"split-pane-horizontal":{"key":"o","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"swap-pane-prev":{"key":"b","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"swap-pane-next":{"key":"n","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"close-surface":{"key":"f","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"new-terminal-surface":{"key":"t","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-surface-prev":{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-surface-next":{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"enter-copy-mode":{"key":"u","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"new-workspace":{"key":"r","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-workspace-prev":{"key":"[","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"focus-workspace-next":{"key":"]","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"copy":{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}}}}"#;
+        let expected = r#"{"bindings":{"close-pane":{"key":"d","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"focus-pane-left":{"key":"h","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-down":{"key":"j","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-up":{"key":"k","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-pane-right":{"key":"l","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"split-pane-vertical":{"key":"i","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"split-pane-horizontal":{"key":"o","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"swap-pane-prev":{"key":"b","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"swap-pane-next":{"key":"n","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"close-surface":{"key":"f","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"new-terminal-surface":{"key":"t","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-surface-prev":{"key":"[","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-surface-next":{"key":"]","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"enter-copy-mode":{"key":"u","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"new-workspace":{"key":"r","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"focus-workspace-prev":{"key":"[","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"focus-workspace-next":{"key":"]","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"copy":{"key":"c","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-inline-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
         assert_eq!(json, expected);
     }
 

--- a/docs/inline-webview.md
+++ b/docs/inline-webview.md
@@ -1,0 +1,120 @@
+# Inline webviews
+
+ozmux can render a registered extension view **inline in the terminal text
+flow** — like the Kitty image protocol, but the surface is a live CEF webview.
+The view is composited inside the terminal's own fragment shader, so it scrolls
+with the surrounding text, clips at the viewport edges, and sits under the
+glyphs (text drawn over it). This is macOS-only today (the headless GPU path
+rides the IOSurface accelerated-paint pipeline).
+
+## Enabling it
+
+- Inline webviews ride the same OSC 5379 gate as tab-style webviews:
+  `osc_webview.enabled` in `~/.config/ozmux/config.toml` (default **on**).
+- The bundled `extensions/` directory is **dev-only** — it is discovered only
+  under the `debug` cargo feature. Run with `cargo run --features debug` to use
+  the bundled `memo` sample; a shipped binary discovers only user-installed
+  extensions.
+
+## Protocol — OSC 5379
+
+A program running in the terminal mounts a view by writing a private OSC 5379
+sequence to stdout. The 7-bit `ESC ]` introducer and `ESC \` (ST) terminator
+are the canonical forms.
+
+```
+mount-inline:    ESC ] 5379 ; mount-inline ; <view_id> ; <rows> ; <cols> ESC \
+unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> ] ESC \
+```
+
+- `<view_id>` — a view declared in an extension's `ozmux.toml`; must match
+  `^[A-Za-z0-9._-]{1,128}$`.
+- `<rows>` / `<cols>` — the rect size in **terminal cells**; integers
+  `1..=200` and `1..=400`. The CEF page is laid out at exactly that cell
+  rectangle (× DPR); content is not scaled, so the page reflows to fit (no
+  crop — a small browser window, not a shrunken screenshot).
+- Out-of-range, non-numeric, or malformed sequences are silently dropped by the
+  VT layer.
+- `unmount-inline` with a `<view_id>` removes that view; with **no third
+  parameter** (and no trailing `;`) it removes *every* inline webview on the
+  terminal. A present-but-empty id field is malformed.
+
+### Anchor and vertical space
+
+The webview is anchored at the **cursor position when the OSC appears in the
+stream**. Position the cursor first (e.g. print a heading) and the view mounts
+there. Reserving the vertical space is the caller's job: print `<rows>`
+newlines after the mount sequence so following output lands below the view.
+
+```sh
+# raw printf: heading, then mount memo.main as a 12×48 cell rect + 12 newlines
+printf 'memo:\n\033]5379;mount-inline;memo.main;12;48\033\\'
+printf '\n%.0s' $(seq 12)
+```
+
+Caveats (the rect is anchored to an absolute scrollback line, not reflowed):
+
+- Do not mount while a **scroll region** (DECSTBM) is set or on the
+  **alternate screen** — the anchor semantics don't hold there (alt-screen
+  mounts are rejected).
+- There is no automatic text reflow on width resize; the anchor stays on its
+  absolute line and the layout is manual.
+- `clear` (CSI 3 J) and scrollback saturation unmount all inline webviews on
+  the terminal. While the scrollback stays saturated, new `mount-inline`
+  sequences are rejected until the history drops below the limit (e.g. after
+  `clear`).
+
+## SDK helper
+
+`@ozmux/sdk/inline` builds the sequences (with validation and the newline
+reservation) so extension tooling doesn't hand-roll escape codes:
+
+```ts
+import { mountInline, unmountInline } from '@ozmux/sdk/inline';
+
+process.stdout.write('memo:\n');                          // anchor heading
+process.stdout.write(mountInline('memo.main', { rows: 12, cols: 48 }));
+// later:
+process.stdout.write(unmountInline('memo.main'));         // or unmountInline() for all
+```
+
+`mountInline` returns the OSC sequence followed by `rows` newlines as one
+string (one atomic `write`). It throws `RangeError` on an invalid view id or
+out-of-range geometry rather than emitting a sequence the terminal would drop.
+
+The bundled sample is `extensions/memo/mount.ts` — run it inside an ozmux
+terminal (`cargo run --features debug`) with `node extensions/memo/mount.ts`
+(or `pnpm --filter memo mount`).
+
+## Focus and input
+
+An inline webview starts render-only. Interaction follows a click-to-focus
+model (this matches the `interactive = true` flag in the view's `ozmux.toml`;
+a non-interactive view never takes focus or input):
+
+- **Click** inside the rect focuses the page (a focus ring appears); the click
+  is delivered to the page, not the terminal.
+- While focused, **keystrokes and IME** route to the page. The **wheel**
+  scrolls the page only while the page is focused *and* the pointer is over it;
+  otherwise it scrolls the terminal. **Mouse movement** is forwarded whenever
+  the pointer is over the rect (focus or not) — though before the page is first
+  focused, hover events may not reach it until CEF establishes its focused
+  frame.
+- **`Ctrl+Shift+Escape`** (the configurable `release_inline_focus` shortcut)
+  returns focus to the terminal; clicking on terminal text outside the rect
+  also releases focus.
+
+Two intentional behaviors worth knowing:
+
+- ozmux's own shortcuts still fire while a page is focused, and because key
+  events are broadcast, the focused page **also** receives those keystrokes.
+- A plain `Escape` typed into a focused page does **not** snap the terminal
+  viewport to the bottom (the scroll-to-bottom shortcut is suppressed while an
+  inline webview of the active surface holds focus).
+
+## Limits
+
+- Up to **4** inline webviews per terminal surface.
+- macOS only (the headless GPU compositing path).
+- One terminal pane composites its inline webviews in its own shader pass; the
+  text always draws on top of the webview.

--- a/docs/inline-webview.md
+++ b/docs/inline-webview.md
@@ -23,8 +23,8 @@ sequence to stdout. The 7-bit `ESC ]` introducer and `ESC \` (ST) terminator
 are the canonical forms.
 
 ```
-mount-inline:    ESC ] 5379 ; mount-inline ; <view_id> ; <rows> ; <cols> ESC \
-unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> ] ESC \
+mount-inline:    ESC ] 5379 ; mount-inline ; <view_id> ; <rows> ; <cols> [ ; <instance_id> ] ESC \
+unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> [ ; <instance_id> ] ] ESC \
 ```
 
 - `<view_id>` — a view declared in an extension's `ozmux.toml`; must match
@@ -33,11 +33,18 @@ unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> ] ESC \
   `1..=200` and `1..=400`. The CEF page is laid out at exactly that cell
   rectangle (× DPR); content is not scaled, so the page reflows to fit (no
   crop — a small browser window, not a shrunken screenshot).
+- `<instance_id>` — optional, client-assigned, same charset as `<view_id>`.
+  It lets the **same `<view_id>` mount more than once** on one terminal:
+  `(view_id, instance_id)` is the address. Omitting it selects the implicit
+  default instance (the original "one per view_id" behavior is unchanged).
 - Out-of-range, non-numeric, or malformed sequences are silently dropped by the
   VT layer.
-- `unmount-inline` with a `<view_id>` removes that view; with **no third
-  parameter** (and no trailing `;`) it removes *every* inline webview on the
-  terminal. A present-but-empty id field is malformed.
+- `unmount-inline` scopes by how many fields are present: `; <view_id> ;
+  <instance_id>` removes that one instance; `; <view_id>` removes *every*
+  instance of that view; **no third parameter** (and no trailing `;`) removes
+  *every* inline webview on the terminal. A present-but-empty field — a
+  trailing `;`, or `; ; <instance_id>` with no view id — is malformed and
+  dropped.
 
 ### Anchor and vertical space
 
@@ -74,8 +81,13 @@ import { mountInline, unmountInline } from '@ozmux/sdk/inline';
 
 process.stdout.write('memo:\n');                          // anchor heading
 process.stdout.write(mountInline('memo.main', { rows: 12, cols: 48 }));
+// a second instance of the same view, addressed by instanceId:
+process.stdout.write('\nmemo (second):\n');
+process.stdout.write(mountInline('memo.main', { rows: 12, cols: 48, instanceId: 'b' }));
 // later:
-process.stdout.write(unmountInline('memo.main'));         // or unmountInline() for all
+process.stdout.write(unmountInline('memo.main', 'b'));    // just instance 'b'
+process.stdout.write(unmountInline('memo.main'));         // every instance of memo.main
+process.stdout.write(unmountInline());                    // every inline webview
 ```
 
 `mountInline` returns the OSC sequence followed by `rows` newlines as one

--- a/extensions/memo/mount.ts
+++ b/extensions/memo/mount.ts
@@ -1,0 +1,14 @@
+/**
+ * Demo: mount the memo view inline in the current ozmux terminal.
+ *
+ * Run inside an ozmux terminal: `node mount.ts` (or `pnpm --filter memo mount`).
+ * Prints a heading so the inline webview anchors below it, then writes the
+ * mount-inline OSC + reserved rows in one write.
+ */
+import { mountInline } from '@ozmux/sdk/inline';
+
+const ROWS = 12;
+const COLS = 48;
+
+process.stdout.write('memo (inline webview demo):\n');
+process.stdout.write(mountInline('memo.main', { rows: ROWS, cols: COLS }));

--- a/extensions/memo/mount.ts
+++ b/extensions/memo/mount.ts
@@ -1,14 +1,17 @@
 /**
- * Demo: mount the memo view inline in the current ozmux terminal.
+ * Demo: mount the memo view inline twice in the current ozmux terminal.
  *
  * Run inside an ozmux terminal: `node mount.ts` (or `pnpm --filter memo mount`).
- * Prints a heading so the inline webview anchors below it, then writes the
- * mount-inline OSC + reserved rows in one write.
+ * Prints a heading before each mount so the inline webviews anchor below them,
+ * then writes each mount-inline OSC + reserved rows in one write. The two
+ * mounts share `view_id` `memo.main` and are distinguished by `instanceId`.
  */
 import { mountInline } from '@ozmux/sdk/inline';
 
 const ROWS = 12;
 const COLS = 48;
 
-process.stdout.write('memo (inline webview demo):\n');
-process.stdout.write(mountInline('memo.main', { rows: ROWS, cols: COLS }));
+process.stdout.write('memo (instance a):\n');
+process.stdout.write(mountInline('memo.main', { rows: ROWS, cols: COLS, instanceId: 'a' }));
+process.stdout.write('\nmemo (instance b):\n');
+process.stdout.write(mountInline('memo.main', { rows: ROWS, cols: COLS, instanceId: 'b' }));

--- a/extensions/memo/package.json
+++ b/extensions/memo/package.json
@@ -1,7 +1,11 @@
 {
   "type": "module",
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "mount": "node mount.ts"
+  },
+  "dependencies": {
+    "@ozmux/sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/extensions/memo/tsconfig.json
+++ b/extensions/memo/tsconfig.json
@@ -17,5 +17,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["api.ts"]
+  "include": ["api.ts", "mount.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,10 @@ importers:
         version: 24.12.2
 
   extensions/memo:
+    dependencies:
+      '@ozmux/sdk':
+        specifier: workspace:*
+        version: link:../../sdk/typescript
     devDependencies:
       '@types/node':
         specifier: 'catalog:'

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -7,6 +7,10 @@
     "./extension": {
       "types": "./src/extension/index.ts",
       "default": "./src/extension/index.ts"
+    },
+    "./inline": {
+      "types": "./src/inline/index.ts",
+      "default": "./src/inline/index.ts"
     }
   },
   "scripts": {

--- a/sdk/typescript/src/inline/index.ts
+++ b/sdk/typescript/src/inline/index.ts
@@ -1,0 +1,2 @@
+export type { InlineGeometry } from './inline.ts';
+export { mountInline, unmountInline } from './inline.ts';

--- a/sdk/typescript/src/inline/inline.test.ts
+++ b/sdk/typescript/src/inline/inline.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { mountInline, unmountInline } from './inline.ts';
+
+const ESC = '\x1b';
+const ST = `${ESC}\\`;
+
+describe('mountInline', () => {
+  it('emits the OSC 5379 mount-inline sequence followed by rows newlines', () => {
+    const out = mountInline('memo.main', { rows: 3, cols: 20 });
+    expect(out).toBe(`${ESC}]5379;mount-inline;memo.main;3;20${ST}\n\n\n`);
+  });
+
+  it('reserves exactly rows newlines', () => {
+    expect(mountInline('v', { rows: 1, cols: 1 }).endsWith(`${ST}\n`)).toBe(true);
+    expect([...mountInline('v', { rows: 5, cols: 2 })].filter((c) => c === '\n')).toHaveLength(5);
+  });
+
+  it('rejects out-of-range rows/cols', () => {
+    expect(() => mountInline('v', { rows: 0, cols: 10 })).toThrow();
+    expect(() => mountInline('v', { rows: 201, cols: 10 })).toThrow();
+    expect(() => mountInline('v', { rows: 10, cols: 0 })).toThrow();
+    expect(() => mountInline('v', { rows: 10, cols: 401 })).toThrow();
+    expect(() => mountInline('v', { rows: 1.5, cols: 10 })).toThrow();
+  });
+
+  it('accepts the boundary values', () => {
+    expect(() => mountInline('v', { rows: 1, cols: 1 })).not.toThrow();
+    expect(() => mountInline('v', { rows: 200, cols: 400 })).not.toThrow();
+  });
+
+  it('rejects invalid view ids', () => {
+    expect(() => mountInline('', { rows: 1, cols: 1 })).toThrow();
+    expect(() => mountInline('a;b', { rows: 1, cols: 1 })).toThrow();
+    expect(() => mountInline('../etc', { rows: 1, cols: 1 })).toThrow();
+    expect(() => mountInline('a'.repeat(129), { rows: 1, cols: 1 })).toThrow();
+  });
+
+  it('accepts the full legal view-id charset', () => {
+    expect(() => mountInline('a.b_c-D9', { rows: 1, cols: 1 })).not.toThrow();
+  });
+});
+
+describe('unmountInline', () => {
+  it('emits a view-scoped unmount with the id', () => {
+    expect(unmountInline('memo.main')).toBe(`${ESC}]5379;unmount-inline;memo.main${ST}`);
+  });
+
+  it('emits an unmount-all with NO trailing semicolon when no id is given', () => {
+    expect(unmountInline()).toBe(`${ESC}]5379;unmount-inline${ST}`);
+  });
+
+  it('rejects an invalid view id', () => {
+    expect(() => unmountInline('a;b')).toThrow();
+  });
+});

--- a/sdk/typescript/src/inline/inline.test.ts
+++ b/sdk/typescript/src/inline/inline.test.ts
@@ -38,6 +38,21 @@ describe('mountInline', () => {
   it('accepts the full legal view-id charset', () => {
     expect(() => mountInline('a.b_c-D9', { rows: 1, cols: 1 })).not.toThrow();
   });
+
+  it('appends the instance id as the 5th field when given', () => {
+    const out = mountInline('memo.main', { rows: 3, cols: 20, instanceId: 'a' });
+    expect(out).toBe(`${ESC}]5379;mount-inline;memo.main;3;20;a${ST}\n\n\n`);
+  });
+
+  it('omits the instance field when instanceId is undefined', () => {
+    const out = mountInline('memo.main', { rows: 3, cols: 20 });
+    expect(out).toBe(`${ESC}]5379;mount-inline;memo.main;3;20${ST}\n\n\n`);
+  });
+
+  it('rejects an invalid instance id', () => {
+    expect(() => mountInline('memo.main', { rows: 1, cols: 1, instanceId: 'a;b' })).toThrow();
+    expect(() => mountInline('memo.main', { rows: 1, cols: 1, instanceId: '' })).toThrow();
+  });
 });
 
 describe('unmountInline', () => {
@@ -51,5 +66,17 @@ describe('unmountInline', () => {
 
   it('rejects an invalid view id', () => {
     expect(() => unmountInline('a;b')).toThrow();
+  });
+
+  it('emits an instance-scoped unmount with both ids', () => {
+    expect(unmountInline('memo.main', 'a')).toBe(`${ESC}]5379;unmount-inline;memo.main;a${ST}`);
+  });
+
+  it('throws when an instanceId is given without a viewId', () => {
+    expect(() => unmountInline(undefined, 'a')).toThrow();
+  });
+
+  it('rejects an invalid instance id', () => {
+    expect(() => unmountInline('memo.main', 'a;b')).toThrow();
   });
 });

--- a/sdk/typescript/src/inline/inline.ts
+++ b/sdk/typescript/src/inline/inline.ts
@@ -35,9 +35,9 @@ function assertDim(name: string, value: number, max: number): void {
  *
  * The webview is anchored at the cursor position when this is written, so the
  * caller positions the cursor first (e.g. print a heading). `view_id` must be
- * registered in an extension's `ozmux.toml`; `rows`/`cols` are clamped to
- * 1..=200 / 1..=400 by the validator (out-of-range throws rather than emitting
- * a sequence the terminal would silently drop).
+ * registered in an extension's `ozmux.toml`; `rows`/`cols` are validated to
+ * 1..=200 / 1..=400 (out-of-range throws `RangeError` rather than emitting a
+ * sequence the terminal would silently drop).
  */
 export function mountInline(viewId: string, geometry: InlineGeometry): string {
   assertViewId(viewId);

--- a/sdk/typescript/src/inline/inline.ts
+++ b/sdk/typescript/src/inline/inline.ts
@@ -13,12 +13,14 @@ export interface InlineGeometry {
   rows: number;
   /** Rect width in cells; integer 1..=400. */
   cols: number;
+  /** Optional client-assigned instance id; same charset/length as a view id. */
+  instanceId?: string;
 }
 
-function assertViewId(viewId: string): void {
-  if (!VIEW_ID_RE.test(viewId)) {
+function assertId(label: string, value: string): void {
+  if (!VIEW_ID_RE.test(value)) {
     throw new RangeError(
-      `invalid inline webview id ${JSON.stringify(viewId)}: must match ${VIEW_ID_RE}`,
+      `invalid inline webview ${label} ${JSON.stringify(value)}: must match ${VIEW_ID_RE}`,
     );
   }
 }
@@ -37,25 +39,40 @@ function assertDim(name: string, value: number, max: number): void {
  * caller positions the cursor first (e.g. print a heading). `view_id` must be
  * registered in an extension's `ozmux.toml`; `rows`/`cols` are validated to
  * 1..=200 / 1..=400 (out-of-range throws `RangeError` rather than emitting a
- * sequence the terminal would silently drop).
+ * sequence the terminal would silently drop). An optional `instanceId` is
+ * appended as a 5th field to address a specific instance of the view.
  */
 export function mountInline(viewId: string, geometry: InlineGeometry): string {
-  assertViewId(viewId);
+  assertId('view id', viewId);
   assertDim('rows', geometry.rows, MAX_ROWS);
   assertDim('cols', geometry.cols, MAX_COLS);
-  const seq = `${OSC}${OSC_WEBVIEW_CODE};mount-inline;${viewId};${geometry.rows};${geometry.cols}${ST}`;
+  let seq = `${OSC}${OSC_WEBVIEW_CODE};mount-inline;${viewId};${geometry.rows};${geometry.cols}`;
+  if (geometry.instanceId !== undefined) {
+    assertId('instance id', geometry.instanceId);
+    seq += `;${geometry.instanceId}`;
+  }
+  seq += ST;
   return seq + '\n'.repeat(geometry.rows);
 }
 
 /**
- * Builds the `unmount-inline` OSC 5379 sequence. With a `viewId`, unmounts that
- * inline webview; with none, unmounts every inline webview on the terminal
- * (emitted with no trailing separator — an empty id field is malformed).
+ * Builds the `unmount-inline` OSC 5379 sequence. With `viewId` + `instanceId`,
+ * unmounts that one instance; with `viewId` only, unmounts every instance of
+ * that view; with neither, unmounts every inline webview on the terminal
+ * (emitted with no trailing separator — an empty field is malformed). Passing
+ * an `instanceId` without a `viewId` throws `RangeError`.
  */
-export function unmountInline(viewId?: string): string {
-  if (viewId !== undefined) {
-    assertViewId(viewId);
+export function unmountInline(viewId?: string, instanceId?: string): string {
+  if (viewId === undefined) {
+    if (instanceId !== undefined) {
+      throw new RangeError('unmountInline: instanceId requires a viewId');
+    }
+    return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline${ST}`;
+  }
+  assertId('view id', viewId);
+  if (instanceId === undefined) {
     return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline;${viewId}${ST}`;
   }
-  return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline${ST}`;
+  assertId('instance id', instanceId);
+  return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline;${viewId};${instanceId}${ST}`;
 }

--- a/sdk/typescript/src/inline/inline.ts
+++ b/sdk/typescript/src/inline/inline.ts
@@ -1,0 +1,61 @@
+/** ECMAScript-erasable only (Node type-stripping): no enum / namespace / param-properties. */
+
+const OSC = '\x1b]';
+const ST = '\x1b\\';
+const OSC_WEBVIEW_CODE = '5379';
+const VIEW_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+const MAX_ROWS = 200;
+const MAX_COLS = 400;
+
+/** Geometry for an inline webview, in terminal cells (spec §2 normative bounds). */
+export interface InlineGeometry {
+  /** Rect height in cells; integer 1..=200. */
+  rows: number;
+  /** Rect width in cells; integer 1..=400. */
+  cols: number;
+}
+
+function assertViewId(viewId: string): void {
+  if (!VIEW_ID_RE.test(viewId)) {
+    throw new RangeError(
+      `invalid inline webview id ${JSON.stringify(viewId)}: must match ${VIEW_ID_RE}`,
+    );
+  }
+}
+
+function assertDim(name: string, value: number, max: number): void {
+  if (!Number.isInteger(value) || value < 1 || value > max) {
+    throw new RangeError(`inline ${name} must be an integer in 1..=${max}, got ${value}`);
+  }
+}
+
+/**
+ * Builds the `mount-inline` OSC 5379 sequence plus the `rows` newlines that
+ * reserve its vertical space, as a single string for one atomic `write()`.
+ *
+ * The webview is anchored at the cursor position when this is written, so the
+ * caller positions the cursor first (e.g. print a heading). `view_id` must be
+ * registered in an extension's `ozmux.toml`; `rows`/`cols` are clamped to
+ * 1..=200 / 1..=400 by the validator (out-of-range throws rather than emitting
+ * a sequence the terminal would silently drop).
+ */
+export function mountInline(viewId: string, geometry: InlineGeometry): string {
+  assertViewId(viewId);
+  assertDim('rows', geometry.rows, MAX_ROWS);
+  assertDim('cols', geometry.cols, MAX_COLS);
+  const seq = `${OSC}${OSC_WEBVIEW_CODE};mount-inline;${viewId};${geometry.rows};${geometry.cols}${ST}`;
+  return seq + '\n'.repeat(geometry.rows);
+}
+
+/**
+ * Builds the `unmount-inline` OSC 5379 sequence. With a `viewId`, unmounts that
+ * inline webview; with none, unmounts every inline webview on the terminal
+ * (emitted with no trailing separator — an empty id field is malformed).
+ */
+export function unmountInline(viewId?: string): string {
+  if (viewId !== undefined) {
+    assertViewId(viewId);
+    return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline;${viewId}${ST}`;
+  }
+  return `${OSC}${OSC_WEBVIEW_CODE};unmount-inline${ST}`;
+}

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -5,6 +5,7 @@
 //! via `HostRpc`, with replies routed back on the `ozmux` channel).
 
 use self::preload::{build_preload, webview_url};
+use crate::inline_webview::{InlineWebview, focused_inline_of};
 use crate::osc_webview::GrantedNamespaces;
 use crate::osc_webview::NonInteractive;
 use crate::system_set::OzmuxSystems;
@@ -164,36 +165,36 @@ impl Plugin for OzmuxExtensionRenderPlugin {
 /// from the active pane fixes both — keyboard follows the focused pane, and CEF
 /// blurs the webview on focus-leave (`bevy_cef`'s `apply_webview_focus` releases
 /// CEF focus when `FocusedWebview` becomes `None`).
+///
+/// One case is PRESERVED instead of driven: when `FocusedWebview` holds an
+/// inline webview child (`InlineWebview`) whose `ChildOf` parent is the
+/// resolved active surface, the click-granted inline focus stands (spec §7,
+/// single focus source). Without this arm the per-frame sync would map the
+/// active terminal surface to `None` and clobber an inline click one frame
+/// after `dispatch_mouse_buttons` set it. Every other case — a different pane
+/// or surface becoming active, the inline child despawning, a tab-type
+/// webview surface — keeps the drive-from-active-pane behavior above.
 fn sync_focused_webview(
     mut focused: ResMut<FocusedWebview>,
     mux: MultiplexerCommands,
     attached_workspace: Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
     webviews: Query<(), With<WebviewSource>>,
     non_interactive: Query<(), With<NonInteractive>>,
+    inline_parents: Query<&ChildOf, With<InlineWebview>>,
 ) {
-    let active = active_webview(&mux, &attached_workspace, &webviews, &non_interactive);
+    let active_surface = attached_workspace
+        .iter()
+        .next()
+        .and_then(|workspace| mux.workspaces_active_pane(workspace))
+        .and_then(|pane| mux.panes_active_surface(pane));
+    if focused_inline_of(Some(&focused), &inline_parents, active_surface).is_some() {
+        return;
+    }
+    let active = active_surface
+        .filter(|surface| webviews.contains(*surface) && !non_interactive.contains(*surface));
     if focused.0 != active {
         focused.0 = active;
     }
-}
-
-/// The active pane's focused webview entity, or `None` when the active surface
-/// is not a webview (e.g. a terminal pane) or is render-only
-/// (`NonInteractive`). For extension surfaces the webview is on the Surface
-/// entity itself (`WebviewSource`).
-fn active_webview(
-    mux: &MultiplexerCommands,
-    attached_workspace: &Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
-    webviews: &Query<(), With<WebviewSource>>,
-    non_interactive: &Query<(), With<NonInteractive>>,
-) -> Option<Entity> {
-    let workspace = attached_workspace.iter().next()?;
-    let pane = mux.workspaces_active_pane(workspace)?;
-    let surface = mux.panes_active_surface(pane)?;
-    if webviews.contains(surface) && !non_interactive.contains(surface) {
-        return Some(surface);
-    }
-    None
 }
 
 /// Attaches a `bevy_cef` webview to each Extension Surface host once its pane
@@ -773,6 +774,67 @@ mod tests {
             app.world().resource::<FocusedWebview>().0,
             None,
             "NonInteractive webview surface must never become FocusedWebview"
+        );
+    }
+
+    #[test]
+    fn sync_preserves_inline_focus_on_the_active_surface_and_clears_on_pane_switch() {
+        use bevy::ecs::system::RunSystemOnce;
+        use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin, Side, SplitOrientation};
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<FocusedWebview>();
+        app.add_systems(Update, sync_focused_webview);
+
+        let (workspace, terminal_pane, terminal_surface) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_workspace(Some("t".into()));
+                (o.workspace, o.pane, o.surface)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut()
+            .entity_mut(workspace)
+            .insert(AttachedWorkspace);
+
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(terminal_surface),
+                InlineWebview {
+                    view_id: "inline-test".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.insert_resource(FocusedWebview(Some(child)));
+
+        app.update();
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "an inline-focused child of the ACTIVE terminal surface must survive the sync"
+        );
+
+        // Splitting promotes the fresh pane to active; the focused child's
+        // parent is no longer the active surface, so the preservation arm
+        // must NOT hold and the terminal-pane mapping (None) must win.
+        app.world_mut()
+            .run_system_once(move |mut mux: MultiplexerCommands| {
+                mux.split_pane(terminal_pane, Side::After, SplitOrientation::Horizontal)
+                    .expect("split_pane")
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "inline focus must clear once a different pane/surface becomes active"
         );
     }
 

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -806,6 +806,7 @@ mod tests {
                 ChildOf(terminal_surface),
                 InlineWebview {
                     view_id: "inline-test".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -4,6 +4,7 @@
 //! surface (capability-gated `host.call` frames forwarded to the single Node host
 //! via `HostRpc`, with replies routed back on the `ozmux` channel).
 
+use self::preload::{build_preload, webview_url};
 use crate::osc_webview::GrantedNamespaces;
 use crate::osc_webview::NonInteractive;
 use crate::system_set::OzmuxSystems;
@@ -20,11 +21,7 @@ use ozmux_multiplexer::{
 };
 use serde_json::Value;
 
-/// Builds the `ozmux-ext://<name>/<entry>` webview URL for an extension surface,
-/// where `entry` is the client's HTML path relative to the extension dir.
-fn webview_url(extension_name: &str, entry: &str) -> String {
-    format!("ozmux-ext://{extension_name}/{entry}")
-}
+pub(crate) mod preload;
 
 /// One frame emitted by the page bridge `host_bridge.js` via
 /// `cef.emit({ kind: 'host.call', … })`, inspected by `on_host_call_frame`.
@@ -91,11 +88,6 @@ impl HostRpc {
 #[derive(Component)]
 struct WebviewMountUnresolved;
 
-/// JS defining the new-model `window.<ns>.<method>` host-API bridge over
-/// `cef.emit` / `cef.listen`, injected (with `window.__ozmuxGranted`) per
-/// webview as a `PreloadScripts` entry.
-const HOST_BRIDGE_JS: &str = include_str!("extension_render/host_bridge.js");
-
 /// The `kind` discriminator that routes a `Receive<OzmuxFrame>` to the new-model
 /// host-API path (`on_host_call_frame`). The page side emits the matching literal
 /// in `host_bridge.js`.
@@ -107,7 +99,7 @@ const HOST_CALL_KIND: &str = "host.call";
 /// registry on each request, so entries registered after `CefPlugin::build()`
 /// resolve; unregistered names 404. The host-API bridge is intentionally NOT
 /// registered as a global extension here; it is injected per-webview via
-/// `PreloadScripts` in `finish_extension_setup` (see the NOTE there).
+/// `PreloadScripts` by `preload::build_preload` (see the NOTE there).
 pub fn cef_plugin(registry: AssetSourceRegistry) -> CefPlugin {
     CefPlugin {
         custom_schemes: vec![custom_scheme(registry)],
@@ -262,16 +254,8 @@ fn finish_extension_setup(
         let name = owner.0.as_str();
         let url = webview_url(name, &entry);
         tracing::debug!(?surface, ?logical, %url, "spawning extension webview");
-        // NOTE: `window.<ns>` MUST be a PreloadScript, not a global CefExtension.
-        // host_bridge.js calls cef.listen() at top level; a global extension runs
-        // that during V8 context creation, where there is no entered V8 context, so
-        // the native cef.listen handler's v8_context_get_current_context() crashes
-        // the render process. PreloadScripts are eval'd at on_context_created inside
-        // an entered context (and their exceptions are caught, not fatal), so
-        // cef.listen registers correctly there.
-        let ctx_js = context_preload_js(workspace, pane, surface, name);
-        let granted_json = match granted.get(surface) {
-            Ok(g) => serde_json::to_string(&g.0).expect("namespace set serializes infallibly"),
+        let preload = match granted.get(surface) {
+            Ok(g) => build_preload(workspace, pane, surface, name, g),
             Err(_) => {
                 // NOTE: every OSC-mounted Extension surface is stamped with
                 // GrantedNamespaces at mount; reaching setup without it means a
@@ -281,11 +265,15 @@ fn finish_extension_setup(
                     ?surface,
                     "extension surface has no GrantedNamespaces; injecting empty grant"
                 );
-                "[]".to_string()
+                build_preload(
+                    workspace,
+                    pane,
+                    surface,
+                    name,
+                    &GrantedNamespaces::default(),
+                )
             }
         };
-        let granted_js = format!("window.__ozmuxGranted={granted_json};");
-        let preload = PreloadScripts::from([ctx_js, granted_js, HOST_BRIDGE_JS.to_string()]);
         commands.entity(surface).insert((
             WebviewSource::new(url),
             WebviewSize(logical),
@@ -306,28 +294,6 @@ fn surface_multiplexer_chain(
     let pane = mux.pane_of_surface(surface)?;
     let workspace = mux.workspace_of_pane(pane)?;
     Some((workspace, pane))
-}
-
-/// Builds the per-webview context PreloadScript assigning `window.__ozmuxContext`.
-///
-/// NOTE: PreloadScripts are joined with `;` and eval'd as one unit, so this MUST
-/// be a complete statement; a syntax error here would break the bridge eval too.
-fn context_preload_js(
-    workspace: Entity,
-    pane: Entity,
-    surface: Entity,
-    extension_name: &str,
-) -> String {
-    let workspace_id = workspace.to_bits().to_string();
-    // NOTE: the JS keys "sessionId"/"windowId" keep their legacy names on purpose — a
-    // browser-side wire contract the SDK surface client reads; renaming them breaks extensions.
-    format!(
-        "window.__ozmuxContext={{sessionId:{s:?},windowId:{s:?},paneId:{p:?},surfaceId:{a:?},role:\"extension\",extensionName:{n:?}}};",
-        s = workspace_id,
-        p = pane.to_bits().to_string(),
-        a = surface.to_bits().to_string(),
-        n = extension_name,
-    )
 }
 
 /// Converts a host pane's `ComputedNode` physical-pixel size to the logical
@@ -729,36 +695,6 @@ mod tests {
     }
 
     #[test]
-    fn context_preload_js_assigns_window_context_with_workspace_bits_as_window_id() {
-        let world = &mut App::new();
-        world
-            .add_plugins(MinimalPlugins)
-            .add_plugins(MultiplexerPlugin);
-        let (workspace, pane, surface) = world
-            .world_mut()
-            .run_system_once(|mut mux: MultiplexerCommands| {
-                let o = mux.create_workspace(Some("t".into()));
-                (o.workspace, o.pane, o.surface)
-            })
-            .unwrap();
-        world.world_mut().flush();
-
-        let js = context_preload_js(workspace, pane, surface, "memo");
-        let s = workspace.to_bits().to_string();
-        assert!(js.starts_with("window.__ozmuxContext="));
-        assert!(js.ends_with("};"));
-        assert!(js.contains(&format!("sessionId:\"{s}\"")));
-        assert!(
-            js.contains(&format!("windowId:\"{s}\"")),
-            "windowId must equal sessionId per the design"
-        );
-        assert!(js.contains(&format!("paneId:\"{}\"", pane.to_bits())));
-        assert!(js.contains(&format!("surfaceId:\"{}\"", surface.to_bits())));
-        assert!(js.contains("role:\"extension\""));
-        assert!(js.contains("extensionName:\"memo\""));
-    }
-
-    #[test]
     fn pane_logical_size_scales_physical_to_logical() {
         assert_eq!(
             pane_logical_size(Vec2::new(640.0, 480.0), 1.0),
@@ -1128,7 +1064,7 @@ mod tests {
             .get::<PreloadScripts>(host)
             .expect("new-model surface must carry the host bridge as a PreloadScript");
         assert!(
-            preload.0.iter().any(|s| s == HOST_BRIDGE_JS),
+            preload.0.iter().any(|s| s == preload::HOST_BRIDGE_JS),
             "the host-API bridge JS must be injected for a surface with GrantedNamespaces"
         );
         assert!(

--- a/src/extension_render/preload.rs
+++ b/src/extension_render/preload.rs
@@ -1,0 +1,152 @@
+//! Shared preload-script builder for ozmux-managed webviews: the
+//! `window.__ozmuxContext` globals, the `window.__ozmuxGranted` capability
+//! grant, and the `window.<ns>.<method>` host-API bridge JS.
+
+use crate::osc_webview::GrantedNamespaces;
+use bevy::prelude::Entity;
+use bevy_cef::prelude::PreloadScripts;
+
+/// Builds the `ozmux-ext://<name>/<entry>` webview URL for an extension surface,
+/// where `entry` is the client's HTML path relative to the extension dir.
+pub(crate) fn webview_url(extension_name: &str, entry: &str) -> String {
+    format!("ozmux-ext://{extension_name}/{entry}")
+}
+
+/// JS defining the new-model `window.<ns>.<method>` host-API bridge over
+/// `cef.emit` / `cef.listen`, injected (with `window.__ozmuxGranted`) per
+/// webview as a `PreloadScripts` entry.
+pub(super) const HOST_BRIDGE_JS: &str = include_str!("host_bridge.js");
+
+/// Builds the full preload script set for an ozmux-managed webview:
+/// context globals, the capability grant, and the host-API bridge.
+pub(crate) fn build_preload(
+    workspace: Entity,
+    pane: Entity,
+    surface: Entity,
+    extension_name: &str,
+    granted: &GrantedNamespaces,
+) -> PreloadScripts {
+    let ctx_js = context_preload_js(workspace, pane, surface, extension_name);
+    let granted_json =
+        serde_json::to_string(&granted.0).expect("namespace set serializes infallibly");
+    let granted_js = format!("window.__ozmuxGranted={granted_json};");
+    // NOTE: `window.<ns>` MUST be a PreloadScript, not a global CefExtension.
+    // host_bridge.js calls cef.listen() at top level; a global extension runs
+    // that during V8 context creation, where there is no entered V8 context, so
+    // the native cef.listen handler's v8_context_get_current_context() crashes
+    // the render process. PreloadScripts are eval'd at on_context_created inside
+    // an entered context (and their exceptions are caught, not fatal), so
+    // cef.listen registers correctly there.
+    PreloadScripts::from([ctx_js, granted_js, HOST_BRIDGE_JS.to_string()])
+}
+
+/// Builds the per-webview context PreloadScript assigning `window.__ozmuxContext`.
+///
+/// NOTE: PreloadScripts are joined with `;` and eval'd as one unit, so this MUST
+/// be a complete statement; a syntax error here would break the bridge eval too.
+fn context_preload_js(
+    workspace: Entity,
+    pane: Entity,
+    surface: Entity,
+    extension_name: &str,
+) -> String {
+    let workspace_id = workspace.to_bits().to_string();
+    // NOTE: the JS keys "sessionId"/"windowId" keep their legacy names on purpose — a
+    // browser-side wire contract the SDK surface client reads; renaming them breaks extensions.
+    format!(
+        "window.__ozmuxContext={{sessionId:{s:?},windowId:{s:?},paneId:{p:?},surfaceId:{a:?},role:\"extension\",extensionName:{n:?}}};",
+        s = workspace_id,
+        p = pane.to_bits().to_string(),
+        a = surface.to_bits().to_string(),
+        n = extension_name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::app::App;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::MinimalPlugins;
+    use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
+
+    #[test]
+    fn context_preload_js_assigns_window_context_with_workspace_bits_as_window_id() {
+        let world = &mut App::new();
+        world
+            .add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        let (workspace, pane, surface) = world
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_workspace(Some("t".into()));
+                (o.workspace, o.pane, o.surface)
+            })
+            .unwrap();
+        world.world_mut().flush();
+
+        let js = context_preload_js(workspace, pane, surface, "memo");
+        let s = workspace.to_bits().to_string();
+        assert!(js.starts_with("window.__ozmuxContext="));
+        assert!(js.ends_with("};"));
+        assert!(js.contains(&format!("sessionId:\"{s}\"")));
+        assert!(
+            js.contains(&format!("windowId:\"{s}\"")),
+            "windowId must equal sessionId per the design"
+        );
+        assert!(js.contains(&format!("paneId:\"{}\"", pane.to_bits())));
+        assert!(js.contains(&format!("surfaceId:\"{}\"", surface.to_bits())));
+        assert!(js.contains("role:\"extension\""));
+        assert!(js.contains("extensionName:\"memo\""));
+    }
+
+    #[test]
+    fn build_preload_orders_context_grant_then_bridge() {
+        let world = &mut App::new();
+        world
+            .add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        let (workspace, pane, surface) = world
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_workspace(Some("t".into()));
+                (o.workspace, o.pane, o.surface)
+            })
+            .unwrap();
+        world.world_mut().flush();
+
+        let mut caps = std::collections::HashSet::new();
+        caps.insert("fs".to_string());
+        let preload = build_preload(workspace, pane, surface, "memo", &GrantedNamespaces(caps));
+
+        assert_eq!(preload.0.len(), 3);
+        assert!(preload.0[0].starts_with("window.__ozmuxContext="));
+        assert_eq!(preload.0[1], "window.__ozmuxGranted=[\"fs\"];");
+        assert_eq!(preload.0[2], HOST_BRIDGE_JS);
+    }
+
+    #[test]
+    fn build_preload_serializes_an_empty_grant_as_empty_array() {
+        let world = &mut App::new();
+        world
+            .add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        let (workspace, pane, surface) = world
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_workspace(Some("t".into()));
+                (o.workspace, o.pane, o.surface)
+            })
+            .unwrap();
+        world.world_mut().flush();
+
+        let preload = build_preload(
+            workspace,
+            pane,
+            surface,
+            "memo",
+            &GrantedNamespaces::default(),
+        );
+        assert_eq!(preload.0[1], "window.__ozmuxGranted=[];");
+    }
+}

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -1,22 +1,26 @@
 //! Inline webviews: `ChildOf` children of a terminal surface that render a
 //! registered view into the terminal's text flow. This module owns the
-//! components and the mount/unmount policy executed by the `MountInline` /
-//! `UnmountInline` arms of `osc_webview::on_osc_webview_request`.
+//! components, the mount/unmount policy executed by the `MountInline` /
+//! `UnmountInline` arms of `osc_webview::on_osc_webview_request`, and the
+//! `OzmuxInlineWebviewPlugin` runtime systems that keep `WebviewSize` in
+//! sync with cell metrics and project placements into `TerminalOverlays`.
 
 use crate::extension_render::preload::{build_preload, webview_url};
 use crate::osc_webview::{GrantedNamespaces, NonInteractive};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
+use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
+use bevy::ui_render::PreparedUiMaterial;
 use bevy::window::PrimaryWindow;
-use bevy_cef::prelude::{WebviewSize, WebviewSource, WebviewTextureTarget};
+use bevy_cef::prelude::{
+    WebviewGpuImageInjectSet, WebviewSize, WebviewSource, WebviewTextureTarget,
+};
 use bevy_terminal::InlineAnchor;
 use bevy_terminal_renderer::TerminalCellMetricsResource;
-use bevy_terminal_renderer::material::TerminalMaterialSystems;
+use bevy_terminal_renderer::material::{TerminalMaterialSystems, TerminalUiMaterial};
 use bevy_terminal_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
 use bevy_terminal_renderer::schema::TerminalGrid;
 use ozmux_extension_host::ViewRegistry;
-
-// TODO: Task 5 adds the WebviewSize/DPR size-sync system to this plugin.
 
 /// Marks an inline webview entity and records its identity: the mounted
 /// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
@@ -52,21 +56,40 @@ pub(crate) struct InlinePlacement {
     pub(crate) frame_seq: u32,
 }
 
-/// Registers the per-frame projection that derives `TerminalOverlays` from
-/// inline-webview children (spec §5).
+/// Registers the inline-webview runtime systems: the `WebviewSize` size sync
+/// (`Update`), the per-frame projection that derives `TerminalOverlays` from
+/// inline-webview children (spec §5), and the render-world ordering edge that
+/// keeps webview GPU texture injection ahead of the terminal material's
+/// bind-group rebuild.
 ///
-/// Scheduled in `PostUpdate` before `TerminalMaterialSystems::UpdateMaterial`:
-/// grid state settles during `Update` (the PTY drain systems flush the
-/// `FrameSnapshot` / `FrameDelta` observers there), so projecting just before
-/// the material rebuild hands the same frame's overlays to the shader.
+/// The projection is scheduled in `PostUpdate` before
+/// `TerminalMaterialSystems::UpdateMaterial`: grid state settles during
+/// `Update` (the PTY drain systems flush the `FrameSnapshot` / `FrameDelta`
+/// observers there), so projecting just before the material rebuild hands the
+/// same frame's overlays to the shader.
 pub(crate) struct OzmuxInlineWebviewPlugin;
 
 impl Plugin for OzmuxInlineWebviewPlugin {
     fn build(&self, app: &mut App) {
+        app.add_systems(Update, sync_inline_webview_size);
         app.add_systems(
             PostUpdate,
             project_inline_overlays.before(TerminalMaterialSystems::UpdateMaterial),
         );
+        // NOTE: without this edge, `TerminalUiMaterial`'s bind-group rebuild
+        // can run between bevy_cef's rebind image-touch (which re-uploads the
+        // CPU placeholder) and the GPU texture injection, capturing the
+        // placeholder permanently — a forever-black overlay (see the
+        // `WebviewGpuImageInjectSet` docs in bevy_cef's texture_target.rs).
+        // It also transitively orders the GpuImage prepare before the
+        // material prepare, avoiding a 1-frame RetryNextUpdate stall.
+        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.configure_sets(
+                Render,
+                WebviewGpuImageInjectSet
+                    .before(prepare_assets::<PreparedUiMaterial<TerminalUiMaterial>>),
+            );
+        }
     }
 }
 
@@ -118,8 +141,8 @@ pub(crate) struct InlineWebviewParams<'w, 's> {
 /// from it at creation. The seed is `(cols × cell_w, rows × cell_h) /
 /// scale_factor` in logical px from `TerminalCellMetricsResource` and the
 /// primary window; when neither exists yet (headless tests, pre-first-render)
-/// a placeholder cell of 8×16 physical px at scale 1.0 is used — Task 5's
-/// size-sync system corrects it.
+/// a placeholder cell of 8×16 physical px at scale 1.0 is used —
+/// `sync_inline_webview_size` corrects it once real metrics arrive.
 pub(crate) fn mount_inline(
     params: &mut InlineWebviewParams,
     registry: &ViewRegistry,
@@ -263,6 +286,36 @@ fn seed_logical_size(
         / scale_factor.max(f32::EPSILON)
 }
 
+/// Recomputes every inline webview's `WebviewSize` from the current cell
+/// metrics and primary-window scale factor (spec §6.5), writing only when the
+/// value differs — `bevy_cef` commits sizes to CEF on `Changed<WebviewSize>`,
+/// so a spurious write each frame would re-commit (and re-create the
+/// IOSurface) every frame. Exact equality suffices: the inputs are identical
+/// frame-to-frame unless metrics/scale actually changed, and this math is
+/// deterministic.
+fn sync_inline_webview_size(
+    mut sizes: Query<(&mut WebviewSize, &InlinePlacement)>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let scale_factor = windows
+        .iter()
+        .next()
+        .map(Window::scale_factor)
+        .unwrap_or(1.0);
+    let (cell_w_phys, cell_h_phys) = cell_size_phys(metrics.as_deref());
+    for (mut size, placement) in &mut sizes {
+        let next = seed_logical_size(
+            placement.rows,
+            placement.cols,
+            cell_w_phys,
+            cell_h_phys,
+            scale_factor,
+        );
+        size.set_if_neq(WebviewSize(next));
+    }
+}
+
 /// The wire mode string `bevy_terminal`'s `mode_diff` emits for
 /// `TermMode::ALT_SCREEN`.
 const ALT_SCREEN_MODE: &str = "alt-screen";
@@ -351,6 +404,7 @@ mod tests {
     use bevy::ecs::system::RunSystemOnce;
     use bevy_cef::prelude::PreloadScripts;
     use bevy_terminal::{OscWebviewRequest, OscWebviewVerb};
+    use bevy_terminal_renderer::CellMetrics;
     use ozmux_extension_host::RegisteredView;
     use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
 
@@ -759,33 +813,33 @@ mod tests {
         assert!(overlays.textures[0].is_some());
     }
 
+    fn formula_grid(history_size: u32, display_offset: u32) -> TerminalGrid {
+        TerminalGrid {
+            cols: 80,
+            rows: 5,
+            last_seq: 1,
+            history_base: 0,
+            history_size,
+            display_offset,
+            ..Default::default()
+        }
+    }
+
+    fn formula_placement() -> InlinePlacement {
+        InlinePlacement {
+            anchor_line: 30,
+            anchor_col: 2,
+            rows: 4,
+            cols: 10,
+            frame_seq: 0,
+        }
+    }
+
     #[test]
     fn projection_formula_maps_absolute_line_to_viewport_row() {
         let mut app = make_test_app();
-        let terminal = app
-            .world_mut()
-            .spawn(TerminalGrid {
-                cols: 80,
-                rows: 5,
-                last_seq: 1,
-                history_base: 0,
-                history_size: 26,
-                display_offset: 0,
-                ..Default::default()
-            })
-            .id();
-        spawn_projection_child(
-            &mut app,
-            terminal,
-            0,
-            InlinePlacement {
-                anchor_line: 30,
-                anchor_col: 2,
-                rows: 4,
-                cols: 10,
-                frame_seq: 0,
-            },
-        );
+        let terminal = app.world_mut().spawn(formula_grid(26, 0)).id();
+        spawn_projection_child(&mut app, terminal, 0, formula_placement());
 
         project(&mut app);
         assert_eq!(
@@ -793,19 +847,24 @@ mod tests {
             IVec4::new(4, 2, 4, 10),
             "30 - (0 + 26 - 0) must land on viewport row 4"
         );
+    }
 
-        app.world_mut()
-            .get_mut::<TerminalGrid>(terminal)
-            .unwrap()
-            .display_offset = 3;
+    #[test]
+    fn projection_formula_culls_rect_pushed_below_viewport_by_scrollback() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(formula_grid(26, 3)).id();
+        spawn_projection_child(&mut app, terminal, 0, formula_placement());
+
         project(&mut app);
         assert_all_sentinel(overlays_of(&app, terminal));
+    }
 
-        {
-            let mut grid = app.world_mut().get_mut::<TerminalGrid>(terminal).unwrap();
-            grid.display_offset = 0;
-            grid.history_size = 32;
-        }
+    #[test]
+    fn projection_formula_keeps_negative_row_for_partially_above_rect() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(formula_grid(32, 0)).id();
+        spawn_projection_child(&mut app, terminal, 0, formula_placement());
+
         project(&mut app);
         assert_eq!(
             overlays_of(&app, terminal).rects[0],
@@ -856,6 +915,31 @@ mod tests {
 
         project(&mut app);
         assert_all_sentinel(overlays_of(&app, terminal));
+    }
+
+    #[test]
+    fn projection_keeps_rect_anchored_at_last_valid_column() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(projection_grid(7)).id();
+        spawn_projection_child(
+            &mut app,
+            terminal,
+            0,
+            InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 79,
+                rows: 10,
+                cols: 10,
+                frame_seq: 7,
+            },
+        );
+
+        project(&mut app);
+        assert_eq!(
+            overlays_of(&app, terminal).rects[0],
+            IVec4::new(2, 79, 10, 10),
+            "a rect anchored at the last valid column (cols - 1) must project, not cull"
+        );
     }
 
     #[test]
@@ -977,6 +1061,83 @@ mod tests {
             overlays_of(&app, terminal).rects[0],
             IVec4::new(2, 3, 10, 40),
             "a last_seq that wrapped past 0 must release the hold"
+        );
+    }
+
+    #[test]
+    fn size_sync_updates_webview_size_when_metrics_change() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+        let child = inline_children_of(&app, terminal)[0];
+        assert_eq!(
+            app.world().get::<WebviewSize>(child),
+            Some(&WebviewSize(Vec2::new(320.0, 160.0))),
+            "the metrics-less mount must seed from the 8x16 placeholder"
+        );
+
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 10.0,
+                line_height_phys: 20.0,
+                ascent_phys: 15.0,
+                descent_phys: 5.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 24,
+        });
+        app.world_mut()
+            .run_system_once(sync_inline_webview_size)
+            .unwrap();
+
+        assert_eq!(
+            app.world().get::<WebviewSize>(child),
+            Some(&WebviewSize(Vec2::new(400.0, 200.0))),
+            "size sync must recompute the 40x10-cell rect at the real 10x20 px pitch"
+        );
+    }
+
+    #[derive(Resource, Default)]
+    struct SizeChangeProbe(bool);
+
+    fn probe_webview_size_changed(
+        mut probe: ResMut<SizeChangeProbe>,
+        sizes: Query<Ref<WebviewSize>>,
+    ) {
+        probe.0 = sizes.iter().any(|size| size.is_changed());
+    }
+
+    #[test]
+    fn size_sync_is_quiescent_when_nothing_changed() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &[]);
+        app.init_resource::<SizeChangeProbe>();
+        app.add_systems(
+            Update,
+            (sync_inline_webview_size, probe_webview_size_changed).chain(),
+        );
+        let terminal = spawn_terminal(&mut app);
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+
+        app.update();
+        assert!(
+            app.world().resource::<SizeChangeProbe>().0,
+            "the first update after mount must see the freshly-added WebviewSize as changed"
+        );
+
+        app.update();
+        assert!(
+            !app.world().resource::<SizeChangeProbe>().0,
+            "a second run with identical inputs must not change-flag WebviewSize"
+        );
+        let child = inline_children_of(&app, terminal)[0];
+        assert_eq!(
+            app.world().get::<WebviewSize>(child),
+            Some(&WebviewSize(Vec2::new(320.0, 160.0))),
+            "the value must stay at the placeholder seed"
         );
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -11,12 +11,12 @@ use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::{WebviewSize, WebviewSource, WebviewTextureTarget};
 use bevy_terminal::InlineAnchor;
 use bevy_terminal_renderer::TerminalCellMetricsResource;
-use bevy_terminal_renderer::prelude::OVERLAY_SLOTS;
+use bevy_terminal_renderer::material::TerminalMaterialSystems;
+use bevy_terminal_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
+use bevy_terminal_renderer::schema::TerminalGrid;
 use ozmux_extension_host::ViewRegistry;
 
-// TODO: Task 5 adds the per-frame projection / size-sync systems and their
-// plugin. Task 3 registers nothing — the mount/unmount arms ride the existing
-// `on_osc_webview_request` observer wired by `OzmuxOscWebviewPlugin`.
+// TODO: Task 5 adds the WebviewSize/DPR size-sync system to this plugin.
 
 /// Marks an inline webview entity and records its identity: the mounted
 /// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
@@ -35,8 +35,8 @@ pub(crate) struct InlineWebview {
 /// Where an inline webview sits in its terminal's scrollback: the anchor cell
 /// (absolute line = `history_base + history_size + cursor row` at the OSC byte
 /// position, plus the cursor column), the rect extent in cells, and the VT
-/// `frame_seq` the next grid emit carries (Task 5 defers first projection
-/// until the grid catches up to it).
+/// `frame_seq` the next grid emit carries (`project_inline_overlays` defers
+/// first projection until the grid catches up to it).
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct InlinePlacement {
     /// Absolute scrollback line of the rect's TOP row.
@@ -50,6 +50,24 @@ pub(crate) struct InlinePlacement {
     /// The VT frame seq stamped at mount; grid frames at or after this seq
     /// (wrap-aware compare) may project the placement.
     pub(crate) frame_seq: u32,
+}
+
+/// Registers the per-frame projection that derives `TerminalOverlays` from
+/// inline-webview children (spec §5).
+///
+/// Scheduled in `PostUpdate` before `TerminalMaterialSystems::UpdateMaterial`:
+/// grid state settles during `Update` (the PTY drain systems flush the
+/// `FrameSnapshot` / `FrameDelta` observers there), so projecting just before
+/// the material rebuild hands the same frame's overlays to the shader.
+pub(crate) struct OzmuxInlineWebviewPlugin;
+
+impl Plugin for OzmuxInlineWebviewPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            project_inline_overlays.before(TerminalMaterialSystems::UpdateMaterial),
+        );
+    }
 }
 
 /// Everything the `MountInline` verb carries into `mount_inline`: the target
@@ -93,8 +111,8 @@ pub(crate) struct InlineWebviewParams<'w, 's> {
 /// multiplexer Surface entity itself: `finish_terminal_setup` inserts both
 /// `TerminalBundle` (`TerminalHandle`, which emits the OSC request) and
 /// `TerminalRenderBundle` (`TerminalGrid`) onto that one entity, so the
-/// `ChildOf` parent is also the entity Task 5's projection reads grid state
-/// from.
+/// `ChildOf` parent is also the entity `project_inline_overlays` reads grid
+/// state from.
 ///
 /// `WebviewSize` is seeded here because `bevy_cef` builds the CEF browser
 /// from it at creation. The seed is `(cols × cell_w, rows × cell_h) /
@@ -245,6 +263,87 @@ fn seed_logical_size(
         / scale_factor.max(f32::EPSILON)
 }
 
+/// The wire mode string `bevy_terminal`'s `mode_diff` emits for
+/// `TermMode::ALT_SCREEN`.
+const ALT_SCREEN_MODE: &str = "alt-screen";
+
+/// Derives each terminal's `TerminalOverlays` from its live inline-webview
+/// children, every frame, starting from the all-sentinel default (spec §5).
+///
+/// Per-child projection rules, in order:
+/// 1. Alt-screen: while the grid is on the alternate screen, every slot stays
+///    sentinel (the placement re-projects on return to the primary screen).
+/// 2. Seq-hold: a placement is skipped until the grid's `last_seq` reaches the
+///    mount-stamped `frame_seq` (wrap-aware compare).
+/// 3. `viewport_row = anchor_line - (history_base + history_size -
+///    display_offset)`; rects fully above/below the viewport or anchored at or
+///    past the right edge are culled; a partially-above rect keeps its
+///    negative row (the shader clips).
+///
+/// The component is (re)inserted for every terminal that has inline children
+/// OR already carries `TerminalOverlays`, so a terminal whose last inline
+/// child despawned converges to all-sentinel / all-`None` instead of keeping
+/// stale texture handles alive.
+fn project_inline_overlays(
+    mut commands: Commands,
+    terminals: Query<(
+        Entity,
+        &TerminalGrid,
+        Option<&Children>,
+        Has<TerminalOverlays>,
+    )>,
+    inline: Query<(&InlineWebview, &InlinePlacement, &WebviewTextureTarget)>,
+) {
+    for (terminal, grid, children, has_overlays) in &terminals {
+        // NOTE: `grid.modes` refreshes only on snapshots (FrameDelta carries
+        // no modes), which suffices here: alt-screen entry/exit always
+        // arrives as a snapshot — alacritty's `Term::swap_alt` calls
+        // `mark_fully_damaged()`, full damage collects as `DirtyRows::Full`,
+        // and `decide_frame_kind` maps that to `FrameKind::Snapshot`. A
+        // delta can therefore never carry an alt-screen flip past this check.
+        let on_alt_screen = grid.modes.iter().any(|m| m == ALT_SCREEN_MODE);
+        let mut overlays = TerminalOverlays::default();
+        let mut has_inline_child = false;
+        if let Some(kids) = children {
+            for child in kids.iter() {
+                let Ok((view, placement, texture)) = inline.get(child) else {
+                    continue;
+                };
+                has_inline_child = true;
+                if on_alt_screen {
+                    continue;
+                }
+                if (grid.last_seq.wrapping_sub(placement.frame_seq) as i32) < 0 {
+                    continue;
+                }
+                let viewport_row = placement.anchor_line as i64
+                    - (grid.history_base as i64 + i64::from(grid.history_size)
+                        - i64::from(grid.display_offset));
+                if viewport_row + i64::from(placement.rows) <= 0
+                    || viewport_row >= i64::from(grid.rows)
+                    || u32::from(placement.anchor_col) >= u32::from(grid.cols)
+                {
+                    continue;
+                }
+                let slot = usize::from(view.slot);
+                if slot >= OVERLAY_SLOTS {
+                    continue;
+                }
+                overlays.rects[slot] = IVec4::new(
+                    viewport_row as i32,
+                    i32::from(placement.anchor_col),
+                    i32::from(placement.rows),
+                    i32::from(placement.cols),
+                );
+                overlays.textures[slot] = Some(texture.0.clone());
+            }
+        }
+        if has_inline_child || has_overlays {
+            commands.entity(terminal).insert(overlays);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,7 +417,7 @@ mod tests {
             anchor: None,
         });
         app.world_mut().flush();
-        // Despawn is deferred; an update applies it.
+        // NOTE: despawn is deferred; a flush + update applies it.
         app.update();
     }
 
@@ -565,6 +664,319 @@ mod tests {
         assert_eq!(
             cell_size_phys(None),
             (FALLBACK_CELL_W_PHYS, FALLBACK_CELL_H_PHYS)
+        );
+    }
+
+    fn projection_grid(last_seq: u32) -> TerminalGrid {
+        TerminalGrid {
+            cols: 80,
+            rows: 24,
+            last_seq,
+            history_base: 0,
+            history_size: 40,
+            display_offset: 0,
+            ..Default::default()
+        }
+    }
+
+    fn spawn_projection_child(
+        app: &mut App,
+        terminal: Entity,
+        slot: u8,
+        placement: InlinePlacement,
+    ) -> Handle<Image> {
+        let handle = app
+            .world_mut()
+            .resource_mut::<Assets<Image>>()
+            .add(Image::default());
+        app.world_mut().spawn((
+            ChildOf(terminal),
+            InlineWebview {
+                view_id: format!("view-{slot}"),
+                slot,
+            },
+            placement,
+            WebviewTextureTarget(handle.clone()),
+        ));
+        handle
+    }
+
+    fn project(app: &mut App) {
+        app.world_mut()
+            .run_system_once(project_inline_overlays)
+            .unwrap();
+    }
+
+    fn overlays_of(app: &App, terminal: Entity) -> &TerminalOverlays {
+        app.world()
+            .get::<TerminalOverlays>(terminal)
+            .expect("projection must insert TerminalOverlays on the terminal")
+    }
+
+    fn assert_all_sentinel(overlays: &TerminalOverlays) {
+        assert_eq!(
+            overlays.rects,
+            [IVec4::ZERO; OVERLAY_SLOTS],
+            "every rect must stay at the rows == 0 sentinel"
+        );
+        assert!(
+            overlays.textures.iter().all(Option::is_none),
+            "every texture slot must stay None"
+        );
+    }
+
+    #[test]
+    fn projection_holds_until_grid_seq_reaches_anchor_seq() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(projection_grid(6)).id();
+        spawn_projection_child(
+            &mut app,
+            terminal,
+            0,
+            InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 3,
+                rows: 10,
+                cols: 40,
+                frame_seq: 7,
+            },
+        );
+
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+
+        app.world_mut()
+            .get_mut::<TerminalGrid>(terminal)
+            .unwrap()
+            .last_seq = 7;
+        project(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(
+            overlays.rects[0],
+            IVec4::new(2, 3, 10, 40),
+            "once last_seq reaches frame_seq the rect must project (42 - 40 = row 2)"
+        );
+        assert!(overlays.textures[0].is_some());
+    }
+
+    #[test]
+    fn projection_formula_maps_absolute_line_to_viewport_row() {
+        let mut app = make_test_app();
+        let terminal = app
+            .world_mut()
+            .spawn(TerminalGrid {
+                cols: 80,
+                rows: 5,
+                last_seq: 1,
+                history_base: 0,
+                history_size: 26,
+                display_offset: 0,
+                ..Default::default()
+            })
+            .id();
+        spawn_projection_child(
+            &mut app,
+            terminal,
+            0,
+            InlinePlacement {
+                anchor_line: 30,
+                anchor_col: 2,
+                rows: 4,
+                cols: 10,
+                frame_seq: 0,
+            },
+        );
+
+        project(&mut app);
+        assert_eq!(
+            overlays_of(&app, terminal).rects[0],
+            IVec4::new(4, 2, 4, 10),
+            "30 - (0 + 26 - 0) must land on viewport row 4"
+        );
+
+        app.world_mut()
+            .get_mut::<TerminalGrid>(terminal)
+            .unwrap()
+            .display_offset = 3;
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+
+        {
+            let mut grid = app.world_mut().get_mut::<TerminalGrid>(terminal).unwrap();
+            grid.display_offset = 0;
+            grid.history_size = 32;
+        }
+        project(&mut app);
+        assert_eq!(
+            overlays_of(&app, terminal).rects[0],
+            IVec4::new(-2, 2, 4, 10),
+            "a partially-above rect must pass its negative row through as i32"
+        );
+    }
+
+    #[test]
+    fn projection_culls_fully_outside_rects() {
+        let mut app = make_test_app();
+        let terminal = app
+            .world_mut()
+            .spawn(TerminalGrid {
+                cols: 80,
+                rows: 24,
+                last_seq: 1,
+                history_base: 0,
+                history_size: 30,
+                display_offset: 0,
+                ..Default::default()
+            })
+            .id();
+        let above = InlinePlacement {
+            anchor_line: 10,
+            anchor_col: 0,
+            rows: 10,
+            cols: 10,
+            frame_seq: 0,
+        };
+        let below = InlinePlacement {
+            anchor_line: 100,
+            anchor_col: 0,
+            rows: 10,
+            cols: 10,
+            frame_seq: 0,
+        };
+        let col_out = InlinePlacement {
+            anchor_line: 35,
+            anchor_col: 80,
+            rows: 10,
+            cols: 10,
+            frame_seq: 0,
+        };
+        spawn_projection_child(&mut app, terminal, 0, above);
+        spawn_projection_child(&mut app, terminal, 1, below);
+        spawn_projection_child(&mut app, terminal, 2, col_out);
+
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+    }
+
+    #[test]
+    fn alt_screen_blanks_all_slots() {
+        let mut app = make_test_app();
+        let terminal = app
+            .world_mut()
+            .spawn(TerminalGrid {
+                modes: vec![ALT_SCREEN_MODE.to_string()],
+                ..projection_grid(7)
+            })
+            .id();
+        spawn_projection_child(
+            &mut app,
+            terminal,
+            0,
+            InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 3,
+                rows: 10,
+                cols: 40,
+                frame_seq: 7,
+            },
+        );
+
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+
+        app.world_mut()
+            .get_mut::<TerminalGrid>(terminal)
+            .unwrap()
+            .modes
+            .clear();
+        project(&mut app);
+        assert_eq!(
+            overlays_of(&app, terminal).rects[0],
+            IVec4::new(2, 3, 10, 40),
+            "returning to the primary screen must re-project the placement"
+        );
+    }
+
+    #[test]
+    fn texture_handle_lands_in_the_childs_slot() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(projection_grid(7)).id();
+        let handle = spawn_projection_child(
+            &mut app,
+            terminal,
+            2,
+            InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 3,
+                rows: 10,
+                cols: 40,
+                frame_seq: 7,
+            },
+        );
+
+        project(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(
+            overlays.textures[2].as_ref().map(Handle::id),
+            Some(handle.id()),
+            "the child's texture handle must land in ITS slot"
+        );
+        assert_ne!(overlays.rects[2], IVec4::ZERO);
+        for slot in [0, 1, 3] {
+            assert!(overlays.textures[slot].is_none());
+            assert_eq!(overlays.rects[slot], IVec4::ZERO);
+        }
+    }
+
+    #[test]
+    fn stale_overlays_clear_after_unmount_all() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+        app.world_mut()
+            .entity_mut(terminal)
+            .insert(projection_grid(7));
+
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+        project(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_ne!(overlays.rects[0], IVec4::ZERO);
+        assert!(overlays.textures[0].is_some());
+
+        unmount(&mut app, terminal, None);
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+    }
+
+    #[test]
+    fn seq_hold_is_wrap_aware_near_u32_max() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(projection_grid(u32::MAX - 3)).id();
+        spawn_projection_child(
+            &mut app,
+            terminal,
+            0,
+            InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 3,
+                rows: 10,
+                cols: 40,
+                frame_seq: u32::MAX - 1,
+            },
+        );
+
+        project(&mut app);
+        assert_all_sentinel(overlays_of(&app, terminal));
+
+        app.world_mut()
+            .get_mut::<TerminalGrid>(terminal)
+            .unwrap()
+            .last_seq = 2;
+        project(&mut app);
+        assert_eq!(
+            overlays_of(&app, terminal).rects[0],
+            IVec4::new(2, 3, 10, 40),
+            "a last_seq that wrapped past 0 must release the hold"
         );
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -13,7 +13,7 @@ use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
 use bevy::ui_render::PreparedUiMaterial;
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::{
-    WebviewGpuImageInjectSet, WebviewSize, WebviewSource, WebviewTextureTarget,
+    FocusedWebview, WebviewGpuImageInjectSet, WebviewSize, WebviewSource, WebviewTextureTarget,
 };
 use bevy_terminal::InlineAnchor;
 use bevy_terminal_renderer::TerminalCellMetricsResource;
@@ -234,6 +234,21 @@ pub(crate) fn unmount_inline(
     for entity in targets {
         params.commands.entity(entity).despawn();
     }
+}
+
+/// Returns the inline webview entity that currently holds keyboard focus on
+/// `active_surface`: `Some(e)` iff `FocusedWebview` points at `e`, `e` carries
+/// `InlineWebview`, and its `ChildOf` parent is the active surface. The input
+/// dispatcher uses this to hoist the release-chord check, restrict the Escape
+/// scroll-to-bottom pre-handler, and suppress PTY key forwarding (spec §7).
+pub(crate) fn focused_inline_of(
+    focused: Option<&FocusedWebview>,
+    inline_parents: &Query<&ChildOf, With<InlineWebview>>,
+    active_surface: Option<Entity>,
+) -> Option<Entity> {
+    let candidate = focused?.0?;
+    let parent = inline_parents.get(candidate).ok()?.parent();
+    (Some(parent) == active_surface).then_some(candidate)
 }
 
 const FALLBACK_CELL_W_PHYS: f32 = 8.0;

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -6,21 +6,27 @@
 //! sync with cell metrics and project placements into `TerminalOverlays`.
 
 use crate::extension_render::preload::{build_preload, webview_url};
+use crate::input::InputPhase;
+use crate::input::mouse_buttons::resolve_pane_at_phys;
 use crate::osc_webview::{GrantedNamespaces, NonInteractive};
+use crate::ui::Slotted;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
+use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::ui_render::PreparedUiMaterial;
-use bevy::window::PrimaryWindow;
+use bevy::window::{CursorMoved, PrimaryWindow};
 use bevy_cef::prelude::{
     FocusedWebview, WebviewGpuImageInjectSet, WebviewSize, WebviewSource, WebviewTextureTarget,
 };
+use bevy_cef_core::prelude::Browsers;
 use bevy_terminal::InlineAnchor;
 use bevy_terminal_renderer::TerminalCellMetricsResource;
 use bevy_terminal_renderer::material::{TerminalMaterialSystems, TerminalUiMaterial};
 use bevy_terminal_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
 use bevy_terminal_renderer::schema::TerminalGrid;
 use ozmux_extension_host::ViewRegistry;
+use ozmux_multiplexer::SurfaceMarker;
 
 /// Marks an inline webview entity and records its identity: the mounted
 /// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
@@ -57,10 +63,11 @@ pub(crate) struct InlinePlacement {
 }
 
 /// Registers the inline-webview runtime systems: the `WebviewSize` size sync
-/// (`Update`), the per-frame projection that derives `TerminalOverlays` from
-/// inline-webview children (spec §5), and the render-world ordering edge that
-/// keeps webview GPU texture injection ahead of the terminal material's
-/// bind-group rebuild.
+/// (`Update`), the pointer-move forwarder that hands `CursorMoved` motion
+/// over interactive inline rects to CEF (spec §7, `InputPhase::Hover`), the
+/// per-frame projection that derives `TerminalOverlays` from inline-webview
+/// children (spec §5), and the render-world ordering edge that keeps webview
+/// GPU texture injection ahead of the terminal material's bind-group rebuild.
 ///
 /// The projection is scheduled in `PostUpdate` before
 /// `TerminalMaterialSystems::UpdateMaterial`: grid state settles during
@@ -71,7 +78,10 @@ pub(crate) struct OzmuxInlineWebviewPlugin;
 
 impl Plugin for OzmuxInlineWebviewPlugin {
     fn build(&self, app: &mut App) {
+        app.add_message::<CursorMoved>();
+        app.init_resource::<ButtonInput<MouseButton>>();
         app.add_systems(Update, sync_inline_webview_size);
+        app.add_systems(Update, forward_inline_mouse_moves.in_set(InputPhase::Hover));
         app.add_systems(
             PostUpdate,
             project_inline_overlays.before(TerminalMaterialSystems::UpdateMaterial),
@@ -251,6 +261,92 @@ pub(crate) fn focused_inline_of(
     (Some(parent) == active_surface).then_some(candidate)
 }
 
+/// A pointer hit on an interactive inline webview rect: the child entity that
+/// owns the rect and the pointer position in webview-local DIP (logical px).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct InlineHit {
+    /// The interactive inline webview child under the pointer.
+    pub(crate) child: Entity,
+    /// `(local_phys − rect_origin_phys) / scale_factor` — the pointer in
+    /// webview-local DIP, the coordinate space CEF mouse events expect.
+    pub(crate) local_dip: Vec2,
+}
+
+/// Hit-tests a terminal-local physical-pixel point against the terminal's
+/// ACTIVE inline overlay rects (the same `TerminalOverlays` projection the
+/// shader composites, spec §7's single coordinate source) and returns the
+/// interactive child whose rect contains it.
+///
+/// Cell coordinates are 0-indexed (`row = floor(local_phys.y / cell_h)`,
+/// column analog) — NOT the 1-indexed `cell_at_local` convention the terminal
+/// click pipeline uses. `rows == 0` sentinel slots never match; a
+/// partially-scrolled rect with a negative `row` origin still hits in its
+/// visible cells (its DIP origin lies above the viewport, so `local_dip.y`
+/// lands past the clipped rows). `NonInteractive` children are invisible to
+/// the hit-test, so their rects pass through as plain terminal input.
+pub(crate) fn inline_hit_at(
+    children: &Query<&Children>,
+    inline: &Query<(&InlineWebview, Has<NonInteractive>)>,
+    overlays: &TerminalOverlays,
+    terminal: Entity,
+    local_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Option<InlineHit> {
+    let row = (local_phys.y / cell_h_phys).floor() as i32;
+    let col = (local_phys.x / cell_w_phys).floor() as i32;
+    let kids = children.get(terminal).ok()?;
+    kids.iter().find_map(|child| {
+        let Ok((view, non_interactive)) = inline.get(child) else {
+            return None;
+        };
+        if non_interactive {
+            return None;
+        }
+        let rect = *overlays.rects.get(usize::from(view.slot))?;
+        let contains = rect.z != 0
+            && row >= rect.x
+            && row < rect.x + rect.z
+            && col >= rect.y
+            && col < rect.y + rect.w;
+        if !contains {
+            return None;
+        }
+        let local_dip = inline_local_dip(
+            overlays,
+            view.slot,
+            local_phys,
+            cell_w_phys,
+            cell_h_phys,
+            scale_factor,
+        )?;
+        Some(InlineHit { child, local_dip })
+    })
+}
+
+/// Converts a terminal-local physical-pixel point to webview-local DIP
+/// relative to a slot's active overlay rect, WITHOUT containment checking —
+/// the release leg of an in-flight inline press uses this so a pointer that
+/// drifted off the rect still produces a (possibly out-of-view) release
+/// position. Returns `None` for an out-of-range slot or a `rows == 0`
+/// sentinel rect.
+pub(crate) fn inline_local_dip(
+    overlays: &TerminalOverlays,
+    slot: u8,
+    local_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Option<Vec2> {
+    let rect = *overlays.rects.get(usize::from(slot))?;
+    if rect.z == 0 {
+        return None;
+    }
+    let origin_phys = Vec2::new(rect.y as f32 * cell_w_phys, rect.x as f32 * cell_h_phys);
+    Some((local_phys - origin_phys) / scale_factor.max(f32::EPSILON))
+}
+
 const FALLBACK_CELL_W_PHYS: f32 = 8.0;
 const FALLBACK_CELL_H_PHYS: f32 = 16.0;
 
@@ -328,6 +424,63 @@ fn sync_inline_webview_size(
             scale_factor,
         );
         size.set_if_neq(WebviewSize(next));
+    }
+}
+
+/// Forwards pointer motion over an interactive inline rect to the child's CEF
+/// browser as `send_mouse_move` in webview-local DIP (spec §7).
+///
+/// The attempt is focus-independent — `bevy_cef`'s `send_mouse_move` is gated
+/// on CEF's `focused_frame()` internally, so hovers over an unfocused browser
+/// are dropped browser-side, not here. Forwarding is driven by `CursorMoved`
+/// (at most one forward per frame, at the latest position), never by per-frame
+/// polling. `Browsers` is optional so CEF-less tests can construct the system;
+/// without it the resolution still runs but nothing is forwarded.
+fn forward_inline_mouse_moves(
+    mut cursor_msg: MessageReader<CursorMoved>,
+    hosts: Query<(Entity, &ComputedNode, &UiGlobalTransform), (With<SurfaceMarker>, With<Slotted>)>,
+    children: Query<&Children>,
+    inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<&TerminalOverlays>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    mouse_buttons: Res<ButtonInput<MouseButton>>,
+    browsers: Option<NonSend<Browsers>>,
+) {
+    let Some(moved) = cursor_msg.read().last() else {
+        return;
+    };
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    let scale_factor = window.scale_factor();
+    let cursor_phys = moved.position * scale_factor;
+    let (cell_w_phys, cell_h_phys) = cell_size_phys(metrics.as_deref());
+    let Some((terminal, local_phys)) = resolve_pane_at_phys(&hosts, cursor_phys) else {
+        return;
+    };
+    let Ok(overlays) = overlay_rects.get(terminal) else {
+        return;
+    };
+    let Some(hit) = inline_hit_at(
+        &children,
+        &inline,
+        overlays,
+        terminal,
+        local_phys,
+        cell_w_phys,
+        cell_h_phys,
+        scale_factor,
+    ) else {
+        return;
+    };
+    if let Some(browsers) = browsers.as_ref() {
+        browsers.send_mouse_move(
+            &hit.child,
+            mouse_buttons.get_pressed(),
+            hit.local_dip,
+            false,
+        );
     }
 }
 
@@ -1154,5 +1307,243 @@ mod tests {
             Some(&WebviewSize(Vec2::new(320.0, 160.0))),
             "the value must stay at the placeholder seed"
         );
+    }
+
+    // Hit-test fixtures use an 8x16 physical-pixel cell pitch throughout.
+    const HIT_CELL_W: f32 = 8.0;
+    const HIT_CELL_H: f32 = 16.0;
+
+    fn spawn_hit_child(app: &mut App, terminal: Entity, slot: u8, non_interactive: bool) -> Entity {
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(terminal),
+                InlineWebview {
+                    view_id: format!("view-{slot}"),
+                    slot,
+                },
+            ))
+            .id();
+        if non_interactive {
+            app.world_mut().entity_mut(child).insert(NonInteractive);
+        }
+        child
+    }
+
+    fn overlays_with(rects: &[(usize, IVec4)]) -> TerminalOverlays {
+        let mut overlays = TerminalOverlays::default();
+        for (slot, rect) in rects {
+            overlays.rects[*slot] = *rect;
+        }
+        overlays
+    }
+
+    fn run_hit(
+        app: &mut App,
+        overlays: TerminalOverlays,
+        terminal: Entity,
+        local_phys: Vec2,
+        scale: f32,
+    ) -> Option<InlineHit> {
+        app.world_mut()
+            .run_system_once(
+                move |children: Query<&Children>,
+                      inline: Query<(&InlineWebview, Has<NonInteractive>)>| {
+                    inline_hit_at(
+                        &children, &inline, &overlays, terminal, local_phys, HIT_CELL_W,
+                        HIT_CELL_H, scale,
+                    )
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn hit_inside_active_rect_returns_child_and_dip() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        let child = spawn_hit_child(&mut app, terminal, 0, false);
+        // Rect rows 2..12, cols 3..43 → phys y 32..192, x 24..344.
+        let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
+
+        let hit = run_hit(&mut app, overlays, terminal, Vec2::new(100.0, 100.0), 1.0);
+        assert_eq!(
+            hit,
+            Some(InlineHit {
+                child,
+                local_dip: Vec2::new(100.0 - 24.0, 100.0 - 32.0),
+            }),
+            "a point inside the rect must hit the slot's child with rect-relative DIP"
+        );
+    }
+
+    #[test]
+    fn hit_misses_outside_the_rect() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        spawn_hit_child(&mut app, terminal, 0, false);
+        let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
+
+        assert_eq!(
+            run_hit(&mut app, overlays, terminal, Vec2::new(400.0, 300.0), 1.0),
+            None,
+            "a point outside every rect must miss"
+        );
+    }
+
+    #[test]
+    fn hit_maps_each_slot_to_its_own_child() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        let _slot0 = spawn_hit_child(&mut app, terminal, 0, false);
+        let slot1 = spawn_hit_child(&mut app, terminal, 1, false);
+        let overlays = overlays_with(&[(0, IVec4::new(0, 0, 2, 2)), (1, IVec4::new(4, 4, 2, 2))]);
+
+        // (36, 72) → col 4, row 4: inside slot 1's rect only.
+        let hit = run_hit(&mut app, overlays, terminal, Vec2::new(36.0, 72.0), 1.0)
+            .expect("the point lies inside slot 1's rect");
+        assert_eq!(
+            hit.child, slot1,
+            "the hit must resolve slot → child via InlineWebview.slot"
+        );
+        assert_eq!(hit.local_dip, Vec2::new(36.0 - 32.0, 72.0 - 64.0));
+    }
+
+    #[test]
+    fn hit_skips_non_interactive_children() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        spawn_hit_child(&mut app, terminal, 0, true);
+        let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
+
+        assert_eq!(
+            run_hit(&mut app, overlays, terminal, Vec2::new(100.0, 100.0), 1.0),
+            None,
+            "a NonInteractive child must be invisible to the hit-test"
+        );
+    }
+
+    #[test]
+    fn hit_dip_divides_physical_offset_by_scale_factor() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        spawn_hit_child(&mut app, terminal, 0, false);
+        let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
+
+        let hit = run_hit(&mut app, overlays, terminal, Vec2::new(100.0, 100.0), 2.0)
+            .expect("the point lies inside the rect regardless of scale");
+        assert_eq!(
+            hit.local_dip,
+            Vec2::new((100.0 - 24.0) / 2.0, (100.0 - 32.0) / 2.0),
+            "DIP must be the physical rect offset divided by the scale factor"
+        );
+    }
+
+    #[test]
+    fn hit_ignores_sentinel_slots() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        spawn_hit_child(&mut app, terminal, 0, false);
+
+        assert_eq!(
+            run_hit(
+                &mut app,
+                TerminalOverlays::default(),
+                terminal,
+                Vec2::new(1.0, 1.0),
+                1.0,
+            ),
+            None,
+            "a rows == 0 sentinel slot must never match, even with a live child"
+        );
+    }
+
+    #[test]
+    fn hit_negative_row_rect_still_hits_in_its_visible_cells() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn_empty().id();
+        let child = spawn_hit_child(&mut app, terminal, 0, false);
+        // Partially scrolled above: rows -2..2 visible in viewport rows 0..2.
+        let overlays = overlays_with(&[(0, IVec4::new(-2, 3, 4, 10))]);
+
+        // (44, 24) → col 5, row 1: inside the visible remainder.
+        let hit = run_hit(&mut app, overlays, terminal, Vec2::new(44.0, 24.0), 1.0)
+            .expect("the visible cells of a negative-row rect must still hit");
+        assert_eq!(hit.child, child);
+        assert_eq!(
+            hit.local_dip,
+            Vec2::new(44.0 - 24.0, 24.0 - (-2.0 * HIT_CELL_H)),
+            "the DIP origin lies above the viewport, so local y lands past the clipped rows"
+        );
+    }
+
+    #[test]
+    fn inline_local_dip_rejects_sentinel_and_out_of_range_slots() {
+        let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
+        assert_eq!(
+            inline_local_dip(&overlays, 0, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
+            Some(Vec2::new(76.0, 68.0)),
+        );
+        assert_eq!(
+            inline_local_dip(&overlays, 1, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
+            None,
+            "a sentinel slot has no DIP mapping"
+        );
+        assert_eq!(
+            inline_local_dip(&overlays, OVERLAY_SLOTS as u8, Vec2::ZERO, 8.0, 16.0, 1.0),
+            None,
+            "an out-of-range slot has no DIP mapping"
+        );
+    }
+
+    #[test]
+    fn move_forwarder_constructs_and_runs_without_cef() {
+        use bevy::math::DVec2;
+        use bevy::window::WindowResolution;
+
+        let mut app = make_test_app();
+        app.add_message::<CursorMoved>();
+        app.init_resource::<ButtonInput<MouseButton>>();
+        app.add_systems(Update, forward_inline_mouse_moves);
+
+        let terminal = app
+            .world_mut()
+            .spawn((
+                SurfaceMarker,
+                Slotted,
+                ComputedNode {
+                    size: Vec2::new(800.0, 600.0),
+                    ..ComputedNode::DEFAULT
+                },
+                UiGlobalTransform::from_xy(400.0, 300.0),
+                overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]),
+            ))
+            .id();
+        spawn_hit_child(&mut app, terminal, 0, false);
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    resolution: WindowResolution::new(800, 600),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
+        app.world_mut()
+            .get_mut::<Window>(window)
+            .unwrap()
+            .set_physical_cursor_position(Some(DVec2::new(100.0, 100.0)));
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<CursorMoved>>()
+            .write(CursorMoved {
+                window,
+                position: Vec2::new(100.0, 100.0),
+                delta: None,
+            });
+        // Without a Browsers NonSend resource the full resolution path runs
+        // and the forwarding is skipped — the system must not panic.
+        app.update();
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -624,6 +624,7 @@ mod tests {
                 view_id: view_id.into(),
                 rows: 10,
                 cols: 40,
+                instance_id: None,
             },
             anchor,
         });
@@ -635,6 +636,7 @@ mod tests {
             entity: terminal,
             verb: OscWebviewVerb::UnmountInline {
                 view_id: view_id.map(str::to_string),
+                instance_id: None,
             },
             anchor: None,
         });

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -690,7 +690,6 @@ mod tests {
             })
     }
 
-    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
     fn mount_instance(
         app: &mut App,
         terminal: Entity,
@@ -711,7 +710,6 @@ mod tests {
         app.world_mut().flush();
     }
 
-    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
     fn unmount_instance(app: &mut App, terminal: Entity, view_id: &str, instance_id: &str) {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
@@ -725,7 +723,6 @@ mod tests {
         app.update();
     }
 
-    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
     fn slot_of_instance(
         app: &App,
         terminal: Entity,
@@ -943,6 +940,119 @@ mod tests {
             inline_children_of(&app, terminal).is_empty(),
             "a mount-inline for an unregistered view must be dropped"
         );
+    }
+
+    #[test]
+    fn two_instances_of_same_view_both_mount_in_separate_slots() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+        mount_instance(&mut app, terminal, "memo", "b", Some(test_anchor()));
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            2,
+            "two distinct (view_id, instance_id) tuples must both mount"
+        );
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), Some(0));
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("b")), Some(1));
+    }
+
+    #[test]
+    fn duplicate_view_instance_tuple_is_rejected() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            1,
+            "a duplicate (view_id, instance_id) mount must be dropped"
+        );
+    }
+
+    #[test]
+    fn default_instance_and_named_instance_coexist() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "memo", Some(test_anchor()));
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            2,
+            "the default (None) instance and a named instance are distinct"
+        );
+        assert_eq!(slot_of_instance(&app, terminal, "memo", None), Some(0));
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), Some(1));
+    }
+
+    #[test]
+    fn unmount_one_instance_leaves_the_other() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+        mount_instance(&mut app, terminal, "memo", "b", Some(test_anchor()));
+
+        unmount_instance(&mut app, terminal, "memo", "a");
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            1,
+            "unmounting one instance must despawn exactly that instance"
+        );
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), None);
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("b")), Some(1));
+    }
+
+    #[test]
+    fn unmount_view_scope_despawns_every_instance_of_that_view() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        register_view(&mut app, "other", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
+        mount_instance(&mut app, terminal, "memo", "b", Some(test_anchor()));
+        mount(&mut app, terminal, "other", Some(test_anchor()));
+
+        unmount(&mut app, terminal, Some("memo"));
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            1,
+            "view-scoped unmount must despawn every instance of that view_id only"
+        );
+        assert_eq!(slot_of_instance(&app, terminal, "other", None), Some(2));
+    }
+
+    #[test]
+    fn slot_cap_counts_all_instances_together() {
+        let mut app = make_test_app();
+        register_view(&mut app, "memo", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        for inst in ["a", "b", "c", "d"] {
+            mount_instance(&mut app, terminal, "memo", inst, Some(test_anchor()));
+        }
+        assert_eq!(inline_children_of(&app, terminal).len(), OVERLAY_SLOTS);
+
+        mount_instance(&mut app, terminal, "memo", "e", Some(test_anchor()));
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            OVERLAY_SLOTS,
+            "the 4-slot cap is per-terminal across all instances; a 5th is rejected"
+        );
+        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("e")), None);
     }
 
     #[test]

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -38,6 +38,9 @@ use ozmux_multiplexer::SurfaceMarker;
 pub(crate) struct InlineWebview {
     /// The registered view id this inline webview was mounted from.
     pub(crate) view_id: String,
+    /// The client-assigned instance id; `None` is the implicit default
+    /// instance. `(view_id, instance_id)` is the per-terminal address.
+    pub(crate) instance_id: Option<String>,
     /// The overlay texture slot (0..`OVERLAY_SLOTS`) on the parent terminal.
     pub(crate) slot: u8,
 }
@@ -115,6 +118,8 @@ pub(crate) struct InlineMountContext<'a> {
     pub(crate) pane: Entity,
     /// The registered view id to mount.
     pub(crate) view_id: &'a str,
+    /// The client-assigned instance id (`None` = implicit default instance).
+    pub(crate) instance_id: Option<&'a str>,
     /// Rect height in terminal cells (validated 1..=200 by `bevy_terminal`).
     pub(crate) rows: u16,
     /// Rect width in terminal cells (validated 1..=400 by `bevy_terminal`).
@@ -167,8 +172,15 @@ pub(crate) fn mount_inline(
         return;
     };
     let live = live_inline_children(&params.children, &params.views, ctx.terminal_surface);
-    if live.iter().any(|(_, v)| v.view_id == ctx.view_id) {
-        tracing::debug!(view_id = %ctx.view_id, "osc-webview: duplicate inline mount on this terminal, dropping");
+    if live
+        .iter()
+        .any(|(_, v)| v.view_id == ctx.view_id && v.instance_id.as_deref() == ctx.instance_id)
+    {
+        tracing::debug!(
+            view_id = %ctx.view_id,
+            instance_id = ?ctx.instance_id,
+            "osc-webview: duplicate inline mount on this terminal, dropping"
+        );
         return;
     }
     let Some(slot) = smallest_free_slot(&live) else {
@@ -200,6 +212,7 @@ pub(crate) fn mount_inline(
         WebviewSize(size),
         InlineWebview {
             view_id: ctx.view_id.to_string(),
+            instance_id: ctx.instance_id.map(str::to_string),
             slot,
         },
         InlinePlacement {
@@ -226,19 +239,27 @@ pub(crate) fn mount_inline(
     );
 }
 
-/// Despawns the inline child(ren) of `terminal_surface` matching `view_id`,
-/// or ALL of them when `view_id` is `None`. The all-case is an explicit
-/// iteration over every live inline child — it also executes the
-/// VT-synthesized fold/saturation `UnmountInline { view_id: None }` frames.
+/// Despawns the inline child(ren) of `terminal_surface` matching the scope:
+/// `(Some(vid), Some(inst))` removes that one instance; `(Some(vid), None)`
+/// removes every instance of `vid`; `(None, _)` removes all inline children
+/// (the VT-synthesized fold/saturation `UnmountInline { view_id: None }`
+/// frames take this path).
 pub(crate) fn unmount_inline(
     params: &mut InlineWebviewParams,
     terminal_surface: Entity,
     view_id: Option<&str>,
+    instance_id: Option<&str>,
 ) {
     let targets: Vec<Entity> =
         live_inline_children(&params.children, &params.views, terminal_surface)
             .into_iter()
-            .filter(|(_, v)| view_id.is_none_or(|id| v.view_id == id))
+            .filter(|(_, v)| match (view_id, instance_id) {
+                (Some(vid), Some(inst)) => {
+                    v.view_id == vid && v.instance_id.as_deref() == Some(inst)
+                }
+                (Some(vid), None) => v.view_id == vid,
+                (None, _) => true,
+            })
             .map(|(entity, _)| entity)
             .collect();
     for entity in targets {
@@ -669,6 +690,58 @@ mod tests {
             })
     }
 
+    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
+    fn mount_instance(
+        app: &mut App,
+        terminal: Entity,
+        view_id: &str,
+        instance_id: &str,
+        anchor: Option<InlineAnchor>,
+    ) {
+        app.world_mut().trigger(OscWebviewRequest {
+            entity: terminal,
+            verb: OscWebviewVerb::MountInline {
+                view_id: view_id.into(),
+                rows: 10,
+                cols: 40,
+                instance_id: Some(instance_id.into()),
+            },
+            anchor,
+        });
+        app.world_mut().flush();
+    }
+
+    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
+    fn unmount_instance(app: &mut App, terminal: Entity, view_id: &str, instance_id: &str) {
+        app.world_mut().trigger(OscWebviewRequest {
+            entity: terminal,
+            verb: OscWebviewVerb::UnmountInline {
+                view_id: Some(view_id.into()),
+                instance_id: Some(instance_id.into()),
+            },
+            anchor: None,
+        });
+        app.world_mut().flush();
+        app.update();
+    }
+
+    #[expect(dead_code, reason = "used by Task 2.2 multi-instance tests")]
+    fn slot_of_instance(
+        app: &App,
+        terminal: Entity,
+        view_id: &str,
+        instance_id: Option<&str>,
+    ) -> Option<u8> {
+        inline_children_of(app, terminal)
+            .into_iter()
+            .find_map(|child| {
+                app.world()
+                    .get::<InlineWebview>(child)
+                    .filter(|v| v.view_id == view_id && v.instance_id.as_deref() == instance_id)
+                    .map(|v| v.slot)
+            })
+    }
+
     #[test]
     fn mount_spawns_child_with_inline_components() {
         let mut app = make_test_app();
@@ -690,6 +763,7 @@ mod tests {
             app.world().get::<InlineWebview>(child),
             Some(&InlineWebview {
                 view_id: "dash".into(),
+                instance_id: None,
                 slot: 0
             }),
         );
@@ -917,6 +991,7 @@ mod tests {
             ChildOf(terminal),
             InlineWebview {
                 view_id: format!("view-{slot}"),
+                instance_id: None,
                 slot,
             },
             placement,
@@ -1322,6 +1397,7 @@ mod tests {
                 ChildOf(terminal),
                 InlineWebview {
                     view_id: format!("view-{slot}"),
+                    instance_id: None,
                     slot,
                 },
             ))

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -1,0 +1,570 @@
+//! Inline webviews: `ChildOf` children of a terminal surface that render a
+//! registered view into the terminal's text flow. This module owns the
+//! components and the mount/unmount policy executed by the `MountInline` /
+//! `UnmountInline` arms of `osc_webview::on_osc_webview_request`.
+
+use crate::extension_render::preload::{build_preload, webview_url};
+use crate::osc_webview::{GrantedNamespaces, NonInteractive};
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use bevy_cef::prelude::{WebviewSize, WebviewSource, WebviewTextureTarget};
+use bevy_terminal::InlineAnchor;
+use bevy_terminal_renderer::TerminalCellMetricsResource;
+use bevy_terminal_renderer::prelude::OVERLAY_SLOTS;
+use ozmux_extension_host::ViewRegistry;
+
+// TODO: Task 5 adds the per-frame projection / size-sync systems and their
+// plugin. Task 3 registers nothing — the mount/unmount arms ride the existing
+// `on_osc_webview_request` observer wired by `OzmuxOscWebviewPlugin`.
+
+/// Marks an inline webview entity and records its identity: the mounted
+/// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
+/// on its parent terminal. The owning terminal surface is NOT duplicated
+/// here — it is the `ChildOf` parent, per the multiplexer's "no typed
+/// back-references" convention. Each child's `slot` is the single source of
+/// truth for slot allocation (no separate allocation table).
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InlineWebview {
+    /// The registered view id this inline webview was mounted from.
+    pub(crate) view_id: String,
+    /// The overlay texture slot (0..`OVERLAY_SLOTS`) on the parent terminal.
+    pub(crate) slot: u8,
+}
+
+/// Where an inline webview sits in its terminal's scrollback: the anchor cell
+/// (absolute line = `history_base + history_size + cursor row` at the OSC byte
+/// position, plus the cursor column), the rect extent in cells, and the VT
+/// `frame_seq` the next grid emit carries (Task 5 defers first projection
+/// until the grid catches up to it).
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InlinePlacement {
+    /// Absolute scrollback line of the rect's TOP row.
+    pub(crate) anchor_line: u64,
+    /// Column of the anchor cell.
+    pub(crate) anchor_col: u16,
+    /// Rect height in terminal cells.
+    pub(crate) rows: u16,
+    /// Rect width in terminal cells.
+    pub(crate) cols: u16,
+    /// The VT frame seq stamped at mount; grid frames at or after this seq
+    /// (wrap-aware compare) may project the placement.
+    pub(crate) frame_seq: u32,
+}
+
+/// Everything the `MountInline` verb carries into `mount_inline`: the target
+/// terminal surface, its resolved multiplexer owners (for the preload
+/// context), and the parsed verb + anchor payload.
+pub(crate) struct InlineMountContext<'a> {
+    /// The requesting terminal surface — the `ChildOf` parent of the mount.
+    pub(crate) terminal_surface: Entity,
+    /// The workspace owning the terminal's pane (preload context).
+    pub(crate) workspace: Entity,
+    /// The pane owning the terminal surface (preload context).
+    pub(crate) pane: Entity,
+    /// The registered view id to mount.
+    pub(crate) view_id: &'a str,
+    /// Rect height in terminal cells (validated 1..=200 by `bevy_terminal`).
+    pub(crate) rows: u16,
+    /// Rect width in terminal cells (validated 1..=400 by `bevy_terminal`).
+    pub(crate) cols: u16,
+    /// The VT-stamped anchor; `None` is a policy rejection (gate 1).
+    pub(crate) anchor: Option<InlineAnchor>,
+}
+
+/// The system params `mount_inline` / `unmount_inline` need, bundled so the
+/// `on_osc_webview_request` observer gains a single extra parameter.
+#[derive(SystemParam)]
+pub(crate) struct InlineWebviewParams<'w, 's> {
+    commands: Commands<'w, 's>,
+    images: ResMut<'w, Assets<Image>>,
+    children: Query<'w, 's, &'static Children>,
+    views: Query<'w, 's, &'static InlineWebview>,
+    metrics: Option<Res<'w, TerminalCellMetricsResource>>,
+    windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
+}
+
+/// Mounts a registered view as an inline webview child of the requesting
+/// terminal surface, applying the policy gates in order (each rejection is a
+/// `tracing::debug!` + return): missing anchor, unregistered view, duplicate
+/// `view_id` on this terminal, overlay-slot exhaustion.
+///
+/// The parent (`ctx.terminal_surface`, the `OscWebviewRequest` target) is the
+/// multiplexer Surface entity itself: `finish_terminal_setup` inserts both
+/// `TerminalBundle` (`TerminalHandle`, which emits the OSC request) and
+/// `TerminalRenderBundle` (`TerminalGrid`) onto that one entity, so the
+/// `ChildOf` parent is also the entity Task 5's projection reads grid state
+/// from.
+///
+/// `WebviewSize` is seeded here because `bevy_cef` builds the CEF browser
+/// from it at creation. The seed is `(cols × cell_w, rows × cell_h) /
+/// scale_factor` in logical px from `TerminalCellMetricsResource` and the
+/// primary window; when neither exists yet (headless tests, pre-first-render)
+/// a placeholder cell of 8×16 physical px at scale 1.0 is used — Task 5's
+/// size-sync system corrects it.
+pub(crate) fn mount_inline(
+    params: &mut InlineWebviewParams,
+    registry: &ViewRegistry,
+    ctx: InlineMountContext<'_>,
+) {
+    let Some(anchor) = ctx.anchor else {
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount-inline without anchor, dropping");
+        return;
+    };
+    let Some(view) = registry.get(ctx.view_id) else {
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount-inline for unregistered view, dropping");
+        return;
+    };
+    let live = live_inline_children(&params.children, &params.views, ctx.terminal_surface);
+    if live.iter().any(|(_, v)| v.view_id == ctx.view_id) {
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: duplicate inline mount on this terminal, dropping");
+        return;
+    }
+    let Some(slot) = smallest_free_slot(&live) else {
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: all inline overlay slots occupied, dropping");
+        return;
+    };
+    let scale_factor = params
+        .windows
+        .iter()
+        .next()
+        .map(Window::scale_factor)
+        .unwrap_or(1.0);
+    let (cell_w_phys, cell_h_phys) = cell_size_phys(params.metrics.as_deref());
+    let size = seed_logical_size(ctx.rows, ctx.cols, cell_w_phys, cell_h_phys, scale_factor);
+    let texture = WebviewTextureTarget(params.images.add(Image::default()));
+    let granted = GrantedNamespaces(view.capabilities.iter().cloned().collect());
+    let webview = params.commands.spawn_empty().id();
+    let preload = build_preload(ctx.workspace, ctx.pane, webview, &view.owning_ext, &granted);
+    // NOTE: keep this entity free of Node / Mesh2d / Mesh3d / Sprite /
+    // MaterialNode (even for debug visualization). bevy_cef's mesh/sprite
+    // input paths and display-size allocators key on `With<WebviewSource>`
+    // plus exactly those components; adding one double-attaches input
+    // forwarding and display allocation on top of ozmux's inline routing
+    // (design spec §4 invariant).
+    params.commands.entity(webview).insert((
+        ChildOf(ctx.terminal_surface),
+        WebviewSource::new(webview_url(&view.owning_ext, &view.entry)),
+        texture,
+        WebviewSize(size),
+        InlineWebview {
+            view_id: ctx.view_id.to_string(),
+            slot,
+        },
+        InlinePlacement {
+            anchor_line: anchor.line,
+            anchor_col: anchor.col,
+            rows: ctx.rows,
+            cols: ctx.cols,
+            frame_seq: anchor.frame_seq,
+        },
+        granted,
+        preload,
+    ));
+    if !view.interactive {
+        params.commands.entity(webview).insert(NonInteractive);
+    }
+    tracing::debug!(
+        view_id = %ctx.view_id,
+        terminal = ?ctx.terminal_surface,
+        slot,
+        rows = ctx.rows,
+        cols = ctx.cols,
+        anchor_line = anchor.line,
+        "osc-webview: inline webview mounted"
+    );
+}
+
+/// Despawns the inline child(ren) of `terminal_surface` matching `view_id`,
+/// or ALL of them when `view_id` is `None`. The all-case is an explicit
+/// iteration over every live inline child — it also executes the
+/// VT-synthesized fold/saturation `UnmountInline { view_id: None }` frames.
+pub(crate) fn unmount_inline(
+    params: &mut InlineWebviewParams,
+    terminal_surface: Entity,
+    view_id: Option<&str>,
+) {
+    let targets: Vec<Entity> =
+        live_inline_children(&params.children, &params.views, terminal_surface)
+            .into_iter()
+            .filter(|(_, v)| view_id.is_none_or(|id| v.view_id == id))
+            .map(|(entity, _)| entity)
+            .collect();
+    for entity in targets {
+        params.commands.entity(entity).despawn();
+    }
+}
+
+const FALLBACK_CELL_W_PHYS: f32 = 8.0;
+const FALLBACK_CELL_H_PHYS: f32 = 16.0;
+
+/// The live inline-webview children of a terminal surface.
+fn live_inline_children<'a>(
+    children: &Query<&Children>,
+    views: &'a Query<&'static InlineWebview>,
+    terminal_surface: Entity,
+) -> Vec<(Entity, &'a InlineWebview)> {
+    let Ok(kids) = children.get(terminal_surface) else {
+        return Vec::new();
+    };
+    kids.iter()
+        .filter_map(|child| views.get(child).ok().map(|view| (child, view)))
+        .collect()
+}
+
+/// The smallest slot in `0..OVERLAY_SLOTS` not occupied by a live child, or
+/// `None` when every slot is taken.
+fn smallest_free_slot(live: &[(Entity, &InlineWebview)]) -> Option<u8> {
+    (0..OVERLAY_SLOTS as u8).find(|slot| live.iter().all(|(_, v)| v.slot != *slot))
+}
+
+/// Physical cell pitch from the metrics resource (the same floor/max the
+/// terminal resize path applies), or the 8×16 placeholder when no terminal
+/// has rendered yet.
+fn cell_size_phys(metrics: Option<&TerminalCellMetricsResource>) -> (f32, f32) {
+    metrics
+        .map(|m| {
+            (
+                m.metrics.advance_phys.floor().max(1.0),
+                m.metrics.line_height_phys.floor().max(1.0),
+            )
+        })
+        .unwrap_or((FALLBACK_CELL_W_PHYS, FALLBACK_CELL_H_PHYS))
+}
+
+/// The initial `WebviewSize` (logical px) for a rows×cols rect:
+/// `(cols × cell_w_phys, rows × cell_h_phys) / scale_factor`.
+fn seed_logical_size(
+    rows: u16,
+    cols: u16,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Vec2 {
+    Vec2::new(f32::from(cols) * cell_w_phys, f32::from(rows) * cell_h_phys)
+        / scale_factor.max(f32::EPSILON)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::osc_webview::on_osc_webview_request;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy_cef::prelude::PreloadScripts;
+    use bevy_terminal::{OscWebviewRequest, OscWebviewVerb};
+    use ozmux_extension_host::RegisteredView;
+    use ozmux_multiplexer::{MultiplexerCommands, MultiplexerPlugin};
+
+    fn make_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin)
+            .init_resource::<ViewRegistry>()
+            .init_resource::<Assets<Image>>()
+            .add_observer(on_osc_webview_request);
+        app
+    }
+
+    fn register_view(app: &mut App, view_id: &str, interactive: bool, caps: &[&str]) {
+        app.world_mut().resource_mut::<ViewRegistry>().register(
+            view_id.into(),
+            RegisteredView {
+                entry: "ui/dash.html".into(),
+                owning_ext: "memo".into(),
+                interactive,
+                capabilities: caps.iter().map(|s| (*s).to_string()).collect(),
+            },
+        );
+    }
+
+    fn spawn_terminal(app: &mut App) -> Entity {
+        let surface = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                mux.create_workspace(Some("t".into())).surface
+            })
+            .unwrap();
+        app.world_mut().flush();
+        surface
+    }
+
+    fn test_anchor() -> InlineAnchor {
+        InlineAnchor {
+            line: 42,
+            col: 3,
+            frame_seq: 7,
+        }
+    }
+
+    fn mount(app: &mut App, terminal: Entity, view_id: &str, anchor: Option<InlineAnchor>) {
+        app.world_mut().trigger(OscWebviewRequest {
+            entity: terminal,
+            verb: OscWebviewVerb::MountInline {
+                view_id: view_id.into(),
+                rows: 10,
+                cols: 40,
+            },
+            anchor,
+        });
+        app.world_mut().flush();
+    }
+
+    fn unmount(app: &mut App, terminal: Entity, view_id: Option<&str>) {
+        app.world_mut().trigger(OscWebviewRequest {
+            entity: terminal,
+            verb: OscWebviewVerb::UnmountInline {
+                view_id: view_id.map(str::to_string),
+            },
+            anchor: None,
+        });
+        app.world_mut().flush();
+        // Despawn is deferred; an update applies it.
+        app.update();
+    }
+
+    fn inline_children_of(app: &App, terminal: Entity) -> Vec<Entity> {
+        let world = app.world();
+        world
+            .get::<Children>(terminal)
+            .map(|children| {
+                children
+                    .iter()
+                    .filter(|child| world.get::<InlineWebview>(*child).is_some())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn slot_of(app: &App, terminal: Entity, view_id: &str) -> Option<u8> {
+        inline_children_of(app, terminal)
+            .into_iter()
+            .find_map(|child| {
+                app.world()
+                    .get::<InlineWebview>(child)
+                    .filter(|v| v.view_id == view_id)
+                    .map(|v| v.slot)
+            })
+    }
+
+    #[test]
+    fn mount_spawns_child_with_inline_components() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &["fs"]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+
+        let children = inline_children_of(&app, terminal);
+        assert_eq!(children.len(), 1, "mount must spawn one inline child");
+        let child = children[0];
+
+        assert_eq!(
+            app.world().get::<ChildOf>(child).map(|c| c.parent()),
+            Some(terminal),
+            "the inline webview must be a ChildOf the terminal surface"
+        );
+        assert_eq!(
+            app.world().get::<InlineWebview>(child),
+            Some(&InlineWebview {
+                view_id: "dash".into(),
+                slot: 0
+            }),
+        );
+        assert_eq!(
+            app.world().get::<InlinePlacement>(child),
+            Some(&InlinePlacement {
+                anchor_line: 42,
+                anchor_col: 3,
+                rows: 10,
+                cols: 40,
+                frame_seq: 7
+            }),
+        );
+        match app
+            .world()
+            .get::<WebviewSource>(child)
+            .expect("inline webview must carry WebviewSource")
+        {
+            WebviewSource::Url(url) => assert_eq!(url, "ozmux-ext://memo/ui/dash.html"),
+            other => panic!("unexpected WebviewSource: {other:?}"),
+        }
+        assert!(
+            app.world().get::<WebviewTextureTarget>(child).is_some(),
+            "inline webview must carry a headless WebviewTextureTarget"
+        );
+        let granted = app
+            .world()
+            .get::<GrantedNamespaces>(child)
+            .expect("inline webview must carry GrantedNamespaces");
+        assert!(granted.0.contains("fs"));
+        assert!(
+            app.world().get::<PreloadScripts>(child).is_some(),
+            "inline webview must carry the shared preload scripts"
+        );
+        assert_eq!(
+            app.world().get::<WebviewSize>(child),
+            Some(&WebviewSize(Vec2::new(40.0 * 8.0, 10.0 * 16.0))),
+            "headless seed must use the 8x16 placeholder cell at scale 1.0"
+        );
+        assert!(
+            app.world().get::<NonInteractive>(child).is_none(),
+            "an interactive view must not be stamped NonInteractive"
+        );
+    }
+
+    #[test]
+    fn duplicate_mount_same_view_is_rejected() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+        mount(&mut app, terminal, "dash", Some(test_anchor()));
+
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            1,
+            "a duplicate (terminal, view_id) mount must be dropped"
+        );
+    }
+
+    #[test]
+    fn slots_fill_in_order_and_a_fifth_mount_is_rejected() {
+        let mut app = make_test_app();
+        for id in ["a", "b", "c", "d", "e"] {
+            register_view(&mut app, id, true, &[]);
+        }
+        let terminal = spawn_terminal(&mut app);
+
+        for id in ["a", "b", "c", "d"] {
+            mount(&mut app, terminal, id, Some(test_anchor()));
+        }
+        assert_eq!(slot_of(&app, terminal, "a"), Some(0));
+        assert_eq!(slot_of(&app, terminal, "b"), Some(1));
+        assert_eq!(slot_of(&app, terminal, "c"), Some(2));
+        assert_eq!(slot_of(&app, terminal, "d"), Some(3));
+
+        mount(&mut app, terminal, "e", Some(test_anchor()));
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            OVERLAY_SLOTS,
+            "a fifth mount must be rejected once all slots are taken"
+        );
+        assert_eq!(slot_of(&app, terminal, "e"), None);
+    }
+
+    #[test]
+    fn unmount_frees_the_slot_for_the_next_mount() {
+        let mut app = make_test_app();
+        for id in ["a", "b", "c"] {
+            register_view(&mut app, id, true, &[]);
+        }
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "a", Some(test_anchor()));
+        mount(&mut app, terminal, "b", Some(test_anchor()));
+        unmount(&mut app, terminal, Some("a"));
+        assert_eq!(
+            inline_children_of(&app, terminal).len(),
+            1,
+            "unmounting one view must despawn exactly its child"
+        );
+
+        mount(&mut app, terminal, "c", Some(test_anchor()));
+        assert_eq!(
+            slot_of(&app, terminal, "c"),
+            Some(0),
+            "the freed slot 0 must be reused by the next mount"
+        );
+        assert_eq!(slot_of(&app, terminal, "b"), Some(1));
+    }
+
+    #[test]
+    fn unmount_all_despawns_every_inline_child() {
+        let mut app = make_test_app();
+        for id in ["a", "b"] {
+            register_view(&mut app, id, true, &[]);
+        }
+        let terminal = spawn_terminal(&mut app);
+        mount(&mut app, terminal, "a", Some(test_anchor()));
+        mount(&mut app, terminal, "b", Some(test_anchor()));
+        let children = inline_children_of(&app, terminal);
+        assert_eq!(children.len(), 2);
+
+        unmount(&mut app, terminal, None);
+
+        assert!(
+            inline_children_of(&app, terminal).is_empty(),
+            "unmount-all must despawn every inline child of the terminal"
+        );
+        for child in children {
+            assert!(
+                app.world().get_entity(child).is_err(),
+                "despawned inline entity must not survive"
+            );
+        }
+    }
+
+    #[test]
+    fn non_interactive_view_is_stamped_non_interactive() {
+        let mut app = make_test_app();
+        register_view(&mut app, "hud", false, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "hud", Some(test_anchor()));
+
+        let children = inline_children_of(&app, terminal);
+        assert_eq!(children.len(), 1);
+        assert!(
+            app.world().get::<NonInteractive>(children[0]).is_some(),
+            "a non-interactive view must carry NonInteractive"
+        );
+    }
+
+    #[test]
+    fn mount_without_anchor_is_dropped() {
+        let mut app = make_test_app();
+        register_view(&mut app, "dash", true, &[]);
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "dash", None);
+
+        assert!(
+            inline_children_of(&app, terminal).is_empty(),
+            "a mount-inline without an anchor must be dropped"
+        );
+    }
+
+    #[test]
+    fn mount_of_unregistered_view_is_dropped() {
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, "ghost", Some(test_anchor()));
+
+        assert!(
+            inline_children_of(&app, terminal).is_empty(),
+            "a mount-inline for an unregistered view must be dropped"
+        );
+    }
+
+    #[test]
+    fn seed_logical_size_divides_physical_cells_by_scale() {
+        assert_eq!(
+            seed_logical_size(10, 40, 8.0, 16.0, 2.0),
+            Vec2::new(160.0, 80.0)
+        );
+        assert_eq!(
+            seed_logical_size(10, 40, 8.0, 16.0, 1.0),
+            Vec2::new(320.0, 160.0)
+        );
+    }
+
+    #[test]
+    fn cell_size_phys_falls_back_without_metrics() {
+        assert_eq!(
+            cell_size_phys(None),
+            (FALLBACK_CELL_W_PHYS, FALLBACK_CELL_H_PHYS)
+        );
+    }
+}

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -1368,6 +1368,36 @@ mod tests {
     }
 
     #[test]
+    fn projection_draws_two_instances_in_their_own_slots() {
+        let mut app = make_test_app();
+        let terminal = app.world_mut().spawn(projection_grid(7)).id();
+        let placement = InlinePlacement {
+            anchor_line: 42,
+            anchor_col: 3,
+            rows: 10,
+            cols: 40,
+            frame_seq: 7,
+        };
+        let h0 = spawn_projection_child(&mut app, terminal, 0, placement);
+        let h1 = spawn_projection_child(&mut app, terminal, 1, placement);
+
+        project(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(
+            overlays.textures[0].as_ref().map(Handle::id),
+            Some(h0.id()),
+            "slot 0 must carry the first instance's texture"
+        );
+        assert_eq!(
+            overlays.textures[1].as_ref().map(Handle::id),
+            Some(h1.id()),
+            "slot 1 must carry the second instance's texture"
+        );
+        assert_ne!(overlays.rects[0], IVec4::ZERO);
+        assert_ne!(overlays.rects[1], IVec4::ZERO);
+    }
+
+    #[test]
     fn stale_overlays_clear_after_unmount_all() {
         let mut app = make_test_app();
         register_view(&mut app, "dash", true, &[]);

--- a/src/input.rs
+++ b/src/input.rs
@@ -1643,7 +1643,7 @@ mod tests {
     }
 
     #[test]
-    fn modified_escape_does_not_snap_to_bottom() {
+    fn modified_escape_skips_the_escape_pre_handler() {
         let (mut app, window_entity) = make_app(true);
         let surface = install_active_terminal_surface_with_handle(&mut app);
         scroll_surface_back(&mut app, surface);

--- a/src/input.rs
+++ b/src/input.rs
@@ -192,7 +192,13 @@ pub(crate) fn dispatch_focused_key(
             continue;
         }
 
+        // NOTE: a focused inline webview wins over copy mode (same precedence
+        // as the wheel path in `mouse_wheel.rs`): without the `focused_inline`
+        // guard the copy-mode gate would consume keystrokes before the
+        // inline-focus PTY suppression below, so keys would drive the vi cursor
+        // instead of reaching the focused page while copy mode is active.
         if let Some(entity) = focused_entity
+            && focused_inline.is_none()
             && copy_modes.get(entity).is_ok()
             && !just_exited.contains(&entity)
         {
@@ -1597,6 +1603,43 @@ mod tests {
             captured.is_empty(),
             "copy mode must still swallow ordinary keys after the chord released focus; captured: {:?}",
             captured,
+        );
+    }
+
+    #[test]
+    fn focused_inline_webview_wins_over_copy_mode_for_shortcuts() {
+        let (mut app, window_entity) = make_app(true);
+        app.insert_resource(CapturedClipboardOps::default());
+        app.add_observer(capture_copy_op);
+        let surface = install_active_terminal_surface(&mut app);
+        app.world_mut()
+            .entity_mut(surface)
+            .insert(crate::ui::copy_mode::CopyModeState);
+        spawn_focused_inline_child(&mut app, surface);
+
+        // Copy mode normally SWALLOWS Cmd+C (see
+        // `cmd_c_in_copy_mode_does_not_trigger_copy_event`). With an inline
+        // webview focused the copy-mode gate must be skipped so global
+        // shortcuts still fire — the firing Copy is what distinguishes the
+        // fixed precedence (focused inline wins over copy mode, matching the
+        // wheel path) from the pre-fix behavior, where copy mode ate the chord.
+        {
+            let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            keys.press(KeyCode::SuperLeft);
+        }
+        press(&mut app, window_entity, Bk::Character("c".into()));
+        app.update();
+
+        let ops = app
+            .world()
+            .resource::<CapturedClipboardOps>()
+            .0
+            .lock()
+            .unwrap();
+        assert_eq!(
+            *ops,
+            vec!["copy"],
+            "a focused inline webview must let the Cmd+C shortcut fire past the copy-mode gate"
         );
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,6 +19,7 @@ use crate::action::workspace::{
 };
 use crate::clipboard::{Clipboard, CopyToClipboardActionEvent, PasteFromClipboardActionEvent};
 use crate::configs::OzmuxConfigsResource;
+use crate::inline_webview::{InlineWebview, focused_inline_of};
 use crate::input::ime::{ImeState, read_ime_events};
 use crate::system_set::OzmuxSystems;
 use crate::ui::copy_mode::{
@@ -117,11 +118,13 @@ pub(crate) fn dispatch_focused_key(
     keys: Res<ButtonInput<KeyCode>>,
     configs: Res<OzmuxConfigsResource>,
     copy_modes: Query<(), With<CopyModeState>>,
+    inline_parents: Query<&ChildOf, With<InlineWebview>>,
 ) {
     let bindings = &configs.shortcuts.bindings;
     // NOTE: ButtonInput<KeyCode> is updated in PreUpdate; every Update-tick event
     // sees the same modifier snapshot. Read once outside the loop.
     let mods = current_modifiers(&keys);
+    let mods_empty = mods == Modifiers::default();
     let mut just_exited: HashSet<Entity> = HashSet::new();
 
     for ev in events.read() {
@@ -155,8 +158,31 @@ pub(crate) fn dispatch_focused_key(
 
         let active_pane = mux.workspaces_active_pane(workspace);
         let focused_entity = active_pane.and_then(|p| mux.panes_active_surface(p));
+        let focused_inline =
+            focused_inline_of(focused_webview.as_deref(), &inline_parents, focused_entity);
+
+        // NOTE: the release-chord check is hoisted ABOVE both the Escape
+        // pre-handler and the copy-mode gate (spec §7): the pre-handler would
+        // otherwise consume the chord's Escape while scrolled back (snapping
+        // the viewport and culling the focused webview), and copy mode would
+        // swallow it outright — leaving no way to release inline focus.
+        if focused_inline.is_some()
+            && let Some(release_chord) = bindings.release_inline_focus.as_ref()
+            && bevy_to_configs_key(&ev.logical_key)
+                .is_some_and(|key| release_chord.key == key && release_chord.modifiers == mods)
+        {
+            if ev.repeat {
+                continue;
+            }
+            if let Some(ref mut fw) = focused_webview {
+                fw.0 = None;
+            }
+            continue;
+        }
 
         if matches!(ev.logical_key, Key::Escape)
+            && mods_empty
+            && focused_inline.is_none()
             && let Some(entity) = focused_entity
             && copy_modes.get(entity).is_err()
             && let Ok((mut handle, _pty, mut coalescer)) = handles.get_mut(entity)
@@ -207,6 +233,10 @@ pub(crate) fn dispatch_focused_key(
                 );
                 continue;
             }
+        }
+
+        if focused_inline.is_some() {
+            continue;
         }
 
         if let Some(tk) = bevy_to_terminal_key(&ev.logical_key) {
@@ -637,6 +667,65 @@ mod tests {
         let surface = install_active_terminal_surface(app);
         app.world_mut().entity_mut(surface).insert(bundle);
         surface
+    }
+
+    /// Spawns an `InlineWebview` child of `surface` and points the
+    /// `FocusedWebview` resource at it, mirroring the click-to-focus path.
+    fn spawn_focused_inline_child(app: &mut App, surface: Entity) -> Entity {
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(surface),
+                crate::inline_webview::InlineWebview {
+                    view_id: "inline-test".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.insert_resource(FocusedWebview(Some(child)));
+        child
+    }
+
+    /// Feeds enough lines into the surface's VT emulator to grow scrollback,
+    /// then scrolls the viewport up so `is_at_bottom()` turns false.
+    fn scroll_surface_back(app: &mut App, surface: Entity) {
+        app.world_mut()
+            .run_system_once(
+                move |mut q: Query<(
+                    &mut bevy_terminal::TerminalHandle,
+                    &mut bevy_terminal::Coalescer,
+                )>| {
+                    let (mut handle, mut coalescer) = q.get_mut(surface).unwrap();
+                    for _ in 0..30 {
+                        handle.advance(b"x\r\n");
+                    }
+                    handle.scroll(&mut coalescer, 3);
+                },
+            )
+            .unwrap();
+        assert!(
+            !is_at_bottom(app, surface),
+            "precondition: viewport must be scrolled back"
+        );
+    }
+
+    fn is_at_bottom(app: &App, surface: Entity) -> bool {
+        app.world()
+            .get::<bevy_terminal::TerminalHandle>(surface)
+            .unwrap()
+            .is_at_bottom()
+    }
+
+    fn press_ctrl_shift(app: &mut App) {
+        let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        keys.press(KeyCode::ControlLeft);
+        keys.press(KeyCode::ShiftLeft);
+    }
+
+    fn release_ctrl_shift(app: &mut App) {
+        let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        keys.release(KeyCode::ControlLeft);
+        keys.release(KeyCode::ShiftLeft);
     }
 
     #[test]
@@ -1447,6 +1536,203 @@ mod tests {
             captured.is_empty(),
             "dispatch_focused_key must suppress keys while ImeState is composing; captured: {:?}",
             captured,
+        );
+    }
+
+    #[test]
+    fn release_chord_clears_inline_focus_even_when_scrolled_back() {
+        let (mut app, window_entity) = make_app(true);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        scroll_surface_back(&mut app, surface);
+        spawn_focused_inline_child(&mut app, surface);
+
+        press_ctrl_shift(&mut app);
+        press(&mut app, window_entity, Bk::Escape);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "Ctrl+Shift+Escape must clear inline focus even while scrolled back"
+        );
+        assert!(
+            !is_at_bottom(&app, surface),
+            "the release chord must NOT snap the viewport to the bottom"
+        );
+    }
+
+    #[test]
+    fn release_chord_works_during_copy_mode() {
+        let (mut app, window_entity) = make_app(true);
+        app.insert_resource(CapturedKeys::default());
+        app.add_observer(capture_key_input);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        app.world_mut()
+            .entity_mut(surface)
+            .insert(crate::ui::copy_mode::CopyModeState);
+        spawn_focused_inline_child(&mut app, surface);
+
+        press_ctrl_shift(&mut app);
+        press(&mut app, window_entity, Bk::Escape);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "Ctrl+Shift+Escape must clear inline focus even while copy mode is active"
+        );
+        assert!(
+            app.world()
+                .get::<crate::ui::copy_mode::CopyModeState>(surface)
+                .is_some(),
+            "the hoisted chord check must consume the event before copy mode's Escape arm"
+        );
+
+        release_ctrl_shift(&mut app);
+        press(&mut app, window_entity, Bk::Character("x".into()));
+        app.update();
+
+        let captured = app.world().resource::<CapturedKeys>().0.lock().unwrap();
+        assert!(
+            captured.is_empty(),
+            "copy mode must still swallow ordinary keys after the chord released focus; captured: {:?}",
+            captured,
+        );
+    }
+
+    #[test]
+    fn release_chord_repeat_is_consumed_without_clearing_focus() {
+        let (mut app, window_entity) = make_app(true);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        let child = spawn_focused_inline_child(&mut app, surface);
+
+        press_ctrl_shift(&mut app);
+        let ev = KeyboardInput {
+            key_code: KeyCode::Unidentified(NativeKeyCode::Unidentified),
+            logical_key: Bk::Escape,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: true,
+            window: window_entity,
+        };
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<KeyboardInput>>()
+            .write(ev);
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "a repeat release-chord event must be consumed without clearing focus"
+        );
+    }
+
+    #[test]
+    fn unmodified_escape_still_snaps_to_bottom_without_inline_focus() {
+        let (mut app, window_entity) = make_app(true);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        scroll_surface_back(&mut app, surface);
+
+        press(&mut app, window_entity, Bk::Escape);
+        app.update();
+
+        assert!(
+            is_at_bottom(&app, surface),
+            "plain Escape while scrolled back (no inline focus) must snap to bottom"
+        );
+    }
+
+    #[test]
+    fn modified_escape_does_not_snap_to_bottom() {
+        let (mut app, window_entity) = make_app(true);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        scroll_surface_back(&mut app, surface);
+
+        {
+            let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            keys.press(KeyCode::AltLeft);
+        }
+        press(&mut app, window_entity, Bk::Escape);
+        app.update();
+
+        assert!(
+            !is_at_bottom(&app, surface),
+            "Alt+Escape must not trigger the scroll-to-bottom Escape pre-handler"
+        );
+    }
+
+    #[test]
+    fn escape_while_inline_focused_neither_snaps_nor_forwards() {
+        let (mut app, window_entity) = make_app(true);
+        app.insert_resource(CapturedKeys::default());
+        app.add_observer(capture_key_input);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        scroll_surface_back(&mut app, surface);
+        let child = spawn_focused_inline_child(&mut app, surface);
+
+        press(&mut app, window_entity, Bk::Escape);
+        app.update();
+
+        assert!(
+            !is_at_bottom(&app, surface),
+            "plain Escape typed into a focused page must not snap the viewport"
+        );
+        let captured = app.world().resource::<CapturedKeys>().0.lock().unwrap();
+        assert!(
+            captured.is_empty(),
+            "plain Escape while inline-focused must not forward to the PTY; captured: {:?}",
+            captured,
+        );
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "plain Escape must not release inline focus"
+        );
+    }
+
+    #[test]
+    fn keys_suppressed_to_pty_while_inline_focused_but_shortcuts_fire() {
+        let (mut app, window_entity) = make_app(true);
+        app.insert_resource(CapturedKeys::default());
+        app.add_observer(capture_key_input);
+        app.insert_resource(CapturedClipboardOps::default());
+        app.add_observer(capture_copy_op);
+        let surface = install_active_terminal_surface_with_handle(&mut app);
+        let child = spawn_focused_inline_child(&mut app, surface);
+
+        press(&mut app, window_entity, Bk::Character("h".into()));
+        app.update();
+        {
+            let captured = app.world().resource::<CapturedKeys>().0.lock().unwrap();
+            assert!(
+                captured.is_empty(),
+                "printable keys must not reach the PTY while an inline webview holds focus; captured: {:?}",
+                captured,
+            );
+        }
+
+        {
+            let mut keys = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            keys.press(KeyCode::SuperLeft);
+        }
+        press(&mut app, window_entity, Bk::Character("c".into()));
+        app.update();
+
+        let ops = app
+            .world()
+            .resource::<CapturedClipboardOps>()
+            .0
+            .lock()
+            .unwrap();
+        assert_eq!(
+            *ops,
+            vec!["copy"],
+            "bound global shortcuts must still execute while inline-focused"
+        );
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "Cmd+C must not clear inline focus"
         );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,6 +27,7 @@ use crate::ui::copy_mode::{
 use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::prelude::*;
+use bevy_cef::prelude::FocusedWebview;
 use bevy_terminal::{TerminalKey, TerminalKeyInput, TerminalModifiers};
 use ozmux_configs::shortcuts::{
     Direction as ConfigDirection, KeyChord, Modifiers, ShortcutAction, SplitDirection,
@@ -109,6 +110,7 @@ pub(crate) fn dispatch_focused_key(
         &mut bevy_terminal::PtyHandle,
         &mut bevy_terminal::Coalescer,
     )>,
+    mut focused_webview: Option<ResMut<FocusedWebview>>,
     mux: MultiplexerCommands,
     windows: Query<&Window>,
     attached_workspace: Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
@@ -196,7 +198,13 @@ pub(crate) fn dispatch_focused_key(
                 if ev.repeat {
                     continue;
                 }
-                execute_action(&mut commands, &mux, action, workspace);
+                execute_action(
+                    focused_webview.as_deref_mut(),
+                    &mut commands,
+                    &mux,
+                    action,
+                    workspace,
+                );
                 continue;
             }
         }
@@ -298,7 +306,11 @@ fn bevy_to_configs_key(key: &Key) -> Option<ozmux_configs::shortcuts::Key> {
 /// actions target the active Terminal Surface; workspace and pane/surface
 /// actions target `workspace`; not-yet-implemented variants fall through to a
 /// `tracing::debug!` log.
+///
+/// `focused_webview` is `Option<>` so callers that run without `bevy_cef`
+/// (e.g., unit tests) can pass `None` and remain green.
 fn execute_action(
+    mut focused_webview: Option<&mut FocusedWebview>,
     commands: &mut Commands,
     mux: &MultiplexerCommands,
     action: ShortcutAction,
@@ -373,6 +385,11 @@ fn execute_action(
         }
         ShortcutAction::CloseSurface => {
             commands.trigger(CloseSurfaceActionEvent { workspace });
+        }
+        ShortcutAction::ReleaseInlineFocus => {
+            if let Some(ref mut fw) = focused_webview {
+                fw.0 = None;
+            }
         }
         other => tracing::debug!(
             target: "ozmux_gui::input",
@@ -1245,7 +1262,7 @@ mod tests {
     fn run_execute_action(app: &mut App, action: ShortcutAction, workspace: Entity) {
         app.world_mut()
             .run_system_once(move |mut commands: Commands, mux: MultiplexerCommands| {
-                execute_action(&mut commands, &mux, action.clone(), workspace);
+                execute_action(None, &mut commands, &mux, action.clone(), workspace);
             })
             .unwrap();
         app.world_mut().flush();

--- a/src/input.rs
+++ b/src/input.rs
@@ -684,6 +684,7 @@ mod tests {
                 ChildOf(surface),
                 crate::inline_webview::InlineWebview {
                     view_id: "inline-test".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -177,7 +177,7 @@ pub(crate) fn ime_policy_system(
         if !window.ime_enabled {
             window.ime_enabled = true;
         }
-        // Inline arm (spec §7): an inline child has no UI node, so the
+        // NOTE: Inline arm (spec §7): an inline child has no UI node, so the
         // tab-webview `webview_anchors` arm below cannot anchor it. Derive the
         // candidate-window position from the owning terminal's node transform
         // plus the inline placement rect's origin — the SAME px conversion the
@@ -293,7 +293,7 @@ pub(crate) fn read_ime_events(
     let active_surface = super::resolve_focused_terminal(&mux, &attached_workspace);
     for event in events.read() {
         if let Some(commit_text) = apply_event(&mut state, event) {
-            // Inline-focus commit suppression (spec §7): bevy_cef's own IME
+            // NOTE: Inline-focus commit suppression (spec §7): bevy_cef's own IME
             // systems independently consume the winit `Ime` events for the
             // focused webview, so ozmux must NOT also commit this text to the
             // PTY — doing so double-delivers the composition (once to the page,

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -722,6 +722,7 @@ mod tests {
                 ChildOf(surface),
                 InlineWebview {
                     view_id: "inline".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))
@@ -766,6 +767,7 @@ mod tests {
                 ChildOf(term_entity),
                 InlineWebview {
                     view_id: "inline".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -6,9 +6,11 @@
 //! the attached terminal), and `ime_policy_system` (toggles
 //! `Window::ime_enabled` and `.ime_position`).
 
+use crate::inline_webview::{InlineWebview, focused_inline_of};
 use crate::ui::TerminalSurfaceMarker;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::app::{App, Plugin, Update};
+use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::query::With;
 use bevy::ecs::resource::Resource;
@@ -21,7 +23,7 @@ use bevy::window::{Ime, PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
 use bevy_terminal::{TerminalKey, TerminalModifiers};
 use bevy_terminal_renderer::TerminalCellMetricsResource;
-use bevy_terminal_renderer::prelude::TerminalGrid;
+use bevy_terminal_renderer::prelude::{TerminalGrid, TerminalOverlays};
 use ozmux_multiplexer::{AttachedWorkspace, MultiplexerCommands, WorkspaceMarker};
 
 /// Bevy plugin that registers `ImeState` and the IME-event handling
@@ -144,7 +146,10 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 /// `ime_position` is the logical-pixel anchor for the OS candidate
 /// window — computed from the attached terminal's `UiGlobalTransform`
 /// translation + `TerminalGrid.cursor` × cell pitch, then divided by
-/// the window scale factor.
+/// the window scale factor. When the focused webview is an INLINE child of
+/// the active surface, the anchor instead comes from that child's overlay
+/// rect origin (`inline_ime_position`), since inline entities carry no UI
+/// node for `webview_anchors` to read (spec §7).
 pub(crate) fn ime_policy_system(
     mux: MultiplexerCommands,
     attached_workspace: Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
@@ -154,6 +159,9 @@ pub(crate) fn ime_policy_system(
     metrics: Res<TerminalCellMetricsResource>,
     focused_webview: Res<FocusedWebview>,
     webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
+    inline_parents: Query<&ChildOf, With<InlineWebview>>,
+    inline_slots: Query<&InlineWebview>,
+    overlays: Query<&TerminalOverlays>,
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
 ) {
     let Ok(mut window) = primary_window.single_mut() else {
@@ -168,6 +176,30 @@ pub(crate) fn ime_policy_system(
     if let Some(target) = focused_webview.0 {
         if !window.ime_enabled {
             window.ime_enabled = true;
+        }
+        // Inline arm (spec §7): an inline child has no UI node, so the
+        // tab-webview `webview_anchors` arm below cannot anchor it. Derive the
+        // candidate-window position from the owning terminal's node transform
+        // plus the inline placement rect's origin — the SAME px conversion the
+        // wheel/click hit-test uses (`inline_local_dip`'s `origin_phys`), so
+        // composition appears at the inline rect, not the terminal cursor.
+        let active_surface = super::resolve_focused_terminal(&mux, &attached_workspace);
+        if let Some(child) =
+            focused_inline_of(Some(&focused_webview), &inline_parents, active_surface)
+            && let Some(pos) = inline_ime_position(
+                window.resolution.scale_factor(),
+                &inline_parents,
+                &inline_slots,
+                &anchors,
+                &overlays,
+                &metrics,
+                child,
+            )
+        {
+            if window.ime_position != pos {
+                window.ime_position = pos;
+            }
+            return;
         }
         if let Ok((node, ui_xform)) = webview_anchors.get(target) {
             let scale = window.resolution.scale_factor();
@@ -240,7 +272,9 @@ pub(crate) fn ime_policy_system(
 }
 
 /// Drains `Ime` events, mutates `ImeState`, and forwards `Ime::Commit`
-/// text to the attached terminal.
+/// text to the attached terminal — UNLESS an inline webview owns focus, in
+/// which case the commit-to-PTY write is suppressed (bevy_cef commits it to
+/// the page; see spec §7).
 ///
 /// Modifiers are forced to `TerminalModifiers::default()` on commit:
 /// `crates/bevy_terminal/src/input_codec.rs::encode_key` converts
@@ -253,9 +287,22 @@ pub(crate) fn read_ime_events(
     mut commands: Commands,
     mux: MultiplexerCommands,
     attached_workspace: Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
+    focused_webview: Res<FocusedWebview>,
+    inline_parents: Query<&ChildOf, With<InlineWebview>>,
 ) {
+    let active_surface = super::resolve_focused_terminal(&mux, &attached_workspace);
     for event in events.read() {
         if let Some(commit_text) = apply_event(&mut state, event) {
+            // Inline-focus commit suppression (spec §7): bevy_cef's own IME
+            // systems independently consume the winit `Ime` events for the
+            // focused webview, so ozmux must NOT also commit this text to the
+            // PTY — doing so double-delivers the composition (once to the page,
+            // once to the terminal). The state machine above still ran, so
+            // `ImeState` stays consistent; only the PTY write is skipped.
+            if focused_inline_of(Some(&focused_webview), &inline_parents, active_surface).is_some()
+            {
+                continue;
+            }
             let Some(workspace) = attached_workspace.iter().next() else {
                 tracing::warn!(
                     target: "ozmux_gui::input::ime",
@@ -272,6 +319,35 @@ pub(crate) fn read_ime_events(
             );
         }
     }
+}
+
+/// The logical-pixel anchor for the OS candidate window when an inline webview
+/// owns focus: the owning terminal node's top-left (physical px) plus the
+/// child's active overlay rect origin (`rect.y × cell_w`, `rect.x × cell_h`),
+/// divided by the window scale factor. `None` when the focus chain is gone
+/// (child/terminal despawned, no terminal node, or a sentinel rect) — the
+/// caller then leaves `ime_position` unchanged rather than mis-anchoring.
+fn inline_ime_position(
+    scale_factor: f32,
+    inline_parents: &Query<&ChildOf, With<InlineWebview>>,
+    inline_slots: &Query<&InlineWebview>,
+    anchors: &Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
+    overlays: &Query<&TerminalOverlays>,
+    metrics: &TerminalCellMetricsResource,
+    child: Entity,
+) -> Option<Vec2> {
+    let terminal = inline_parents.get(child).ok()?.parent();
+    let slot = inline_slots.get(child).ok()?.slot;
+    let (node, ui_xform, _) = anchors.get(terminal).ok()?;
+    let rect = *overlays.get(terminal).ok()?.rects.get(usize::from(slot))?;
+    if rect.z == 0 {
+        return None;
+    }
+    let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
+    let host_origin_phys = ui_xform.translation - 0.5 * node.size();
+    let rect_origin_phys = Vec2::new(rect.y as f32 * cell_w_phys, rect.x as f32 * cell_h_phys);
+    Some((host_origin_phys + rect_origin_phys) / scale_factor.max(f32::EPSILON))
 }
 
 #[cfg(test)]
@@ -479,6 +555,7 @@ mod tests {
             .add_plugins(MultiplexerPlugin)
             .add_systems(Update, read_ime_events);
         app.init_resource::<ImeState>();
+        app.init_resource::<FocusedWebview>();
         app.insert_resource(CapturedKeys::default());
         app.add_observer(capture_key_input);
         app.add_message::<Ime>();
@@ -586,6 +663,140 @@ mod tests {
             captured[0].modifiers,
             TerminalModifiers::default(),
             "modifiers MUST be default — see input_codec.rs::encode_key ctrl path",
+        );
+    }
+
+    #[test]
+    fn ime_position_anchors_at_inline_rect_origin_for_focused_inline() {
+        use bevy::ui::{ComputedNode, UiGlobalTransform};
+        use bevy_terminal_renderer::CellMetrics;
+        use bevy_terminal_renderer::prelude::{TerminalGrid, TerminalOverlays};
+        use ozmux_multiplexer::AttachedWorkspace;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<FocusedWebview>();
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+
+        let outcome = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                mux.create_workspace(Some("default".into()))
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut()
+            .entity_mut(outcome.workspace)
+            .insert(AttachedWorkspace);
+        let surface = outcome.surface;
+
+        // Host node spans the window with no transform → top-left at (0, 0).
+        // Inline rect at rows 2.., cols 3.. → phys origin (24, 32) at 8x16 px.
+        let mut overlays = TerminalOverlays::default();
+        overlays.rects[0] = bevy::math::IVec4::new(2, 3, 10, 40);
+        app.world_mut().entity_mut(surface).insert((
+            crate::ui::TerminalSurfaceMarker,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalGrid::default(),
+            overlays,
+        ));
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(surface),
+                InlineWebview {
+                    view_id: "inline".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ime_enabled: false,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+
+        app.world_mut().run_system_once(ime_policy_system).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>();
+        let window = q.single(app.world()).expect("primary window");
+        assert!(
+            window.ime_enabled,
+            "IME must stay enabled while an inline webview owns focus"
+        );
+        assert!(
+            window.ime_position.abs_diff_eq(Vec2::new(24.0, 32.0), 1e-3),
+            "candidate window must anchor at the inline rect origin (phys 24,32 / scale 1), got {:?}",
+            window.ime_position,
+        );
+    }
+
+    #[test]
+    fn commit_suppressed_to_pty_while_inline_focused() {
+        let (mut app, term_entity) = build_app_with_attached_entity();
+
+        // Focus an inline child of the active surface.
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(term_entity),
+                InlineWebview {
+                    view_id: "inline".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .write(Ime::Commit {
+                window: Entity::PLACEHOLDER,
+                value: "こんにちは".into(),
+            });
+
+        app.update();
+
+        let captured = app
+            .world()
+            .resource::<CapturedKeys>()
+            .0
+            .lock()
+            .unwrap()
+            .clone();
+        assert!(
+            captured.is_empty(),
+            "an IME commit while inline-focused must NOT write to the PTY (bevy_cef commits it to the page); captured: {:?}",
+            captured,
+        );
+        // The composition state machine still ran: ImeState cleared on commit.
+        assert!(
+            !app.world().resource::<ImeState>().is_composing(),
+            "the state machine must still consume the commit, leaving ImeState non-composing",
         );
     }
 

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -1879,6 +1879,7 @@ mod tests {
                 ChildOf(surface),
                 InlineWebview {
                     view_id: "inline-test".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -135,13 +135,34 @@ pub(crate) fn resolve_pane_at_phys(
         if !node.contains_point(*transform, cursor_phys_px) {
             continue;
         }
-        let Some(normalized) = node.normalize_point(*transform, cursor_phys_px) else {
+        let Some(local) = phys_to_terminal_local(node, transform, cursor_phys_px) else {
             continue;
         };
-        let local = (normalized + Vec2::splat(0.5)) * node.size;
         return Some((entity, local));
     }
     None
+}
+
+/// Maps a window physical-pixel point to a terminal node's local physical px
+/// with origin at the node's TOP-LEFT corner (`(0, 0)` top-left,
+/// `(size.x, size.y)` bottom-right) — the coordinate space the inline overlay
+/// rects and `cell_at_local` are expressed in.
+///
+/// Uses the affine inverse of `UiGlobalTransform` (via
+/// `ComputedNode::normalize_point`) so the projection stays correct under any
+/// transform, not just a pure translation. Returns `None` for a degenerate
+/// (zero-area) node, mirroring `normalize_point`.
+///
+/// This is the single projection both the inline hit-test paths
+/// (`inline_release_dip`, the wheel router) and `resolve_pane_at_phys` share,
+/// so a coordinate-space change has one place to live.
+pub(crate) fn phys_to_terminal_local(
+    node: &ComputedNode,
+    transform: &UiGlobalTransform,
+    cursor_phys_px: Vec2,
+) -> Option<Vec2> {
+    node.normalize_point(*transform, cursor_phys_px)
+        .map(|normalized| (normalized + Vec2::splat(0.5)) * node.size)
 }
 
 /// Projects a pane-local physical-pixel point onto 1-indexed
@@ -806,10 +827,7 @@ fn inline_release_dip(
 ) -> Option<Vec2> {
     let terminal = route.inline_parents.get(child).ok()?.parent();
     let (_, node, transform) = hosts.get(terminal).ok()?;
-    // NOTE: UiGlobalTransform.translation is the node CENTER, not the
-    // top-left corner — every hit-test in this file relies on the
-    // `translation ± half * size` form.
-    let local_phys = cursor_phys - (transform.translation - node.size * 0.5);
+    let local_phys = phys_to_terminal_local(node, transform, cursor_phys)?;
     let (view, _) = route.inline.get(child).ok()?;
     inline_local_dip(
         route.overlay_rects.get(terminal).ok()?,

--- a/src/input/mouse_buttons.rs
+++ b/src/input/mouse_buttons.rs
@@ -7,16 +7,23 @@
 //! §6.
 
 use crate::configs::OzmuxConfigsResource;
+use crate::inline_webview::{InlineWebview, inline_hit_at, inline_local_dip};
 use crate::input::hyperlink::{link_modifier_held, should_open_at, try_open_uri};
 use crate::input::{InputPhase, current_modifiers};
+use crate::osc_webview::NonInteractive;
 use crate::ui::Slotted;
 use crate::ui::copy_mode::CopyModeState;
+use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
 use bevy::input::mouse::{MouseButton, MouseButtonInput};
+use bevy::picking::pointer::PointerButton;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{CursorMoved, PrimaryWindow};
+use bevy_cef::prelude::FocusedWebview;
+use bevy_cef_core::prelude::Browsers;
 use bevy_terminal::{ButtonAction, CellCoord, Column, Line, Point, SelectionType, Side};
+use bevy_terminal_renderer::prelude::TerminalOverlays;
 use std::time::Instant;
 
 /// Per-frame state for the mouse-selection system.
@@ -26,6 +33,11 @@ pub(crate) struct MouseSelectionState {
     last_click: Option<LastClick>,
     /// Next allowed autoscroll tick. `None` outside autoscroll.
     next_autoscroll_at: Option<Instant>,
+    /// The inline webview child holding an in-flight left press: the press
+    /// was forwarded to it instead of the terminal pipeline, so the matching
+    /// release must reach the SAME child even if the pointer drifted off the
+    /// rect. `None` outside an inline press.
+    inline_press: Option<Entity>,
 }
 
 #[derive(Clone)]
@@ -71,6 +83,20 @@ struct LastClick {
     cursor_pos_logical_px: Vec2,
     at: Instant,
     count: u8,
+}
+
+/// The system params the inline-webview routing leg of
+/// `dispatch_mouse_buttons` needs (`route_inline_left_click`), bundled so the
+/// system stays within Bevy's system-parameter limit. `focused_webview` and
+/// `browsers` are optional so CEF-less tests construct the system.
+#[derive(SystemParam)]
+struct InlineRouteParams<'w, 's> {
+    focused_webview: Option<ResMut<'w, FocusedWebview>>,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
 }
 
 /// Bevy plugin that registers `MouseSelectionState` and the per-frame
@@ -365,6 +391,13 @@ fn synthesize_drag_cell(
 /// press/release through `ButtonAction::route`, and pre-routes
 /// click-to-focus per spec §6 step 4. Drag-state tracking + autoscroll
 /// (Tasks 19-20) are layered on later.
+///
+/// Left presses/releases are first offered to the inline-webview layer
+/// (`route_inline_left_click`, spec §7): a press inside an interactive inline
+/// rect focuses + forwards to the child's CEF browser and never reaches the
+/// terminal click pipeline (no selection arm, no click-count update); a press
+/// on terminal text outside every rect drops inline focus and proceeds as a
+/// normal terminal click.
 fn dispatch_mouse_buttons(
     mut state: ResMut<MouseSelectionState>,
     mut mux: ozmux_multiplexer::MultiplexerCommands,
@@ -375,6 +408,7 @@ fn dispatch_mouse_buttons(
         &mut bevy_terminal::PtyHandle,
         &mut bevy_terminal::Coalescer,
     )>,
+    mut inline_route: InlineRouteParams,
     keys: Res<ButtonInput<KeyCode>>,
     configs: Res<OzmuxConfigsResource>,
     hosts: Query<
@@ -445,6 +479,28 @@ fn dispatch_mouse_buttons(
             && let Ok(attached_workspace) = attached_workspace.single()
         {
             try_click_to_focus(&mut mux, attached_workspace, entity);
+        }
+
+        // NOTE: inline routing must stay AFTER click-to-focus (the clicked
+        // pane must still activate, or sync_focused_webview's inline
+        // preservation arm sees a non-active parent and clobbers the focus
+        // one frame later) and BEFORE the click-count / selection pipeline
+        // below (a consumed press must not arm a drag or bump the count).
+        if matches!(bevy_button, bevy_terminal::MouseButtonKind::Left)
+            && route_inline_left_click(
+                &mut state,
+                &mut inline_route,
+                &hosts,
+                entity,
+                local,
+                cursor_phys,
+                ev.state,
+                cell_w_phys,
+                cell_h_phys,
+                scale,
+            )
+        {
+            continue;
         }
 
         let (cols, rows) = match handles.get(entity) {
@@ -630,6 +686,139 @@ fn dispatch_mouse_buttons(
         drag.anchor_cell.col = drag.anchor_cell.col.min(cols as u32).max(1);
         drag.anchor_cell.row = drag.anchor_cell.row.min(rows as u32).max(1);
     }
+}
+
+/// Routes a left press/release through the inline-webview layer (spec §7),
+/// returning `true` when the event was consumed and must NOT reach the
+/// terminal click pipeline.
+///
+/// Press inside an interactive inline rect: sets `FocusedWebview` to the
+/// child, issues the direct UNGATED `set_focus` BEFORE the gated
+/// `send_mouse_click` (CEF drops clicks to a browser with no
+/// `focused_frame()`, so without the pre-focus the first click on an
+/// unfocused browser would be swallowed), forwards the press in webview-local
+/// DIP, and records the in-flight press. Release while a press is in flight:
+/// forwards the release to the SAME child (pointer drift included) and clears
+/// the marker. A press outside every interactive rect returns `false` after
+/// clearing `FocusedWebview` if it held an inline child, so terminal-text
+/// clicks drop inline focus and proceed as normal clicks.
+///
+/// `route.focused_webview` / `route.browsers` are optional so CEF-less tests
+/// construct the caller; when `browsers` is absent the state effects (focus,
+/// in-flight marker, consumption) still apply — only the CEF forwarding is
+/// skipped.
+fn route_inline_left_click(
+    state: &mut MouseSelectionState,
+    route: &mut InlineRouteParams,
+    hosts: &Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        (With<ozmux_multiplexer::SurfaceMarker>, With<Slotted>),
+    >,
+    terminal: Entity,
+    local_phys: Vec2,
+    cursor_phys: Vec2,
+    button_state: ButtonState,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> bool {
+    match button_state {
+        ButtonState::Pressed => {
+            // NOTE: a fresh left press invalidates any lingering in-flight
+            // marker — its matching release was lost (released outside the
+            // window, where the dispatcher early-returns before this layer)
+            // — or THIS press's release would be mis-routed to the stale
+            // child and the terminal pipeline would keep a phantom drag.
+            state.inline_press = None;
+            let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
+                inline_hit_at(
+                    &route.children,
+                    &route.inline,
+                    overlays,
+                    terminal,
+                    local_phys,
+                    cell_w_phys,
+                    cell_h_phys,
+                    scale,
+                )
+            });
+            let Some(hit) = hit else {
+                if let Some(focused) = route.focused_webview.as_deref_mut()
+                    && focused
+                        .0
+                        .is_some_and(|current| route.inline_parents.contains(current))
+                {
+                    focused.0 = None;
+                }
+                return false;
+            };
+            if let Some(focused) = route.focused_webview.as_deref_mut()
+                && focused.0 != Some(hit.child)
+            {
+                focused.0 = Some(hit.child);
+            }
+            if let Some(browsers) = route.browsers.as_deref() {
+                browsers.set_focus(&hit.child, true);
+                browsers.send_mouse_click(&hit.child, hit.local_dip, PointerButton::Primary, false);
+            }
+            state.inline_press = Some(hit.child);
+            true
+        }
+        ButtonState::Released => {
+            let Some(child) = state.inline_press.take() else {
+                return false;
+            };
+            if let Some(browsers) = route.browsers.as_deref()
+                && let Some(dip) = inline_release_dip(
+                    route,
+                    hosts,
+                    child,
+                    cursor_phys,
+                    cell_w_phys,
+                    cell_h_phys,
+                    scale,
+                )
+            {
+                browsers.send_mouse_click(&child, dip, PointerButton::Primary, true);
+            }
+            true
+        }
+    }
+}
+
+/// The current-cursor webview-local DIP for an in-flight inline press's
+/// child, derived from the child's LIVE overlay rect (the placement may have
+/// scrolled between press and release; the result may lie outside the rect,
+/// which CEF accepts for a release). `None` when the chain is gone — child or
+/// terminal despawned, terminal unslotted, or the rect back at the sentinel —
+/// in which case the release is dropped rather than mis-aimed.
+fn inline_release_dip(
+    route: &InlineRouteParams,
+    hosts: &Query<
+        (Entity, &ComputedNode, &UiGlobalTransform),
+        (With<ozmux_multiplexer::SurfaceMarker>, With<Slotted>),
+    >,
+    child: Entity,
+    cursor_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> Option<Vec2> {
+    let terminal = route.inline_parents.get(child).ok()?.parent();
+    let (_, node, transform) = hosts.get(terminal).ok()?;
+    // NOTE: UiGlobalTransform.translation is the node CENTER, not the
+    // top-left corner — every hit-test in this file relies on the
+    // `translation ± half * size` form.
+    let local_phys = cursor_phys - (transform.translation - node.size * 0.5);
+    let (view, _) = route.inline.get(child).ok()?;
+    inline_local_dip(
+        route.overlay_rects.get(terminal).ok()?,
+        view.slot,
+        local_phys,
+        cell_w_phys,
+        cell_h_phys,
+        scale,
+    )
 }
 
 /// Converts a 1-indexed `CellCoord` (the wire format from
@@ -1597,5 +1786,257 @@ mod tests {
             Some(ext_pane),
             "clicking a pane whose host has no TerminalHandle must still move focus to it",
         );
+    }
+
+    /// Full-pipeline harness for the inline-webview click routing: one
+    /// terminal surface (REAL `TerminalHandle`, so a non-intercepted press
+    /// observably arms a drag) carrying a slot-0 overlay rect at rows 2..12,
+    /// cols 3..43 (8x16 px cells → phys y 32..192, x 24..344), plus one
+    /// inline child in that slot. Returns `(app, window, surface, child)`.
+    fn inline_click_harness(non_interactive: bool) -> (App, Entity, Entity, Entity) {
+        use bevy::ecs::system::RunSystemOnce;
+        use bevy::window::WindowResolution;
+        use ozmux_multiplexer::{AttachedWorkspace, MultiplexerCommands, MultiplexerPlugin};
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(MultiplexerPlugin);
+        app.init_resource::<MouseSelectionState>();
+        app.init_resource::<FocusedWebview>();
+        app.insert_resource(ButtonInput::<KeyCode>::default());
+        app.insert_resource(OzmuxConfigsResource(ozmux_configs::OzmuxConfigs::default()));
+        app.insert_resource(bevy_terminal_renderer::TerminalCellMetricsResource {
+            metrics: bevy_terminal_renderer::CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+        app.add_message::<MouseButtonInput>();
+        app.add_message::<CursorMoved>();
+        app.add_systems(Update, dispatch_mouse_buttons);
+
+        let (workspace, surface) = app
+            .world_mut()
+            .run_system_once(|mut mux: MultiplexerCommands| {
+                let o = mux.create_workspace(Some("t".into()));
+                (o.workspace, o.surface)
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut()
+            .entity_mut(workspace)
+            .insert(AttachedWorkspace);
+
+        let opts = bevy_terminal::SpawnOptions {
+            cols: 80,
+            rows: 24,
+            shell: std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into()),
+            cwd: None,
+            env: Vec::new(),
+            osc_webview_gate: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+        let bundle = bevy_terminal::TerminalBundle::spawn(opts).unwrap();
+        let mut overlays = TerminalOverlays::default();
+        overlays.rects[0] = IVec4::new(2, 3, 10, 40);
+        app.world_mut().entity_mut(surface).insert((
+            Slotted,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            bundle,
+            overlays,
+        ));
+
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(surface),
+                InlineWebview {
+                    view_id: "inline-test".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        if non_interactive {
+            app.world_mut().entity_mut(child).insert(NonInteractive);
+        }
+
+        let window = app
+            .world_mut()
+            .spawn((
+                Window {
+                    resolution: WindowResolution::new(800, 600),
+                    ..default()
+                },
+                PrimaryWindow,
+            ))
+            .id();
+        (app, window, surface, child)
+    }
+
+    fn set_cursor_phys(app: &mut App, window: Entity, pos: Vec2) {
+        use bevy::math::DVec2;
+        app.world_mut()
+            .get_mut::<Window>(window)
+            .unwrap()
+            .set_physical_cursor_position(Some(DVec2::new(pos.x as f64, pos.y as f64)));
+    }
+
+    fn send_left_button(app: &mut App, window: Entity, state: ButtonState) {
+        use bevy::ecs::message::Messages;
+        app.world_mut()
+            .resource_mut::<Messages<MouseButtonInput>>()
+            .write(MouseButtonInput {
+                button: MouseButton::Left,
+                state,
+                window,
+            });
+        app.update();
+    }
+
+    #[test]
+    fn press_inside_inline_rect_focuses_child_and_bypasses_terminal_click() {
+        let (mut app, window, _surface, child) = inline_click_harness(false);
+        set_cursor_phys(&mut app, window, Vec2::new(100.0, 100.0));
+
+        send_left_button(&mut app, window, ButtonState::Pressed);
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "a press inside an interactive inline rect must focus the child"
+        );
+        let state = app.world().resource::<MouseSelectionState>();
+        assert!(
+            state.drag.is_none(),
+            "an intercepted press must NOT arm a terminal selection drag"
+        );
+        assert!(
+            state.last_click.is_none(),
+            "an intercepted press must NOT update the click count"
+        );
+        assert_eq!(
+            state.inline_press,
+            Some(child),
+            "the press must be recorded in flight for the matching release"
+        );
+    }
+
+    #[test]
+    fn release_after_inline_press_clears_the_in_flight_marker() {
+        let (mut app, window, _surface, child) = inline_click_harness(false);
+        set_cursor_phys(&mut app, window, Vec2::new(100.0, 100.0));
+        send_left_button(&mut app, window, ButtonState::Pressed);
+        assert_eq!(
+            app.world().resource::<MouseSelectionState>().inline_press,
+            Some(child),
+        );
+
+        // Drift the pointer off the rect before releasing: the release must
+        // still resolve against the in-flight child, not the hit-test.
+        set_cursor_phys(&mut app, window, Vec2::new(700.0, 500.0));
+        send_left_button(&mut app, window, ButtonState::Released);
+
+        let state = app.world().resource::<MouseSelectionState>();
+        assert!(
+            state.inline_press.is_none(),
+            "the release must consume the in-flight inline press"
+        );
+        assert!(
+            state.drag.is_none(),
+            "the consumed release must not have reached the terminal pipeline"
+        );
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "the release must not disturb the inline focus"
+        );
+    }
+
+    #[test]
+    fn press_outside_inline_rect_clears_inline_focus_and_proceeds_as_terminal_click() {
+        let (mut app, window, _surface, child) = inline_click_harness(false);
+        app.insert_resource(FocusedWebview(Some(child)));
+        set_cursor_phys(&mut app, window, Vec2::new(400.0, 300.0));
+
+        send_left_button(&mut app, window, ButtonState::Pressed);
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "a press on terminal text outside every rect must drop inline focus"
+        );
+        let state = app.world().resource::<MouseSelectionState>();
+        assert!(
+            state.drag.is_some(),
+            "the same press must still arm the normal terminal selection drag"
+        );
+        assert!(
+            state.last_click.is_some(),
+            "the same press must still update the click count"
+        );
+        assert!(state.inline_press.is_none());
+    }
+
+    #[test]
+    fn stale_in_flight_press_is_invalidated_by_the_next_press() {
+        // A release dropped by the dispatcher's early-returns (cursor left
+        // the window) leaves the in-flight marker set; the next press must
+        // invalidate it so ITS release is not mis-routed to the stale child.
+        let (mut app, window, _surface, child) = inline_click_harness(false);
+        set_cursor_phys(&mut app, window, Vec2::new(100.0, 100.0));
+        send_left_button(&mut app, window, ButtonState::Pressed);
+        assert_eq!(
+            app.world().resource::<MouseSelectionState>().inline_press,
+            Some(child),
+        );
+
+        // No release arrives; the next press lands on terminal text.
+        set_cursor_phys(&mut app, window, Vec2::new(400.0, 300.0));
+        send_left_button(&mut app, window, ButtonState::Pressed);
+
+        let state = app.world().resource::<MouseSelectionState>();
+        assert!(
+            state.inline_press.is_none(),
+            "a fresh press must drop the stale in-flight marker"
+        );
+        assert!(
+            state.drag.is_some(),
+            "the fresh press must arm a normal terminal drag"
+        );
+
+        send_left_button(&mut app, window, ButtonState::Released);
+        assert!(
+            app.world().resource::<MouseSelectionState>().drag.is_none(),
+            "the matching release must reach the terminal pipeline and clear the drag"
+        );
+    }
+
+    #[test]
+    fn press_inside_non_interactive_rect_is_a_plain_terminal_click() {
+        let (mut app, window, _surface, _child) = inline_click_harness(true);
+        set_cursor_phys(&mut app, window, Vec2::new(100.0, 100.0));
+
+        send_left_button(&mut app, window, ButtonState::Pressed);
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "a NonInteractive rect must never take webview focus"
+        );
+        let state = app.world().resource::<MouseSelectionState>();
+        assert!(
+            state.drag.is_some(),
+            "a press over a NonInteractive rect must pass through as a terminal click"
+        );
+        assert!(state.inline_press.is_none());
     }
 }

--- a/src/input/mouse_wheel.rs
+++ b/src/input/mouse_wheel.rs
@@ -1,12 +1,23 @@
-//! Bevy system that translates mouse-wheel input into either host
-//! scrollback adjustments or PTY-bound mouse / arrow-key bytes via the
-//! pure router in `bevy_terminal::wheel::WheelAction::route`.
+//! Bevy system that translates mouse-wheel input into either an inline
+//! webview page scroll, host scrollback adjustments, or PTY-bound mouse /
+//! arrow-key bytes via the pure router in
+//! `bevy_terminal::wheel::WheelAction::route`.
+//!
+//! Inline-webview fork (spec §7): when a `FocusedWebview` holds an inline
+//! child of the active surface AND the pointer currently sits over THAT
+//! child's rect, each `MouseWheel` event is forwarded RAW to CEF
+//! (`MouseScrollUnit::Line → delta × 120`, `Pixel` as-is, NO `-ev.y` flip)
+//! and skipped before the terminal accumulator — routing the gesture through
+//! the terminal's notch quantization would break the scroll magnitude and
+//! lose smooth scrolling. Wheel follows FOCUS: an unfocused (or tab-webview)
+//! inline rect under the pointer still scrolls the terminal.
 //!
 //! Per-frame flow:
 //!
-//! 1. Read `MessageReader<MouseWheel>`. For `Line` units, accumulate
-//!    `y` into `residual_y`. For `Pixel` units, divide by the cell
-//!    height and accumulate.
+//! 1. Read `MessageReader<MouseWheel>`. Inline-routed events are forwarded
+//!    and dropped here. For terminal `Line` units, accumulate `y` into
+//!    `residual_y`. For `Pixel` units, divide by the cell height and
+//!    accumulate.
 //! 2. Reset the residual when the sign flips or the focused entity
 //!    changes — both signals indicate the previous accumulation is
 //!    stale.
@@ -22,19 +33,28 @@
 //! 7. Call `WheelAction::route` once; dispatch the returned
 //!    `WheelAction` to the focused entity's `TerminalHandle`.
 
+use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonInput;
 use bevy::input::keyboard::KeyCode;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::PrimaryWindow;
+use bevy_cef::prelude::FocusedWebview;
+use bevy_cef_core::prelude::Browsers;
 use bevy_terminal::{
     CellCoord, Coalescer, PtyHandle, TerminalHandle, WheelAction, WheelConfig, WheelModifiers,
 };
 use bevy_terminal_renderer::TerminalCellMetricsResource;
+use bevy_terminal_renderer::prelude::TerminalOverlays;
 use ozmux_configs::mouse::FineModifier;
 
 use crate::configs::OzmuxConfigsResource;
+use crate::inline_webview::{InlineWebview, focused_inline_of};
 use crate::input::InputPhase;
+use crate::input::mouse_buttons::phys_to_terminal_local;
+use crate::osc_webview::NonInteractive;
+use crate::ui::Slotted;
 use crate::ui::copy_mode::CopyModeState;
 
 /// Per-frame accumulator that carries fractional Pixel deltas across
@@ -44,6 +64,26 @@ use crate::ui::copy_mode::CopyModeState;
 pub(crate) struct WheelAccumulator {
     residual_y: f32,
     last_entity: Option<Entity>,
+}
+
+/// The system params the inline-webview fork of `dispatch_mouse_wheel` needs,
+/// bundled so the system stays within Bevy's system-parameter limit.
+/// `focused_webview` and `browsers` are optional so CEF-less tests construct
+/// the system.
+#[derive(SystemParam)]
+pub(crate) struct InlineWheelParams<'w, 's> {
+    focused_webview: Option<Res<'w, FocusedWebview>>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    hosts: Query<
+        'w,
+        's,
+        (Entity, &'static ComputedNode, &'static UiGlobalTransform),
+        (With<ozmux_multiplexer::SurfaceMarker>, With<Slotted>),
+    >,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
 }
 
 /// Bevy Plugin that registers `WheelAccumulator` and the
@@ -61,6 +101,7 @@ fn dispatch_mouse_wheel(
     mut wheel_msgs: MessageReader<MouseWheel>,
     mut accumulator: ResMut<WheelAccumulator>,
     mut handles: Query<(&mut TerminalHandle, &mut PtyHandle, &mut Coalescer)>,
+    inline_wheel: InlineWheelParams,
     keys: Res<ButtonInput<KeyCode>>,
     configs: Res<OzmuxConfigsResource>,
     mux: ozmux_multiplexer::MultiplexerCommands,
@@ -86,11 +127,30 @@ fn dispatch_mouse_wheel(
         .unwrap_or(1.0);
     let cell_w_logical = (metrics.metrics.advance_phys.floor() / dpr).max(1.0);
     let cell_h_logical = (metrics.metrics.line_height_phys.floor() / dpr).max(1.0);
+    let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
 
-    let Some(delta_y) = aggregate_wheel_delta(&mut wheel_msgs, cell_h_logical) else {
+    // The active surface is the focused terminal; an inline child of it that
+    // holds keyboard focus AND sits under the pointer claims the wheel.
+    let active_surface = super::resolve_focused_terminal(&mux, &attached_workspace);
+    let inline_target = resolve_inline_wheel_target(
+        &inline_wheel,
+        active_surface,
+        cursor_phys(&windows, dpr),
+        cell_w_phys,
+        cell_h_phys,
+        dpr,
+    );
+
+    let Some(delta_y) = aggregate_wheel_delta(
+        &mut wheel_msgs,
+        inline_target,
+        inline_wheel.browsers.as_deref(),
+        cell_h_logical,
+    ) else {
         return;
     };
-    let Some(entity) = super::resolve_focused_terminal(&mux, &attached_workspace) else {
+    let Some(entity) = active_surface else {
         return;
     };
     if copy_modes.get(entity).is_ok() {
@@ -117,28 +177,120 @@ fn dispatch_mouse_wheel(
     apply_wheel_action(action, &mut handle, &mut pty, &mut coalescer, entity);
 }
 
-/// Aggregates a frame's `MouseWheel` events into a single signed
-/// cell-delta. Returns `None` when no events arrived.
+/// A focused inline webview child claiming the wheel: the child entity to
+/// forward `send_mouse_wheel` to, and the pointer position in that child's
+/// webview-local DIP (the coordinate CEF wheel events expect).
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct InlineWheelTarget {
+    child: Entity,
+    position_dip: Vec2,
+}
+
+/// Aggregates a frame's `MouseWheel` events into a single signed terminal
+/// cell-delta, forking inline-routed events out FIRST (spec §7). Returns
+/// `None` when no terminal-bound events arrived (every event went inline, or
+/// the frame was empty) — the caller then skips the whole terminal path.
 ///
-/// winit reports positive `y` when natural scrolling moves the
-/// viewport content downward (revealing older lines above); our
-/// router uses the opposite convention (`notches < 0` = up / older),
-/// so the sign is flipped here.
+/// When `inline_target` is `Some`, every event is forwarded RAW to that
+/// child's CEF browser via `send_mouse_wheel` (`Line → ×120`, `Pixel` as-is,
+/// no `-ev.y` flip) and dropped before terminal accumulation, so the gesture
+/// never reaches the notch quantizer.
+///
+/// For terminal-bound events: winit reports positive `y` when natural
+/// scrolling moves the viewport content downward (revealing older lines
+/// above); our router uses the opposite convention (`notches < 0` = up /
+/// older), so the sign is flipped here.
 fn aggregate_wheel_delta(
     events: &mut MessageReader<MouseWheel>,
+    inline_target: Option<InlineWheelTarget>,
+    browsers: Option<&Browsers>,
     cell_h_logical: f32,
 ) -> Option<f32> {
     let mut delta_y = 0.0f32;
-    let mut had_input = false;
+    let mut had_terminal_input = false;
     for ev in events.read() {
-        had_input = true;
+        if let Some(target) = inline_target {
+            if let Some(browsers) = browsers {
+                browsers.send_mouse_wheel(
+                    &target.child,
+                    target.position_dip,
+                    inline_wheel_delta(ev.unit, ev.x, ev.y),
+                );
+            }
+            continue;
+        }
+        had_terminal_input = true;
         let cells = match ev.unit {
             MouseScrollUnit::Line => -ev.y,
             MouseScrollUnit::Pixel => -ev.y / cell_h_logical,
         };
         delta_y += cells;
     }
-    had_input.then_some(delta_y)
+    had_terminal_input.then_some(delta_y)
+}
+
+/// Converts one `MouseWheel` event into the RAW CEF wheel delta (spec §7,
+/// matching bevy_cef's UI input path): `MouseScrollUnit::Line → (x, y) × 120`
+/// (one line = 120 px, the Win32 `WHEEL_DELTA` convention CEF expects),
+/// `MouseScrollUnit::Pixel → (x, y)` unchanged. The sign is NOT flipped — the
+/// terminal path's `-ev.y` inversion does not apply to the webview path.
+fn inline_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
+    match unit {
+        MouseScrollUnit::Line => Vec2::new(x, y) * 120.0,
+        MouseScrollUnit::Pixel => Vec2::new(x, y),
+    }
+}
+
+/// The window cursor position in physical px, or `None` when no cursor
+/// position is available (cursor outside the window, no primary window).
+fn cursor_phys(windows: &Query<&Window, With<PrimaryWindow>>, scale_factor: f32) -> Option<Vec2> {
+    windows
+        .iter()
+        .next()
+        .and_then(Window::cursor_position)
+        .map(|pos| pos * scale_factor)
+}
+
+/// Resolves the inline webview that should receive this frame's wheel events,
+/// or `None` (the terminal scrollback path runs instead). Returns `Some` only
+/// when a `FocusedWebview` holds an inline child of `active_surface`
+/// (`focused_inline_of`) AND the pointer currently sits over THAT child's
+/// active overlay rect — wheel follows FOCUS, not mere hover (spec §7).
+fn resolve_inline_wheel_target(
+    params: &InlineWheelParams,
+    active_surface: Option<Entity>,
+    cursor_phys: Option<Vec2>,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Option<InlineWheelTarget> {
+    let focused_child = focused_inline_of(
+        params.focused_webview.as_deref(),
+        &params.inline_parents,
+        active_surface,
+    )?;
+    let terminal = params.inline_parents.get(focused_child).ok()?.parent();
+    let cursor_phys = cursor_phys?;
+    let (_, node, transform) = params.hosts.get(terminal).ok()?;
+    if !node.contains_point(*transform, cursor_phys) {
+        return None;
+    }
+    let local_phys = phys_to_terminal_local(node, transform, cursor_phys)?;
+    let overlays = params.overlay_rects.get(terminal).ok()?;
+    let hit = crate::inline_webview::inline_hit_at(
+        &params.children,
+        &params.inline,
+        overlays,
+        terminal,
+        local_phys,
+        cell_w_phys,
+        cell_h_phys,
+        scale_factor,
+    )?;
+    (hit.child == focused_child).then_some(InlineWheelTarget {
+        child: hit.child,
+        position_dip: hit.local_dip,
+    })
 }
 
 /// Updates the per-frame accumulator and returns the integer notch
@@ -250,11 +402,260 @@ fn apply_wheel_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inline_webview::InlineWebview;
+    use crate::ui::Slotted;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::math::DVec2;
+    use bevy::window::WindowResolution;
+    use bevy_terminal_renderer::prelude::TerminalOverlays;
+    use ozmux_multiplexer::SurfaceMarker;
 
     #[test]
     fn wheel_accumulator_default_is_zero() {
         let acc = WheelAccumulator::default();
         assert_eq!(acc.residual_y, 0.0);
         assert!(acc.last_entity.is_none());
+    }
+
+    #[test]
+    fn inline_wheel_delta_scales_line_units_by_120_with_raw_sign() {
+        assert_eq!(
+            inline_wheel_delta(MouseScrollUnit::Line, 0.0, 1.0),
+            Vec2::new(0.0, 120.0),
+            "one line down must produce +120 on y (raw sign, no flip)"
+        );
+        assert_eq!(
+            inline_wheel_delta(MouseScrollUnit::Line, -2.0, 0.0),
+            Vec2::new(-240.0, 0.0),
+            "horizontal lines scale by 120 too, sign preserved"
+        );
+    }
+
+    #[test]
+    fn inline_wheel_delta_passes_pixel_units_through_unchanged() {
+        assert_eq!(
+            inline_wheel_delta(MouseScrollUnit::Pixel, 3.0, 7.0),
+            Vec2::new(3.0, 7.0),
+            "pixel units pass through raw, no 120 scale, no flip"
+        );
+        assert_eq!(
+            inline_wheel_delta(MouseScrollUnit::Pixel, 0.0, -7.0),
+            Vec2::new(0.0, -7.0),
+        );
+    }
+
+    fn write_wheel(app: &mut App, unit: MouseScrollUnit, x: f32, y: f32) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseWheel>>()
+            .write(MouseWheel {
+                unit,
+                x,
+                y,
+                window: Entity::PLACEHOLDER,
+            });
+    }
+
+    fn drain_terminal_delta(app: &mut App, target: Option<InlineWheelTarget>) -> Option<f32> {
+        app.world_mut()
+            .run_system_once(
+                move |mut reader: MessageReader<MouseWheel>,
+                      browsers: Option<NonSend<Browsers>>| {
+                    aggregate_wheel_delta(&mut reader, target, browsers.as_deref(), 16.0)
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn aggregate_skips_terminal_path_when_inline_target_present() {
+        let mut app = App::new();
+        app.add_message::<MouseWheel>();
+        write_wheel(&mut app, MouseScrollUnit::Line, 0.0, 1.0);
+        write_wheel(&mut app, MouseScrollUnit::Line, 0.0, 1.0);
+
+        let target = Some(InlineWheelTarget {
+            child: Entity::PLACEHOLDER,
+            position_dip: Vec2::new(10.0, 20.0),
+        });
+        assert_eq!(
+            drain_terminal_delta(&mut app, target),
+            None,
+            "with an inline target every event is forked to CEF; the terminal accumulator must see nothing"
+        );
+    }
+
+    #[test]
+    fn aggregate_feeds_terminal_when_no_inline_target() {
+        let mut app = App::new();
+        app.add_message::<MouseWheel>();
+        write_wheel(&mut app, MouseScrollUnit::Line, 0.0, 1.0);
+
+        assert_eq!(
+            drain_terminal_delta(&mut app, None),
+            Some(-1.0),
+            "without an inline target the terminal path runs with the -ev.y sign flip"
+        );
+    }
+
+    fn make_wheel_app() -> (App, Entity, Entity) {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(ozmux_multiplexer::MultiplexerPlugin);
+        app.init_resource::<FocusedWebview>();
+        app.init_resource::<Assets<Image>>();
+
+        let workspace = app
+            .world_mut()
+            .run_system_once(|mut mux: ozmux_multiplexer::MultiplexerCommands| {
+                mux.create_workspace(Some("t".into()))
+            })
+            .unwrap();
+        app.world_mut().flush();
+        app.world_mut()
+            .entity_mut(workspace.workspace)
+            .insert(ozmux_multiplexer::AttachedWorkspace);
+        let surface = workspace.surface;
+
+        // The Surface is its own host: give it the layout components
+        // `resolve_inline_wheel_target` hit-tests against. Node at window
+        // center (400, 300), size 800x600 → top-left at (0, 0).
+        app.world_mut().entity_mut(surface).insert((
+            SurfaceMarker,
+            Slotted,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalOverlays::default(),
+        ));
+
+        // Rect rows 2..12, cols 3..43 → phys y 32..192, x 24..344 at 8x16 px.
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(surface),
+                InlineWebview {
+                    view_id: "inline".into(),
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.world_mut()
+            .get_mut::<TerminalOverlays>(surface)
+            .unwrap()
+            .rects[0] = IVec4::new(2, 3, 10, 40);
+
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        (app, surface, child)
+    }
+
+    fn set_cursor(app: &mut App, phys: Vec2) {
+        let win = app
+            .world_mut()
+            .query_filtered::<Entity, With<PrimaryWindow>>()
+            .single(app.world())
+            .unwrap();
+        app.world_mut()
+            .get_mut::<Window>(win)
+            .unwrap()
+            .set_physical_cursor_position(Some(DVec2::new(phys.x as f64, phys.y as f64)));
+    }
+
+    fn run_resolve_target(app: &mut App) -> Option<InlineWheelTarget> {
+        app.world_mut()
+            .run_system_once(
+                |params: InlineWheelParams,
+                 mux: ozmux_multiplexer::MultiplexerCommands,
+                 attached: Query<
+                    Entity,
+                    (
+                        With<ozmux_multiplexer::WorkspaceMarker>,
+                        With<ozmux_multiplexer::AttachedWorkspace>,
+                    ),
+                >,
+                 windows: Query<&Window, With<PrimaryWindow>>| {
+                    let active = super::super::resolve_focused_terminal(&mux, &attached);
+                    resolve_inline_wheel_target(
+                        &params,
+                        active,
+                        cursor_phys(&windows, 1.0),
+                        8.0,
+                        16.0,
+                        1.0,
+                    )
+                },
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn target_resolves_when_focused_inline_under_pointer() {
+        let (mut app, _surface, child) = make_wheel_app();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        set_cursor(&mut app, Vec2::new(100.0, 100.0));
+
+        let target = run_resolve_target(&mut app).expect("focused inline under pointer must hit");
+        assert_eq!(target.child, child);
+        // The host node spans the full window with no transform, so the
+        // affine inverse maps (100, 100) to the same local point; the DIP is
+        // the pointer minus the rect origin (phys 24, 32) at scale 1.
+        assert!(
+            target
+                .position_dip
+                .abs_diff_eq(Vec2::new(100.0 - 24.0, 100.0 - 32.0), 1e-3),
+            "rect-local DIP mismatch: {:?}",
+            target.position_dip,
+        );
+    }
+
+    #[test]
+    fn target_none_when_pointer_off_the_rect() {
+        let (mut app, _surface, child) = make_wheel_app();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        // (400, 400) is inside the host node but outside the inline rect.
+        set_cursor(&mut app, Vec2::new(400.0, 400.0));
+
+        assert_eq!(
+            run_resolve_target(&mut app),
+            None,
+            "a focused inline child not under the pointer must yield to terminal scrollback"
+        );
+    }
+
+    #[test]
+    fn target_none_when_inline_not_focused() {
+        let (mut app, _surface, _child) = make_wheel_app();
+        // FocusedWebview stays None: pointer over the rect, but no focus.
+        set_cursor(&mut app, Vec2::new(100.0, 100.0));
+
+        assert_eq!(
+            run_resolve_target(&mut app),
+            None,
+            "wheel follows FOCUS — an unfocused inline rect under the pointer must scroll the terminal"
+        );
+    }
+
+    #[test]
+    fn target_none_when_focus_is_a_non_child_webview() {
+        let (mut app, _surface, _child) = make_wheel_app();
+        // Focus a webview that is NOT an inline child of the active surface
+        // (e.g. a tab webview) — it carries no InlineWebview/ChildOf chain.
+        let tab = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(tab);
+        set_cursor(&mut app, Vec2::new(100.0, 100.0));
+
+        assert_eq!(
+            run_resolve_target(&mut app),
+            None,
+            "a focused non-inline (tab) webview must not claim the inline wheel"
+        );
     }
 }

--- a/src/input/mouse_wheel.rs
+++ b/src/input/mouse_wheel.rs
@@ -535,6 +535,7 @@ mod tests {
                 ChildOf(surface),
                 InlineWebview {
                     view_id: "inline".into(),
+                    instance_id: None,
                     slot: 0,
                 },
             ))

--- a/src/input/mouse_wheel.rs
+++ b/src/input/mouse_wheel.rs
@@ -71,7 +71,7 @@ pub(crate) struct WheelAccumulator {
 /// `focused_webview` and `browsers` are optional so CEF-less tests construct
 /// the system.
 #[derive(SystemParam)]
-pub(crate) struct InlineWheelParams<'w, 's> {
+struct InlineWheelParams<'w, 's> {
     focused_webview: Option<Res<'w, FocusedWebview>>,
     inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
     hosts: Query<
@@ -130,8 +130,6 @@ fn dispatch_mouse_wheel(
     let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
 
-    // The active surface is the focused terminal; an inline child of it that
-    // holds keyboard focus AND sits under the pointer claims the wheel.
     let active_surface = super::resolve_focused_terminal(&mux, &attached_workspace);
     let inline_target = resolve_inline_wheel_target(
         &inline_wheel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use crate::action::OzmuxActionPlugin;
 use crate::clipboard::ClipboardActionPlugin;
 use crate::extension_manager::ExtensionManagerPlugin;
 use crate::extension_render::{OzmuxExtensionRenderPlugin, cef_plugin};
+use crate::inline_webview::OzmuxInlineWebviewPlugin;
 use crate::input::hyperlink::HyperlinkInputPlugin;
 use crate::input::mouse_buttons::MouseButtonsInputPlugin;
 use crate::input::mouse_wheel::MouseWheelInputPlugin;
@@ -77,6 +78,7 @@ fn main() {
             ImePlugin,
             ImeOverlayPlugin,
             OzmuxOscWebviewPlugin,
+            OzmuxInlineWebviewPlugin,
             ExtensionManagerPlugin::new(registry),
             OzmuxActionPlugin,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod configs;
 mod extension_manager;
 mod extension_render;
 mod font;
+mod inline_webview;
 mod input;
 mod multiplexer;
 mod osc_webview;

--- a/src/osc_webview.rs
+++ b/src/osc_webview.rs
@@ -105,6 +105,12 @@ fn on_osc_webview_request(
             }
             let _ = mux.set_active_surface(pane, surface);
         }
+        OscWebviewVerb::MountInline { view_id, .. } => {
+            tracing::debug!(%view_id, "osc-webview: mount-inline arrives in phase 3; dropping");
+        }
+        OscWebviewVerb::UnmountInline { .. } => {
+            tracing::debug!("osc-webview: unmount-inline arrives in phase 3; dropping");
+        }
         OscWebviewVerb::Unmount { view_id } => {
             let target = mounted.iter().find(|(_, m, so)| {
                 so.0 == pane && view_id.as_ref().is_none_or(|v| m.view_id == *v)
@@ -196,6 +202,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -242,6 +249,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -251,6 +259,7 @@ mod tests {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal_surface,
             verb: OscWebviewVerb::Unmount { view_id: None },
+            anchor: None,
         });
         app.world_mut().flush();
         // NOTE: despawn is deferred; a flush + update applies it.
@@ -300,6 +309,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
         let webview = active_surface(&app, pane).expect("webview active");
@@ -312,6 +322,7 @@ mod tests {
         app.world_mut().trigger(OscWebviewRequest {
             entity: survivor,
             verb: OscWebviewVerb::Unmount { view_id: None },
+            anchor: None,
         });
         app.world_mut().flush();
         app.update();
@@ -351,6 +362,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "hud".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -384,6 +396,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "ghost".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -419,6 +432,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -431,6 +445,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 
@@ -465,6 +480,7 @@ mod tests {
             verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
             },
+            anchor: None,
         });
         app.world_mut().flush();
 

--- a/src/osc_webview.rs
+++ b/src/osc_webview.rs
@@ -113,7 +113,7 @@ pub(crate) fn on_osc_webview_request(
             view_id,
             rows,
             cols,
-            instance_id: _,
+            instance_id,
         } => {
             let Some(workspace) = mux.workspace_of_pane(pane) else {
                 tracing::debug!(%view_id, "osc-webview: mount-inline from a pane with no workspace, dropping");
@@ -127,6 +127,7 @@ pub(crate) fn on_osc_webview_request(
                     workspace,
                     pane,
                     view_id,
+                    instance_id: instance_id.as_deref(),
                     rows: *rows,
                     cols: *cols,
                     anchor: req.anchor,
@@ -135,9 +136,14 @@ pub(crate) fn on_osc_webview_request(
         }
         OscWebviewVerb::UnmountInline {
             view_id,
-            instance_id: _,
+            instance_id,
         } => {
-            unmount_inline(&mut inline, terminal_surface, view_id.as_deref());
+            unmount_inline(
+                &mut inline,
+                terminal_surface,
+                view_id.as_deref(),
+                instance_id.as_deref(),
+            );
         }
         OscWebviewVerb::Unmount { view_id } => {
             let target = mounted.iter().find(|(_, m, so)| {

--- a/src/osc_webview.rs
+++ b/src/osc_webview.rs
@@ -113,6 +113,7 @@ pub(crate) fn on_osc_webview_request(
             view_id,
             rows,
             cols,
+            instance_id: _,
         } => {
             let Some(workspace) = mux.workspace_of_pane(pane) else {
                 tracing::debug!(%view_id, "osc-webview: mount-inline from a pane with no workspace, dropping");
@@ -132,7 +133,10 @@ pub(crate) fn on_osc_webview_request(
                 },
             );
         }
-        OscWebviewVerb::UnmountInline { view_id } => {
+        OscWebviewVerb::UnmountInline {
+            view_id,
+            instance_id: _,
+        } => {
             unmount_inline(&mut inline, terminal_surface, view_id.as_deref());
         }
         OscWebviewVerb::Unmount { view_id } => {

--- a/src/osc_webview.rs
+++ b/src/osc_webview.rs
@@ -1,6 +1,9 @@
 //! Observes `OscWebviewRequest` and mounts/unmounts a registered webview as a
 //! tab in the requesting terminal's pane, reusing the extension-surface path.
 
+use crate::inline_webview::{
+    InlineMountContext, InlineWebviewParams, mount_inline, unmount_inline,
+};
 use bevy::prelude::*;
 use bevy_terminal::{OscWebviewRequest, OscWebviewVerb};
 use ozmux_extension_host::ViewRegistry;
@@ -55,9 +58,10 @@ fn init_gate_from_config(
     gate.0.store(configs.osc_webview.enabled, Ordering::Relaxed);
 }
 
-fn on_osc_webview_request(
+pub(crate) fn on_osc_webview_request(
     ev: On<OscWebviewRequest>,
     mut mux: MultiplexerCommands,
+    mut inline: InlineWebviewParams,
     registry: Res<ViewRegistry>,
     surface_of: Query<&SurfaceOf>,
     mounted: Query<(Entity, &OscMounted, &SurfaceOf)>,
@@ -105,11 +109,31 @@ fn on_osc_webview_request(
             }
             let _ = mux.set_active_surface(pane, surface);
         }
-        OscWebviewVerb::MountInline { view_id, .. } => {
-            tracing::debug!(%view_id, "osc-webview: mount-inline arrives in phase 3; dropping");
+        OscWebviewVerb::MountInline {
+            view_id,
+            rows,
+            cols,
+        } => {
+            let Some(workspace) = mux.workspace_of_pane(pane) else {
+                tracing::debug!(%view_id, "osc-webview: mount-inline from a pane with no workspace, dropping");
+                return;
+            };
+            mount_inline(
+                &mut inline,
+                &registry,
+                InlineMountContext {
+                    terminal_surface,
+                    workspace,
+                    pane,
+                    view_id,
+                    rows: *rows,
+                    cols: *cols,
+                    anchor: req.anchor,
+                },
+            );
         }
-        OscWebviewVerb::UnmountInline { .. } => {
-            tracing::debug!("osc-webview: unmount-inline arrives in phase 3; dropping");
+        OscWebviewVerb::UnmountInline { view_id } => {
+            unmount_inline(&mut inline, terminal_surface, view_id.as_deref());
         }
         OscWebviewVerb::Unmount { view_id } => {
             let target = mounted.iter().find(|(_, m, so)| {
@@ -143,6 +167,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .add_plugins(MultiplexerPlugin)
             .init_resource::<ViewRegistry>()
+            .init_resource::<Assets<Image>>()
             .add_observer(on_osc_webview_request);
         app
     }


### PR DESCRIPTION
## Problem

Closes #99

ozmux のターミナルに、拡張機能の Web ビューを **タブではなくテキストフローへインライン表示**したい。Kitty の画像プロトコルのように、ビューがテキストと一緒にスクロールし、ビューポート端でクリップされ、グリフの下に合成される形を目指す。タブ切り替え型の Web ビュー（既存の OSC mount/unmount）はビューを画面全体で置き換えてしまい、「行間に小さなライブビューを埋め込む」用途に合わない。

## Solution

ターミナル自身のフラグメントシェーダ内で Web ビューを 1 パス合成する方式（案②: in-shader compositing）を採用。プログラムは OSC 5379 プライベートシーケンス（`ESC ] 5379 ; mount-inline ; <view_id> ; <rows> ; <cols> [ ; <instance_id> ] ESC \`）を stdout に書くことでカーソル位置にビューをアンカーする。アンカーは絶対スクロールバック行に固定され、テキストと一緒にスクロール／クリップする。

レイヤーごとの変更（affected: engine = `bevy_terminal` / `bevy_terminal_renderer`、`ozmux-gui`、`@ozmux/sdk`、`extensions/memo`、docs）:

- **`bevy_terminal`（VT 層）**: OSC 5379 を別 `vte::Perform` でキャプチャし、`advance_until_terminated` の停止点で `InlineAnchor`（絶対行・列・frame_seq）をスタンプ。`history_base` フォールド規則＋スクロールバック飽和規則（`clear`/CSI 3J・飽和時は全インライン unmount-all を合成）、alt-screen での mount 拒否。フレームに `history_base` / `history_size` を載せ両 apply サイトでミラー。
- **`bevy_terminal_renderer`（レンダラ）**: `TerminalOverlays { rects, textures }` コンポーネント＋`OVERLAY_SLOTS = 4`、WGSL シェーダの 1 パス合成（背景→オーバーレイ→グリフ、premultiplied-over）。
- **`ozmux-gui`**: mount/unmount ポリシー（anchor→registry→重複→スロットのゲート）、毎フレームの placement 投影（seq-hold・3 軸カル・alt-screen 非表示）、`WebviewSize` サイズ同期、フォーカス/入力ルーティング（クリックフォーカス、解除チョード `Ctrl+Shift+Escape`、キー/ホイール/IME のインライン委譲）。
- **複数インスタンス**: 同一 `view_id` を 1 ターミナルに N 個マウント可能に。クライアント採番の `instance_id`（Kitty placement モデル、応答チャネルなし）で `(view_id, instance_id)` をアドレッシング。`unmount-inline` は 3 段スコープ（1 インスタンス / view 全体 / 全部）。**`instance_id` 省略時は従来挙動を完全維持（後方互換）**。
- **`@ozmux/sdk`（`@ozmux/sdk/inline`）**: `mountInline(viewId, { rows, cols, instanceId? })` / `unmountInline(viewId?, instanceId?)` の OSC ビルダー＋検証。
- **サンプル / ドキュメント**: `extensions/memo/mount.ts`（2 インスタンスのデモ）、`docs/inline-webview.md`（プロトコル・フォーカスモデル・著者向けガイド）。

対応プラットフォームは現状 **macOS のみ**（headless GPU の IOSurface accelerated-paint パスに依存）。

テスト: ワークスペース **784 Rust テスト + 17 SDK テスト** が green（`cargo test --workspace -- --test-threads=1`、`pnpm --filter @ozmux/sdk test`）。clippy / rustfmt / biome clean。複数インスタンス部分はタスクごとに spec レビュー＋コード品質レビュー（mutation testing）を通過。

<details><summary>Screenshots</summary>

手動 E2E（2 つの `memo.main` インスタンス a/b の同時表示・個別フォーカス・個別 unmount）は実機（`cargo run --features debug`）で確認済み。スクリーンショットは必要に応じて追記。

</details>

### Breaking Changes

- **依存関係**: `bevy_cef` / `bevy_cef_core` を `not-elm/bevy_cef` の `headless-gpu` ブランチに切り替え（ヘッドレス GPU API のため）。ビルドには `make setup-cef` 済みの CEF v145 が必要。
- **フレームスキーマ**: `FrameSnapshot` / `FrameDelta` に `history_base` / `history_size` を追加。単一バイナリ内では影響なし。ただし rmp-serde の wire 形式に依存する派生ブランチ（daemon 系）にとっては positional-breaking のため、それらのブランチをリベースする際は再同期が必要。
