### PR TITLE
feat(ratatui-ozma): ratatui webview widget + RPC SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,11 +122,17 @@ dependencies = [
  "rustix 1.1.4",
  "rustix-openpty",
  "serde",
- "signal-hook",
- "unicode-width",
+ "signal-hook 0.4.4",
+ "unicode-width 0.2.0",
  "vte",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
@@ -2012,6 +2018,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,7 +2186,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2182,6 +2203,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2202,7 +2237,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2476,6 +2511,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook 0.3.18",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +2557,40 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dasp_sample"
@@ -3266,6 +3360,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3490,6 +3586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,9 +3646,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3573,6 +3684,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3884,6 +4008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,6 +4087,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4604,7 +4749,7 @@ dependencies = [
  "percent-encoding",
  "portable-pty",
  "tracing",
- "unicode-width",
+ "unicode-width 0.2.0",
  "vte",
 ]
 
@@ -4621,7 +4766,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4648,7 +4793,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -5043,8 +5188,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "ratatui-ozma"
 version = "0.1.0"
+dependencies = [
+ "crossbeam-channel",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -5324,6 +5498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,12 +5677,33 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -5686,6 +5887,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -6228,10 +6451,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/docs/superpowers/plans/2026-06-14-ratatui-ozma-webview.md
+++ b/docs/superpowers/plans/2026-06-14-ratatui-ozma-webview.md
@@ -1,0 +1,1699 @@
+# ratatui-ozma Webview SDK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `ratatui-ozma` crate — a ratatui `StatefulWidget` that embeds an ozmux inline webview at a cell rect, plus an RPC handler API for bidirectional `window.ozmux` communication.
+
+**Architecture:** A `Ozma` session owns one `$OZMUX_SOCK` Unix-socket connection and one background reader thread. `Webview` is a builder (content + RPC handlers); `Ozma::register` mints a handle and returns a cloneable `WebviewHandle` (`emit`, `id`). Per frame, a `Webview` widget blanks its cells, paints an optional fallback, and records its rect into `Ozma`'s frame collector; after `terminal.draw()`, `Ozma::flush` diffs placements and emits `mount-inline`/`unmount-inline` OSC at each rect via `terminal.backend_mut()`. RPC handlers run on the reader thread; the socket write-mutex is never held across a handler.
+
+**Tech Stack:** Rust edition 2024, `ratatui 0.29` (+ its re-exported `crossterm`), `serde`/`serde_json`, `crossbeam-channel`, `thiserror`. Tokio-free (std threads). Unix-only (`std::os::unix::net::UnixStream`); compositing is macOS-only but the protocol layers are testable everywhere via a fake control server.
+
+Spec: `docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md`. Raw reference client: `examples/dyn_webview_client.rs`.
+
+---
+
+## File Structure
+
+```
+sdk/ratatui-ozma/
+  Cargo.toml                  # deps; [lints] workspace = true
+  src/
+    lib.rs                    # crate root: //!, module decls, re-exports, #![warn(missing_docs)]
+    error.rs                  # OzmaError, RpcError
+    osc.rs                    # OSC 5379 + CUP sequence builders + validation
+    protocol.rs               # wire types (register/reply/emit/call) + serde
+    handler.rs                # BoxedHandler type + make_handler<P,R,F> (tuple-param dispatch)
+    webview.rs                # Webview builder (inline/dir/interactive/fallback/on), WebviewHandle (emit/id)
+    session.rs               # Ozma: connect/register/frame/flush + reader thread + Placement/FramePlacements
+    widget.rs                 # WebviewWidget StatefulWidget (blank + fallback + record placement)
+  examples/
+    ratatui_webview.rs        # end-to-end demo (layout -> widget -> RPC handler -> emit loop)
+  tests/
+    support/mod.rs            # fake NDJSON control server over a UnixListener
+    integration.rs            # register -> call -> reply -> emit round-trip vs fake server
+```
+
+**Naming note:** `WebviewWidget` is the rendered widget type; `Webview` is the pre-register builder; `WebviewHandle` is the registered handle. (Spec §8 records a possible later merge of widget+handle; v1 keeps them separate.)
+
+**Handler ergonomics decision (locks in spec §8 option 4):** v1 ships the proven path — handler params are a **tuple** deserialized from the JSON args array (`|(arg,): (String,)|` for one arg, `|(a, b): (u32, String)|` for two, `|(): ()|` for none). The bare-`|arg: T|` extractor and a `Params` wrapper are deferred. This compiles with no proc-macros and maps 1:1 to `window.ozmux.call(method, args)`.
+
+---
+
+## Task 1: Crate scaffolding
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/Cargo.toml`
+- Modify: `sdk/ratatui-ozma/src/lib.rs`
+
+- [ ] **Step 1: Set crate dependencies**
+
+Replace `sdk/ratatui-ozma/Cargo.toml` with:
+
+```toml
+[package]
+name = "ratatui-ozma"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[dependencies]
+ratatui = "0.29"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+crossbeam-channel = "0.5"
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Write the crate root with module decls**
+
+Replace `sdk/ratatui-ozma/src/lib.rs` with:
+
+```rust
+//! ratatui widget + RPC handler for embedding an ozmux inline webview.
+//!
+//! Run inside an ozmux pane: [`Ozma::connect`] dials `$OZMUX_SOCK`, [`Webview`]
+//! registers content (minting a handle), [`WebviewWidget`] renders it as a
+//! ratatui widget, and [`Ozma::flush`] emits the mount OSC after each draw.
+#![warn(missing_docs)]
+
+mod error;
+mod handler;
+mod osc;
+mod protocol;
+mod session;
+mod webview;
+mod widget;
+
+pub use error::{OzmaError, RpcError};
+pub use session::Ozma;
+pub use webview::{Webview, WebviewHandle};
+pub use widget::WebviewWidget;
+```
+
+- [ ] **Step 3: Stub the modules so the crate compiles**
+
+Create each module file with a `//!` line and minimal content (later tasks fill them). Create `src/error.rs`, `src/handler.rs`, `src/osc.rs`, `src/protocol.rs`, `src/session.rs`, `src/webview.rs`, `src/widget.rs` each containing only a doc line for now — but since later tasks need real types, instead create them empty-but-doc'd and accept that `lib.rs`'s `pub use` will fail until those types exist. To keep this task green, comment the `pub use` lines temporarily:
+
+Set the bottom of `lib.rs` to:
+
+```rust
+mod error;
+mod handler;
+mod osc;
+mod protocol;
+mod session;
+mod webview;
+mod widget;
+```
+
+And give each module file a single doc line, e.g. `src/error.rs`:
+
+```rust
+//! Error types for the ratatui-ozma SDK.
+```
+
+Use the matching one-line `//!` for the others:
+- `src/handler.rs`: `//! RPC handler boxing and tuple-param dispatch.`
+- `src/osc.rs`: `//! OSC 5379 and CUP escape-sequence builders.`
+- `src/protocol.rs`: `//! Control-socket NDJSON wire types.`
+- `src/session.rs`: `//! The Ozma session: socket connection, reader thread, flush.`
+- `src/webview.rs`: `//! Webview builder and registered handle.`
+- `src/widget.rs`: `//! The ratatui StatefulWidget that records placements.`
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo build -p ratatui-ozma`
+Expected: PASS (downloads ratatui; empty modules compile).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/Cargo.toml sdk/ratatui-ozma/src/
+git commit -m "feat(ratatui-ozma): scaffold crate with deps and module skeleton"
+```
+
+---
+
+## Task 2: Error types
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/error.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/error.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_rejection_renders_reason() {
+        let e = OzmaError::Register {
+            reason: "html_too_large".to_owned(),
+        };
+        assert!(e.to_string().contains("html_too_large"));
+    }
+
+    #[test]
+    fn rpc_error_message_roundtrips() {
+        let e = RpcError::new("unknown_method");
+        assert_eq!(e.message(), "unknown_method");
+    }
+
+    #[test]
+    fn io_error_converts() {
+        let io = std::io::Error::other("boom");
+        let e: OzmaError = io.into();
+        assert!(matches!(e, OzmaError::Io(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma error`
+Expected: FAIL (types not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put this above the `#[cfg(test)]` block in `src/error.rs` (under the `//!` line):
+
+```rust
+use std::sync::PoisonError;
+
+/// An error from the ratatui-ozma SDK.
+#[derive(Debug, thiserror::Error)]
+pub enum OzmaError {
+    /// `$OZMUX_SOCK` or `$OZMUX_TOKEN` was unset — not running inside an ozmux pane.
+    #[error("not inside an ozmux pane: {0} is unset")]
+    NotInPane(&'static str),
+
+    /// A socket connect/read/write failure.
+    #[error("control-socket io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The control plane rejected a `register` request.
+    #[error("register rejected: {reason}")]
+    Register {
+        /// The control-plane error string (e.g. `html_too_large`, `unsafe_entry`).
+        reason: String,
+    },
+
+    /// The connection closed while a `register` reply was pending.
+    #[error("control socket closed before register reply")]
+    Disconnected,
+
+    /// A serde (de)serialization failure.
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// An internal lock was poisoned by a panicked thread.
+    #[error("internal lock poisoned")]
+    Poisoned,
+}
+
+impl<T> From<PoisonError<T>> for OzmaError {
+    fn from(_: PoisonError<T>) -> Self {
+        OzmaError::Poisoned
+    }
+}
+
+/// An error returned by an RPC handler, surfaced to the page as a rejected Promise.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct RpcError {
+    message: String,
+}
+
+impl RpcError {
+    /// Creates an `RpcError` with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Returns the error message sent back to the page.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl From<serde_json::Error> for RpcError {
+    fn from(e: serde_json::Error) -> Self {
+        RpcError::new(e.to_string())
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma error`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/error.rs
+git commit -m "feat(ratatui-ozma): OzmaError and RpcError types"
+```
+
+---
+
+## Task 3: OSC + CUP sequence builders
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/osc.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/osc.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mount_sequence_is_canonical() {
+        let s = mount_inline("memo.main", 12, 48).unwrap();
+        assert_eq!(s, "\x1b]5379;mount-inline;memo.main;12;48\x1b\\");
+    }
+
+    #[test]
+    fn unmount_sequence_is_canonical() {
+        assert_eq!(unmount_inline("memo.main"), "\x1b]5379;unmount-inline;memo.main\x1b\\");
+    }
+
+    #[test]
+    fn cup_is_one_based() {
+        assert_eq!(cursor_to(0, 0), "\x1b[1;1H");
+        assert_eq!(cursor_to(4, 9), "\x1b[5;10H");
+    }
+
+    #[test]
+    fn rejects_out_of_range_dims() {
+        assert!(mount_inline("h", 0, 10).is_err());
+        assert!(mount_inline("h", 201, 10).is_err());
+        assert!(mount_inline("h", 10, 401).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_handle_charset() {
+        assert!(mount_inline("bad handle", 10, 10).is_err());
+        assert!(mount_inline("", 10, 10).is_err());
+    }
+
+    #[test]
+    fn clamp_fits_range() {
+        assert_eq!(clamp_dims(0, 0), (1, 1));
+        assert_eq!(clamp_dims(500, 500), (200, 400));
+        assert_eq!(clamp_dims(12, 48), (12, 48));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma osc`
+Expected: FAIL (functions not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put above the test block in `src/osc.rs`:
+
+```rust
+use crate::error::OzmaError;
+
+/// Max inline-webview rows accepted by the VT layer (`1..=MAX_ROWS`).
+pub(crate) const MAX_ROWS: u16 = 200;
+/// Max inline-webview cols accepted by the VT layer (`1..=MAX_COLS`).
+pub(crate) const MAX_COLS: u16 = 400;
+
+/// Returns the `mount-inline` OSC 5379 sequence, or an error if the handle
+/// charset is invalid or the dimensions are out of range.
+pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> Result<String, OzmaError> {
+    validate_handle(handle)?;
+    if !(1..=MAX_ROWS).contains(&rows) || !(1..=MAX_COLS).contains(&cols) {
+        return Err(OzmaError::Register {
+            reason: format!("geometry out of range: {rows}x{cols}"),
+        });
+    }
+    Ok(format!("\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"))
+}
+
+/// Returns the `unmount-inline` OSC 5379 sequence for a single view handle.
+pub(crate) fn unmount_inline(handle: &str) -> String {
+    format!("\x1b]5379;unmount-inline;{handle}\x1b\\")
+}
+
+/// Returns a CUP (cursor position) sequence for a 0-based viewport cell.
+pub(crate) fn cursor_to(row: u16, col: u16) -> String {
+    format!("\x1b[{};{}H", row.saturating_add(1), col.saturating_add(1))
+}
+
+/// Clamps a (rows, cols) pair into the accepted `1..=MAX` range.
+pub(crate) fn clamp_dims(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.clamp(1, MAX_ROWS), cols.clamp(1, MAX_COLS))
+}
+
+/// Validates a view handle against the `^[A-Za-z0-9._-]{1,128}$` charset.
+fn validate_handle(handle: &str) -> Result<(), OzmaError> {
+    let ok = (1..=128).contains(&handle.len())
+        && handle
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if ok {
+        Ok(())
+    } else {
+        Err(OzmaError::Register {
+            reason: format!("invalid view handle: {handle:?}"),
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma osc`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/osc.rs
+git commit -m "feat(ratatui-ozma): OSC mount/unmount + CUP sequence builders"
+```
+
+---
+
+## Task 4: Wire protocol types
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/protocol.rs`
+
+These mirror the control-plane NDJSON (`src/control_plane/protocol.rs`): outbound `hello`/`register`/`unregister`/`reply`/`emit`, inbound `call` and the untagged register reply `{ok, handle}` / `{ok:false, error}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/protocol.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hello_serializes() {
+        let line = serde_json::to_string(&ClientMsg::Hello { token: "T".into() }).unwrap();
+        assert_eq!(line, r#"{"op":"hello","token":"T"}"#);
+    }
+
+    #[test]
+    fn register_inline_serializes() {
+        let v = serde_json::to_value(ClientMsg::Register(RegisterKind::Inline {
+            html: "<h1>hi</h1>".into(),
+            interactive: true,
+        }))
+        .unwrap();
+        assert_eq!(v["op"], "register");
+        assert_eq!(v["kind"], "inline");
+        assert_eq!(v["html"], "<h1>hi</h1>");
+        assert_eq!(v["interactive"], true);
+    }
+
+    #[test]
+    fn reply_ok_serializes() {
+        let v = serde_json::to_value(ClientMsg::Reply {
+            req_id: json!("17"),
+            result: Ok(json!("pong")),
+        })
+        .unwrap();
+        assert_eq!(v["op"], "reply");
+        assert_eq!(v["reqId"], "17");
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["value"], "pong");
+    }
+
+    #[test]
+    fn reply_err_serializes() {
+        let v = serde_json::to_value(ClientMsg::Reply {
+            req_id: json!("9"),
+            result: Err("unknown_method".into()),
+        })
+        .unwrap();
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "unknown_method");
+    }
+
+    #[test]
+    fn register_reply_deserializes_ok_and_err() {
+        let ok: RegisterReply = serde_json::from_str(r#"{"ok":true,"handle":"abc"}"#).unwrap();
+        assert_eq!(ok.handle.as_deref(), Some("abc"));
+        let err: RegisterReply =
+            serde_json::from_str(r#"{"ok":false,"error":"unsafe_entry"}"#).unwrap();
+        assert!(!err.ok);
+        assert_eq!(err.error.as_deref(), Some("unsafe_entry"));
+    }
+
+    #[test]
+    fn call_deserializes() {
+        let c: IncomingCall =
+            serde_json::from_str(r#"{"op":"call","handle":"h","reqId":"3","method":"ping","args":["x"]}"#)
+                .unwrap();
+        assert_eq!(c.handle, "h");
+        assert_eq!(c.method, "ping");
+        assert_eq!(c.args, vec![serde_json::json!("x")]);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma protocol`
+Expected: FAIL (types not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put above the test block in `src/protocol.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A message the SDK writes to the control socket.
+#[derive(Debug, Serialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub(crate) enum ClientMsg {
+    /// Handshake with `$OZMUX_TOKEN`.
+    Hello {
+        /// The pane's `$OZMUX_TOKEN`.
+        token: String,
+    },
+    /// Register content; the reply mints a handle.
+    Register(RegisterKind),
+    /// Tear down a previously-registered handle.
+    Unregister {
+        /// The handle to drop.
+        handle: String,
+    },
+    /// Reply to an inbound `call`.
+    Reply {
+        /// Echoes the inbound `reqId` verbatim.
+        #[serde(rename = "reqId")]
+        req_id: Value,
+        /// The handler outcome, flattened into `ok`/`value`/`error`.
+        #[serde(flatten, with = "reply_result")]
+        result: Result<Value, String>,
+    },
+    /// Push an event to the mounted page(s) of a handle.
+    Emit {
+        /// The target handle.
+        handle: String,
+        /// The event name routed to `window.ozmux.on(event, …)`.
+        event: String,
+        /// The event payload.
+        payload: Value,
+    },
+}
+
+/// The content variants of a `register` request.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub(crate) enum RegisterKind {
+    /// A full inline HTML document.
+    Inline {
+        /// The HTML document.
+        html: String,
+        /// Whether the view accepts focus/input.
+        interactive: bool,
+    },
+    /// A directory of assets served at `ozmux-dyn://<handle>/`.
+    Dir {
+        /// Absolute asset root.
+        root: String,
+        /// Entry HTML path relative to `root`.
+        entry: String,
+        /// Whether the view accepts focus/input.
+        interactive: bool,
+    },
+}
+
+/// The untagged reply to a `register` request.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RegisterReply {
+    /// Whether registration succeeded.
+    pub(crate) ok: bool,
+    /// The minted handle, present when `ok`.
+    #[serde(default)]
+    pub(crate) handle: Option<String>,
+    /// The error string, present when `!ok`.
+    #[serde(default)]
+    pub(crate) error: Option<String>,
+}
+
+/// An inbound `call` frame forwarded from a page's `window.ozmux.call`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct IncomingCall {
+    /// The view handle the call targets.
+    pub(crate) handle: String,
+    /// The global request id to echo in the reply.
+    #[serde(rename = "reqId")]
+    pub(crate) req_id: Value,
+    /// The invoked method name.
+    pub(crate) method: String,
+    /// The positional arguments array.
+    #[serde(default)]
+    pub(crate) args: Vec<Value>,
+}
+
+mod reply_result {
+    use serde::ser::SerializeMap;
+    use serde::Serializer;
+    use serde_json::Value;
+
+    pub(super) fn serialize<S>(result: &Result<Value, String>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = s.serialize_map(None)?;
+        match result {
+            Ok(value) => {
+                map.serialize_entry("ok", &true)?;
+                map.serialize_entry("value", value)?;
+            }
+            Err(error) => {
+                map.serialize_entry("ok", &false)?;
+                map.serialize_entry("error", error)?;
+            }
+        }
+        map.end()
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma protocol`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/protocol.rs
+git commit -m "feat(ratatui-ozma): control-socket wire protocol types"
+```
+
+---
+
+## Task 5: RPC handler boxing + tuple dispatch
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/handler.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/handler.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_arg_tuple_dispatch() {
+        let h = make_handler(|(name,): (String,)| Ok(format!("hi {name}")));
+        let out = h(vec![json!("ada")]).unwrap();
+        assert_eq!(out, json!("hi ada"));
+    }
+
+    #[test]
+    fn two_arg_tuple_dispatch() {
+        let h = make_handler(|(a, b): (u32, u32)| Ok(a + b));
+        assert_eq!(h(vec![json!(2), json!(3)]).unwrap(), json!(5));
+    }
+
+    #[test]
+    fn unit_arg_dispatch() {
+        let h = make_handler(|(): ()| Ok("ok"));
+        assert_eq!(h(vec![]).unwrap(), json!("ok"));
+    }
+
+    #[test]
+    fn bad_args_become_rpc_error() {
+        let h = make_handler(|(_n,): (u32,)| Ok(0u32));
+        assert!(h(vec![json!("not a number")]).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma handler`
+Expected: FAIL (functions not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put above the test block in `src/handler.rs`:
+
+```rust
+use crate::error::RpcError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+/// A type-erased RPC handler: args array in, JSON value or error out.
+pub(crate) type BoxedHandler =
+    Arc<dyn Fn(Vec<Value>) -> Result<Value, RpcError> + Send + Sync + 'static>;
+
+/// Boxes a typed handler whose parameter is a tuple deserialized from the
+/// positional args array, returning a `BoxedHandler`.
+pub(crate) fn make_handler<P, R, F>(f: F) -> BoxedHandler
+where
+    P: DeserializeOwned,
+    R: Serialize,
+    F: Fn(P) -> Result<R, RpcError> + Send + Sync + 'static,
+{
+    Arc::new(move |args: Vec<Value>| {
+        let params: P = serde_json::from_value(Value::Array(args))?;
+        let result = f(params)?;
+        Ok(serde_json::to_value(result)?)
+    })
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma handler`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/handler.rs
+git commit -m "feat(ratatui-ozma): tuple-param RPC handler boxing"
+```
+
+---
+
+## Task 6: Webview builder + WebviewHandle
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/webview.rs`
+
+`WebviewHandle::emit` writes through a shared `Arc<Mutex<UnixStream>>` (the same write half `Ozma` holds). Built in Task 8; here we define the types and the builder, testing the builder shape (emit is covered by the integration test in Task 9).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/webview.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn inline_builder_records_kind_and_default_interactive() {
+        let wv = Webview::inline("<h1>hi</h1>");
+        match &wv.kind {
+            RegisterKind::Inline { html, interactive } => {
+                assert_eq!(html, "<h1>hi</h1>");
+                assert!(*interactive);
+            }
+            _ => panic!("expected inline"),
+        }
+    }
+
+    #[test]
+    fn dir_builder_and_non_interactive() {
+        let wv = Webview::dir("/abs/ui", "index.html").interactive(false);
+        match &wv.kind {
+            RegisterKind::Dir { root, entry, interactive } => {
+                assert_eq!(root, "/abs/ui");
+                assert_eq!(entry, "index.html");
+                assert!(!*interactive);
+            }
+            _ => panic!("expected dir"),
+        }
+    }
+
+    #[test]
+    fn on_registers_handler() {
+        let wv = Webview::inline("x").on("ping", |(n,): (String,)| Ok(format!("pong:{n}")));
+        let h = wv.handlers.get("ping").expect("handler present");
+        assert_eq!(h(vec![json!("hi")]).unwrap(), json!("pong:hi"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma webview`
+Expected: FAIL (types not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put above the test block in `src/webview.rs`:
+
+```rust
+use crate::error::OzmaError;
+use crate::handler::{make_handler, BoxedHandler};
+use crate::protocol::{ClientMsg, RegisterKind};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+/// The shared write half of the control socket.
+pub(crate) type SharedWriter = Arc<Mutex<UnixStream>>;
+
+/// A webview definition: content plus RPC handlers, before registration.
+pub struct Webview {
+    pub(crate) kind: RegisterKind,
+    pub(crate) handlers: HashMap<String, BoxedHandler>,
+}
+
+impl Webview {
+    /// Creates a webview from a full inline HTML document.
+    pub fn inline(html: impl Into<String>) -> Self {
+        Self {
+            kind: RegisterKind::Inline {
+                html: html.into(),
+                interactive: true,
+            },
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Creates a webview served from a directory of assets.
+    pub fn dir(root: impl AsRef<Path>, entry: impl Into<String>) -> Self {
+        Self {
+            kind: RegisterKind::Dir {
+                root: root.as_ref().display().to_string(),
+                entry: entry.into(),
+                interactive: true,
+            },
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Sets the control-plane `interactive` flag (focus/input). Fixed at register.
+    pub fn interactive(mut self, interactive: bool) -> Self {
+        match &mut self.kind {
+            RegisterKind::Inline { interactive: i, .. } => *i = interactive,
+            RegisterKind::Dir { interactive: i, .. } => *i = interactive,
+        }
+        self
+    }
+
+    /// Registers an RPC handler for `method`. The parameter is a tuple
+    /// deserialized from the page's `window.ozmux.call(method, args)` array.
+    pub fn on<P, R, F>(mut self, method: impl Into<String>, f: F) -> Self
+    where
+        P: DeserializeOwned,
+        R: Serialize,
+        F: Fn(P) -> Result<R, crate::error::RpcError> + Send + Sync + 'static,
+    {
+        self.handlers.insert(method.into(), make_handler(f));
+        self
+    }
+}
+
+/// A registered webview handle: emit events to the page, read its id.
+#[derive(Clone)]
+pub struct WebviewHandle {
+    id: String,
+    writer: SharedWriter,
+}
+
+impl WebviewHandle {
+    pub(crate) fn new(id: String, writer: SharedWriter) -> Self {
+        Self { id, writer }
+    }
+
+    /// Returns the opaque handle id minted by the control plane.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Pushes an event to the currently-mounted page(s) of this handle.
+    ///
+    /// Mount-scoped: a no-op (still `Ok`) when nothing is mounted.
+    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> Result<(), OzmaError> {
+        let msg = ClientMsg::Emit {
+            handle: self.id.clone(),
+            event: event.to_owned(),
+            payload: serde_json::to_value(payload)?,
+        };
+        let line = serde_json::to_string(&msg)?;
+        let mut w = self.writer.lock()?;
+        writeln!(w, "{line}")?;
+        w.flush()?;
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma webview`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/webview.rs
+git commit -m "feat(ratatui-ozma): Webview builder and WebviewHandle"
+```
+
+---
+
+## Task 7: Fake control server (test support)
+
+**Files:**
+- Create: `sdk/ratatui-ozma/tests/support/mod.rs`
+
+A `UnixListener`-backed fake speaking the NDJSON protocol, so integration tests run without a real ozmux. Lives in `tests/support/` (a subdirectory module, so Cargo does not treat it as its own test binary).
+
+- [ ] **Step 1: Write the fake server**
+
+Create `sdk/ratatui-ozma/tests/support/mod.rs`:
+
+```rust
+//! A fake ozmux control server for integration tests.
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+/// A fake control server: accepts one client, replies to the first `register`
+/// with a fixed handle, and forwards every client line over `received`.
+pub struct FakeServer {
+    pub sock_path: std::path::PathBuf,
+    received: Receiver<Value>,
+    server_writer: UnixStream,
+    _dir: tempfile::TempDir,
+}
+
+impl FakeServer {
+    /// Boots on a temp socket, waits for one client, and answers its register.
+    pub fn start(handle: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let (conn_tx, conn_rx) = mpsc::channel::<UnixStream>();
+        let (recv_tx, received) = mpsc::channel::<Value>();
+
+        thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            conn_tx.send(stream.try_clone().unwrap()).unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if let Ok(v) = serde_json::from_str::<Value>(line.trim()) {
+                    let _ = recv_tx.send(v);
+                }
+            }
+        });
+
+        let server_writer = conn_rx.recv().unwrap();
+        let me = Self {
+            sock_path,
+            received,
+            server_writer,
+            _dir: dir,
+        };
+        me.drain_until_register();
+        let mut me = me;
+        me.send(json!({ "ok": true, "handle": handle }));
+        me
+    }
+
+    fn drain_until_register(&self) {
+        loop {
+            let v = self.received.recv().unwrap();
+            if v["op"] == "register" {
+                return;
+            }
+        }
+    }
+
+    /// Sends a raw JSON line to the connected client.
+    pub fn send(&mut self, v: Value) {
+        writeln!(self.server_writer, "{v}").unwrap();
+        self.server_writer.flush().unwrap();
+    }
+
+    /// Blocks for the next post-registration line the client sent.
+    pub fn next_message(&self) -> Value {
+        self.received.recv().unwrap()
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles as part of the test target later**
+
+This module is only compiled when a test in `tests/` declares `mod support;`. No standalone check yet; Task 9 exercises it.
+
+- [ ] **Step 3: Add `tempfile` as a dev-dependency**
+
+Append to `sdk/ratatui-ozma/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+tempfile = { workspace = true }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sdk/ratatui-ozma/tests/support/mod.rs sdk/ratatui-ozma/Cargo.toml
+git commit -m "test(ratatui-ozma): fake NDJSON control server"
+```
+
+---
+
+## Task 8: Ozma session — connect, register, frame, flush
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/session.rs`
+
+This task adds `connect`/`register` (and the reader thread skeleton that fulfills register replies + dispatches calls), plus `Placement`/`FramePlacements`/`frame`/`flush`. RPC dispatch correctness is verified in Task 9; here the unit test covers `flush` diffing against an in-memory writer.
+
+- [ ] **Step 1: Write the failing test (flush diffing)**
+
+Append to `src/session.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect { x, y, width: w, height: h }
+    }
+
+    #[test]
+    fn flush_emits_mount_then_skips_unchanged() {
+        let mut state = FlushState::default();
+        let mut placements = vec![Placement { handle: "h1".into(), area: rect(2, 3, 48, 12) }];
+
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &placements).unwrap();
+        let first = String::from_utf8(buf).unwrap();
+        assert!(first.contains("\x1b[4;3H"));
+        assert!(first.contains("mount-inline;h1;12;48"));
+
+        let mut buf2 = Vec::new();
+        flush_placements(&mut buf2, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf2).unwrap().is_empty(), "unchanged frame emits nothing");
+
+        placements[0].area = rect(2, 3, 50, 12);
+        let mut buf3 = Vec::new();
+        flush_placements(&mut buf3, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf3).unwrap().contains("mount-inline;h1;12;50"));
+    }
+
+    #[test]
+    fn flush_unmounts_vanished_handle() {
+        let mut state = FlushState::default();
+        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 10, 5) }];
+        flush_placements(&mut Vec::new(), &mut state, &placements).unwrap();
+
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &[]).unwrap();
+        assert!(String::from_utf8(buf).unwrap().contains("unmount-inline;h1"));
+    }
+
+    #[test]
+    fn flush_skips_degenerate_area() {
+        let mut state = FlushState::default();
+        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 0, 5) }];
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf).unwrap().is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma session`
+Expected: FAIL (types/functions not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+Put above the test block in `src/session.rs`:
+
+```rust
+use crate::error::OzmaError;
+use crate::handler::BoxedHandler;
+use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline};
+use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
+use crate::webview::{SharedWriter, Webview, WebviewHandle};
+use crossbeam_channel::{bounded, Receiver, Sender};
+use ratatui::backend::Backend;
+use ratatui::layout::Rect;
+use ratatui::Terminal;
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// One webview's requested position this frame.
+#[derive(Debug, Clone)]
+pub(crate) struct Placement {
+    pub(crate) handle: String,
+    pub(crate) area: Rect,
+}
+
+/// The per-frame collector handed to the [`crate::WebviewWidget`] as its state.
+#[derive(Debug, Default)]
+pub struct FramePlacements {
+    placements: Vec<Placement>,
+}
+
+impl FramePlacements {
+    pub(crate) fn record(&mut self, handle: String, area: Rect) {
+        self.placements.push(Placement { handle, area });
+    }
+}
+
+/// Last-emitted geometry per handle, for diff-driven flush.
+#[derive(Debug, Default)]
+pub(crate) struct FlushState {
+    last: HashMap<String, (u16, u16, u16, u16)>,
+}
+
+/// Shared map from handle to its method handlers, read by the reader thread.
+type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
+/// FIFO of pending register-reply senders (register replies are untagged).
+type PendingRegisters = Arc<Mutex<VecDeque<Sender<Result<String, OzmaError>>>>>;
+
+/// An ozmux session: owns the control-socket connection and reader thread.
+pub struct Ozma {
+    writer: SharedWriter,
+    handlers: HandlerRegistry,
+    pending: PendingRegisters,
+    frame: FramePlacements,
+    flush_state: FlushState,
+}
+
+impl Ozma {
+    /// Connects to `$OZMUX_SOCK`, performs the `hello` handshake, and spawns the
+    /// background reader thread.
+    pub fn connect() -> Result<Self, OzmaError> {
+        let sock = std::env::var("OZMUX_SOCK").map_err(|_| OzmaError::NotInPane("OZMUX_SOCK"))?;
+        let token =
+            std::env::var("OZMUX_TOKEN").map_err(|_| OzmaError::NotInPane("OZMUX_TOKEN"))?;
+        let stream = UnixStream::connect(sock)?;
+        let writer: SharedWriter = Arc::new(Mutex::new(stream.try_clone()?));
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+
+        {
+            let line = serde_json::to_string(&ClientMsg::Hello { token })?;
+            let mut w = writer.lock()?;
+            writeln!(w, "{line}")?;
+            w.flush()?;
+        }
+
+        spawn_reader(stream, writer.clone(), handlers.clone(), pending.clone());
+
+        Ok(Self {
+            writer,
+            handlers,
+            pending,
+            frame: FramePlacements::default(),
+            flush_state: FlushState::default(),
+        })
+    }
+
+    /// Registers a webview, blocking until the control plane mints its handle.
+    pub fn register(&self, webview: Webview) -> Result<WebviewHandle, OzmaError> {
+        let (tx, rx) = bounded(1);
+        self.pending.lock()?.push_back(tx);
+
+        let line = serde_json::to_string(&ClientMsg::Register(webview.kind))?;
+        {
+            let mut w = self.writer.lock()?;
+            writeln!(w, "{line}")?;
+            w.flush()?;
+        }
+
+        let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
+        self.handlers
+            .lock()?
+            .insert(handle.clone(), Arc::new(webview.handlers));
+        Ok(WebviewHandle::new(handle, self.writer.clone()))
+    }
+
+    /// Returns the per-frame placement collector, cleared, for `render_stateful_widget`.
+    pub fn frame(&mut self) -> &mut FramePlacements {
+        self.frame.placements.clear();
+        &mut self.frame
+    }
+
+    /// Emits mount/unmount OSC for this frame's placements, after `terminal.draw()`.
+    pub fn flush<B: Backend + Write>(
+        &mut self,
+        terminal: &mut Terminal<B>,
+    ) -> Result<(), OzmaError> {
+        let placements = std::mem::take(&mut self.frame.placements);
+        flush_placements(terminal.backend_mut(), &mut self.flush_state, &placements)?;
+        self.frame.placements = placements;
+        Ok(())
+    }
+}
+
+/// Emits CUP + mount-inline for new/changed placements and unmount for vanished
+/// handles, updating `state` to the new frame. Degenerate rects are skipped.
+pub(crate) fn flush_placements(
+    out: &mut impl Write,
+    state: &mut FlushState,
+    placements: &[Placement],
+) -> Result<(), OzmaError> {
+    let mut current: HashMap<String, (u16, u16, u16, u16)> = HashMap::new();
+    for p in placements {
+        if p.area.width == 0 || p.area.height == 0 {
+            continue;
+        }
+        let (rows, cols) = clamp_dims(p.area.height, p.area.width);
+        let key = (p.area.y, p.area.x, rows, cols);
+        current.insert(p.handle.clone(), key);
+        if state.last.get(&p.handle) != Some(&key) {
+            let seq = mount_inline(&p.handle, rows, cols)?;
+            write!(out, "{}{}", cursor_to(p.area.y, p.area.x), seq)?;
+        }
+    }
+    for handle in state.last.keys() {
+        if !current.contains_key(handle) {
+            write!(out, "{}", unmount_inline(handle))?;
+        }
+    }
+    out.flush()?;
+    state.last = current;
+    Ok(())
+}
+
+fn spawn_reader(
+    stream: UnixStream,
+    writer: SharedWriter,
+    handlers: HandlerRegistry,
+    pending: PendingRegisters,
+) {
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let is_call = serde_json::from_str::<serde_json::Value>(trimmed)
+                .ok()
+                .map(|v| v["op"] == "call")
+                .unwrap_or(false);
+            if is_call {
+                if let Ok(call) = serde_json::from_str::<IncomingCall>(trimmed) {
+                    dispatch_call(&writer, &handlers, call);
+                }
+            } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed) {
+                if let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front()) {
+                    let outcome = if reply.ok {
+                        reply
+                            .handle
+                            .ok_or_else(|| OzmaError::Register { reason: "missing handle".into() })
+                    } else {
+                        Err(OzmaError::Register {
+                            reason: reply.error.unwrap_or_else(|| "unknown".into()),
+                        })
+                    };
+                    let _ = tx.send(outcome);
+                }
+            }
+        }
+    });
+}
+
+fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: IncomingCall) {
+    let handler = handlers
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&call.handle).cloned())
+        .and_then(|methods| methods.get(&call.method).cloned());
+
+    let result = match handler {
+        Some(h) => h(call.args).map_err(|e| e.message().to_owned()),
+        None => Err("unknown_method".to_owned()),
+    };
+
+    let msg = ClientMsg::Reply {
+        req_id: call.req_id,
+        result: result.map_err(|e| e),
+    };
+    if let Ok(line) = serde_json::to_string(&msg) {
+        if let Ok(mut w) = writer.lock() {
+            let _ = writeln!(w, "{line}");
+            let _ = w.flush();
+        }
+    }
+}
+```
+
+> The `result.map_err(|e| e)` is intentional: `result` is already `Result<Value, String>`; the line keeps the `Reply` construction explicit. Remove the redundant `.map_err` if clippy flags it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma session`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire the re-export**
+
+Add to `src/lib.rs` re-exports (it already lists `pub use session::Ozma;`). Confirm `cargo build -p ratatui-ozma` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/session.rs sdk/ratatui-ozma/src/lib.rs
+git commit -m "feat(ratatui-ozma): Ozma session, reader thread, diff-driven flush"
+```
+
+---
+
+## Task 9: End-to-end RPC integration test
+
+**Files:**
+- Create: `sdk/ratatui-ozma/tests/integration.rs`
+
+Drives the full path against the fake server: connect → register → server sends a `call` → SDK handler replies → server sends nothing → `emit` reaches the server.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `sdk/ratatui-ozma/tests/integration.rs`:
+
+```rust
+mod support;
+
+use ratatui_ozma::{Ozma, Webview};
+use serde_json::json;
+use support::FakeServer;
+
+fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
+    // SAFETY: tests in this binary run serially within this fn; env is set/unset around f.
+    unsafe {
+        std::env::set_var("OZMUX_SOCK", sock);
+        std::env::set_var("OZMUX_TOKEN", "test-token");
+    }
+    f();
+    unsafe {
+        std::env::remove_var("OZMUX_SOCK");
+        std::env::remove_var("OZMUX_TOKEN");
+    }
+}
+
+#[test]
+fn call_is_dispatched_and_replied() {
+    let mut server = FakeServer::start("view-1");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let _handle = ozma
+            .register(Webview::inline("<h1>x</h1>").on("ping", |(n,): (String,)| {
+                Ok(format!("pong:{n}"))
+            }))
+            .unwrap();
+
+        server.send(json!({
+            "op": "call", "handle": "view-1", "reqId": "7", "method": "ping", "args": ["hi"]
+        }));
+
+        let reply = server.next_message();
+        assert_eq!(reply["op"], "reply");
+        assert_eq!(reply["reqId"], "7");
+        assert_eq!(reply["ok"], true);
+        assert_eq!(reply["value"], "pong:hi");
+    });
+}
+
+#[test]
+fn unknown_method_replies_error() {
+    let mut server = FakeServer::start("view-2");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let _h = ozma.register(Webview::inline("x")).unwrap();
+        server.send(json!({
+            "op": "call", "handle": "view-2", "reqId": "1", "method": "nope", "args": []
+        }));
+        let reply = server.next_message();
+        assert_eq!(reply["ok"], false);
+        assert_eq!(reply["error"], "unknown_method");
+    });
+}
+
+#[test]
+fn emit_reaches_the_server() {
+    let mut server = FakeServer::start("view-3");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma.register(Webview::inline("x")).unwrap();
+        handle.emit("tick", &42u32).unwrap();
+        let msg = server.next_message();
+        assert_eq!(msg["op"], "emit");
+        assert_eq!(msg["handle"], "view-3");
+        assert_eq!(msg["event"], "tick");
+        assert_eq!(msg["payload"], 42);
+    });
+}
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `cargo test -p ratatui-ozma --test integration`
+Expected: PASS (3 tests). If a test hangs, the reader thread or fake server blocked — verify `drain_until_register` consumed both `hello` and `register` before the test sends a `call`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sdk/ratatui-ozma/tests/integration.rs
+git commit -m "test(ratatui-ozma): end-to-end register/call/reply/emit"
+```
+
+---
+
+## Task 10: WebviewWidget (StatefulWidget)
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/widget.rs`
+
+Blanks its cells (so the webview shows through), paints an optional fallback under-layer, and records its rect into `FramePlacements`. Generic over the fallback widget; the default is a private `Blank` (renders nothing).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/widget.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::FramePlacements;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::text::Text;
+    use ratatui::widgets::{StatefulWidget, Widget};
+
+    #[test]
+    fn records_placement_and_blanks_cells() {
+        let area = Rect { x: 1, y: 1, width: 6, height: 2 };
+        let mut buf = Buffer::filled(Rect::new(0, 0, 10, 5), ratatui::buffer::Cell::new("Z"));
+        let mut state = FramePlacements::default();
+
+        WebviewWidget::new("view-x").render(area, &mut buf, &mut state);
+
+        assert_eq!(state.placements_for_test().len(), 1);
+        assert_eq!(state.placements_for_test()[0].handle, "view-x");
+        assert_eq!(buf[(1, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn fallback_is_painted() {
+        let area = Rect { x: 0, y: 0, width: 5, height: 1 };
+        let mut buf = Buffer::empty(area);
+        let mut state = FramePlacements::default();
+
+        WebviewWidget::new("v").fallback(Text::raw("hi")).render(area, &mut buf, &mut state);
+
+        assert_eq!(buf[(0, 0)].symbol(), "h");
+    }
+}
+```
+
+- [ ] **Step 2: Add a test accessor on FramePlacements**
+
+In `src/session.rs`, inside `impl FramePlacements`, add:
+
+```rust
+    #[cfg(test)]
+    pub(crate) fn placements_for_test(&self) -> &[Placement] {
+        &self.placements
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p ratatui-ozma widget`
+Expected: FAIL (`WebviewWidget` not defined).
+
+- [ ] **Step 4: Write the implementation**
+
+Put above the test block in `src/widget.rs`:
+
+```rust
+use crate::session::FramePlacements;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::widgets::{Clear, StatefulWidget, Widget};
+
+/// A ratatui widget that mounts an ozmux webview at its area.
+///
+/// Blanks its cells (the webview composites under the text) and records its rect
+/// for the next [`crate::Ozma::flush`]. Optionally paints a fallback under-layer
+/// (shown on non-macOS or before the page composites).
+pub struct WebviewWidget<'a, W = Blank> {
+    handle: &'a str,
+    fallback: W,
+}
+
+impl<'a> WebviewWidget<'a, Blank> {
+    /// Creates a widget for the given webview handle id.
+    pub fn new(handle: &'a str) -> Self {
+        Self { handle, fallback: Blank }
+    }
+}
+
+impl<'a, W> WebviewWidget<'a, W> {
+    /// Sets a fallback widget painted into the cells under the webview.
+    pub fn fallback<W2: Widget>(self, widget: W2) -> WebviewWidget<'a, W2> {
+        WebviewWidget {
+            handle: self.handle,
+            fallback: widget,
+        }
+    }
+}
+
+impl<W: Widget> StatefulWidget for WebviewWidget<'_, W> {
+    type State = FramePlacements;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        Clear.render(area, buf);
+        self.fallback.render(area, buf);
+        state.record(self.handle.to_owned(), area);
+    }
+}
+
+/// A no-op fallback widget (the default): renders nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Blank;
+
+impl Widget for Blank {
+    fn render(self, _area: Rect, _buf: &mut Buffer) {}
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma widget`
+Expected: PASS (2 tests). If `WebviewWidget::new` does not need `mut`, that is fine.
+
+- [ ] **Step 6: Export `Blank`**
+
+In `src/lib.rs`, change `pub use widget::WebviewWidget;` to:
+
+```rust
+pub use widget::{Blank, WebviewWidget};
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sdk/ratatui-ozma/src/widget.rs sdk/ratatui-ozma/src/session.rs sdk/ratatui-ozma/src/lib.rs
+git commit -m "feat(ratatui-ozma): WebviewWidget StatefulWidget with fallback"
+```
+
+---
+
+## Task 11: End-to-end example
+
+**Files:**
+- Create: `sdk/ratatui-ozma/examples/ratatui_webview.rs`
+
+The ergonomic twin of `examples/dyn_webview_client.rs`: enter the alt screen, register a page with a `ping` handler, render it as a widget each frame, emit a `tick` every second, quit on `q`.
+
+- [ ] **Step 1: Write the example**
+
+Create `sdk/ratatui-ozma/examples/ratatui_webview.rs`:
+
+```rust
+//! Run inside an ozmux pane: `cargo run -p ratatui-ozma --example ratatui_webview`.
+//!
+//! Renders a webview widget in the alternate screen, replies to `ping`, and
+//! emits a `tick` event every second. Press `q` to quit.
+use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::crossterm::execute;
+use ratatui::layout::{Constraint, Layout};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui_ozma::{Ozma, Webview, WebviewWidget};
+use std::io::stdout;
+use std::time::{Duration, Instant};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ozma = Ozma::connect()?;
+    let html = concat!(
+        "<body style='background:#13131a;color:#8be9fd;font:16px sans-serif;margin:0;padding:8px'>",
+        "<h1>ratatui-ozma</h1><div id='out'>calling ping…</div><div id='tick'>no ticks</div>",
+        "<script>",
+        "window.ozmux.call('ping',['hi']).then(v=>out.textContent='ping → '+v);",
+        "window.ozmux.on('tick',n=>tick.textContent='tick #'+n);",
+        "</script></body>"
+    );
+    let view = ozma.register(
+        Webview::inline(html).on("ping", |(arg,): (String,)| Ok::<_, ratatui_ozma::RpcError>(format!("pong:{arg}"))),
+    )?;
+
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    let mut n: u64 = 0;
+    let mut last = Instant::now();
+    let result = run(&mut terminal, &mut ozma, &view, &mut n, &mut last);
+
+    disable_raw_mode()?;
+    execute!(stdout(), LeaveAlternateScreen)?;
+    result
+}
+
+fn run(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    ozma: &mut Ozma,
+    view: &ratatui_ozma::WebviewHandle,
+    n: &mut u64,
+    last: &mut Instant,
+) -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        terminal.draw(|f| {
+            let rows = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
+            f.render_widget(Paragraph::new("press q to quit"), rows[0]);
+            let cols = Layout::horizontal([Constraint::Percentage(60), Constraint::Min(0)]).split(rows[1]);
+            f.render_stateful_widget(
+                WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                cols[0],
+                ozma.frame(),
+            );
+        })?;
+        ozma.flush(terminal)?;
+
+        if last.elapsed() >= Duration::from_secs(1) {
+            *n += 1;
+            let _ = view.emit("tick", n);
+            *last = Instant::now();
+        }
+        if event::poll(Duration::from_millis(50))? {
+            if let Event::Key(k) = event::read()? {
+                if k.code == KeyCode::Char('q') {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify the example compiles**
+
+Run: `cargo build -p ratatui-ozma --example ratatui_webview`
+Expected: PASS. (Running it requires a macOS ozmux pane; compilation is the gate here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sdk/ratatui-ozma/examples/ratatui_webview.rs
+git commit -m "docs(ratatui-ozma): end-to-end ratatui webview example"
+```
+
+---
+
+## Task 12: Final lint, format, and full test sweep
+
+**Files:**
+- Possibly modify any `src/*.rs` for clippy fixes.
+
+- [ ] **Step 1: Run clippy with the workspace lints**
+
+Run: `cargo clippy -p ratatui-ozma --all-targets -- -D warnings`
+Expected: PASS. Fix any findings (e.g. remove the redundant `.map_err(|e| e)` noted in Task 8; drop unused imports). Re-run until clean.
+
+- [ ] **Step 2: Format**
+
+Run: `cargo fmt -p ratatui-ozma`
+Expected: no diff after a second run.
+
+- [ ] **Step 3: Full test sweep**
+
+Run: `cargo test -p ratatui-ozma`
+Expected: PASS — all unit tests (error, osc, protocol, handler, webview, session, widget) and the integration suite green.
+
+- [ ] **Step 4: Verify the whole workspace still builds**
+
+Run: `cargo build`
+Expected: PASS (the new crate is a workspace member; nothing else depends on it, so this only confirms no breakage).
+
+- [ ] **Step 5: Commit any lint/format fixes**
+
+```bash
+git add sdk/ratatui-ozma/
+git commit -m "chore(ratatui-ozma): clippy + rustfmt pass"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 scope → Task 1; §3 object model → Tasks 6 (`Webview`/`WebviewHandle`), 8 (`Ozma`); §4 render flow/flush diff/area validation/cursor caveat → Tasks 8, 10; §5 RPC handlers/threading/emit mount-scope → Tasks 5, 6, 8, 9; §6 lifecycle/errors → Tasks 2, 8 (`Disconnected`, unmount-on-vanish); §7 testing (fake server, sequence builders, widget render, example) → Tasks 3, 7, 9, 10, 11; §8 resolutions (crossbeam-channel, `flush_to` core via `flush_placements`, method-before-deserialize, tuple handler) → Tasks 5, 8.
+- **Deferred (spec §8 plan-time options, intentionally not built):** bare-`|arg: T|` extractor + `Params` wrapper (tuples used instead); widget+handle merge and `ozma.draw()` wrapper (kept separate). These do not affect correctness.
+- **Type consistency:** `FramePlacements`/`Placement`/`flush_placements`/`FlushState` are defined in Task 8 and reused verbatim in Tasks 9–10; `BoxedHandler`/`make_handler` from Task 5 are used in Task 6; `SharedWriter` from Task 6 is used in Task 8; `RegisterKind`/`ClientMsg`/`IncomingCall`/`RegisterReply` from Task 4 flow through Tasks 6 and 8.
+- **Known cleanups left to Task 12:** the redundant `.map_err(|e| e)` (Task 8) and any unused-import warnings are resolved in the clippy step rather than pre-emptively, so each TDD task stays focused.

--- a/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
+++ b/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
@@ -85,15 +85,15 @@ Webview              // builder: content + handlers, pre-registration
  ├─ inline(html: impl Into<String>) -> Webview
  ├─ dir(root: impl AsRef<Path>, entry: impl Into<String>) -> Webview
  ├─ interactive(bool) -> Webview           // control-plane focus/input flag (default true); fixed at register, not changeable per-frame
- ├─ fallback(impl Widget) -> Webview       // under-layer painted into cells
  └─ on(method, handler) -> Webview         // RPC handler, serde-typed
 
 WebviewHandle        // cheap Clone (Arc to write-half + handle id), returned by register
  ├─ emit(event, &payload) -> Result<()>    // push to window.ozmux.on(event, …)
  └─ id() -> &str
 
-WebviewWidget<'a>    // the StatefulWidget rendered each frame
- └─ new(&WebviewHandle) -> WebviewWidget   // optionally .fallback(...) per-frame
+WebviewWidget<'a, W = Blank>    // the StatefulWidget rendered each frame (State = FramePlacements)
+ ├─ new(handle_id: &str) -> WebviewWidget<'_, Blank>
+ └─ fallback(impl Widget) -> WebviewWidget   // under-layer painted into the cells (non-macOS / pre-paint)
 ```
 
 - `Ozma` owns the single `UnixStream`. Dropping it closes the socket; the control

--- a/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
+++ b/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
@@ -1,0 +1,255 @@
+# `ratatui-ozma` — ratatui Webview Widget + RPC handler
+
+**Status:** Design (approved in brainstorming, pending spec review)
+**Date:** 2026-06-14
+**Crate:** `sdk/ratatui-ozma` (currently a stub: `Cargo.toml` + empty `src/lib.rs`)
+
+## 1. Purpose & scope
+
+`ratatui-ozma` is a **client-side Rust library** that a [ratatui](https://ratatui.rs)
+TUI app — running *inside* an ozmux pane — depends on to embed a live ozmux
+webview as a ratatui widget, and to talk to that webview over RPC.
+
+It is the ergonomic Rust twin of the existing `@ozmux/sdk` (`sdk/typescript`)
+and of `examples/dyn_webview_client.rs`, which already demonstrate the raw
+register → mount → RPC → emit round-trip. This crate wraps that raw protocol so
+apps never hand-roll escape codes or NDJSON.
+
+### What it wraps (all pre-existing ozmux mechanisms)
+
+1. **Control socket** — `$OZMUX_SOCK` (Unix domain socket) authenticated with
+   `$OZMUX_TOKEN`. Used to `register` content (→ mint an opaque handle), and as
+   the bidirectional RPC channel (`call` / `reply` / `emit`).
+   - Code: `src/control_plane.rs`, `src/control_plane/protocol.rs`,
+     `src/control_plane/listener.rs`.
+2. **OSC 5379 `mount-inline` / `unmount-inline`** — positions the webview at a
+   viewport cell rect using the **alt-screen fixed-anchor** model added in
+   commit `57cc03f` (#115). This is exactly what a redraw-every-frame TUI needs.
+   - Code: `src/osc_webview.rs`, `src/inline_webview.rs`,
+     `crates/ozma_tty_engine/src/handle.rs` (anchor stamping),
+     `crates/ozma_tty_engine/src/vt/listener.rs` (`AnchorMode`).
+   - Spec: `docs/inline-webview.md` (note: its "alt-screen mounts are rejected"
+     line is **obsolete** after #115).
+3. **`window.ozmux`** JS bridge — `call` / `on` / `off`, injected into every
+   Tier 1 page. The SDK is the program-side peer of this bridge.
+   - Code: `src/extension_render/ozmux_bridge.js`, `src/extension_render.rs`.
+
+### Constraints (inherited from the repo)
+
+- **Tokio-free.** std threads + one background I/O thread + `crossbeam`/std
+  channels, matching `examples/dyn_webview_client.rs` and the rest of ozmux.
+- **ratatui 0.29** (latest) as the target.
+- **macOS-only compositing.** The inline-webview GPU path is macOS-only; on
+  other platforms the OSC is silently dropped, so the widget must degrade
+  gracefully (see §4 fallback).
+- Comment / doc / visibility rules per `.claude/rules/rust.md`.
+
+### Out of scope for v1 (YAGNI)
+
+- `instance_id` multi-mount. One `Webview` = one handle = one mount.
+- The dormant `window.<ns>.<method>` Node host-API bridge (separate subsystem).
+- Normal-screen (scrollback text-flow) mounting — ratatui runs in the alternate
+  screen, so v1 targets the `FixedScreen` anchor only.
+- Async runtimes (tokio/async-std).
+
+## 2. The alt-screen fixed-anchor model (background)
+
+Why this design is possible at all (from `#115`):
+
+- On the alternate screen, `mount-inline` stamps an
+  `AnchorMode::FixedScreen { row, col }` from the **cursor position at the OSC
+  stop-point** (`crates/ozma_tty_engine/src/handle.rs`). `row`/`col` are
+  **viewport-relative** cells (0 = top-left of the visible grid).
+- The webview stays at that cell rect across full-buffer redraws (which ratatui
+  does every frame). Re-emitting `mount-inline` with the same handle is an
+  **idempotent in-place re-anchor** — ozmux's `set_if_neq` fast path means the
+  CEF page is **not reloaded** and the surface is only resized when `rows`/`cols`
+  actually change (`src/inline_webview.rs`). Safe at 60 fps.
+- Moving the widget = re-emit with a new `(row, col)`; there is no separate
+  "move" op. Terminal resize → ratatui recomputes layout → next re-emit
+  re-anchors in one frame.
+- **Auto-unmount:** leaving the alt screen despawns all `FixedScreen` webviews
+  (`despawn_fixed_screen_on_alt_exit` in `src/inline_webview.rs`); the underlying
+  registration survives and can be re-mounted on re-entering the alt screen.
+
+## 3. Object model
+
+```
+Ozma                 // session: owns the socket + background I/O thread
+ ├─ connect() -> Result<Ozma>             // read env, hello, spawn reader thread
+ ├─ register(Webview) -> Result<WebviewHandle>
+ ├─ frame() -> &mut FramePlacements        // StatefulWidget state for this frame
+ └─ flush(&mut Terminal<B>) -> Result<()>  // emit cursor moves + OSC after draw
+
+Webview              // builder: content + handlers, pre-registration
+ ├─ inline(html: impl Into<String>) -> Webview
+ ├─ dir(root: impl AsRef<Path>, entry: impl Into<String>) -> Webview
+ ├─ interactive(bool) -> Webview           // control-plane focus/input flag (default true); fixed at register, not changeable per-frame
+ ├─ fallback(impl Widget) -> Webview       // under-layer painted into cells
+ └─ on(method, handler) -> Webview         // RPC handler, serde-typed
+
+WebviewHandle        // cheap Clone (Arc to write-half + handle id), returned by register
+ ├─ emit(event, &payload) -> Result<()>    // push to window.ozmux.on(event, …)
+ └─ id() -> &str
+
+WebviewWidget<'a>    // the StatefulWidget rendered each frame
+ └─ new(&WebviewHandle) -> WebviewWidget   // optionally .fallback(...) per-frame
+```
+
+- `Ozma` owns the single `UnixStream`. Dropping it closes the socket; the control
+  plane tears down every handle registered on that connection.
+- `WebviewHandle` is `Clone` (shares an `Arc<Mutex<impl Write>>` to the socket
+  write-half plus the handle id), so one copy lives in app state (for `emit`) and
+  another is handed to the widget each frame.
+
+## 4. Render flow — StatefulWidget + post-draw flush
+
+A ratatui `Widget::render(area, buf)` only writes an in-memory cell `Buffer`; it
+cannot write escape sequences to stdout. Mounting requires positioning the real
+cursor and writing the OSC **after** `terminal.draw()` flushes. So the widget and
+the OSC emission are split across the draw boundary:
+
+```rust
+loop {
+    terminal.draw(|f| {
+        f.render_stateful_widget(
+            WebviewWidget::new(&chart).fallback(Paragraph::new("loading…")),
+            layout[0],
+            ozma.frame(),               // FramePlacements collector
+        );
+    })?;
+    ozma.flush(&mut terminal)?;          // real cursor moves + OSC, after ratatui's flush
+    // handle input / RPC-driven state …
+}
+```
+
+- `FramePlacements` is a per-frame collector: `ozma.frame()` returns it cleared,
+  and `flush()` consumes it — a skipped `draw()` cannot leave stale placements.
+- **`render(area, buf, state)`** (in-memory, pure): paint the fallback widget into
+  `buf` (or blank the cells if no fallback), and record
+  `(handle_id, area, interactive)` into the `FramePlacements` collector.
+- **`flush(&mut terminal)`**: emission is **diff-driven** against the previous
+  frame. The SDK keeps a `HashMap<Handle, (row, col, rows, cols)>` of the
+  last-emitted placement and, for each recorded placement, writes
+  `ESC[{y+1};{x+1}H` (CUP — 1-based, viewport-relative, matching `FixedScreen`)
+  then `ESC]5379;mount-inline;{handle};{height};{width}ESC\` **only when the
+  tuple is new or changed** (e.g. a resize/move). It emits `unmount-inline;{handle}`
+  only for handles that vanished. **No reserved newlines** (alt-screen; the buffer
+  cells already hold the space). Re-emitting an unchanged placement would be
+  idempotent and no-reload (`set_if_neq`), but diffing avoids the per-frame PTY
+  write and the forced grid emit (`force_next_emit`) the parser path triggers
+  (`crates/ozma_tty_engine/src/handle.rs`), so the SDK only emits on change.
+- `flush` is generic over `B: Backend + Write` (crossterm and termion backends
+  both implement `Write`) and writes through `terminal.backend_mut()` so the OSC
+  lands immediately after ratatui's own flush, with the cursor under our control.
+- **Area validation:** before emitting, `flush` skips any placement whose rect is
+  degenerate (0 width/height) or out of the OSC's accepted range (rows `1..=200`,
+  cols `1..=400`; handle charset `[A-Za-z0-9._-]{1,128}`). An out-of-range or
+  malformed sequence is *silently dropped* by the VT layer with no error path
+  (`crates/ozma_tty_engine/src/osc_webview.rs`), so the SDK must clamp/skip and
+  surface the skip rather than emit a sequence that vanishes.
+- **Cursor desync:** writing raw bytes through `backend_mut()` leaves ratatui's
+  tracked cursor position stale (`Terminal::backend_mut` docs warn of this). This
+  is safe *only* because the next `draw()` repositions the cursor — i.e. the SDK
+  assumes a redraw-every-frame loop. We rely on `CrosstermBackend: Write` (stable)
+  and deliberately avoid the unstable `writer()`/`writer_mut()` accessors.
+
+**Fallback:** `Webview`/`WebviewWidget` take an optional inner `impl Widget`. When
+set, it is rendered into the cells as the under-layer (visible on non-macOS or
+before the page first composites — text always draws over the webview anyway);
+when unset, the cells are blanked.
+
+## 5. RPC handler model
+
+Handlers are method-keyed closures; arguments and return values are
+serde-(de)serialized JSON, mirroring the `window.ozmux` bridge.
+
+```rust
+let mut wv = Webview::inline(html);
+wv = wv
+    .on("ping", |arg: String| Ok::<_, RpcError>(format!("pong:{arg}")))
+    .on("save", |doc: Doc| { /* … */ Ok(()) });
+let chart = ozma.register(wv)?;
+chart.emit("tick", &n)?;          // -> window.ozmux.on('tick', n)
+```
+
+- **Wire protocol** (the control plane already speaks these; note the inbound
+  `call` frame is synthesized in `src/extension_render.rs`, not a `ServerMsg`
+  variant in `protocol.rs`, and register replies are untagged `{ok, handle}` /
+  `{ok:false, error}` — the SDK serializes `register()` through its single I/O
+  thread so each reply matches its request):
+  - inbound to the program: `{"op":"call","handle":H,"reqId":R,"method":M,"args":[…]}`
+  - program reply: `{"op":"reply","reqId":R,"ok":true,"value":V}` /
+    `{"op":"reply","reqId":R,"ok":false,"error":E}`
+  - program → page push: `{"op":"emit","handle":H,"event":E,"payload":P}`.
+    **`emit` is mount-scoped:** it fans out only to a *currently-mounted*
+    page (`src/control_plane.rs` `Emit` arm), and is a silent no-op when the
+    handle is not mounted (e.g. off the alt screen). `WebviewHandle::emit`
+    returns `Ok(())` on a successful socket write regardless of delivery.
+- **Threading:** handlers run on the background I/O thread, so they are
+  `Send + 'static`. To touch app state, a handler shares it via
+  `Arc<Mutex<…>>` or sends a message into a channel the main render loop drains.
+  This tradeoff is documented prominently.
+  **Lock-scope invariant (critical):** the socket write-half mutex is *never*
+  held across a user handler invocation. A handler may call
+  `WebviewHandle::emit` (which locks the write half) from inside dispatch; holding
+  the write lock across the handler would deadlock. The reader thread locks only
+  around each `writeln!`, matching `examples/dyn_webview_client.rs`. A
+  channel-drained command pattern is offered as the deadlock-free default, with
+  `Arc<Mutex<…>>` as the terser escape hatch.
+- **Args mapping:** `window.ozmux.call(method, args)` always sends `args` as a
+  JSON **array**. The handler parameter is deserialized from that array:
+  single-arg closures via an extractor-style trait impl (`|arg: String|` ⇐
+  `["hi"]`), multi-arg via a tuple (`|(a, b): (u32, String)|` ⇐ `[1, "x"]`). The
+  precise extractor ergonomics (how many arities, the trait shape) are settled in
+  the implementation plan; the fallback if extractors prove fiddly is a single
+  `Params` argument with `.get::<T>(i)` accessors.
+- **Errors:** a handler returning `Err(_)`, an unknown method, or a
+  deserialization failure produces `{ok:false, error}`, surfacing as a rejected
+  Promise in the page.
+
+## 6. Lifecycle & error handling
+
+- **Unmount on disappear:** when a widget is not rendered in a frame, the next
+  `flush` emits `unmount-inline` for its handle (placement-set diff).
+- **App exit / alt-screen leave:** ozmux auto-unmounts `FixedScreen` views;
+  dropping `Ozma` unregisters everything on the connection.
+- **`OzmaError`** (via `thiserror`):
+  - `NotInPane` — `$OZMUX_SOCK` / `$OZMUX_TOKEN` unset.
+  - `Io` — socket connect / read / write failures.
+  - `Register` — control-plane rejection (`invalid_root`, `unsafe_entry`,
+    `html_too_large`, `internal`).
+  - `Serde` — (de)serialization failures.
+- **`RpcError`** — per-handler failure type returned to the page.
+
+## 7. Testing strategy
+
+- **Fake control server:** a `UnixListener` test fixture speaking the NDJSON
+  protocol, driving full register → call → reply → emit round-trips against the
+  SDK with no real ozmux process. This is the primary integration test.
+- **Sequence builders:** unit-test the exact CUP + `mount-inline` /
+  `unmount-inline` bytes, and the mount/unmount placement-diff set.
+- **Widget render:** render `WebviewWidget` into ratatui's `TestBackend` buffer;
+  assert the fallback is painted (or cells blanked) and the placement is recorded
+  in `FramePlacements`.
+- **Example:** `examples/ratatui_webview.rs` — the ergonomic, end-to-end twin of
+  `examples/dyn_webview_client.rs` (layout → widget → RPC handler → emit loop).
+
+## 8. Resolved decisions & plan-time options
+
+Resolved from spec review:
+1. **Channels:** use `crossbeam-channel` for the internal plumbing, matching the
+   rest of ozmux and `examples/dyn_webview_client.rs`.
+2. **`flush` shape:** implement the byte emission as `flush_to(&mut impl Write)`
+   and provide `flush(&mut Terminal<B>)` as the ergonomic wrapper over it (eases
+   sequence tests and custom backend/output splits).
+3. **RPC dispatch:** look up the method *before* deserializing args (return
+   `unknown_method` first).
+
+Plan-time options (ergonomics; do not affect correctness):
+4. RPC-handler extractor arities and trait shape (axum-style, proc-macro-free)
+   vs. shipping the `Params` wrapper first.
+5. Whether to merge `WebviewHandle` + `WebviewWidget` via
+   `impl StatefulWidget for &Webview`, and/or offer a single
+   `ozma.draw(&mut term, |f| …)` wrapper so `flush` cannot be forgotten — weighed
+   against losing per-frame `.fallback(...)` and the raw `Frame` boundary.

--- a/sdk/ratatui-ozma/Cargo.toml
+++ b/sdk/ratatui-ozma/Cargo.toml
@@ -8,6 +8,11 @@ authors.workspace = true
 publish.workspace = true
 
 [dependencies]
+ratatui = "0.29"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+crossbeam-channel = "0.5"
 
 [lints]
 workspace = true

--- a/sdk/ratatui-ozma/Cargo.toml
+++ b/sdk/ratatui-ozma/Cargo.toml
@@ -14,5 +14,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 crossbeam-channel = "0.5"
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -25,11 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "window.ozmux.on('tick',n=>tick.textContent='tick #'+n);",
         "</script></body>"
     );
-    let view = ozma.register(
-        Webview::inline(html).on("ping", |(arg,): (String,)| {
-            Ok::<_, RpcError>(format!("pong:{arg}"))
-        }),
-    )?;
+    let view = ozma.register(Webview::inline(html).on("ping", |(arg,): (String,)| {
+        Ok::<_, RpcError>(format!("pong:{arg}"))
+    }))?;
 
     enable_raw_mode()?;
     execute!(stdout(), EnterAlternateScreen)?;
@@ -72,7 +70,8 @@ fn run(
             *last = Instant::now();
         }
         if event::poll(Duration::from_millis(50))?
-            && let Event::Key(k) = event::read()? && k.code == KeyCode::Char('q')
+            && let Event::Key(k) = event::read()?
+            && k.code == KeyCode::Char('q')
         {
             return Ok(());
         }

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -1,0 +1,80 @@
+//! Run inside an ozmux pane: `cargo run -p ratatui-ozma --example ratatui_webview`.
+//!
+//! Renders a webview widget in the alternate screen, replies to `ping`, and
+//! emits a `tick` event every second. Press `q` to quit.
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui_ozma::{Ozma, RpcError, Webview, WebviewHandle, WebviewWidget};
+use std::io::stdout;
+use std::time::{Duration, Instant};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ozma = Ozma::connect()?;
+    let html = concat!(
+        "<body style='background:#13131a;color:#8be9fd;font:16px sans-serif;margin:0;padding:8px'>",
+        "<h1>ratatui-ozma</h1><div id='out'>calling ping…</div><div id='tick'>no ticks</div>",
+        "<script>",
+        "window.ozmux.call('ping',['hi']).then(v=>out.textContent='ping → '+v);",
+        "window.ozmux.on('tick',n=>tick.textContent='tick #'+n);",
+        "</script></body>"
+    );
+    let view = ozma.register(
+        Webview::inline(html).on("ping", |(arg,): (String,)| {
+            Ok::<_, RpcError>(format!("pong:{arg}"))
+        }),
+    )?;
+
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    let mut n: u64 = 0;
+    let mut last = Instant::now();
+    let result = run(&mut terminal, &mut ozma, &view, &mut n, &mut last);
+
+    disable_raw_mode()?;
+    execute!(stdout(), LeaveAlternateScreen)?;
+    result
+}
+
+fn run(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    ozma: &mut Ozma,
+    view: &WebviewHandle,
+    n: &mut u64,
+    last: &mut Instant,
+) -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        terminal.draw(|f| {
+            let rows =
+                Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
+            f.render_widget(Paragraph::new("press q to quit"), rows[0]);
+            let cols =
+                Layout::horizontal([Constraint::Percentage(60), Constraint::Min(0)]).split(rows[1]);
+            f.render_stateful_widget(
+                WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                cols[0],
+                ozma.frame(),
+            );
+        })?;
+        ozma.flush(terminal)?;
+
+        if last.elapsed() >= Duration::from_secs(1) {
+            *n += 1;
+            let _ = view.emit("tick", n);
+            *last = Instant::now();
+        }
+        if event::poll(Duration::from_millis(50))?
+            && let Event::Key(k) = event::read()? && k.code == KeyCode::Char('q')
+        {
+            return Ok(());
+        }
+    }
+}

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -30,15 +30,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }))?;
 
     enable_raw_mode()?;
