### PR TITLE
fix(tmux): forward keys to the active pane + drop phantom device-reply injection

### DIFF
--- a/crates/tmux_session/src/input.rs
+++ b/crates/tmux_session/src/input.rs
@@ -1,9 +1,13 @@
 //! Pure translation of Bevy keyboard input to tmux `send-keys` commands.
 //!
-//! Forwarded keys route through tmux's key tables (`send-keys -K`), so tmux's
-//! prefix + bindings act. Raw bytes (terminal replies) go to a pane via
-//! `send-keys -H`. All construction here is pure + unit-tested; the binary's
-//! input plugin is a thin adapter.
+//! Forwarded keys go straight to the active pane (`send-keys -t <pane> --`),
+//! which tmux's pane-input encoder translates (respecting the pane's
+//! application-cursor mode). `-K` is deliberately NOT used: under `tmux -CC` it
+//! mis-encodes named keys (e.g. `Up` arrives as a literal `n`), and routing
+//! through the client key tables is not needed since ozmux owns its own chords.
+//! Raw bytes (clipboard paste) go to a pane via `send-keys -H`. All
+//! construction here is pure + unit-tested; the binary's input plugin is a thin
+//! adapter.
 
 use bevy::input::keyboard::{Key, KeyCode};
 use std::fmt::Write;
@@ -94,23 +98,30 @@ pub fn bevy_key_to_tmux_name(key: &Key, code: KeyCode, mods: KeyMods) -> Option<
     Some(prefix(&mods, shift_prefix, &base))
 }
 
-/// Builds a batched `send-keys -K -c <client>` command for the given key names
-/// (one tmux command per frame). `client` and each name are quoted.
-pub fn send_keys_command(client: &str, names: &[String]) -> String {
-    let mut cmd = format!("send-keys -K -c {}", quote(client));
-    for n in names {
-        cmd.push(' ');
-        cmd.push_str(&quote(n));
-    }
-    cmd
-}
-
 /// Builds a `send-keys -H -t <pane> <hex>…` command injecting raw bytes into a
 /// pane (used for terminal replies). `pane` is the tmux pane id like `%3`.
 pub fn send_bytes_command(pane: &str, bytes: &[u8]) -> String {
     let mut cmd = format!("send-keys -H -t {}", quote(pane));
     for b in bytes {
         let _ = write!(cmd, " {b:02x}");
+    }
+    cmd
+}
+
+/// Builds a `send-keys -t <pane> -- <name>…` command delivering the given key
+/// names straight to a pane (one batched command per frame), bypassing tmux's
+/// client key tables. The `--` terminates options so a key whose name is `-`
+/// cannot be parsed as a flag; `pane` and each name are quoted.
+///
+/// NOTE: this is the forward path, NOT `send-keys -K`. Under `tmux -CC`, `-K`
+/// mis-encodes named keys (e.g. `Up` arrives at the pane as a literal `n`),
+/// so keys go directly to the pane, which tmux's pane-input encoder translates
+/// correctly (respecting the pane's application-cursor mode).
+pub fn send_pane_keys_command(pane: &str, names: &[String]) -> String {
+    let mut cmd = format!("send-keys -t {} --", quote(pane));
+    for n in names {
+        cmd.push(' ');
+        cmd.push_str(&quote(n));
     }
     cmd
 }
@@ -360,18 +371,28 @@ mod tests {
     }
 
     #[test]
-    fn send_keys_batches_and_quotes() {
+    fn send_pane_keys_targets_pane_with_double_dash() {
         assert_eq!(
-            send_keys_command("ozmux", &["a".into(), "C-c".into(), "Up".into()]),
-            "send-keys -K -c ozmux a C-c Up"
+            send_pane_keys_command("%3", &["a".into(), "C-c".into(), "Up".into()]),
+            "send-keys -t %3 -- a C-c Up"
         );
+    }
+
+    #[test]
+    fn send_pane_keys_double_dash_guards_a_dash_named_key() {
+        // A key whose name is a bare '-' must reach the pane, not be parsed as a
+        // flag — the `--` terminator guarantees that.
         assert_eq!(
-            send_keys_command("pts 3", &["a".into()]),
-            "send-keys -K -c 'pts 3' a"
+            send_pane_keys_command("%1", &["-".into()]),
+            "send-keys -t %1 -- -"
         );
+    }
+
+    #[test]
+    fn send_pane_keys_quotes_metachars() {
         assert_eq!(
-            send_keys_command("c", &[";".into()]),
-            "send-keys -K -c c ';'"
+            send_pane_keys_command("%2", &[";".into()]),
+            "send-keys -t %2 -- ';'"
         );
     }
 

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -25,7 +25,7 @@ pub use enumerate::{
     LIST_WINDOWS_FORMAT, WindowRow, parse_window_rows, refresh_client_command, select_pane_command,
     select_window_command, set_environment_command,
 };
-pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_keys_command};
+pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
 pub use output::PaneOutput;
 pub use plugin::{TmuxPresence, TmuxProjectionSet, TmuxSessionPlugin};
 pub use select::{AttachTarget, select_attach_target};

