### PR TITLE
feat(ratatui-ozma): remote http(s) URL webviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,6 +4794,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "unicode-width 0.2.0",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 unicode-width = { workspace = true }
+url = "2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/docs/dyn-webview.md
+++ b/docs/dyn-webview.md
@@ -59,15 +59,27 @@ No reply is sent for `hello`.
 {"op":"register","kind":"dir","root":"/absolute/path","entry":"index.html","interactive":true}
 ```
 
+```json
+{"op":"register","kind":"url","url":"https://example.com","interactive":true,"bridge":false}
+```
+
 Fields:
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `kind` | `"inline"` \| `"dir"` | required | Content source |
+| `kind` | `"inline"` \| `"dir"` \| `"url"` | required | Content source |
 | `html` | string | — | Full HTML document (`inline` only). Max 4 MiB. |
 | `root` | string | — | Absolute directory path (`dir` only). Must exist. |
 | `entry` | string | — | HTML entry relative to `root` (`dir` only). No `..` or leading `/`. |
 | `interactive` | bool | `true` | Whether the mounted webview accepts pointer/keyboard input. |
+| `url` | string | — | Remote `http(s)` URL (`url` only). `http`/`https` schemes only. |
+| `bridge` | bool | `false` | Inject the `window.ozmux` back-channel (`url` only; `inline`/`dir` are always bridged). |
+
+A `url` webview is display-only by default: without `bridge:true`, the page
+receives no `window.ozmux` bridge, and ozmux delivers it no `emit` events. The
+URL itself still travels the authenticated socket (never PTY bytes), preserving
+the Tier 1 trust model. `http`/`https` only — other schemes are rejected with
+`unsupported_scheme`.
 
 Reply on success:
 
@@ -88,6 +100,8 @@ Error codes:
 | `invalid_root` | `root` is not absolute, or does not name an existing directory |
 | `unsafe_entry` | `entry` contains `..`, `.`, a leading `/`, or is empty |
 | `html_too_large` | `html` exceeds the 4 MiB limit |
+| `unsupported_scheme` | `url` scheme is not `http`/`https` |
+| `invalid_url` | `url` is unparseable or has no host |
 | `internal` | Server-side fallback if the ECS apply system drops the reply channel before responding — should not occur in normal operation (not a `build_view` validation error). |
 
 The reply arrives synchronously (the listener blocks until the Bevy system
@@ -158,7 +172,6 @@ is killed (`Ctrl-C` → socket disconnect → automatic registration teardown).
 
 The following are explicitly out of scope for Phase A and are deferred:
 
-- **localhost URL mounts** — `kind:"url"` with an `http://localhost/…` source.
 - **Host-API escalation** — dynamic webviews that call `window.<ns>.<method>`
   APIs; Phase A webviews are display-only (no `window.ozmux` bridge).
 - **Untrusted raw-OSC tier** — a lower-trust path that bypasses the socket

--- a/sdk/ratatui-ozma/examples/ratatui_remote_url.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_remote_url.rs
@@ -1,0 +1,60 @@
+//! Minimal remote-URL webview demo. Run inside an ozmux pane:
+//! `cargo run -p ratatui-ozma --example ratatui_remote_url`.
+//!
+//! Mounts a display-only remote page (no `window.ozmux` bridge — `Webview::url`
+//! defaults to display-only) filling the pane, and quits on `q`. This is the
+//! manual end-to-end check for the `url` content source: the remote page should
+//! render inline where the widget is placed.
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyCode};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui_ozma::{Ozma, OzmaBackend, Webview, WebviewWidget};
+use std::io::stdout;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ozma = Ozma::connect()?;
+    let view = ozma.register(Webview::url("https://github.com/not-elm?tab=repositories"))?;
+
+    enable_raw_mode()?;
+    if let Err(e) = execute!(stdout(), EnterAlternateScreen) {
+        // NOTE: EnterAlternateScreen failed after raw mode was enabled — undo it so
+        // the shell isn't left in raw mode.
+        let _ = disable_raw_mode();
+        return Err(e.into());
+    }
+
+    let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), &ozma);
+        let mut terminal = Terminal::new(backend)?;
+        loop {
+            terminal.draw(|f| {
+                let rows =
+                    Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
+                f.render_widget(Paragraph::new("remote url demo · q to quit"), rows[0]);
+                f.render_stateful_widget(
+                    WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                    rows[1],
+                    &mut *ozma.frame(),
+                );
+            })?;
+
+            if event::poll(Duration::from_millis(50))?
+                && let Event::Key(k) = event::read()?
+                && k.code == KeyCode::Char('q')
+            {
+                return Ok(());
+            }
+        }
+    })();
+
+    let _ = disable_raw_mode();
+    let _ = execute!(stdout(), LeaveAlternateScreen);
+    result
+}

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -69,6 +69,18 @@ pub(crate) enum RegisterKind {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         passthrough: Vec<KeyChord>,
     },
+    /// Load a remote `http(s)` URL as the top-level document.
+    Url {
+        /// The `http(s)` URL to load.
+        url: String,
+        /// Whether the view accepts focus/input.
+        interactive: bool,
+        /// Whether the `window.ozmux` back-channel is injected (opt-in).
+        bridge: bool,
+        /// Chords the page lets through to the app while focused.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        passthrough: Vec<KeyChord>,
+    },
 }
 
 /// The untagged reply to a `register` request.
