### PR TITLE
fix(tmux): restore tmux.conf key bindings via list-keys dispatch (not -K)

### DIFF
--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -150,6 +150,12 @@ pub(crate) struct EnumerationState {
     pub(crate) client_name_pending: Option<CommandId>,
     /// The id of the in-flight `display-message` active-pane query, if any.
     pub(crate) active_pane_pending: Option<CommandId>,
+    /// The id of the in-flight `list-keys -T root` command, if any.
+    pub(crate) keys_root_pending: Option<CommandId>,
+    /// The id of the in-flight `list-keys -T prefix` command, if any.
+    pub(crate) keys_prefix_pending: Option<CommandId>,
+    /// The id of the in-flight `display-message` prefix-key query, if any.
+    pub(crate) prefix_keys_pending: Option<CommandId>,
     /// In-flight `capture-pane` commands → the pane each reply seeds.
     pub(crate) capture_pending: HashMap<CommandId, PaneId>,
 }

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -6,11 +6,12 @@ use crate::events::{
     TmuxActivePaneChanged, TmuxActiveWindowChanged, TmuxLayoutChanged, TmuxSessionChanged,
     TmuxWindowAdded, TmuxWindowClosed, TmuxWindowRenamed, TmuxWindowsRetained, pane_geoms,
 };
+use crate::keybindings::{KeyBinding, parse_list_keys, parse_prefix};
 use crate::output::PaneOutput;
 use crate::state::{ConnectionState, next_state};
 use bevy::prelude::Commands;
 use crossbeam_channel::Receiver;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tmux_control::{ClientEvent, CommandId, ControlEvent, TransportEvent};
 use tmux_control_parser::{PaneId, WindowId};
 
@@ -175,6 +176,54 @@ pub(crate) fn take_active_pane(
                 return output.iter().find_map(|line| parse_active_pane(line));
             }
             tracing::warn!("active-pane query command failed");
+            return None;
+        }
+    }
+    None
+}
+
+/// Returns parsed key bindings from a `CommandComplete` matching `pending`
+/// (running `parse_list_keys` on the reply), clearing `pending`. Returns `None`
+/// when no matching reply is in the batch.
+pub(crate) fn take_keybindings(
+    pending: &mut Option<CommandId>,
+    events: &[TransportEvent],
+) -> Option<Vec<KeyBinding>> {
+    for event in events {
+        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
+            && *pending == Some(*id)
+        {
+            *pending = None;
+            if *ok {
+                return Some(parse_list_keys(output));
+            }
+            tracing::warn!("list-keys command failed");
+            return None;
+        }
+    }
+    None
+}
+
+/// Returns the prefix-key set from a `CommandComplete` matching `pending`
+/// (running `parse_prefix` on the first reply line), clearing `pending`.
+pub(crate) fn take_prefix_keys(
+    pending: &mut Option<CommandId>,
+    events: &[TransportEvent],
+) -> Option<HashSet<String>> {
+    for event in events {
+        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
+            && *pending == Some(*id)
+        {
+            *pending = None;
+            if *ok {
+                return Some(
+                    output
+                        .first()
+                        .map(|line| parse_prefix(line))
+                        .unwrap_or_default(),
+                );
+            }
+            tracing::warn!("prefix query command failed");
             return None;
         }
     }
@@ -445,5 +494,48 @@ mod tests {
 
         assert_eq!(*log.0.lock().unwrap(), vec!["add@1", "layout@1", "retain1"]);
         assert_eq!(app.world().resource::<EnumerationState>().pending, None);
+    }
+
+    #[test]
+    fn take_keybindings_parses_matching_reply() {
+        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(11),
+            number: 0,
+            ok: true,
+            output: vec!["bind-key -T root M-i split-window -h".to_string()],
+        })];
+        let mut pending = Some(CommandId(11));
+        let got = take_keybindings(&mut pending, &events).expect("a parsed reply");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "M-i");
+        assert_eq!(got[0].command, "split-window -h");
+        assert_eq!(pending, None);
+    }
+
+    #[test]
+    fn take_keybindings_unmatched_keeps_pending() {
+        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(2),
+            number: 0,
+            ok: true,
+            output: vec![],
+        })];
+        let mut pending = Some(CommandId(11));
+        assert!(take_keybindings(&mut pending, &events).is_none());
+        assert_eq!(pending, Some(CommandId(11)));
+    }
+
+    #[test]
+    fn take_prefix_keys_parses_matching_reply() {
+        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(12),
+            number: 0,
+            ok: true,
+            output: vec!["C-b None".to_string()],
+        })];
+        let mut pending = Some(CommandId(12));
+        let got = take_prefix_keys(&mut pending, &events).expect("a parsed reply");
+        assert_eq!(got, std::collections::HashSet::from(["C-b".to_string()]));
+        assert_eq!(pending, None);
     }
 }

--- a/crates/tmux_session/src/input.rs
+++ b/crates/tmux_session/src/input.rs
@@ -26,8 +26,9 @@ pub struct KeyMods {
 }
 
 /// Maps a Bevy logical key + physical key code + modifiers to a tmux key-name