--- a/crates/tmux_session/tests/real_tmux_input.rs
+++ b/crates/tmux_session/tests/real_tmux_input.rs
@@ -1,11 +1,12 @@
-//! Gated end-to-end test: attach a real tmux `-CC` client, await the
-//! client-name query, forward a keystroke via `send-keys -K -c <client>`,
-//! and verify the typed character echoes back through `%output`.
+//! Gated end-to-end tests against a real tmux `-CC`: forward keys to a pane via
+//! `send_pane_keys_command` (the production forward path) and observe the result
+//! through `%output`.
 //! Run with: `cargo test -p ozmux_tmux --test real_tmux_input -- --ignored`.
 
 use bevy::prelude::*;
 use ozmux_tmux::{
-    ConnectionState, PaneOutput, TmuxConnection, TmuxSessionPlugin, send_keys_command,
+    ConnectionState, PaneOutput, TmuxConnection, TmuxPane, TmuxSessionPlugin,
+    send_pane_keys_command,
 };
 use std::time::{Duration, Instant};
 use tmux_control::TmuxServer;
@@ -19,10 +20,24 @@ fn capture_output(mut sink: ResMut<Captured>, mut reader: MessageReader<PaneOutp
     }
 }
 
-#[test]
-#[ignore = "requires a real tmux binary and a controlling PTY"]
-fn send_keys_echoes_back_from_real_tmux() {
-    let socket = format!("ozmux-phase3a-{}", std::process::id());
+fn pump_until(app: &mut App, secs: u64, mut done: impl FnMut(&mut App) -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        app.update();
+        if done(app) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+fn attach_and_project(tag: &str) -> (App, String) {
+    let socket = format!("ozmux-key-{}-{}", std::process::id(), tag);
     let server = TmuxServer::new().socket_name(&socket);
     let client = server.new_session().expect("spawn tmux -CC new-session");
 
@@ -35,58 +50,87 @@ fn send_keys_echoes_back_from_real_tmux() {
         .expect("TmuxConnection inserted by the plugin")
         .set(client);
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut client_name: Option<String> = None;
-    while Instant::now() < deadline {
-        app.update();
-        let attached = *app.world().resource::<ConnectionState>() == ConnectionState::Attached;
-        if attached {
-            client_name = app
-                .world()
-                .get_non_send_resource::<TmuxConnection>()
-                .expect("TmuxConnection present")
-                .client_name()
-                .map(str::to_owned);
-            if client_name.is_some() {
-                break;
-            }
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    let mut pane_q = app.world_mut().query::<&TmuxPane>();
+    let ready = pump_until(&mut app, 5, |app| {
+        *app.world().resource::<ConnectionState>() == ConnectionState::Attached
+            && pane_q.iter(app.world()).next().is_some()
+    });
+    assert!(ready, "tmux should attach and project a pane within 5s");
 
-    let client_name = client_name
-        .expect("the display-message client-name query should complete shortly after attach");
+    let target = pane_q
+        .iter(app.world())
+        .next()
+        .map(|p| format!("%{}", p.id.0))
+        .expect("a projected pane");
+    (app, target)
+}
 
-    let cmd = send_keys_command(&client_name, &["a".to_string()]);
-    assert!(cmd.starts_with("send-keys -K -c "));
+fn handle_of(app: &App) -> tmux_control::TmuxHandle {
     app.world()
         .get_non_send_resource::<TmuxConnection>()
         .unwrap()
         .client()
         .unwrap()
         .handle()
-        .send(&cmd)
-        .expect("send-keys -K");
+}
 
-    let echo_deadline = Instant::now() + Duration::from_secs(5);
-    let mut echoed = false;
-    while Instant::now() < echo_deadline {
-        app.update();
-        if app.world().resource::<Captured>().0.contains(&b'a') {
-            echoed = true;
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-
-    assert!(echoed, "typed 'a' should echo back via %output");
-
+fn teardown(app: &mut App) {
     if let Some(client) = app
         .world_mut()
         .get_non_send_resource_mut::<TmuxConnection>()
-        .expect("TmuxConnection present")
+        .unwrap()
         .take()
     {
         client.handle().send("kill-server").ok();
     }
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn key_a_echoes_back_from_real_tmux() {
+    let (mut app, target) = attach_and_project("echo");
+    let handle = handle_of(&app);
+    handle
+        .send(&send_pane_keys_command(&target, &["a".to_string()]))
+        .expect("send-keys a");
+    let echoed = pump_until(&mut app, 5, |app| {
+        app.world().resource::<Captured>().0.contains(&b'a')
+    });
+    teardown(&mut app);
+    assert!(echoed, "typed 'a' should echo back via %output");
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn arrow_up_recalls_previous_command_via_pane_send() {
+    let (mut app, target) = attach_and_project("arrowup");
+    let handle = handle_of(&app);
+
+    // Seed one shell-history entry (the pane runs an interactive shell, which
+    // puts the terminal in application-cursor mode for readline).
+    handle
+        .send(&format!("send-keys -t {target} -l -- 'echo OZMUXHIST'"))
+        .expect("type command");
+    handle
+        .send(&format!("send-keys -t {target} Enter"))
+        .expect("run command");
+    pump_until(&mut app, 2, |_| false);
+    app.world_mut().resource_mut::<Captured>().0.clear();
+
+    // Forward ArrowUp exactly as the production input plugin does.
+    handle
+        .send(&send_pane_keys_command(&target, &["Up".to_string()]))
+        .expect("forward Up");
+    let recalled = pump_until(&mut app, 3, |app| {
+        contains(&app.world().resource::<Captured>().0, b"echo OZMUXHIST")
+    });
+
+    let captured = app.world().resource::<Captured>().0.clone();
+    teardown(&mut app);
+    assert!(
+        recalled,
+        "ArrowUp must recall the previous command via history; the `-K` path \
+         instead injected a literal char. Captured after Up: {:?}",
+        String::from_utf8_lossy(&captured)
+    );
 }

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -1,6 +1,6 @@
-//! Forwards focused keyboard input to tmux via `send-keys -K`, intercepting a
-//! fixed set of ozmux GUI chords. Replaces the legacy `dispatch_focused_key`
-//! path for the tmux backend.
+//! Forwards focused keyboard input to the active tmux pane via
+//! `send-keys -t <pane>`, intercepting a fixed set of ozmux GUI chords. Replaces
+//! the legacy `dispatch_focused_key` path for the tmux backend.
 
 use crate::clipboard::{Clipboard, build_paste_bytes};
 use crate::tmux_picker::SessionPicker;
@@ -11,7 +11,7 @@ use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
 use ozmux_tmux::{
     ActivePane, KeyMods, TmuxConnection, TmuxPane, bevy_key_to_tmux_name, send_bytes_command,
-    send_keys_command,
+    send_pane_keys_command,
 };
 
 /// Registers the tmux keyboard-forwarding system.
@@ -142,11 +142,16 @@ fn forward_keys_to_tmux(
     if names.is_empty() {
         return;
     }
-    let Some(client) = connection.client_name() else {
+    // NOTE: forward straight to the active pane, NOT via `send-keys -K -c
+    // <client>`. Under `tmux -CC`, `-K` mis-encodes named keys (Up arrives as a
+    // literal `n`); sending to the pane lets tmux's pane-input encoder translate
+    // them correctly (respecting the pane's application-cursor mode).
+    let Some(active) = active_pane.as_deref() else {
         return;
     };
+    let target = format!("%{}", active.id.0);
     if let Some(c) = connection.client()
-        && let Err(e) = c.handle().send(&send_keys_command(client, &names))
+        && let Err(e) = c.handle().send(&send_pane_keys_command(&target, &names))
     {
         tracing::warn!(?e, "send-keys forward failed");
     }

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -13,7 +13,7 @@ use ozma_tty_renderer::prelude::TerminalRenderBundle;
 use ozma_tty_renderer::schema::TerminalGrid;
 use ozmux_tmux::{
     ActiveWindow, PaneOutput, TmuxConnection, TmuxPane, TmuxProjectionSet, TmuxWindow,
-    refresh_client_command, send_bytes_command,
+    refresh_client_command,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -96,18 +96,18 @@ fn attach_tmux_pane_terminal(
     }
 }
 
-const REPLY_CHUNK_BYTES: usize = 256;
-
 /// Routes tmux `%output` into each pane's handle. Groups a frame's
 /// `PaneOutput` messages by pane, advances all of a pane's bytes, then emits
-/// once per pane (immediate emit, coalesced per pane). Drained terminal replies
-/// (DSR/DA answers) are forwarded back to the owning pane via `send-keys -H`.
+/// once per pane (immediate emit, coalesced per pane).
+///
+/// The per-pane alacritty handle is display-only: tmux is the real terminal and
+/// already answers the program's device queries (DSR/DA) itself. So this drains
+/// the handle's reply queue and discards it — see the `take_replies` `NOTE`.
 fn route_tmux_output(
     mut commands: Commands,
     mut reader: MessageReader<PaneOutput>,
     mut handles: Query<&mut TerminalHandle>,
     panes: Query<(Entity, &TmuxPane)>,
-    connection: NonSend<TmuxConnection>,
 ) {
     let mut by_pane: HashMap<_, Vec<u8>> = HashMap::new();
     for msg in reader.read() {
@@ -126,21 +126,13 @@ fn route_tmux_output(
         };
         handle.advance(&data);
         handle.flush_emit(&mut commands, entity);
-        let replies = handle.take_replies();
-        if replies.is_empty() {
-            continue;
-        }
-        let Some(client) = connection.client() else {
-            continue;
-        };
-        let target = format!("%{}", pane.0);
-        for chunk in replies.chunks(REPLY_CHUNK_BYTES) {
-            let cmd = send_bytes_command(&target, chunk);
-            if let Err(e) = client.handle().send(&cmd) {
-                tracing::warn!(?e, pane = pane.0, "reply forward send failed");
-                break;
-            }
-        }
+        // NOTE: drain and DISCARD — never forward these replies to tmux. The
+        // handle is a display-only renderer; tmux already answered the program's
+        // DSR/DA query. Injecting alacritty's duplicate answer via `send-keys -H`
+        // delivers it to the program as phantom keystrokes (e.g. the DSR-OK reply
+        // `ESC[0n` makes readline self-insert a stray `n` and desyncs arrow-key
+        // history recall). Draining still matters: the reply channel is unbounded.
+        let _ = handle.take_replies();
     }
 }
 
@@ -439,6 +431,127 @@ mod tests {
         assert!(
             app.world().resource::<SnapHits>().0 >= 1,
             "resize emitted a FrameSnapshot (#1)",
+        );
+    }
+
+    #[test]
+    #[ignore = "requires a real tmux binary and a controlling PTY"]
+    fn display_only_pane_does_not_inject_phantom_device_replies() {
+        use ozmux_tmux::{ConnectionState, TmuxSessionPlugin};
+        use std::time::{Duration, Instant};
+        use tmux_control::TmuxServer;
+
+        #[derive(Resource, Default)]
+        struct Captured(Vec<u8>);
+
+        fn capture(mut sink: ResMut<Captured>, mut reader: MessageReader<PaneOutput>) {
+            for msg in reader.read() {
+                sink.0.extend_from_slice(&msg.data);
+            }
+        }
+
+        let socket = format!("ozmux-replyloop-{}", std::process::id());
+        let server = TmuxServer::new().socket_name(&socket);
+        let client = server.new_session().expect("spawn tmux -CC new-session");
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(TerminalGridPlugin);
+        app.init_resource::<Assets<TerminalUiMaterial>>();
+        app.add_plugins(TmuxSessionPlugin);
+        app.init_resource::<Captured>();
+        app.add_systems(
+            Update,
+            (
+                attach_tmux_pane_terminal,
+                route_tmux_output.run_if(on_message::<PaneOutput>),
+                capture,
+            )
+                .chain()
+                .after(TmuxProjectionSet),
+        );
+        app.world_mut()
+            .get_non_send_resource_mut::<TmuxConnection>()
+            .expect("TmuxConnection inserted by the plugin")
+            .set(client);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut pane_id: Option<PaneId> = None;
+        while Instant::now() < deadline {
+            app.update();
+            if *app.world().resource::<ConnectionState>() == ConnectionState::Attached {
+                let mut q = app
+                    .world_mut()
+                    .query_filtered::<&TmuxPane, With<TerminalHandle>>();
+                if let Some(id) = q.iter(app.world()).next().map(|p| p.id) {
+                    pane_id = Some(id);
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let pane_id = pane_id.expect("a pane should be projected with a TerminalHandle attached");
+        let target = format!("%{}", pane_id.0);
+
+        // Run `cat` so the pane TTY is in cooked mode with echo on: any bytes
+        // injected into the pane's input are reflected back as %output, making
+        // a spurious injected device-report reply observable.
+        let handle = app
+            .world()
+            .get_non_send_resource::<TmuxConnection>()
+            .unwrap()
+            .client()
+            .unwrap()
+            .handle();
+        handle
+            .send(&format!("send-keys -t {target} -l -- cat"))
+            .expect("send-keys cat");
+        handle
+            .send(&format!("send-keys -t {target} Enter"))
+            .expect("send-keys Enter");
+
+        let cat_deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < cat_deadline {
+            app.update();
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        app.world_mut().resource_mut::<Captured>().0.clear();
+
+        // NOTE: inject the DSR-5 query as a *synthetic* %output — tmux never saw
+        // a real query, so it answers nothing. Any `[0n` (the DSR-OK reply)
+        // echoed back can therefore only be ozmux's display-only renderer
+        // answering the probe and injecting it into the pane via send-keys -H.
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<PaneOutput>>()
+            .write(PaneOutput {
+                pane: pane_id,
+                data: b"\x1b[5n".to_vec(),
+            });
+
+        let echo_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < echo_deadline {
+            app.update();
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        let (injected, captured_len) = {
+            let captured = &app.world().resource::<Captured>().0;
+            (captured.windows(3).any(|w| w == b"[0n"), captured.len())
+        };
+
+        if let Some(client) = app
+            .world_mut()
+            .get_non_send_resource_mut::<TmuxConnection>()
+            .unwrap()
+            .take()
+        {
+            client.handle().send("kill-server").ok();
+        }
+
+        assert!(
+            !injected,
+            "display-only pane must not answer device queries: an echoed DSR reply ([0n) was \
+             injected back into the tmux pane (captured {captured_len} bytes)"
         );
     }
 


### PR DESCRIPTION
## Problem

Inside a `TmuxPane`, special keys did not work: pressing **Up** showed a literal `n` instead of recalling the previous command (Down → `o`, etc.). Plain typing worked, which masked the breakage. There were two distinct root causes, both reproduced against real `tmux 3.6a` in `-CC` control mode:

1. **Broken key forwarding.** Keys were forwarded with `send-keys -K -c <client>`. Under `tmux -CC`, `-K` mis-encodes *named* keys — `Up` arrives at the pane as a literal `n`, `Down` as `o` — so arrow keys, function keys, history recall, etc. never reached the program. Printable characters happened to work, which is why typing seemed fine.
2. **Phantom device-reply injection.** `route_tmux_output` fed tmux `%output` into a display-only `alacritty` terminal, then injected *that* terminal's DSR/DA replies back into the pane via `send-keys -H`. But tmux already answers device queries itself, so the duplicate reply was delivered to the program as phantom keystrokes — e.g. the DSR-OK reply `ESC[0n` made readline self-insert a stray `n` and desynced arrow-key history recall.

## Solution

Affected: the tmux backend — `crates/tmux_session` (`input.rs`, `lib.rs`) and the binary (`src/tmux_input.rs`, `src/tmux_render.rs`).

- **Forward keys straight to the active pane.** Replace `send-keys -K -c <client>` with `send-keys -t %<active-pane> --` (new `send_pane_keys_command` builder; the old `send_keys_command` is removed). tmux's pane-input encoder then translates the key names correctly and respects the pane's application-cursor mode. The trailing `--` guards a key whose name is a literal `-`. The key-name mapping (`bevy_key_to_tmux_name`) is unchanged.
- **Stop injecting phantom replies.** `route_tmux_output` now drains and **discards** the display-only handle's replies (the reply channel is unbounded, so draining still matters) rather than forwarding them. Verified that tmux `-CC` answers both DSR *and* OSC color queries on the program's behalf, so discarding ozmux's duplicate is correct.

### Trade-off

Forwarding directly to the pane bypasses tmux's own key tables, so the tmux prefix key / `bind -n` bindings are no longer intercepted for forwarded keys. This is acceptable for now because ozmux drives multiplexing through its own UI and intercepts its `Cmd+…` GUI chords before forwarding. (`send-keys -K` cannot be used: it is the source of bug #1.)

### Verification

- New gated real-tmux tests: `arrow_up_recalls_previous_command_via_pane_send` (forwarding `Up` over the real control connection recalls shell history) and `display_only_pane_does_not_inject_phantom_device_replies` (no phantom reply is injected back into the pane). Plus unit tests for the new builder (`--` guard + argument quoting).
- Full binary suite (315 tests) and the `ozmux_tmux` suite pass; `cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