@@ -216,5 +228,25 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
         assert_eq!(v["op"], "focus");
         assert_eq!(v["handle"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn register_url_serializes() {
+        let v = serde_json::to_value(ClientMsg::Register(RegisterKind::Url {
+            url: "https://example.com".into(),
+            interactive: true,
+            bridge: false,
+            passthrough: Vec::new(),
+        }))
+        .unwrap();
+        assert_eq!(v["op"], "register");
+        assert_eq!(v["kind"], "url");
+        assert_eq!(v["url"], "https://example.com");
+        assert_eq!(v["interactive"], true);
+        assert_eq!(v["bridge"], false);
+        assert!(
+            v.get("passthrough").is_none(),
+            "empty passthrough must be skipped"
+        );
     }
 }

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -249,4 +249,17 @@ mod tests {
             "empty passthrough must be skipped"
         );
     }
+
+    #[test]
+    fn register_url_serializes_bridge_true() {
+        let v = serde_json::to_value(ClientMsg::Register(RegisterKind::Url {
+            url: "https://app.example.com".into(),
+            interactive: true,
+            bridge: true,
+            passthrough: Vec::new(),
+        }))
+        .unwrap();
+        assert_eq!(v["kind"], "url");
+        assert_eq!(v["bridge"], true);
+    }
 }

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -52,6 +52,7 @@ impl Webview {
         match &mut self.kind {
             RegisterKind::Inline { interactive: i, .. } => *i = interactive,
             RegisterKind::Dir { interactive: i, .. } => *i = interactive,
+            RegisterKind::Url { interactive: i, .. } => *i = interactive,
         }
         self
     }
@@ -59,7 +60,7 @@ impl Webview {
     /// Declares chords the page lets through to the app while focused (the host
     /// forwards them to the PTY so the app reads them via `crossterm::event::read`).
     pub fn passthrough(mut self, keys: impl IntoIterator<Item = KeyChord>) -> Self {
-        let (RegisterKind::Inline { passthrough, .. } | RegisterKind::Dir { passthrough, .. }) =
+        let (RegisterKind::Inline { passthrough, .. } | RegisterKind::Dir { passthrough, .. } | RegisterKind::Url { passthrough, .. }) =
             &mut self.kind;
         passthrough.extend(keys);
         self

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -86,9 +86,11 @@ impl Webview {
     /// Declares chords the page lets through to the app while focused (the host
     /// forwards them to the PTY so the app reads them via `crossterm::event::read`).
     pub fn passthrough(mut self, keys: impl IntoIterator<Item = KeyChord>) -> Self {
-        let (RegisterKind::Inline { passthrough, .. } | RegisterKind::Dir { passthrough, .. } | RegisterKind::Url { passthrough, .. }) =
-            &mut self.kind;
-        passthrough.extend(keys);
+        match &mut self.kind {
+            RegisterKind::Inline { passthrough, .. }
+            | RegisterKind::Dir { passthrough, .. }
+            | RegisterKind::Url { passthrough, .. } => passthrough.extend(keys),
+        }
         self
     }
 

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -34,6 +34,23 @@ impl Webview {
         }
     }
 
+    /// Creates a webview that loads a remote `http(s)` URL.
+    ///
+    /// Display-only by default — the `window.ozmux` back-channel is **not**
+    /// injected. Call [`Webview::bridge`] (or register a handler with
+    /// [`Webview::on`], which enables it implicitly) to opt in.
+    pub fn url(url: impl Into<String>) -> Self {
+        Self {
+            kind: RegisterKind::Url {
+                url: url.into(),
+                interactive: true,
+                bridge: false,
+                passthrough: Vec::new(),
+            },
+            handlers: HashMap::new(),
+        }
+    }
+
     /// Creates a webview served from a directory of assets.
     pub fn dir(root: impl AsRef<Path>, entry: impl Into<String>) -> Self {
         Self {
@@ -53,6 +70,15 @@ impl Webview {
             RegisterKind::Inline { interactive: i, .. } => *i = interactive,
             RegisterKind::Dir { interactive: i, .. } => *i = interactive,
             RegisterKind::Url { interactive: i, .. } => *i = interactive,
+        }
+        self
+    }
+
+    /// Opts a `url` webview into the `window.ozmux` back-channel. A no-op for
+    /// `inline`/`dir` webviews, which are always bridged. Fixed at register.
+    pub fn bridge(mut self, bridge: bool) -> Self {
+        if let RegisterKind::Url { bridge: b, .. } = &mut self.kind {
+            *b = bridge;
         }
         self
     }
@@ -84,6 +110,9 @@ impl Webview {
             "method {method:?} uses the reserved __ozma. namespace"
         );
         self.handlers.insert(method, make_handler(f));
+        if let RegisterKind::Url { bridge, .. } = &mut self.kind {
+            *bridge = true;
+        }
         self
     }
 }
@@ -199,5 +228,56 @@ mod tests {
             v.get("passthrough").is_none(),
             "empty passthrough must be skipped"
         );
+    }
+
+    #[test]
+    fn url_builder_records_kind_with_display_only_defaults() {
+        let wv = Webview::url("https://example.com");
+        match &wv.kind {
+            RegisterKind::Url {
+                url,
+                interactive,
+                bridge,
+                ..
+            } => {
+                assert_eq!(url, "https://example.com");
+                assert!(*interactive, "url webviews are interactive by default");
+                assert!(!*bridge, "url webviews are display-only by default");
+            }
+            _ => panic!("expected url"),
+        }
+    }
+
+    #[test]
+    fn bridge_opts_a_url_webview_into_the_back_channel() {
+        let wv = Webview::url("https://example.com").bridge(true);
+        match &wv.kind {
+            RegisterKind::Url { bridge, .. } => assert!(*bridge),
+            _ => panic!("expected url"),
+        }
+    }
+
+    #[test]
+    fn on_implicitly_enables_the_bridge_for_url_webviews() {
+        let wv = Webview::url("https://example.com")
+            .on("ping", |(): ()| Ok::<_, crate::error::RpcError>(()));
+        match &wv.kind {
+            RegisterKind::Url { bridge, .. } => {
+                assert!(*bridge, "registering a handler must enable the bridge");
+            }
+            _ => panic!("expected url"),
+        }
+    }
+
+    #[test]
+    fn url_passthrough_rides_register_wire() {
+        use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+        let wv = Webview::url("https://example.com").passthrough([KeyChord {
+            mods: KeyModifiers::ALT,
+            code: KeyCode::Char('h'),
+        }]);
+        let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
+        assert_eq!(v["kind"], "url");
+        assert_eq!(v["passthrough"][0]["key"], "h");
     }
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -1191,8 +1191,6 @@ mod apply_tests {
                 passthrough: vec![],
             },
         );
