### PR TITLE
feat(tmux_control): TmuxServer + attachable-session listing (list_sessions)

### DIFF
--- a/crates/tmux_control/src/error.rs
+++ b/crates/tmux_control/src/error.rs
@@ -23,6 +23,12 @@ pub enum TmuxError {
     /// A command string contained an embedded newline.
     #[error("command contains an embedded newline")]
     InvalidCommand,
+    /// A `list-sessions` output line could not be parsed.
+    #[error("malformed list-sessions line: {line}")]
+    MalformedSessionList {
+        /// The offending line, verbatim.
+        line: String,
+    },
     /// Spawning the tmux process failed.
     // NOTE: `Io` carries `#[from]`, so `?` on an io::Error yields `Io`, not
     // `Spawn`. Construct `Spawn(e)` explicitly via `map_err` at spawn sites.

--- a/crates/tmux_control/src/lib.rs
+++ b/crates/tmux_control/src/lib.rs
@@ -3,9 +3,12 @@
 
 pub use crate::error::{TmuxError, TmuxResult};
 pub use crate::protocol::{ClientEvent, CommandId, ProtocolClient};
+pub use crate::session::SessionInfo;
 pub use crate::transport::{TmuxBuilder, TmuxClient, TmuxHandle, TransportEvent};
 pub use tmux_control_parser::ControlEvent;
+pub use tmux_control_parser::SessionId;
 
 mod error;
 mod protocol;
+mod session;
 mod transport;

--- a/crates/tmux_control/src/lib.rs
+++ b/crates/tmux_control/src/lib.rs
@@ -4,7 +4,7 @@
 pub use crate::error::{TmuxError, TmuxResult};
 pub use crate::protocol::{ClientEvent, CommandId, ProtocolClient};
 pub use crate::session::SessionInfo;
-pub use crate::transport::{TmuxBuilder, TmuxClient, TmuxHandle, TransportEvent};
+pub use crate::transport::{TmuxClient, TmuxHandle, TmuxServer, TransportEvent};
 pub use tmux_control_parser::ControlEvent;
 pub use tmux_control_parser::SessionId;
 

--- a/crates/tmux_control/src/session.rs
+++ b/crates/tmux_control/src/session.rs
@@ -1,0 +1,182 @@
+//! Sans-IO parsing of `tmux list-sessions` output into typed [`SessionInfo`].
+
+use crate::error::{TmuxError, TmuxResult};
+use std::str;
+use tmux_control_parser::SessionId;
+
+/// A tmux session reported by `list-sessions`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionInfo {
+    /// tmux session id (`$N`).
+    pub id: SessionId,
+    /// Session name (may contain spaces, never a raw tab).
+    pub name: String,
+    /// Number of windows in the session.
+    pub windows: u32,
+    /// Whether at least one client is attached.
+    pub attached: bool,
+    /// Session creation time (unix seconds).
+    pub created: u64,
+}
+
+// NOTE: real tab bytes (0x09) separate the fields — `session_name` is LAST so a
+// `splitn(5, b'\t')` keeps the free-text name in the final field even if a
+// delimiter ever leaks in. tmux escapes a tab in a name to the literal `\t`.
+pub(crate) const LIST_FORMAT: &str =
+    "#{session_id}\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{session_name}";
+
+impl SessionInfo {
+    /// Parses the tab-separated `list-sessions -F` output (one session per line).
+    pub fn parse_list(output: &[u8]) -> TmuxResult<Vec<SessionInfo>> {
+        let mut sessions = Vec::new();
+        for line in output.split(|&b| b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            sessions.push(parse_line(line)?);
+        }
+        Ok(sessions)
+    }
+}
+
+fn parse_line(line: &[u8]) -> TmuxResult<SessionInfo> {
+    let mut fields = line.splitn(5, |&b| b == b'\t');
+    let id = fields.next().and_then(parse_session_id).ok_or_else(|| malformed(line))?;
+    let windows = fields.next().and_then(parse_u32).ok_or_else(|| malformed(line))?;
+    let attached = fields.next().and_then(parse_u32).ok_or_else(|| malformed(line))? > 0;
+    let created = fields.next().and_then(parse_u64).ok_or_else(|| malformed(line))?;
+    let name_bytes = fields.next().ok_or_else(|| malformed(line))?;
+    let name = str::from_utf8(name_bytes).map_err(|_| malformed(line))?.to_string();
+    Ok(SessionInfo { id, name, windows, attached, created })
+}
+
+fn malformed(line: &[u8]) -> TmuxError {
+    TmuxError::MalformedSessionList {
+        line: String::from_utf8_lossy(line).into_owned(),
+    }
+}
+
+fn parse_session_id(field: &[u8]) -> Option<SessionId> {
+    let digits = field.strip_prefix(b"$")?;
+    Some(SessionId(str::from_utf8(digits).ok()?.parse().ok()?))
+}
+
+fn parse_u32(field: &[u8]) -> Option<u32> {
+    str::from_utf8(field).ok()?.parse().ok()
+}
+
+fn parse_u64(field: &[u8]) -> Option<u64> {
+    str::from_utf8(field).ok()?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_session() {
+        let out = b"$0\t3\t1\t1781400000\tmain\n";
+        assert_eq!(
+            SessionInfo::parse_list(out).unwrap(),
+            vec![SessionInfo {
+                id: SessionId(0),
+                name: "main".to_string(),
+                windows: 3,
+                attached: true,
+                created: 1781400000,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_multiple_preserves_order() {
+        let out = b"$0\t1\t0\t10\tone\n$1\t2\t1\t20\ttwo\n";
+        let got = SessionInfo::parse_list(out).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!((got[0].id, got[0].name.as_str()), (SessionId(0), "one"));
+        assert_eq!((got[1].id, got[1].name.as_str()), (SessionId(1), "two"));
+    }
+
+    #[test]
+    fn parse_empty_input() {
+        assert_eq!(SessionInfo::parse_list(b"").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn trailing_newline_optional() {
+        let with = SessionInfo::parse_list(b"$0\t1\t0\t1\tx\n").unwrap();
+        let without = SessionInfo::parse_list(b"$0\t1\t0\t1\tx").unwrap();
+        assert_eq!(with, without);
+    }
+
+    #[test]
+    fn name_with_spaces() {
+        let out = b"$5\t1\t0\t1\tmy work session\n";
+        assert_eq!(SessionInfo::parse_list(out).unwrap()[0].name, "my work session");
+    }
+
+    #[test]
+    fn attached_count_to_bool() {
+        let out = b"$0\t1\t0\t1\ta\n$1\t1\t1\t1\tb\n$2\t1\t2\t1\tc\n";
+        let got = SessionInfo::parse_list(out).unwrap();
+        assert_eq!(
+            (got[0].attached, got[1].attached, got[2].attached),
+            (false, true, true)
+        );
+    }
+
+    #[test]
+    fn too_few_fields_errors() {
+        let out = b"$0\t1\t0\t1\n"; // only 4 fields (no name)
+        assert!(matches!(
+            SessionInfo::parse_list(out),
+            Err(TmuxError::MalformedSessionList { .. })
+        ));
+    }
+
+    #[test]
+    fn non_numeric_field_errors() {
+        let out = b"$0\tnotnum\t0\t1\tx\n";
+        assert!(matches!(
+            SessionInfo::parse_list(out),
+            Err(TmuxError::MalformedSessionList { .. })
+        ));
+    }
+
+    #[test]
+    fn bad_id_errors() {
+        let no_dollar = b"0\t1\t0\t1\tx\n";
+        let non_numeric = b"$x\t1\t0\t1\tx\n";
+        assert!(matches!(
+            SessionInfo::parse_list(no_dollar),
+            Err(TmuxError::MalformedSessionList { .. })
+        ));
+        assert!(matches!(
+            SessionInfo::parse_list(non_numeric),
+            Err(TmuxError::MalformedSessionList { .. })
+        ));
+    }
+
+    #[test]
+    fn blank_lines_skipped() {
+        let out = b"\n$0\t1\t0\t1\tx\n\n";
+        assert_eq!(SessionInfo::parse_list(out).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn invalid_utf8_name_errors() {
+        let out = b"$0\t1\t0\t1\t\xff\xfe\n";
+        assert!(matches!(
+            SessionInfo::parse_list(out),
+            Err(TmuxError::MalformedSessionList { .. })
+        ));
+    }
+
+    #[test]
+    fn escaped_tab_in_name_kept_verbatim() {
+        // tmux escapes a real tab in a name to the literal `\t` (backslash + t);
+        // name-last + splitn keep it intact, no column shift.
+        let out = b"$2\t1\t0\t1\tx\\ty\n";
+        assert_eq!(SessionInfo::parse_list(out).unwrap()[0].name, "x\\ty");
+    }
+}

--- a/crates/tmux_control/src/session.rs
+++ b/crates/tmux_control/src/session.rs
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn too_few_fields_errors() {
-        let out = b"$0\t1\t0\t1\n"; // only 4 fields (no name)
+        let out = b"$0\t1\t0\t1\n";
         assert!(matches!(
             SessionInfo::parse_list(out),
             Err(TmuxError::MalformedSessionList { .. })
@@ -174,8 +174,6 @@ mod tests {
 
     #[test]
     fn escaped_tab_in_name_kept_verbatim() {
-        // tmux escapes a real tab in a name to the literal `\t` (backslash + t);
-        // name-last + splitn keep it intact, no column shift.
         let out = b"$2\t1\t0\t1\tx\\ty\n";
         assert_eq!(SessionInfo::parse_list(out).unwrap()[0].name, "x\\ty");
     }

--- a/crates/tmux_control/src/session.rs
+++ b/crates/tmux_control/src/session.rs
@@ -41,13 +41,34 @@ impl SessionInfo {
 
 fn parse_line(line: &[u8]) -> TmuxResult<SessionInfo> {
     let mut fields = line.splitn(5, |&b| b == b'\t');
-    let id = fields.next().and_then(parse_session_id).ok_or_else(|| malformed(line))?;
-    let windows = fields.next().and_then(parse_u32).ok_or_else(|| malformed(line))?;
-    let attached = fields.next().and_then(parse_u32).ok_or_else(|| malformed(line))? > 0;
-    let created = fields.next().and_then(parse_u64).ok_or_else(|| malformed(line))?;
+    let id = fields
+        .next()
+        .and_then(parse_session_id)
+        .ok_or_else(|| malformed(line))?;
+    let windows = fields
+        .next()
+        .and_then(parse_u32)
+        .ok_or_else(|| malformed(line))?;
+    let attached = fields
+        .next()
+        .and_then(parse_u32)
+        .ok_or_else(|| malformed(line))?
+        > 0;
+    let created = fields
+        .next()
+        .and_then(parse_u64)
+        .ok_or_else(|| malformed(line))?;
     let name_bytes = fields.next().ok_or_else(|| malformed(line))?;
-    let name = str::from_utf8(name_bytes).map_err(|_| malformed(line))?.to_string();
-    Ok(SessionInfo { id, name, windows, attached, created })
+    let name = str::from_utf8(name_bytes)
+        .map_err(|_| malformed(line))?
+        .to_string();
+    Ok(SessionInfo {
+        id,
+        name,
+        windows,
+        attached,
+        created,
+    })
 }
 
 fn malformed(line: &[u8]) -> TmuxError {
@@ -112,7 +133,10 @@ mod tests {
     #[test]
     fn name_with_spaces() {
         let out = b"$5\t1\t0\t1\tmy work session\n";
-        assert_eq!(SessionInfo::parse_list(out).unwrap()[0].name, "my work session");
+        assert_eq!(
+            SessionInfo::parse_list(out).unwrap()[0].name,
+            "my work session"
+        );
     }
 
     #[test]

--- a/crates/tmux_control/src/session.rs
+++ b/crates/tmux_control/src/session.rs
@@ -29,7 +29,10 @@ impl SessionInfo {
     /// Parses the tab-separated `list-sessions -F` output (one session per line).
     pub fn parse_list(output: &[u8]) -> TmuxResult<Vec<SessionInfo>> {
         let mut sessions = Vec::new();
-        for line in output.split(|&b| b == b'\n') {
+        for mut line in output.split(|&b| b == b'\n') {
+            if let [rest @ .., b'\r'] = line {
+                line = rest;
+            }
             if line.is_empty() {
                 continue;
             }
@@ -128,6 +131,12 @@ mod tests {
         let with = SessionInfo::parse_list(b"$0\t1\t0\t1\tx\n").unwrap();
         let without = SessionInfo::parse_list(b"$0\t1\t0\t1\tx").unwrap();
         assert_eq!(with, without);
+    }
+
+    #[test]
+    fn crlf_trailing_cr_stripped_from_name() {
+        let out = b"$0\t1\t0\t1\tmain\r\n";
+        assert_eq!(SessionInfo::parse_list(out).unwrap()[0].name, "main");
     }
 
     #[test]

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -3,6 +3,7 @@
 
 use crate::error::{TmuxError, TmuxResult};
 use crate::protocol::{ClientEvent, CommandId, ProtocolClient};
+use crate::session::{LIST_FORMAT, SessionInfo};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use std::io::{Read, Write};
@@ -70,6 +71,28 @@ impl TmuxServer {
     /// Opens a control connection on a fresh session (`tmux -CC new-session`).
     pub fn new_session(&self) -> TmuxResult<TmuxClient> {
         self.spawn(&["new-session"])
+    }
+
+    /// Lists attachable sessions (`tmux [..] list-sessions -F ..`, plain pipe, no
+    /// control mode). Returns `Ok(vec![])` when no server is running.
+    pub fn list_sessions(&self) -> TmuxResult<Vec<SessionInfo>> {
+        let output = std::process::Command::new(&self.program)
+            .args(self.list_sessions_argv())
+            .stdin(std::process::Stdio::null())
+            .output()
+            .map_err(TmuxError::Spawn)?;
+        classify_list_result(output.status.success(), &output.stdout, &output.stderr)
+    }
+
+    /// The argv (after the program) for the list-sessions query, for callers that
+    /// own their own I/O (e.g. running it off the Bevy main thread) and then call
+    /// [`SessionInfo::parse_list`].
+    pub fn list_sessions_argv(&self) -> Vec<String> {
+        let mut argv = self.socket_args();
+        argv.push("list-sessions".to_string());
+        argv.push("-F".to_string());
+        argv.push(LIST_FORMAT.to_string());
+        argv
     }
 
     fn socket_args(&self) -> Vec<String> {
@@ -216,6 +239,21 @@ fn spawn_err(e: impl std::fmt::Display) -> TmuxError {
     TmuxError::Spawn(std::io::Error::other(e.to_string()))
 }
 
+fn classify_list_result(ok: bool, stdout: &[u8], stderr: &[u8]) -> TmuxResult<Vec<SessionInfo>> {
+    if ok {
+        return SessionInfo::parse_list(stdout);
+    }
+    let stderr = String::from_utf8_lossy(stderr);
+    let no_server = stdout.is_empty()
+        && (stderr.contains("no server running")
+            || (stderr.contains("error connecting") && stderr.contains("No such file or directory")));
+    if no_server {
+        Ok(Vec::new())
+    } else {
+        Err(TmuxError::Spawn(std::io::Error::other(stderr.trim().to_string())))
+    }
+}
+
 #[cfg(unix)]
 fn disable_pty_echo(fd: std::os::unix::io::RawFd) {
     // SAFETY: `fd` is the live PTY master fd owned by the `MasterPty` kept in
@@ -281,6 +319,7 @@ fn pump<R: Read>(
 mod tests {
     use super::*;
     use crate::ControlEvent;
+    use crate::SessionId;
     use std::collections::VecDeque;
     use tmux_control_parser::WindowId;
 
@@ -527,6 +566,62 @@ mod tests {
             let _ = h2.send("from-thread");
         });
         t.join().unwrap();
+    }
+
+    #[test]
+    fn list_sessions_argv_default() {
+        assert_eq!(
+            TmuxServer::new().list_sessions_argv(),
+            argv(&["list-sessions", "-F", LIST_FORMAT])
+        );
+    }
+
+    #[test]
+    fn list_sessions_argv_socket_name() {
+        assert_eq!(
+            TmuxServer::new().socket_name("foo").list_sessions_argv(),
+            argv(&["-L", "foo", "list-sessions", "-F", LIST_FORMAT])
+        );
+    }
+
+    #[test]
+    fn list_format_uses_real_tab_and_name_last() {
+        assert!(LIST_FORMAT.as_bytes().contains(&b'\t'));
+        assert!(!LIST_FORMAT.contains("\\t"));
+        assert!(LIST_FORMAT.ends_with("#{session_name}"));
+    }
+
+    #[test]
+    fn classify_ok_parses_stdout() {
+        let out = b"$0\t1\t0\t1\tmain\n";
+        assert_eq!(
+            classify_list_result(true, out, b"").unwrap(),
+            vec![SessionInfo {
+                id: SessionId(0),
+                name: "main".to_string(),
+                windows: 1,
+                attached: false,
+                created: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn classify_no_server_running_is_empty() {
+        let stderr = b"no server running on /tmp/tmux-501/foo\n";
+        assert_eq!(classify_list_result(false, b"", stderr).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn classify_socket_missing_is_empty() {
+        let stderr = b"error connecting to /tmp/tmux-501/foo (No such file or directory)\n";
+        assert_eq!(classify_list_result(false, b"", stderr).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn classify_real_error_is_err() {
+        let stderr = b"error connecting to /tmp/tmux-501/foo (Operation not permitted)\n";
+        assert!(classify_list_result(false, b"", stderr).is_err());
     }
 
     #[test]

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -691,4 +691,25 @@ mod tests {
 
         let _ = client.handle().send("kill-session");
     }
+
+    #[test]
+    #[ignore = "requires a real tmux binary"]
+    fn real_tmux_list_sessions() {
+        use std::time::Duration;
+
+        let socket = format!("ozmux-ls-{}", std::process::id());
+        let server = TmuxServer::new().socket_name(&socket);
+
+        assert_eq!(server.list_sessions().expect("list (no server)"), vec![]);
+
+        let client = server.new_session().expect("spawn tmux -CC new-session");
+        std::thread::sleep(Duration::from_millis(500));
+
+        let sessions = server.list_sessions().expect("list");
+        assert!(!sessions.is_empty(), "expected at least one session");
+        assert!(sessions[0].windows >= 1);
+
+        let _ = client.handle().send("kill-server");
+        drop(client);
+    }
 }

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -259,9 +259,13 @@ fn classify_list_result(ok: bool, stdout: &[u8], stderr: &[u8]) -> TmuxResult<Ve
     if no_server {
         Ok(Vec::new())
     } else {
-        Err(TmuxError::Spawn(std::io::Error::other(
-            stderr.trim().to_string(),
-        )))
+        let message = stderr.trim();
+        let message = if message.is_empty() {
+            "tmux list-sessions failed"
+        } else {
+            message
+        };
+        Err(TmuxError::Spawn(std::io::Error::other(message.to_string())))
     }
 }
 
@@ -655,6 +659,15 @@ mod tests {
     fn classify_real_error_is_err() {
         let stderr = b"error connecting to /tmp/tmux-501/foo (Operation not permitted)\n";
         assert!(classify_list_result(false, b"", stderr).is_err());
+    }
+
+    #[test]
+    fn classify_blank_stderr_still_has_message() {
+        let err = classify_list_result(false, b"", b"").unwrap_err();
+        let TmuxError::Spawn(io) = err else {
+            panic!("expected Spawn");
+        };
+        assert!(!io.to_string().is_empty());
     }
 
     #[test]

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -703,11 +703,20 @@ mod tests {
         assert_eq!(server.list_sessions().expect("list (no server)"), vec![]);
 
         let client = server.new_session().expect("spawn tmux -CC new-session");
+        let name = format!("ozmux-ls-sess-{}", std::process::id());
+        client
+            .handle()
+            .send(&format!("rename-session {name}"))
+            .expect("rename-session");
         std::thread::sleep(Duration::from_millis(500));
 
         let sessions = server.list_sessions().expect("list");
-        assert!(!sessions.is_empty(), "expected at least one session");
-        assert!(sessions[0].windows >= 1);
+        let found = sessions
+            .iter()
+            .find(|s| s.name == name)
+            .expect("created session listed by name");
+        assert!(found.attached, "the -CC client is attached");
+        assert!(found.windows >= 1);
 
         let _ = client.handle().send("kill-server");
         drop(client);

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -21,23 +21,26 @@ pub enum TransportEvent {
     },
 }
 
-/// Builder for launching `tmux -CC`; the `-CC` flag is always injected.
-pub struct TmuxBuilder {
-    program: String,
-    socket_name: Option<String>,
-    socket_path: Option<String>,
-    subcommand: Vec<String>,
+/// Which tmux server socket to talk to.
+#[derive(Clone)]
+enum Socket {
+    Default,
+    Name(String), // -L
+    Path(String), // -S
 }
 
-impl TmuxBuilder {
-    /// Returns a builder defaulting to the `tmux` binary on `PATH`.
+/// A reusable handle to a tmux server on a given socket (config only; holds no
+/// connection or threads). Lists sessions and opens control connections.
+#[derive(Clone)]
+pub struct TmuxServer {
+    program: String,
+    socket: Socket,
+}
+
+impl TmuxServer {
+    /// Returns a server targeting the default socket via the `tmux` binary on `PATH`.
     pub fn new() -> Self {
-        Self {
-            program: "tmux".to_string(),
-            socket_name: None,
-            socket_path: None,
-            subcommand: Vec::new(),
-        }
+        Self { program: "tmux".to_string(), socket: Socket::Default }
     }
 
     /// Overrides the tmux binary path.
@@ -46,57 +49,47 @@ impl TmuxBuilder {
         self
     }
 
-    /// Sets the server socket name (`-L`).
+    /// Targets the named server socket (`-L`). Overrides any prior socket choice.
     pub fn socket_name(mut self, name: &str) -> Self {
-        self.socket_name = Some(name.to_string());
+        self.socket = Socket::Name(name.to_string());
         self
     }
 
-    /// Sets the server socket path (`-S`).
+    /// Targets the server socket path (`-S`). Overrides any prior socket choice.
     pub fn socket_path(mut self, path: &str) -> Self {
-        self.socket_path = Some(path.to_string());
+        self.socket = Socket::Path(path.to_string());
         self
     }
 
-    /// Launches `tmux -CC new-session`.
-    pub fn new_session(mut self) -> TmuxResult<TmuxClient> {
-        self.subcommand = vec!["new-session".to_string()];
-        self.spawn()
+    /// Opens a control connection by attaching to `name`
+    /// (`tmux -CC attach-session -t name`).
+    pub fn attach(&self, name: &str) -> TmuxResult<TmuxClient> {
+        self.spawn(&["attach-session", "-t", name])
     }
 
-    /// Launches `tmux -CC attach-session -t <name>`.
-    pub fn attach(mut self, name: &str) -> TmuxResult<TmuxClient> {
-        self.subcommand = vec![
-            "attach-session".to_string(),
-            "-t".to_string(),
-            name.to_string(),
-        ];
-        self.spawn()
+    /// Opens a control connection on a fresh session (`tmux -CC new-session`).
+    pub fn new_session(&self) -> TmuxResult<TmuxClient> {
+        self.spawn(&["new-session"])
     }
 
-    fn build_argv(&self) -> Vec<String> {
-        let mut argv = Vec::new();
-        if let Some(name) = &self.socket_name {
-            argv.push("-L".to_string());
-            argv.push(name.clone());
+    fn socket_args(&self) -> Vec<String> {
+        match &self.socket {
+            Socket::Default => Vec::new(),
+            Socket::Name(name) => vec!["-L".to_string(), name.clone()],
+            Socket::Path(path) => vec!["-S".to_string(), path.clone()],
         }
-        if let Some(path) = &self.socket_path {
-            argv.push("-S".to_string());
-            argv.push(path.clone());
-        }
+    }
+
+    fn connect_argv(&self, subcommand: &[&str]) -> Vec<String> {
+        let mut argv = self.socket_args();
         argv.push("-CC".to_string());
-        argv.extend(self.subcommand.iter().cloned());
+        argv.extend(subcommand.iter().map(|s| s.to_string()));
         argv
     }
 
-    fn spawn(self) -> TmuxResult<TmuxClient> {
+    fn spawn(&self, subcommand: &[&str]) -> TmuxResult<TmuxClient> {
         let pair = native_pty_system()
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
+            .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
             .map_err(spawn_err)?;
 
         // NOTE: disable PTY echo before tmux starts. Otherwise our command
@@ -109,7 +102,7 @@ impl TmuxBuilder {
         }
 
         let mut cmd = CommandBuilder::new(&self.program);
-        for arg in self.build_argv() {
+        for arg in self.connect_argv(subcommand) {
             cmd.arg(arg);
         }
         let child = pair.slave.spawn_command(cmd).map_err(spawn_err)?;
@@ -137,7 +130,7 @@ impl TmuxBuilder {
     }
 }
 
-impl Default for TmuxBuilder {
+impl Default for TmuxServer {
     fn default() -> Self {
         Self::new()
     }
@@ -359,33 +352,34 @@ mod tests {
     }
 
     #[test]
-    fn build_argv_new_session() {
-        let mut b = TmuxBuilder::new();
-        b.subcommand = vec!["new-session".to_string()];
-        assert_eq!(b.build_argv(), argv(&["-CC", "new-session"]));
+    fn connect_argv_new_session() {
+        assert_eq!(
+            TmuxServer::new().connect_argv(&["new-session"]),
+            argv(&["-CC", "new-session"])
+        );
     }
 
     #[test]
-    fn build_argv_attach() {
-        let mut b = TmuxBuilder::new();
-        b.subcommand = vec!["attach-session".into(), "-t".into(), "work".into()];
+    fn connect_argv_attach() {
         assert_eq!(
-            b.build_argv(),
+            TmuxServer::new().connect_argv(&["attach-session", "-t", "work"]),
             argv(&["-CC", "attach-session", "-t", "work"])
         );
     }
 
     #[test]
-    fn build_argv_socket_name() {
-        let b = TmuxBuilder::new().socket_name("foo");
-        assert_eq!(b.build_argv(), argv(&["-L", "foo", "-CC"]));
+    fn connect_argv_socket_name() {
+        assert_eq!(
+            TmuxServer::new().socket_name("foo").connect_argv(&["new-session"]),
+            argv(&["-L", "foo", "-CC", "new-session"])
+        );
     }
 
     #[test]
-    fn build_argv_default_program_and_cc() {
-        let b = TmuxBuilder::new();
-        assert_eq!(b.program, "tmux");
-        assert_eq!(b.build_argv(), argv(&["-CC"]));
+    fn connect_argv_default_program_and_cc() {
+        let server = TmuxServer::new();
+        assert_eq!(server.program, "tmux");
+        assert_eq!(server.connect_argv(&[]), argv(&["-CC"]));
     }
 
     #[test]
@@ -541,10 +535,8 @@ mod tests {
         use std::time::{Duration, Instant};
 
         let socket = format!("ozmux-test-{}", std::process::id());
-        let client = TmuxBuilder::new()
-            .socket_name(&socket)
-            .new_session()
-            .expect("spawn tmux -CC new-session");
+        let server = TmuxServer::new().socket_name(&socket);
+        let client = server.new_session().expect("spawn tmux -CC new-session");
 
         let id = client.handle().send("list-panes").expect("send list-panes");
 

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -26,8 +26,8 @@ pub enum TransportEvent {
 #[derive(Clone)]
 enum Socket {
     Default,
-    Name(String), // -L
-    Path(String), // -S
+    Name(String),
+    Path(String),
 }
 
 /// A reusable handle to a tmux server on a given socket (config only; holds no
@@ -41,7 +41,10 @@ pub struct TmuxServer {
 impl TmuxServer {
     /// Returns a server targeting the default socket via the `tmux` binary on `PATH`.
     pub fn new() -> Self {
-        Self { program: "tmux".to_string(), socket: Socket::Default }
+        Self {
+            program: "tmux".to_string(),
+            socket: Socket::Default,
+        }
     }
 
     /// Overrides the tmux binary path.
@@ -112,7 +115,12 @@ impl TmuxServer {
 
     fn spawn(&self, subcommand: &[&str]) -> TmuxResult<TmuxClient> {
         let pair = native_pty_system()
-            .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
             .map_err(spawn_err)?;
 
         // NOTE: disable PTY echo before tmux starts. Otherwise our command
@@ -246,11 +254,14 @@ fn classify_list_result(ok: bool, stdout: &[u8], stderr: &[u8]) -> TmuxResult<Ve
     let stderr = String::from_utf8_lossy(stderr);
     let no_server = stdout.is_empty()
         && (stderr.contains("no server running")
-            || (stderr.contains("error connecting") && stderr.contains("No such file or directory")));
+            || (stderr.contains("error connecting")
+                && stderr.contains("No such file or directory")));
     if no_server {
         Ok(Vec::new())
     } else {
-        Err(TmuxError::Spawn(std::io::Error::other(stderr.trim().to_string())))
+        Err(TmuxError::Spawn(std::io::Error::other(
+            stderr.trim().to_string(),
+        )))
     }
 }
 
@@ -409,8 +420,20 @@ mod tests {
     #[test]
     fn connect_argv_socket_name() {
         assert_eq!(
-            TmuxServer::new().socket_name("foo").connect_argv(&["new-session"]),
+            TmuxServer::new()
+                .socket_name("foo")
+                .connect_argv(&["new-session"]),
             argv(&["-L", "foo", "-CC", "new-session"])
+        );
+    }
+
+    #[test]
+    fn connect_argv_socket_path() {
+        assert_eq!(
+            TmuxServer::new()
+                .socket_path("/tmp/foo")
+                .connect_argv(&["new-session"]),
+            argv(&["-S", "/tmp/foo", "-CC", "new-session"])
         );
     }
 
@@ -581,6 +604,16 @@ mod tests {
         assert_eq!(
             TmuxServer::new().socket_name("foo").list_sessions_argv(),
             argv(&["-L", "foo", "list-sessions", "-F", LIST_FORMAT])
+        );
+    }
+
+    #[test]
+    fn list_sessions_argv_socket_path() {
+        assert_eq!(
+            TmuxServer::new()
+                .socket_path("/tmp/foo")
+                .list_sessions_argv(),
+            argv(&["-S", "/tmp/foo", "list-sessions", "-F", LIST_FORMAT])
         );
     }
 


### PR DESCRIPTION
## Problem

ozmux needs to discover which tmux sessions exist *before* attaching — the "which session do I attach to?" problem. This is a server-level query that a `-CC` control connection cannot answer, because entering control mode itself requires an existing session (chicken-and-egg). The `tmux_control` client from #112 could open and drive a session but had no way to enumerate attachable sessions, and its `TmuxBuilder` consumed itself on connect, so the natural "list → pick → attach" flow wasn't expressible.

> Stacked on #112 (base `tmux-client`); the diff here is only the `TmuxServer` + session-listing addition.

## Solution

Introduces `TmuxServer` — a cheap `Clone` config value (program + socket) that is the single entry point for both server queries and control connections — replacing the consuming `TmuxBuilder`.

- **`TmuxServer`** (`transport.rs`): `attach`/`new_session` are now `&self`, so one server value is reusable (list → pick → attach, multiple connections, storable in a Bevy resource). A private `Socket` enum (`Default`/`Name`/`Path`) replaces the prior two `Option<String>` socket fields and makes the invalid `-L`+`-S`-both-set state unrepresentable.
- **Session listing**: `list_sessions()` runs `tmux [..] list-sessions -F …` once over a plain pipe (`std::process::Command`, no PTY — unlike `-CC`), returning `Vec<SessionInfo>`. "No server running" and "socket missing" map to `Ok(vec![])` (nothing to attach to); genuine failures surface as errors. `list_sessions_argv()` exposes the argv for callers that own their own I/O (e.g. running it off the Bevy main thread).
- **`SessionInfo` + `SessionInfo::parse_list`** (`session.rs`): sans-io parsing of the tab-separated output — `session_name` last + `splitn(5)` + strict UTF-8 + trailing-`\r` tolerant — yielding `{ id: SessionId, name, windows, attached, created }`. Reusable later for an in-band (control-reply) path.

Behavior was validated against real tmux 3.6a (live pipe capture): the `-F` field semantics (`session_attached` is a client count → `>0` bool; `session_id` is `$N`), the two distinct no-server stderr messages, and tab-escaping in session names.

**Affected parts:** `crates/tmux_control` only (no engine/app changes).

**Testing:** 68 in-crate unit tests (parser edge cases, no-server classification, builder argv, CRLF handling) + 2 `#[ignore]` real-tmux smokes (control roundtrip + `list_sessions` name/attached round-trip). `cargo clippy --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
