### PR TITLE
feat(ratatui-ozma): emit webview OSC via OzmaBackend (drop post-draw flush)

### DIFF
--- a/sdk/ratatui-ozma/examples/focus_grid.rs
+++ b/sdk/ratatui-ozma/examples/focus_grid.rs
@@ -7,9 +7,9 @@
 //! The webview cells declare those chords as PASSTHROUGH, so the host forwards
 //! them to the PTY (reaching plain `event::read`) and suppresses them from the
 //! page even while a webview is focused — that is how focus can leave a focused
-//! webview. `WebviewWidget::focused` reports focus to the SDK; `Ozma::flush`
-//! emits the control-plane focus op on change (the host gives CEF focus to the
-//! focused webview, so bare keys type into its input).
+//! webview. `WebviewWidget::focused` reports focus to the SDK; the `OzmaBackend`
+//! wrapping the terminal emits the control-plane focus op on change (the host gives
+//! CEF focus to the focused webview, so bare keys type into its input).
 //!
 //! Verify:
 //! - Initial focus is NW (highlighted border).
@@ -27,9 +27,12 @@ use ratatui::crossterm::terminal::{
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Style};
 use ratatui::widgets::{Block, Paragraph};
-use ratatui_ozma::{KeyChord, Ozma, Webview, WebviewHandle, WebviewWidget};
+use ratatui_ozma::{KeyChord, Ozma, OzmaBackend, Webview, WebviewHandle, WebviewWidget};
+use std::io::Stdout;
 use std::io::stdout;
 use std::time::Duration;
+
+type Backend = OzmaBackend<CrosstermBackend<Stdout>>;
 
 #[derive(Clone, Copy)]
 enum Dir {
@@ -73,7 +76,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let result = (|| -> Result<(), Box<dyn std::error::Error>> {
-        let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+        let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), &ozma);
+        let mut terminal = Terminal::new(backend)?;
         run(&mut terminal, &mut ozma, &ne, &sw)
     })();
 
