### PR TITLE
feat(tmux_control_parser): tmux control-mode parser (ControlEvent + BlockAssembler + layout tree)

### DIFF
--- a/crates/tmux_control_parser/Cargo.toml
+++ b/crates/tmux_control_parser/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tmux_control_parser"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -57,7 +57,14 @@ mod tests {
     #[test]
     fn empty_reply_block() {
         let frames = feed_all(&[b"%begin 1 7 1", b"%end 1 7 1"]);
-        assert_eq!(frames, vec![Frame::Reply { number: 7, ok: true, body: Vec::new() }]);
+        assert_eq!(
+            frames,
+            vec![Frame::Reply {
+                number: 7,
+                ok: true,
+                body: Vec::new()
+            }]
+        );
     }
 
     #[test]
@@ -129,7 +136,9 @@ mod tests {
         let frames = feed_all(&[b"%window-add @1"]);
         assert_eq!(
             frames,
-            vec![Frame::Notification(ControlEvent::WindowAdd { window: WindowId(1) })]
+            vec![Frame::Notification(ControlEvent::WindowAdd {
+                window: WindowId(1)
+            })]
         );
     }
 
@@ -145,9 +154,18 @@ mod tests {
         assert_eq!(
             frames,
             vec![
-                Frame::Notification(ControlEvent::Output { pane: PaneId(1), data: b"hi".to_vec() }),
-                Frame::Reply { number: 12, ok: true, body: vec!["reply".to_string()] },
-                Frame::Notification(ControlEvent::WindowClose { window: WindowId(4) }),
+                Frame::Notification(ControlEvent::Output {
+                    pane: PaneId(1),
+                    data: b"hi".to_vec()
+                }),
+                Frame::Reply {
+                    number: 12,
+                    ok: true,
+                    body: vec!["reply".to_string()]
+                },
+                Frame::Notification(ControlEvent::WindowClose {
+                    window: WindowId(4)
+                }),
             ]
         );
     }
@@ -159,14 +177,21 @@ mod tests {
         assert_eq!(asm.feed(b"line"), Ok(None));
         assert_eq!(
             asm.feed(b"%end 1 13 1"),
-            Ok(Some(Frame::Reply { number: 13, ok: true, body: vec!["line".to_string()] }))
+            Ok(Some(Frame::Reply {
+                number: 13,
+                ok: true,
+                body: vec!["line".to_string()]
+            }))
         );
     }
 
     #[test]
     fn end_without_open_block_errors() {
         let mut asm = BlockAssembler::new();
-        assert!(matches!(asm.feed(b"%end 1 14 1"), Err(TmuxError::UnexpectedEnd { number: 14 })));
+        assert!(matches!(
+            asm.feed(b"%end 1 14 1"),
+            Err(TmuxError::UnexpectedEnd { number: 14 })
+        ));
     }
 
     #[test]