-    execute!(stdout(), EnterAlternateScreen)?;
-    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    if let Err(e) = execute!(stdout(), EnterAlternateScreen) {
+        // EnterAlternateScreen failed after raw mode was enabled — undo it so the
+        // shell isn't left in raw mode.
+        let _ = disable_raw_mode();
+        return Err(e.into());
+    }
 
-    let mut n: u64 = 0;
-    let mut last = Instant::now();
-    let result = run(&mut terminal, &mut ozma, &view, &mut n, &mut last);
+    let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+        let mut n: u64 = 0;
+        let mut last = Instant::now();
+        run(&mut terminal, &mut ozma, &view, &mut n, &mut last)
+    })();
 
-    disable_raw_mode()?;
-    execute!(stdout(), LeaveAlternateScreen)?;
+    // Always restore the terminal; ignore teardown errors so the real outcome in
+    // `result` surfaces rather than a cleanup error masking it.
+    let _ = disable_raw_mode();
+    let _ = execute!(stdout(), LeaveAlternateScreen);
     result
 }
 

--- a/sdk/ratatui-ozma/src/error.rs
+++ b/sdk/ratatui-ozma/src/error.rs
@@ -1,1 +1,93 @@
 //! Error types for the ratatui-ozma SDK.
+
+use std::sync::PoisonError;
+
+/// An error from the ratatui-ozma SDK.
+#[derive(Debug, thiserror::Error)]
+pub enum OzmaError {
+    /// `$OZMUX_SOCK` or `$OZMUX_TOKEN` was unset — not running inside an ozmux pane.
+    #[error("not inside an ozmux pane: {0} is unset")]
+    NotInPane(&'static str),
+
+    /// A socket connect/read/write failure.
+    #[error("control-socket io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The control plane rejected a `register` request.
+    #[error("register rejected: {reason}")]
+    Register {
+        /// The control-plane error string (e.g. `html_too_large`, `unsafe_entry`).
+        reason: String,
+    },
+
+    /// The connection closed while a `register` reply was pending.
+    #[error("control socket closed before register reply")]
+    Disconnected,
+
+    /// A serde (de)serialization failure.
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// An internal lock was poisoned by a panicked thread.
+    #[error("internal lock poisoned")]
+    Poisoned,
+}
+
+impl<T> From<PoisonError<T>> for OzmaError {
+    fn from(_: PoisonError<T>) -> Self {
+        OzmaError::Poisoned
+    }
+}
+
+/// An error returned by an RPC handler, surfaced to the page as a rejected Promise.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct RpcError {
+    message: String,
+}
+
+impl RpcError {
+    /// Creates an `RpcError` with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// Returns the error message sent back to the page.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl From<serde_json::Error> for RpcError {
+    fn from(e: serde_json::Error) -> Self {
+        RpcError::new(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_rejection_renders_reason() {
+        let e = OzmaError::Register {
+            reason: "html_too_large".to_owned(),
+        };
+        assert!(e.to_string().contains("html_too_large"));
+    }
+
+    #[test]
+    fn rpc_error_message_roundtrips() {
+        let e = RpcError::new("unknown_method");
+        assert_eq!(e.message(), "unknown_method");
+    }
+
+    #[test]
+    fn io_error_converts() {
+        let io = std::io::Error::other("boom");
+        let e: OzmaError = io.into();
+        assert!(matches!(e, OzmaError::Io(_)));
+    }
+}

--- a/sdk/ratatui-ozma/src/error.rs
+++ b/sdk/ratatui-ozma/src/error.rs
@@ -2,6 +2,9 @@
 
 use std::sync::PoisonError;
 
+/// A `Result` whose error is [`OzmaError`].
+pub type OzmaResult<T> = Result<T, OzmaError>;
+
 /// An error from the ratatui-ozma SDK.
 #[derive(Debug, thiserror::Error)]
 pub enum OzmaError {

--- a/sdk/ratatui-ozma/src/error.rs
+++ b/sdk/ratatui-ozma/src/error.rs
@@ -1,0 +1,1 @@
+//! Error types for the ratatui-ozma SDK.

--- a/sdk/ratatui-ozma/src/handler.rs
+++ b/sdk/ratatui-ozma/src/handler.rs
@@ -1,8 +1,8 @@
 //! RPC handler boxing and tuple-param dispatch.
 
 use crate::error::RpcError;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::sync::Arc;
 

--- a/sdk/ratatui-ozma/src/handler.rs
+++ b/sdk/ratatui-ozma/src/handler.rs
@@ -1,1 +1,64 @@
 //! RPC handler boxing and tuple-param dispatch.
+
+use crate::error::RpcError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+/// A type-erased RPC handler: args array in, JSON value or error out.
+pub(crate) type BoxedHandler =
+    Arc<dyn Fn(Vec<Value>) -> Result<Value, RpcError> + Send + Sync + 'static>;
+
+/// Boxes a typed handler whose parameter is a tuple deserialized from the
+/// positional args array, returning a `BoxedHandler`.
+pub(crate) fn make_handler<P, R, F>(f: F) -> BoxedHandler
+where
+    P: DeserializeOwned,
+    R: Serialize,
+    F: Fn(P) -> Result<R, RpcError> + Send + Sync + 'static,
+{
+    Arc::new(move |args: Vec<Value>| {
+        // NOTE: serde_json deserializes () from null, not from an empty array, so
+        // an empty args list must be presented as Value::Null to satisfy unit params.
+        let raw = if args.is_empty() {
+            Value::Null
+        } else {
+            Value::Array(args)
+        };
+        let params: P = serde_json::from_value(raw)?;
+        let result = f(params)?;
+        Ok(serde_json::to_value(result)?)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_arg_tuple_dispatch() {
+        let h = make_handler(|(name,): (String,)| Ok(format!("hi {name}")));
+        let out = h(vec![json!("ada")]).unwrap();
+        assert_eq!(out, json!("hi ada"));
+    }
+
+    #[test]
+    fn two_arg_tuple_dispatch() {
+        let h = make_handler(|(a, b): (u32, u32)| Ok(a + b));
+        assert_eq!(h(vec![json!(2), json!(3)]).unwrap(), json!(5));
+    }
+
+    #[test]
+    fn unit_arg_dispatch() {
+        let h = make_handler(|(): ()| Ok("ok"));
+        assert_eq!(h(vec![]).unwrap(), json!("ok"));
+    }
+
+    #[test]
+    fn bad_args_become_rpc_error() {
+        let h = make_handler(|(_n,): (u32,)| Ok(0u32));
+        assert!(h(vec![json!("not a number")]).is_err());
+    }
+}

--- a/sdk/ratatui-ozma/src/handler.rs
+++ b/sdk/ratatui-ozma/src/handler.rs
@@ -1,0 +1,1 @@
+//! RPC handler boxing and tuple-param dispatch.

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -13,7 +13,7 @@ mod session;
 mod webview;
 mod widget;
 
-pub use error::{OzmaError, RpcError};
+pub use error::{OzmaError, OzmaResult, RpcError};
 pub use session::Ozma;
 pub use webview::{Webview, WebviewHandle};
 pub use widget::{Blank, WebviewWidget};

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -13,6 +13,7 @@ mod session;
 mod webview;
 mod widget;
 
+pub use error::{OzmaError, RpcError};
 pub use session::Ozma;
 pub use webview::{Webview, WebviewHandle};
 pub use widget::{Blank, WebviewWidget};

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -13,4 +13,5 @@ mod session;
 mod webview;
 mod widget;
 
+pub use session::Ozma;
 pub use webview::{Webview, WebviewHandle};

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -1,14 +1,14 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+//! ratatui widget + RPC handler for embedding an ozmux inline webview.
+//!
+//! Run inside an ozmux pane: [`Ozma::connect`] dials `$OZMUX_SOCK`, [`Webview`]
+//! registers content (minting a handle), [`WebviewWidget`] renders it as a
+//! ratatui widget, and [`Ozma::flush`] emits the mount OSC after each draw.
+#![warn(missing_docs)]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+mod error;
+mod handler;
+mod osc;
+mod protocol;
+mod session;
+mod webview;
+mod widget;

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -15,3 +15,4 @@ mod widget;
 
 pub use session::Ozma;
 pub use webview::{Webview, WebviewHandle};
+pub use widget::{Blank, WebviewWidget};

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -12,3 +12,5 @@ mod protocol;
 mod session;
 mod webview;
 mod widget;
+
+pub use webview::{Webview, WebviewHandle};

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -1,0 +1,1 @@
+//! OSC 5379 and CUP escape-sequence builders.

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -16,7 +16,9 @@ pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> Result<String,
             reason: format!("geometry out of range: {rows}x{cols}"),
         });
     }
-    Ok(format!("\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"))
+    Ok(format!(
+        "\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"
+    ))
 }
 
 /// Returns the `unmount-inline` OSC 5379 sequence for a single view handle.
@@ -60,7 +62,10 @@ mod tests {
 
     #[test]
     fn unmount_sequence_is_canonical() {
-        assert_eq!(unmount_inline("memo.main"), "\x1b]5379;unmount-inline;memo.main\x1b\\");
+        assert_eq!(
+            unmount_inline("memo.main"),
+            "\x1b]5379;unmount-inline;memo.main\x1b\\"
+        );
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -1,1 +1,91 @@
 //! OSC 5379 and CUP escape-sequence builders.
+
+use crate::error::OzmaError;
+
+/// Max inline-webview rows accepted by the VT layer (`1..=MAX_ROWS`).
+pub(crate) const MAX_ROWS: u16 = 200;
+/// Max inline-webview cols accepted by the VT layer (`1..=MAX_COLS`).
+pub(crate) const MAX_COLS: u16 = 400;
+
+/// Returns the `mount-inline` OSC 5379 sequence, or an error if the handle
+/// charset is invalid or the dimensions are out of range.
+pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> Result<String, OzmaError> {
+    validate_handle(handle)?;
+    if !(1..=MAX_ROWS).contains(&rows) || !(1..=MAX_COLS).contains(&cols) {
+        return Err(OzmaError::Register {
+            reason: format!("geometry out of range: {rows}x{cols}"),
+        });
+    }
+    Ok(format!("\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"))
+}
+
+/// Returns the `unmount-inline` OSC 5379 sequence for a single view handle.
+pub(crate) fn unmount_inline(handle: &str) -> String {
+    format!("\x1b]5379;unmount-inline;{handle}\x1b\\")
+}
+
+/// Returns a CUP (cursor position) sequence for a 0-based viewport cell.
+pub(crate) fn cursor_to(row: u16, col: u16) -> String {
+    format!("\x1b[{};{}H", row.saturating_add(1), col.saturating_add(1))
+}
+
+/// Clamps a (rows, cols) pair into the accepted `1..=MAX` range.
+pub(crate) fn clamp_dims(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.clamp(1, MAX_ROWS), cols.clamp(1, MAX_COLS))
+}
+
+fn validate_handle(handle: &str) -> Result<(), OzmaError> {
+    let ok = (1..=128).contains(&handle.len())
+        && handle
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if ok {
+        Ok(())
+    } else {
+        Err(OzmaError::Register {
+            reason: format!("invalid view handle: {handle:?}"),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mount_sequence_is_canonical() {
+        let s = mount_inline("memo.main", 12, 48).unwrap();
+        assert_eq!(s, "\x1b]5379;mount-inline;memo.main;12;48\x1b\\");
+    }
+
+    #[test]
+    fn unmount_sequence_is_canonical() {
+        assert_eq!(unmount_inline("memo.main"), "\x1b]5379;unmount-inline;memo.main\x1b\\");
+    }
+
+    #[test]
+    fn cup_is_one_based() {
+        assert_eq!(cursor_to(0, 0), "\x1b[1;1H");
+        assert_eq!(cursor_to(4, 9), "\x1b[5;10H");
+    }
+
+    #[test]
+    fn rejects_out_of_range_dims() {
+        assert!(mount_inline("h", 0, 10).is_err());
+        assert!(mount_inline("h", 201, 10).is_err());
+        assert!(mount_inline("h", 10, 401).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_handle_charset() {
+        assert!(mount_inline("bad handle", 10, 10).is_err());
+        assert!(mount_inline("", 10, 10).is_err());
+    }
+
+    #[test]
+    fn clamp_fits_range() {
+        assert_eq!(clamp_dims(0, 0), (1, 1));
+        assert_eq!(clamp_dims(500, 500), (200, 400));
+        assert_eq!(clamp_dims(12, 48), (12, 48));
+    }
+}

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -1,6 +1,6 @@
 //! OSC 5379 and CUP escape-sequence builders.
 
-use crate::error::OzmaError;
+use crate::error::{OzmaError, OzmaResult};
 
 /// Max inline-webview rows accepted by the VT layer (`1..=MAX_ROWS`).
 pub(crate) const MAX_ROWS: u16 = 200;
@@ -9,7 +9,7 @@ pub(crate) const MAX_COLS: u16 = 400;
 
 /// Returns the `mount-inline` OSC 5379 sequence, or an error if the handle
 /// charset is invalid or the dimensions are out of range.
-pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> Result<String, OzmaError> {
+pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> OzmaResult<String> {
     validate_handle(handle)?;
     if !(1..=MAX_ROWS).contains(&rows) || !(1..=MAX_COLS).contains(&cols) {
         return Err(OzmaError::Register {
@@ -36,12 +36,16 @@ pub(crate) fn clamp_dims(rows: u16, cols: u16) -> (u16, u16) {
     (rows.clamp(1, MAX_ROWS), cols.clamp(1, MAX_COLS))
 }
 
-fn validate_handle(handle: &str) -> Result<(), OzmaError> {
-    let ok = (1..=128).contains(&handle.len())
+/// Returns whether a view handle matches the `^[A-Za-z0-9._-]{1,128}$` charset.
+pub(crate) fn valid_handle(handle: &str) -> bool {
+    (1..=128).contains(&handle.len())
         && handle
             .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
-    if ok {
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+fn validate_handle(handle: &str) -> OzmaResult<()> {
+    if valid_handle(handle) {
         Ok(())
     } else {
         Err(OzmaError::Register {

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -1,0 +1,1 @@
+//! Control-socket NDJSON wire types.

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -1,1 +1,183 @@
 //! Control-socket NDJSON wire types.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A message the SDK writes to the control socket.
+#[derive(Debug, Serialize)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub(crate) enum ClientMsg {
+    /// Handshake with `$OZMUX_TOKEN`.
+    Hello {
+        /// The pane's `$OZMUX_TOKEN`.
+        token: String,
+    },
+    /// Register content; the reply mints a handle.
+    Register(RegisterKind),
+    /// Tear down a previously-registered handle.
+    Unregister {
+        /// The handle to drop.
+        handle: String,
+    },
+    /// Reply to an inbound `call`.
+    Reply {
+        /// Echoes the inbound `reqId` verbatim.
+        #[serde(rename = "reqId")]
+        req_id: Value,
+        /// The handler outcome, flattened into `ok`/`value`/`error`.
+        #[serde(flatten, with = "reply_result")]
+        result: Result<Value, String>,
+    },
+    /// Push an event to the mounted page(s) of a handle.
+    Emit {
+        /// The target handle.
+        handle: String,
+        /// The event name routed to `window.ozmux.on(event, …)`.
+        event: String,
+        /// The event payload.
+        payload: Value,
+    },
+}
+
+/// The content variants of a `register` request.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub(crate) enum RegisterKind {
+    /// A full inline HTML document.
+    Inline {
+        /// The HTML document.
+        html: String,
+        /// Whether the view accepts focus/input.
+        interactive: bool,
+    },
+    /// A directory of assets served at `ozmux-dyn://<handle>/`.
+    Dir {
+        /// Absolute asset root.
+        root: String,
+        /// Entry HTML path relative to `root`.
+        entry: String,
+        /// Whether the view accepts focus/input.
+        interactive: bool,
+    },
+}
+
+/// The untagged reply to a `register` request.
+#[derive(Debug, Deserialize)]
+pub(crate) struct RegisterReply {
+    /// Whether registration succeeded.
+    pub(crate) ok: bool,
+    /// The minted handle, present when `ok`.
+    #[serde(default)]
+    pub(crate) handle: Option<String>,
+    /// The error string, present when `!ok`.
+    #[serde(default)]
+    pub(crate) error: Option<String>,
+}
+
+/// An inbound `call` frame forwarded from a page's `window.ozmux.call`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct IncomingCall {
+    /// The view handle the call targets.
+    pub(crate) handle: String,
+    /// The global request id to echo in the reply.
+    #[serde(rename = "reqId")]
+    pub(crate) req_id: Value,
+    /// The invoked method name.
+    pub(crate) method: String,
+    /// The positional arguments array.
+    #[serde(default)]
+    pub(crate) args: Vec<Value>,
+}
+
+mod reply_result {
+    use serde::ser::SerializeMap;
+    use serde::Serializer;
+    use serde_json::Value;
+
+    pub(super) fn serialize<S>(result: &Result<Value, String>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = s.serialize_map(None)?;
+        match result {
+            Ok(value) => {
+                map.serialize_entry("ok", &true)?;
+                map.serialize_entry("value", value)?;
+            }
+            Err(error) => {
+                map.serialize_entry("ok", &false)?;
+                map.serialize_entry("error", error)?;
+            }
+        }
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hello_serializes() {
+        let line = serde_json::to_string(&ClientMsg::Hello { token: "T".into() }).unwrap();
+        assert_eq!(line, r#"{"op":"hello","token":"T"}"#);
+    }
+
+    #[test]
+    fn register_inline_serializes() {
+        let v = serde_json::to_value(ClientMsg::Register(RegisterKind::Inline {
+            html: "<h1>hi</h1>".into(),
+            interactive: true,
+        }))
+        .unwrap();
+        assert_eq!(v["op"], "register");
+        assert_eq!(v["kind"], "inline");
+        assert_eq!(v["html"], "<h1>hi</h1>");
+        assert_eq!(v["interactive"], true);
+    }
+
+    #[test]
+    fn reply_ok_serializes() {
+        let v = serde_json::to_value(ClientMsg::Reply {
+            req_id: json!("17"),
+            result: Ok(json!("pong")),
+        })
+        .unwrap();
+        assert_eq!(v["op"], "reply");
+        assert_eq!(v["reqId"], "17");
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["value"], "pong");
+    }
+
+    #[test]
+    fn reply_err_serializes() {
+        let v = serde_json::to_value(ClientMsg::Reply {
+            req_id: json!("9"),
+            result: Err("unknown_method".into()),
+        })
+        .unwrap();
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["error"], "unknown_method");
+    }
+
+    #[test]
+    fn register_reply_deserializes_ok_and_err() {
+        let ok: RegisterReply = serde_json::from_str(r#"{"ok":true,"handle":"abc"}"#).unwrap();
+        assert_eq!(ok.handle.as_deref(), Some("abc"));
+        let err: RegisterReply =
+            serde_json::from_str(r#"{"ok":false,"error":"unsafe_entry"}"#).unwrap();
+        assert!(!err.ok);
+        assert_eq!(err.error.as_deref(), Some("unsafe_entry"));
+    }
+
+    #[test]
+    fn call_deserializes() {
+        let c: IncomingCall =
+            serde_json::from_str(r#"{"op":"call","handle":"h","reqId":"3","method":"ping","args":["x"]}"#)
+                .unwrap();
+        assert_eq!(c.handle, "h");
+        assert_eq!(c.method, "ping");
+        assert_eq!(c.args, vec![serde_json::json!("x")]);
+    }
+}

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -14,11 +14,6 @@ pub(crate) enum ClientMsg {
     },
     /// Register content; the reply mints a handle.
     Register(RegisterKind),
-    /// Tear down a previously-registered handle.
-    Unregister {
-        /// The handle to drop.
-        handle: String,
-    },
     /// Reply to an inbound `call`.
     Reply {
         /// Echoes the inbound `reqId` verbatim.
@@ -90,8 +85,8 @@ pub(crate) struct IncomingCall {
 }
 
 mod reply_result {
-    use serde::ser::SerializeMap;
     use serde::Serializer;
+    use serde::ser::SerializeMap;
     use serde_json::Value;
 
     pub(super) fn serialize<S>(result: &Result<Value, String>, s: S) -> Result<S::Ok, S::Error>
@@ -173,9 +168,10 @@ mod tests {
 
     #[test]
     fn call_deserializes() {
-        let c: IncomingCall =
-            serde_json::from_str(r#"{"op":"call","handle":"h","reqId":"3","method":"ping","args":["x"]}"#)
-                .unwrap();
+        let c: IncomingCall = serde_json::from_str(
+            r#"{"op":"call","handle":"h","reqId":"3","method":"ping","args":["x"]}"#,
+        )
+        .unwrap();
         assert_eq!(c.handle, "h");
         assert_eq!(c.method, "ping");
         assert_eq!(c.args, vec![serde_json::json!("x")]);

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -85,11 +85,13 @@ impl Ozma {
     /// Registers a webview, blocking until the control plane mints its handle.
     pub fn register(&self, webview: Webview) -> Result<WebviewHandle, OzmaError> {
         let (tx, rx) = bounded(1);
-        self.pending.lock()?.push_back(tx);
-
         let line = serde_json::to_string(&ClientMsg::Register(webview.kind))?;
         {
             let mut w = self.writer.lock()?;
+            // NOTE: push the pending sender while holding the writer lock so the
+            // FIFO order matches the on-wire order — register replies are untagged,
+            // so concurrent registrants would otherwise mismatch their handles.
+            self.pending.lock()?.push_back(tx);
             writeln!(w, "{line}")?;
             w.flush()?;
         }
@@ -176,19 +178,19 @@ fn spawn_reader(
                 if let Ok(call) = serde_json::from_str::<IncomingCall>(trimmed) {
                     dispatch_call(&writer, &handlers, call);
                 }
-            } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed) {
-                if let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front()) {
-                    let outcome = if reply.ok {
-                        reply
-                            .handle
-                            .ok_or_else(|| OzmaError::Register { reason: "missing handle".into() })
-                    } else {
-                        Err(OzmaError::Register {
-                            reason: reply.error.unwrap_or_else(|| "unknown".into()),
-                        })
-                    };
-                    let _ = tx.send(outcome);
-                }
+            } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed)
+                && let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front())
+            {
+                let outcome = if reply.ok {
+                    reply
+                        .handle
+                        .ok_or_else(|| OzmaError::Register { reason: "missing handle".into() })
+                } else {
+                    Err(OzmaError::Register {
+                        reason: reply.error.unwrap_or_else(|| "unknown".into()),
+                    })
+                };
+                let _ = tx.send(outcome);
             }
         }
     });
@@ -210,11 +212,11 @@ fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: Incomi
         req_id: call.req_id,
         result,
     };
-    if let Ok(line) = serde_json::to_string(&msg) {
-        if let Ok(mut w) = writer.lock() {
-            let _ = writeln!(w, "{line}");
-            let _ = w.flush();
-        }
+    if let Ok(line) = serde_json::to_string(&msg)
+        && let Ok(mut w) = writer.lock()
+    {
+        let _ = writeln!(w, "{line}");
+        let _ = w.flush();
     }
 }
 

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -1,1 +1,270 @@
 //! The Ozma session: socket connection, reader thread, flush.
+
+use crate::error::OzmaError;
+use crate::handler::BoxedHandler;
+use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline};
+use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
+use crate::webview::{SharedWriter, Webview, WebviewHandle};
+use crossbeam_channel::{bounded, Sender};
+use ratatui::backend::Backend;
+use ratatui::layout::Rect;
+use ratatui::Terminal;
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// One webview's requested position this frame.
+#[derive(Debug, Clone)]
+pub(crate) struct Placement {
+    pub(crate) handle: String,
+    pub(crate) area: Rect,
+}
+
+/// The per-frame collector handed to the [`crate::WebviewWidget`] as its state.
+#[derive(Debug, Default)]
+pub struct FramePlacements {
+    placements: Vec<Placement>,
+}
+
+impl FramePlacements {
+    pub(crate) fn record(&mut self, handle: String, area: Rect) {
+        self.placements.push(Placement { handle, area });
+    }
+}
+
+/// Last-emitted geometry per handle, for diff-driven flush.
+#[derive(Debug, Default)]
+pub(crate) struct FlushState {
+    last: HashMap<String, (u16, u16, u16, u16)>,
+}
+
+type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
+type PendingRegisters = Arc<Mutex<VecDeque<Sender<Result<String, OzmaError>>>>>;
+
+/// An ozmux session: owns the control-socket connection and reader thread.
+pub struct Ozma {
+    writer: SharedWriter,
+    handlers: HandlerRegistry,
+    pending: PendingRegisters,
+    frame: FramePlacements,
+    flush_state: FlushState,
+}
+
+impl Ozma {
+    /// Connects to `$OZMUX_SOCK`, performs the `hello` handshake, and spawns the
+    /// background reader thread.
+    pub fn connect() -> Result<Self, OzmaError> {
+        let sock = std::env::var("OZMUX_SOCK").map_err(|_| OzmaError::NotInPane("OZMUX_SOCK"))?;
+        let token =
+            std::env::var("OZMUX_TOKEN").map_err(|_| OzmaError::NotInPane("OZMUX_TOKEN"))?;
+        let stream = UnixStream::connect(sock)?;
+        let writer: SharedWriter = Arc::new(Mutex::new(stream.try_clone()?));
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+
+        {
+            let line = serde_json::to_string(&ClientMsg::Hello { token })?;
+            let mut w = writer.lock()?;
+            writeln!(w, "{line}")?;
+            w.flush()?;
+        }
+
+        spawn_reader(stream, writer.clone(), handlers.clone(), pending.clone());
+
+        Ok(Self {
+            writer,
+            handlers,
+            pending,
+            frame: FramePlacements::default(),
+            flush_state: FlushState::default(),
+        })
+    }
+
+    /// Registers a webview, blocking until the control plane mints its handle.
+    pub fn register(&self, webview: Webview) -> Result<WebviewHandle, OzmaError> {
+        let (tx, rx) = bounded(1);
+        self.pending.lock()?.push_back(tx);
+
+        let line = serde_json::to_string(&ClientMsg::Register(webview.kind))?;
+        {
+            let mut w = self.writer.lock()?;
+            writeln!(w, "{line}")?;
+            w.flush()?;
+        }
+
+        let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
+        self.handlers
+            .lock()?
+            .insert(handle.clone(), Arc::new(webview.handlers));
+        Ok(WebviewHandle::new(handle, self.writer.clone()))
+    }
+
+    /// Returns the per-frame placement collector, cleared, for `render_stateful_widget`.
+    pub fn frame(&mut self) -> &mut FramePlacements {
+        self.frame.placements.clear();
+        &mut self.frame
+    }
+
+    /// Emits mount/unmount OSC for this frame's placements, after `terminal.draw()`.
+    pub fn flush<B: Backend + Write>(
+        &mut self,
+        terminal: &mut Terminal<B>,
+    ) -> Result<(), OzmaError> {
+        let placements = std::mem::take(&mut self.frame.placements);
+        let result = flush_placements(terminal.backend_mut(), &mut self.flush_state, &placements);
+        self.frame.placements = placements;
+        result
+    }
+}
+
+/// Emits CUP + mount-inline for new/changed placements and unmount for vanished
+/// handles, updating `state` to the new frame. Degenerate rects are skipped.
+pub(crate) fn flush_placements(
+    out: &mut impl Write,
+    state: &mut FlushState,
+    placements: &[Placement],
+) -> Result<(), OzmaError> {
+    let mut current: HashMap<String, (u16, u16, u16, u16)> = HashMap::new();
+    for p in placements {
+        if p.area.width == 0 || p.area.height == 0 {
+            continue;
+        }
+        let (rows, cols) = clamp_dims(p.area.height, p.area.width);
+        let key = (p.area.y, p.area.x, rows, cols);
+        current.insert(p.handle.clone(), key);
+        if state.last.get(&p.handle) != Some(&key) {
+            let seq = mount_inline(&p.handle, rows, cols)?;
+            write!(out, "{}{}", cursor_to(p.area.y, p.area.x), seq)?;
+        }
+    }
+    for handle in state.last.keys() {
+        if !current.contains_key(handle) {
+            write!(out, "{}", unmount_inline(handle))?;
+        }
+    }
+    out.flush()?;
+    state.last = current;
+    Ok(())
+}
+
+fn spawn_reader(
+    stream: UnixStream,
+    writer: SharedWriter,
+    handlers: HandlerRegistry,
+    pending: PendingRegisters,
+) {
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let is_call = serde_json::from_str::<serde_json::Value>(trimmed)
+                .ok()
+                .map(|v| v["op"] == "call")
+                .unwrap_or(false);
+            if is_call {
+                if let Ok(call) = serde_json::from_str::<IncomingCall>(trimmed) {
+                    dispatch_call(&writer, &handlers, call);
+                }
+            } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed) {
+                if let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front()) {
+                    let outcome = if reply.ok {
+                        reply
+                            .handle
+                            .ok_or_else(|| OzmaError::Register { reason: "missing handle".into() })
+                    } else {
+                        Err(OzmaError::Register {
+                            reason: reply.error.unwrap_or_else(|| "unknown".into()),
+                        })
+                    };
+                    let _ = tx.send(outcome);
+                }
+            }
+        }
+    });
+}
+
+fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: IncomingCall) {
+    let handler = handlers
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&call.handle).cloned())
+        .and_then(|methods| methods.get(&call.method).cloned());
+
+    let result = match handler {
+        Some(h) => h(call.args).map_err(|e| e.message().to_owned()),
+        None => Err("unknown_method".to_owned()),
+    };
+
+    let msg = ClientMsg::Reply {
+        req_id: call.req_id,
+        result,
+    };
+    if let Ok(line) = serde_json::to_string(&msg) {
+        if let Ok(mut w) = writer.lock() {
+            let _ = writeln!(w, "{line}");
+            let _ = w.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect { x, y, width: w, height: h }
+    }
+
+    #[test]
+    fn flush_emits_mount_then_skips_unchanged() {
+        let mut state = FlushState::default();
+        let mut placements = vec![Placement { handle: "h1".into(), area: rect(2, 3, 48, 12) }];
+
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &placements).unwrap();
+        let first = String::from_utf8(buf).unwrap();
+        assert!(first.contains("\x1b[4;3H"));
+        assert!(first.contains("mount-inline;h1;12;48"));
+
+        let mut buf2 = Vec::new();
+        flush_placements(&mut buf2, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf2).unwrap().is_empty(), "unchanged frame emits nothing");
+
+        placements[0].area = rect(2, 3, 50, 12);
+        let mut buf3 = Vec::new();
+        flush_placements(&mut buf3, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf3).unwrap().contains("mount-inline;h1;12;50"));
+    }
+
+    #[test]
+    fn flush_unmounts_vanished_handle() {
+        let mut state = FlushState::default();
+        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 10, 5) }];
+        flush_placements(&mut Vec::new(), &mut state, &placements).unwrap();
+
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &[]).unwrap();
+        assert!(String::from_utf8(buf).unwrap().contains("unmount-inline;h1"));
+    }
+
+    #[test]
+    fn flush_skips_degenerate_area() {
+        let mut state = FlushState::default();
+        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 0, 5) }];
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf).unwrap().is_empty());
+    }
+}

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -1,0 +1,1 @@
+//! The Ozma session: socket connection, reader thread, flush.

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -5,10 +5,10 @@ use crate::handler::BoxedHandler;
 use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline};
 use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
