### PR TITLE
feat(dyn-webview): Phase B Stage 1 — window.ozmux back-channel + per-handle origin 分離 (#106)

### DIFF
--- a/crates/extension_host/src/dyn_scheme.rs
+++ b/crates/extension_host/src/dyn_scheme.rs
@@ -127,7 +127,13 @@ impl OzmuxDynScheme {
 impl CefSchemeHandler for OzmuxDynScheme {
     fn handle(&self, request: &CefSchemeRequest) -> CefSchemeResponse {
         match resolve_request(&self.registry, &request.url) {
-            Err(_) => CefSchemeResponse::not_found(),
+            Err(_) => {
+                bevy::log::debug!(
+                    url = %request.url,
+                    "ozmux-dyn request unresolved (unknown handle or non-index inline path) -> 404"
+                );
+                CefSchemeResponse::not_found()
+            }
             Ok(ResolvedDyn::Inline(html)) => {
                 bevy::log::debug!(
                     url = %request.url,

--- a/crates/extension_host/src/dyn_scheme.rs
+++ b/crates/extension_host/src/dyn_scheme.rs
@@ -1,7 +1,7 @@
 //! `ozmux-dyn://<handle>/<path>` custom-scheme handler for Tier 1 dynamic
-//! webviews. Resolves `<handle>` to a registered asset root via a shared
-//! `DynAssetRegistry` and serves files through `serve_static_asset`, reusing
-//! the `ozmux-ext` MIME/error helpers. Behind the `cef` feature.
+//! webviews. Resolves `<handle>` to a registered asset (`Dir` root or inline
+//! HTML bytes) via a shared `DynAssetRegistry` and serves files through
+//! `serve_static_asset` or directly from memory. Behind the `cef` feature.
 
 #[cfg(feature = "cef")]
 use crate::asset::{AssetOutcome, serve_static_asset};
@@ -16,22 +16,42 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-/// A shared, interior-mutable map of dynamic `handle → on-disk asset root` for
-/// `Dir`-source Tier 1 registrations. The CEF scheme handler is constructed at
-/// `CefPlugin::build()` and reads handles registered after its construction,
+/// The content backing one dynamic handle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DynAsset {
+    /// Files served under this absolute root directory.
+    Dir(PathBuf),
+    /// A single inline HTML document served from memory.
+    Inline(Vec<u8>),
+}
+
+/// A shared, interior-mutable map of dynamic `handle → DynAsset` for
+/// Tier 1 dynamic webview registrations. The CEF scheme handler is constructed
+/// at `CefPlugin::build()` and reads handles registered after its construction,
 /// mirroring `AssetSourceRegistry`.
 #[derive(Clone, Default)]
-pub struct DynAssetRegistry(Arc<RwLock<HashMap<String, PathBuf>>>);
+pub struct DynAssetRegistry(Arc<RwLock<HashMap<String, DynAsset>>>);
 
 impl DynAssetRegistry {
-    /// Returns (cloning) the asset root for `handle`, if registered.
-    pub fn get(&self, handle: &str) -> Option<PathBuf> {
+    /// Returns (cloning) the asset for `handle`, if registered.
+    pub fn get(&self, handle: &str) -> Option<DynAsset> {
         self.0.read().unwrap().get(handle).cloned()
     }
 
-    /// Inserts/replaces the asset root for `handle`.
-    pub fn insert(&self, handle: impl Into<String>, root: PathBuf) {
-        self.0.write().unwrap().insert(handle.into(), root);
+    /// Inserts/replaces an on-disk directory root for `handle`.
+    pub fn insert_dir(&self, handle: impl Into<String>, root: PathBuf) {
+        self.0
+            .write()
+            .unwrap()
+            .insert(handle.into(), DynAsset::Dir(root));
+    }
+
+    /// Inserts/replaces inline HTML bytes for `handle`.
+    pub fn insert_inline(&self, handle: impl Into<String>, html: Vec<u8>) {
+        self.0
+            .write()
+            .unwrap()
+            .insert(handle.into(), DynAsset::Inline(html));
     }
 
     /// Removes `handle`, if present.
@@ -60,16 +80,24 @@ fn parse_dyn_url(url: &str) -> Option<(&str, &str)> {
     Some((handle, path))
 }
 
-/// Resolves an `ozmux-dyn://<handle>/<path>` URL to `(root, path)` via the
-/// registry, or `Err(404)` for an unknown/unparseable handle.
+/// The resolved outcome of an `ozmux-dyn://` URL lookup.
 #[cfg_attr(not(feature = "cef"), allow(dead_code))]
-fn resolve_request<'a>(
-    registry: &DynAssetRegistry,
-    url: &'a str,
-) -> Result<(PathBuf, &'a str), u16> {
+enum ResolvedDyn<'a> {
+    /// Serve files from this directory root; `path` is the relative file path.
+    Dir { root: PathBuf, path: &'a str },
+    /// Serve these inline HTML bytes directly from memory.
+    Inline(Vec<u8>),
+}
+
+/// Resolves an `ozmux-dyn://<handle>/<path>` URL via the registry, or `Err(404)`
+/// for an unknown or unparseable handle.
+#[cfg_attr(not(feature = "cef"), allow(dead_code))]
+fn resolve_request<'a>(registry: &DynAssetRegistry, url: &'a str) -> Result<ResolvedDyn<'a>, u16> {
     let (handle, path) = parse_dyn_url(url).ok_or(404u16)?;
-    let root = registry.get(handle).ok_or(404u16)?;
-    Ok((root, path))
+    match registry.get(handle).ok_or(404u16)? {
+        DynAsset::Dir(root) => Ok(ResolvedDyn::Dir { root, path }),
+        DynAsset::Inline(html) => Ok(ResolvedDyn::Inline(html)),
+    }
 }
 
 /// The custom scheme name registered with CEF for dynamic Tier 1 webviews.
@@ -77,7 +105,7 @@ fn resolve_request<'a>(
 pub const SCHEME_NAME: &str = "ozmux-dyn";
 
 /// Serves `ozmux-dyn://<handle>/<path>` by dispatching `<handle>` through a
-/// shared `DynAssetRegistry` to `serve_static_asset`.
+/// shared `DynAssetRegistry` to `serve_static_asset` (Dir) or memory (Inline).
 #[cfg(feature = "cef")]
 struct OzmuxDynScheme {
     registry: DynAssetRegistry,
@@ -93,29 +121,41 @@ impl OzmuxDynScheme {
 #[cfg(feature = "cef")]
 impl CefSchemeHandler for OzmuxDynScheme {
     fn handle(&self, request: &CefSchemeRequest) -> CefSchemeResponse {
-        let (root, path) = match resolve_request(&self.registry, &request.url) {
-            Ok(resolved) => resolved,
-            Err(_) => return CefSchemeResponse::not_found(),
-        };
-        match serve_static_asset(&root, path) {
-            AssetOutcome::Ok { content_type, body } => {
-                let mime = bare_mime(&content_type);
+        match resolve_request(&self.registry, &request.url) {
+            Err(_) => CefSchemeResponse::not_found(),
+            Ok(ResolvedDyn::Inline(html)) => {
                 bevy::log::debug!(
                     url = %request.url,
-                    mime = %mime,
-                    bytes = body.len(),
-                    "ozmux-dyn static asset served"
+                    bytes = html.len(),
+                    "ozmux-dyn inline html served"
                 );
                 CefSchemeResponse {
                     status: 200,
-                    mime_type: mime,
+                    mime_type: "text/html".to_string(),
                     headers: Vec::new(),
-                    body: CefSchemeBody::Bytes(body),
+                    body: CefSchemeBody::Bytes(html),
                 }
             }
-            AssetOutcome::NotFound => CefSchemeResponse::not_found(),
-            AssetOutcome::Forbidden => status_text(403, "forbidden asset path"),
-            AssetOutcome::TooLarge => status_text(413, "asset too large"),
+            Ok(ResolvedDyn::Dir { root, path }) => match serve_static_asset(&root, path) {
+                AssetOutcome::Ok { content_type, body } => {
+                    let mime = bare_mime(&content_type);
+                    bevy::log::debug!(
+                        url = %request.url,
+                        mime = %mime,
+                        bytes = body.len(),
+                        "ozmux-dyn static asset served"
+                    );
+                    CefSchemeResponse {
+                        status: 200,
+                        mime_type: mime,
+                        headers: Vec::new(),
+                        body: CefSchemeBody::Bytes(body),
+                    }
+                }
+                AssetOutcome::NotFound => CefSchemeResponse::not_found(),
+                AssetOutcome::Forbidden => status_text(403, "forbidden asset path"),
+                AssetOutcome::TooLarge => status_text(413, "asset too large"),
+            },
         }
     }
 }
@@ -183,22 +223,50 @@ mod tests {
     }
 
     #[test]
-    fn resolves_registered_handle_and_404s_unknown() {
+    fn registry_holds_dir_and_inline_variants() {
+        let reg = DynAssetRegistry::default();
+        reg.insert_dir("d1", PathBuf::from("/abs/ui"));
+        reg.insert_inline("i1", b"<h1>hi</h1>".to_vec());
+        assert!(
+            matches!(reg.get("d1"), Some(DynAsset::Dir(p)) if *p == *std::path::Path::new("/abs/ui"))
+        );
+        assert!(matches!(reg.get("i1"), Some(DynAsset::Inline(b)) if b == b"<h1>hi</h1>"));
+        assert!(reg.get("missing").is_none());
+        reg.remove("i1");
+        assert!(reg.get("i1").is_none());
+    }
+
+    #[test]
+    fn resolve_request_returns_inline_bytes_as_html() {
+        let reg = DynAssetRegistry::default();
+        reg.insert_inline("i1", b"<h1>hi</h1>".to_vec());
+        match resolve_request(&reg, "ozmux-dyn://i1/index.html").expect("registered") {
+            ResolvedDyn::Inline(html) => assert_eq!(html, b"<h1>hi</h1>"),
+            ResolvedDyn::Dir { .. } => panic!("expected inline"),
+        }
+    }
+
+    #[test]
+    fn resolves_registered_dir_and_404s_unknown() {
         let reg = DynAssetRegistry::default();
         assert_eq!(
             resolve_request(&reg, "ozmux-dyn://ghost/index.html").err(),
             Some(404)
         );
-        reg.insert("h1", PathBuf::from("/abs/ui"));
-        let (root, path) = resolve_request(&reg, "ozmux-dyn://h1/app.js").expect("registered");
-        assert_eq!(root, PathBuf::from("/abs/ui"));
-        assert_eq!(path, "app.js");
+        reg.insert_dir("h1", PathBuf::from("/abs/ui"));
+        match resolve_request(&reg, "ozmux-dyn://h1/app.js").expect("registered") {
+            ResolvedDyn::Dir { root, path } => {
+                assert_eq!(root, PathBuf::from("/abs/ui"));
+                assert_eq!(path, "app.js");
+            }
+            ResolvedDyn::Inline(_) => panic!("expected dir"),
+        }
     }
 
     #[test]
     fn remove_drops_the_handle() {
         let reg = DynAssetRegistry::default();
-        reg.insert("h1", PathBuf::from("/abs/ui"));
+        reg.insert_dir("h1", PathBuf::from("/abs/ui"));
         reg.remove("h1");
         assert_eq!(
             resolve_request(&reg, "ozmux-dyn://h1/index.html").err(),

--- a/crates/extension_host/src/dyn_scheme.rs
+++ b/crates/extension_host/src/dyn_scheme.rs
@@ -96,7 +96,12 @@ fn resolve_request<'a>(registry: &DynAssetRegistry, url: &'a str) -> Result<Reso
     let (handle, path) = parse_dyn_url(url).ok_or(404u16)?;
     match registry.get(handle).ok_or(404u16)? {
         DynAsset::Dir(root) => Ok(ResolvedDyn::Dir { root, path }),
-        DynAsset::Inline(html) => Ok(ResolvedDyn::Inline(html)),
+        // NOTE: an inline registration is a single self-contained document served
+        // at the canonical entry only. A relative subresource request gets 404
+        // rather than the document body under a mismatched MIME type — use a Dir
+        // registration for multi-file content.
+        DynAsset::Inline(html) if path == "index.html" => Ok(ResolvedDyn::Inline(html)),
+        DynAsset::Inline(_) => Err(404),
     }
 }
 
@@ -244,6 +249,22 @@ mod tests {
             ResolvedDyn::Inline(html) => assert_eq!(html, b"<h1>hi</h1>"),
             ResolvedDyn::Dir { .. } => panic!("expected inline"),
         }
+    }
+
+    #[test]
+    fn inline_404s_subresource_paths_other_than_the_index() {
+        let reg = DynAssetRegistry::default();
+        reg.insert_inline("i1", b"<h1>hi</h1>".to_vec());
+        assert!(resolve_request(&reg, "ozmux-dyn://i1/").is_ok());
+        assert!(resolve_request(&reg, "ozmux-dyn://i1/index.html").is_ok());
+        assert_eq!(
+            resolve_request(&reg, "ozmux-dyn://i1/app.js").err(),
+            Some(404)
+        );
+        assert_eq!(
+            resolve_request(&reg, "ozmux-dyn://i1/logo.png").err(),
+            Some(404)
+        );
     }
 
     #[test]

--- a/crates/extension_host/src/lib.rs
+++ b/crates/extension_host/src/lib.rs
@@ -17,9 +17,9 @@ pub mod registry;
 pub mod rpc_client;
 pub mod scheme;
 
-pub use dyn_scheme::DynAssetRegistry;
 #[cfg(feature = "cef")]
 pub use dyn_scheme::custom_dyn_scheme;
+pub use dyn_scheme::{DynAsset, DynAssetRegistry};
 pub use error::{ExtensionError, ExtensionResult};
 pub use extension_discovery::{DiscoveredExtension, discover_extensions};
 pub use extension_manifest::{ExtensionManifest, ExtensionView};

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -5,6 +5,9 @@
 //!   - replying to `ping` calls from the page (`window.ozmux.call`)
 //!   - emitting a `tick` event every second (`window.ozmux.on`)
 //!
+//! The page also has an `<input>`, so clicking it shows the focus ring and typing
+//! (routed to the focused inline webview) echoes back into the page.
+//!
 //! Usage (inside an ozmux pane, with the control plane up):
 //!   cargo run --example dyn_webview_client
 
@@ -31,11 +34,17 @@ fn main() -> std::io::Result<()> {
             "<h1>window.ozmux demo</h1>",
             "<div id='out'>calling ping\u{2026}</div>",
             "<div id='tick'>no ticks yet</div>",
+            // A focusable element so click-to-focus is visible: clicking it shows the
+            // browser focus ring, and typing (routed to the focused webview) echoes here.
+            "<input id='field' placeholder='click here, then type\u{2026}' ",
+            "style='font:16px sans-serif;padding:4px;width:92%;margin-top:8px'>",
             "<script>",
             "window.ozmux.call('ping',['hi'])",
             ".then(function(v){document.getElementById('out').textContent='ping \u{2192} '+v;})",
             ".catch(function(e){document.getElementById('out').textContent='error: '+e.message;});",
             "window.ozmux.on('tick',function(n){document.getElementById('tick').textContent='tick #'+n;});",
+            "document.getElementById('field').addEventListener('input',function(e){",
+            "document.getElementById('out').textContent='typed: '+e.target.value;});",
             "</script>",
             "</body>"
         );

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -1,7 +1,9 @@
 //! Minimal reference client for ozmux Tier 1 dynamic webviews. Run inside an
 //! ozmux pane: it reads `$OZMUX_SOCK`/`$OZMUX_TOKEN`, registers an inline HTML
 //! view over the control socket, prints the `mount-inline` OSC at the cursor,
-//! then stays alive so the registration persists.
+//! then demonstrates the back-channel by:
+//!   - replying to `ping` calls from the page (`window.ozmux.call`)
+//!   - emitting a `tick` event every second (`window.ozmux.on`)
 //!
 //! Usage (inside an ozmux pane, with the control plane up):
 //!   cargo run --example dyn_webview_client
@@ -9,6 +11,7 @@
 use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 fn main() -> std::io::Result<()> {
@@ -16,18 +19,33 @@ fn main() -> std::io::Result<()> {
         .expect("not inside an ozmux pane (or control plane down): $OZMUX_SOCK unset");
     let token = std::env::var("OZMUX_TOKEN").expect("$OZMUX_TOKEN unset");
 
-    let mut stream = UnixStream::connect(&sock)?;
-    let mut reader = BufReader::new(stream.try_clone()?);
+    let stream = UnixStream::connect(&sock)?;
+    let writer = Arc::new(Mutex::new(stream.try_clone()?));
+    let mut reader = BufReader::new(stream);
 
-    writeln!(stream, "{}", json!({ "op": "hello", "token": token }))?;
-    let html = "<body style='background:#13131a;color:#8be9fd;font:16px sans-serif;margin:0;padding:8px'>\
-                <h1>hello from a TUI app</h1><p>rendered inline by ozmux</p></body>";
-    writeln!(
-        stream,
-        "{}",
-        json!({ "op": "register", "kind": "inline", "html": html, "interactive": false })
-    )?;
-    stream.flush()?;
+    {
+        let mut w = writer.lock().unwrap();
+        writeln!(w, "{}", json!({ "op": "hello", "token": token }))?;
+        let html = concat!(
+            "<body style='background:#13131a;color:#8be9fd;font:16px sans-serif;margin:0;padding:8px'>",
+            "<h1>window.ozmux demo</h1>",
+            "<div id='out'>calling ping\u{2026}</div>",
+            "<div id='tick'>no ticks yet</div>",
+            "<script>",
+            "window.ozmux.call('ping',['hi'])",
+            ".then(function(v){document.getElementById('out').textContent='ping \u{2192} '+v;})",
+            ".catch(function(e){document.getElementById('out').textContent='error: '+e.message;});",
+            "window.ozmux.on('tick',function(n){document.getElementById('tick').textContent='tick #'+n;});",
+            "</script>",
+            "</body>"
+        );
+        writeln!(
+            w,
+            "{}",
+            json!({ "op": "register", "kind": "inline", "html": html, "interactive": true })
+        )?;
+        w.flush()?;
+    }
 
     let mut line = String::new();
     reader.read_line(&mut line)?;
@@ -36,18 +54,75 @@ fn main() -> std::io::Result<()> {
     let handle = reply
         .get("handle")
         .and_then(Value::as_str)
-        .unwrap_or_else(|| panic!("register failed: {reply}"));
+        .unwrap_or_else(|| panic!("register failed: {reply}"))
+        .to_owned();
 
-    let rows = 8;
-    let cols = 48;
+    let rows = 8u16;
+    let cols = 48u16;
     print!("dynamic webview:\n\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\");
     for _ in 0..rows {
         println!();
     }
     std::io::stdout().flush()?;
 
-    // NOTE: the registration lives only as long as this connection; exiting (or closing the socket) tears the inline webview down.
-    loop {
-        std::thread::sleep(Duration::from_secs(3600));
+    // Tick emitter: sends {op:"emit", handle, event:"tick", payload: n} each second.
+    {
+        let tick_handle = handle.clone();
+        let tick_writer = Arc::clone(&writer);
+        std::thread::spawn(move || {
+            let mut n: u64 = 0;
+            loop {
+                std::thread::sleep(Duration::from_secs(1));
+                n += 1;
+                let msg =
+                    json!({ "op": "emit", "handle": tick_handle, "event": "tick", "payload": n });
+                let mut w = tick_writer.lock().unwrap();
+                // NOTE: ignore write errors on the emitter thread; the main thread will detect EOF and exit.
+                let _ = writeln!(w, "{msg}");
+                let _ = w.flush();
+            }
+        });
     }
+
+    // Back-channel serve loop: dispatch incoming {op:"call"} messages.
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("read error: {e}");
+                break;
+            }
+        }
+        let Ok(msg) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if msg.get("op").and_then(Value::as_str) != Some("call") {
+            continue;
+        }
+        let Some(req_id) = msg.get("reqId") else {
+            continue;
+        };
+        let req_id = req_id.clone();
+        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+        let reply = if method == "ping" {
+            let arg = msg
+                .get("args")
+                .and_then(Value::as_array)
+                .and_then(|a| a.first())
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            json!({ "op": "reply", "reqId": req_id, "ok": true, "value": format!("pong:{arg}") })
+        } else {
+            json!({ "op": "reply", "reqId": req_id, "ok": false, "error": "unknown_method" })
+        };
+        let mut w = writer.lock().unwrap();
+        if writeln!(w, "{reply}").is_err() {
+            break;
+        }
+        let _ = w.flush();
+    }
+
+    Ok(())
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -49,6 +49,20 @@ pub(crate) struct DynamicView {
     pub(crate) connection_id: u64,
 }
 
+/// Stamped on a Tier 1 inline webview entity at mount: the control-plane
+/// connection that registered it (back-channel routing target) and its handle.
+#[derive(Component, Clone, Debug, PartialEq, Eq)]
+#[allow(
+    dead_code,
+    reason = "consumed by back-channel routing in stage1 tasks 7-9"
+)]
+pub(crate) struct WebviewOwner {
+    /// The owning connection (push `call` frames here).
+    pub(crate) connection_id: u64,
+    /// The registration handle (for `emit` fan-out + ownership checks).
+    pub(crate) handle: String,
+}
+
 /// Maps an opaque `handle` to its dynamic registration. The single Bevy-side
 /// registry for Tier 1 (the CEF scheme handler reads the thin `DynAssetRegistry`
 /// separately). Carries scoped removal for teardown.
@@ -96,6 +110,86 @@ impl DynamicRegistry {
             self.by_handle.remove(h);
         }
         drained
+    }
+}
+
+/// In-flight `globalReqId → (webview, pageReqId, connection_id)` correlation for
+/// the back-channel, plus the Rust-minted id counter. Mirrors `HostRpc` but
+/// routes to a control-plane connection rather than the single host.
+#[derive(Resource, Default)]
+pub(crate) struct OzmuxRpc {
+    inflight: HashMap<String, (Entity, String, u64)>,
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    next_id: u64,
+}
+
+impl OzmuxRpc {
+    /// Mints the next global reqId.
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    pub(crate) fn mint(&mut self) -> String {
+        let id = self.next_id.to_string();
+        self.next_id += 1;
+        id
+    }
+
+    /// Records an in-flight call.
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    pub(crate) fn note(
+        &mut self,
+        global_id: &str,
+        webview: Entity,
+        page_req: &str,
+        connection_id: u64,
+    ) {
+        self.inflight.insert(
+            global_id.to_string(),
+            (webview, page_req.to_string(), connection_id),
+        );
+    }
+
+    /// Removes and returns one in-flight entry.
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    pub(crate) fn take(&mut self, global_id: &str) -> Option<(Entity, String, u64)> {
+        self.inflight.remove(global_id)
+    }
+
+    /// Removes every in-flight call for `connection_id`, returning each
+    /// `(webview, pageReqId)` so the caller can reject the page Promise.
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    pub(crate) fn drain_connection(&mut self, connection_id: u64) -> Vec<(Entity, String)> {
+        let hit: Vec<String> = self
+            .inflight
+            .iter()
+            .filter(|(_, (_, _, c))| *c == connection_id)
+            .map(|(g, _)| g.clone())
+            .collect();
+        hit.into_iter()
+            .filter_map(|g| self.inflight.remove(&g).map(|(e, p, _)| (e, p)))
+            .collect()
+    }
+
+    /// Removes every in-flight call targeting `webview` (despawn prune).
+    #[allow(
+        dead_code,
+        reason = "consumed by back-channel routing in stage1 tasks 7-9"
+    )]
+    pub(crate) fn drain_webview(&mut self, webview: Entity) {
+        self.inflight.retain(|_, (e, _, _)| *e != webview);
     }
 }
 
@@ -216,6 +310,7 @@ impl Plugin for OzmuxControlPlanePlugin {
         }
         app.insert_resource(writers);
         app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(DynAssetRegistryRes(self.dyn_assets.clone()));
         app.add_systems(Update, apply_control_events);
         app.add_observer(purge_dynamic_on_surface_removed);
@@ -720,5 +815,35 @@ mod apply_tests {
                 .get("HMOUNT")
                 .is_none()
         );
+    }
+}
+
+#[cfg(test)]
+mod back_channel_state_tests {
+    use super::*;
+    use bevy::prelude::Entity;
+
+    #[test]
+    fn ozmux_rpc_notes_and_takes_inflight() {
+        let mut rpc = OzmuxRpc::default();
+        let g = rpc.mint();
+        assert_eq!(g, "0");
+        rpc.note(&g, Entity::from_bits(2), "p1", 5);
+        let taken = rpc.take(&g).expect("present");
+        assert_eq!(taken, (Entity::from_bits(2), "p1".to_string(), 5));
+        assert!(rpc.take(&g).is_none());
+    }
+
+    #[test]
+    fn ozmux_rpc_drains_a_connections_inflight() {
+        let mut rpc = OzmuxRpc::default();
+        let a = rpc.mint();
+        let b = rpc.mint();
+        rpc.note(&a, Entity::from_bits(1), "p", 5);
+        rpc.note(&b, Entity::from_bits(2), "p", 9);
+        let drained = rpc.drain_connection(5);
+        assert_eq!(drained, vec![(Entity::from_bits(1), "p".to_string())]);
+        assert!(rpc.take(&a).is_none());
+        assert!(rpc.take(&b).is_some());
     }
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -25,7 +25,8 @@ mod protocol;
 pub(crate) enum DynSource {
     /// Files served under this absolute root via `ozmux-dyn://`.
     Dir(PathBuf),
-    /// A single inline HTML document served via `WebviewSource::InlineHtml`.
+    /// A single inline HTML document, registered into `DynAssetRegistry` and
+    /// served under `ozmux-dyn://<handle>/`.
     Inline(String),
 }
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -8,7 +8,7 @@ use crate::control_plane::listener::{ControlEvent, spawn_listener};
 use crate::control_plane::protocol::{RegisterKind, ServerMsg};
 use crate::inline_webview::InlineWebview;
 use bevy::prelude::*;
-use crossbeam_channel::Receiver;
+use crossbeam_channel::{Receiver, Sender};
 use data_encoding::BASE32_NOPAD;
 use ozmux_extension_host::DynAssetRegistry;
 use ozmux_extension_host::host::RuntimeRoot;
@@ -118,6 +118,35 @@ impl TokenRegistry {
     }
 }
 
+/// A shared `connection_id → outbound-line sender` table. Each live control
+/// connection owns a writer thread draining a `Sender<String>`; ECS pushes
+/// server-initiated `{op:"call",…}` lines here to reach a specific program.
+#[derive(Resource, Clone, Default)]
+pub(crate) struct ConnectionWriters(Arc<RwLock<HashMap<u64, Sender<String>>>>);
+
+impl ConnectionWriters {
+    /// Registers a writer channel for `connection_id`.
+    pub(crate) fn insert(&self, connection_id: u64, tx: Sender<String>) {
+        self.0.write().unwrap().insert(connection_id, tx);
+    }
+
+    /// Removes the writer channel for `connection_id` when the connection closes.
+    pub(crate) fn remove(&self, connection_id: u64) {
+        self.0.write().unwrap().remove(&connection_id);
+    }
+
+    /// Queues one NDJSON line to `connection_id`; returns false if the connection
+    /// is gone or its writer has exited.
+    #[allow(dead_code)]
+    pub(crate) fn send(&self, connection_id: u64, line: String) -> bool {
+        let guard = self.0.read().unwrap();
+        guard
+            .get(&connection_id)
+            .map(|tx| tx.send(line).is_ok())
+            .unwrap_or(false)
+    }
+}
+
 /// Mints a per-surface env token (same generator as handles).
 pub(crate) fn mint_token() -> String {
     mint_id()
@@ -167,10 +196,11 @@ impl OzmuxControlPlanePlugin {
 impl Plugin for OzmuxControlPlanePlugin {
     fn build(&self, app: &mut App) {
         let tokens = TokenRegistry::default();
+        let writers = ConnectionWriters::default();
         match RuntimeRoot::resolve_in(&std::env::temp_dir(), std::process::id(), "control") {
             Ok(runtime) => {
                 let sock_path = runtime.sock_dir().join("control.sock");
-                match spawn_listener(&sock_path, tokens.clone()) {
+                match spawn_listener(&sock_path, tokens.clone(), writers.clone()) {
                     Ok(events) => {
                         app.insert_resource(ControlEvents(events));
                         app.insert_resource(ControlPlaneHandle { sock_path, tokens });
@@ -181,6 +211,7 @@ impl Plugin for OzmuxControlPlanePlugin {
             }
             Err(e) => tracing::error!(error = %e, "control-plane runtime dir failed"),
         }
+        app.insert_resource(writers);
         app.insert_resource(DynamicRegistry::default());
         app.insert_resource(DynAssetRegistryRes(self.dyn_assets.clone()));
         app.add_systems(Update, apply_control_events);

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -52,10 +52,6 @@ pub(crate) struct DynamicView {
 /// Stamped on a Tier 1 inline webview entity at mount: the control-plane
 /// connection that registered it (back-channel routing target) and its handle.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
-#[allow(
-    dead_code,
-    reason = "consumed by back-channel routing in stage1 tasks 7-9"
-)]
 pub(crate) struct WebviewOwner {
     /// The owning connection (push `call` frames here).
     pub(crate) connection_id: u64,

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -237,13 +237,19 @@ pub(crate) fn mint_token() -> String {
     mint_id()
 }
 
-/// Mints an opaque 128-bit identifier (CSPRNG), base32-encoded (unpadded). The
-/// alphabet `A-Z2-7` is a subset of the OSC `view_id` charset
+/// Mints an opaque 128-bit identifier (CSPRNG), base32-encoded (unpadded) and
+/// lowercased. The alphabet `a-z2-7` is a subset of the OSC `view_id` charset
 /// `^[A-Za-z0-9._-]{1,128}$`, so a minted handle is a valid `mount-inline;<id>`.
+///
+/// # Invariants
+/// The output MUST be lowercase. A handle is used as the host of the
+/// `ozmux-dyn://<handle>/` URL, and Chromium canonicalizes (lowercases) the host
+/// of a STANDARD-scheme URL before it reaches the scheme handler; an uppercase
+/// handle would then miss the case-sensitive `DynAssetRegistry` lookup → 404.
 fn mint_id() -> String {
     let mut bytes = [0u8; 16];
     getrandom::getrandom(&mut bytes).expect("OS CSPRNG is available");
-    BASE32_NOPAD.encode(&bytes)
+    BASE32_NOPAD.encode(&bytes).to_ascii_lowercase()
 }
 
 /// The receiver of `ControlEvent`s from the listener threads.
@@ -526,6 +532,10 @@ mod token_tests {
                 id.chars()
                     .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-'),
                 "minted id {id} must satisfy the OSC charset"
+            );
+            assert!(
+                !id.chars().any(|c| c.is_ascii_uppercase()),
+                "minted id {id} must be lowercase — it is used as an ozmux-dyn:// host that Chromium lowercases"
             );
         }
     }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -503,6 +503,42 @@ mod apply_tests {
     }
 
     #[test]
+    fn apply_register_inline_populates_dyn_asset_registry_with_html_bytes() {
+        use ozmux_extension_host::DynAsset;
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let dyn_assets = DynAssetRegistry::default();
+        app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
+        app.add_systems(Update, apply_control_events);
+
+        let (reply_tx, reply_rx) = bounded::<ServerMsg>(1);
+        ev_tx
+            .send(ControlEvent::Register {
+                connection_id: 1,
+                owner_surface: Entity::from_bits(11),
+                kind: RegisterKind::Inline {
+                    html: "<h1>x</h1>".into(),
+                    interactive: true,
+                },
+                reply: reply_tx,
+            })
+            .unwrap();
+
+        app.update();
+
+        let handle = match reply_rx.try_recv().expect("apply must reply") {
+            ServerMsg::Ok { handle, .. } => handle,
+            ServerMsg::Err { error, .. } => panic!("unexpected err: {error}"),
+        };
+        assert!(
+            matches!(dyn_assets.get(&handle), Some(DynAsset::Inline(bytes)) if bytes == b"<h1>x</h1>"),
+            "DynAssetRegistry must carry the inline HTML bytes for the minted handle"
+        );
+    }
+
+    #[test]
     fn apply_register_invalid_root_replies_err() {
         let mut app = App::new();
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -227,8 +227,13 @@ fn apply_control_events(
                     }
                 };
                 let handle = mint_id();
-                if let DynSource::Dir(root) = &view.source {
-                    dyn_assets.0.insert(handle.clone(), root.clone());
+                match &view.source {
+                    DynSource::Dir(root) => dyn_assets.0.insert_dir(handle.clone(), root.clone()),
+                    DynSource::Inline(html) => {
+                        dyn_assets
+                            .0
+                            .insert_inline(handle.clone(), html.clone().into_bytes());
+                    }
                 }
                 registry.insert(handle.clone(), view);
                 let _ = reply.send(ServerMsg::ok(handle));
@@ -541,7 +546,7 @@ mod apply_tests {
                 connection_id: 5,
             },
         );
-        dyn_assets.insert("h", "/x".into());
+        dyn_assets.insert_dir("h", "/x".into());
         app.insert_resource(reg);
         app.insert_resource(ControlEvents(ev_rx));
         app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
@@ -583,7 +588,7 @@ mod apply_tests {
                 connection_id: 1,
             },
         );
-        dyn_assets.insert("h", "/x".into());
+        dyn_assets.insert_dir("h", "/x".into());
         app.insert_resource(reg);
         app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -115,17 +115,9 @@ impl DynamicRegistry {
 #[derive(Resource, Default)]
 pub(crate) struct OzmuxRpc {
     inflight: HashMap<String, (Entity, String, u64)>,
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     next_id: u64,
 }
 
-#[allow(
-    dead_code,
-    reason = "consumed by back-channel routing in stage1 tasks 7-9"
-)]
 impl OzmuxRpc {
     /// Mints the next global reqId.
     pub(crate) fn mint(&mut self) -> String {
@@ -149,12 +141,20 @@ impl OzmuxRpc {
     }
 
     /// Removes and returns one in-flight entry.
+    #[allow(
+        dead_code,
+        reason = "consumed by apply_control_events Reply drain in stage1 task 9"
+    )]
     pub(crate) fn take(&mut self, global_id: &str) -> Option<(Entity, String, u64)> {
         self.inflight.remove(global_id)
     }
 
     /// Removes every in-flight call for `connection_id`, returning each
     /// `(webview, pageReqId)` so the caller can reject the page Promise.
+    #[allow(
+        dead_code,
+        reason = "consumed by apply_control_events Disconnect drain in stage1 task 9"
+    )]
     pub(crate) fn drain_connection(&mut self, connection_id: u64) -> Vec<(Entity, String)> {
         self.inflight
             .extract_if(|_, (_, _, c)| *c == connection_id)
@@ -165,6 +165,11 @@ impl OzmuxRpc {
     /// Removes every in-flight call targeting `webview` (despawn prune).
     pub(crate) fn drain_webview(&mut self, webview: Entity) {
         self.inflight.retain(|_, (e, _, _)| *e != webview);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn count_in_flight_for_test(&self) -> usize {
+        self.inflight.len()
     }
 }
 
@@ -206,10 +211,6 @@ impl ConnectionWriters {
 
     /// Queues one NDJSON line to `connection_id`; returns false if the connection
     /// is gone or its writer has exited.
-    #[allow(
-        dead_code,
-        reason = "consumed by on_ozmux_call_frame in Task 8; until then only the test target calls send, so #[expect] would misfire under --all-targets"
-    )]
     pub(crate) fn send(&self, connection_id: u64, line: String) -> bool {
         let guard = self.0.read().unwrap();
         guard

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -137,7 +137,10 @@ impl ConnectionWriters {
 
     /// Queues one NDJSON line to `connection_id`; returns false if the connection
     /// is gone or its writer has exited.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "consumed by on_ozmux_call_frame in Task 8; until then only the test target calls send, so #[expect] would misfire under --all-targets"
+    )]
     pub(crate) fn send(&self, connection_id: u64, line: String) -> bool {
         let guard = self.0.read().unwrap();
         guard

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -375,8 +375,10 @@ fn apply_control_events(
                 let Some((webview, page_req, conn)) = rpc.take(&req_id) else {
                     continue;
                 };
-                // NOTE: a reply from a different connection than the one that
-                // registered the call is a spoofing attempt; drop it.
+                // NOTE: conn is the connection that originated this call (stored
+                // at routing time); a reply whose sending connection differs is a
+                // different program trying to answer a call it didn't make, which
+                // would redirect the page response to an unrelated program. Drop it.
                 if conn != connection_id {
                     continue;
                 }
@@ -393,8 +395,6 @@ fn apply_control_events(
                 event,
                 payload,
             } => {
-                // NOTE: only the connection that registered the handle may emit
-                // to its webviews; guard prevents cross-connection spoofing.
                 let owns = registry
                     .get(&handle)
                     .is_some_and(|v| v.connection_id == connection_id);

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -141,9 +141,28 @@ impl OzmuxRpc {
         );
     }
 
-    /// Removes and returns one in-flight entry.
-    pub(crate) fn take(&mut self, global_id: &str) -> Option<(Entity, String, u64)> {
-        self.inflight.remove(global_id)
+    /// Removes and returns the in-flight call for `global_id`, but ONLY when it
+    /// was registered by `connection_id`. A mismatching connection leaves the
+    /// entry intact and returns `None`.
+    ///
+    /// # Invariants
+    /// The match-before-remove order is load-bearing: global reqIds are a
+    /// monotonic counter shared across all connections, so they are guessable. A
+    /// foreign program replaying another connection's reqId must NOT be able to
+    /// consume (and thereby drop) that connection's pending call — checking
+    /// ownership only AFTER removing would orphan the page Promise.
+    pub(crate) fn take_for_connection(
+        &mut self,
+        global_id: &str,
+        connection_id: u64,
+    ) -> Option<(Entity, String)> {
+        match self.inflight.get(global_id) {
+            Some((_, _, conn)) if *conn == connection_id => self
+                .inflight
+                .remove(global_id)
+                .map(|(webview, page_req, _)| (webview, page_req)),
+            _ => None,
+        }
     }
 
     /// Removes every in-flight call for `connection_id`, returning each
@@ -372,16 +391,14 @@ fn apply_control_events(
                 error,
                 connection_id,
             } => {
-                let Some((webview, page_req, conn)) = rpc.take(&req_id) else {
+                // NOTE: take_for_connection drops a reply whose sending connection
+                // is not the one that originated the call, WITHOUT consuming the
+                // pending entry — a foreign program replaying another connection's
+                // (monotonic, guessable) global reqId must not settle or drop its call.
+                let Some((webview, page_req)) = rpc.take_for_connection(&req_id, connection_id)
+                else {
                     continue;
                 };
-                // NOTE: conn is the connection that originated this call (stored
-                // at routing time); a reply whose sending connection differs is a
-                // different program trying to answer a call it didn't make, which
-                // would redirect the page response to an unrelated program. Drop it.
-                if conn != connection_id {
-                    continue;
-                }
                 let payload = if ok {
                     serde_json::json!({ "reqId": page_req, "ok": true, "value": value })
                 } else {
@@ -881,6 +898,57 @@ mod apply_tests {
     }
 
     #[test]
+    fn apply_reply_from_wrong_connection_does_not_drop_the_pending_call() {
+        use bevy_cef::prelude::HostEmitEvent;
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let mut rpc = OzmuxRpc::default();
+        let webview = app.world_mut().spawn_empty().id();
+        let g = rpc.mint();
+        rpc.note(&g, webview, "p9", 5);
+        app.insert_resource(rpc);
+        app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
+        #[derive(Resource, Default)]
+        struct Caps(Vec<(Entity, String)>);
+        app.insert_resource(Caps::default());
+        app.add_observer(|e: On<HostEmitEvent>, mut c: ResMut<Caps>| {
+            c.0.push((e.webview, e.id.clone()));
+        });
+        app.add_systems(Update, apply_control_events);
+
+        // A reply replaying the (monotonic, guessable) global reqId from a DIFFERENT
+        // connection must be dropped WITHOUT consuming the pending entry...
+        ev_tx
+            .send(ControlEvent::Reply {
+                req_id: g.clone(),
+                ok: true,
+                value: serde_json::json!(1),
+                error: None,
+                connection_id: 9,
+            })
+            .unwrap();
+        // ...so the legitimate reply from the originating connection still settles.
+        ev_tx
+            .send(ControlEvent::Reply {
+                req_id: g.clone(),
+                ok: true,
+                value: serde_json::json!(2),
+                error: None,
+                connection_id: 5,
+            })
+            .unwrap();
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Caps>().0,
+            vec![(webview, "ozmux".to_string())],
+            "only the owning connection's reply settles the page"
+        );
+    }
+
+    #[test]
     fn apply_emit_broadcasts_only_to_owning_connections_handle() {
         use bevy_cef::prelude::HostEmitEvent;
         let mut app = App::new();
@@ -951,14 +1019,16 @@ mod back_channel_state_tests {
     use bevy::prelude::Entity;
 
     #[test]
-    fn ozmux_rpc_notes_and_takes_inflight() {
+    fn ozmux_rpc_take_for_connection_matches_only_the_owning_connection() {
         let mut rpc = OzmuxRpc::default();
         let g = rpc.mint();
         assert_eq!(g, "0");
         rpc.note(&g, Entity::from_bits(2), "p1", 5);
-        let taken = rpc.take(&g).expect("present");
-        assert_eq!(taken, (Entity::from_bits(2), "p1".to_string(), 5));
-        assert!(rpc.take(&g).is_none());
+        // A mismatching connection must NOT consume the entry.
+        assert!(rpc.take_for_connection(&g, 999).is_none());
+        let taken = rpc.take_for_connection(&g, 5).expect("present");
+        assert_eq!(taken, (Entity::from_bits(2), "p1".to_string()));
+        assert!(rpc.take_for_connection(&g, 5).is_none());
     }
 
     #[test]
@@ -970,8 +1040,8 @@ mod back_channel_state_tests {
         rpc.note(&b, Entity::from_bits(2), "p", 9);
         let drained = rpc.drain_connection(5);
         assert_eq!(drained, vec![(Entity::from_bits(1), "p".to_string())]);
-        assert!(rpc.take(&a).is_none());
-        assert!(rpc.take(&b).is_some());
+        assert!(rpc.take_for_connection(&a, 5).is_none());
+        assert!(rpc.take_for_connection(&b, 9).is_some());
     }
 
     #[test]
@@ -982,7 +1052,7 @@ mod back_channel_state_tests {
         rpc.note(&a, Entity::from_bits(1), "p", 5);
         rpc.note(&b, Entity::from_bits(2), "p", 5);
         rpc.drain_webview(Entity::from_bits(1));
-        assert!(rpc.take(&a).is_none());
-        assert!(rpc.take(&b).is_some());
+        assert!(rpc.take_for_connection(&a, 5).is_none());
+        assert!(rpc.take_for_connection(&b, 5).is_some());
     }
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -126,12 +126,12 @@ pub(crate) struct OzmuxRpc {
     next_id: u64,
 }
 
+#[allow(
+    dead_code,
+    reason = "consumed by back-channel routing in stage1 tasks 7-9"
+)]
 impl OzmuxRpc {
     /// Mints the next global reqId.
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     pub(crate) fn mint(&mut self) -> String {
         let id = self.next_id.to_string();
         self.next_id += 1;
@@ -139,10 +139,6 @@ impl OzmuxRpc {
     }
 
     /// Records an in-flight call.
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     pub(crate) fn note(
         &mut self,
         global_id: &str,
@@ -157,37 +153,20 @@ impl OzmuxRpc {
     }
 
     /// Removes and returns one in-flight entry.
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     pub(crate) fn take(&mut self, global_id: &str) -> Option<(Entity, String, u64)> {
         self.inflight.remove(global_id)
     }
 
     /// Removes every in-flight call for `connection_id`, returning each
     /// `(webview, pageReqId)` so the caller can reject the page Promise.
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     pub(crate) fn drain_connection(&mut self, connection_id: u64) -> Vec<(Entity, String)> {
-        let hit: Vec<String> = self
-            .inflight
-            .iter()
-            .filter(|(_, (_, _, c))| *c == connection_id)
-            .map(|(g, _)| g.clone())
-            .collect();
-        hit.into_iter()
-            .filter_map(|g| self.inflight.remove(&g).map(|(e, p, _)| (e, p)))
+        self.inflight
+            .extract_if(|_, (_, _, c)| *c == connection_id)
+            .map(|(_, (e, p, _))| (e, p))
             .collect()
     }
 
     /// Removes every in-flight call targeting `webview` (despawn prune).
-    #[allow(
-        dead_code,
-        reason = "consumed by back-channel routing in stage1 tasks 7-9"
-    )]
     pub(crate) fn drain_webview(&mut self, webview: Entity) {
         self.inflight.retain(|_, (e, _, _)| *e != webview);
     }
@@ -843,6 +822,18 @@ mod back_channel_state_tests {
         rpc.note(&b, Entity::from_bits(2), "p", 9);
         let drained = rpc.drain_connection(5);
         assert_eq!(drained, vec![(Entity::from_bits(1), "p".to_string())]);
+        assert!(rpc.take(&a).is_none());
+        assert!(rpc.take(&b).is_some());
+    }
+
+    #[test]
+    fn ozmux_rpc_drain_webview_drops_only_that_webviews_calls() {
+        let mut rpc = OzmuxRpc::default();
+        let a = rpc.mint();
+        let b = rpc.mint();
+        rpc.note(&a, Entity::from_bits(1), "p", 5);
+        rpc.note(&b, Entity::from_bits(2), "p", 5);
+        rpc.drain_webview(Entity::from_bits(1));
         assert!(rpc.take(&a).is_none());
         assert!(rpc.take(&b).is_some());
     }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -8,6 +8,7 @@ use crate::control_plane::listener::{ControlEvent, spawn_listener};
 use crate::control_plane::protocol::{RegisterKind, ServerMsg};
 use crate::inline_webview::InlineWebview;
 use bevy::prelude::*;
+use bevy_cef::prelude::HostEmitEvent;
 use crossbeam_channel::{Receiver, Sender};
 use data_encoding::BASE32_NOPAD;
 use ozmux_extension_host::DynAssetRegistry;
@@ -141,20 +142,12 @@ impl OzmuxRpc {
     }
 
     /// Removes and returns one in-flight entry.
-    #[allow(
-        dead_code,
-        reason = "consumed by apply_control_events Reply drain in stage1 task 9"
-    )]
     pub(crate) fn take(&mut self, global_id: &str) -> Option<(Entity, String, u64)> {
         self.inflight.remove(global_id)
     }
 
     /// Removes every in-flight call for `connection_id`, returning each
     /// `(webview, pageReqId)` so the caller can reject the page Promise.
-    #[allow(
-        dead_code,
-        reason = "consumed by apply_control_events Disconnect drain in stage1 task 9"
-    )]
     pub(crate) fn drain_connection(&mut self, connection_id: u64) -> Vec<(Entity, String)> {
         self.inflight
             .extract_if(|_, (_, _, c)| *c == connection_id)
@@ -310,6 +303,7 @@ struct ControlRuntime(
 fn apply_control_events(
     mut commands: Commands,
     mut registry: ResMut<DynamicRegistry>,
+    mut rpc: ResMut<OzmuxRpc>,
     events: Option<Res<ControlEvents>>,
     dyn_assets: Res<DynAssetRegistryRes>,
     inline: Query<(Entity, &InlineWebview)>,
@@ -366,9 +360,54 @@ fn apply_control_events(
                     dyn_assets.0.remove(h);
                 }
                 despawn_mounted(&mut commands, &inline, &removed);
+                for (webview, page_req) in rpc.drain_connection(connection_id) {
+                    let payload = serde_json::json!({ "reqId": page_req, "ok": false, "error": "owner_disconnected" });
+                    commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
+                }
             }
-            // TODO(stage1 task 9): handle Reply/Emit (back-channel drain) here.
-            ControlEvent::Reply { .. } | ControlEvent::Emit { .. } => {}
+            ControlEvent::Reply {
+                req_id,
+                ok,
+                value,
+                error,
+                connection_id,
+            } => {
+                let Some((webview, page_req, conn)) = rpc.take(&req_id) else {
+                    continue;
+                };
+                // NOTE: a reply from a different connection than the one that
+                // registered the call is a spoofing attempt; drop it.
+                if conn != connection_id {
+                    continue;
+                }
+                let payload = if ok {
+                    serde_json::json!({ "reqId": page_req, "ok": true, "value": value })
+                } else {
+                    serde_json::json!({ "reqId": page_req, "ok": false, "error": error.unwrap_or_default() })
+                };
+                commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
+            }
+            ControlEvent::Emit {
+                connection_id,
+                handle,
+                event,
+                payload,
+            } => {
+                // NOTE: only the connection that registered the handle may emit
+                // to its webviews; guard prevents cross-connection spoofing.
+                let owns = registry
+                    .get(&handle)
+                    .is_some_and(|v| v.connection_id == connection_id);
+                if !owns {
+                    continue;
+                }
+                let frame = serde_json::json!({ "event": event, "payload": payload });
+                for (entity, view) in &inline {
+                    if view.view_id == handle {
+                        commands.trigger(HostEmitEvent::new(entity, "ozmux.event", &frame));
+                    }
+                }
+            }
         }
     }
 }
@@ -572,6 +611,7 @@ mod apply_tests {
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
         let dyn_assets = DynAssetRegistry::default();
         app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(ControlEvents(ev_rx));
         app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
         app.add_systems(Update, apply_control_events);
@@ -616,6 +656,7 @@ mod apply_tests {
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
         let dyn_assets = DynAssetRegistry::default();
         app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(ControlEvents(ev_rx));
         app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
         app.add_systems(Update, apply_control_events);
@@ -650,6 +691,7 @@ mod apply_tests {
         let mut app = App::new();
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
         app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(ControlEvents(ev_rx));
         app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
         app.add_systems(Update, apply_control_events);
@@ -692,6 +734,7 @@ mod apply_tests {
         );
         dyn_assets.insert_dir("h", "/x".into());
         app.insert_resource(reg);
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(ControlEvents(ev_rx));
         app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
         app.add_systems(Update, apply_control_events);
@@ -706,12 +749,12 @@ mod apply_tests {
 
     #[test]
     fn apply_is_a_noop_when_control_events_missing() {
-        // Simulates the control plane failing to bind: ControlEvents was never inserted.
         let mut app = App::new();
         app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
         app.add_systems(Update, apply_control_events);
-        app.update(); // must not panic
+        app.update();
         assert!(app.world().get_resource::<ControlEvents>().is_none());
     }
 
@@ -774,6 +817,7 @@ mod apply_tests {
             })
             .id();
         app.insert_resource(reg);
+        app.insert_resource(OzmuxRpc::default());
         app.insert_resource(DynAssetRegistryRes(dyn_assets));
         app.insert_resource(ControlEvents(ev_rx));
         app.add_systems(Update, apply_control_events);
@@ -791,6 +835,113 @@ mod apply_tests {
                 .get("HMOUNT")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn apply_reply_reemits_to_the_originating_webview() {
+        use bevy_cef::prelude::HostEmitEvent;
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let mut rpc = OzmuxRpc::default();
+        let webview = app.world_mut().spawn_empty().id();
+        let g = rpc.mint();
+        rpc.note(&g, webview, "p9", 5);
+        app.insert_resource(rpc);
+        app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
+        #[derive(Resource, Default)]
+        struct Caps(Vec<(Entity, String, serde_json::Value)>);
+        app.insert_resource(Caps::default());
+        app.add_observer(|e: On<HostEmitEvent>, mut c: ResMut<Caps>| {
+            let payload: serde_json::Value = serde_json::from_str(&e.payload).unwrap_or_default();
+            c.0.push((e.webview, e.id.clone(), payload));
+        });
+        app.add_systems(Update, apply_control_events);
+
+        ev_tx
+            .send(ControlEvent::Reply {
+                req_id: g.clone(),
+                ok: true,
+                value: serde_json::json!(99),
+                error: None,
+                connection_id: 5,
+            })
+            .unwrap();
+        app.update();
+
+        let caps = app.world().resource::<Caps>();
+        assert_eq!(caps.0.len(), 1);
+        let (wv, channel, payload) = &caps.0[0];
+        assert_eq!(*wv, webview);
+        assert_eq!(channel, "ozmux");
+        assert_eq!(payload["reqId"], "p9");
+        assert_eq!(payload["ok"], true);
+        assert_eq!(payload["value"], 99);
+    }
+
+    #[test]
+    fn apply_emit_broadcasts_only_to_owning_connections_handle() {
+        use bevy_cef::prelude::HostEmitEvent;
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let mut reg = DynamicRegistry::default();
+        reg.insert(
+            "H".into(),
+            DynamicView {
+                source: DynSource::Inline("<h1>x</h1>".into()),
+                entry: "index.html".into(),
+                interactive: true,
+                owner_surface: Entity::from_bits(1),
+                connection_id: 5,
+            },
+        );
+        let mounted = app
+            .world_mut()
+            .spawn((
+                InlineWebview {
+                    view_id: "H".into(),
+                    instance_id: None,
+                    slot: 0,
+                },
+                WebviewOwner {
+                    connection_id: 5,
+                    handle: "H".into(),
+                },
+            ))
+            .id();
+        app.insert_resource(reg);
+        app.insert_resource(OzmuxRpc::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
+        #[derive(Resource, Default)]
+        struct Caps(Vec<(Entity, String)>);
+        app.insert_resource(Caps::default());
+        app.add_observer(|e: On<HostEmitEvent>, mut c: ResMut<Caps>| {
+            c.0.push((e.webview, e.id.clone()))
+        });
+        app.add_systems(Update, apply_control_events);
+
+        ev_tx
+            .send(ControlEvent::Emit {
+                connection_id: 5,
+                handle: "H".into(),
+                event: "tick".into(),
+                payload: serde_json::json!(1),
+            })
+            .unwrap();
+        ev_tx
+            .send(ControlEvent::Emit {
+                connection_id: 99,
+                handle: "H".into(),
+                event: "tick".into(),
+                payload: serde_json::json!(1),
+            })
+            .unwrap();
+        app.update();
+
+        let caps = app.world().resource::<Caps>();
+        assert_eq!(caps.0, vec![(mounted, "ozmux.event".to_string())]);
     }
 }
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -296,6 +296,8 @@ fn apply_control_events(
                 }
                 despawn_mounted(&mut commands, &inline, &removed);
             }
+            // TODO(stage1 task 9): handle Reply/Emit (back-channel drain) here.
+            ControlEvent::Reply { .. } | ControlEvent::Emit { .. } => {}
         }
     }
 }

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -209,6 +209,12 @@ fn serve_connection(
     // thread exit so writer.join() below doesn't hang.
     writers.remove(connection_id);
     drop(out_tx);
+    // NOTE: shut the shared socket fd down before joining. Dropping out_tx unblocks
+    // a writer parked in recv(), but a writer parked in write_all() (peer stopped
+    // reading with a full send buffer) only unblocks when the fd is shut down —
+    // otherwise writer.join() hangs forever and this connection's Disconnect (and
+    // its registry / in-flight cleanup) is never delivered.
+    let _ = stream.shutdown(std::net::Shutdown::Both);
     let _ = writer.join();
     let _ = events.send(ControlEvent::Disconnect { connection_id });
 }

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -45,7 +45,6 @@ pub(crate) enum ControlEvent {
         connection_id: u64,
     },
     /// A program's reply to an ozmux-initiated back-channel `call`.
-    #[allow(dead_code, reason = "Reply fields are consumed in stage1 task 9")]
     Reply {
         /// The global reqId the apply system correlates.
         req_id: String,
@@ -59,7 +58,6 @@ pub(crate) enum ControlEvent {
         connection_id: u64,
     },
     /// A program-initiated push to its handle's webviews.
-    #[allow(dead_code, reason = "Emit fields are consumed in stage1 task 9")]
     Emit {
         /// The connection that sent the emit (ownership is checked in apply).
         connection_id: u64,

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -19,7 +19,6 @@ use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 
 /// An event the listener emits to the ECS apply system.
-#[allow(dead_code, reason = "Reply/Emit fields are consumed in stage1 task 9")]
 pub(crate) enum ControlEvent {
     /// A `register` from a hello'd connection; the apply system mints a handle,
     /// populates the registries, and sends the reply back on `reply`.
@@ -46,12 +45,13 @@ pub(crate) enum ControlEvent {
         connection_id: u64,
     },
     /// A program's reply to an ozmux-initiated back-channel `call`.
+    #[allow(dead_code, reason = "Reply fields are consumed in stage1 task 9")]
     Reply {
         /// The global reqId the apply system correlates.
         req_id: String,
         /// Whether the call succeeded.
         ok: bool,
-        /// The success value.
+        /// The success value; `null` when `ok` is false.
         value: Value,
         /// The error message when `ok` is false.
         error: Option<String>,
@@ -59,6 +59,7 @@ pub(crate) enum ControlEvent {
         connection_id: u64,
     },
     /// A program-initiated push to its handle's webviews.
+    #[allow(dead_code, reason = "Emit fields are consumed in stage1 task 9")]
     Emit {
         /// The connection that sent the emit (ownership is checked in apply).
         connection_id: u64,
@@ -416,6 +417,36 @@ mod tests {
                 break;
             }
             assert!(Instant::now() < deadline, "no Reply event within 2s");
+        }
+    }
+
+    #[test]
+    fn client_emit_line_emits_an_emit_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ctl.sock");
+        let tokens = TokenRegistry::default();
+        tokens.insert("tok", Entity::from_bits(1));
+        let events = spawn_listener(&sock, tokens, ConnectionWriters::default()).unwrap();
+
+        let mut client = UnixStream::connect(&sock).unwrap();
+        writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
+        writeln!(
+            client,
+            r#"{{"op":"emit","handle":"H","event":"tick","payload":{{"n":1}}}}"#
+        )
+        .unwrap();
+        client.flush().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(ControlEvent::Emit { handle, event, .. }) =
+                events.recv_timeout(Duration::from_millis(50))
+            {
+                assert_eq!(handle, "H");
+                assert_eq!(event, "tick");
+                break;
+            }
+            assert!(Instant::now() < deadline, "no Emit event within 2s");
         }
     }
 

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -1,15 +1,19 @@
 //! Tokio-free control-plane listener: an accept loop thread plus one reader
-//! thread per connection. Each connection is peer-UID-checked, must `hello`
-//! with a valid token (resolved via `TokenRegistry` to its surface), then its
-//! `register`/`unregister` lines and its disconnect are emitted as
-//! `ControlEvent`s. A bounded reply channel per request carries the minted
-//! handle back from the ECS apply system. Mirrors `rpc_client.rs`.
+//! thread and one writer thread per connection. Each connection is
+//! peer-UID-checked, must `hello` with a valid token (resolved via
+//! `TokenRegistry` to its surface), then its `register`/`unregister` lines
+//! and its disconnect are emitted as `ControlEvent`s. A bounded reply channel
+//! per request carries the minted handle back from the ECS apply system; the
+//! reply is relayed through the per-connection writer thread so all writes go
+//! through a single owner. Mirrors `rpc_client.rs`.
 
+use crate::control_plane::ConnectionWriters;
 use crate::control_plane::TokenRegistry;
 use crate::control_plane::protocol::{ClientMsg, RegisterKind, ServerMsg};
 use bevy::prelude::Entity;
 use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use std::io::{BufRead, BufReader, Write};
+use std::ops::ControlFlow;
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 
@@ -42,11 +46,13 @@ pub(crate) enum ControlEvent {
 }
 
 /// Binds `sock_path`, spawns the accept loop, and returns the receiver of
-/// `ControlEvent`s. The accept loop and per-connection readers run on detached
-/// threads (process-lifetime; the socket is removed when the runtime dir drops).
+/// `ControlEvent`s. The accept loop, per-connection readers, and per-connection
+/// writers run on detached threads (process-lifetime; the socket is removed
+/// when the runtime dir drops).
 pub(crate) fn spawn_listener(
     sock_path: &std::path::Path,
     tokens: TokenRegistry,
+    writers: ConnectionWriters,
 ) -> std::io::Result<Receiver<ControlEvent>> {
     let _ = std::fs::remove_file(sock_path);
     let listener = UnixListener::bind(sock_path)?;
@@ -64,7 +70,10 @@ pub(crate) fn spawn_listener(
             next_id += 1;
             let ev_tx = ev_tx.clone();
             let tokens = tokens.clone();
-            std::thread::spawn(move || serve_connection(stream, connection_id, tokens, ev_tx));
+            let writers = writers.clone();
+            std::thread::spawn(move || {
+                serve_connection(stream, connection_id, tokens, ev_tx, writers);
+            });
         }
     });
     Ok(ev_rx)
@@ -114,15 +123,22 @@ fn peer_uid(stream: &UnixStream) -> Option<u32> {
     (rc == 0).then_some(cred.uid)
 }
 
-/// Reads one connection: requires a valid `hello`, then forwards each
-/// `register`/`unregister`, then emits `Disconnect` on EOF.
+/// Reads one connection: requires a valid `hello`, spawns a writer thread for
+/// all outbound lines (register replies + future server-push), registers the
+/// writer in `writers`, then forwards each `register`/`unregister`, then emits
+/// `Disconnect` and removes the writer on EOF.
 fn serve_connection(
-    mut stream: UnixStream,
+    stream: UnixStream,
     connection_id: u64,
     tokens: TokenRegistry,
     events: Sender<ControlEvent>,
+    writers: ConnectionWriters,
 ) {
     let read_half = match stream.try_clone() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let mut write_half = match stream.try_clone() {
         Ok(s) => s,
         Err(_) => return,
     };
@@ -131,6 +147,20 @@ fn serve_connection(
         Some(surface) => surface,
         None => return,
     };
+
+    let (out_tx, out_rx) = unbounded::<String>();
+    let writer = std::thread::spawn(move || {
+        while let Ok(line) = out_rx.recv() {
+            if write_half.write_all(line.as_bytes()).is_err()
+                || write_half.write_all(b"\n").is_err()
+                || write_half.flush().is_err()
+            {
+                break;
+            }
+        }
+    });
+    writers.insert(connection_id, out_tx.clone());
+
     let mut buf = String::new();
     loop {
         buf.clear();
@@ -141,38 +171,17 @@ fn serve_connection(
                 let Ok(msg) = serde_json::from_str::<ClientMsg>(line) else {
                     continue;
                 };
-                match msg {
-                    ClientMsg::Register(kind) => {
-                        let (reply_tx, reply_rx) = bounded::<ServerMsg>(1);
-                        if events
-                            .send(ControlEvent::Register {
-                                connection_id,
-                                owner_surface,
-                                kind,
-                                reply: reply_tx,
-                            })
-                            .is_err()
-                        {
-                            break;
-                        }
-                        let reply = reply_rx
-                            .recv()
-                            .unwrap_or_else(|_| ServerMsg::err("internal"));
-                        if write_reply(&mut stream, &reply).is_err() {
-                            break;
-                        }
-                    }
-                    ClientMsg::Unregister { handle } => {
-                        let _ = events.send(ControlEvent::Unregister {
-                            connection_id,
-                            handle,
-                        });
-                    }
-                    ClientMsg::Hello { .. } => {}
+                if handle_client_msg(msg, connection_id, owner_surface, &events, &out_tx).is_break()
+                {
+                    break;
                 }
             }
         }
     }
+
+    writers.remove(connection_id);
+    drop(out_tx);
+    let _ = writer.join();
     let _ = events.send(ControlEvent::Disconnect { connection_id });
 }
 
@@ -189,17 +198,53 @@ fn read_hello(lines: &mut BufReader<UnixStream>, tokens: &TokenRegistry) -> Opti
     tokens.resolve(&token)
 }
 
-/// Writes one `ServerMsg` reply line (`\n`-terminated).
-fn write_reply(stream: &mut UnixStream, reply: &ServerMsg) -> std::io::Result<()> {
-    let line = serde_json::to_string(reply).expect("ServerMsg serializes infallibly");
-    stream.write_all(line.as_bytes())?;
-    stream.write_all(b"\n")?;
-    stream.flush()
+/// Dispatches one parsed `ClientMsg`; relays the register reply through `out_tx`
+/// so all writes go through the single writer thread. Returns `Break` when the
+/// connection should be torn down.
+fn handle_client_msg(
+    msg: ClientMsg,
+    connection_id: u64,
+    owner_surface: Entity,
+    events: &Sender<ControlEvent>,
+    out_tx: &Sender<String>,
+) -> ControlFlow<()> {
+    match msg {
+        ClientMsg::Register(kind) => {
+            let (reply_tx, reply_rx) = bounded::<ServerMsg>(1);
+            if events
+                .send(ControlEvent::Register {
+                    connection_id,
+                    owner_surface,
+                    kind,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return ControlFlow::Break(());
+            }
+            let reply = reply_rx
+                .recv()
+                .unwrap_or_else(|_| ServerMsg::err("internal"));
+            let line = serde_json::to_string(&reply).expect("ServerMsg serializes infallibly");
+            if out_tx.send(line).is_err() {
+                return ControlFlow::Break(());
+            }
+        }
+        ClientMsg::Unregister { handle } => {
+            let _ = events.send(ControlEvent::Unregister {
+                connection_id,
+                handle,
+            });
+        }
+        ClientMsg::Hello { .. } => {}
+    }
+    ControlFlow::Continue(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control_plane::ConnectionWriters;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -210,7 +255,7 @@ mod tests {
         let surface = Entity::from_bits(11);
         tokens.insert("tok", surface);
 
-        let events = spawn_listener(&sock, tokens).unwrap();
+        let events = spawn_listener(&sock, tokens, ConnectionWriters::default()).unwrap();
 
         let mut client = UnixStream::connect(&sock).unwrap();
         writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
@@ -248,7 +293,12 @@ mod tests {
     fn unknown_token_drops_the_connection_without_events() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("ctl.sock");
-        let events = spawn_listener(&sock, TokenRegistry::default()).unwrap();
+        let events = spawn_listener(
+            &sock,
+            TokenRegistry::default(),
+            ConnectionWriters::default(),
+        )
+        .unwrap();
 
         let mut client = UnixStream::connect(&sock).unwrap();
         writeln!(client, r#"{{"op":"hello","token":"bogus"}}"#).unwrap();
@@ -266,7 +316,7 @@ mod tests {
         let sock = dir.path().join("ctl.sock");
         let tokens = TokenRegistry::default();
         tokens.insert("tok", Entity::from_bits(1));
-        let events = spawn_listener(&sock, tokens).unwrap();
+        let events = spawn_listener(&sock, tokens, ConnectionWriters::default()).unwrap();
 
         let mut client = UnixStream::connect(&sock).unwrap();
         writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
@@ -282,5 +332,40 @@ mod tests {
             }
             assert!(Instant::now() < deadline, "no Disconnect within 2s");
         }
+    }
+
+    #[test]
+    fn server_push_reaches_a_hello_d_client() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ctl.sock");
+        let tokens = TokenRegistry::default();
+        tokens.insert("tok", Entity::from_bits(1));
+        let writers = ConnectionWriters::default();
+        let _events = spawn_listener(&sock, tokens, writers.clone()).unwrap();
+
+        let mut client = UnixStream::connect(&sock).unwrap();
+        writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
+        client.flush().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if writers.send(
+                1,
+                r#"{"op":"call","handle":"H","reqId":"g0","method":"m","args":[]}"#.into(),
+            ) {
+                break;
+            }
+            assert!(Instant::now() < deadline, "writer never registered");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut line = String::new();
+        BufReader::new(client.try_clone().unwrap())
+            .read_line(&mut line)
+            .unwrap();
+        assert!(
+            line.contains(r#""op":"call""#) && line.contains(r#""reqId":"g0""#),
+            "got {line}"
+        );
     }
 }

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -179,6 +179,9 @@ fn serve_connection(
         }
     }
 
+    // NOTE: remove the table's Sender clone BEFORE dropping out_tx — only when the
+    // last Sender is gone does out_rx.recv() return Disconnected, letting the writer
+    // thread exit so writer.join() below doesn't hang.
     writers.remove(connection_id);
     drop(out_tx);
     let _ = writer.join();

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -12,12 +12,14 @@ use crate::control_plane::TokenRegistry;
 use crate::control_plane::protocol::{ClientMsg, RegisterKind, ServerMsg};
 use bevy::prelude::Entity;
 use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
+use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};
 use std::ops::ControlFlow;
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 
 /// An event the listener emits to the ECS apply system.
+#[allow(dead_code, reason = "Reply/Emit fields are consumed in stage1 task 9")]
 pub(crate) enum ControlEvent {
     /// A `register` from a hello'd connection; the apply system mints a handle,
     /// populates the registries, and sends the reply back on `reply`.
@@ -42,6 +44,30 @@ pub(crate) enum ControlEvent {
     Disconnect {
         /// Connection id.
         connection_id: u64,
+    },
+    /// A program's reply to an ozmux-initiated back-channel `call`.
+    Reply {
+        /// The global reqId the apply system correlates.
+        req_id: String,
+        /// Whether the call succeeded.
+        ok: bool,
+        /// The success value.
+        value: Value,
+        /// The error message when `ok` is false.
+        error: Option<String>,
+        /// The connection that sent the reply (for in-flight ownership).
+        connection_id: u64,
+    },
+    /// A program-initiated push to its handle's webviews.
+    Emit {
+        /// The connection that sent the emit (ownership is checked in apply).
+        connection_id: u64,
+        /// The target handle.
+        handle: String,
+        /// The event name.
+        event: String,
+        /// The event payload.
+        payload: Value,
     },
 }
 
@@ -240,6 +266,32 @@ fn handle_client_msg(
             });
         }
         ClientMsg::Hello { .. } => {}
+        ClientMsg::Reply {
+            req_id,
+            ok,
+            value,
+            error,
+        } => {
+            let _ = events.send(ControlEvent::Reply {
+                req_id,
+                ok,
+                value,
+                error,
+                connection_id,
+            });
+        }
+        ClientMsg::Emit {
+            handle,
+            event,
+            payload,
+        } => {
+            let _ = events.send(ControlEvent::Emit {
+                connection_id,
+                handle,
+                event,
+                payload,
+            });
+        }
     }
     ControlFlow::Continue(())
 }
@@ -334,6 +386,36 @@ mod tests {
                 break;
             }
             assert!(Instant::now() < deadline, "no Disconnect within 2s");
+        }
+    }
+
+    #[test]
+    fn client_reply_line_emits_a_reply_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ctl.sock");
+        let tokens = TokenRegistry::default();
+        tokens.insert("tok", Entity::from_bits(1));
+        let events = spawn_listener(&sock, tokens, ConnectionWriters::default()).unwrap();
+
+        let mut client = UnixStream::connect(&sock).unwrap();
+        writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
+        writeln!(
+            client,
+            r#"{{"op":"reply","reqId":"g1","ok":true,"value":7}}"#
+        )
+        .unwrap();
+        client.flush().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(ControlEvent::Reply { req_id, ok, .. }) =
+                events.recv_timeout(Duration::from_millis(50))
+            {
+                assert_eq!(req_id, "g1");
+                assert!(ok);
+                break;
+            }
+            assert!(Instant::now() < deadline, "no Reply event within 2s");
         }
     }
 

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -4,9 +4,10 @@
 //! OSC parser ethos).
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// One inbound control-plane request line.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub(crate) enum ClientMsg {
     /// Connection handshake: binds this connection to the pane whose env
@@ -21,6 +22,30 @@ pub(crate) enum ClientMsg {
     Unregister {
         /// The handle returned by a prior `register`.
         handle: String,
+    },
+    /// A program's reply to an ozmux-initiated `call` (back-channel).
+    Reply {
+        /// The global reqId ozmux assigned to the originating `call`.
+        #[serde(rename = "reqId")]
+        req_id: String,
+        /// Whether the call succeeded.
+        ok: bool,
+        /// The success value (absent ⇒ `null`).
+        #[serde(default)]
+        value: Value,
+        /// The error message when `ok` is false.
+        #[serde(default)]
+        error: Option<String>,
+    },
+    /// A program-initiated push event to its handle's mounted webviews.
+    Emit {
+        /// The handle whose mounted webviews receive the event.
+        handle: String,
+        /// The event name dispatched to page `window.ozmux.on(name, …)`.
+        event: String,
+        /// The event payload.
+        #[serde(default)]
+        payload: Value,
     },
 }
 
@@ -145,6 +170,48 @@ mod tests {
     #[test]
     fn rejects_unknown_op() {
         assert!(serde_json::from_str::<ClientMsg>(r#"{"op":"nope"}"#).is_err());
+    }
+
+    #[test]
+    fn parses_reply_ok_and_err() {
+        let ok: ClientMsg =
+            serde_json::from_str(r#"{"op":"reply","reqId":"g7","ok":true,"value":42}"#).unwrap();
+        assert_eq!(
+            ok,
+            ClientMsg::Reply {
+                req_id: "g7".into(),
+                ok: true,
+                value: serde_json::json!(42),
+                error: None
+            }
+        );
+        let err: ClientMsg =
+            serde_json::from_str(r#"{"op":"reply","reqId":"g8","ok":false,"error":"boom"}"#)
+                .unwrap();
+        assert_eq!(
+            err,
+            ClientMsg::Reply {
+                req_id: "g8".into(),
+                ok: false,
+                value: serde_json::Value::Null,
+                error: Some("boom".into())
+            }
+        );
+    }
+
+    #[test]
+    fn parses_emit() {
+        let m: ClientMsg =
+            serde_json::from_str(r#"{"op":"emit","handle":"H","event":"tick","payload":{"n":1}}"#)
+                .unwrap();
+        assert_eq!(
+            m,
+            ClientMsg::Emit {
+                handle: "H".into(),
+                event: "tick".into(),
+                payload: serde_json::json!({"n":1})
+            }
+        );
     }
 
     #[test]

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -5,6 +5,7 @@
 //! via `HostRpc`, with replies routed back on the `ozmux` channel).
 
 use self::preload::{build_preload, webview_url};
+use crate::control_plane::{ConnectionWriters, OzmuxRpc, WebviewOwner};
 use crate::inline_webview::{InlineWebview, focused_inline_of};
 use crate::osc_webview::GrantedNamespaces;
 use crate::osc_webview::NonInteractive;
@@ -26,16 +27,16 @@ use serde_json::Value;
 
 pub(crate) mod preload;
 
-/// One frame emitted by the page bridge `host_bridge.js` via
-/// `cef.emit({ kind: 'host.call', … })`, inspected by `on_host_call_frame`.
+/// One frame emitted by the page bridge (`host_bridge.js` or `ozmux_bridge.js`)
+/// via `cef.emit({ kind: '…', … })`, inspected by the per-kind observers.
 ///
 /// `#[serde(transparent)]` makes it deserialize from the bare emitted object
-/// (`{kind, reqId, ns, method, args}`), not from a `{"0": …}` wrapper — `bevy_cef`'s
+/// (`{kind, reqId, …}`), not from a `{"0": …}` wrapper — `bevy_cef`'s
 /// `cef.emit(frame)` serializes only its first argument into one global
 /// `Receive<OzmuxFrame>`.
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(transparent)]
-struct OzmuxFrame(serde_json::Value);
+pub(crate) struct OzmuxFrame(pub(crate) serde_json::Value);
 
 /// The connected host RPC client plus the in-flight `globalReqId → (webview,
 /// pageReqId)` correlation. `globalReqId` is minted Rust-side (a monotonic
@@ -96,6 +97,10 @@ struct WebviewMountUnresolved;
 /// in `host_bridge.js`.
 const HOST_CALL_KIND: &str = "host.call";
 
+/// The `kind` discriminator routing a `Receive<OzmuxFrame>` to the Tier 1
+/// back-channel (`on_ozmux_call_frame`). The page side emits it in `ozmux_bridge.js`.
+const OZMUX_CALL_KIND: &str = "ozmux.call";
+
 /// Builds the `CefPlugin` with the `ozmux-ext://` (static, Tier 2) and
 /// `ozmux-dyn://` (dynamic, Tier 1) schemes bound to their shared registries.
 pub fn cef_plugin(ext_registry: AssetSourceRegistry, dyn_registry: DynAssetRegistry) -> CefPlugin {
@@ -139,6 +144,8 @@ impl Plugin for OzmuxExtensionRenderPlugin {
             .init_resource::<HostRpc>()
             .add_observer(on_host_call_frame)
             .add_observer(drop_inflight_host_calls_on_webview_despawn)
+            .add_observer(on_ozmux_call_frame)
+            .add_observer(drop_ozmux_inflight_on_webview_despawn)
             .add_observer(log_webview_load_started)
             .add_observer(log_webview_load_finished)
             .add_observer(log_webview_load_error)
@@ -384,6 +391,72 @@ fn on_host_call_frame(
 fn reject_host_call(commands: &mut Commands, webview: Entity, req_id: &str, error: &str) {
     let payload = serde_json::json!({ "reqId": req_id, "ok": false, "error": error });
     commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
+}
+
+/// Inbound (Tier 1 back-channel): a `window.ozmux.call` arrives as a
+/// `Receive<OzmuxFrame>` with `kind:"ozmux.call"`. The trusted caller is
+/// `frame.webview` (bound per-webview by `bevy_cef`, never the JS payload); its
+/// `WebviewOwner` names the registering connection. The call is forwarded over
+/// that connection's writer under a Rust-minted global reqId; a missing
+/// owner/connection rejects the page Promise directly.
+///
+/// Registered as an observer on the shared `Receive<OzmuxFrame>` event (NOT a
+/// second `JsEmitEventPlugin`): the event carries all frames; non-`ozmux.call`
+/// frames are ignored via the early return on `OZMUX_CALL_KIND`.
+fn on_ozmux_call_frame(
+    frame: On<Receive<OzmuxFrame>>,
+    mut commands: Commands,
+    mut rpc: ResMut<OzmuxRpc>,
+    writers: Res<ConnectionWriters>,
+    owners: Query<&WebviewOwner>,
+) {
+    let payload = &frame.payload.0;
+    if payload.get("kind").and_then(Value::as_str) != Some(OZMUX_CALL_KIND) {
+        return;
+    }
+    let webview = frame.webview;
+    let req_id = payload
+        .get("reqId")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let method = payload
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let args = payload
+        .get("args")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+
+    let Ok(owner) = owners.get(webview) else {
+        reject_ozmux_call(&mut commands, webview, req_id, "no_owner");
+        return;
+    };
+    let global_id = rpc.mint();
+    let line = serde_json::json!({
+        "op": "call", "handle": owner.handle, "reqId": global_id, "method": method, "args": args
+    })
+    .to_string();
+    if !writers.send(owner.connection_id, line) {
+        reject_ozmux_call(&mut commands, webview, req_id, "owner_unavailable");
+        return;
+    }
+    rpc.note(&global_id, webview, req_id, owner.connection_id);
+}
+
+/// Emits a `{reqId, ok:false, error}` reply to one webview on the `"ozmux"`
+/// channel (settling the page Promise).
+fn reject_ozmux_call(commands: &mut Commands, webview: Entity, req_id: &str, error: &str) {
+    let payload = serde_json::json!({ "reqId": req_id, "ok": false, "error": error });
+    commands.trigger(HostEmitEvent::new(webview, "ozmux", &payload));
+}
+
+/// Despawn prune: drop a despawned webview's in-flight back-channel calls.
+fn drop_ozmux_inflight_on_webview_despawn(
+    remove: On<Remove, WebviewOwner>,
+    mut rpc: ResMut<OzmuxRpc>,
+) {
+    rpc.drain_webview(remove.entity);
 }
 
 /// Outbound (new-model host API): drains the host's NDJSON reply lines, maps the
@@ -1157,6 +1230,48 @@ mod tests {
             app.world().resource::<HostRpc>().count_in_flight_for_test(),
             1,
             "prune must drop ONLY the despawned surface's in-flight calls (retain, not clear)"
+        );
+    }
+
+    #[test]
+    fn ozmux_call_frame_pushes_call_to_owner_connection() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(OzmuxRpc::default());
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_call_frame);
+
+        let webview = app
+            .world_mut()
+            .spawn(WebviewOwner {
+                connection_id: 7,
+                handle: "H".into(),
+            })
+            .id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozmux.call", "reqId": "p0", "method": "save", "args": [1, 2]
+            })),
+        });
+
+        let line = rx.try_recv().expect("a call was pushed");
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["op"], "call");
+        assert_eq!(v["handle"], "H");
+        assert_eq!(v["method"], "save");
+        assert_eq!(v["reqId"], "0");
+        assert_eq!(
+            app.world()
+                .resource::<OzmuxRpc>()
+                .count_in_flight_for_test(),
+            1
         );
     }
 

--- a/src/extension_render.rs
+++ b/src/extension_render.rs
@@ -36,7 +36,7 @@ pub(crate) mod preload;
 /// `Receive<OzmuxFrame>`.
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(transparent)]
-pub(crate) struct OzmuxFrame(pub(crate) serde_json::Value);
+struct OzmuxFrame(serde_json::Value);
 
 /// The connected host RPC client plus the in-flight `globalReqId → (webview,
 /// pageReqId)` correlation. `globalReqId` is minted Rust-side (a monotonic

--- a/src/extension_render/ozmux_bridge.js
+++ b/src/extension_render/ozmux_bridge.js
@@ -6,6 +6,7 @@
 (function () {
   var cef = window.cef;
   var nextId = 0;
+  // NOTE: a call that never receives a reply leaks its calls entry and pending Promise; the Rust side MUST send an error reply (e.g. on owner disconnect) to clear it. There is no client-side timeout.
   var calls = new Map();
   var listeners = new Map();
 

--- a/src/extension_render/ozmux_bridge.js
+++ b/src/extension_render/ozmux_bridge.js
@@ -51,7 +51,14 @@
       var encoded = (args || []).map(encodeArg);
       return new Promise(function (resolve, reject) {
         calls.set(reqId, { resolve: resolve, reject: reject });
-        cef.emit({ kind: 'ozmux.call', reqId: reqId, method: method, args: encoded });
+        try {
+          cef.emit({ kind: 'ozmux.call', reqId: reqId, method: method, args: encoded });
+        } catch (e) {
+          // A synchronous emit failure never gets a reply, so settle and drop the
+          // entry here — otherwise it leaks in calls forever.
+          calls.delete(reqId);
+          reject(e);
+        }
       });
     },
     on: function (event, handler) {

--- a/src/extension_render/ozmux_bridge.js
+++ b/src/extension_render/ozmux_bridge.js
@@ -1,0 +1,68 @@
+// NOTE: bevy_cef contract — Rust->JS cef.listen delivers a JSON *string* (hence
+// JSON.parse); JS->Rust cef.emit serializes only its FIRST argument. Replies
+// arrive on the "ozmux" channel keyed by reqId; push events on "ozmux.event".
+// The {__u8} base64 tag mirrors binary-codec.ts (top-level only). window.ozmux
+// is frozen so a page cannot shadow it.
+(function () {
+  var cef = window.cef;
+  var nextId = 0;
+  var calls = new Map();
+  var listeners = new Map();
+
+  function encodeArg(a) {
+    if (a instanceof Uint8Array) {
+      var bin = '';
+      for (var i = 0; i < a.length; i++) bin += String.fromCharCode(a[i]);
+      return { __u8: btoa(bin) };
+    }
+    return a;
+  }
+  function decodeValue(v) {
+    if (v && typeof v === 'object' && typeof v.__u8 === 'string') {
+      var s = atob(v.__u8);
+      var out = new Uint8Array(s.length);
+      for (var i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+      return out;
+    }
+    return v;
+  }
+
+  cef.listen('ozmux', function (raw) {
+    var frame = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    var c = calls.get(frame.reqId);
+    if (!c) return;
+    calls.delete(frame.reqId);
+    if (frame.ok) c.resolve(decodeValue(frame.value));
+    else c.reject(new Error(frame.error));
+  });
+
+  cef.listen('ozmux.event', function (raw) {
+    var frame = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    var hs = listeners.get(frame.event);
+    if (!hs) return;
+    var payload = decodeValue(frame.payload);
+    hs.slice().forEach(function (h) { try { h(payload); } catch (e) {} });
+  });
+
+  var api = {
+    call: function (method, args) {
+      var reqId = 'o' + nextId++;
+      var encoded = (args || []).map(encodeArg);
+      return new Promise(function (resolve, reject) {
+        calls.set(reqId, { resolve: resolve, reject: reject });
+        cef.emit({ kind: 'ozmux.call', reqId: reqId, method: method, args: encoded });
+      });
+    },
+    on: function (event, handler) {
+      var hs = listeners.get(event) || [];
+      hs.push(handler);
+      listeners.set(event, hs);
+    },
+    off: function (event, handler) {
+      var hs = listeners.get(event);
+      if (hs) listeners.set(event, hs.filter(function (h) { return h !== handler; }));
+    },
+  };
+
+  Object.defineProperty(window, 'ozmux', { value: Object.freeze(api), configurable: false, writable: false });
+})();

--- a/src/extension_render/preload.rs
+++ b/src/extension_render/preload.rs
@@ -17,6 +17,11 @@ pub(crate) fn webview_url(extension_name: &str, entry: &str) -> String {
 /// webview as a `PreloadScripts` entry.
 pub(super) const HOST_BRIDGE_JS: &str = include_str!("host_bridge.js");
 
+/// JS defining the unified `window.ozmux` back-channel bridge (`.call` / `.on`),
+/// injected per Tier 1 dynamic webview as a `PreloadScripts` entry. Frozen onto
+/// `window` so a page cannot shadow it.
+pub(super) const OZMUX_BRIDGE_JS: &str = include_str!("ozmux_bridge.js");
+
 /// Builds the full preload script set for an ozmux-managed webview:
 /// context globals, the capability grant, and the host-API bridge.
 pub(crate) fn build_preload(
@@ -40,16 +45,16 @@ pub(crate) fn build_preload(
     PreloadScripts::from([ctx_js, granted_js, HOST_BRIDGE_JS.to_string()])
 }
 
-/// Builds the preload for a Tier 1 dynamic webview: context globals only, with
-/// `role: "dynamic"`. No capability grant and no host bridge — a dynamic view
-/// has `capabilities = []`, so `window.<ns>` would only reject every call.
+/// Builds the preload for a Tier 1 dynamic webview: context globals + the
+/// `window.ozmux` back-channel bridge. No capability grant (the bridge routes to
+/// the registering program, not the host).
 pub(crate) fn build_dynamic_preload(
     workspace: Entity,
     pane: Entity,
     surface: Entity,
 ) -> PreloadScripts {
     let ctx_js = context_preload_js_role(workspace, pane, surface, "dynamic", "");
-    PreloadScripts::from([ctx_js])
+    PreloadScripts::from([ctx_js, OZMUX_BRIDGE_JS.to_string()])
 }
 
 /// Builds the per-webview context PreloadScript assigning `window.__ozmuxContext`
@@ -153,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_preload_has_context_only_no_bridge() {
+    fn dynamic_preload_injects_context_and_ozmux_bridge() {
         let world = &mut App::new();
         world
             .add_plugins(MinimalPlugins)
@@ -168,15 +173,14 @@ mod tests {
         world.world_mut().flush();
 
         let preload = build_dynamic_preload(workspace, pane, surface);
-        assert_eq!(preload.0.len(), 1, "dynamic preload is context-only");
+        assert_eq!(preload.0.len(), 2, "context + ozmux bridge");
         assert!(preload.0[0].starts_with("window.__ozmuxContext="));
+        assert_eq!(preload.0[1], OZMUX_BRIDGE_JS);
         assert!(
-            !preload
-                .0
-                .iter()
-                .any(|s| s.contains("__ozmuxGranted") || s == HOST_BRIDGE_JS),
-            "no capability grant, no host bridge for a Tier 1 dynamic view"
+            OZMUX_BRIDGE_JS.contains("window, 'ozmux'")
+                && OZMUX_BRIDGE_JS.contains("defineProperty")
         );
+        assert!(OZMUX_BRIDGE_JS.contains("kind: 'ozmux.call'"));
     }
 
     #[test]

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -5,7 +5,7 @@
 //! `OzmuxInlineWebviewPlugin` runtime systems that keep `WebviewSize` in
 //! sync with cell metrics and project placements into `TerminalOverlays`.
 
-use crate::control_plane::{DynSource, DynamicRegistry};
+use crate::control_plane::{DynSource, DynamicRegistry, WebviewOwner};
 use crate::extension_render::preload::{build_dynamic_preload, build_preload, webview_url};
 use crate::input::InputPhase;
 use crate::input::mouse_buttons::resolve_pane_at_phys;
@@ -307,13 +307,10 @@ pub(crate) fn mount_inline(
         params.commands.entity(webview).insert(NonInteractive);
     }
     if let Some((connection_id, handle)) = resolved.owner {
-        params
-            .commands
-            .entity(webview)
-            .insert(crate::control_plane::WebviewOwner {
-                connection_id,
-                handle,
-            });
+        params.commands.entity(webview).insert(WebviewOwner {
+            connection_id,
+            handle,
+        });
     }
     tracing::debug!(
         view_id = %ctx.view_id,

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -155,6 +155,10 @@ pub(crate) struct ResolvedWebviewMount {
     pub(crate) host_bridge: bool,
     /// The owning extension name for the preload context (`""` for dynamic).
     pub(crate) extension_name: String,
+    /// For Tier 1 dynamic mounts: `(connection_id, handle)` of the registering
+    /// program, used to stamp `WebviewOwner` for back-channel routing. `None` for
+    /// Tier 2 (static extension) mounts.
+    pub(crate) owner: Option<(u64, String)>,
 }
 
 /// Resolves a `mount-inline` `<id>` to its content + trust facts: the static
@@ -177,6 +181,7 @@ pub(crate) fn resolve_mount(
             capabilities: view.capabilities.clone(),
             host_bridge: true,
             extension_name: view.owning_ext.clone(),
+            owner: None,
         });
     }
     let view = dynamic.get(id)?;
@@ -193,6 +198,7 @@ pub(crate) fn resolve_mount(
         capabilities: Vec::new(),
         host_bridge: false,
         extension_name: String::new(),
+        owner: Some((view.connection_id, id.to_string())),
     })
 }
 
@@ -299,6 +305,15 @@ pub(crate) fn mount_inline(
     ));
     if !resolved.interactive {
         params.commands.entity(webview).insert(NonInteractive);
+    }
+    if let Some((connection_id, handle)) = resolved.owner {
+        params
+            .commands
+            .entity(webview)
+            .insert(crate::control_plane::WebviewOwner {
+                connection_id,
+                handle,
+            });
     }
     tracing::debug!(
         view_id = %ctx.view_id,
@@ -1886,6 +1901,39 @@ mod tests {
         assert_eq!(r.url.as_deref(), Some("ozmux-dyn://INLINEH/index.html"));
         assert!(!r.host_bridge);
         assert!(r.capabilities.is_empty());
+    }
+
+    #[test]
+    fn dynamic_mount_stamps_webview_owner() {
+        use crate::control_plane::{DynSource, DynamicView, WebviewOwner};
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        app.world_mut().resource_mut::<DynamicRegistry>().insert(
+            "HANDLE".into(),
+            DynamicView {
+                source: DynSource::Inline("<h1>hi</h1>".into()),
+                entry: "index.html".into(),
+                interactive: true,
+                owner_surface: terminal,
+                connection_id: 42,
+            },
+        );
+
+        mount(&mut app, terminal, "HANDLE", Some(test_anchor()));
+
+        let children = inline_children_of(&app, terminal);
+        assert_eq!(
+            children.len(),
+            1,
+            "dynamic mount must spawn one inline child"
+        );
+        let child = children[0];
+        let owner = app
+            .world()
+            .get::<WebviewOwner>(child)
+            .expect("dynamic mount must stamp WebviewOwner");
+        assert_eq!(owner.connection_id, 42);
+        assert_eq!(owner.handle, "HANDLE");
     }
 
     #[test]

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -185,7 +185,7 @@ pub(crate) fn resolve_mount(
     }
     let entry = match &view.source {
         DynSource::Dir(_) => view.entry.clone(),
-        DynSource::Inline(_) => "index.html".to_string(),
+        DynSource::Inline(_) => "index.html".into(),
     };
     Some(ResolvedWebviewMount {
         url: Some(format!("ozmux-dyn://{id}/{entry}")),
@@ -1937,25 +1937,5 @@ mod tests {
         // Without a Browsers NonSend resource the full resolution path runs
         // and the forwarding is skipped — the system must not panic.
         app.update();
-    }
-
-    #[test]
-    fn resolve_mount_dynamic_inline_yields_ozmux_dyn_url() {
-        use crate::control_plane::{DynSource, DynamicRegistry, DynamicView};
-        let views = ViewRegistry::default();
-        let mut dynamic = DynamicRegistry::default();
-        let surface = Entity::from_bits(3);
-        dynamic.insert(
-            "HANDLE".into(),
-            DynamicView {
-                source: DynSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: surface,
-                connection_id: 5,
-            },
-        );
-        let r = resolve_mount("HANDLE", surface, &views, &dynamic).expect("resolves");
-        assert_eq!(r.url.as_deref(), Some("ozmux-dyn://HANDLE/index.html"));
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -141,15 +141,12 @@ pub(crate) struct InlineWebviewParams<'w, 's> {
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
 
-/// The resolved content + trust facts for a `mount-inline;<id>`: either a URL
-/// (`ozmux-ext://` static or `ozmux-dyn://` dynamic-Dir) or inline HTML
-/// (dynamic-Inline), the input policy, the granted capabilities, and whether the
-/// host bridge preload is injected.
+/// The resolved content + trust facts for a `mount-inline;<id>`: a URL
+/// (`ozmux-ext://` static or `ozmux-dyn://` dynamic), the input policy, the
+/// granted capabilities, and whether the host bridge preload is injected.
 pub(crate) struct ResolvedWebviewMount {
-    /// The `WebviewSource::Url` to load, when the source is URL-backed.
+    /// The URL to load (`WebviewSource::Url`). `None` signals a policy rejection.
     pub(crate) url: Option<String>,
-    /// The HTML for `WebviewSource::InlineHtml`, when the source is inline.
-    pub(crate) inline_html: Option<String>,
     /// Whether the page receives pointer/keyboard input.
     pub(crate) interactive: bool,
     /// Host-API namespaces granted (empty for Tier 1 dynamic).
@@ -162,7 +159,9 @@ pub(crate) struct ResolvedWebviewMount {
 
 /// Resolves a `mount-inline` `<id>` to its content + trust facts: the static
 /// `ViewRegistry` (Tier 2) takes precedence, then the `DynamicRegistry`
-/// (Tier 1). A dynamic handle resolves ONLY when `requesting_surface` is its
+/// (Tier 1). Dynamic handles (both Dir and Inline) resolve to an
+/// `ozmux-dyn://<handle>/…` URL so each gets its own per-handle origin. A
+/// dynamic handle resolves ONLY when `requesting_surface` is its
 /// `owner_surface` — the scoping gate that stops one surface from mounting
 /// another's handle. Returns `None` for an unregistered or unowned id.
 pub(crate) fn resolve_mount(
@@ -174,7 +173,6 @@ pub(crate) fn resolve_mount(
     if let Some(view) = views.get(id) {
         return Some(ResolvedWebviewMount {
             url: Some(webview_url(&view.owning_ext, &view.entry)),
-            inline_html: None,
             interactive: view.interactive,
             capabilities: view.capabilities.clone(),
             host_bridge: true,
@@ -185,13 +183,12 @@ pub(crate) fn resolve_mount(
     if view.owner_surface != requesting_surface {
         return None;
     }
-    let (url, inline_html) = match &view.source {
-        DynSource::Dir(_) => (Some(format!("ozmux-dyn://{id}/{}", view.entry)), None),
-        DynSource::Inline(html) => (None, Some(html.clone())),
+    let entry = match &view.source {
+        DynSource::Dir(_) => view.entry.clone(),
+        DynSource::Inline(_) => "index.html".to_string(),
     };
     Some(ResolvedWebviewMount {
-        url,
-        inline_html,
+        url: Some(format!("ozmux-dyn://{id}/{entry}")),
         interactive: view.interactive,
         capabilities: Vec::new(),
         host_bridge: false,
@@ -256,14 +253,11 @@ pub(crate) fn mount_inline(
     let (cell_w_phys, cell_h_phys) = cell_size_phys(params.metrics.as_deref());
     let size = seed_logical_size(ctx.rows, ctx.cols, cell_w_phys, cell_h_phys, scale_factor);
     let texture = WebviewTextureTarget(params.images.add(Image::default()));
-    let source = match (&resolved.url, &resolved.inline_html) {
-        (Some(url), _) => WebviewSource::new(url),
-        (None, Some(html)) => WebviewSource::InlineHtml(html.clone()),
-        (None, None) => {
-            tracing::debug!(view_id = %ctx.view_id, "osc-webview: resolved mount had no source, dropping");
-            return;
-        }
+    let Some(url) = resolved.url.as_deref() else {
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: resolved mount had no url, dropping");
+        return;
     };
+    let source = WebviewSource::new(url);
     let granted = GrantedNamespaces(resolved.capabilities.iter().cloned().collect());
     let webview = params.commands.spawn_empty().id();
     let preload = if resolved.host_bridge {
@@ -1865,7 +1859,6 @@ mod tests {
 
         let d = resolve_mount("DYNHANDLE", owner, &views, &dynamic).expect("dynamic resolves");
         assert_eq!(d.url.as_deref(), Some("ozmux-dyn://DYNHANDLE/index.html"));
-        assert!(d.inline_html.is_none());
         assert!(!d.host_bridge, "dynamic (Tier 1) has no host bridge");
         assert!(d.capabilities.is_empty());
 
@@ -1874,7 +1867,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_mount_dynamic_inline_carries_html_not_url() {
+    fn resolve_mount_dynamic_inline_yields_ozmux_dyn_url_via_index_html() {
         use crate::control_plane::{DynSource, DynamicRegistry, DynamicView};
         let owner = Entity::from_bits(1);
         let views = ViewRegistry::default();
@@ -1890,8 +1883,9 @@ mod tests {
             },
         );
         let r = resolve_mount("INLINEH", owner, &views, &dynamic).expect("inline resolves");
-        assert_eq!(r.inline_html.as_deref(), Some("<h1>x</h1>"));
-        assert!(r.url.is_none());
+        assert_eq!(r.url.as_deref(), Some("ozmux-dyn://INLINEH/index.html"));
+        assert!(!r.host_bridge);
+        assert!(r.capabilities.is_empty());
     }
 
     #[test]
@@ -1943,5 +1937,25 @@ mod tests {
         // Without a Browsers NonSend resource the full resolution path runs
         // and the forwarding is skipped — the system must not panic.
         app.update();
+    }
+
+    #[test]
+    fn resolve_mount_dynamic_inline_yields_ozmux_dyn_url() {
+        use crate::control_plane::{DynSource, DynamicRegistry, DynamicView};
+        let views = ViewRegistry::default();
+        let mut dynamic = DynamicRegistry::default();
+        let surface = Entity::from_bits(3);
+        dynamic.insert(
+            "HANDLE".into(),
+            DynamicView {
+                source: DynSource::Inline("<h1>x</h1>".into()),
+                entry: "index.html".into(),
+                interactive: true,
+                owner_surface: surface,
+                connection_id: 5,
+            },
+        );
+        let r = resolve_mount("HANDLE", surface, &views, &dynamic).expect("resolves");
+        assert_eq!(r.url.as_deref(), Some("ozmux-dyn://HANDLE/index.html"));
     }
 }


### PR DESCRIPTION
## Problem

issue #106（Phase B）の**統一 Webview モデル**の基盤（Stage 1 / 全3段階）。

現状の課題:
- Tier 1 動的 webview（Phase A, #103）は **表示専用**で、ページ→登録元プログラムへ戻る経路が無く、埋め込み UI をインタラクティブにできない。
- インライン HTML は共有 `cef://localhost` オリジンで配信され、登録ごとに storage/script が分離されない。

> brainstorming の過程で issue #106 原文の「既存 host-API 昇格 + capability ゲート」は **per-owner closed scope（webview は自分のオーナーとだけ話す）** に再設計され、最終的に Extension 機構自体を後段で撤去する方針に収束しました。spec/plan は `docs/`（gitignore）にローカル保持。本 PR は **Stage 1（back-channel + origin 分離）のみ**。

## Solution

**① back-channel RPC（`window.ozmux`）** — 各 Tier 1 webview に単一チャネル `window.ozmux.call(method, args)`（req/reply）＋ `.on(event, cb)`（push）を凍結注入。ページのコールは webview エンティティの `WebviewOwner(connection_id, handle)` を引いて **登録元プログラムへ** ルーティング。制御ソケットを双方向 NDJSON RPC に拡張（per-connection writer スレッド + `ConnectionWriters`、inbound `reply`/`emit`）。`OzmuxRpc` が global↔page reqId を相関。

**② origin 分離** — インライン HTML を `DynAssetRegistry`（`Dir | Inline`）に保持し `ozmux-dyn://<handle>/` で配信（共有 `WebviewSource::InlineHtml` を廃止）。webview ごとに一意 origin で storage/script を分離。

**影響範囲**: `crates/extension_host`（dyn_scheme）、`src/control_plane*`、`src/extension_render`（+ `ozmux_bridge.js`）、`src/inline_webview`、`examples/dyn_webview_client.rs`。

**Tier 2 共存**: 既存 extension の host-API（`on_host_call_frame` / `ozmux-ext://` / `window.<ns>`）は無改変。`on_ozmux_call_frame` は共有 `Receive<OzmuxFrame>` の 2 つ目の observer で `kind` により振り分け（新規 receive plugin なし）。

**security 不変条件**: PTY/OSC は handle 参照のみを運ぶ。ルーティングは server 付与の `frame.webview` 由来で、ページは別オーナーを詐称不可。reply は connection-match、emit は handle-ownership でゲート。origin 分離でページ間も相互遮断。

**後続フェーズ**: Stage 2（TS SDK クライアント + memo をプログラム化）、Stage 3（Extension 機構撤去: Node host・`ozmux.toml`・`ozmux-ext://`・`ViewRegistry`・`capabilities`・`SurfaceKind::Extension`）。

### テスト
- 387 GUI + 49 extension_host tests green（`cargo test ... -- --test-threads=1`）
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo build --features debug`（CEF-gated）clean
- 実装は subagent-driven（task ごと spec + quality review）→ opus 全体 review → `/code-review max --fix`（実バグ 1 件修正: reply drain の connection-check 順序）
- `window.ozmux` の call/emit 往復 + per-origin 分離の視覚 E2E は `examples/dyn_webview_client.rs` で手動確認（`cargo run --features debug`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)