-/// string for `send-keys -K`, or `None` if the key has no tmux representation OR
-/// carries `Super` (which is GUI-only and must never be forwarded).
+/// string (used to forward the key pane-direct and to match it against tmux
+/// bindings), or `None` if the key has no tmux representation OR carries `Super`
+/// (which is GUI-only and must never be forwarded).
 ///
 /// NOTE: `Shift` is folded into the glyph for `Key::Character` (so a shifted
 /// letter arrives already uppercased) — the `S-` prefix is only emitted for

--- a/crates/tmux_session/src/keybindings.rs
+++ b/crates/tmux_session/src/keybindings.rs
@@ -136,24 +136,27 @@ fn parse_binding_line(line: &str) -> Option<KeyBinding> {
     let mut repeat = false;
     loop {
         rest = rest.trim_start();
-        if let Some(after) = rest.strip_prefix("-T") {
-            let (name, tail) = split_first_token(after);
-            table = match name {
-                "root" => Some(Table::Root),
-                "prefix" => Some(Table::Prefix),
-                _ => return None,
-            };
-            rest = tail;
-        } else if let Some(after) = rest.strip_prefix("-N") {
-            let (_count, tail) = split_first_token(after);
-            rest = tail;
-        } else if let Some(after) = rest.strip_prefix("-r") {
-            repeat = true;
-            rest = after;
-        } else if let Some(after) = rest.strip_prefix("-a") {
-            rest = after;
-        } else {
-            break;
+        let (token, tail) = split_first_token(rest);
+        match token {
+            "-T" => {
+                let (name, after) = split_first_token(tail);
+                table = match name {
+                    "root" => Some(Table::Root),
+                    "prefix" => Some(Table::Prefix),
+                    _ => return None,
+                };
+                rest = after;
+            }
+            "-N" => {
+                let (_count, after) = split_first_token(tail);
+                rest = after;
+            }
+            "-r" => {
+                repeat = true;
+                rest = tail;
+            }
+            "-a" => rest = tail,
+            _ => break,
         }
     }
     let (key_raw, command) = split_first_token(rest);

--- a/crates/tmux_session/src/keybindings.rs
+++ b/crates/tmux_session/src/keybindings.rs
@@ -4,7 +4,78 @@
 //! adapter. `-K` is deliberately NOT used — it mis-encodes named keys under
 //! `tmux -CC` — and tmux.conf is the single source of truth for bindings.
 
-use std::collections::HashSet;
+use bevy::prelude::Resource;
+use std::collections::{HashMap, HashSet};
+
+/// tmux key bindings read from `list-keys`, plus the prefix-key set. Built once
+/// on attach; empty until then, so every key forwards pane-direct (the
+/// pre-binding behavior).
+#[derive(Resource, Default, Debug)]
+pub struct KeyBindings {
+    root: HashMap<String, String>,
+    prefix: HashMap<String, String>,
+    prefix_keys: HashSet<String>,
+}
+
+impl KeyBindings {
+    /// Installs parsed bindings, routing each into its table's map.
+    pub(crate) fn install(&mut self, bindings: Vec<KeyBinding>) {
+        for binding in bindings {
+            match binding.table {
+                Table::Root => {
+                    self.root.insert(binding.key, binding.command);
+                }
+                Table::Prefix => {
+                    self.prefix.insert(binding.key, binding.command);
+                }
+            }
+        }
+    }
+
+    /// Replaces the prefix-key set.
+    pub(crate) fn set_prefix_keys(&mut self, keys: HashSet<String>) {
+        self.prefix_keys = keys;
+    }
+
+    /// Clears all tables (on disconnect, so a reconnect re-reads).
+    pub(crate) fn clear(&mut self) {
+        self.root.clear();
+        self.prefix.clear();
+        self.prefix_keys.clear();
+    }
+}
+
+/// One ordered forwarding action for a frame of key input.
+#[derive(Debug)]
+pub enum Forwarded {
+    /// Run a bound tmux command verbatim over the control connection.
+    Run(String),
+    /// Forward these key names to the active pane (one batched `send-keys`).
+    Keys(Vec<String>),
+}
+
+/// Plans the ordered forwarding actions for a frame's tmux key names, threading
+/// `prefix_pending` across frames. Consecutive forwarded keys coalesce into one
+/// `Keys` batch; a bound key emits a `Run`; the prefix key and unmatched
+/// prefix-table keys are swallowed.
+pub fn plan_forward(
+    prefix_pending: &mut bool,
+    bindings: &KeyBindings,
+    key_names: impl IntoIterator<Item = String>,
+) -> Vec<Forwarded> {
+    let mut actions: Vec<Forwarded> = Vec::new();
+    for name in key_names {
+        match dispatch(prefix_pending, bindings, &name) {
+            Dispatch::Run(command) => actions.push(Forwarded::Run(command)),
+            Dispatch::Forward => match actions.last_mut() {
+                Some(Forwarded::Keys(batch)) => batch.push(name),
+                _ => actions.push(Forwarded::Keys(vec![name])),
+            },
+            Dispatch::Swallow => {}
+        }
+    }
+    actions
+}
 
 /// Builds `list-keys -T <table>` to list one key table's bindings.
 pub(crate) fn list_keys_command(table: &str) -> String {
@@ -123,6 +194,32 @@ fn unescape_key(s: &str) -> String {
     out
 }
 
+/// What to do with one keypress.
+enum Dispatch {
+    Run(String),
+    Forward,
+    Swallow,
+}
+
+/// Routes one key name against the bindings, threading prefix state.
+fn dispatch(prefix_pending: &mut bool, bindings: &KeyBindings, key_name: &str) -> Dispatch {
+    if *prefix_pending {
+        *prefix_pending = false;
+        return lookup(&bindings.prefix, key_name).map_or(Dispatch::Swallow, Dispatch::Run);
+    }
+    if bindings.prefix_keys.contains(key_name) {
+        *prefix_pending = true;
+        return Dispatch::Swallow;
+    }
+    lookup(&bindings.root, key_name).map_or(Dispatch::Forward, Dispatch::Run)
+}
+
+/// Looks up a key in a table, falling back to the table's `Any` binding (tmux
+/// runs `Any` when no more-specific key matches).
+fn lookup(table: &HashMap<String, String>, key_name: &str) -> Option<String> {
+    table.get(key_name).or_else(|| table.get("Any")).cloned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,5 +303,106 @@ mod tests {
             HashSet::from(["C-a".to_string(), "C-b".to_string()])
         );
         assert!(parse_prefix("none None").is_empty());
+    }
+
+    fn bindings(
+        root: &[(&str, &str)],
+        prefix: &[(&str, &str)],
+        prefix_keys: &[&str],
+    ) -> KeyBindings {
+        let mut kb = KeyBindings::default();
+        kb.install(
+            root.iter()
+                .map(|(k, c)| KeyBinding {
+                    table: Table::Root,
+                    key: (*k).to_string(),
+                    command: (*c).to_string(),
+                    repeat: false,
+                })
+                .chain(prefix.iter().map(|(k, c)| KeyBinding {
+                    table: Table::Prefix,
+                    key: (*k).to_string(),
+                    command: (*c).to_string(),
+                    repeat: false,
+                }))
+                .collect(),
+        );
+        kb.set_prefix_keys(prefix_keys.iter().map(|k| (*k).to_string()).collect());
+        kb
+    }
+
+    #[test]
+    fn root_bound_key_runs_its_command() {
+        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
+        let actions = plan_forward(&mut false, &kb, vec!["M-i".to_string()]);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(&actions[0], Forwarded::Run(c) if c == "split-window -h"));
+    }
+
+    #[test]
+    fn unbound_key_is_forwarded() {
+        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
+        let actions = plan_forward(&mut false, &kb, vec!["Up".to_string()]);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(&actions[0], Forwarded::Keys(v) if v == &vec!["Up".to_string()]));
+    }
+
+    #[test]
+    fn prefix_then_bound_key_runs_prefix_command() {
+        let kb = bindings(&[], &[("c", "new-window")], &["C-b"]);
+        let mut pending = false;
+        let first = plan_forward(&mut pending, &kb, vec!["C-b".to_string()]);
+        assert!(first.is_empty(), "prefix key is swallowed");
+        assert!(pending, "prefix is now pending");
+        let second = plan_forward(&mut pending, &kb, vec!["c".to_string()]);
+        assert!(matches!(&second[0], Forwarded::Run(c) if c == "new-window"));
+        assert!(!pending, "pending cleared after the prefix key");
+    }
+
+    #[test]
+    fn prefix_then_unbound_key_is_swallowed() {
+        let kb = bindings(&[], &[("c", "new-window")], &["C-b"]);
+        let mut pending = false;
+        plan_forward(&mut pending, &kb, vec!["C-b".to_string()]);
+        let actions = plan_forward(&mut pending, &kb, vec!["z".to_string()]);
+        assert!(
+            actions.is_empty(),
+            "unbound prefix key is dropped, not forwarded"
+        );
+        assert!(!pending);
+    }
+
+    #[test]
+    fn any_binding_is_the_fallback() {
+        let kb = bindings(
+            &[("M-i", "split-window -h"), ("Any", "display-message hi")],
+            &[],
+            &["C-b"],
+        );
+        let specific = plan_forward(&mut false, &kb, vec!["M-i".to_string()]);
+        assert!(matches!(&specific[0], Forwarded::Run(c) if c == "split-window -h"));
+        let fallback = plan_forward(&mut false, &kb, vec!["X".to_string()]);
+        assert!(matches!(&fallback[0], Forwarded::Run(c) if c == "display-message hi"));
+    }
+
+    #[test]
+    fn consecutive_forwards_coalesce_then_split_on_run() {
+        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
+        let actions = plan_forward(
+            &mut false,
+            &kb,
+            vec![
+                "a".to_string(),
+                "b".to_string(),
+                "M-i".to_string(),
+                "c".to_string(),
+            ],
+        );
+        assert_eq!(actions.len(), 3);
+        assert!(
+            matches!(&actions[0], Forwarded::Keys(v) if v == &vec!["a".to_string(), "b".to_string()])
+        );
+        assert!(matches!(&actions[1], Forwarded::Run(c) if c == "split-window -h"));
+        assert!(matches!(&actions[2], Forwarded::Keys(v) if v == &vec!["c".to_string()]));
     }
 }