@@ -185,12 +210,18 @@ mod tests {
         assert_eq!(
             frames,
             vec![
-                Frame::Reply { number: 1, ok: true, body: Vec::new() },
+                Frame::Reply {
+                    number: 1,
+                    ok: true,
+                    body: Vec::new()
+                },
                 Frame::Notification(ControlEvent::SessionChanged {
                     session: SessionId(0),
                     name: "0".to_string(),
                 }),
-                Frame::Notification(ControlEvent::WindowAdd { window: WindowId(0) }),
+                Frame::Notification(ControlEvent::WindowAdd {
+                    window: WindowId(0)
+                }),
                 Frame::Notification(ControlEvent::Output {
                     pane: PaneId(0),
                     data: b"\x1b]0;ksh\x07$ ".to_vec(),

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -1,0 +1,38 @@
+//! Stateful assembler that groups `%begin`..`%end`/`%error` blocks into replies
+//! and passes standalone notifications through.
+
+use crate::error::TmuxResult;
+use crate::event::ControlEvent;
+
+/// A higher-level frame emitted by [`BlockAssembler`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Frame {
+    /// A completed command output block.
+    Reply {
+        /// The command number shared by the matching `%begin`/`%end`/`%error`.
+        number: u32,
+        /// `true` if closed by `%end`, `false` if closed by `%error`.
+        ok: bool,
+        /// Reply body lines, verbatim, in order.
+        body: Vec<String>,
+    },
+    /// A standalone notification that occurred outside any block.
+    Notification(ControlEvent),
+}
+
+/// Groups raw control-mode lines into [`Frame`]s, tracking the active block.
+#[derive(Debug, Default, Clone)]
+pub struct BlockAssembler;
+
+impl BlockAssembler {
+    /// Returns a new assembler with no block open.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Feeds one raw line, returning a completed [`Frame`] when one is ready.
+    pub fn feed(&mut self, line: &[u8]) -> TmuxResult<Option<Frame>> {
+        let _ = line;
+        todo!("BlockAssembler::feed")
+    }
+}

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -36,3 +36,170 @@ impl BlockAssembler {
         todo!("BlockAssembler::feed")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::TmuxError;
+    use crate::event::{PaneId, SessionId, WindowId};
+
+    fn feed_all(lines: &[&[u8]]) -> Vec<Frame> {
+        let mut asm = BlockAssembler::new();
+        let mut frames = Vec::new();
+        for line in lines {
+            if let Some(frame) = asm.feed(line).expect("feed should not error") {
+                frames.push(frame);
+            }
+        }
+        frames
+    }
+
+    #[test]
+    fn empty_reply_block() {
+        let frames = feed_all(&[b"%begin 1 7 1", b"%end 1 7 1"]);
+        assert_eq!(frames, vec![Frame::Reply { number: 7, ok: true, body: Vec::new() }]);
+    }
+
+    #[test]
+    fn multi_line_reply_body() {
+        let frames = feed_all(&[
+            b"%begin 1 8 1",
+            b"0: ksh* (1 panes) [80x24]",
+            b"1: bash- (1 panes) [80x24]",
+            b"%end 1 8 1",
+        ]);
+        assert_eq!(
+            frames,
+            vec![Frame::Reply {
+                number: 8,
+                ok: true,
+                body: vec![
+                    "0: ksh* (1 panes) [80x24]".to_string(),
+                    "1: bash- (1 panes) [80x24]".to_string(),
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn error_reply_block() {
+        let frames = feed_all(&[b"%begin 1 9 1", b"unknown command: bogus", b"%error 1 9 1"]);
+        assert_eq!(
+            frames,
+            vec![Frame::Reply {
+                number: 9,
+                ok: false,
+                body: vec!["unknown command: bogus".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn reply_body_line_starting_with_percent_stays_body() {
+        let frames = feed_all(&[
+            b"%begin 1 10 1",
+            b"%not-a-notification literally text",
+            b"%end 1 10 1",
+        ]);
+        assert_eq!(
+            frames,
+            vec![Frame::Reply {
+                number: 10,
+                ok: true,
+                body: vec!["%not-a-notification literally text".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn stray_end_with_wrong_number_stays_body() {
+        let frames = feed_all(&[b"%begin 1 11 1", b"%end 1 999 1", b"%end 1 11 1"]);
+        assert_eq!(
+            frames,
+            vec![Frame::Reply {
+                number: 11,
+                ok: true,
+                body: vec!["%end 1 999 1".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn standalone_notification_passes_through() {
+        let frames = feed_all(&[b"%window-add @1"]);
+        assert_eq!(
+            frames,
+            vec![Frame::Notification(ControlEvent::WindowAdd { window: WindowId(1) })]
+        );
+    }
+
+    #[test]
+    fn notifications_interleaved_with_blocks() {
+        let frames = feed_all(&[
+            b"%output %1 hi",
+            b"%begin 1 12 1",
+            b"reply",
+            b"%end 1 12 1",
+            b"%window-close @4",
+        ]);
+        assert_eq!(
+            frames,
+            vec![
+                Frame::Notification(ControlEvent::Output { pane: PaneId(1), data: b"hi".to_vec() }),
+                Frame::Reply { number: 12, ok: true, body: vec!["reply".to_string()] },
+                Frame::Notification(ControlEvent::WindowClose { window: WindowId(4) }),
+            ]
+        );
+    }
+
+    #[test]
+    fn mid_block_feed_returns_none() {
+        let mut asm = BlockAssembler::new();
+        assert_eq!(asm.feed(b"%begin 1 13 1"), Ok(None));
+        assert_eq!(asm.feed(b"line"), Ok(None));
+        assert_eq!(
+            asm.feed(b"%end 1 13 1"),
+            Ok(Some(Frame::Reply { number: 13, ok: true, body: vec!["line".to_string()] }))
+        );
+    }
+
+    #[test]
+    fn end_without_open_block_errors() {
+        let mut asm = BlockAssembler::new();
+        assert!(matches!(asm.feed(b"%end 1 14 1"), Err(TmuxError::UnexpectedEnd { number: 14 })));
+    }
+
+    #[test]
+    fn startup_transcript_produces_expected_frames() {
+        let transcript: &[&[u8]] = &[
+            b"%begin 1363006971 1 1",
+            b"%end 1363006971 1 1",
+            b"%session-changed $0 0",
+            b"%window-add @0",
+            b"%output %0 \\033]0;ksh\\007$ ",
+            b"%window-renamed @0 ksh",
+        ];
+
+        let frames = feed_all(transcript);
+
+        assert_eq!(
+            frames,
+            vec![
+                Frame::Reply { number: 1, ok: true, body: Vec::new() },
+                Frame::Notification(ControlEvent::SessionChanged {
+                    session: SessionId(0),
+                    name: "0".to_string(),
+                }),
+                Frame::Notification(ControlEvent::WindowAdd { window: WindowId(0) }),
+                Frame::Notification(ControlEvent::Output {
+                    pane: PaneId(0),
+                    data: b"\x1b]0;ksh\x07$ ".to_vec(),
+                }),
+                Frame::Notification(ControlEvent::WindowRenamed {
+                    window: WindowId(0),
+                    name: "ksh".to_string(),
+                }),
+            ]
+        );
+    }
+}

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -40,27 +40,25 @@ impl BlockAssembler {
     /// line is never reparsed as a notification.
     pub fn feed(&mut self, line: &[u8]) -> TmuxResult<Option<Frame>> {
         match self.open.take() {
-            Some(mut block) => match ControlEvent::parse(line) {
-                Ok(ControlEvent::End { number, .. }) if number == block.number => {
-                    Ok(Some(Frame::Reply {
+            Some(mut block) => {
+                let closed_ok = match ControlEvent::parse(line) {
+                    Ok(ControlEvent::End { number, .. }) if number == block.number => Some(true),
+                    Ok(ControlEvent::Error { number, .. }) if number == block.number => Some(false),
+                    _ => None,
+                };
+                match closed_ok {
+                    Some(ok) => Ok(Some(Frame::Reply {
                         number: block.number,
-                        ok: true,
+                        ok,
                         body: block.body,
-                    }))
+                    })),
+                    None => {
+                        block.body.push(String::from_utf8_lossy(line).into_owned());
+                        self.open = Some(block);
+                        Ok(None)
+                    }
                 }
-                Ok(ControlEvent::Error { number, .. }) if number == block.number => {
-                    Ok(Some(Frame::Reply {
-                        number: block.number,
-                        ok: false,
-                        body: block.body,
-                    }))
-                }
-                _ => {
-                    block.body.push(String::from_utf8_lossy(line).into_owned());
-                    self.open = Some(block);
-                    Ok(None)
-                }
-            },
+            }
             None => match ControlEvent::parse(line)? {
                 ControlEvent::Begin { number, .. } => {
                     self.open = Some(OpenBlock {

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -1,7 +1,7 @@
 //! Stateful assembler that groups `%begin`..`%end`/`%error` blocks into replies
 //! and passes standalone notifications through.
 
-use crate::error::TmuxResult;
+use crate::error::{TmuxError, TmuxResult};
 use crate::event::ControlEvent;
 
 /// A higher-level frame emitted by [`BlockAssembler`].
@@ -22,19 +22,66 @@ pub enum Frame {
 
 /// Groups raw control-mode lines into [`Frame`]s, tracking the active block.
 #[derive(Debug, Default, Clone)]
-pub struct BlockAssembler;
+pub struct BlockAssembler {
+    open: Option<OpenBlock>,
+}
 
 impl BlockAssembler {
     /// Returns a new assembler with no block open.
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 
     /// Feeds one raw line, returning a completed [`Frame`] when one is ready.
+    ///
+    /// Outside a block, a line is a standalone notification and `%begin` opens a
+    /// block. Inside a block, every line is collected verbatim until the
+    /// `%end`/`%error` whose command number matches the open `%begin` — a body
+    /// line is never reparsed as a notification.
     pub fn feed(&mut self, line: &[u8]) -> TmuxResult<Option<Frame>> {
-        let _ = line;
-        todo!("BlockAssembler::feed")
+        match self.open.take() {
+            Some(mut block) => match ControlEvent::parse(line) {
+                Ok(ControlEvent::End { number, .. }) if number == block.number => {
+                    Ok(Some(Frame::Reply {
+                        number: block.number,
+                        ok: true,
+                        body: block.body,
+                    }))
+                }
+                Ok(ControlEvent::Error { number, .. }) if number == block.number => {
+                    Ok(Some(Frame::Reply {
+                        number: block.number,
+                        ok: false,
+                        body: block.body,
+                    }))
+                }
+                _ => {
+                    block.body.push(String::from_utf8_lossy(line).into_owned());
+                    self.open = Some(block);
+                    Ok(None)
+                }
+            },
+            None => match ControlEvent::parse(line)? {
+                ControlEvent::Begin { number, .. } => {
+                    self.open = Some(OpenBlock {
+                        number,
+                        body: Vec::new(),
+                    });
+                    Ok(None)
+                }
+                ControlEvent::End { number, .. } | ControlEvent::Error { number, .. } => {
+                    Err(TmuxError::UnexpectedEnd { number })
+                }
+                event => Ok(Some(Frame::Notification(event))),
+            },
+        }
     }
+}
+
+#[derive(Debug, Clone)]
+struct OpenBlock {
+    number: u32,
+    body: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/tmux_control_parser/src/error.rs
+++ b/crates/tmux_control_parser/src/error.rs
@@ -63,4 +63,52 @@ pub enum TmuxError {
         /// The command number carried by the stray guard.
         number: u32,
     },
+
+    /// A tmux window-layout string was malformed.
+    #[error("invalid layout: {reason}")]
+    InvalidLayout {
+        /// The specific structural failure.
+        reason: LayoutError,
+    },
+}
+
+/// The specific structural failure behind a [`TmuxError::InvalidLayout`].
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum LayoutError {
+    /// The string had no comma separating checksum from body.
+    #[error("missing comma after checksum")]
+    MissingChecksumComma,
+
+    /// The checksum was not exactly 4 lowercase hex digits.
+    #[error("checksum must be 4 lowercase hex digits")]
+    BadChecksum,
+
+    /// Expected a specific literal byte that was absent.
+    #[error("expected byte {expected:?}")]
+    Expected {
+        /// The byte the grammar required at this position.
+        expected: u8,
+    },
+
+    /// A `,` introduced a pane id but no digits followed.
+    #[error("expected pane id digits after ','")]
+    ExpectedPaneId,
+
+    /// A split was never closed by its matching bracket.
+    #[error("unbalanced bracket, expected {expected:?}")]
+    UnbalancedBracket {
+        /// The closing byte (`}`, `]`, or `>`) that was expected.
+        expected: u8,
+    },
+
+    /// An unexpected byte appeared where a cell or separator was expected.
+    #[error("unexpected byte {byte:?}")]
+    UnexpectedByte {
+        /// The offending byte.
+        byte: u8,
+    },
+
+    /// Bytes remained after the root cell was fully parsed.
+    #[error("trailing data after layout root cell")]
+    TrailingData,
 }

--- a/crates/tmux_control_parser/src/error.rs
+++ b/crates/tmux_control_parser/src/error.rs
@@ -111,4 +111,8 @@ pub enum LayoutError {
     /// Bytes remained after the root cell was fully parsed.
     #[error("trailing data after layout root cell")]
     TrailingData,
+
+    /// The layout nested deeper than the supported limit.
+    #[error("layout nesting too deep")]
+    TooDeep,
 }

--- a/crates/tmux_control_parser/src/error.rs
+++ b/crates/tmux_control_parser/src/error.rs
@@ -1,0 +1,66 @@
+//! Error and result types for tmux control-mode parsing.
+
+use thiserror::Error;
+
+/// Result alias used throughout the parser.
+pub type TmuxResult<T = ()> = Result<T, TmuxError>;
+
+/// An error produced while parsing a control-mode line or assembling a block.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum TmuxError {
+    /// The line does not begin with `%`.
+    #[error("line does not start with '%'")]
+    NotControlLine,
+
+    /// The line was empty or whitespace-only.
+    #[error("empty or whitespace-only line")]
+    Empty,
+
+    /// A required positional field was missing from the line.
+    #[error("missing field '{field}' in {event}")]
+    MissingField {
+        /// The notification keyword being parsed (e.g. `window-renamed`).
+        event: &'static str,
+        /// The name of the absent field.
+        field: &'static str,
+    },
+
+    /// An entity id was malformed (bad/missing prefix or non-integer body).
+    #[error("invalid id {raw:?}, expected prefix '{expected}'")]
+    InvalidId {
+        /// The offending raw token.
+        raw: String,
+        /// The prefix that was expected (`%`, `@`, or `$`).
+        expected: char,
+    },
+
+    /// An integer field could not be parsed.
+    #[error("invalid integer for field '{field}': {raw:?}")]
+    InvalidInt {
+        /// The field whose integer parse failed.
+        field: &'static str,
+        /// The offending raw token.
+        raw: String,
+    },
+
+    /// A `\xxx` octal escape in `%output` data was malformed.
+    #[error("invalid octal escape: {raw:?}")]
+    InvalidOctal {
+        /// The offending escape fragment.
+        raw: String,
+    },
+
+    /// A text sub-slice (name, layout, reply body) was not valid UTF-8.
+    #[error("invalid UTF-8 in field '{field}'")]
+    InvalidUtf8 {
+        /// The field whose UTF-8 decode failed.
+        field: &'static str,
+    },
+
+    /// A `%end` / `%error` guard arrived with no open `%begin` block.
+    #[error("%end/%error with no open block (number {number})")]
+    UnexpectedEnd {
+        /// The command number carried by the stray guard.
+        number: u32,
+    },
+}

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -170,6 +170,15 @@ impl ControlEvent {
             b"%pause" => Ok(ControlEvent::Pause {
                 pane: fields.pane("pause")?,
             }),
+            b"%exit" => {
+                let rest = fields.rest();
+                let reason = if rest.is_empty() {
+                    None
+                } else {
+                    Some(text(rest, "reason")?)
+                };
+                Ok(ControlEvent::Exit { reason })
+            }
             _ => todo!("ControlEvent::parse"),
         }
     }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -52,8 +52,8 @@ pub enum ControlEvent {
 
     /// `%session-changed <session> <name>`.
     SessionChanged { session: SessionId, name: String },
-    /// `%session-renamed <name>`.
-    SessionRenamed { name: String },
+    /// `%session-renamed <session> <name>`.
+    SessionRenamed { session: SessionId, name: String },
     /// `%session-window-changed <session> <window>`.
     SessionWindowChanged {
         session: SessionId,
@@ -160,6 +160,7 @@ impl ControlEvent {
                 name: fields.name("session-changed")?,
             }),
             b"%session-renamed" => Ok(ControlEvent::SessionRenamed {
+                session: fields.session("session-renamed")?,
                 name: fields.name("session-renamed")?,
             }),
             b"%session-window-changed" => Ok(ControlEvent::SessionWindowChanged {
@@ -529,8 +530,9 @@ mod tests {
             }
         );
         assert_eq!(
-            ev(b"%session-renamed renamed"),
+            ev(b"%session-renamed $0 renamed"),
             ControlEvent::SessionRenamed {
+                session: SessionId(0),
                 name: "renamed".to_string()
             }
         );

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -149,6 +149,18 @@ impl ControlEvent {
             b"%unlinked-window-renamed" => Ok(ControlEvent::UnlinkedWindowRenamed {
                 window: fields.window("unlinked-window-renamed")?,
             }),
+            b"%session-changed" => Ok(ControlEvent::SessionChanged {
+                session: fields.session("session-changed")?,
+                name: fields.name("session-changed")?,
+            }),
+            b"%session-renamed" => Ok(ControlEvent::SessionRenamed {
+                name: fields.name("session-renamed")?,
+            }),
+            b"%session-window-changed" => Ok(ControlEvent::SessionWindowChanged {
+                session: fields.session("session-window-changed")?,
+                window: fields.window("session-window-changed")?,
+            }),
+            b"%sessions-changed" => Ok(ControlEvent::SessionsChanged),
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -224,6 +236,14 @@ impl<'a> Fields<'a> {
             field: "pane",
         })?;
         parse_id(bytes, b'%').map(PaneId)
+    }
+
+    fn session(&mut self, event: &'static str) -> TmuxResult<SessionId> {
+        let bytes = self.next().ok_or(TmuxError::MissingField {
+            event,
+            field: "session",
+        })?;
+        parse_id(bytes, b'$').map(SessionId)
     }
 
     fn name(&self, event: &'static str) -> TmuxResult<String> {

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -185,6 +185,12 @@ impl ControlEvent {
             b"%config-error" => Ok(ControlEvent::ConfigError {
                 message: fields.required_text("config-error", "message")?,
             }),
+            b"%paste-buffer-changed" => Ok(ControlEvent::PasteBufferChanged {
+                name: fields.name("paste-buffer-changed")?,
+            }),
+            b"%paste-buffer-deleted" => Ok(ControlEvent::PasteBufferDeleted {
+                name: fields.name("paste-buffer-deleted")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -1,6 +1,6 @@
 //! Parsed control-mode events and the typed entity ids they carry.
 
-use crate::error::TmuxResult;
+use crate::{TmuxError, error::TmuxResult};
 
 /// A tmux pane id (`%N`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -27,7 +27,11 @@ pub enum ControlEvent {
     /// `%output <pane> <data>` — pane output, octal-decoded to raw bytes.
     Output { pane: PaneId, data: Vec<u8> },
     /// `%extended-output <pane> <age> ... : <data>` — output with buffering age (ms).
-    ExtendedOutput { pane: PaneId, age: u64, data: Vec<u8> },
+    ExtendedOutput {
+        pane: PaneId,
+        age: u64,
+        data: Vec<u8>,
+    },
 
     /// `%window-add <window>`.
     WindowAdd { window: WindowId },
@@ -51,16 +55,28 @@ pub enum ControlEvent {
     /// `%session-renamed <name>`.
     SessionRenamed { name: String },
     /// `%session-window-changed <session> <window>`.
-    SessionWindowChanged { session: SessionId, window: WindowId },
+    SessionWindowChanged {
+        session: SessionId,
+        window: WindowId,
+    },
     /// `%sessions-changed`.
     SessionsChanged,
 
     /// `%client-detached <client>`.
     ClientDetached { client: String },
     /// `%client-session-changed <client> <session> <name>`.
-    ClientSessionChanged { client: String, session: SessionId, name: String },
+    ClientSessionChanged {
+        client: String,
+        session: SessionId,
+        name: String,
+    },
     /// `%layout-change <window> <layout> <visible-layout> <flags>`.
-    LayoutChange { window: WindowId, layout: String, visible_layout: String, flags: String },
+    LayoutChange {
+        window: WindowId,
+        layout: String,
+        visible_layout: String,
+        flags: String,
+    },
     /// `%continue <pane>`.
     Continue { pane: PaneId },
     /// `%pause <pane>`.
@@ -92,9 +108,95 @@ pub enum ControlEvent {
 impl ControlEvent {
     /// Parses a single control-mode line into a [`ControlEvent`].
     pub fn parse(line: &[u8]) -> TmuxResult<Self> {
-        let _ = line;
-        todo!("ControlEvent::parse")
+        let mut fields = Fields(line);
+        let argv = fields.next().ok_or(TmuxError::NotControlLine)?;
+        match argv {
+            b"%begin" => fields.parse_guard("begin", |time, number, flags| ControlEvent::Begin {
+                time,
+                number,
+                flags,
+            }),
+            b"%end" => fields.parse_guard("end", |time, number, flags| ControlEvent::End {
+                time,
+                number,
+                flags,
+            }),
+            b"%error" => fields.parse_guard("error", |time, number, flags| ControlEvent::Error {
+                time,
+                number,
+                flags,
+            }),
+            _ => todo!("ControlEvent::parse"),
+        }
     }
+}
+
+struct Fields<'a>(&'a [u8]);
+
+impl<'a> Fields<'a> {
+    /// Next space-delimited field, or None when exhausted.
+    fn next(&mut self) -> Option<&'a [u8]> {
+        if self.0.is_empty() {
+            return None;
+        }
+        match self.0.iter().position(|&b| b == b' ') {
+            Some(i) => {
+                let (field, rest) = self.0.split_at(i);
+                self.0 = &rest[1..]; // drop the single separating space
+                Some(field)
+            }
+            None => {
+                let field = self.0;
+                self.0 = &[];
+                Some(field)
+            }
+        }
+    }
+
+    /// Everything left, verbatim — the trailing name/message/value.
+    fn rest(&self) -> &'a [u8] {
+        self.0
+    }
+
+    fn parse_guard(
+        &mut self,
+        event: &'static str,
+        build: fn(u64, u32, u32) -> ControlEvent,
+    ) -> TmuxResult<ControlEvent> {
+        let time = int(
+            self.next().ok_or(TmuxError::MissingField {
+                event,
+                field: "time",
+            })?,
+            "time",
+        )?;
+        let number = int(
+            self.next().ok_or(TmuxError::MissingField {
+                event,
+                field: "number",
+            })?,
+            "number",
+        )?;
+        let flags = int(
+            self.next().ok_or(TmuxError::MissingField {
+                event,
+                field: "flags",
+            })?,
+            "flags",
+        )?;
+        Ok(build(time, number, flags))
+    }
+}
+
+/// Parses an ASCII integer field into `T`, mapping failures to [`TmuxError::InvalidInt`].
+fn int<T: core::str::FromStr>(bytes: &[u8], field: &'static str) -> TmuxResult<T> {
+    core::str::from_utf8(bytes)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| TmuxError::InvalidInt {
+            field,
+            raw: String::from_utf8_lossy(bytes).into_owned(),
+        })
 }
 
 #[cfg(test)]
@@ -110,60 +212,117 @@ mod tests {
     fn command_block_guards() {
         assert_eq!(
             ev(b"%begin 1363006971 2 1"),
-            ControlEvent::Begin { time: 1363006971, number: 2, flags: 1 }
+            ControlEvent::Begin {
+                time: 1363006971,
+                number: 2,
+                flags: 1
+            }
         );
         assert_eq!(
             ev(b"%end 1363006971 2 1"),
-            ControlEvent::End { time: 1363006971, number: 2, flags: 1 }
+            ControlEvent::End {
+                time: 1363006971,
+                number: 2,
+                flags: 1
+            }
         );
         assert_eq!(
             ev(b"%error 1363006971 2 1"),
-            ControlEvent::Error { time: 1363006971, number: 2, flags: 1 }
+            ControlEvent::Error {
+                time: 1363006971,
+                number: 2,
+                flags: 1
+            }
         );
     }
 
     #[test]
     fn window_lifecycle() {
-        assert_eq!(ev(b"%window-add @1"), ControlEvent::WindowAdd { window: WindowId(1) });
-        assert_eq!(ev(b"%window-close @2"), ControlEvent::WindowClose { window: WindowId(2) });
+        assert_eq!(
+            ev(b"%window-add @1"),
+            ControlEvent::WindowAdd {
+                window: WindowId(1)
+            }
+        );
+        assert_eq!(
+            ev(b"%window-close @2"),
+            ControlEvent::WindowClose {
+                window: WindowId(2)
+            }
+        );
         assert_eq!(
             ev(b"%window-renamed @3 my window"),
-            ControlEvent::WindowRenamed { window: WindowId(3), name: "my window".to_string() }
+            ControlEvent::WindowRenamed {
+                window: WindowId(3),
+                name: "my window".to_string()
+            }
         );
         assert_eq!(
             ev(b"%window-pane-changed @3 %7"),
-            ControlEvent::WindowPaneChanged { window: WindowId(3), pane: PaneId(7) }
+            ControlEvent::WindowPaneChanged {
+                window: WindowId(3),
+                pane: PaneId(7)
+            }
         );
     }
 
     #[test]
     fn unlinked_window() {
-        assert_eq!(ev(b"%unlinked-window-add @9"), ControlEvent::UnlinkedWindowAdd { window: WindowId(9) });
-        assert_eq!(ev(b"%unlinked-window-close @9"), ControlEvent::UnlinkedWindowClose { window: WindowId(9) });
-        assert_eq!(ev(b"%unlinked-window-renamed @9"), ControlEvent::UnlinkedWindowRenamed { window: WindowId(9) });
+        assert_eq!(
+            ev(b"%unlinked-window-add @9"),
+            ControlEvent::UnlinkedWindowAdd {
+                window: WindowId(9)
+            }
+        );
+        assert_eq!(
+            ev(b"%unlinked-window-close @9"),
+            ControlEvent::UnlinkedWindowClose {
+                window: WindowId(9)
+            }
+        );
+        assert_eq!(
+            ev(b"%unlinked-window-renamed @9"),
+            ControlEvent::UnlinkedWindowRenamed {
+                window: WindowId(9)
+            }
+        );
     }
 
     #[test]
     fn session_notifications() {
         assert_eq!(
             ev(b"%session-changed $1 main"),
-            ControlEvent::SessionChanged { session: SessionId(1), name: "main".to_string() }
+            ControlEvent::SessionChanged {
+                session: SessionId(1),
+                name: "main".to_string()
+            }
         );
         assert_eq!(
             ev(b"%session-renamed renamed"),
-            ControlEvent::SessionRenamed { name: "renamed".to_string() }
+            ControlEvent::SessionRenamed {
+                name: "renamed".to_string()
+            }
         );
         assert_eq!(
             ev(b"%session-window-changed $1 @4"),
-            ControlEvent::SessionWindowChanged { session: SessionId(1), window: WindowId(4) }
+            ControlEvent::SessionWindowChanged {
+                session: SessionId(1),
+                window: WindowId(4)
+            }
         );
         assert_eq!(ev(b"%sessions-changed"), ControlEvent::SessionsChanged);
     }
 
     #[test]
     fn pane_mode_continue_pause() {
-        assert_eq!(ev(b"%pane-mode-changed %5"), ControlEvent::PaneModeChanged { pane: PaneId(5) });
-        assert_eq!(ev(b"%continue %5"), ControlEvent::Continue { pane: PaneId(5) });
+        assert_eq!(
+            ev(b"%pane-mode-changed %5"),
+            ControlEvent::PaneModeChanged { pane: PaneId(5) }
+        );
+        assert_eq!(
+            ev(b"%continue %5"),
+            ControlEvent::Continue { pane: PaneId(5) }
+        );
         assert_eq!(ev(b"%pause %5"), ControlEvent::Pause { pane: PaneId(5) });
     }
 
@@ -171,7 +330,9 @@ mod tests {
     fn client_notifications() {
         assert_eq!(
             ev(b"%client-detached /dev/ttys003"),
-            ControlEvent::ClientDetached { client: "/dev/ttys003".to_string() }
+            ControlEvent::ClientDetached {
+                client: "/dev/ttys003".to_string()
+            }
         );
         assert_eq!(
             ev(b"%client-session-changed /dev/ttys003 $2 work"),
@@ -201,7 +362,9 @@ mod tests {
         assert_eq!(ev(b"%exit"), ControlEvent::Exit { reason: None });
         assert_eq!(
             ev(b"%exit server exited unexpectedly"),
-            ControlEvent::Exit { reason: Some("server exited unexpectedly".to_string()) }
+            ControlEvent::Exit {
+                reason: Some("server exited unexpectedly".to_string())
+            }
         );
     }
 
@@ -209,11 +372,15 @@ mod tests {
     fn message_and_config_error() {
         assert_eq!(
             ev(b"%message hello there"),
-            ControlEvent::Message { message: "hello there".to_string() }
+            ControlEvent::Message {
+                message: "hello there".to_string()
+            }
         );
         assert_eq!(
             ev(b"%config-error /home/u/.tmux.conf:3: unknown command"),
-            ControlEvent::ConfigError { message: "/home/u/.tmux.conf:3: unknown command".to_string() }
+            ControlEvent::ConfigError {
+                message: "/home/u/.tmux.conf:3: unknown command".to_string()
+            }
         );
     }
 
@@ -221,11 +388,15 @@ mod tests {
     fn paste_buffer_notifications() {
         assert_eq!(
             ev(b"%paste-buffer-changed buffer0"),
-            ControlEvent::PasteBufferChanged { name: "buffer0".to_string() }
+            ControlEvent::PasteBufferChanged {
+                name: "buffer0".to_string()
+            }
         );
         assert_eq!(
             ev(b"%paste-buffer-deleted buffer0"),
-            ControlEvent::PasteBufferDeleted { name: "buffer0".to_string() }
+            ControlEvent::PasteBufferDeleted {
+                name: "buffer0".to_string()
+            }
         );
     }
 
@@ -250,7 +421,10 @@ mod tests {
     fn output_octal_round_trip() {
         assert_eq!(
             ControlEvent::parse(b"%output %1 abc\\015\\012def"),
-            Ok(ControlEvent::Output { pane: PaneId(1), data: b"abc\r\ndef".to_vec() })
+            Ok(ControlEvent::Output {
+                pane: PaneId(1),
+                data: b"abc\r\ndef".to_vec()
+            })
         );
     }
 
@@ -258,7 +432,10 @@ mod tests {
     fn output_escaped_backslash() {
         assert_eq!(
             ControlEvent::parse(b"%output %1 a\\134b"),
-            Ok(ControlEvent::Output { pane: PaneId(1), data: b"a\\b".to_vec() })
+            Ok(ControlEvent::Output {
+                pane: PaneId(1),
+                data: b"a\\b".to_vec()
+            })
         );
     }
 
@@ -266,7 +443,10 @@ mod tests {
     fn output_value_keeps_spaces() {
         assert_eq!(
             ControlEvent::parse(b"%output %1 echo hello world"),
-            Ok(ControlEvent::Output { pane: PaneId(1), data: b"echo hello world".to_vec() })
+            Ok(ControlEvent::Output {
+                pane: PaneId(1),
+                data: b"echo hello world".to_vec()
+            })
         );
     }
 
@@ -274,7 +454,10 @@ mod tests {
     fn output_empty_value() {
         assert_eq!(
             ControlEvent::parse(b"%output %1 "),
-            Ok(ControlEvent::Output { pane: PaneId(1), data: Vec::new() })
+            Ok(ControlEvent::Output {
+                pane: PaneId(1),
+                data: Vec::new()
+            })
         );
     }
 
@@ -284,7 +467,10 @@ mod tests {
         line.extend_from_slice(&[0xC3, 0xA9]);
         assert_eq!(
             ControlEvent::parse(&line),
-            Ok(ControlEvent::Output { pane: PaneId(2), data: vec![b'c', b'a', b'f', 0xC3, 0xA9] })
+            Ok(ControlEvent::Output {
+                pane: PaneId(2),
+                data: vec![b'c', b'a', b'f', 0xC3, 0xA9]
+            })
         );
     }
 
@@ -292,7 +478,10 @@ mod tests {
     fn output_octal_escape_to_control_byte() {
         assert_eq!(
             ControlEvent::parse(b"%output %1 \\033[31m"),
-            Ok(ControlEvent::Output { pane: PaneId(1), data: vec![0x1b, b'[', b'3', b'1', b'm'] })
+            Ok(ControlEvent::Output {
+                pane: PaneId(1),
+                data: vec![0x1b, b'[', b'3', b'1', b'm']
+            })
         );
     }
 
@@ -300,7 +489,11 @@ mod tests {
     fn extended_output_basic() {
         assert_eq!(
             ControlEvent::parse(b"%extended-output %1 250 : abc\\015"),
-            Ok(ControlEvent::ExtendedOutput { pane: PaneId(1), age: 250, data: b"abc\r".to_vec() })
+            Ok(ControlEvent::ExtendedOutput {
+                pane: PaneId(1),
+                age: 250,
+                data: b"abc\r".to_vec()
+            })
         );
     }
 
@@ -308,7 +501,11 @@ mod tests {
     fn extended_output_skips_future_args() {
         assert_eq!(
             ControlEvent::parse(b"%extended-output %1 0 reserved1 reserved2 : data"),
-            Ok(ControlEvent::ExtendedOutput { pane: PaneId(1), age: 0, data: b"data".to_vec() })
+            Ok(ControlEvent::ExtendedOutput {
+                pane: PaneId(1),
+                age: 0,
+                data: b"data".to_vec()
+            })
         );
     }
 
@@ -346,7 +543,10 @@ mod tests {
 
     #[test]
     fn rejects_non_control_line() {
-        assert!(matches!(ControlEvent::parse(b"hello world"), Err(TmuxError::NotControlLine)));
+        assert!(matches!(
+            ControlEvent::parse(b"hello world"),
+            Err(TmuxError::NotControlLine)
+        ));
     }
 
     #[test]

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -126,6 +126,29 @@ impl ControlEvent {
                 number,
                 flags,
             }),
+            b"%window-add" => Ok(ControlEvent::WindowAdd {
+                window: fields.window("window-add")?,
+            }),
+            b"%window-close" => Ok(ControlEvent::WindowClose {
+                window: fields.window("window-close")?,
+            }),
+            b"%window-renamed" => Ok(ControlEvent::WindowRenamed {
+                window: fields.window("window-renamed")?,
+                name: fields.name("window-renamed")?,
+            }),
+            b"%window-pane-changed" => Ok(ControlEvent::WindowPaneChanged {
+                window: fields.window("window-pane-changed")?,
+                pane: fields.pane("window-pane-changed")?,
+            }),
+            b"%unlinked-window-add" => Ok(ControlEvent::UnlinkedWindowAdd {
+                window: fields.window("unlinked-window-add")?,
+            }),
+            b"%unlinked-window-close" => Ok(ControlEvent::UnlinkedWindowClose {
+                window: fields.window("unlinked-window-close")?,
+            }),
+            b"%unlinked-window-renamed" => Ok(ControlEvent::UnlinkedWindowRenamed {
+                window: fields.window("unlinked-window-renamed")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -186,6 +209,32 @@ impl<'a> Fields<'a> {
         )?;
         Ok(build(time, number, flags))
     }
+
+    fn window(&mut self, event: &'static str) -> TmuxResult<WindowId> {
+        let bytes = self.next().ok_or(TmuxError::MissingField {
+            event,
+            field: "window",
+        })?;
+        parse_id(bytes, b'@').map(WindowId)
+    }
+
+    fn pane(&mut self, event: &'static str) -> TmuxResult<PaneId> {
+        let bytes = self.next().ok_or(TmuxError::MissingField {
+            event,
+            field: "pane",
+        })?;
+        parse_id(bytes, b'%').map(PaneId)
+    }
+
+    fn name(&self, event: &'static str) -> TmuxResult<String> {
+        if self.0.is_empty() {
+            return Err(TmuxError::MissingField {
+                event,
+                field: "name",
+            });
+        }
+        text(self.rest(), "name")
+    }
 }
 
 /// Parses an ASCII integer field into `T`, mapping failures to [`TmuxError::InvalidInt`].
@@ -197,6 +246,28 @@ fn int<T: core::str::FromStr>(bytes: &[u8], field: &'static str) -> TmuxResult<T
             field,
             raw: String::from_utf8_lossy(bytes).into_owned(),
         })
+}
+
+/// Parses an entity id (`@3` / `%7` / `$1`) into its numeric part, checking the prefix.
+fn parse_id(bytes: &[u8], prefix: u8) -> TmuxResult<u32> {
+    let err = || TmuxError::InvalidId {
+        raw: String::from_utf8_lossy(bytes).into_owned(),
+        expected: prefix as char,
+    };
+    match bytes.split_first() {
+        Some((&p, rest)) if p == prefix => core::str::from_utf8(rest)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(err),
+        _ => Err(err()),
+    }
+}
+
+/// Decodes a byte slice tmux guarantees to be UTF-8 (name/layout/message) into a [`String`].
+fn text(bytes: &[u8], field: &'static str) -> TmuxResult<String> {
+    core::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|_| TmuxError::InvalidUtf8 { field })
 }
 
 #[cfg(test)]

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -221,6 +221,17 @@ impl ControlEvent {
                     value,
                 })
             }
+            b"%output" => Ok(ControlEvent::Output {
+                pane: fields.pane("output")?,
+                data: unescape_output(fields.rest())?,
+            }),
+            b"%extended-output" => {
+                let pane = fields.pane("extended-output")?;
+                let age = fields.int_field("extended-output", "age")?;
+                fields.skip_to_colon("extended-output")?;
+                let data = unescape_output(fields.rest())?;
+                Ok(ControlEvent::ExtendedOutput { pane, age, data })
+            }
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -313,10 +324,10 @@ impl<'a> Fields<'a> {
         int(bytes, field)
     }
 
-    fn skip_to_colon_value(&mut self, event: &'static str) -> TmuxResult<String> {
+    fn skip_to_colon(&mut self, event: &'static str) -> TmuxResult<()> {
         loop {
             match self.next() {
-                Some(b":") => break,
+                Some(b":") => return Ok(()),
                 Some(_) => {}
                 None => {
                     return Err(TmuxError::MissingField {
@@ -326,6 +337,10 @@ impl<'a> Fields<'a> {
                 }
             }
         }
+    }
+
+    fn skip_to_colon_value(&mut self, event: &'static str) -> TmuxResult<String> {
+        self.skip_to_colon(event)?;
         text(self.rest(), "value")
     }
 
@@ -372,6 +387,36 @@ fn text(bytes: &[u8], field: &'static str) -> TmuxResult<String> {
     core::str::from_utf8(bytes)
         .map(str::to_owned)
         .map_err(|_| TmuxError::InvalidUtf8 { field })
+}
+
+/// Decodes `%output` data: `\xxx` octal escapes back to bytes, others verbatim.
+fn unescape_output(bytes: &[u8]) -> TmuxResult<Vec<u8>> {
+    let invalid = |raw: &[u8]| TmuxError::InvalidOctal {
+        raw: String::from_utf8_lossy(raw).into_owned(),
+    };
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        match bytes.get(i + 1..i + 4) {
+            Some(triple) if triple.iter().all(|&d| matches!(d, b'0'..=b'7')) => {
+                let value = u16::from(triple[0] - b'0') * 64
+                    + u16::from(triple[1] - b'0') * 8
+                    + u16::from(triple[2] - b'0');
+                if value > u16::from(u8::MAX) {
+                    return Err(invalid(&bytes[i..i + 4]));
+                }
+                out.push(value as u8);
+                i += 4;
+            }
+            _ => return Err(invalid(&bytes[i..bytes.len().min(i + 4)])),
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -1,6 +1,6 @@
 //! Parsed control-mode events and the typed entity ids they carry.
 
-use crate::{TmuxError, error::TmuxResult};
+use crate::{TmuxError, error::TmuxResult, layout::WindowLayout};
 
 /// A tmux pane id (`%N`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -73,8 +73,8 @@ pub enum ControlEvent {
     /// `%layout-change <window> <layout> <visible-layout> <flags>`.
     LayoutChange {
         window: WindowId,
-        layout: String,
-        visible_layout: String,
+        layout: WindowLayout,
+        visible_layout: WindowLayout,
         flags: String,
     },
     /// `%continue <pane>`.
@@ -191,6 +191,12 @@ impl ControlEvent {
             b"%paste-buffer-deleted" => Ok(ControlEvent::PasteBufferDeleted {
                 name: fields.name("paste-buffer-deleted")?,
             }),
+            b"%layout-change" => Ok(ControlEvent::LayoutChange {
+                window: fields.window("layout-change")?,
+                layout: fields.layout("layout-change", "layout")?,
+                visible_layout: fields.layout("layout-change", "visible_layout")?,
+                flags: text(fields.rest(), "flags")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -276,6 +282,13 @@ impl<'a> Fields<'a> {
         parse_id(bytes, b'$').map(SessionId)
     }
 
+    fn layout(&mut self, event: &'static str, field: &'static str) -> TmuxResult<WindowLayout> {
+        let bytes = self
+            .next()
+            .ok_or(TmuxError::MissingField { event, field })?;
+        WindowLayout::parse(bytes)
+    }
+
     fn name(&self, event: &'static str) -> TmuxResult<String> {
         self.required_text(event, "name")
     }
@@ -325,6 +338,7 @@ fn text(bytes: &[u8], field: &'static str) -> TmuxResult<String> {
 mod tests {
     use super::*;
     use crate::error::TmuxError;
+    use crate::layout::{Cell, CellDims};
 
     fn ev(line: &[u8]) -> ControlEvent {
         ControlEvent::parse(line).expect("line should parse")
@@ -472,8 +486,30 @@ mod tests {
             ev(b"%layout-change @1 b25f,80x24,0,0,2 b25f,80x24,0,0,2 *"),
             ControlEvent::LayoutChange {
                 window: WindowId(1),
-                layout: "b25f,80x24,0,0,2".to_string(),
-                visible_layout: "b25f,80x24,0,0,2".to_string(),
+                layout: WindowLayout {
+                    checksum: 0xb25f,
+                    root: Cell::Leaf {
+                        dims: CellDims {
+                            width: 80,
+                            height: 24,
+                            xoff: 0,
+                            yoff: 0,
+                        },
+                        pane_id: Some(2),
+                    },
+                },
+                visible_layout: WindowLayout {
+                    checksum: 0xb25f,
+                    root: Cell::Leaf {
+                        dims: CellDims {
+                            width: 80,
+                            height: 24,
+                            xoff: 0,
+                            yoff: 0,
+                        },
+                        pane_id: Some(2),
+                    },
+                },
                 flags: "*".to_string(),
             }
         );

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -197,6 +197,14 @@ impl ControlEvent {
                 visible_layout: fields.layout("layout-change", "visible_layout")?,
                 flags: text(fields.rest(), "flags")?,
             }),
+            b"%client-detached" => Ok(ControlEvent::ClientDetached {
+                client: fields.required_text("client-detached", "client")?,
+            }),
+            b"%client-session-changed" => Ok(ControlEvent::ClientSessionChanged {
+                client: fields.token("client-session-changed", "client")?,
+                session: fields.session("client-session-changed")?,
+                name: fields.name("client-session-changed")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -287,6 +295,13 @@ impl<'a> Fields<'a> {
             .next()
             .ok_or(TmuxError::MissingField { event, field })?;
         WindowLayout::parse(bytes)
+    }
+
+    fn token(&mut self, event: &'static str, field: &'static str) -> TmuxResult<String> {
+        let bytes = self
+            .next()
+            .ok_or(TmuxError::MissingField { event, field })?;
+        text(bytes, field)
     }
 
     fn name(&self, event: &'static str) -> TmuxResult<String> {

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -1,5 +1,7 @@
 //! Parsed control-mode events and the typed entity ids they carry.
 
+use crate::error::TmuxResult;
+
 /// A tmux pane id (`%N`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PaneId(pub u32);
@@ -85,4 +87,321 @@ pub enum ControlEvent {
 
     /// An unrecognised `%keyword rest` line, kept for forward compatibility.
     Unknown { name: String, rest: String },
+}
+
+impl ControlEvent {
+    /// Parses a single control-mode line into a [`ControlEvent`].
+    pub fn parse(line: &[u8]) -> TmuxResult<Self> {
+        let _ = line;
+        todo!("ControlEvent::parse")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::TmuxError;
+
+    fn ev(line: &[u8]) -> ControlEvent {
+        ControlEvent::parse(line).expect("line should parse")
+    }
+
+    #[test]
+    fn command_block_guards() {
+        assert_eq!(
+            ev(b"%begin 1363006971 2 1"),
+            ControlEvent::Begin { time: 1363006971, number: 2, flags: 1 }
+        );
+        assert_eq!(
+            ev(b"%end 1363006971 2 1"),
+            ControlEvent::End { time: 1363006971, number: 2, flags: 1 }
+        );
+        assert_eq!(
+            ev(b"%error 1363006971 2 1"),
+            ControlEvent::Error { time: 1363006971, number: 2, flags: 1 }
+        );
+    }
+
+    #[test]
+    fn window_lifecycle() {
+        assert_eq!(ev(b"%window-add @1"), ControlEvent::WindowAdd { window: WindowId(1) });
+        assert_eq!(ev(b"%window-close @2"), ControlEvent::WindowClose { window: WindowId(2) });
+        assert_eq!(
+            ev(b"%window-renamed @3 my window"),
+            ControlEvent::WindowRenamed { window: WindowId(3), name: "my window".to_string() }
+        );
+        assert_eq!(
+            ev(b"%window-pane-changed @3 %7"),
+            ControlEvent::WindowPaneChanged { window: WindowId(3), pane: PaneId(7) }
+        );
+    }
+
+    #[test]
+    fn unlinked_window() {
+        assert_eq!(ev(b"%unlinked-window-add @9"), ControlEvent::UnlinkedWindowAdd { window: WindowId(9) });
+        assert_eq!(ev(b"%unlinked-window-close @9"), ControlEvent::UnlinkedWindowClose { window: WindowId(9) });
+        assert_eq!(ev(b"%unlinked-window-renamed @9"), ControlEvent::UnlinkedWindowRenamed { window: WindowId(9) });
+    }
+
+    #[test]
+    fn session_notifications() {
+        assert_eq!(
+            ev(b"%session-changed $1 main"),
+            ControlEvent::SessionChanged { session: SessionId(1), name: "main".to_string() }
+        );
+        assert_eq!(
+            ev(b"%session-renamed renamed"),
+            ControlEvent::SessionRenamed { name: "renamed".to_string() }
+        );
+        assert_eq!(
+            ev(b"%session-window-changed $1 @4"),
+            ControlEvent::SessionWindowChanged { session: SessionId(1), window: WindowId(4) }
+        );
+        assert_eq!(ev(b"%sessions-changed"), ControlEvent::SessionsChanged);
+    }
+
+    #[test]
+    fn pane_mode_continue_pause() {
+        assert_eq!(ev(b"%pane-mode-changed %5"), ControlEvent::PaneModeChanged { pane: PaneId(5) });
+        assert_eq!(ev(b"%continue %5"), ControlEvent::Continue { pane: PaneId(5) });
+        assert_eq!(ev(b"%pause %5"), ControlEvent::Pause { pane: PaneId(5) });
+    }
+
+    #[test]
+    fn client_notifications() {
+        assert_eq!(
+            ev(b"%client-detached /dev/ttys003"),
+            ControlEvent::ClientDetached { client: "/dev/ttys003".to_string() }
+        );
+        assert_eq!(
+            ev(b"%client-session-changed /dev/ttys003 $2 work"),
+            ControlEvent::ClientSessionChanged {
+                client: "/dev/ttys003".to_string(),
+                session: SessionId(2),
+                name: "work".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn layout_change() {
+        assert_eq!(
+            ev(b"%layout-change @1 b25f,80x24,0,0,2 b25f,80x24,0,0,2 *"),
+            ControlEvent::LayoutChange {
+                window: WindowId(1),
+                layout: "b25f,80x24,0,0,2".to_string(),
+                visible_layout: "b25f,80x24,0,0,2".to_string(),
+                flags: "*".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn exit_with_and_without_reason() {
+        assert_eq!(ev(b"%exit"), ControlEvent::Exit { reason: None });
+        assert_eq!(
+            ev(b"%exit server exited unexpectedly"),
+            ControlEvent::Exit { reason: Some("server exited unexpectedly".to_string()) }
+        );
+    }
+
+    #[test]
+    fn message_and_config_error() {
+        assert_eq!(
+            ev(b"%message hello there"),
+            ControlEvent::Message { message: "hello there".to_string() }
+        );
+        assert_eq!(
+            ev(b"%config-error /home/u/.tmux.conf:3: unknown command"),
+            ControlEvent::ConfigError { message: "/home/u/.tmux.conf:3: unknown command".to_string() }
+        );
+    }
+
+    #[test]
+    fn paste_buffer_notifications() {
+        assert_eq!(
+            ev(b"%paste-buffer-changed buffer0"),
+            ControlEvent::PasteBufferChanged { name: "buffer0".to_string() }
+        );
+        assert_eq!(
+            ev(b"%paste-buffer-deleted buffer0"),
+            ControlEvent::PasteBufferDeleted { name: "buffer0".to_string() }
+        );
+    }
+
+    #[test]
+    fn subscription_changed_documented_form() {
+        // TODO: verify against a live session — for session-scoped subscriptions the
+        // session/window/index/pane fields may be empty and require Option<>.
+        assert_eq!(
+            ev(b"%subscription-changed my-sub $1 @2 0 %3 : the-value"),
+            ControlEvent::SubscriptionChanged {
+                name: "my-sub".to_string(),
+                session: SessionId(1),
+                window: WindowId(2),
+                window_index: 0,
+                pane: PaneId(3),
+                value: "the-value".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn output_octal_round_trip() {
+        assert_eq!(
+            ControlEvent::parse(b"%output %1 abc\\015\\012def"),
+            Ok(ControlEvent::Output { pane: PaneId(1), data: b"abc\r\ndef".to_vec() })
+        );
+    }
+
+    #[test]
+    fn output_escaped_backslash() {
+        assert_eq!(
+            ControlEvent::parse(b"%output %1 a\\134b"),
+            Ok(ControlEvent::Output { pane: PaneId(1), data: b"a\\b".to_vec() })
+        );
+    }
+
+    #[test]
+    fn output_value_keeps_spaces() {
+        assert_eq!(
+            ControlEvent::parse(b"%output %1 echo hello world"),
+            Ok(ControlEvent::Output { pane: PaneId(1), data: b"echo hello world".to_vec() })
+        );
+    }
+
+    #[test]
+    fn output_empty_value() {
+        assert_eq!(
+            ControlEvent::parse(b"%output %1 "),
+            Ok(ControlEvent::Output { pane: PaneId(1), data: Vec::new() })
+        );
+    }
+
+    #[test]
+    fn output_passes_through_high_bytes() {
+        let mut line = b"%output %2 caf".to_vec();
+        line.extend_from_slice(&[0xC3, 0xA9]);
+        assert_eq!(
+            ControlEvent::parse(&line),
+            Ok(ControlEvent::Output { pane: PaneId(2), data: vec![b'c', b'a', b'f', 0xC3, 0xA9] })
+        );
+    }
+
+    #[test]
+    fn output_octal_escape_to_control_byte() {
+        assert_eq!(
+            ControlEvent::parse(b"%output %1 \\033[31m"),
+            Ok(ControlEvent::Output { pane: PaneId(1), data: vec![0x1b, b'[', b'3', b'1', b'm'] })
+        );
+    }
+
+    #[test]
+    fn extended_output_basic() {
+        assert_eq!(
+            ControlEvent::parse(b"%extended-output %1 250 : abc\\015"),
+            Ok(ControlEvent::ExtendedOutput { pane: PaneId(1), age: 250, data: b"abc\r".to_vec() })
+        );
+    }
+
+    #[test]
+    fn extended_output_skips_future_args() {
+        assert_eq!(
+            ControlEvent::parse(b"%extended-output %1 0 reserved1 reserved2 : data"),
+            Ok(ControlEvent::ExtendedOutput { pane: PaneId(1), age: 0, data: b"data".to_vec() })
+        );
+    }
+
+    #[test]
+    fn output_rejects_short_octal() {
+        assert!(matches!(
+            ControlEvent::parse(b"%output %1 ab\\01"),
+            Err(TmuxError::InvalidOctal { .. })
+        ));
+    }
+
+    #[test]
+    fn output_rejects_non_octal_digit() {
+        assert!(matches!(
+            ControlEvent::parse(b"%output %1 \\1a2"),
+            Err(TmuxError::InvalidOctal { .. })
+        ));
+    }
+
+    #[test]
+    fn output_rejects_overflow_octal() {
+        assert!(matches!(
+            ControlEvent::parse(b"%output %1 \\400"),
+            Err(TmuxError::InvalidOctal { .. })
+        ));
+    }
+
+    #[test]
+    fn output_rejects_trailing_backslash() {
+        assert!(matches!(
+            ControlEvent::parse(b"%output %1 abc\\"),
+            Err(TmuxError::InvalidOctal { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_control_line() {
+        assert!(matches!(ControlEvent::parse(b"hello world"), Err(TmuxError::NotControlLine)));
+    }
+
+    #[test]
+    fn rejects_empty_line() {
+        assert!(matches!(ControlEvent::parse(b""), Err(TmuxError::Empty)));
+    }
+
+    #[test]
+    fn rejects_id_without_prefix() {
+        assert!(matches!(
+            ControlEvent::parse(b"%window-add 3"),
+            Err(TmuxError::InvalidId { expected: '@', .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_id_with_wrong_prefix() {
+        assert!(matches!(
+            ControlEvent::parse(b"%window-add %3"),
+            Err(TmuxError::InvalidId { expected: '@', .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_numeric_id() {
+        assert!(matches!(
+            ControlEvent::parse(b"%window-add @x"),
+            Err(TmuxError::InvalidId { expected: '@', .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_field() {
+        assert!(matches!(
+            ControlEvent::parse(b"%window-renamed @3"),
+            Err(TmuxError::MissingField { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_bad_integer_in_guard() {
+        assert!(matches!(
+            ControlEvent::parse(b"%begin notanumber 2 1"),
+            Err(TmuxError::InvalidInt { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_notification_maps_to_unknown() {
+        assert_eq!(
+            ControlEvent::parse(b"%future-thing some args"),
+            Ok(ControlEvent::Unknown {
+                name: "future-thing".to_string(),
+                rest: "some args".to_string(),
+            })
+        );
+    }
 }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -108,8 +108,14 @@ pub enum ControlEvent {
 impl ControlEvent {
     /// Parses a single control-mode line into a [`ControlEvent`].
     pub fn parse(line: &[u8]) -> TmuxResult<Self> {
+        if line.iter().all(|b| b.is_ascii_whitespace()) {
+            return Err(TmuxError::Empty);
+        }
+        if line[0] != b'%' {
+            return Err(TmuxError::NotControlLine);
+        }
         let mut fields = Fields(line);
-        let argv = fields.next().ok_or(TmuxError::NotControlLine)?;
+        let argv = fields.next().ok_or(TmuxError::Empty)?;
         match argv {
             b"%begin" => fields.parse_guard("begin", |time, number, flags| ControlEvent::Begin {
                 time,
@@ -232,7 +238,11 @@ impl ControlEvent {
                 let data = unescape_output(fields.rest())?;
                 Ok(ControlEvent::ExtendedOutput { pane, age, data })
             }
-            _ => todo!("ControlEvent::parse"),
+            _ => {
+                let name = text(&argv[1..], "name")?;
+                let rest = text(fields.rest(), "rest")?;
+                Ok(ControlEvent::Unknown { name, rest })
+            }
         }
     }
 }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -179,6 +179,12 @@ impl ControlEvent {
                 };
                 Ok(ControlEvent::Exit { reason })
             }
+            b"%message" => Ok(ControlEvent::Message {
+                message: fields.required_text("message", "message")?,
+            }),
+            b"%config-error" => Ok(ControlEvent::ConfigError {
+                message: fields.required_text("config-error", "message")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -265,13 +271,14 @@ impl<'a> Fields<'a> {
     }
 
     fn name(&self, event: &'static str) -> TmuxResult<String> {
+        self.required_text(event, "name")
+    }
+
+    fn required_text(&self, event: &'static str, field: &'static str) -> TmuxResult<String> {
         if self.0.is_empty() {
-            return Err(TmuxError::MissingField {
-                event,
-                field: "name",
-            });
+            return Err(TmuxError::MissingField { event, field });
         }
-        text(self.rest(), "name")
+        text(self.rest(), field)
     }
 }
 

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -205,6 +205,22 @@ impl ControlEvent {
                 session: fields.session("client-session-changed")?,
                 name: fields.name("client-session-changed")?,
             }),
+            b"%subscription-changed" => {
+                let name = fields.token("subscription-changed", "name")?;
+                let session = fields.session("subscription-changed")?;
+                let window = fields.window("subscription-changed")?;
+                let window_index = fields.int_field("subscription-changed", "window_index")?;
+                let pane = fields.pane("subscription-changed")?;
+                let value = fields.skip_to_colon_value("subscription-changed")?;
+                Ok(ControlEvent::SubscriptionChanged {
+                    name,
+                    session,
+                    window,
+                    window_index,
+                    pane,
+                    value,
+                })
+            }
             _ => todo!("ControlEvent::parse"),
         }
     }
@@ -242,27 +258,9 @@ impl<'a> Fields<'a> {
         event: &'static str,
         build: fn(u64, u32, u32) -> ControlEvent,
     ) -> TmuxResult<ControlEvent> {
-        let time = int(
-            self.next().ok_or(TmuxError::MissingField {
-                event,
-                field: "time",
-            })?,
-            "time",
-        )?;
-        let number = int(
-            self.next().ok_or(TmuxError::MissingField {
-                event,
-                field: "number",
-            })?,
-            "number",
-        )?;
-        let flags = int(
-            self.next().ok_or(TmuxError::MissingField {
-                event,
-                field: "flags",
-            })?,
-            "flags",
-        )?;
+        let time = self.int_field(event, "time")?;
+        let number = self.int_field(event, "number")?;
+        let flags = self.int_field(event, "flags")?;
         Ok(build(time, number, flags))
     }
 
@@ -302,6 +300,33 @@ impl<'a> Fields<'a> {
             .next()
             .ok_or(TmuxError::MissingField { event, field })?;
         text(bytes, field)
+    }
+
+    fn int_field<T: core::str::FromStr>(
+        &mut self,
+        event: &'static str,
+        field: &'static str,
+    ) -> TmuxResult<T> {
+        let bytes = self
+            .next()
+            .ok_or(TmuxError::MissingField { event, field })?;
+        int(bytes, field)
+    }
+
+    fn skip_to_colon_value(&mut self, event: &'static str) -> TmuxResult<String> {
+        loop {
+            match self.next() {
+                Some(b":") => break,
+                Some(_) => {}
+                None => {
+                    return Err(TmuxError::MissingField {
+                        event,
+                        field: "value",
+                    });
+                }
+            }
+        }
+        text(self.rest(), "value")
     }
 
     fn name(&self, event: &'static str) -> TmuxResult<String> {

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -161,6 +161,15 @@ impl ControlEvent {
                 window: fields.window("session-window-changed")?,
             }),
             b"%sessions-changed" => Ok(ControlEvent::SessionsChanged),
+            b"%pane-mode-changed" => Ok(ControlEvent::PaneModeChanged {
+                pane: fields.pane("pane-mode-changed")?,
+            }),
+            b"%continue" => Ok(ControlEvent::Continue {
+                pane: fields.pane("continue")?,
+            }),
+            b"%pause" => Ok(ControlEvent::Pause {
+                pane: fields.pane("pause")?,
+            }),
             _ => todo!("ControlEvent::parse"),
         }
     }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -1,0 +1,88 @@
+//! Parsed control-mode events and the typed entity ids they carry.
+
+/// A tmux pane id (`%N`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PaneId(pub u32);
+
+/// A tmux window id (`@N`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WindowId(pub u32);
+
+/// A tmux session id (`$N`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionId(pub u32);
+
+/// A single parsed control-mode line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlEvent {
+    /// `%begin <time> <number> <flags>` — start of a command output block.
+    Begin { time: u64, number: u32, flags: u32 },
+    /// `%end <time> <number> <flags>` — successful end of a command output block.
+    End { time: u64, number: u32, flags: u32 },
+    /// `%error <time> <number> <flags>` — failed end of a command output block.
+    Error { time: u64, number: u32, flags: u32 },
+
+    /// `%output <pane> <data>` — pane output, octal-decoded to raw bytes.
+    Output { pane: PaneId, data: Vec<u8> },
+    /// `%extended-output <pane> <age> ... : <data>` — output with buffering age (ms).
+    ExtendedOutput { pane: PaneId, age: u64, data: Vec<u8> },
+
+    /// `%window-add <window>`.
+    WindowAdd { window: WindowId },
+    /// `%window-close <window>`.
+    WindowClose { window: WindowId },
+    /// `%window-renamed <window> <name>`.
+    WindowRenamed { window: WindowId, name: String },
+    /// `%window-pane-changed <window> <pane>`.
+    WindowPaneChanged { window: WindowId, pane: PaneId },
+    /// `%unlinked-window-add <window>`.
+    UnlinkedWindowAdd { window: WindowId },
+    /// `%unlinked-window-close <window>`.
+    UnlinkedWindowClose { window: WindowId },
+    /// `%unlinked-window-renamed <window>` (no name arg in tmux 3.6a).
+    UnlinkedWindowRenamed { window: WindowId },
+    /// `%pane-mode-changed <pane>`.
+    PaneModeChanged { pane: PaneId },
+
+    /// `%session-changed <session> <name>`.
+    SessionChanged { session: SessionId, name: String },
+    /// `%session-renamed <name>`.
+    SessionRenamed { name: String },
+    /// `%session-window-changed <session> <window>`.
+    SessionWindowChanged { session: SessionId, window: WindowId },
+    /// `%sessions-changed`.
+    SessionsChanged,
+
+    /// `%client-detached <client>`.
+    ClientDetached { client: String },
+    /// `%client-session-changed <client> <session> <name>`.
+    ClientSessionChanged { client: String, session: SessionId, name: String },
+    /// `%layout-change <window> <layout> <visible-layout> <flags>`.
+    LayoutChange { window: WindowId, layout: String, visible_layout: String, flags: String },
+    /// `%continue <pane>`.
+    Continue { pane: PaneId },
+    /// `%pause <pane>`.
+    Pause { pane: PaneId },
+    /// `%exit [reason]`.
+    Exit { reason: Option<String> },
+    /// `%message <message>`.
+    Message { message: String },
+    /// `%config-error <message>`.
+    ConfigError { message: String },
+    /// `%paste-buffer-changed <name>`.
+    PasteBufferChanged { name: String },
+    /// `%paste-buffer-deleted <name>`.
+    PasteBufferDeleted { name: String },
+    /// `%subscription-changed <name> <session> <window> <index> <pane> ... : <value>`.
+    SubscriptionChanged {
+        name: String,
+        session: SessionId,
+        window: WindowId,
+        window_index: i32,
+        pane: PaneId,
+        value: String,
+    },
+
+    /// An unrecognised `%keyword rest` line, kept for forward compatibility.
+    Unknown { name: String, rest: String },
+}

--- a/crates/tmux_control_parser/src/layout.rs
+++ b/crates/tmux_control_parser/src/layout.rs
@@ -80,7 +80,7 @@ impl WindowLayout {
         let checksum = parse_checksum(&input[..comma])?;
         let body = &input[comma + 1..];
         let mut cur = Cursor::new(body);
-        let root = parse_cell(&mut cur)?;
+        let root = parse_cell(&mut cur, 0)?;
         if !cur.at_end() {
             return Err(TmuxError::InvalidLayout {
                 reason: LayoutError::TrailingData,
@@ -199,7 +199,16 @@ fn parse_checksum(bytes: &[u8]) -> TmuxResult<u16> {
     Ok(value)
 }
 
-fn parse_cell(cur: &mut Cursor) -> TmuxResult<Cell> {
+/// Recursion-depth cap for nested splits; guards against a stack overflow on a
+/// pathologically nested layout string (tmux's own layouts are far shallower).
+const MAX_DEPTH: usize = 256;
+
+fn parse_cell(cur: &mut Cursor, depth: usize) -> TmuxResult<Cell> {
+    if depth > MAX_DEPTH {
+        return Err(TmuxError::InvalidLayout {
+            reason: LayoutError::TooDeep,
+        });
+    }
     let dims = parse_dims(cur)?;
     match cur.peek() {
         None => Ok(Cell::Leaf {
@@ -208,7 +217,7 @@ fn parse_cell(cur: &mut Cursor) -> TmuxResult<Cell> {
         }),
         Some(b'{') => {
             cur.bump();
-            let children = parse_children(cur, b'}')?;
+            let children = parse_children(cur, b'}', depth)?;
             Ok(Cell::Split {
                 dims,
                 dir: SplitDir::LeftRight,
@@ -217,7 +226,7 @@ fn parse_cell(cur: &mut Cursor) -> TmuxResult<Cell> {
         }
         Some(b'[') => {
             cur.bump();
-            let children = parse_children(cur, b']')?;
+            let children = parse_children(cur, b']', depth)?;
             Ok(Cell::Split {
                 dims,
                 dir: SplitDir::TopBottom,
@@ -226,7 +235,7 @@ fn parse_cell(cur: &mut Cursor) -> TmuxResult<Cell> {
         }
         Some(b'<') => {
             cur.bump();
-            let children = parse_children(cur, b'>')?;
+            let children = parse_children(cur, b'>', depth)?;
             Ok(Cell::Split {
                 dims,
                 dir: SplitDir::Floating,
@@ -281,10 +290,10 @@ fn parse_after_comma(cur: &mut Cursor, dims: CellDims) -> TmuxResult<Cell> {
     })
 }
 
-fn parse_children(cur: &mut Cursor, close: u8) -> TmuxResult<Vec<Cell>> {
+fn parse_children(cur: &mut Cursor, close: u8, depth: usize) -> TmuxResult<Vec<Cell>> {
     let mut children = Vec::new();
     loop {
-        children.push(parse_cell(cur)?);
+        children.push(parse_cell(cur, depth + 1)?);
         match cur.peek() {
             Some(b',') => cur.bump(),
             Some(b) if b == close => {
@@ -576,6 +585,22 @@ mod tests {
             err(b""),
             TmuxError::InvalidLayout {
                 reason: LayoutError::MissingChecksumComma
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_excessive_nesting() {
+        let mut s = b"0000,".to_vec();
+        for _ in 0..400 {
+            s.extend_from_slice(b"80x24,0,0{");
+        }
+        s.extend_from_slice(b"80x24,0,0,1");
+        s.resize(s.len() + 400, b'}');
+        assert!(matches!(
+            err(&s),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::TooDeep
             }
         ));
     }

--- a/crates/tmux_control_parser/src/layout.rs
+++ b/crates/tmux_control_parser/src/layout.rs
@@ -1,0 +1,582 @@
+//! Parser for tmux window-layout strings (e.g. `b25f,80x24,0,0,2`) into a
+//! typed recursive cell tree, mirroring tmux's `layout-custom.c` grammar.
+
+use crate::error::{LayoutError, TmuxError, TmuxResult};
+
+/// Orientation of a split cell, named after tmux's `{`/`[`/`<` delimiters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SplitDir {
+    /// `{ ... }` — children side-by-side, left to right.
+    LeftRight,
+    /// `[ ... ]` — children stacked, top to bottom.
+    TopBottom,
+    /// `< ... >` — floating/popup group (newer tmux).
+    Floating,
+}
+
+/// A cell's geometry within the window grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellDims {
+    /// Cell width in character cells (tmux `%u`).
+    pub width: u32,
+    /// Cell height in character cells (tmux `%u`).
+    pub height: u32,
+    /// Horizontal offset from the window origin (tmux `%d`, may be negative).
+    pub xoff: i32,
+    /// Vertical offset from the window origin (tmux `%d`, may be negative).
+    pub yoff: i32,
+}
+
+/// One node in the layout tree: a leaf pane or a split of child cells.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cell {
+    /// A pane. `pane_id` is `None` when the grammar's `x`-lookahead proved a
+    /// trailing comma was a sibling separator rather than a pane id.
+    Leaf {
+        /// Geometry of this pane.
+        dims: CellDims,
+        /// The tmux pane id, when present in the layout string.
+        pane_id: Option<u32>,
+    },
+    /// A container split into child cells along one axis (or a floating group).
+    Split {
+        /// Geometry of the container.
+        dims: CellDims,
+        /// Whether children run left-right (`{}`), top-bottom (`[]`), or float (`<>`).
+        dir: SplitDir,
+        /// The child cells, in layout order.
+        children: Vec<Cell>,
+    },
+}
+
+impl Cell {
+    /// Returns the geometry of this cell, regardless of leaf/split.
+    pub fn dims(&self) -> CellDims {
+        match self {
+            Cell::Leaf { dims, .. } | Cell::Split { dims, .. } => *dims,
+        }
+    }
+}
+
+/// A parsed window-layout string: the leading checksum plus the root cell.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowLayout {
+    /// The 16-bit checksum tmux prefixed (4 lowercase hex digits). Stored
+    /// verbatim; parsing never fails on a mismatch.
+    pub checksum: u16,
+    /// The root cell of the layout tree.
+    pub root: Cell,
+}
+
+impl WindowLayout {
+    /// Parses a `CHECKSUM,CELL` window-layout string into a typed tree.
+    pub fn parse(input: &[u8]) -> TmuxResult<Self> {
+        let comma = input
+            .iter()
+            .position(|&b| b == b',')
+            .ok_or(TmuxError::InvalidLayout {
+                reason: LayoutError::MissingChecksumComma,
+            })?;
+        let checksum = parse_checksum(&input[..comma])?;
+        let body = &input[comma + 1..];
+        let mut cur = Cursor::new(body);
+        let root = parse_cell(&mut cur)?;
+        if !cur.at_end() {
+            return Err(TmuxError::InvalidLayout {
+                reason: LayoutError::TrailingData,
+            });
+        }
+        Ok(WindowLayout { checksum, root })
+    }
+
+    /// Recomputes tmux's 16-bit rolling checksum over a layout body (the bytes
+    /// after the first comma of the original string).
+    pub fn recompute_checksum(body: &[u8]) -> u16 {
+        let mut csum: u16 = 0;
+        for &b in body {
+            csum = (csum >> 1).wrapping_add((csum & 1) << 15);
+            csum = csum.wrapping_add(b as u16);
+        }
+        csum
+    }
+
+    /// Returns `true` if the stored checksum matches a recomputation over `body`.
+    pub fn verify(&self, body: &[u8]) -> bool {
+        self.checksum == Self::recompute_checksum(body)
+    }
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) {
+        self.pos += 1;
+    }
+
+    fn at_end(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+
+    fn mark(&self) -> usize {
+        self.pos
+    }
+
+    fn reset(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
+    fn slice(&self, start: usize, end: usize) -> &'a [u8] {
+        &self.bytes[start..end]
+    }
+
+    fn expect(&mut self, byte: u8) -> TmuxResult<()> {
+        if self.peek() == Some(byte) {
+            self.bump();
+            Ok(())
+        } else {
+            Err(TmuxError::InvalidLayout {
+                reason: LayoutError::Expected { expected: byte },
+            })
+        }
+    }
+
+    fn skip_digits(&mut self) {
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.bump();
+        }
+    }
+
+    fn take_u32(&mut self, field: &'static str) -> TmuxResult<u32> {
+        let start = self.pos;
+        self.skip_digits();
+        parse_u32(self.slice(start, self.pos), field)
+    }
+
+    fn take_i32(&mut self, field: &'static str) -> TmuxResult<i32> {
+        let start = self.pos;
+        if self.peek() == Some(b'-') {
+            self.bump();
+        }
+        self.skip_digits();
+        let raw = self.slice(start, self.pos);
+        core::str::from_utf8(raw)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| TmuxError::InvalidInt {
+                field,
+                raw: String::from_utf8_lossy(raw).into_owned(),
+            })
+    }
+}
+
+fn parse_checksum(bytes: &[u8]) -> TmuxResult<u16> {
+    let bad = || TmuxError::InvalidLayout {
+        reason: LayoutError::BadChecksum,
+    };
+    if bytes.len() != 4 {
+        return Err(bad());
+    }
+    let mut value: u16 = 0;
+    for &b in bytes {
+        let nibble = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            _ => return Err(bad()),
+        };
+        value = (value << 4) | u16::from(nibble);
+    }
+    Ok(value)
+}
+
+fn parse_cell(cur: &mut Cursor) -> TmuxResult<Cell> {
+    let dims = parse_dims(cur)?;
+    match cur.peek() {
+        None => Ok(Cell::Leaf {
+            dims,
+            pane_id: None,
+        }),
+        Some(b'{') => {
+            cur.bump();
+            let children = parse_children(cur, b'}')?;
+            Ok(Cell::Split {
+                dims,
+                dir: SplitDir::LeftRight,
+                children,
+            })
+        }
+        Some(b'[') => {
+            cur.bump();
+            let children = parse_children(cur, b']')?;
+            Ok(Cell::Split {
+                dims,
+                dir: SplitDir::TopBottom,
+                children,
+            })
+        }
+        Some(b'<') => {
+            cur.bump();
+            let children = parse_children(cur, b'>')?;
+            Ok(Cell::Split {
+                dims,
+                dir: SplitDir::Floating,
+                children,
+            })
+        }
+        Some(b',') => parse_after_comma(cur, dims),
+        Some(byte) => Err(TmuxError::InvalidLayout {
+            reason: LayoutError::UnexpectedByte { byte },
+        }),
+    }
+}
+
+fn parse_dims(cur: &mut Cursor) -> TmuxResult<CellDims> {
+    let width = cur.take_u32("width")?;
+    cur.expect(b'x')?;
+    let height = cur.take_u32("height")?;
+    cur.expect(b',')?;
+    let xoff = cur.take_i32("xoff")?;
+    cur.expect(b',')?;
+    let yoff = cur.take_i32("yoff")?;
+    Ok(CellDims {
+        width,
+        height,
+        xoff,
+        yoff,
+    })
+}
+
+fn parse_after_comma(cur: &mut Cursor, dims: CellDims) -> TmuxResult<Cell> {
+    let save = cur.mark();
+    cur.bump();
+    let start = cur.mark();
+    cur.skip_digits();
+    if cur.peek() == Some(b'x') {
+        cur.reset(save);
+        return Ok(Cell::Leaf {
+            dims,
+            pane_id: None,
+        });
+    }
+    let end = cur.mark();
+    if end == start {
+        return Err(TmuxError::InvalidLayout {
+            reason: LayoutError::ExpectedPaneId,
+        });
+    }
+    let pane_id = parse_u32(cur.slice(start, end), "pane_id")?;
+    Ok(Cell::Leaf {
+        dims,
+        pane_id: Some(pane_id),
+    })
+}
+
+fn parse_children(cur: &mut Cursor, close: u8) -> TmuxResult<Vec<Cell>> {
+    let mut children = Vec::new();
+    loop {
+        children.push(parse_cell(cur)?);
+        match cur.peek() {
+            Some(b',') => cur.bump(),
+            Some(b) if b == close => {
+                cur.bump();
+                break;
+            }
+            _ => {
+                return Err(TmuxError::InvalidLayout {
+                    reason: LayoutError::UnbalancedBracket { expected: close },
+                });
+            }
+        }
+    }
+    Ok(children)
+}
+
+fn parse_u32(bytes: &[u8], field: &'static str) -> TmuxResult<u32> {
+    core::str::from_utf8(bytes)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| TmuxError::InvalidInt {
+            field,
+            raw: String::from_utf8_lossy(bytes).into_owned(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &[u8]) -> WindowLayout {
+        WindowLayout::parse(s).expect("should parse")
+    }
+
+    fn err(s: &[u8]) -> TmuxError {
+        WindowLayout::parse(s).unwrap_err()
+    }
+
+    fn leaf(width: u32, height: u32, xoff: i32, yoff: i32, pane_id: Option<u32>) -> Cell {
+        Cell::Leaf {
+            dims: CellDims {
+                width,
+                height,
+                xoff,
+                yoff,
+            },
+            pane_id,
+        }
+    }
+
+    #[test]
+    fn single_leaf() {
+        assert_eq!(
+            p(b"b25f,80x24,0,0,2"),
+            WindowLayout {
+                checksum: 0xb25f,
+                root: leaf(80, 24, 0, 0, Some(2)),
+            }
+        );
+    }
+
+    #[test]
+    fn single_leaf_no_id() {
+        assert_eq!(
+            p(b"0000,80x24,0,0"),
+            WindowLayout {
+                checksum: 0,
+                root: leaf(80, 24, 0, 0, None),
+            }
+        );
+    }
+
+    #[test]
+    fn left_right_split() {
+        assert_eq!(
+            p(b"0000,80x24,0,0{40x24,0,0,1,39x24,41,0,2}").root,
+            Cell::Split {
+                dims: CellDims {
+                    width: 80,
+                    height: 24,
+                    xoff: 0,
+                    yoff: 0,
+                },
+                dir: SplitDir::LeftRight,
+                children: vec![leaf(40, 24, 0, 0, Some(1)), leaf(39, 24, 41, 0, Some(2))],
+            }
+        );
+    }
+
+    #[test]
+    fn top_bottom_split() {
+        assert_eq!(
+            p(b"0000,80x24,0,0[80x12,0,0,1,80x11,0,13,2]").root,
+            Cell::Split {
+                dims: CellDims {
+                    width: 80,
+                    height: 24,
+                    xoff: 0,
+                    yoff: 0,
+                },
+                dir: SplitDir::TopBottom,
+                children: vec![leaf(80, 12, 0, 0, Some(1)), leaf(80, 11, 0, 13, Some(2))],
+            }
+        );
+    }
+
+    #[test]
+    fn nested_mixed() {
+        let root = p(b"0000,80x24,0,0{40x24,0,0,1,39x24,41,0[39x12,41,0,2,39x11,41,13,3]}").root;
+        assert_eq!(
+            root,
+            Cell::Split {
+                dims: CellDims {
+                    width: 80,
+                    height: 24,
+                    xoff: 0,
+                    yoff: 0,
+                },
+                dir: SplitDir::LeftRight,
+                children: vec![
+                    leaf(40, 24, 0, 0, Some(1)),
+                    Cell::Split {
+                        dims: CellDims {
+                            width: 39,
+                            height: 24,
+                            xoff: 41,
+                            yoff: 0,
+                        },
+                        dir: SplitDir::TopBottom,
+                        children: vec![leaf(39, 12, 41, 0, Some(2)), leaf(39, 11, 41, 13, Some(3))],
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn pane_id_vs_x_ambiguity() {
+        // First child `40x24,0,0` has NO pane id: the comma before `39` is a
+        // sibling separator because `39` is followed by `x`.
+        let root = p(b"0000,80x24,0,0{40x24,0,0,39x24,41,0,2}").root;
+        let Cell::Split { children, .. } = root else {
+            panic!("expected split");
+        };
+        assert_eq!(children[0], leaf(40, 24, 0, 0, None));
+        assert_eq!(children[1], leaf(39, 24, 41, 0, Some(2)));
+    }
+
+    #[test]
+    fn pane_id_present_contrast() {
+        // Same shape, but the first child carries id 7 (`,7,` — the byte after
+        // the digit is `,`, not `x`), proving the lookahead flips correctly.
+        let root = p(b"0000,80x24,0,0{40x24,0,0,7,39x24,41,0,2}").root;
+        let Cell::Split { children, .. } = root else {
+            panic!("expected split");
+        };
+        assert_eq!(children[0], leaf(40, 24, 0, 0, Some(7)));
+        assert_eq!(children[1], leaf(39, 24, 41, 0, Some(2)));
+    }
+
+    #[test]
+    fn floating_group() {
+        let root = p(b"0000,80x24,0,0<40x24,0,0,1,39x24,41,0,2>").root;
+        assert!(matches!(
+            root,
+            Cell::Split {
+                dir: SplitDir::Floating,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn negative_offsets() {
+        assert_eq!(p(b"0000,80x24,-3,-5,1").root, leaf(80, 24, -3, -5, Some(1)));
+    }
+
+    #[test]
+    fn multi_digit_ids_and_dims() {
+        assert_eq!(
+            p(b"0000,200x150,0,0,123").root,
+            leaf(200, 150, 0, 0, Some(123))
+        );
+    }
+
+    #[test]
+    fn checksum_recompute_matches_tmux() {
+        assert_eq!(WindowLayout::recompute_checksum(b"80x24,0,0,2"), 0xb25f);
+    }
+
+    #[test]
+    fn checksum_mismatch_is_lenient() {
+        let wl = p(b"0000,80x24,0,0,2");
+        assert_eq!(wl.checksum, 0);
+        assert!(!wl.verify(b"80x24,0,0,2"));
+    }
+
+    #[test]
+    fn missing_checksum_comma() {
+        assert!(matches!(
+            err(b"b25f80x24"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::MissingChecksumComma
+            }
+        ));
+    }
+
+    #[test]
+    fn bad_checksum_too_short() {
+        assert!(matches!(
+            err(b"b2f,80x24,0,0,2"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::BadChecksum
+            }
+        ));
+    }
+
+    #[test]
+    fn bad_checksum_uppercase() {
+        assert!(matches!(
+            err(b"B25F,80x24,0,0,2"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::BadChecksum
+            }
+        ));
+    }
+
+    #[test]
+    fn bad_checksum_non_hex() {
+        assert!(matches!(
+            err(b"b2zf,80x24,0,0,2"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::BadChecksum
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_x_in_dims() {
+        assert!(matches!(
+            err(b"0000,8024,0,0,2"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::Expected { expected: b'x' }
+            }
+        ));
+    }
+
+    #[test]
+    fn non_numeric_dims() {
+        assert!(matches!(
+            err(b"0000,AAxBB,0,0,1"),
+            TmuxError::InvalidInt { field: "width", .. }
+        ));
+    }
+
+    #[test]
+    fn comma_then_no_pane_digits() {
+        assert!(matches!(
+            err(b"0000,80x24,0,0,}"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::ExpectedPaneId
+            }
+        ));
+    }
+
+    #[test]
+    fn unbalanced_open_brace() {
+        assert!(matches!(
+            err(b"0000,80x24,0,0{40x24,0,0,1"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::UnbalancedBracket { expected: b'}' }
+            }
+        ));
+    }
+
+    #[test]
+    fn trailing_junk() {
+        assert!(matches!(
+            err(b"b25f,80x24,0,0,2}"),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::TrailingData
+            }
+        ));
+    }
+
+    #[test]
+    fn empty_input() {
+        assert!(matches!(
+            err(b""),
+            TmuxError::InvalidLayout {
+                reason: LayoutError::MissingChecksumComma
+            }
+        ));
+    }
+}

--- a/crates/tmux_control_parser/src/lib.rs
+++ b/crates/tmux_control_parser/src/lib.rs
@@ -8,9 +8,3 @@ pub use crate::event::{ControlEvent, PaneId, SessionId, WindowId};
 pub mod assembler;
 pub mod error;
 pub mod event;
-
-/// Parses a single control-mode line into a [`ControlEvent`].
-pub fn parse_line(line: &[u8]) -> TmuxResult<ControlEvent> {
-    let _ = line;
-    todo!("parse_line")
-}

--- a/crates/tmux_control_parser/src/lib.rs
+++ b/crates/tmux_control_parser/src/lib.rs
@@ -2,9 +2,11 @@
 //! parser plus a stateful block assembler.
 
 pub use crate::assembler::{BlockAssembler, Frame};
-pub use crate::error::{TmuxError, TmuxResult};
+pub use crate::error::{LayoutError, TmuxError, TmuxResult};
 pub use crate::event::{ControlEvent, PaneId, SessionId, WindowId};
+pub use crate::layout::{Cell, CellDims, SplitDir, WindowLayout};
 
 pub mod assembler;
 pub mod error;
 pub mod event;
+pub mod layout;

--- a/crates/tmux_control_parser/src/lib.rs
+++ b/crates/tmux_control_parser/src/lib.rs
@@ -1,0 +1,16 @@
+//! Parser for tmux control-mode (`tmux -CC`) output: a stateless per-line
+//! parser plus a stateful block assembler.
+
+pub use crate::assembler::{BlockAssembler, Frame};
+pub use crate::error::{TmuxError, TmuxResult};
+pub use crate::event::{ControlEvent, PaneId, SessionId, WindowId};
+
+pub mod assembler;
+pub mod error;
+pub mod event;
+
+/// Parses a single control-mode line into a [`ControlEvent`].
+pub fn parse_line(line: &[u8]) -> TmuxResult<ControlEvent> {
+    let _ = line;
+    todo!("parse_line")
+}


### PR DESCRIPTION
## Problem

ozmux を tmux control mode (`tmux -CC`) のクライアントとして動かすには、tmux から受信するフレーム（非同期通知とコマンド応答ブロックが同一ストリームに混在）を構造化してパースする層が必要ですが、これまで存在しませんでした。

## Solution

新しいワークスペースクレート **`crates/tmux_control_parser`** を追加しました。`man tmux` 3.6a の CONTROL MODE 仕様 + tmux ソース + **実機キャプチャ**で検証した、2層構成のパーサです。依存は `thiserror` のみ（`bevy` / `multiplexer` 非依存で、変換は上位の消費側に委ねる）。

**Layer 1 — `ControlEvent::parse(&[u8]) -> TmuxResult<ControlEvent>`**（ステートレス／行単位）
- 全 control-mode 通知・ガード（`%begin`/`%end`/`%error`）・`%window-*`/`%session-*`/`%client-*`/`%pane-mode-changed`/`%continue`/`%pause`/`%exit`/`%message`/`%config-error`/`%paste-buffer-*`/`%subscription-changed` を網羅
- `%output` / `%extended-output` は8進エスケープ `\xxx` を復号して `Vec<u8>` に（**バイト指向入力** — pane 出力は非UTF-8を含むため）
- 未知の `%keyword` は `ControlEvent::Unknown` に退避（前方互換）

**Layer 2 — `BlockAssembler::feed(&[u8]) -> TmuxResult<Option<Frame>>`**（ステートフル）
- `%begin..%end/%error` ブロックを number 一致で組み立て `Frame::Reply` に、それ以外は `Frame::Notification` として通過。ブロック本文は verbatim 収集（再パースしない）

**`src/layout.rs`** — window-layout 文字列（例 `b25f,80x24,0,0,2`）の再帰下降パーサ
- typed Cell ツリー（`{}`=左右 / `[]`=上下 / `<>`=floating、leaf の pane-id、署名付きオフセット）
- pane-id-vs-`x` の先読み、寛容な u16 チェックサム、**再帰深度ガード（stack overflow 防止）**

### 検証 / レビュー
- house-style の in-module `#[cfg(test)]` ユニットテスト、**64/64 緑・`clippy --all-targets` クリーン・`todo!()` ゼロ**
- `/code-review max --fix` で3件修正：**`%session-renamed` が実機では `$<id> <name>`**（man ページの誤りを live capture で確認）／layout の再帰深度ガード／assembler のアーム重複解消

### Affected
新クレート `crates/tmux_control_parser`（workspace member として自動追加）。**既存コードへの変更なし**。

### Breaking Changes
なし（新規追加のみ。まだ消費者はいない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