-use crossbeam_channel::{bounded, Sender};
+use crossbeam_channel::{Sender, bounded};
+use ratatui::Terminal;
 use ratatui::backend::Backend;
 use ratatui::layout::Rect;
-use ratatui::Terminal;
 use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
@@ -187,9 +187,9 @@ fn spawn_reader(
                 && let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front())
             {
                 let outcome = if reply.ok {
-                    reply
-                        .handle
-                        .ok_or_else(|| OzmaError::Register { reason: "missing handle".into() })
+                    reply.handle.ok_or_else(|| OzmaError::Register {
+                        reason: "missing handle".into(),
+                    })
                 } else {
                     Err(OzmaError::Register {
                         reason: reply.error.unwrap_or_else(|| "unknown".into()),
@@ -231,13 +231,21 @@ mod tests {
     use ratatui::layout::Rect;
 
     fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
-        Rect { x, y, width: w, height: h }
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
     }
 
     #[test]
     fn flush_emits_mount_then_skips_unchanged() {
         let mut state = FlushState::default();
-        let mut placements = vec![Placement { handle: "h1".into(), area: rect(2, 3, 48, 12) }];
+        let mut placements = vec![Placement {
+            handle: "h1".into(),
+            area: rect(2, 3, 48, 12),
+        }];
 
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &placements).unwrap();
@@ -247,29 +255,46 @@ mod tests {
 
         let mut buf2 = Vec::new();
         flush_placements(&mut buf2, &mut state, &placements).unwrap();
-        assert!(String::from_utf8(buf2).unwrap().is_empty(), "unchanged frame emits nothing");
+        assert!(
+            String::from_utf8(buf2).unwrap().is_empty(),
+            "unchanged frame emits nothing"
+        );
 
         placements[0].area = rect(2, 3, 50, 12);
         let mut buf3 = Vec::new();
         flush_placements(&mut buf3, &mut state, &placements).unwrap();
-        assert!(String::from_utf8(buf3).unwrap().contains("mount-inline;h1;12;50"));
+        assert!(
+            String::from_utf8(buf3)
+                .unwrap()
+                .contains("mount-inline;h1;12;50")
+        );
     }
 
     #[test]
     fn flush_unmounts_vanished_handle() {
         let mut state = FlushState::default();
-        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 10, 5) }];
+        let placements = vec![Placement {
+            handle: "h1".into(),
+            area: rect(0, 0, 10, 5),
+        }];
         flush_placements(&mut Vec::new(), &mut state, &placements).unwrap();
 
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &[]).unwrap();
-        assert!(String::from_utf8(buf).unwrap().contains("unmount-inline;h1"));
+        assert!(
+            String::from_utf8(buf)
+                .unwrap()
+                .contains("unmount-inline;h1")
+        );
     }
 
     #[test]
     fn flush_skips_degenerate_area() {
         let mut state = FlushState::default();
-        let placements = vec![Placement { handle: "h1".into(), area: rect(0, 0, 0, 5) }];
+        let placements = vec![Placement {
+            handle: "h1".into(),
+            area: rect(0, 0, 0, 5),
+        }];
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &placements).unwrap();
         assert!(String::from_utf8(buf).unwrap().is_empty());

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -32,6 +32,11 @@ impl FramePlacements {
     pub(crate) fn record(&mut self, handle: String, area: Rect) {
         self.placements.push(Placement { handle, area });
     }
+
+    #[cfg(test)]
+    pub(crate) fn placements_for_test(&self) -> &[Placement] {
+        &self.placements
+    }
 }
 
 /// Last-emitted geometry per handle, for diff-driven flush.

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -1,8 +1,8 @@
 //! The Ozma session: socket connection, reader thread, flush.
 