-        // A mounted inline child for that handle — it WOULD receive the emit if
-        // the fan-out were not bridge-gated.
         app.world_mut().spawn(InlineWebview {
             view_id: "disp".into(),
             instance_id: None,

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -463,10 +463,10 @@ fn apply_control_events(
                 event,
                 payload,
             } => {
-                let owns = registry
-                    .get(&handle)
-                    .is_some_and(|v| v.connection_id == connection_id);
-                if !owns {
+                let deliver = registry.get(&handle).is_some_and(|v| {
+                    v.connection_id == connection_id && v.source.is_bridged()
+                });
+                if !deliver {
                     continue;
                 }
                 let frame = serde_json::json!({ "event": event, "payload": payload });
@@ -1168,6 +1168,59 @@ mod apply_tests {
             app.world().resource::<Caps>().0,
             vec![(webview, "ozmux".to_string())],
             "only the owning connection's reply settles the page"
+        );
+    }
+
+    #[test]
+    fn apply_emit_is_dropped_for_a_non_bridged_url_view() {
+        use bevy_cef::prelude::HostEmitEvent;
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let mut reg = DynamicRegistry::default();
+        reg.insert(
+            "disp".into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: "https://example.com".into(),
+                    bridge: false,
+                },
+                entry: String::new(),
+                interactive: true,
+                owner_surface: Entity::from_bits(1),
+                connection_id: 5,
+                passthrough: vec![],
+            },
+        );
+        // A mounted inline child for that handle — it WOULD receive the emit if
+        // the fan-out were not bridge-gated.
+        app.world_mut().spawn(InlineWebview {
+            view_id: "disp".into(),
+            instance_id: None,
+            slot: 0,
+        });
+        app.insert_resource(reg);
+        app.insert_resource(OzmuxRpc::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(DynAssetRegistry::default()));
+        #[derive(Resource, Default)]
+        struct Caps(Vec<Entity>);
+        app.insert_resource(Caps::default());
+        app.add_observer(|e: On<HostEmitEvent>, mut c: ResMut<Caps>| c.0.push(e.webview));
+        app.add_systems(Update, apply_control_events);
+
+        ev_tx
+            .send(ControlEvent::Emit {
+                connection_id: 5,
+                handle: "disp".into(),
+                event: "tick".into(),
+                payload: serde_json::json!(1),
+            })
+            .unwrap();
+        app.update();
+
+        assert!(
+            app.world().resource::<Caps>().0.is_empty(),
+            "a non-bridged url view must receive no emit"
         );
     }
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -64,7 +64,10 @@ impl DynSource {
     /// back-channel. Only a display-only (`bridge: false`) `Url` source is
     /// unbridged; `Dir`/`Inline` are always bridged.
     pub(crate) fn is_bridged(&self) -> bool {
-        !matches!(self, DynSource::Url { bridge: false, .. })
+        match self {
+            DynSource::Dir(_) | DynSource::Inline(_) => true,
+            DynSource::Url { bridge, .. } => *bridge,
+        }
     }
 }
 
@@ -637,7 +640,7 @@ fn validate_url_source(url: &str) -> Result<String, &'static str> {
     if parsed.host_str().is_none_or(str::is_empty) {
         return Err("invalid_url");
     }
-    Ok(parsed.to_string())
+    Ok(parsed.into())
 }
 
 /// Converts a wire [`HostKeyChord`] to a [`NormalizedChord`], returning `None`

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -463,9 +463,9 @@ fn apply_control_events(
                 event,
                 payload,
             } => {
-                let deliver = registry.get(&handle).is_some_and(|v| {
-                    v.connection_id == connection_id && v.source.is_bridged()
-                });
+                let deliver = registry
+                    .get(&handle)
+                    .is_some_and(|v| v.connection_id == connection_id && v.source.is_bridged());
                 if !deliver {
                     continue;
                 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -18,6 +18,7 @@ use ozmux_webview_host::host::RuntimeRoot;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use url::Url;
 
 mod listener;
 mod protocol;
@@ -47,6 +48,24 @@ pub(crate) enum DynSource {
     /// A single inline HTML document, registered into `DynAssetRegistry` and
     /// served under `ozmux-dyn://<handle>/`.
     Inline(String),
+    /// A remote `http(s)` URL loaded directly by CEF (no `ozmux-dyn://` origin,
+    /// no `DynAssetRegistry` entry). `bridge` records whether the registering
+    /// program opted into the `window.ozmux` back-channel.
+    Url {
+        /// The validated `http(s)` URL.
+        url: String,
+        /// Whether the `window.ozmux` back-channel is injected.
+        bridge: bool,
+    },
+}
+
+impl DynSource {
+    /// Whether a mounted view of this source receives the `window.ozmux`
+    /// back-channel. Only a display-only (`bridge: false`) `Url` source is
+    /// unbridged; `Dir`/`Inline` are always bridged.
+    pub(crate) fn is_bridged(&self) -> bool {
+        !matches!(self, DynSource::Url { bridge: false, .. })
+    }
 }
 
 /// A Tier 1 dynamic registration: its content source, entry, input policy, and
@@ -384,6 +403,7 @@ fn apply_control_events(
                             .0
                             .insert_inline(handle.clone(), html.clone().into_bytes());
                     }
+                    DynSource::Url { .. } => {}
                 }
                 registry.insert(handle.clone(), view);
                 let _ = reply.send(ServerMsg::ok(handle));
@@ -574,6 +594,22 @@ fn build_view(
                 passthrough: passthrough.iter().filter_map(normalize_chord).collect(),
             })
         }