@@ -83,7 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run(
-    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    terminal: &mut Terminal<Backend>,
     ozma: &mut Ozma,
     ne: &WebviewHandle,
     sw: &WebviewHandle,
@@ -92,7 +96,6 @@ fn run(
     let mut last_key = String::from("(none yet)");
     loop {
         terminal.draw(|f| draw(f, ozma, ne, sw, &focused, &last_key))?;
-        ozma.flush(terminal)?;
 
         if event::poll(Duration::from_millis(50))?
             && let Event::Key(k) = event::read()?
@@ -179,7 +182,7 @@ fn draw(
 
     // NOTE: Ozma::frame clears the collector, so call it once before rendering both
     // webviews — calling it twice would drop the first placement.
-    let frame = ozma.frame();
+    let mut frame = ozma.frame();
     f.render_stateful_widget(
         WebviewWidget::new(ne.id())
             .focused(focused == "ne")
@@ -192,7 +195,7 @@ fn draw(
             .focused(focused == "sw")
             .fallback(focus_block("SW (webview)", focused == "sw")),
         sw_area,
-        frame,
+        &mut *frame,
     );
 
     f.render_widget(

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -5,8 +5,8 @@
 //! app, and `q` quits while the app is focused. `Alt+h`/`Alt+l` are declared as
 //! passthrough chords, so the host forwards them to the PTY (reaching plain
 //! `event::read`) and suppresses them from the page even while the webview is
-//! focused. `WebviewWidget::focused` tells the SDK the current focus; `Ozma::flush`
-//! emits the control-plane focus op on change.
+//! focused. `WebviewWidget::focused` tells the SDK the current focus; the
+//! `OzmaBackend` wrapping the terminal emits the control-plane focus op on change.
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
@@ -16,9 +16,12 @@ use ratatui::crossterm::terminal::{
 };
 use ratatui::layout::{Constraint, Layout};
 use ratatui::widgets::{Block, Paragraph};
-use ratatui_ozma::{KeyChord, Ozma, RpcError, Webview, WebviewHandle, WebviewWidget};
+use ratatui_ozma::{KeyChord, Ozma, OzmaBackend, RpcError, Webview, WebviewHandle, WebviewWidget};
+use std::io::Stdout;
 use std::io::stdout;
 use std::time::{Duration, Instant};
+
+type Backend = OzmaBackend<CrosstermBackend<Stdout>>;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut ozma = Ozma::connect()?;
@@ -59,7 +62,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let result = (|| -> Result<(), Box<dyn std::error::Error>> {
-        let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+        let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), &ozma);
+        let mut terminal = Terminal::new(backend)?;
         run(&mut terminal, &mut ozma, &view)
     })();
 
@@ -69,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run(
-    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    terminal: &mut Terminal<Backend>,
     ozma: &mut Ozma,
     view: &WebviewHandle,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -89,10 +93,9 @@ fn run(
                     .focused(web_focused)
                     .fallback(Block::bordered().title("loading…")),
                 rows[1],
-                ozma.frame(),
+                &mut *ozma.frame(),
             );
         })?;
-        ozma.flush(terminal)?;
 
         if last.elapsed() >= Duration::from_secs(1) {
             n += 1;

--- a/sdk/ratatui-ozma/src/backend.rs
+++ b/sdk/ratatui-ozma/src/backend.rs
@@ -1,0 +1,105 @@
+//! A ratatui `Backend` wrapper that emits webview OSC during `terminal.draw()`.
+
+use crate::error::OzmaError;
+use crate::session::{FlushState, FramePlacements, Ozma};
+use crate::webview::SharedWriter;
+use ratatui::backend::{Backend, ClearType, WindowSize};
+use ratatui::buffer::Cell;
+use ratatui::layout::{Position, Size};
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+/// A ratatui [`Backend`] that wraps another backend and emits ozmux webview
+/// mount/unmount OSC (and the control-plane focus op) after each frame's cell
+/// diff — so an app needs no separate post-draw flush call.
+///
+/// Construct it with [`OzmaBackend::new`], passing the [`Ozma`] session it links
+/// to, then build a normal ratatui terminal:
+///
+/// ```no_run
+/// # use ratatui::Terminal;
+/// # use ratatui::backend::CrosstermBackend;
+/// # use ratatui_ozma::{Ozma, OzmaBackend};
+/// # use std::io::stdout;
+/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let ozma = Ozma::connect()?;
+/// let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), &ozma);
+/// let mut terminal = Terminal::new(backend)?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct OzmaBackend<B> {
+    inner: B,
+    frame: Arc<Mutex<FramePlacements>>,
+    writer: SharedWriter,
+    flush_state: FlushState,
+}
+
+impl<B> OzmaBackend<B> {
+    /// Wraps `inner`, linking it to `ozma`'s per-frame collector and control socket.
+    pub fn new(inner: B, ozma: &Ozma) -> Self {
+        Self {
+            inner,
+            frame: ozma.frame_handle(),
+            writer: ozma.writer_handle(),
+            flush_state: FlushState::default(),
+        }
+    }
+}
+
+impl<B: Backend + Write> Backend for OzmaBackend<B> {
+    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        self.inner.draw(content)?;
+        let frame = self.frame.lock().unwrap_or_else(|e| e.into_inner());
+        self.flush_state
+            .emit_frame(&mut self.inner, &self.writer, &frame)
+            .map_err(to_io)
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        self.inner.hide_cursor()
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        self.inner.show_cursor()
+    }
+
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
+        self.inner.get_cursor_position()
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        self.inner.set_cursor_position(position)
+    }
+
+    fn clear(&mut self) -> io::Result<()> {
+        self.inner.clear()
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+        self.inner.clear_region(clear_type)
+    }
+
+    fn append_lines(&mut self, n: u16) -> io::Result<()> {
+        self.inner.append_lines(n)
+    }
+
+    fn size(&self) -> io::Result<Size> {
+        self.inner.size()
+    }
+
+    fn window_size(&mut self) -> io::Result<WindowSize> {
+        self.inner.window_size()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Backend::flush(&mut self.inner)
+    }
+}
+
+fn to_io(e: OzmaError) -> io::Error {
+    io::Error::other(e)
+}

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -19,6 +19,6 @@ mod widget;
 pub use backend::OzmaBackend;
 pub use error::{OzmaError, OzmaResult, RpcError};
 pub use keychord::KeyChord;
-pub use session::Ozma;
+pub use session::{FramePlacements, Ozma};
 pub use webview::{Webview, WebviewHandle};
 pub use widget::{WebviewDefaultPlaceholder, WebviewWidget};

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -2,9 +2,11 @@
 //!
 //! Run inside an ozmux pane: [`Ozma::connect`] dials `$OZMUX_SOCK`, [`Webview`]
 //! registers content (minting a handle), [`WebviewWidget`] renders it as a
-//! ratatui widget, and [`Ozma::flush`] emits the mount OSC after each draw.
+//! ratatui widget, and [`OzmaBackend`] (wrapping the terminal backend) emits the
+//! mount OSC during each draw — no separate flush call.
 #![warn(missing_docs)]
 
+mod backend;
 mod error;
 mod handler;
 mod keychord;
@@ -14,6 +16,7 @@ mod session;
 mod webview;
 mod widget;
 
+pub use backend::OzmaBackend;
 pub use error::{OzmaError, OzmaResult, RpcError};
 pub use keychord::KeyChord;
 pub use session::Ozma;

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -21,4 +21,4 @@ pub use error::{OzmaError, OzmaResult, RpcError};
 pub use keychord::KeyChord;
 pub use session::Ozma;
 pub use webview::{Webview, WebviewHandle};
-pub use widget::{Blank, WebviewWidget};
+pub use widget::{WebviewDefaultPlaceholder, WebviewWidget};

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -6,13 +6,11 @@ use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline, valid_hand
 use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
-use ratatui::Terminal;
-use ratatui::backend::Backend;
 use ratatui::layout::Rect;
 use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 
 /// One webview's requested position this frame.
@@ -64,6 +62,27 @@ pub(crate) struct FlushState {
     last_focused: Option<String>,
 }
 
+impl FlushState {
+    /// Emits this frame's geometry (mount/unmount OSC) to `out` and, when focus
+    /// changed since the last frame, the control-plane focus op to `socket`.
+    pub(crate) fn emit_frame(
+        &mut self,
+        out: &mut impl Write,
+        socket: &SharedWriter,
+        frame: &FramePlacements,
+    ) -> OzmaResult<()> {
+        flush_placements(out, self, &frame.placements)?;
+        // NOTE: only take the writer lock (shared with the reader thread and
+        // every WebviewHandle::emit) when focus actually changed; this runs every
+        // render frame and the unchanged path must not contend the lock.
+        if self.last_focused == frame.focused {
+            return Ok(());
+        }
+        let mut w = socket.lock()?;
+        flush_focus(&mut *w, &mut self.last_focused, &frame.focused)
+    }
+}
+
 type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
 type PendingRegisters = Arc<Mutex<VecDeque<PendingRegister>>>;
 
@@ -78,8 +97,7 @@ struct PendingRegister {
 pub struct Ozma {
     writer: SharedWriter,
     pending: PendingRegisters,
-    frame: FramePlacements,
-    flush_state: FlushState,
+    frame: Arc<Mutex<FramePlacements>>,
 }
 
 impl Ozma {
@@ -106,8 +124,7 @@ impl Ozma {
         Ok(Self {
             writer,
             pending,
-            frame: FramePlacements::default(),
-            flush_state: FlushState::default(),
+            frame: Arc::new(Mutex::new(FramePlacements::default())),
         })
     }
 
@@ -137,37 +154,30 @@ impl Ozma {
         Ok(WebviewHandle::new(handle, self.writer.clone()))
     }
 
-    /// Returns the per-frame placement collector, cleared, for `render_stateful_widget`.
-    pub fn frame(&mut self) -> &mut FramePlacements {
-        self.frame.placements.clear();
-        self.frame.focused = None;
-        &mut self.frame
+    /// Locks and clears the per-frame placement collector for `render_stateful_widget`.
+    ///
+    /// The returned guard derefs to [`FramePlacements`]; pass `&mut *ozma.frame()`
+    /// as the widget state. Let it drop at the end of the `terminal.draw` closure
+    /// so the [`crate::OzmaBackend`] can read the frame during that draw's flush.
+    pub fn frame(&self) -> MutexGuard<'_, FramePlacements> {
+        let mut frame = self.frame.lock().unwrap_or_else(|e| e.into_inner());
+        frame.placements.clear();
+        frame.focused = None;
+        frame
     }
 
-    /// Emits mount/unmount OSC for this frame's placements, after `terminal.draw()`.
-    pub fn flush<B: Backend + Write>(&mut self, terminal: &mut Terminal<B>) -> OzmaResult<()> {
-        let placements = std::mem::take(&mut self.frame.placements);
-        let result = flush_placements(terminal.backend_mut(), &mut self.flush_state, &placements);
-        self.frame.placements = placements;
-        result?;
-        // NOTE: only take the writer lock (shared with the reader thread and
-        // every WebviewHandle::emit) when focus actually changed; flush runs
-        // every render frame and the unchanged path must not contend the lock.
-        if self.flush_state.last_focused == self.frame.focused {
-            return Ok(());
-        }
-        let mut w = self.writer.lock()?;
-        flush_focus(
-            &mut *w,
-            &mut self.flush_state.last_focused,
-            &self.frame.focused,
-        )
+    pub(crate) fn frame_handle(&self) -> Arc<Mutex<FramePlacements>> {
+        self.frame.clone()
+    }
+
+    pub(crate) fn writer_handle(&self) -> SharedWriter {
+        self.writer.clone()
     }
 }
 
 /// Emits CUP + mount-inline for new/changed placements and unmount for vanished
 /// handles, updating `state` to the new frame. Degenerate rects are skipped.
-pub(crate) fn flush_placements(
+fn flush_placements(
     out: &mut impl Write,
     state: &mut FlushState,
     placements: &[Placement],
@@ -207,7 +217,7 @@ pub(crate) fn flush_placements(
 /// Emits the control-plane focus op (`ClientMsg::Focus`) when the focused handle
 /// changed from the last flush. `Some(h)` focuses handle `h`; `None` blurs. No
 /// write when unchanged (diff-driven, like geometry in `flush_placements`).
-pub(crate) fn flush_focus(
+fn flush_focus(
     out: &mut impl Write,
     last_focused: &mut Option<String>,
     focused: &Option<String>,

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -8,8 +8,8 @@ use ratatui::widgets::{Clear, StatefulWidget, Widget};
 /// A ratatui widget that mounts an ozmux webview at its area.
 ///
 /// Blanks its cells (the webview composites under the text) and records its rect
-/// for the next [`crate::Ozma::flush`]. Optionally paints a fallback under-layer
-/// (shown on non-macOS or before the page composites).
+/// into the frame the [`crate::OzmaBackend`] emits on the next draw. Optionally
+/// paints a fallback under-layer (shown on non-macOS or before the page composites).
 pub struct WebviewWidget<'a, W = Blank> {
     handle: &'a str,
     fallback: W,

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -10,18 +10,18 @@ use ratatui::widgets::{Clear, StatefulWidget, Widget};
 /// Blanks its cells (the webview composites under the text) and records its rect
 /// into the frame the [`crate::OzmaBackend`] emits on the next draw. Optionally
 /// paints a fallback under-layer (shown on non-macOS or before the page composites).
-pub struct WebviewWidget<'a, W = Blank> {
+pub struct WebviewWidget<'a, W = WebviewDefaultPlaceholder> {
     handle: &'a str,
     fallback: W,
     focused: bool,
 }
 
-impl<'a> WebviewWidget<'a, Blank> {
+impl<'a> WebviewWidget<'a, WebviewDefaultPlaceholder> {
     /// Creates a widget for the given webview handle id.
     pub fn new(handle: &'a str) -> Self {
         Self {
             handle,
-            fallback: Blank,
+            fallback: WebviewDefaultPlaceholder,
             focused: false,
         }
     }
@@ -74,9 +74,9 @@ impl<W: Widget> StatefulWidget for WebviewWidget<'_, W> {
 
 /// A no-op fallback widget (the default): renders nothing.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct Blank;
+pub struct WebviewDefaultPlaceholder;
 
-impl Widget for Blank {
+impl Widget for WebviewDefaultPlaceholder {
     fn render(self, _area: Rect, _buf: &mut Buffer) {}
 }
 

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -1,8 +1,13 @@
 mod support;
 
-use ratatui_ozma::{Ozma, OzmaError, RpcError, Webview};
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::buffer::{Buffer, Cell};
+use ratatui::layout::Rect;
+use ratatui::widgets::StatefulWidget;
+use ratatui_ozma::{Ozma, OzmaBackend, OzmaError, RpcError, Webview, WebviewWidget};
 use serde_json::json;
-use std::sync::Mutex;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
 use support::FakeServer;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -21,6 +26,57 @@ fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
         std::env::remove_var("OZMUX_SOCK");
         std::env::remove_var("OZMUX_TOKEN");
     }
+}
+
+#[derive(Clone)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn backend_draw_emits_mount_osc_and_focus_op() {
+    let server = FakeServer::start("view-1");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma.register(Webview::inline("x")).unwrap();
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &ozma);
+
+        // A WebviewWidget records its placement + focus into the frame the SDK
+        // shares with the backend — the same path render_stateful_widget drives.
+        {
+            let mut scratch = Buffer::empty(Rect::new(0, 0, 80, 40));
+            let mut frame = ozma.frame();
+            WebviewWidget::new(handle.id()).focused(true).render(
+                Rect::new(2, 3, 48, 12),
+                &mut scratch,
+                &mut *frame,
+            );
+        }
+
+        // Terminal::flush calls Backend::draw once per frame; drive it directly.
+        let no_cells: Vec<(u16, u16, &Cell)> = Vec::new();
+        Backend::draw(&mut backend, no_cells.into_iter()).unwrap();
+
+        let out = String::from_utf8(term_bytes.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            out.contains("mount-inline;view-1;12;48"),
+            "terminal output missing mount OSC: {out:?}"
+        );
+
+        let msg = server.next_message();
+        assert_eq!(msg["op"], "focus");
+        assert_eq!(msg["handle"], "view-1");
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`ratatui-ozma` required apps to call `ozma.flush(terminal)` after every
`terminal.draw()` to emit the webview mount/unmount OSC (to the terminal) and the
focus op (to the control socket). That extra call is easy to forget — and when
forgotten, the webview silently never mounts.

The goal was to remove the separate flush **without** changing the user's
`terminal.draw(|f| {...})` loop and **without** an `Ozma::draw` wrapper.

## Solution

Affects: `sdk/ratatui-ozma` (SDK crate only — no in-workspace consumers).

Introduce `OzmaBackend<B>`, a ratatui `Backend` that wraps the real backend and
emits the webview OSC during `terminal.draw()`. Apps wrap their backend once and
keep an unchanged draw loop with no flush call:

```rust
let ozma = Ozma::connect()?;
let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), &ozma);
let mut terminal = Terminal::new(backend)?;   // ratatui's own Terminal::new

terminal.draw(|f| {
    f.render_stateful_widget(
        WebviewWidget::new(view.id()).focused(web_focused),
        area,
        &mut *ozma.frame(),
    );
})?;                                            // no ozma.flush
```

Why a backend wrapper (vs. cell-symbol smuggling à la ratatui-image): the OSC
must reach the real terminal **after** the cell diff, and ozma also needs
cross-frame unmount of vanished handles plus a focus op over a non-terminal
socket — neither fits in a buffer cell. The wrapper is the only technique that
keeps the draw call unchanged while covering all three.

How it works:
- `Ozma` and `OzmaBackend` share the per-frame placement collector
  (`Arc<Mutex<FramePlacements>>`) and the control socket.
- `OzmaBackend::draw` delegates to `inner.draw(diff)`, then runs `emit_frame`
  (mount/unmount OSC + focus op when changed). `Backend::draw` fires every frame
  even with an empty diff, so vanished-handle unmounts and focus changes still
  flush.
- The frame guard is released before the draw's flush, and no path takes
  socket-then-frame, so there is no deadlock.

Also renames the default fallback widget `Blank` -> `WebviewDefaultPlaceholder`.

### Breaking Changes

- `ozma.frame()` now returns a `MutexGuard` — pass `&mut *ozma.frame()` as the
  widget state (was `ozma.frame()`).
- `Ozma::flush` is removed; wrap the backend with `OzmaBackend` instead.
- The exported `Blank` fallback widget is renamed to `WebviewDefaultPlaceholder`.

### Testing

- New integration test drives `OzmaBackend::draw` and asserts the mount OSC
  reaches the terminal writer and the focus op reaches the control socket.
- Existing `flush_placements` / `flush_focus` unit tests retained (the diff
  logic is unchanged and reused).
- `cargo test -p ratatui-ozma` (39 unit + 6 integration + 1 doctest), clippy
  `--all-targets`, and `cargo fmt --check` all clean; both examples build.