-use crate::error::OzmaError;
+use crate::error::{OzmaError, OzmaResult};
 use crate::handler::BoxedHandler;
-use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline};
+use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline, valid_handle};
 use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
@@ -46,12 +46,18 @@ pub(crate) struct FlushState {
 }
 
 type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
-type PendingRegisters = Arc<Mutex<VecDeque<Sender<Result<String, OzmaError>>>>>;
+type PendingRegisters = Arc<Mutex<VecDeque<PendingRegister>>>;
+
+/// One in-flight `register` awaiting its untagged reply: the oneshot to wake the
+/// caller, plus the handlers to install once the control plane mints the handle.
+struct PendingRegister {
+    reply: Sender<OzmaResult<String>>,
+    handlers: Arc<HashMap<String, BoxedHandler>>,
+}
 
 /// An ozmux session: owns the control-socket connection and reader thread.
 pub struct Ozma {
     writer: SharedWriter,
-    handlers: HandlerRegistry,
     pending: PendingRegisters,
     frame: FramePlacements,
     flush_state: FlushState,
@@ -60,7 +66,7 @@ pub struct Ozma {
 impl Ozma {
     /// Connects to `$OZMUX_SOCK`, performs the `hello` handshake, and spawns the
     /// background reader thread.
-    pub fn connect() -> Result<Self, OzmaError> {
+    pub fn connect() -> OzmaResult<Self> {
         let sock = std::env::var("OZMUX_SOCK").map_err(|_| OzmaError::NotInPane("OZMUX_SOCK"))?;
         let token =
             std::env::var("OZMUX_TOKEN").map_err(|_| OzmaError::NotInPane("OZMUX_TOKEN"))?;
@@ -80,7 +86,6 @@ impl Ozma {
 
         Ok(Self {
             writer,
-            handlers,
             pending,
             frame: FramePlacements::default(),
             flush_state: FlushState::default(),
@@ -88,23 +93,28 @@ impl Ozma {
     }
 
     /// Registers a webview, blocking until the control plane mints its handle.
-    pub fn register(&self, webview: Webview) -> Result<WebviewHandle, OzmaError> {
+    pub fn register(&self, webview: Webview) -> OzmaResult<WebviewHandle> {
+        let Webview { kind, handlers } = webview;
         let (tx, rx) = bounded(1);
-        let line = serde_json::to_string(&ClientMsg::Register(webview.kind))?;
+        let line = serde_json::to_string(&ClientMsg::Register(kind))?;
         {
             let mut w = self.writer.lock()?;
-            // NOTE: push the pending sender while holding the writer lock so the
+            // NOTE: push the pending entry while holding the writer lock so the
             // FIFO order matches the on-wire order — register replies are untagged,
             // so concurrent registrants would otherwise mismatch their handles.
-            self.pending.lock()?.push_back(tx);
-            writeln!(w, "{line}")?;
-            w.flush()?;
+            self.pending.lock()?.push_back(PendingRegister {
+                reply: tx,
+                handlers: Arc::new(handlers),
+            });
+            if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
+                // The register never went out, so no reply will arrive for this
+                // entry; drop it so it can't consume a later registrant's reply.
+                self.pending.lock()?.pop_back();
+                return Err(e.into());
+            }
         }
 
         let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
-        self.handlers
-            .lock()?
-            .insert(handle.clone(), Arc::new(webview.handlers));
         Ok(WebviewHandle::new(handle, self.writer.clone()))
     }
 
@@ -115,10 +125,7 @@ impl Ozma {
     }
 
     /// Emits mount/unmount OSC for this frame's placements, after `terminal.draw()`.
-    pub fn flush<B: Backend + Write>(
-        &mut self,
-        terminal: &mut Terminal<B>,
-    ) -> Result<(), OzmaError> {
+    pub fn flush<B: Backend + Write>(&mut self, terminal: &mut Terminal<B>) -> OzmaResult<()> {
         let placements = std::mem::take(&mut self.frame.placements);
         let result = flush_placements(terminal.backend_mut(), &mut self.flush_state, &placements);
         self.frame.placements = placements;
@@ -132,10 +139,14 @@ pub(crate) fn flush_placements(
     out: &mut impl Write,
     state: &mut FlushState,
     placements: &[Placement],
-) -> Result<(), OzmaError> {
+) -> OzmaResult<()> {
     let mut current: HashMap<String, (u16, u16, u16, u16)> = HashMap::new();
     for p in placements {
-        if p.area.width == 0 || p.area.height == 0 {
+        // Skip degenerate rects and invalid handles so a single bad placement
+        // can't abort the whole flush (which would also desync flush state for
+        // every later placement). An invalid handle never came from a minted
+        // WebviewHandle, so it can never mount.
+        if p.area.width == 0 || p.area.height == 0 || !valid_handle(&p.handle) {
             continue;
         }
         let (rows, cols) = clamp_dims(p.area.height, p.area.width);
@@ -184,19 +195,37 @@ fn spawn_reader(
                     dispatch_call(&writer, &handlers, call);
                 }
             } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed)
-                && let Some(tx) = pending.lock().ok().and_then(|mut q| q.pop_front())
+                && let Some(reg) = pending.lock().ok().and_then(|mut q| q.pop_front())
             {
                 let outcome = if reply.ok {
-                    reply.handle.ok_or_else(|| OzmaError::Register {
-                        reason: "missing handle".into(),
-                    })
+                    match reply.handle {
+                        // Install handlers under the minted handle on this thread,
+                        // before the next line is read, so a `call` pipelined right
+                        // after the reply finds its handlers rather than racing the
+                        // registrant's main thread.
+                        Some(h) => {
+                            if let Ok(mut map) = handlers.lock() {
+                                map.insert(h.clone(), reg.handlers);
+                            }
+                            Ok(h)
+                        }
+                        None => Err(OzmaError::Register {
+                            reason: "missing handle".into(),
+                        }),
+                    }
                 } else {
                     Err(OzmaError::Register {
                         reason: reply.error.unwrap_or_else(|| "unknown".into()),
                     })
                 };
-                let _ = tx.send(outcome);
+                let _ = reg.reply.send(outcome);
             }
+        }
+        // The socket closed: drop every pending sender so any in-flight
+        // register() waiter returns OzmaError::Disconnected instead of blocking
+        // forever on a reply that will never arrive.
+        if let Ok(mut q) = pending.lock() {
+            q.clear();
         }
     });
 }
@@ -209,7 +238,13 @@ fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: Incomi
         .and_then(|methods| methods.get(&call.method).cloned());
 
     let result = match handler {
-        Some(h) => h(call.args).map_err(|e| e.message().to_owned()),
+        // A user handler runs on this reader thread; isolate panics so one bad
+        // handler can't unwind the thread and silence all future RPC + register
+        // replies. A panicked handler reports as a rejected call.
+        Some(h) => match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| h(call.args))) {
+            Ok(r) => r.map_err(|e| e.message().to_owned()),
+            Err(_) => Err("handler panicked".to_owned()),
+        },
         None => Err("unknown_method".to_owned()),
     };
 

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,6 +1,6 @@
 //! Webview builder and registered handle.
 
-use crate::error::OzmaError;
+use crate::error::OzmaResult;
 use crate::handler::{BoxedHandler, make_handler};
 use crate::protocol::{ClientMsg, RegisterKind};
 use serde::Serialize;
@@ -86,7 +86,7 @@ impl WebviewHandle {
     /// Pushes an event to the currently-mounted page(s) of this handle.
     ///
     /// Mount-scoped: a no-op (still `Ok`) when nothing is mounted.
-    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> Result<(), OzmaError> {
+    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> OzmaResult<()> {
         let msg = ClientMsg::Emit {
             handle: self.id.clone(),
             event: event.to_owned(),

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,1 +1,139 @@
 //! Webview builder and registered handle.
+
+use crate::error::OzmaError;
+use crate::handler::{make_handler, BoxedHandler};
+use crate::protocol::{ClientMsg, RegisterKind};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+/// The shared write half of the control socket.
+pub(crate) type SharedWriter = Arc<Mutex<UnixStream>>;
+
+/// A webview definition: content plus RPC handlers, before registration.
+pub struct Webview {
+    pub(crate) kind: RegisterKind,
+    pub(crate) handlers: HashMap<String, BoxedHandler>,
+}
+
+impl Webview {
+    /// Creates a webview from a full inline HTML document.
+    pub fn inline(html: impl Into<String>) -> Self {
+        Self {
+            kind: RegisterKind::Inline {
+                html: html.into(),
+                interactive: true,
+            },
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Creates a webview served from a directory of assets.
+    pub fn dir(root: impl AsRef<Path>, entry: impl Into<String>) -> Self {
+        Self {
+            kind: RegisterKind::Dir {
+                root: root.as_ref().display().to_string(),
+                entry: entry.into(),
+                interactive: true,
+            },
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Sets the control-plane `interactive` flag (focus/input). Fixed at register.
+    pub fn interactive(mut self, interactive: bool) -> Self {
+        match &mut self.kind {
+            RegisterKind::Inline { interactive: i, .. } => *i = interactive,
+            RegisterKind::Dir { interactive: i, .. } => *i = interactive,
+        }
+        self
+    }
+
+    /// Registers an RPC handler for `method`. The parameter is a tuple
+    /// deserialized from the page's `window.ozmux.call(method, args)` array.
+    pub fn on<P, R, F>(mut self, method: impl Into<String>, f: F) -> Self
+    where
+        P: DeserializeOwned,
+        R: Serialize,
+        F: Fn(P) -> Result<R, crate::error::RpcError> + Send + Sync + 'static,
+    {
+        self.handlers.insert(method.into(), make_handler(f));
+        self
+    }
+}
+
+/// A registered webview handle: emit events to the page, read its id.
+#[derive(Clone)]
+pub struct WebviewHandle {
+    id: String,
+    writer: SharedWriter,
+}
+
+impl WebviewHandle {
+    pub(crate) fn new(id: String, writer: SharedWriter) -> Self {
+        Self { id, writer }
+    }
+
+    /// Returns the opaque handle id minted by the control plane.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Pushes an event to the currently-mounted page(s) of this handle.
+    ///
+    /// Mount-scoped: a no-op (still `Ok`) when nothing is mounted.
+    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> Result<(), OzmaError> {
+        let msg = ClientMsg::Emit {
+            handle: self.id.clone(),
+            event: event.to_owned(),
+            payload: serde_json::to_value(payload)?,
+        };
+        let line = serde_json::to_string(&msg)?;
+        let mut w = self.writer.lock()?;
+        writeln!(w, "{line}")?;
+        w.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn inline_builder_records_kind_and_default_interactive() {
+        let wv = Webview::inline("<h1>hi</h1>");
+        match &wv.kind {
+            RegisterKind::Inline { html, interactive } => {
+                assert_eq!(html, "<h1>hi</h1>");
+                assert!(*interactive);
+            }
+            _ => panic!("expected inline"),
+        }
+    }
+
+    #[test]
+    fn dir_builder_and_non_interactive() {
+        let wv = Webview::dir("/abs/ui", "index.html").interactive(false);
+        match &wv.kind {
+            RegisterKind::Dir { root, entry, interactive } => {
+                assert_eq!(root, "/abs/ui");
+                assert_eq!(entry, "index.html");
+                assert!(!*interactive);
+            }
+            _ => panic!("expected dir"),
+        }
+    }
+
+    #[test]
+    fn on_registers_handler() {
+        let wv = Webview::inline("x").on("ping", |(n,): (String,)| Ok(format!("pong:{n}")));
+        let h = wv.handlers.get("ping").expect("handler present");
+        assert_eq!(h(vec![json!("hi")]).unwrap(), json!("pong:hi"));
+    }
+}

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,10 +1,10 @@
 //! Webview builder and registered handle.
 
 use crate::error::OzmaError;
-use crate::handler::{make_handler, BoxedHandler};
+use crate::handler::{BoxedHandler, make_handler};
 use crate::protocol::{ClientMsg, RegisterKind};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
@@ -121,7 +121,11 @@ mod tests {
     fn dir_builder_and_non_interactive() {
         let wv = Webview::dir("/abs/ui", "index.html").interactive(false);
         match &wv.kind {
-            RegisterKind::Dir { root, entry, interactive } => {
+            RegisterKind::Dir {
+                root,
+                entry,
+                interactive,
+            } => {
                 assert_eq!(root, "/abs/ui");
                 assert_eq!(entry, "index.html");
                 assert!(!*interactive);

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,0 +1,1 @@
+//! Webview builder and registered handle.

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -18,7 +18,10 @@ pub struct WebviewWidget<'a, W = Blank> {
 impl<'a> WebviewWidget<'a, Blank> {
     /// Creates a widget for the given webview handle id.
     pub fn new(handle: &'a str) -> Self {
-        Self { handle, fallback: Blank }
+        Self {
+            handle,
+            fallback: Blank,
+        }
     }
 }
 
@@ -64,7 +67,12 @@ mod tests {
 
     #[test]
     fn records_placement_and_blanks_cells() {
-        let area = Rect { x: 1, y: 1, width: 6, height: 2 };
+        let area = Rect {
+            x: 1,
+            y: 1,
+            width: 6,
+            height: 2,
+        };
         let mut buf = Buffer::filled(Rect::new(0, 0, 10, 5), ratatui::buffer::Cell::new("Z"));
         let mut state = FramePlacements::default();
 
@@ -77,11 +85,18 @@ mod tests {
 
     #[test]
     fn fallback_is_painted() {
-        let area = Rect { x: 0, y: 0, width: 5, height: 1 };
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 1,
+        };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
 
-        WebviewWidget::new("v").fallback(Text::raw("hi")).render(area, &mut buf, &mut state);
+        WebviewWidget::new("v")
+            .fallback(Text::raw("hi"))
+            .render(area, &mut buf, &mut state);
 
         assert_eq!(buf[(0, 0)].symbol(), "h");
     }

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -1,0 +1,1 @@
+//! The ratatui StatefulWidget that records placements.

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -1,1 +1,88 @@
 //! The ratatui StatefulWidget that records placements.
+
+use crate::session::FramePlacements;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::widgets::{Clear, StatefulWidget, Widget};
+
+/// A ratatui widget that mounts an ozmux webview at its area.
+///
+/// Blanks its cells (the webview composites under the text) and records its rect
+/// for the next [`crate::Ozma::flush`]. Optionally paints a fallback under-layer
+/// (shown on non-macOS or before the page composites).
+pub struct WebviewWidget<'a, W = Blank> {
+    handle: &'a str,
+    fallback: W,
+}
+
+impl<'a> WebviewWidget<'a, Blank> {
+    /// Creates a widget for the given webview handle id.
+    pub fn new(handle: &'a str) -> Self {
+        Self { handle, fallback: Blank }
+    }
+}
+
+impl<'a, W> WebviewWidget<'a, W> {
+    /// Sets a fallback widget painted into the cells under the webview.
+    pub fn fallback<W2: Widget>(self, widget: W2) -> WebviewWidget<'a, W2> {
+        WebviewWidget {
+            handle: self.handle,
+            fallback: widget,
+        }
+    }
+}
+
+impl<W: Widget> StatefulWidget for WebviewWidget<'_, W> {
+    type State = FramePlacements;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        Clear.render(area, buf);
+        self.fallback.render(area, buf);
+        state.record(self.handle.to_owned(), area);
+    }
+}
+
+/// A no-op fallback widget (the default): renders nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Blank;
+
+impl Widget for Blank {
+    fn render(self, _area: Rect, _buf: &mut Buffer) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::FramePlacements;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::text::Text;
+    use ratatui::widgets::StatefulWidget;
+
+    #[test]
+    fn records_placement_and_blanks_cells() {
+        let area = Rect { x: 1, y: 1, width: 6, height: 2 };
+        let mut buf = Buffer::filled(Rect::new(0, 0, 10, 5), ratatui::buffer::Cell::new("Z"));
+        let mut state = FramePlacements::default();
+
+        WebviewWidget::new("view-x").render(area, &mut buf, &mut state);
+
+        assert_eq!(state.placements_for_test().len(), 1);
+        assert_eq!(state.placements_for_test()[0].handle, "view-x");
+        assert_eq!(buf[(1, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn fallback_is_painted() {
+        let area = Rect { x: 0, y: 0, width: 5, height: 1 };
+        let mut buf = Buffer::empty(area);
+        let mut state = FramePlacements::default();
+
+        WebviewWidget::new("v").fallback(Text::raw("hi")).render(area, &mut buf, &mut state);
+
+        assert_eq!(buf[(0, 0)].symbol(), "h");
+    }
+}

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -2,10 +2,14 @@ mod support;
 
 use ratatui_ozma::{Ozma, Webview};
 use serde_json::json;
+use std::sync::Mutex;
 use support::FakeServer;
 
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
 fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
-    // SAFETY: tests in this binary run serially within this fn; env is set/unset around f.
+    let _guard = ENV_LOCK.lock().unwrap();
+    // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
     unsafe {
         std::env::set_var("OZMUX_SOCK", sock);
         std::env::set_var("OZMUX_TOKEN", "test-token");
@@ -23,9 +27,9 @@ fn call_is_dispatched_and_replied() {
     with_env(&server.sock_path.clone(), || {
         let ozma = Ozma::connect().unwrap();
         let _handle = ozma
-            .register(Webview::inline("<h1>x</h1>").on("ping", |(n,): (String,)| {
-                Ok(format!("pong:{n}"))
-            }))
+            .register(
+                Webview::inline("<h1>x</h1>").on("ping", |(n,): (String,)| Ok(format!("pong:{n}"))),
+            )
             .unwrap();
 
         server.send(json!({

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -1,0 +1,71 @@
+mod support;
+
+use ratatui_ozma::{Ozma, Webview};
+use serde_json::json;
+use support::FakeServer;
+
+fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
+    // SAFETY: tests in this binary run serially within this fn; env is set/unset around f.
+    unsafe {
+        std::env::set_var("OZMUX_SOCK", sock);
+        std::env::set_var("OZMUX_TOKEN", "test-token");
+    }
+    f();
+    unsafe {
+        std::env::remove_var("OZMUX_SOCK");
+        std::env::remove_var("OZMUX_TOKEN");
+    }
+}
+
+#[test]
+fn call_is_dispatched_and_replied() {
+    let server = FakeServer::start("view-1");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let _handle = ozma
+            .register(Webview::inline("<h1>x</h1>").on("ping", |(n,): (String,)| {
+                Ok(format!("pong:{n}"))
+            }))
+            .unwrap();
+
+        server.send(json!({
+            "op": "call", "handle": "view-1", "reqId": "7", "method": "ping", "args": ["hi"]
+        }));
+
+        let reply = server.next_message();
+        assert_eq!(reply["op"], "reply");
+        assert_eq!(reply["reqId"], "7");
+        assert_eq!(reply["ok"], true);
+        assert_eq!(reply["value"], "pong:hi");
+    });
+}
+
+#[test]
+fn unknown_method_replies_error() {
+    let server = FakeServer::start("view-2");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let _h = ozma.register(Webview::inline("x")).unwrap();
+        server.send(json!({
+            "op": "call", "handle": "view-2", "reqId": "1", "method": "nope", "args": []
+        }));
+        let reply = server.next_message();
+        assert_eq!(reply["ok"], false);
+        assert_eq!(reply["error"], "unknown_method");
+    });
+}
+
+#[test]
+fn emit_reaches_the_server() {
+    let server = FakeServer::start("view-3");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma.register(Webview::inline("x")).unwrap();
+        handle.emit("tick", &42u32).unwrap();
+        let msg = server.next_message();
+        assert_eq!(msg["op"], "emit");
+        assert_eq!(msg["handle"], "view-3");
+        assert_eq!(msg["event"], "tick");
+        assert_eq!(msg["payload"], 42);
+    });
+}

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use ratatui_ozma::{Ozma, Webview};
+use ratatui_ozma::{Ozma, OzmaError, RpcError, Webview};
 use serde_json::json;
 use std::sync::Mutex;
 use support::FakeServer;
@@ -8,7 +8,9 @@ use support::FakeServer;
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
-    let _guard = ENV_LOCK.lock().unwrap();
+    // A panicking test poisons the lock; recover the guard so it doesn't cascade
+    // and mask the test that actually failed.
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
     unsafe {
         std::env::set_var("OZMUX_SOCK", sock);
@@ -71,5 +73,54 @@ fn emit_reaches_the_server() {
         assert_eq!(msg["handle"], "view-3");
         assert_eq!(msg["event"], "tick");
         assert_eq!(msg["payload"], 42);
+    });
+}
+
+#[test]
+fn register_returns_disconnected_when_socket_closes() {
+    // Regression: a register whose reply never arrives because the socket closes
+    // must return Disconnected, not block forever on the pending reply.
+    let server = FakeServer::start_dropping();
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        assert!(matches!(
+            ozma.register(Webview::inline("x")),
+            Err(OzmaError::Disconnected)
+        ));
+    });
+}
+
+#[test]
+fn panicking_handler_does_not_kill_reader() {
+    // Regression: a panicking handler must report a rejected call and leave the
+    // reader thread alive to serve subsequent calls.
+    let server = FakeServer::start("view-5");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let _h = ozma
+            .register(
+                Webview::inline("x")
+                    .on("boom", |(): ()| -> Result<(), RpcError> { panic!("boom") })
+                    .on("ping", |(): ()| Ok::<_, RpcError>("pong")),
+            )
+            .unwrap();
+
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        server.send(
+            json!({ "op": "call", "handle": "view-5", "reqId": "1", "method": "boom", "args": [] }),
+        );
+        let boom = server.next_message();
+        std::panic::set_hook(prev);
+        assert_eq!(boom["reqId"], "1");
+        assert_eq!(boom["ok"], false);
+
+        server.send(
+            json!({ "op": "call", "handle": "view-5", "reqId": "2", "method": "ping", "args": [] }),
+        );
+        let ping = server.next_message();
+        assert_eq!(ping["reqId"], "2");
+        assert_eq!(ping["ok"], true);
+        assert_eq!(ping["value"], "pong");
     });
 }

--- a/sdk/ratatui-ozma/tests/support/mod.rs
+++ b/sdk/ratatui-ozma/tests/support/mod.rs
@@ -1,5 +1,5 @@
 //! A fake ozmux control server for integration tests.
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixListener;
 use std::sync::mpsc::{self, Receiver, Sender};

--- a/sdk/ratatui-ozma/tests/support/mod.rs
+++ b/sdk/ratatui-ozma/tests/support/mod.rs
@@ -67,6 +67,41 @@ impl FakeServer {
         }
     }
 
+    /// Binds a socket, accepts one client, then closes the connection upon
+    /// receiving the first `register` WITHOUT replying — exercises the
+    /// reader-thread disconnect / pending-drain path.
+    pub fn start_dropping() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let (_recv_tx, received) = mpsc::channel::<Value>();
+        let (to_client, _client_rx) = mpsc::channel::<Value>();
+
+        thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if let Ok(v) = serde_json::from_str::<Value>(line.trim())
+                    && v["op"] == "register"
+                {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            sock_path,
+            received,
+            to_client,
+            _dir: dir,
+        }
+    }
+
     /// Pushes a raw JSON line to the connected client.
     pub fn send(&self, v: Value) {
         self.to_client.send(v).unwrap();

--- a/sdk/ratatui-ozma/tests/support/mod.rs
+++ b/sdk/ratatui-ozma/tests/support/mod.rs
@@ -1,74 +1,84 @@
 //! A fake ozmux control server for integration tests.
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::sync::mpsc::{self, Receiver};
+use std::os::unix::net::UnixListener;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
-/// A fake control server: accepts one client, replies to the first `register`
-/// with a fixed handle, and forwards every client line over `received`.
+/// A fake control server: accepts one client, auto-replies to the first
+/// `register` with a fixed handle, forwards every client line over `received`,
+/// and pushes lines to the client via `to_client`.
+///
+/// `start` is non-blocking: it binds the socket and spawns the accept/reader and
+/// writer threads, then returns immediately so the client can connect afterward.
 pub struct FakeServer {
     pub sock_path: std::path::PathBuf,
     received: Receiver<Value>,
-    server_writer: UnixStream,
+    to_client: Sender<Value>,
     _dir: tempfile::TempDir,
 }
 
 impl FakeServer {
-    /// Boots on a temp socket, waits for one client, and answers its register.
+    /// Binds a temp socket and spawns the server threads (does not block on accept).
     pub fn start(handle: &str) -> Self {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("control.sock");
         let listener = UnixListener::bind(&sock_path).unwrap();
-        let (conn_tx, conn_rx) = mpsc::channel::<UnixStream>();
         let (recv_tx, received) = mpsc::channel::<Value>();
+        let (to_client, client_rx) = mpsc::channel::<Value>();
+        let reply_tx = to_client.clone();
+        let handle = handle.to_owned();
 
         thread::spawn(move || {
             let (stream, _) = listener.accept().unwrap();
-            conn_tx.send(stream.try_clone().unwrap()).unwrap();
+            let mut write_half = stream.try_clone().unwrap();
+            thread::spawn(move || {
+                while let Ok(v) = client_rx.recv() {
+                    if writeln!(write_half, "{v}").is_err() {
+                        break;
+                    }
+                    let _ = write_half.flush();
+                }
+            });
+
             let mut reader = BufReader::new(stream);
             let mut line = String::new();
+            let mut replied = false;
             loop {
                 line.clear();
                 if reader.read_line(&mut line).unwrap_or(0) == 0 {
                     break;
                 }
                 if let Ok(v) = serde_json::from_str::<Value>(line.trim()) {
+                    if !replied && v["op"] == "register" {
+                        replied = true;
+                        let _ = reply_tx.send(json!({ "ok": true, "handle": handle }));
+                    }
                     let _ = recv_tx.send(v);
                 }
             }
         });
 
-        let server_writer = conn_rx.recv().unwrap();
-        let me = Self {
+        Self {
             sock_path,
             received,
-            server_writer,
+            to_client,
             _dir: dir,
-        };
-        me.drain_until_register();
-        let mut me = me;
-        me.send(json!({ "ok": true, "handle": handle }));
-        me
-    }
-
-    fn drain_until_register(&self) {
-        loop {
-            let v = self.received.recv().unwrap();
-            if v["op"] == "register" {
-                return;
-            }
         }
     }
 
-    /// Sends a raw JSON line to the connected client.
-    pub fn send(&mut self, v: Value) {
-        writeln!(self.server_writer, "{v}").unwrap();
-        self.server_writer.flush().unwrap();
+    /// Pushes a raw JSON line to the connected client.
+    pub fn send(&self, v: Value) {
+        self.to_client.send(v).unwrap();
     }
 
-    /// Blocks for the next post-registration line the client sent.
+    /// Blocks for the next post-handshake line the client sent (skips hello/register).
     pub fn next_message(&self) -> Value {
-        self.received.recv().unwrap()
+        loop {
+            let v = self.received.recv().unwrap();
+            if v["op"] != "hello" && v["op"] != "register" {
+                return v;
+            }
+        }
     }
 }

--- a/sdk/ratatui-ozma/tests/support/mod.rs
+++ b/sdk/ratatui-ozma/tests/support/mod.rs
@@ -1,0 +1,74 @@
+//! A fake ozmux control server for integration tests.
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+/// A fake control server: accepts one client, replies to the first `register`
+/// with a fixed handle, and forwards every client line over `received`.
+pub struct FakeServer {
+    pub sock_path: std::path::PathBuf,
+    received: Receiver<Value>,
+    server_writer: UnixStream,
+    _dir: tempfile::TempDir,
+}
+
+impl FakeServer {
+    /// Boots on a temp socket, waits for one client, and answers its register.
+    pub fn start(handle: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("control.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let (conn_tx, conn_rx) = mpsc::channel::<UnixStream>();
+        let (recv_tx, received) = mpsc::channel::<Value>();
+
+        thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            conn_tx.send(stream.try_clone().unwrap()).unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    break;
+                }
+                if let Ok(v) = serde_json::from_str::<Value>(line.trim()) {
+                    let _ = recv_tx.send(v);
+                }
+            }
+        });
+
+        let server_writer = conn_rx.recv().unwrap();
+        let me = Self {
+            sock_path,
+            received,
+            server_writer,
+            _dir: dir,
+        };
+        me.drain_until_register();
+        let mut me = me;
+        me.send(json!({ "ok": true, "handle": handle }));
+        me
+    }
+
+    fn drain_until_register(&self) {
+        loop {
+            let v = self.received.recv().unwrap();
+            if v["op"] == "register" {
+                return;
+            }
+        }
+    }
+
+    /// Sends a raw JSON line to the connected client.
+    pub fn send(&mut self, v: Value) {
+        writeln!(self.server_writer, "{v}").unwrap();
+        self.server_writer.flush().unwrap();
+    }
+
+    /// Blocks for the next post-registration line the client sent.
+    pub fn next_message(&self) -> Value {
+        self.received.recv().unwrap()
+    }
+}


### PR DESCRIPTION
## Problem

There was no Rust SDK for embedding an ozmux inline webview from a [ratatui](https://ratatui.rs) TUI app. The mechanics existed (control socket, OSC 5379 `mount-inline`, the `window.ozmux` bridge, and the alt-screen fixed-anchor model from #115), but a ratatui program had to hand-roll NDJSON + escape sequences — see the raw reference client `examples/dyn_webview_client.rs`. The `sdk/ratatui-ozma` crate was an empty stub.

## Solution

Implement `sdk/ratatui-ozma` — the ergonomic Rust twin of `@ozmux/sdk`, providing a ratatui `StatefulWidget` that embeds an ozmux webview plus a bidirectional RPC handler API. Affects **only the new crate** under `sdk/ratatui-ozma/` (plus design/plan docs and `Cargo.lock`); no engine or existing-crate changes.

**Public API**
- `Ozma` — session owning one `$OZMUX_SOCK` connection + a background reader thread (`connect` / `register` / `frame` / `flush`).
- `Webview` builder — `inline(html)` / `dir(root, entry)` / `interactive(bool)` / `on(method, handler)`; RPC handler params are tuples deserialized from the `window.ozmux.call` args array.
- `WebviewHandle` — `id()` / `emit(event, &payload)` (push to `window.ozmux.on`).
- `WebviewWidget` — `StatefulWidget` that blanks its cells, paints an optional `fallback`, and records its rect; `Ozma::flush` then diffs placements and emits `mount-inline` / `unmount-inline` OSC after `terminal.draw()`.
- `OzmaError` / `OzmaResult<T>` / `RpcError`.

Tokio-free (std threads + `crossbeam-channel`), targets ratatui 0.29, macOS for compositing with graceful fallback elsewhere.

**Design & process.** Built TDD task-by-task from a reviewed spec; the spec was checked by a parallel Codex + Claude review, and the design choice (eager registration with a returned handle, over widget-internal lazy registration) was validated by a follow-up investigation. Includes a fake NDJSON control server so the full register → call → reply → emit round-trip is integration-tested without a running ozmux.

**Hardening (from a max-effort code review).**
- Reader thread drains pending registers on exit → `register()` returns `Disconnected` instead of hanging when the socket closes.
- Failed register write pops its pending entry (no orphaned/mis-correlated reply sender).
- Handlers are installed on the reader thread before the next line is read (closes a register/dispatch race).
- `catch_unwind` around user handlers so a panic can't kill the reader thread.
- `flush` skips invalid/degenerate placements instead of aborting the whole frame.

**Verification:** 27 unit + 5 integration tests pass; clippy `-D warnings` clean; rustfmt clean.

### Breaking Changes

None — new crate only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