+        RegisterKind::Url {
+            url,
+            interactive,
+            bridge,
+            passthrough,
+        } => {
+            let url = validate_url_source(&url)?;
+            Ok(DynamicView {
+                source: DynSource::Url { url, bridge },
+                entry: String::new(),
+                interactive,
+                owner_surface,
+                connection_id,
+                passthrough: passthrough.iter().filter_map(normalize_chord).collect(),
+            })
+        }
     }
 }
 
@@ -584,6 +620,22 @@ fn is_safe_entry(entry: &str) -> bool {
     !p.as_os_str().is_empty()
         && p.components()
             .all(|c| matches!(c, std::path::Component::Normal(_)))
+}
+
+/// Validates a `url` register source: parses it, requires an `http`/`https`
+/// scheme, then a non-empty host. The scheme check precedes the host check on
+/// purpose — `url::Url::parse("javascript:…")` succeeds with no host, so a
+/// host-first order would mis-report `javascript:` as `invalid_url` instead of
+/// `unsupported_scheme`.
+fn validate_url_source(url: &str) -> Result<String, &'static str> {
+    let parsed = Url::parse(url).map_err(|_| "invalid_url")?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("unsupported_scheme");
+    }
+    if parsed.host_str().is_none_or(str::is_empty) {
+        return Err("invalid_url");
+    }
+    Ok(url.to_string())
 }
 
 /// Converts a wire [`HostKeyChord`] to a [`NormalizedChord`], returning `None`
@@ -1120,6 +1172,50 @@ mod apply_tests {
     }
 
     #[test]
+    fn apply_register_url_mints_handle_without_dyn_asset() {
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let dyn_assets = DynAssetRegistry::default();
+        app.insert_resource(DynamicRegistry::default());
+        app.insert_resource(OzmuxRpc::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(DynAssetRegistryRes(dyn_assets.clone()));
+        app.add_systems(Update, apply_control_events);
+
+        let (reply_tx, reply_rx) = bounded::<ServerMsg>(1);
+        ev_tx
+            .send(ControlEvent::Register {
+                connection_id: 1,
+                owner_surface: Entity::from_bits(11),
+                kind: RegisterKind::Url {
+                    url: "https://example.com".into(),
+                    interactive: true,
+                    bridge: false,
+                    passthrough: vec![],
+                },
+                reply: reply_tx,
+            })
+            .unwrap();
+        app.update();
+
+        let handle = match reply_rx.try_recv().expect("apply must reply") {
+            ServerMsg::Ok { handle, .. } => handle,
+            ServerMsg::Err { error, .. } => panic!("unexpected err: {error}"),
+        };
+        assert!(
+            app.world()
+                .resource::<DynamicRegistry>()
+                .get(&handle)
+                .is_some(),
+            "DynamicRegistry populated"
+        );
+        assert!(
+            dyn_assets.get(&handle).is_none(),
+            "DynAssetRegistry must NOT be populated for a url handle"
+        );
+    }
+
+    #[test]
     fn apply_emit_broadcasts_only_to_owning_connections_handle() {
         use bevy_cef::prelude::HostEmitEvent;
         let mut app = App::new();
@@ -1609,5 +1705,84 @@ mod normalize_tests {
             })
             .is_none()
         );