--- a/crates/tmux_session/src/keybindings.rs
+++ b/crates/tmux_session/src/keybindings.rs
@@ -1,0 +1,210 @@
+//! Reads tmux key bindings (`list-keys`) and dispatches keypresses against them:
+//! a bound key issues its tmux command verbatim, an unbound key is forwarded to
+//! the pane. Pure translation + lookup; the binary's input plugin is a thin
+//! adapter. `-K` is deliberately NOT used — it mis-encodes named keys under
+//! `tmux -CC` — and tmux.conf is the single source of truth for bindings.
+
+use std::collections::HashSet;
+
+/// Builds `list-keys -T <table>` to list one key table's bindings.
+pub(crate) fn list_keys_command(table: &str) -> String {
+    format!("list-keys -T {table}")
+}
+
+/// Builds `display-message -p '#{prefix} #{prefix2}'`. `prefix`/`prefix2` are
+/// session options; tmux expands an option name placed inside `#{}`.
+pub(crate) fn prefix_options_command() -> String {
+    "display-message -p '#{prefix} #{prefix2}'".to_string()
+}
+
+/// Which tmux key table a binding belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Table {
+    Root,
+    Prefix,
+}
+
+/// One parsed tmux key binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct KeyBinding {
+    pub(crate) table: Table,
+    pub(crate) key: String,
+    pub(crate) command: String,
+    pub(crate) repeat: bool,
+}
+
+/// Parses `list-keys -T <table>` reply lines into bindings, skipping any line
+/// that does not parse (per-line resilience — one exotic binding must not drop
+/// the rest).
+pub(crate) fn parse_list_keys(lines: &[String]) -> Vec<KeyBinding> {
+    lines
+        .iter()
+        .filter_map(|line| parse_binding_line(line))
+        .collect()
+}
+
+/// Parses a `#{prefix} #{prefix2}` reply line into the set of prefix keys,
+/// skipping the literal `none` / `None` (tmux's unset `prefix2`).
+pub(crate) fn parse_prefix(line: &str) -> HashSet<String> {
+    line.split_whitespace()
+        .filter(|t| !t.eq_ignore_ascii_case("none"))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Parses one `bind-key [flags…] -T <table> <key> <command…>` line. Tokenizes
+/// the leading flags (order-independent: `-r`, `-N <n>`, `-a`, `-T <table>`),
+/// takes the next token as the backslash-escaped key, and keeps the remainder
+/// verbatim as the command (tmux re-parses it on re-send).
+fn parse_binding_line(line: &str) -> Option<KeyBinding> {
+    let rest = line.trim_start();
+    let mut rest = rest
+        .strip_prefix("bind-key")
+        .or_else(|| rest.strip_prefix("bind"))?;
+    let mut table: Option<Table> = None;
+    let mut repeat = false;
+    loop {
+        rest = rest.trim_start();
+        if let Some(after) = rest.strip_prefix("-T") {
+            let (name, tail) = split_first_token(after);
+            table = match name {
+                "root" => Some(Table::Root),
+                "prefix" => Some(Table::Prefix),
+                _ => return None,
+            };
+            rest = tail;
+        } else if let Some(after) = rest.strip_prefix("-N") {
+            let (_count, tail) = split_first_token(after);
+            rest = tail;
+        } else if let Some(after) = rest.strip_prefix("-r") {
+            repeat = true;
+            rest = after;
+        } else if let Some(after) = rest.strip_prefix("-a") {
+            rest = after;
+        } else {
+            break;
+        }
+    }
+    let (key_raw, command) = split_first_token(rest);
+    if key_raw.is_empty() {
+        return None;
+    }
+    Some(KeyBinding {
+        table: table?,
+        key: unescape_key(key_raw),
+        command: command.trim().to_string(),
+        repeat,
+    })
+}
+
+/// Splits off the first whitespace-delimited token, returning it and the
+/// remainder (original spacing preserved after the token).
+fn split_first_token(s: &str) -> (&str, &str) {
+    let s = s.trim_start();
+    match s.find(char::is_whitespace) {
+        Some(i) => (&s[..i], &s[i..]),
+        None => (s, ""),
+    }
+}
+
+/// Removes tmux's backslash escaping from a key token (e.g. `\;` → `;`).
+fn unescape_key(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_keys_command_targets_table() {
+        assert_eq!(list_keys_command("root"), "list-keys -T root");
+        assert_eq!(list_keys_command("prefix"), "list-keys -T prefix");
+    }
+
+    #[test]
+    fn prefix_options_command_reads_both_prefixes() {
+        assert_eq!(
+            prefix_options_command(),
+            "display-message -p '#{prefix} #{prefix2}'"
+        );
+    }
+
+    #[test]
+    fn parses_root_binding() {
+        let lines =
+            vec!["bind-key    -T root         M-i               split-window -h".to_string()];
+        let got = parse_list_keys(&lines);
+        assert_eq!(
+            got,
+            vec![KeyBinding {
+                table: Table::Root,
+                key: "M-i".to_string(),
+                command: "split-window -h".to_string(),
+                repeat: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_repeat_flag_before_table() {
+        let lines = vec!["bind-key -r -T prefix Up   resize-pane -U".to_string()];
+        let got = parse_list_keys(&lines);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].table, Table::Prefix);
+        assert_eq!(got[0].key, "Up");
+        assert_eq!(got[0].command, "resize-pane -U");
+        assert!(got[0].repeat);
+    }
+
+    #[test]
+    fn unescapes_backslash_escaped_key() {
+        let lines = vec![r#"bind-key -T prefix \;   last-pane"#.to_string()];
+        let got = parse_list_keys(&lines);
+        assert_eq!(got[0].key, ";");
+        assert_eq!(got[0].command, "last-pane");
+    }
+
+    #[test]
+    fn preserves_command_internal_spacing_and_semicolons() {
+        let lines =
+            vec![r#"bind-key -T root C-x   display-message "a  b" \; refresh-client"#.to_string()];
+        let got = parse_list_keys(&lines);
+        assert_eq!(
+            got[0].command,
+            r#"display-message "a  b" \; refresh-client"#
+        );
+    }
+
+    #[test]
+    fn skips_unparseable_lines_keeping_others() {
+        let lines = vec![
+            "garbage line".to_string(),
+            "bind-key -T root a   new-window".to_string(),
+        ];
+        let got = parse_list_keys(&lines);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].key, "a");
+    }
+
+    #[test]
+    fn parse_prefix_skips_none_case_insensitive() {
+        assert_eq!(parse_prefix("C-b None"), HashSet::from(["C-b".to_string()]));
+        assert_eq!(
+            parse_prefix("C-a C-b"),
+            HashSet::from(["C-a".to_string(), "C-b".to_string()])
+        );
+        assert!(parse_prefix("none None").is_empty());
+    }
+}

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -27,6 +27,7 @@ pub use enumerate::{
     select_window_command, set_environment_command,
 };
 pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
+pub use keybindings::{Forwarded, KeyBindings, plan_forward};
 pub use output::PaneOutput;
 pub use plugin::{TmuxPresence, TmuxProjectionSet, TmuxSessionPlugin};
 pub use select::{AttachTarget, select_attach_target};

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -12,6 +12,7 @@ mod enumerate;
 mod event_pump;
 mod events;
 mod input;
+mod keybindings;
 mod observers;
 mod output;
 mod plugin;

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -8,10 +8,11 @@ use crate::enumerate::{
     list_windows_command,
 };
 use crate::event_pump::{
-    advance_state, drain_transport, take_active_pane, take_client_name, take_pane_captures,
-    trigger_events,
+    advance_state, drain_transport, take_active_pane, take_client_name, take_keybindings,
+    take_pane_captures, take_prefix_keys, trigger_events,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxConnectionReset};
+use crate::keybindings::{KeyBindings, list_keys_command, prefix_options_command};
 use crate::observers::{TmuxProjection, register_observers};
 use crate::output::{PaneOutput, collect_pane_outputs};
 use crate::state::ConnectionState;
@@ -40,6 +41,7 @@ impl Plugin for TmuxSessionPlugin {
         app.init_resource::<ConnectionState>()
             .init_resource::<TmuxProjection>()
             .init_resource::<EnumerationState>()
+            .init_resource::<KeyBindings>()
             .insert_resource(TmuxPresence)
             .insert_non_send_resource(TmuxConnection::default())
             .add_message::<PaneOutput>()
@@ -90,6 +92,7 @@ fn drain_tmux_events(
     mut commands: Commands,
     mut state: ResMut<ConnectionState>,
     mut enumeration: ResMut<EnumerationState>,
+    mut keybindings: ResMut<KeyBindings>,
     mut connection: NonSendMut<TmuxConnection>,
     mut pane_output: MessageWriter<PaneOutput>,
 ) {
@@ -120,6 +123,18 @@ fn drain_tmux_events(
                 Ok(id) => enumeration.active_pane_pending = Some(id),
                 Err(error) => tracing::warn!(?error, "failed to send active-pane query"),
             }
+            match client.handle().send(&list_keys_command("root")) {
+                Ok(id) => enumeration.keys_root_pending = Some(id),
+                Err(error) => tracing::warn!(?error, "failed to send list-keys -T root"),
+            }
+            match client.handle().send(&list_keys_command("prefix")) {
+                Ok(id) => enumeration.keys_prefix_pending = Some(id),
+                Err(error) => tracing::warn!(?error, "failed to send list-keys -T prefix"),
+            }
+            match client.handle().send(&prefix_options_command()) {
+                Ok(id) => enumeration.prefix_keys_pending = Some(id),
+                Err(error) => tracing::warn!(?error, "failed to send prefix query"),
+            }
         }
     }
     if events
@@ -131,6 +146,10 @@ fn drain_tmux_events(
         enumeration.client_name_pending = None;
         enumeration.active_pane_pending = None;
         enumeration.capture_pending.clear();
+        enumeration.keys_root_pending = None;
+        enumeration.keys_prefix_pending = None;
+        enumeration.prefix_keys_pending = None;
+        keybindings.clear();
         commands.trigger(TmuxConnectionReset);
     } else {
         if let Some(name) = take_client_name(&mut enumeration.client_name_pending, &events) {
@@ -143,6 +162,15 @@ fn drain_tmux_events(
         }
         for output in take_pane_captures(&mut enumeration.capture_pending, &events) {
             pane_output.write(output);
+        }
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, &events) {
+            keybindings.install(bindings);
+        }
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, &events) {
+            keybindings.install(bindings);
+        }
+        if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, &events) {
+            keybindings.set_prefix_keys(keys);
         }
         trigger_events(&mut commands, &mut enumeration.pending, &events);
     }

--- a/crates/tmux_session/tests/real_tmux_keybindings.rs
+++ b/crates/tmux_session/tests/real_tmux_keybindings.rs
@@ -1,0 +1,172 @@
+//! Gated end-to-end tests against a real tmux `-CC`: drive `TmuxSessionPlugin`
+//! until it has read the key bindings, then dispatch keypresses via the public
+//! `plan_forward` and assert bound commands run while unbound keys forward.
+//! The tests force prefix=C-b and bind their own keys, so they're independent
+//! of the developer's ~/.tmux.conf (the only remaining assumption is that the
+//! config doesn't bind `-n Up`, which would shadow the unbound-key test).
+//! Run with: `cargo test -p ozmux_tmux --test real_tmux_keybindings -- --ignored`.
+
+use bevy::prelude::*;
+use ozmux_tmux::{
+    ConnectionState, Forwarded, KeyBindings, TmuxConnection, TmuxPane, TmuxSessionPlugin,
+    plan_forward,
+};
+use std::time::{Duration, Instant};
+use tmux_control::TmuxServer;
+
+fn pump_until(app: &mut App, secs: u64, mut done: impl FnMut(&mut App) -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        app.update();
+        if done(app) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+fn run_cmd(app: &App, cmd: &str) {
+    app.world()
+        .get_non_send_resource::<TmuxConnection>()
+        .unwrap()
+        .client()
+        .unwrap()
+        .handle()
+        .send(cmd)
+        .expect("send command");
+}
+
+fn pane_count(app: &mut App) -> usize {
+    let mut q = app.world_mut().query::<&TmuxPane>();
+    q.iter(app.world()).count()
+}
+
+/// True once the prefix-key query reply (the last of the three on-attach
+/// keybinding reads) has landed — which, because replies are FIFO, implies the
+/// root and prefix tables are already installed too.
+fn bindings_ready(app: &App) -> bool {
+    let kb = app.world().resource::<KeyBindings>();
+    let mut pending = false;
+    plan_forward(&mut pending, kb, vec!["C-b".to_string()]);
+    pending
+}
+
+fn teardown(app: &mut App) {
+    if let Some(client) = app
+        .world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .unwrap()
+        .take()
+    {
+        client.handle().send("kill-server").ok();
+    }
+}
+
+/// Attaches an app to a fresh `-CC` session that already has `extra_binding`
+/// installed, pumping until a pane is projected and all key bindings are read.
+fn attach_with_binding(tag: &str, extra_binding: &str) -> App {
+    let socket = format!("ozmux-kb-{}-{}", std::process::id(), tag);
+    let server = TmuxServer::new().socket_name(&socket);
+    let client = server.new_session().expect("spawn tmux -CC new-session");
+    client
+        .handle()
+        .send(extra_binding)
+        .expect("install binding");
+    // Force a known prefix so the tests are independent of the developer's
+    // ~/.tmux.conf (a fresh tmux server still sources it).
+    client
+        .handle()
+        .send("set -g prefix C-b")
+        .expect("force prefix");
+    client
+        .handle()
+        .send("set -g prefix2 None")
+        .expect("force prefix2");
+
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    app.world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .expect("TmuxConnection inserted by the plugin")
+        .set(client);
+
+    let ready = pump_until(&mut app, 5, |app| {
+        let attached = *app.world().resource::<ConnectionState>() == ConnectionState::Attached;
+        let mut q = app.world_mut().query::<&TmuxPane>();
+        let has_pane = q.iter(app.world()).next().is_some();
+        attached && has_pane && bindings_ready(app)
+    });
+    assert!(
+        ready,
+        "tmux should attach, project a pane, and read bindings within 5s"
+    );
+    app
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn root_binding_runs_command_and_splits() {
+    let mut app = attach_with_binding("root", "bind-key -n M-i split-window -h");
+    assert_eq!(pane_count(&mut app), 1);
+
+    let cmd = {
+        let kb = app.world().resource::<KeyBindings>();
+        match plan_forward(&mut false, kb, vec!["M-i".to_string()])
+            .into_iter()
+            .next()
+        {
+            Some(Forwarded::Run(cmd)) => cmd,
+            other => panic!("expected Run for bound M-i, got {other:?}"),
+        }
+    };
+    assert_eq!(cmd, "split-window -h");
+    run_cmd(&app, &cmd);
+
+    let split = pump_until(&mut app, 3, |app| pane_count(app) == 2);
+    teardown(&mut app);
+    assert!(
+        split,
+        "running the bound split-window command must create a second pane"
+    );
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn prefix_binding_runs_after_prefix_key() {
+    // Default tmux: prefix is C-b and `bind c new-window` is a default binding.
+    let mut app = attach_with_binding("prefix", "bind-key -T prefix c new-window");
+
+    let result = {
+        let kb = app.world().resource::<KeyBindings>();
+        let mut pending = false;
+        let first = plan_forward(&mut pending, kb, vec!["C-b".to_string()]);
+        assert!(first.is_empty(), "the prefix key is swallowed");
+        assert!(pending, "prefix is pending after C-b");
+        plan_forward(&mut pending, kb, vec!["c".to_string()])
+            .into_iter()
+            .next()
+    };
+    teardown(&mut app);
+    match result {
+        Some(Forwarded::Run(cmd)) => assert!(cmd.contains("new-window"), "got: {cmd}"),
+        other => panic!("prefix + c should run the default new-window binding, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn unbound_key_is_forwarded() {
+    let mut app = attach_with_binding("unbound", "bind-key -n M-i split-window -h");
+    let result = {
+        let kb = app.world().resource::<KeyBindings>();
+        plan_forward(&mut false, kb, vec!["Up".to_string()])
+            .into_iter()
+            .next()
+    };
+    teardown(&mut app);
+    match result {
+        Some(Forwarded::Keys(keys)) => assert_eq!(keys, vec!["Up".to_string()]),
+        other => panic!("an unbound key must be forwarded to the pane, got {other:?}"),
+    }
+}

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -101,12 +101,12 @@ fn forward_keys_to_tmux(
         return;
     }
 
-    let Some(active) = active_pane.as_deref() else {
-        *prefix_pending = false;
-        events.clear();
-        return;
-    };
-    let target = format!("%{}", active.id.0);
+    // The active pane (if any) is the forward/paste target. GUI chords below do
+    // not need it (so quit/picker work before a pane is projected); tmux key
+    // dispatch does.
+    let target = active_pane
+        .as_deref()
+        .map(|active| format!("%{}", active.id.0));
 
     // Collect forwardable tmux key names in event order. Super-modified keys are
     // handled as GUI chords (Paste/Quit/Picker) or swallowed; none reach tmux.
@@ -116,6 +116,8 @@ fn forward_keys_to_tmux(
             continue;
         }
         if let Some(chord) = gui_chord(&ev.key_code, mods) {
+            // A GUI action abandons any pending tmux prefix sequence.
+            *prefix_pending = false;
             match chord {
                 GuiChord::OpenPicker => picker.open = true,
                 GuiChord::Quit => {
@@ -128,13 +130,14 @@ fn forward_keys_to_tmux(
                     if text.is_empty() {
                         continue;
                     }
-                    let Some(client) = connection.client() else {
+                    let (Some(target), Some(client)) = (target.as_deref(), connection.client())
+                    else {
                         continue;
                     };
                     let bytes = build_paste_bytes(&text, false);
                     for chunk in bytes.chunks(PASTE_CHUNK_BYTES) {
-                        if let Err(e) = client.handle().send(&send_bytes_command(&target, chunk)) {
-                            tracing::warn!(?e, pane = active.id.0, "paste send failed");
+                        if let Err(e) = client.handle().send(&send_bytes_command(target, chunk)) {
+                            tracing::warn!(?e, "paste send failed");
                             break;
                         }
                     }
@@ -156,14 +159,14 @@ fn forward_keys_to_tmux(
     if actions.is_empty() {
         return;
     }
-    let Some(client) = connection.client() else {
+    let (Some(target), Some(client)) = (target.as_deref(), connection.client()) else {
         return;
     };
     let handle = client.handle();
     for action in actions {
         let cmd = match action {
             Forwarded::Run(command) => command,
-            Forwarded::Keys(names) => send_pane_keys_command(&target, &names),
+            Forwarded::Keys(names) => send_pane_keys_command(target, &names),
         };
         if let Err(e) = handle.send(&cmd) {
             tracing::warn!(?e, "tmux forward send failed");

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -10,8 +10,8 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
 use ozmux_tmux::{
-    ActivePane, KeyMods, TmuxConnection, TmuxPane, bevy_key_to_tmux_name, send_bytes_command,
-    send_pane_keys_command,
+    ActivePane, Forwarded, KeyBindings, KeyMods, TmuxConnection, TmuxPane, bevy_key_to_tmux_name,
+    plan_forward, send_bytes_command, send_pane_keys_command,
 };
 
 /// Registers the tmux keyboard-forwarding system.
@@ -44,26 +44,31 @@ fn forward_keys_to_tmux(
     mut events: MessageReader<KeyboardInput>,
     mut clipboard: ResMut<Clipboard>,
     mut focused_webview: ResMut<FocusedWebview>,
+    mut prefix_pending: Local<bool>,
     connection: NonSend<TmuxConnection>,
     keys: Res<ButtonInput<KeyCode>>,
     ime: Res<crate::input::ime::ImeState>,
+    bindings: Res<KeyBindings>,
     active_pane: Option<Single<&TmuxPane, With<ActivePane>>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     // NOTE: while the picker is open it owns the keyboard; forwarding would
     // leak picker-navigation keys to the active tmux pane. Drain (don't replay).
     if picker.open {
+        *prefix_pending = false;
         events.clear();
         return;
     }
     // NOTE: drain (don't replay) while composing — forwarding preedit
     // navigation keys would both garble IME composition and double-send.
     if ime.is_composing() {
+        *prefix_pending = false;
         events.clear();
         return;
     }
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if !focused {
+        *prefix_pending = false;
         events.clear();
         return;
     }
@@ -91,11 +96,21 @@ fn forward_keys_to_tmux(
                 break;
             }
         }
+        *prefix_pending = false;
         events.clear();
         return;
     }
 
-    let mut names: Vec<String> = Vec::new();
+    let Some(active) = active_pane.as_deref() else {
+        *prefix_pending = false;
+        events.clear();
+        return;
+    };
+    let target = format!("%{}", active.id.0);
+
+    // Collect forwardable tmux key names in event order. Super-modified keys are
+    // handled as GUI chords (Paste/Quit/Picker) or swallowed; none reach tmux.
+    let mut key_names: Vec<String> = Vec::new();
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
@@ -113,19 +128,13 @@ fn forward_keys_to_tmux(
                     if text.is_empty() {
                         continue;
                     }
-                    let Some(active) = active_pane.as_deref() else {
-                        continue;
-                    };
-                    let pane = active.id;
                     let Some(client) = connection.client() else {
                         continue;
                     };
                     let bytes = build_paste_bytes(&text, false);
-                    let target = format!("%{}", pane.0);
                     for chunk in bytes.chunks(PASTE_CHUNK_BYTES) {
-                        let cmd = send_bytes_command(&target, chunk);
-                        if let Err(e) = client.handle().send(&cmd) {
-                            tracing::warn!(?e, pane = pane.0, "paste send failed");
+                        if let Err(e) = client.handle().send(&send_bytes_command(&target, chunk)) {
+                            tracing::warn!(?e, pane = active.id.0, "paste send failed");
                             break;
                         }
                     }
@@ -135,25 +144,31 @@ fn forward_keys_to_tmux(
             continue;
         }
         if let Some(name) = bevy_key_to_tmux_name(&ev.logical_key, ev.key_code, mods) {
-            names.push(name);
+            key_names.push(name);
         }
     }
 
-    if names.is_empty() {
+    // Dispatch the keys against the tmux bindings: bound keys run their command
+    // verbatim, unbound keys forward to the active pane. NOTE: the bound command
+    // acts on tmux's current pane; ozmux keeps that synced to the focused pane
+    // via select-pane, and both travel this FIFO control connection in order.
+    let actions = plan_forward(&mut prefix_pending, &bindings, key_names);
+    if actions.is_empty() {
         return;
     }
-    // NOTE: forward straight to the active pane, NOT via `send-keys -K -c
-    // <client>`. Under `tmux -CC`, `-K` mis-encodes named keys (Up arrives as a
-    // literal `n`); sending to the pane lets tmux's pane-input encoder translate
-    // them correctly (respecting the pane's application-cursor mode).
-    let Some(active) = active_pane.as_deref() else {
+    let Some(client) = connection.client() else {
         return;
     };
-    let target = format!("%{}", active.id.0);
-    if let Some(c) = connection.client()
-        && let Err(e) = c.handle().send(&send_pane_keys_command(&target, &names))
-    {
-        tracing::warn!(?e, "send-keys forward failed");
+    let handle = client.handle();
+    for action in actions {
+        let cmd = match action {
+            Forwarded::Run(command) => command,
+            Forwarded::Keys(names) => send_pane_keys_command(&target, &names),
+        };
+        if let Err(e) = handle.send(&cmd) {
+            tracing::warn!(?e, "tmux forward send failed");
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

After #127 (`f69dc7f`), tmux.conf key bindings stopped working under the `tmux -CC` backend — `ALT(Prefix)+i` vertical split, and with it the whole family of tmux operations (focus-pane, swap-pane, new-window, …), no longer fired. That commit switched key forwarding from key-table routing (`send-keys -K -c <client>`) to pane-direct (`send-keys -t %pane`), which delivers keys straight to the program in the pane and bypasses tmux's prefix/binding machinery.

The switch itself was fixing two real bugs (both reproduced on tmux 3.6a): `-K` mis-encodes named keys under `-CC` (`Up` arrives as a literal `n`), and a phantom device-reply injection made readline self-insert a stray `n`. Those fixes are correct — but they threw out tmux.conf bindings as collateral.

## Solution

App policy: **tmux.conf is the single source of truth** for tmux operations. On attach, ozmux now reads the user's bindings via `list-keys -T root` / `-T prefix` (plus the prefix option) into a `KeyBindings` resource, and dispatches each keypress through a small state machine:

- a **bound** key issues its tmux command verbatim over the control connection (e.g. `split-window -h`);
- an **unbound** key forwards to the active pane (`send-keys -t %pane`, correct encoding).

`-K` is never used, so the named-key encoding bug stays fixed. Root + prefix tables are supported with ozmux-side prefix-state tracking and an `Any`-binding fallback. This is deliberately the inverse of iTerm2's tmux integration (which ignores tmux.conf and owns operations via its own Cmd shortcuts) — we borrow iTerm2's "issue explicit tmux commands" mechanism but read the *mapping* from tmux.conf.

Affected (`engine` side, tmux backend):
- `crates/tmux_session/src/keybindings.rs` — new, pure: `list-keys` command builders + parsers, the `KeyBindings` resource, and the `dispatch`/`plan_forward` state machine.
- `crates/tmux_session/src/{event_pump,enumerate,plugin,lib}.rs` — reply consumers, in-flight command-id tracking, and on-attach wiring (reuses the existing once-on-attach correlation path).
- `src/tmux_input.rs` — routes keypresses through `plan_forward`; GUI (Cmd) chords stay ozmux-owned.

Verified **end-to-end against real tmux 3.6a** via gated `-CC` integration tests: `M-i` → `split-window` creates a second pane; `C-b c` → `new-window`; unbound `Up` forwards to the pane. Full workspace test suite green, clippy + fmt clean.

### Out of scope / follow-ups

- `repeat (-r)`, `prefix-timeout`, `switch-client -T` custom key-tables, and runtime `bind` re-read are deferred (bindings are read once on attach).
- `prefix_pending` is reset on every in-frame input guard, but persists across a window-focus-loss that carries no keystroke (and across a fast reconnect). The robust fix is to promote it to a `Resource` reset from a focus-change system — left as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)