### PR TITLE
feat(webview)!: single `params` value for RPC handlers (drop positional args array)

### DIFF
--- a/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
+++ b/docs/superpowers/specs/2026-06-14-ratatui-ozma-webview-design.md
@@ -32,7 +32,7 @@ apps never hand-roll escape codes or NDJSON.
      line is **obsolete** after #115).
 3. **`window.ozmux`** JS bridge — `call` / `on` / `off`, injected into every
    Tier 1 page. The SDK is the program-side peer of this bridge.
-   - Code: `src/extension_render/ozmux_bridge.js`, `src/extension_render.rs`.
+   - Code: `src/webview_render/ozmux_bridge.js`, `src/webview_render.rs`.
 
 ### Constraints (inherited from the repo)
 
@@ -174,11 +174,11 @@ chart.emit("tick", &n)?;          // -> window.ozmux.on('tick', n)
 ```
 
 - **Wire protocol** (the control plane already speaks these; note the inbound
-  `call` frame is synthesized in `src/extension_render.rs`, not a `ServerMsg`
+  `call` frame is synthesized in `src/webview_render.rs`, not a `ServerMsg`
   variant in `protocol.rs`, and register replies are untagged `{ok, handle}` /
   `{ok:false, error}` — the SDK serializes `register()` through its single I/O
   thread so each reply matches its request):
-  - inbound to the program: `{"op":"call","handle":H,"reqId":R,"method":M,"args":[…]}`
+  - inbound to the program: `{"op":"call","handle":H,"reqId":R,"method":M,"params":V}`
   - program reply: `{"op":"reply","reqId":R,"ok":true,"value":V}` /
     `{"op":"reply","reqId":R,"ok":false,"error":E}`
   - program → page push: `{"op":"emit","handle":H,"event":E,"payload":P}`.
@@ -197,13 +197,13 @@ chart.emit("tick", &n)?;          // -> window.ozmux.on('tick', n)
   around each `writeln!`, matching `examples/dyn_webview_client.rs`. A
   channel-drained command pattern is offered as the deadlock-free default, with
   `Arc<Mutex<…>>` as the terser escape hatch.
-- **Args mapping:** `window.ozmux.call(method, args)` always sends `args` as a
-  JSON **array**. The handler parameter is deserialized from that array:
-  single-arg closures via an extractor-style trait impl (`|arg: String|` ⇐
-  `["hi"]`), multi-arg via a tuple (`|(a, b): (u32, String)|` ⇐ `[1, "x"]`). The
-  precise extractor ergonomics (how many arities, the trait shape) are settled in
-  the implementation plan; the fallback if extractors prove fiddly is a single
-  `Params` argument with `.get::<T>(i)` accessors.
+- **Params mapping:** `window.ozmux.call(method, params)` sends a **single**
+  `params` value (any JSON shape, not a positional array). The handler parameter
+  is any `DeserializeOwned` type, deserialized directly from that value: an
+  object becomes a struct (`|p: SaveReq|` ⇐ `{id, name}`), an array a tuple
+  (`|(a, b): (u32, String)|` ⇐ `[1, "x"]`), a scalar a scalar (`|n: u32|` ⇐ `7`),
+  and an omitted/`null` params the unit type (`|_: ()|`). There is no positional
+  arg array and no extractor trait — one value in, one `P` out.
 - **Errors:** a handler returning `Err(_)`, an unknown method, or a
   deserialization failure produces `{ok:false, error}`, surfacing as a rejected
   Promise in the page.
@@ -243,7 +243,7 @@ Resolved from spec review:
 2. **`flush` shape:** implement the byte emission as `flush_to(&mut impl Write)`
    and provide `flush(&mut Terminal<B>)` as the ergonomic wrapper over it (eases
    sequence tests and custom backend/output splits).
-3. **RPC dispatch:** look up the method *before* deserializing args (return
+3. **RPC dispatch:** look up the method *before* deserializing params (return
    `unknown_method` first).
 
 Plan-time options (ergonomics; do not affect correctness):

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -39,7 +39,7 @@ fn main() -> std::io::Result<()> {
             "<input id='field' placeholder='click here, then type\u{2026}' ",
             "style='font:16px sans-serif;padding:4px;width:92%;margin-top:8px'>",
             "<script>",
-            "window.ozmux.call('ping',['hi'])",
+            "window.ozmux.call('ping','hi')",
             ".then(function(v){document.getElementById('out').textContent='ping \u{2192} '+v;})",
             ".catch(function(e){document.getElementById('out').textContent='error: '+e.message;});",
             "window.ozmux.on('tick',function(n){document.getElementById('tick').textContent='tick #'+n;});",
@@ -116,12 +116,7 @@ fn main() -> std::io::Result<()> {
         let req_id = req_id.clone();
         let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
         let reply = if method == "ping" {
-            let arg = msg
-                .get("args")
-                .and_then(Value::as_array)
-                .and_then(|a| a.first())
-                .and_then(Value::as_str)
-                .unwrap_or("");
+            let arg = msg.get("params").and_then(Value::as_str).unwrap_or("");
             json!({ "op": "reply", "reqId": req_id, "ok": true, "value": format!("pong:{arg}") })
         } else {
             json!({ "op": "reply", "reqId": req_id, "ok": false, "error": "unknown_method" })

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "<h1>ratatui-ozma</h1><div id='out'>calling ping…</div><div id='tick'>no ticks</div>",
         "<input id='in' placeholder='type here…' style='font:14px monospace;padding:6px'>",
         "<script>",
-        "window.ozmux.call('ping',['hi']).then(v=>out.textContent='ping → '+v);",
+        "window.ozmux.call('ping','hi').then(v=>out.textContent='ping → '+v);",
         "window.ozmux.on('tick',n=>tick.textContent='tick #'+n);",
         "document.getElementById('in').focus();",
         "</script></body>"
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     code: KeyCode::Char('l'),
                 },
             ])
-            .on("ping", |(arg,): (String,)| {
+            .on("ping", |arg: String| {
                 Ok::<_, RpcError>(format!("pong:{arg}"))
             }),
     )?;

--- a/sdk/ratatui-ozma/src/handler.rs
+++ b/sdk/ratatui-ozma/src/handler.rs
@@ -1,4 +1,4 @@
-//! RPC handler boxing and tuple-param dispatch.
+//! RPC handler boxing and single-params dispatch.
 
 use crate::error::RpcError;
 use serde::Serialize;
@@ -6,28 +6,21 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::sync::Arc;
 
-/// A type-erased RPC handler: args array in, JSON value or error out.
+/// A type-erased RPC handler: the params value in, JSON value or error out.
 pub(crate) type BoxedHandler =
-    Arc<dyn Fn(Vec<Value>) -> Result<Value, RpcError> + Send + Sync + 'static>;
+    Arc<dyn Fn(Value) -> Result<Value, RpcError> + Send + Sync + 'static>;
 
-/// Boxes a typed handler whose parameter is a tuple deserialized from the
-/// positional args array, returning a `BoxedHandler`.
+/// Boxes a typed handler whose parameter is any `DeserializeOwned` type,
+/// deserialized from the single `params` value, returning a `BoxedHandler`.
 pub(crate) fn make_handler<P, R, F>(f: F) -> BoxedHandler
 where
     P: DeserializeOwned,
     R: Serialize,
     F: Fn(P) -> Result<R, RpcError> + Send + Sync + 'static,
 {
-    Arc::new(move |args: Vec<Value>| {
-        // NOTE: serde_json deserializes () from null, not from an empty array, so
-        // an empty args list must be presented as Value::Null to satisfy unit params.
-        let raw = if args.is_empty() {
-            Value::Null
-        } else {
-            Value::Array(args)
-        };
-        let params: P = serde_json::from_value(raw)?;
-        let result = f(params)?;
+    Arc::new(move |params: Value| {
+        let p: P = serde_json::from_value(params)?;
+        let result = f(p)?;
         Ok(serde_json::to_value(result)?)
     })
 }
@@ -37,28 +30,40 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[derive(serde::Deserialize)]
+    struct SaveReq {
+        id: u32,
+        name: String,
+    }
+
     #[test]
-    fn single_arg_tuple_dispatch() {
-        let h = make_handler(|(name,): (String,)| Ok(format!("hi {name}")));
-        let out = h(vec![json!("ada")]).unwrap();
+    fn scalar_params_dispatch() {
+        let h = make_handler(|name: String| Ok(format!("hi {name}")));
+        let out = h(json!("ada")).unwrap();
         assert_eq!(out, json!("hi ada"));
     }
 
     #[test]
-    fn two_arg_tuple_dispatch() {
+    fn struct_params_dispatch() {
+        let h = make_handler(|req: SaveReq| Ok(format!("{}:{}", req.id, req.name)));
+        assert_eq!(h(json!({"id": 7, "name": "ada"})).unwrap(), json!("7:ada"));
+    }
+
+    #[test]
+    fn tuple_params_dispatch() {
         let h = make_handler(|(a, b): (u32, u32)| Ok(a + b));
-        assert_eq!(h(vec![json!(2), json!(3)]).unwrap(), json!(5));
+        assert_eq!(h(json!([2, 3])).unwrap(), json!(5));
     }
 
     #[test]
-    fn unit_arg_dispatch() {
-        let h = make_handler(|(): ()| Ok("ok"));
-        assert_eq!(h(vec![]).unwrap(), json!("ok"));
+    fn unit_params_dispatch() {
+        let h = make_handler(|_: ()| Ok("ok"));
+        assert_eq!(h(Value::Null).unwrap(), json!("ok"));
     }
 
     #[test]
-    fn bad_args_become_rpc_error() {
-        let h = make_handler(|(_n,): (u32,)| Ok(0u32));
-        assert!(h(vec![json!("not a number")]).is_err());
+    fn bad_params_become_rpc_error() {
+        let h = make_handler(|_n: u32| Ok(0u32));
+        assert!(h(json!("not a number")).is_err());
     }
 }

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -94,9 +94,9 @@ pub(crate) struct IncomingCall {
     pub(crate) req_id: Value,
     /// The invoked method name.
     pub(crate) method: String,
-    /// The positional arguments array.
+    /// The single params value (any JSON shape; absent deserializes as null).
     #[serde(default)]
-    pub(crate) args: Vec<Value>,
+    pub(crate) params: Value,
 }
 
 mod reply_result {
@@ -185,12 +185,20 @@ mod tests {
     #[test]
     fn call_deserializes() {
         let c: IncomingCall = serde_json::from_str(
-            r#"{"op":"call","handle":"h","reqId":"3","method":"ping","args":["x"]}"#,
+            r#"{"op":"call","handle":"h","reqId":"3","method":"ping","params":"x"}"#,
         )
         .unwrap();
         assert_eq!(c.handle, "h");
         assert_eq!(c.method, "ping");
-        assert_eq!(c.args, vec![serde_json::json!("x")]);
+        assert_eq!(c.params, serde_json::json!("x"));
+    }
+
+    #[test]
+    fn call_without_params_deserializes_as_null() {
+        let c: IncomingCall =
+            serde_json::from_str(r#"{"op":"call","handle":"h","reqId":"3","method":"ping"}"#)
+                .unwrap();
+        assert_eq!(c.params, Value::Null);
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -309,10 +309,12 @@ fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: Incomi
         // A user handler runs on this reader thread; isolate panics so one bad
         // handler can't unwind the thread and silence all future RPC + register
         // replies. A panicked handler reports as a rejected call.
-        Some(h) => match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| h(call.args))) {
-            Ok(r) => r.map_err(|e| e.message().to_owned()),
-            Err(_) => Err("handler panicked".to_owned()),
-        },
+        Some(h) => {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| h(call.params))) {
+                Ok(r) => r.map_err(|e| e.message().to_owned()),
+                Err(_) => Err("handler panicked".to_owned()),
+            }
+        }
         None => Err("unknown_method".to_owned()),
     };
 

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -65,8 +65,10 @@ impl Webview {
         self
     }
 
-    /// Registers an RPC handler for `method`. The parameter is a tuple
-    /// deserialized from the page's `window.ozmux.call(method, args)` array.
+    /// Registers an RPC handler for `method`. The parameter is any
+    /// `DeserializeOwned` type, deserialized from the single `params` value the
+    /// page passes to `window.ozmux.call(method, params)` (an object becomes a
+    /// struct, an array a tuple, and an omitted/`null` params the unit `()`).
     ///
     /// # Panics
     /// Panics if `method` starts with the reserved `__ozma.` prefix, which is
@@ -166,15 +168,15 @@ mod tests {
 
     #[test]
     fn on_registers_handler() {
-        let wv = Webview::inline("x").on("ping", |(n,): (String,)| Ok(format!("pong:{n}")));
+        let wv = Webview::inline("x").on("ping", |n: String| Ok(format!("pong:{n}")));
         let h = wv.handlers.get("ping").expect("handler present");
-        assert_eq!(h(vec![json!("hi")]).unwrap(), json!("pong:hi"));
+        assert_eq!(h(json!("hi")).unwrap(), json!("pong:hi"));
     }
 
     #[test]
     #[should_panic(expected = "__ozma.")]
     fn user_on_rejects_reserved_namespace() {
-        let _ = Webview::inline("x").on("__ozma.nav", |(): ()| Ok::<_, crate::error::RpcError>(()));
+        let _ = Webview::inline("x").on("__ozma.nav", |_: ()| Ok::<_, crate::error::RpcError>(()));
     }
 
     #[test]

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -85,13 +85,11 @@ fn call_is_dispatched_and_replied() {
     with_env(&server.sock_path.clone(), || {
         let ozma = Ozma::connect().unwrap();
         let _handle = ozma
-            .register(
-                Webview::inline("<h1>x</h1>").on("ping", |(n,): (String,)| Ok(format!("pong:{n}"))),
-            )
+            .register(Webview::inline("<h1>x</h1>").on("ping", |n: String| Ok(format!("pong:{n}"))))
             .unwrap();
 
         server.send(json!({
-            "op": "call", "handle": "view-1", "reqId": "7", "method": "ping", "args": ["hi"]
+            "op": "call", "handle": "view-1", "reqId": "7", "method": "ping", "params": "hi"
         }));
 
         let reply = server.next_message();
@@ -109,7 +107,7 @@ fn unknown_method_replies_error() {
         let ozma = Ozma::connect().unwrap();
         let _h = ozma.register(Webview::inline("x")).unwrap();
         server.send(json!({
-            "op": "call", "handle": "view-2", "reqId": "1", "method": "nope", "args": []
+            "op": "call", "handle": "view-2", "reqId": "1", "method": "nope", "params": null
         }));
         let reply = server.next_message();
         assert_eq!(reply["ok"], false);
@@ -156,15 +154,15 @@ fn panicking_handler_does_not_kill_reader() {
         let _h = ozma
             .register(
                 Webview::inline("x")
-                    .on("boom", |(): ()| -> Result<(), RpcError> { panic!("boom") })
-                    .on("ping", |(): ()| Ok::<_, RpcError>("pong")),
+                    .on("boom", |_: ()| -> Result<(), RpcError> { panic!("boom") })
+                    .on("ping", |_: ()| Ok::<_, RpcError>("pong")),
             )
             .unwrap();
 
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
         server.send(
-            json!({ "op": "call", "handle": "view-5", "reqId": "1", "method": "boom", "args": [] }),
+            json!({ "op": "call", "handle": "view-5", "reqId": "1", "method": "boom", "params": null }),
         );
         let boom = server.next_message();
         std::panic::set_hook(prev);
@@ -172,7 +170,7 @@ fn panicking_handler_does_not_kill_reader() {
         assert_eq!(boom["ok"], false);
 
         server.send(
-            json!({ "op": "call", "handle": "view-5", "reqId": "2", "method": "ping", "args": [] }),
+            json!({ "op": "call", "handle": "view-5", "reqId": "2", "method": "ping", "params": null }),
         );
         let ping = server.next_message();
         assert_eq!(ping["reqId"], "2");

--- a/src/control_plane/listener.rs
+++ b/src/control_plane/listener.rs
@@ -520,7 +520,7 @@ mod tests {
         loop {
             if writers.send(
                 1,
-                r#"{"op":"call","handle":"H","reqId":"g0","method":"m","args":[]}"#.into(),
+                r#"{"op":"call","handle":"H","reqId":"g0","method":"m","params":null}"#.into(),
             ) {
                 break;
             }

--- a/src/webview_render.rs
+++ b/src/webview_render.rs
@@ -143,10 +143,7 @@ fn on_ozmux_call_frame(
         .get("method")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let args = payload
-        .get("args")
-        .cloned()
-        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let params = payload.get("params").cloned().unwrap_or(Value::Null);
 
     let Ok(owner) = owners.get(webview) else {
         reject_ozmux_call(&mut commands, webview, req_id, "no_owner");
@@ -154,7 +151,7 @@ fn on_ozmux_call_frame(
     };
     let global_id = rpc.mint();
     let line = serde_json::json!({
-        "op": "call", "handle": owner.handle, "reqId": global_id, "method": method, "args": args
+        "op": "call", "handle": owner.handle, "reqId": global_id, "method": method, "params": params
     })
     .to_string();
     if !writers.send(owner.connection_id, line) {
@@ -446,7 +443,7 @@ mod tests {
         app.world_mut().trigger(Receive {
             webview,
             payload: OzmuxFrame(serde_json::json!({
-                "kind": "ozmux.call", "reqId": "p0", "method": "save", "args": [1, 2]
+                "kind": "ozmux.call", "reqId": "p0", "method": "save", "params": [1, 2]
             })),
         });
 
@@ -456,6 +453,7 @@ mod tests {
         assert_eq!(v["handle"], "H");
         assert_eq!(v["method"], "save");
         assert_eq!(v["reqId"], "0");
+        assert_eq!(v["params"], serde_json::json!([1, 2]));
         assert_eq!(
             app.world()
                 .resource::<OzmuxRpc>()

--- a/src/webview_render/ozmux_bridge.js
+++ b/src/webview_render/ozmux_bridge.js
@@ -1,8 +1,10 @@
 // NOTE: bevy_cef contract — Rust->JS cef.listen delivers a JSON *string* (hence
 // JSON.parse); JS->Rust cef.emit serializes only its FIRST argument. Replies
 // arrive on the "ozmux" channel keyed by reqId; push events on "ozmux.event".
-// The {__u8} base64 tag mirrors binary-codec.ts (top-level only). window.ozmux
-// is frozen so a page cannot shadow it.
+// The {__u8} base64 tag carries a Uint8Array, but only as a top-level value (the
+// `params` sent, or a reply `value`/event `payload` received via decodeValue) —
+// bytes nested inside an object/array param are NOT tagged and won't round-trip.
+// window.ozmux is frozen so a page cannot shadow it.
 (function () {
   var cef = window.cef;
   var nextId = 0;
@@ -10,13 +12,13 @@
   var calls = new Map();
   var listeners = new Map();
 
-  function encodeArg(a) {
-    if (a instanceof Uint8Array) {
+  function encodeParam(p) {
+    if (p instanceof Uint8Array) {
       var bin = '';
-      for (var i = 0; i < a.length; i++) bin += String.fromCharCode(a[i]);
+      for (var i = 0; i < p.length; i++) bin += String.fromCharCode(p[i]);
       return { __u8: btoa(bin) };
     }
-    return a;
+    return p;
   }
   function decodeValue(v) {
     if (v && typeof v === 'object' && typeof v.__u8 === 'string') {
@@ -46,13 +48,13 @@
   });
 
   var api = {
-    call: function (method, args) {
+    call: function (method, params) {
       var reqId = 'o' + nextId++;
-      var encoded = (args || []).map(encodeArg);
+      var encoded = encodeParam(params);
       return new Promise(function (resolve, reject) {
         calls.set(reqId, { resolve: resolve, reject: reject });
         try {
-          cef.emit({ kind: 'ozmux.call', reqId: reqId, method: method, args: encoded });
+          cef.emit({ kind: 'ozmux.call', reqId: reqId, method: method, params: encoded });
         } catch (e) {
           // A synchronous emit failure never gets a reply, so settle and drop the
           // entry here — otherwise it leaks in calls forever.


### PR DESCRIPTION
## Problem

`ratatui-ozma`'s `Webview::on` handler parameter was deserialized from the **positional-arguments JSON array** sent by `window.ozmux.call(method, args)`. That forced the parameter to be array-deserializable — a tuple, `Vec<T>`, or `[T; N]` — so a plain `struct` (which serde decodes from a JSON *object*) could not be received directly as `|p: MyStruct|`. The goal: let handlers accept **any `DeserializeOwned` type**.

A positional array and a single value cannot be disambiguated by one method (`["x"]` is both a 1-tuple `(T,)` and a single `T`), so the convention is unified onto a single value.

## Solution

Switch the RPC convention to a **single `params` value**. `window.ozmux.call(method, params)` now sends one value of any JSON shape (no array wrapper); the host (`src/webview_render.rs`) relays it verbatim, and the SDK deserializes the handler parameter `P` directly from it. This is a **superset** of the old behavior:

- object ⇒ struct — `|p: SaveReq|`
- array ⇒ tuple — `|(a, b): (u32, u32)|` (positional tuples still work)
- scalar ⇒ scalar — `|n: u32|`
- omitted / `null` ⇒ unit — `|_: ()|`

Investigation showed the array was never structural: the host treats the value as an opaque `serde_json::Value` and just forwards it. The array was enforced only at the two ends (the JS `.map` and the SDK's `Vec<Value>`), so dropping it required no protocol-depth rework — just renaming the wire field `args` ⇒ `params` and the JS encoder `encodeArg` ⇒ `encodeParam`.

**Affected:** webview bridge/host (`src/webview_render.rs`, `src/webview_render/ozmux_bridge.js`, control-plane listener test), the `ratatui-ozma` SDK (`handler.rs`, `protocol.rs`, `session.rs`, `webview.rs`), the examples, and the design spec. The TypeScript SDK (`@ozmux/sdk`, OSC builders only) needed no change.

**Tests:** `cargo test -p ratatui-ozma` (incl. new struct / scalar / tuple / unit param-dispatch tests), host `webview_render` + `control_plane::listener` tests, `clippy`, and `fmt` — all green.

### Breaking Changes

- **Wire:** the inbound `call` frame field `"args": [...]` becomes `"params": <value>`.
- **JS:** `window.ozmux.call(method, params)` takes a single value, not an array — `call('ping', ['hi'])` becomes `call('ping', 'hi')`.
- **SDK:** handlers take the value directly (`|n: String|`) instead of a 1-tuple (`|(n,): (String,)|`); no-arg handlers become `|_: ()|`.
- **Binary:** `{__u8}` base64 tagging now applies to a top-level `Uint8Array` *param* (previously each top-level array element); binary must be passed as the param directly, not wrapped in an array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)