+    }
+}
+
+#[cfg(test)]
+mod url_source_tests {
+    use super::*;
+    use bevy::prelude::Entity;
+
+    #[test]
+    fn validate_url_source_accepts_http_and_https() {
+        assert_eq!(
+            validate_url_source("https://example.com").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            validate_url_source("http://localhost:3000/x").unwrap(),
+            "http://localhost:3000/x"
+        );
+    }
+
+    #[test]
+    fn validate_url_source_rejects_non_web_schemes_as_unsupported() {
+        assert_eq!(
+            validate_url_source("file:///etc/passwd"),
+            Err("unsupported_scheme")
+        );
+        assert_eq!(
+            validate_url_source("javascript:alert(1)"),
+            Err("unsupported_scheme")
+        );
+        assert_eq!(
+            validate_url_source("data:text/html,<h1>x</h1>"),
+            Err("unsupported_scheme")
+        );
+        assert_eq!(
+            validate_url_source("ozmux-dyn://h/index.html"),
+            Err("unsupported_scheme")
+        );
+    }
+
+    #[test]
+    fn validate_url_source_rejects_garbage_as_invalid() {
+        assert_eq!(validate_url_source("not a url"), Err("invalid_url"));
+        assert_eq!(validate_url_source(""), Err("invalid_url"));
+    }
+
+    #[test]
+    fn build_view_url_accepts_https_and_carries_bridge() {
+        let v = build_view(
+            RegisterKind::Url {
+                url: "https://example.com".into(),
+                interactive: true,
+                bridge: true,
+                passthrough: vec![],
+            },
+            Entity::from_bits(1),
+            7,
+        )
+        .expect("https accepted");
+        assert!(matches!(
+            v.source,
+            DynSource::Url { ref url, bridge: true } if url == "https://example.com"
+        ));
+    }
+
+    #[test]
+    fn build_view_url_rejects_file_scheme() {
+        let err = build_view(
+            RegisterKind::Url {
+                url: "file:///etc/passwd".into(),
+                interactive: true,
+                bridge: false,
+                passthrough: vec![],
+            },
+            Entity::from_bits(1),
+            7,
+        )
+        .unwrap_err();
+        assert_eq!(err, "unsupported_scheme");
     }
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -627,6 +627,8 @@ fn is_safe_entry(entry: &str) -> bool {
 /// purpose — `url::Url::parse("javascript:…")` succeeds with no host, so a
 /// host-first order would mis-report `javascript:` as `invalid_url` instead of
 /// `unsupported_scheme`.
+/// Returns the parser-normalized URL (not the raw input) so the validated and
+/// loaded forms are identical.
 fn validate_url_source(url: &str) -> Result<String, &'static str> {
     let parsed = Url::parse(url).map_err(|_| "invalid_url")?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -635,7 +637,7 @@ fn validate_url_source(url: &str) -> Result<String, &'static str> {
     if parsed.host_str().is_none_or(str::is_empty) {
         return Err("invalid_url");
     }
-    Ok(url.to_string())
+    Ok(parsed.to_string())
 }
 
 /// Converts a wire [`HostKeyChord`] to a [`NormalizedChord`], returning `None`
@@ -1768,11 +1770,19 @@ mod url_source_tests {
     fn validate_url_source_accepts_http_and_https() {
         assert_eq!(
             validate_url_source("https://example.com").unwrap(),
-            "https://example.com"
+            "https://example.com/"
         );
         assert_eq!(
             validate_url_source("http://localhost:3000/x").unwrap(),
             "http://localhost:3000/x"
+        );
+    }
+
+    #[test]
+    fn validate_url_source_returns_the_normalized_url() {
+        assert_eq!(
+            validate_url_source("  https://example.com  ").unwrap(),
+            "https://example.com/"
         );
     }
 
@@ -1818,7 +1828,7 @@ mod url_source_tests {
         .expect("https accepted");
         assert!(matches!(
             v.source,
-            DynSource::Url { ref url, bridge: true } if url == "https://example.com"
+            DynSource::Url { ref url, bridge: true } if url == "https://example.com/"
         ));
     }
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -75,7 +75,7 @@ impl DynSource {
 pub(crate) struct DynamicView {
     /// The content source.
     pub(crate) source: DynSource,
-    /// HTML entry path relative to a `Dir` root (ignored for `Inline`).
+    /// HTML entry path relative to a `Dir` root (ignored for `Inline` and `Url`).
     pub(crate) entry: String,
     /// Whether the mounted webview accepts pointer/keyboard input.
     pub(crate) interactive: bool,
@@ -1749,6 +1749,7 @@ mod url_source_tests {
     fn validate_url_source_rejects_garbage_as_invalid() {
         assert_eq!(validate_url_source("not a url"), Err("invalid_url"));
         assert_eq!(validate_url_source(""), Err("invalid_url"));
+        assert_eq!(validate_url_source("http://"), Err("invalid_url"));
     }
 
     #[test]

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -96,6 +96,20 @@ pub(crate) enum RegisterKind {
         #[serde(default)]
         passthrough: Vec<HostKeyChord>,
     },
+    /// Load a remote `http(s)` URL as the top-level document.
+    Url {
+        /// The `http(s)` URL to load.
+        url: String,
+        /// Whether the mounted webview accepts pointer/keyboard input.
+        #[serde(default = "default_true")]
+        interactive: bool,
+        /// Whether the `window.ozmux` back-channel is injected (opt-in).
+        #[serde(default)]
+        bridge: bool,
+        /// Chords the host passes through to PTY instead of consuming in CEF.
+        #[serde(default)]
+        passthrough: Vec<HostKeyChord>,
+    },
 }
 
 /// One outbound control-plane reply line.
@@ -280,6 +294,46 @@ mod tests {
             }
             _ => panic!("expected inline register"),
         }
+    }
+
+    #[test]
+    fn parses_url_register_with_defaults() {
+        let m: ClientMsg =
+            serde_json::from_str(r#"{"op":"register","kind":"url","url":"https://example.com"}"#)
+                .unwrap();
+        assert_eq!(
+            m,
+            ClientMsg::Register(RegisterKind::Url {
+                url: "https://example.com".into(),
+                interactive: true,
+                bridge: false,
+                passthrough: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn parses_url_register_with_bridge_true() {
+        let m: ClientMsg = serde_json::from_str(
+            r#"{"op":"register","kind":"url","url":"https://app.example.com","bridge":true}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            m,
+            ClientMsg::Register(RegisterKind::Url {
+                url: "https://app.example.com".into(),
+                interactive: true,
+                bridge: true,
+                passthrough: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn host_parses_the_exact_wire_string_the_sdk_emits() {
+        let wire = r#"{"op":"register","kind":"url","url":"https://example.com","interactive":true,"bridge":false}"#;
+        let m: ClientMsg = serde_json::from_str(wire).unwrap();
+        assert!(matches!(m, ClientMsg::Register(RegisterKind::Url { .. })));
     }
 
     #[test]

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -333,7 +333,15 @@ mod tests {
     fn host_parses_the_exact_wire_string_the_sdk_emits() {
         let wire = r#"{"op":"register","kind":"url","url":"https://example.com","interactive":true,"bridge":false}"#;
         let m: ClientMsg = serde_json::from_str(wire).unwrap();
-        assert!(matches!(m, ClientMsg::Register(RegisterKind::Url { .. })));
+        assert_eq!(
+            m,
+            ClientMsg::Register(RegisterKind::Url {
+                url: "https://example.com".into(),
+                interactive: true,
+                bridge: false,
+                passthrough: vec![],
+            })
+        );
     }
 
     #[test]

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -925,9 +925,13 @@ mod tests {
             app.world().get::<WebviewTextureTarget>(child).is_some(),
             "inline webview must carry a headless WebviewTextureTarget"
         );
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("inline webview must carry PreloadScripts");
         assert!(
-            app.world().get::<PreloadScripts>(child).is_some(),
-            "inline webview must carry the shared preload scripts"
+            !preload.0.is_empty(),
+            "an inline (bridged) webview must carry the populated window.ozmux preload"
         );
         assert_eq!(
             app.world().get::<WebviewSize>(child),

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -145,16 +145,19 @@ pub(crate) struct InlineWebviewParams<'w, 's> {
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
 
-/// The resolved content + trust facts for a `mount-inline;<handle>`: the
-/// `ozmux-dyn://<handle>/…` URL, the input policy, and the registering
-/// program's `(connection_id, handle)` for back-channel routing.
+/// The resolved content + trust facts for a `mount-inline;<handle>`: the URL to
+/// load (an `ozmux-dyn://<handle>/…` origin for `Dir`/`Inline` sources, or the
+/// verbatim remote URL for a `Url` source), the input policy, and the
+/// registering program's `(connection_id, handle)` for back-channel routing.
 pub(crate) struct ResolvedWebviewMount {
     /// The URL to load (`WebviewSource::Url`). `None` signals a policy rejection.
     pub(crate) url: Option<String>,
     /// Whether the page receives pointer/keyboard input.
     pub(crate) interactive: bool,
     /// `(connection_id, handle)` of the registering program, used to stamp
-    /// `WebviewOwner` for `window.ozmux` back-channel routing.
+    /// `WebviewOwner` for `window.ozmux` back-channel routing. `Some` only when
+    /// the registration is bridged; a display-only `Url` view leaves it `None`,
+    /// which is the gate that also withholds the preload at mount.
     pub(crate) owner: Option<(u64, String)>,
     /// The normalized passthrough chords copied from the registration, stamped
     /// as a `PassthroughKeys` component so the focused-key systems read them off
@@ -163,11 +166,12 @@ pub(crate) struct ResolvedWebviewMount {
 }
 
 /// Resolves a `mount-inline` `<handle>` against the `DynamicRegistry` (Tier 1).
-/// Dynamic handles (both Dir and Inline) resolve to an `ozmux-dyn://<handle>/…`
-/// URL so each gets its own per-handle origin. A handle resolves ONLY when
-/// `requesting_surface` is its `owner_surface` — the scoping gate that stops one
-/// surface from mounting another's handle. Returns `None` for an unregistered or
-/// unowned handle.
+/// `Dir`/`Inline` handles resolve to an `ozmux-dyn://<handle>/…` URL (one origin
+/// per handle); a `Url` handle resolves to its verbatim remote URL. A handle
+/// resolves ONLY when `requesting_surface` is its `owner_surface` — the scoping
+/// gate that stops one surface from mounting another's handle. `owner` is
+/// populated only for a bridged registration (a display-only `Url` view leaves it
+/// `None`). Returns `None` for an unregistered or unowned handle.
 pub(crate) fn resolve_mount(
     id: &str,
     requesting_surface: Entity,
@@ -177,14 +181,19 @@ pub(crate) fn resolve_mount(
     if view.owner_surface != requesting_surface {
         return None;
     }
-    let entry = match &view.source {
-        DynSource::Dir(_) => view.entry.clone(),
-        DynSource::Inline(_) => "index.html".into(),
+    let url = match &view.source {
+        DynSource::Dir(_) => format!("ozmux-dyn://{id}/{}", view.entry),
+        DynSource::Inline(_) => format!("ozmux-dyn://{id}/index.html"),
+        DynSource::Url { url, .. } => url.clone(),
     };
+    let owner = view
+        .source
+        .is_bridged()
+        .then(|| (view.connection_id, id.to_string()));
     Some(ResolvedWebviewMount {
-        url: Some(format!("ozmux-dyn://{id}/{entry}")),
+        url: Some(url),
         interactive: view.interactive,
-        owner: Some((view.connection_id, id.to_string())),
+        owner,
         passthrough: view.passthrough.clone(),
     })
 }
@@ -2129,5 +2138,48 @@ mod tests {
                 .anchor,
             AnchorMode::Scrollback { .. }
         ));
+    }
+
+    #[test]
+    fn resolve_mount_url_returns_verbatim_url_and_gates_owner_on_bridge() {
+        use crate::control_plane::{DynSource, DynamicView};
+        let surface = Entity::from_bits(1);
+        let mut reg = DynamicRegistry::default();
+        reg.insert(
+            "disp".into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: "https://example.com".into(),
+                    bridge: false,
+                },
+                entry: String::new(),
+                interactive: true,
+                owner_surface: surface,
+                connection_id: 7,
+                passthrough: vec![],
+            },
+        );
+        reg.insert(
+            "appv".into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: "https://app.example.com".into(),
+                    bridge: true,
+                },
+                entry: String::new(),
+                interactive: true,
+                owner_surface: surface,
+                connection_id: 7,
+                passthrough: vec![],
+            },
+        );
+
+        let disp = resolve_mount("disp", surface, &reg).expect("registered");
+        assert_eq!(disp.url.as_deref(), Some("https://example.com"));
+        assert!(disp.owner.is_none(), "display-only url must have no owner");
+
+        let appv = resolve_mount("appv", surface, &reg).expect("registered");
+        assert_eq!(appv.url.as_deref(), Some("https://app.example.com"));
+        assert_eq!(appv.owner, Some((7, "appv".to_string())));
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -266,7 +266,6 @@ pub(crate) fn mount_inline(
     };
     let source = WebviewSource::new(url);
     let webview = params.commands.spawn_empty().id();
-    let preload = build_dynamic_preload(ctx.workspace, ctx.pane, webview);
     // NOTE: keep this entity free of Node / Mesh2d / Mesh3d / Sprite /
     // MaterialNode (even for debug visualization). bevy_cef's mesh/sprite
     // input paths and display-size allocators key on `With<WebviewSource>`
@@ -289,16 +288,23 @@ pub(crate) fn mount_inline(
             cols: ctx.cols,
             frame_seq: anchor.frame_seq,
         },
-        preload,
     ));
     if !resolved.interactive {
         params.commands.entity(webview).insert(NonInteractive);
     }
+    // NOTE: the ozmux bridge scripts (window.ozmux + __ozmuxContext) and
+    // WebviewOwner (the inbound-call gate) are inserted only for a bridged
+    // registration. A display-only view (owner None) gets no bridge scripts
+    // (PreloadScripts remains the empty default from WebviewSource #[require])
+    // and no WebviewOwner.
     if let Some((connection_id, handle)) = resolved.owner {
-        params.commands.entity(webview).insert(WebviewOwner {
-            connection_id,
-            handle,
-        });
+        params.commands.entity(webview).insert((
+            build_dynamic_preload(ctx.workspace, ctx.pane, webview),
+            WebviewOwner {
+                connection_id,
+                handle,
+            },
+        ));
     }
     params
         .commands
@@ -729,6 +735,30 @@ mod tests {
                 source: DynSource::Inline("<h1>x</h1>".into()),
                 entry: "index.html".into(),
                 interactive,
+                owner_surface,
+                connection_id: 1,
+                passthrough: vec![],
+            },
+        );
+    }
+
+    fn register_url(
+        app: &mut App,
+        view_id: &str,
+        owner_surface: Entity,
+        url: &str,
+        bridge: bool,
+    ) {
+        use crate::control_plane::DynamicView;
+        app.world_mut().resource_mut::<DynamicRegistry>().insert(
+            view_id.into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: url.into(),
+                    bridge,
+                },
+                entry: String::new(),
+                interactive: true,
                 owner_surface,
                 connection_id: 1,
                 passthrough: vec![],
@@ -2181,5 +2211,69 @@ mod tests {
         let appv = resolve_mount("appv", surface, &reg).expect("registered");
         assert_eq!(appv.url.as_deref(), Some("https://app.example.com"));
         assert_eq!(appv.owner, Some((7, "appv".to_string())));
+    }
+
+    #[test]
+    fn mount_url_display_only_has_no_preload_or_owner() {
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        register_url(&mut app, "disp", terminal, "https://example.com", false);
+
+        mount(&mut app, terminal, "disp", Some(test_anchor()));
+
+        let children = inline_children_of(&app, terminal);
+        assert_eq!(children.len(), 1);
+        let child = children[0];
+        match app
+            .world()
+            .get::<WebviewSource>(child)
+            .expect("WebviewSource present")
+        {
+            WebviewSource::Url(url) => assert_eq!(url, "https://example.com"),
+            other => panic!("unexpected WebviewSource: {other:?}"),
+        }
+        // NOTE: WebviewSource carries #[require(PreloadScripts)] in bevy_cef, so
+        // the component is always inserted (Default = empty vec) by Bevy's
+        // required-component machinery. The gate for a display-only view is that
+        // the ozmux bridge scripts are absent (empty vec), not that the component
+        // itself is absent.
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("PreloadScripts always present via WebviewSource #[require]");
+        assert!(
+            preload.0.is_empty(),
+            "a display-only url must carry no ozmux bridge scripts"
+        );
+        assert!(
+            app.world().get::<WebviewOwner>(child).is_none(),
+            "a display-only url must carry no WebviewOwner"
+        );
+    }
+
+    #[test]
+    fn mount_url_bridged_has_preload_and_owner() {
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        register_url(&mut app, "appv", terminal, "https://app.example.com", true);
+
+        mount(&mut app, terminal, "appv", Some(test_anchor()));
+
+        let child = inline_children_of(&app, terminal)[0];
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("PreloadScripts present");
+        assert!(
+            !preload.0.is_empty(),
+            "a bridged url must carry the ozmux bridge scripts"
+        );
+        assert_eq!(
+            app.world().get::<WebviewOwner>(child),
+            Some(&WebviewOwner {
+                connection_id: 1,
+                handle: "appv".into(),
+            }),
+        );
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -742,13 +742,7 @@ mod tests {
         );
     }
 
-    fn register_url(
-        app: &mut App,
-        view_id: &str,
-        owner_surface: Entity,
-        url: &str,
-        bridge: bool,
-    ) {
+    fn register_url(app: &mut App, view_id: &str, owner_surface: Entity, url: &str, bridge: bool) {
         use crate::control_plane::DynamicView;
         app.world_mut().resource_mut::<DynamicRegistry>().insert(
             view_id.into(),


### PR DESCRIPTION
## Problem

The `ratatui-ozma` inline webview only supported the `inline` (HTML string) and `dir` (local asset directory) content sources, both served from a per-handle `ozmux-dyn://` origin. A TUI app had no way to mount a remote `http(s)` page — a hosted dashboard, an external web app, or a localhost dev server. Remote/localhost URL mounts were explicitly deferred in Phase A (`docs/dyn-webview.md`).

## Solution

Add a `url` content source parallel to `inline`/`dir`.

- **SDK** (`sdk/ratatui-ozma`): a new `RegisterKind::Url { url, interactive, bridge, passthrough }` wire variant, plus `Webview::url(...)` and a `.bridge(bool)` builder. The registration travels the authenticated control socket (never PTY bytes), preserving the Tier 1 trust model.
- **Host** (`src/control_plane.rs`, `src/control_plane/protocol.rs`, `src/inline_webview.rs`): `build_view` validates the scheme via the `url` crate (`http`/`https` only — otherwise `unsupported_scheme`/`invalid_url`) and stores a `DynSource::Url { url, bridge }`. `resolve_mount` returns the URL **verbatim**, so CEF loads it directly from the network — the `ozmux-dyn://` scheme handler and `DynAssetRegistry` are bypassed. All existing mount/focus/size/teardown machinery is reused unchanged (it is handle-keyed).

### Security model

Remote pages are **display-only by default**. The `window.ozmux` back-channel is opt-in via `.bridge(true)` (or implicitly by registering an `.on()` handler). The `bridge` flag gates **both** directions:

- inbound `window.ozmux.call` — gated by the `WebviewOwner` component (`on_ozmux_call_frame` rejects a frame with no owner);
- outbound `emit` — the fan-out is bridge-gated.

A display-only page also receives no `__ozmuxContext`, so internal `workspace`/`pane`/`surface` entity ids never reach an untrusted remote origin. `inline`/`dir` are unchanged (always bridged).

### Affected

- engine/host: `src/control_plane.rs`, `src/control_plane/protocol.rs`, `src/inline_webview.rs`
- SDK: `sdk/ratatui-ozma/src/{protocol,webview}.rs`
- docs: `docs/dyn-webview.md` (documents the `url` kind, `bridge`, scheme rules)
- example: `sdk/ratatui-ozma/examples/ratatui_remote_url.rs` (minimal display-only demo)
- deps: adds the `url` crate as a direct root dependency (already in the lockfile transitively)

### Tests

SDK + host unit tests cover the wire round-trip (`kind:"url"` across the SDK `lowercase` / host `snake_case` tags), scheme validation (incl. `http://`/`javascript:`/`file:` and URL normalization), `DynAssetRegistry` non-population for `url` handles, and the owner/emit/preload bridge-gating in both directions. `cargo clippy --workspace --all-targets` and `cargo fmt` are clean.

This is purely additive (a new enum variant + new builder methods) — no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)