### PR TITLE
feat: resolve $OZMA_SOCK in pre-existing and switched tmux panes

### DIFF
--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -95,11 +95,15 @@ impl TmuxServer {
 
     fn new_session_subcommand(&self) -> Vec<String> {
         let mut subcommand = vec!["new-session".to_string()];
-        for (key, value) in &self.env {
-            subcommand.push("-e".to_string());
-            subcommand.push(format!("{key}={value}"));
-        }
+        self.push_env_flags(&mut subcommand);
         subcommand
+    }
+
+    fn push_env_flags(&self, argv: &mut Vec<String>) {
+        for (key, value) in &self.env {
+            argv.push("-e".to_string());
+            argv.push(format!("{key}={value}"));
+        }
     }
 
     /// Lists attachable sessions (`tmux [..] list-sessions -F ..`, plain pipe, no
@@ -193,6 +197,7 @@ impl TmuxServer {
         let mut argv = self.socket_args();
         argv.push("new-session".to_string());
         argv.push("-d".to_string());
+        self.push_env_flags(&mut argv);
         argv.push("-P".to_string());
         argv.push("-F".to_string());
         argv.push("#{session_name}".to_string());
@@ -796,6 +801,24 @@ mod tests {
                 "sock",
                 "new-session",
                 "-d",
+                "-P",
+                "-F",
+                "#{session_name}"
+            ])
+        );
+    }
+
+    #[test]
+    fn create_detached_session_argv_emits_dash_e_per_env_pair() {
+        assert_eq!(
+            TmuxServer::new()
+                .env("OZMA_SOCK", "/tmp/ctl.sock")
+                .create_detached_session_argv(),
+            argv(&[
+                "new-session",
+                "-d",
+                "-e",
+                "OZMA_SOCK=/tmp/ctl.sock",
                 "-P",
                 "-F",
                 "#{session_name}"

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -120,6 +120,25 @@ pub fn set_environment_command(key: &str, value: &str) -> String {
     format!("set-environment {} {}", quote(key), quote(value))
 }
 
+/// Builds `set-environment -t <session> <key> <value>` to set an environment
+/// variable on a specific session rather than the control client's current one,
+/// so panes that session spawns afterward inherit it.
+///
+/// Used when the client switches to another session: the attach path's
+/// current-session [`set_environment_command`] does not re-run on
+/// `switch-client`, so the target session would otherwise never receive
+/// `$OZMA_SOCK`. Session-scoped (no `-g`) for the same reason as
+/// [`set_environment_command`]; already-running panes recover the value via
+/// `tmux show-environment`.
+pub fn set_environment_in_session_command(session: &str, key: &str, value: &str) -> String {
+    format!(
+        "set-environment -t {} {} {}",
+        quote(session),
+        quote(key),
+        quote(value)
+    )
+}
+
 /// Builds `switch-client -t <name>` to repoint the attached control client at
 /// another session. The resulting `%session-changed` / `%client-session-changed`
 /// drives the projection rebuild; ozmux never mutates it optimistically.
@@ -283,6 +302,22 @@ mod tests {
         assert_eq!(
             set_environment_command("OZMA_SOCK", "/tmp/a b/ctl.sock"),
             "set-environment OZMA_SOCK '/tmp/a b/ctl.sock'"
+        );
+    }
+
+    #[test]
+    fn set_environment_in_session_command_targets_named_session() {
+        assert_eq!(
+            set_environment_in_session_command("work", "OZMA_SOCK", "/tmp/ctl.sock"),
+            "set-environment -t work OZMA_SOCK /tmp/ctl.sock"
+        );
+    }
+
+    #[test]
+    fn set_environment_in_session_command_quotes_session_and_value() {
+        assert_eq!(
+            set_environment_in_session_command("my work", "OZMA_SOCK", "/tmp/a b/ctl.sock"),
+            "set-environment -t 'my work' OZMA_SOCK '/tmp/a b/ctl.sock'"
         );
     }
 

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -24,7 +24,8 @@ pub use connect::attach_or_create;
 pub use connection::TmuxConnection;
 pub use enumerate::{
     LIST_WINDOWS_FORMAT, WindowRow, parse_window_rows, refresh_client_command, select_pane_command,
-    select_window_command, set_environment_command, switch_client_command,
+    select_window_command, set_environment_command, set_environment_in_session_command,
+    switch_client_command,
 };
 pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
 pub use keybindings::{Forwarded, KeyBindings, plan_forward};

--- a/crates/tmux_session/tests/real_tmux_switch.rs
+++ b/crates/tmux_session/tests/real_tmux_switch.rs
@@ -9,6 +9,13 @@ fn unique_socket(tag: &str) -> String {
     format!("ozmux-phase4-{tag}-{}", std::process::id())
 }
 
+fn show_environment(socket: &str, session: &str, key: &str) -> std::process::Output {
+    std::process::Command::new("tmux")
+        .args(["-L", socket, "show-environment", "-t", session, key])
+        .output()
+        .expect("run tmux show-environment")
+}
+
 #[test]
 #[ignore = "requires a real tmux binary"]
 fn list_windows_all_spans_sessions() {
@@ -61,6 +68,71 @@ fn switch_client_emits_a_session_change() {
     assert!(
         saw_session_change,
         "switch-client should emit a (client-)session-changed notification"
+    );
+
+    client.handle().send("kill-server").ok();
+}
+
+#[test]
+#[ignore = "requires a real tmux binary"]
+fn create_detached_session_with_env_sets_session_environment() {
+    let socket = unique_socket("createenv");
+    let server = TmuxServer::new()
+        .socket_name(&socket)
+        .env("OZMA_SOCK", "/tmp/ozma-create.sock");
+    let name = server.create_detached_session().expect("create with env");
+    std::thread::sleep(Duration::from_millis(200));
+
+    let out = show_environment(&socket, &name, "OZMA_SOCK");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("OZMA_SOCK=/tmp/ozma-create.sock"),
+        "new-session -e should set OZMA_SOCK in the session environment: {stdout:?} / {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    TmuxServer::new()
+        .socket_name(&socket)
+        .attach(&name)
+        .map(|c| c.handle().send("kill-server").ok())
+        .ok();
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn set_environment_in_session_command_reaches_only_the_target_session() {
+    let socket = unique_socket("setenv");
+    let server = TmuxServer::new().socket_name(&socket);
+    let a = server.create_detached_session().expect("create a");
+    let b = server.create_detached_session().expect("create b");
+
+    // Attached to a, set OZMA_SOCK on b (the switch target) explicitly.
+    let client = server.attach(&a).expect("attach a");
+    std::thread::sleep(Duration::from_millis(300));
+    client
+        .handle()
+        .send(&ozmux_tmux::set_environment_in_session_command(
+            &b,
+            "OZMA_SOCK",
+            "/tmp/ozma-switch.sock",
+        ))
+        .expect("set-environment -t b");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let on_b = show_environment(&socket, &b, "OZMA_SOCK");
+    assert!(
+        String::from_utf8_lossy(&on_b.stdout).contains("OZMA_SOCK=/tmp/ozma-switch.sock"),
+        "target session b should carry OZMA_SOCK: {} / {}",
+        String::from_utf8_lossy(&on_b.stdout),
+        String::from_utf8_lossy(&on_b.stderr)
+    );
+    // The current session a must NOT receive it — proves the `-t` targeting that
+    // a current-session set-environment would have gotten wrong.
+    let on_a = show_environment(&socket, &a, "OZMA_SOCK");
+    assert!(
+        !String::from_utf8_lossy(&on_a.stdout).contains("OZMA_SOCK="),
+        "current session a must not receive b's targeted env: {}",
+        String::from_utf8_lossy(&on_a.stdout)
     );
 
     client.handle().send("kill-server").ok();

--- a/docs/dyn-webview.md
+++ b/docs/dyn-webview.md
@@ -24,15 +24,22 @@ For the full threat model see
 
 ## Environment variables
 
-ozmux injects these into every PTY when the control plane is running:
+How these reach a pane depends on the multiplexer backend:
 
-| Variable | Contents |
-|---|---|
-| `$OZMA_SOCK` | Absolute path to the control Unix socket |
-| `$OZMA_TOKEN` | Opaque per-surface token (attribution only) |
+| Variable | Contents | Availability |
+|---|---|---|
+| `$OZMA_SOCK` | Absolute path to the control Unix socket | Present in every pane the direct-PTY backend spawns. Under the tmux backend, a pane that forked before ozma set it (a pre-existing session, or any pane opened before attach) does **not** inherit it — recover it with `tmux show-environment OZMA_SOCK` (see below). |
+| `$OZMA_TOKEN` | Opaque per-surface token (attribution only) | Set only by the direct-PTY backend. Under the tmux backend it is unset; use the tmux pane id `$TMUX_PANE` (injected into every pane) as the identity instead. |
 
 Both are absent when the control plane is not up (e.g. during `cargo test`
 builds or when the feature flag is off).
+
+The `ratatui-ozma` SDK does this resolution in `Ozma::connect()`: it reads
+`$OZMA_SOCK`, falling back to `tmux -S <socket> show-environment OZMA_SOCK`
+(deriving `<socket>` from `$TMUX`) so a pre-existing tmux pane still resolves the
+path without a shell-rc hook; and it uses `$OZMA_TOKEN` when set, else
+`$TMUX_PANE`. A program that speaks to the socket directly (without the SDK)
+should do the same.
 
 ## Control protocol (NDJSON)
 
@@ -44,7 +51,7 @@ requests, read one reply per `register`. Unknown `op` values are rejected.
 Send once, before any `register`:
 
 ```json
-{"op":"hello","token":"<$OZMA_TOKEN value>"}
+{"op":"hello","token":"<$OZMA_TOKEN, else $TMUX_PANE>"}
 ```
 
 No reply is sent for `hello`.

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -1,5 +1,7 @@
 //! Minimal reference client for ozmux Tier 1 dynamic webviews. Run inside an
-//! ozmux pane: it reads `$OZMA_SOCK`/`$OZMA_TOKEN`, registers an inline HTML
+//! ozmux pane: it resolves `$OZMA_SOCK` (falling back to `tmux show-environment`
+//! for a pre-existing tmux pane) and the pane identity (`$OZMA_TOKEN`, else
+//! `$TMUX_PANE`), registers an inline HTML
 //! view over the control socket, prints the `mount-inline` OSC at the cursor,
 //! then demonstrates the back-channel by:
 //!   - replying to `ping` calls from the page (`window.ozma.call`)
@@ -18,9 +20,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 fn main() -> std::io::Result<()> {
-    let sock = std::env::var("OZMA_SOCK")
-        .expect("not inside an ozmux pane (or control plane down): $OZMA_SOCK unset");
-    let token = std::env::var("OZMA_TOKEN").expect("$OZMA_TOKEN unset");
+    let sock = resolve_sock().expect(
+        "not inside an ozmux pane (or control plane down): $OZMA_SOCK unset and not resolvable via tmux",
+    );
+    let token = resolve_token().expect("no pane identity: neither $OZMA_TOKEN nor $TMUX_PANE set");
 
     let stream = UnixStream::connect(&sock)?;
     let writer = Arc::new(Mutex::new(stream.try_clone()?));
@@ -129,4 +132,37 @@ fn main() -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+/// Resolves `$OZMA_SOCK`, falling back to tmux's session environment (via `$TMUX`)
+/// so a pane that forked before ozma set it still finds the socket. Mirrors what
+/// the `ratatui-ozma` SDK does in `Ozma::connect()`.
+fn resolve_sock() -> Option<String> {
+    if let Some(sock) = std::env::var("OZMA_SOCK").ok().filter(|s| !s.is_empty()) {
+        return Some(sock);
+    }
+    let tmux = std::env::var("TMUX").ok()?;
+    let socket = tmux.split(',').next().filter(|s| !s.is_empty())?;
+    let output = std::process::Command::new("tmux")
+        .args(["-S", socket, "show-environment", "OZMA_SOCK"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("OZMA_SOCK="))
+        .filter(|sock| !sock.is_empty())
+        .map(str::to_owned)
+}
+
+/// Resolves the pane identity sent in `hello`: `$OZMA_TOKEN` (direct-PTY backend)
+/// when set, else the tmux pane id `$TMUX_PANE` (tmux backend).
+fn resolve_token() -> Option<String> {
+    std::env::var("OZMA_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty())
+        .or_else(|| std::env::var("TMUX_PANE").ok())
 }

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -101,10 +101,15 @@ pub struct Ozma {
 }
 
 impl Ozma {
-    /// Connects to `$OZMA_SOCK`, performs the `hello` handshake, and spawns the
-    /// background reader thread.
+    /// Connects to the ozma control socket, performs the `hello` handshake, and
+    /// spawns the background reader thread.
+    ///
+    /// The socket path is `$OZMA_SOCK` when present; otherwise — in a pane that
+    /// forked before ozma set it — it is recovered from tmux's session
+    /// environment via `$TMUX` and `show-environment`, so no shell-rc hook is
+    /// required (see `resolve_ozma_sock`).
     pub fn connect() -> OzmaResult<Self> {
-        let sock = std::env::var("OZMA_SOCK").map_err(|_| OzmaError::NotInPane("OZMA_SOCK"))?;
+        let sock = resolve_ozma_sock().ok_or(OzmaError::NotInPane("OZMA_SOCK"))?;
         let token = pane_identity(
             std::env::var("OZMA_TOKEN").ok(),
             std::env::var("TMUX_PANE").ok(),
@@ -185,6 +190,52 @@ impl Ozma {
 /// when neither is present — the process is not inside an ozmux pane.
 fn pane_identity(ozmux_token: Option<String>, tmux_pane: Option<String>) -> Option<String> {
     ozmux_token.filter(|t| !t.is_empty()).or(tmux_pane)
+}
+
+/// Extracts the tmux server socket path from a `$TMUX` value
+/// (`<socket-path>,<server-pid>,<session-id>`): everything up to the first
+/// comma. `None` for an empty value or one starting with a comma, mirroring
+/// tmux's own `$TMUX` validity guard so a malformed value cannot resolve to an
+/// empty socket path.
+fn socket_from_tmux(tmux: &str) -> Option<&str> {
+    tmux.split(',').next().filter(|first| !first.is_empty())
+}
+
+/// Reads the value of `key` from `tmux show-environment` output. tmux prints one
+/// `KEY=value` line per variable and `-KEY` for an unset one; returns the value
+/// when a `KEY=` line is present, else `None`.
+fn parse_show_environment<'a>(output: &'a str, key: &str) -> Option<&'a str> {
+    let prefix = format!("{key}=");
+    output.lines().find_map(|line| line.strip_prefix(&prefix))
+}
+
+/// Resolves the control-socket path, falling back to tmux when the process did
+/// not inherit `$OZMA_SOCK`.
+///
+/// A pane that forked before ozma ran `set-environment` never received
+/// `$OZMA_SOCK`, and a running process's environment cannot be changed from
+/// outside. tmux does inject `$TMUX` into every pane, so reading the value back
+/// with `tmux -S <socket> show-environment OZMA_SOCK` recovers it without a
+/// shell-rc hook or `send-keys`. `None` when neither the env var nor a tmux
+/// lookup yields a value (outside tmux, or tmux unavailable / the variable
+/// unset on the session).
+fn resolve_ozma_sock() -> Option<String> {
+    if let Some(sock) = std::env::var("OZMA_SOCK").ok().filter(|s| !s.is_empty()) {
+        return Some(sock);
+    }
+    let tmux = std::env::var("TMUX").ok()?;
+    let socket = socket_from_tmux(&tmux)?;
+    let output = std::process::Command::new("tmux")
+        .args(["-S", socket, "show-environment", "OZMA_SOCK"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_show_environment(&stdout, "OZMA_SOCK")
+        .filter(|sock| !sock.is_empty())
+        .map(str::to_owned)
 }
 
 /// Emits CUP + mount-inline for new/changed placements and unmount for vanished
@@ -380,6 +431,67 @@ mod tests {
     #[test]
     fn pane_identity_none_when_neither_set() {
         assert_eq!(pane_identity(None, None), None);
+    }
+
+    #[test]
+    fn socket_from_tmux_takes_first_comma_field() {
+        assert_eq!(
+            socket_from_tmux("/tmp/tmux-501/default,12345,0"),
+            Some("/tmp/tmux-501/default")
+        );
+    }
+
+    #[test]
+    fn socket_from_tmux_handles_path_without_commas() {
+        assert_eq!(
+            socket_from_tmux("/tmp/only-socket"),
+            Some("/tmp/only-socket")
+        );
+    }
+
+    #[test]
+    fn socket_from_tmux_none_for_empty() {
+        assert_eq!(socket_from_tmux(""), None);
+    }
+
+    #[test]
+    fn socket_from_tmux_none_for_leading_comma() {
+        assert_eq!(socket_from_tmux(",12345,0"), None);
+    }
+
+    #[test]
+    fn parse_show_environment_reads_value() {
+        assert_eq!(
+            parse_show_environment("OZMA_SOCK=/tmp/ctl.sock\n", "OZMA_SOCK"),
+            Some("/tmp/ctl.sock")
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_none_for_unset_marker() {
+        assert_eq!(parse_show_environment("-OZMA_SOCK\n", "OZMA_SOCK"), None);
+    }
+
+    #[test]
+    fn parse_show_environment_finds_key_among_many_lines() {
+        let output = "FOO=bar\nOZMA_SOCK=/run/ozma/x.sock\nBAZ=qux\n";
+        assert_eq!(
+            parse_show_environment(output, "OZMA_SOCK"),
+            Some("/run/ozma/x.sock")
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_keeps_equals_in_value() {
+        assert_eq!(
+            parse_show_environment("OZMA_SOCK=/a=b/ctl.sock\n", "OZMA_SOCK"),
+            Some("/a=b/ctl.sock")
+        );
+    }
+
+    #[test]
+    fn parse_show_environment_none_when_key_absent() {
+        assert_eq!(parse_show_environment("OTHER=/x\n", "OZMA_SOCK"), None);
     }
 
     #[test]

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -178,3 +178,107 @@ fn panicking_handler_does_not_kill_reader() {
         assert_eq!(ping["value"], "pong");
     });
 }
+
+// A private tmux server for the gated fallback test: kills the server and
+// removes its socket on drop so a panicking assertion cannot leak it.
+struct TmuxServerGuard {
+    socket: std::path::PathBuf,
+}
+
+impl TmuxServerGuard {
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket)
+            .args(args)
+            .output()
+            .expect("run tmux")
+    }
+}
+
+impl Drop for TmuxServerGuard {
+    fn drop(&mut self) {
+        let _ = self.run(&["kill-server"]);
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+fn set_or_remove(key: &str, val: Option<std::ffi::OsString>) {
+    // SAFETY: callers hold ENV_LOCK; no other test thread touches these vars.
+    unsafe {
+        match val {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a real tmux binary"]
+fn connect_resolves_ozma_sock_from_tmux_when_env_unset() {
+    // The control socket the program connects to once it discovers the path.
+    let server = FakeServer::start("view-fallback");
+    let server_sock = server.sock_path.to_string_lossy().into_owned();
+
+    // A detached tmux session forks its pane shell now — before set-environment —
+    // so the shell never inherits OZMA_SOCK (the pre-existing-pane scenario).
+    let tmux_socket =
+        std::env::temp_dir().join(format!("ozma-resolve-{}.tmuxsock", std::process::id()));
+    let _ = std::fs::remove_file(&tmux_socket);
+    let tmux = TmuxServerGuard {
+        socket: tmux_socket.clone(),
+    };
+    let created = tmux.run(&["new-session", "-d", "-s", "ozmares"]);
+    assert!(
+        created.status.success(),
+        "tmux new-session failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+
+    // ozma's post-attach injection: set OZMA_SOCK in the session environment.
+    let set = tmux.run(&[
+        "set-environment",
+        "-t",
+        "ozmares",
+        "OZMA_SOCK",
+        &server_sock,
+    ]);
+    assert!(
+        set.status.success(),
+        "set-environment failed: {}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    // Reconstruct the $TMUX a pane carries: <socket>,<server-pid>,<session-id>.
+    let session_field = |format: &str| {
+        let out = tmux.run(&["display-message", "-p", "-t", "ozmares", format]);
+        String::from_utf8_lossy(&out.stdout).trim().to_owned()
+    };
+    let sid = session_field("#{session_id}");
+    let sid = sid.trim_start_matches('$');
+    let pid = session_field("#{pid}");
+    let tmux_env = format!("{},{},{}", tmux_socket.display(), pid, sid);
+
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_sock = std::env::var_os("OZMA_SOCK");
+    let prev_token = std::env::var_os("OZMA_TOKEN");
+    let prev_tmux = std::env::var_os("TMUX");
+    // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
+    unsafe {
+        std::env::remove_var("OZMA_SOCK");
+        std::env::set_var("OZMA_TOKEN", "fallback-token");
+        std::env::set_var("TMUX", &tmux_env);
+    }
+
+    let connected = Ozma::connect();
+
+    set_or_remove("OZMA_SOCK", prev_sock);
+    set_or_remove("OZMA_TOKEN", prev_token);
+    set_or_remove("TMUX", prev_tmux);
+
+    assert!(
+        connected.is_ok(),
+        "connect should resolve OZMA_SOCK via tmux show-environment: {:?}",
+        connected.err()
+    );
+}

--- a/src/tmux_picker.rs
+++ b/src/tmux_picker.rs
@@ -12,7 +12,7 @@ use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 use ozmux_tmux::{
     AttachTarget, ConnectionState, TmuxConnection, attach_or_create, select_window_command,
-    set_environment_command, switch_client_command,
+    set_environment_command, set_environment_in_session_command, switch_client_command,
 };
 use tmux_control::{SessionInfo, TmuxServer, WindowEntry};
 
@@ -360,7 +360,14 @@ fn handle_picker_input(
                     .copied()
                     .unwrap_or(PickerRow::NewSession);
                 if connection.client().is_some() {
-                    apply_switch(&mut connection, &mut state, &configs, &picker, row);
+                    apply_switch(
+                        &mut connection,
+                        &mut state,
+                        &configs,
+                        control.as_deref(),
+                        &picker,
+                        row,
+                    );
                 } else {
                     apply_attach(
                         &mut connection,
@@ -386,20 +393,45 @@ fn apply_switch(
     connection: &mut TmuxConnection,
     state: &mut ConnectionState,
     configs: &OzmuxConfigsResource,
+    control: Option<&ControlPlaneHandle>,
     picker: &SessionPicker,
     row: PickerRow,
 ) {
     if connection.client().is_none() {
         return;
     }
-    let cmds: Vec<String> = match row {
-        PickerRow::Session(si) => vec![switch_client_command(&picker.sessions[si].name)],
-        PickerRow::Window { session, window } => vec![
-            switch_client_command(&picker.sessions[session].name),
-            select_window_command(picker.windows[window].window_id),
-        ],
-        PickerRow::NewSession => {
-            let server = build_server(configs);
+    // The attach path's current-session set-environment does not re-run on a
+    // switch, so each switched-to session needs $OZMA_SOCK set explicitly;
+    // newly-created sessions get it via `new-session -e` instead.
+    let ozma_sock = control.map(|handle| handle.sock_path.to_string_lossy().into_owned());
+    let target = match row {
+        PickerRow::Session(si) => Some((picker.sessions[si].name.clone(), None)),
+        PickerRow::Window { session, window } => Some((
+            picker.sessions[session].name.clone(),
+            Some(picker.windows[window].window_id),
+        )),
+        PickerRow::NewSession => None,
+    };
+    let cmds: Vec<String> = match target {
+        Some((name, window)) => {
+            // set-environment before switch-client so the target session carries
+            // $OZMA_SOCK before any pane is spawned there post-switch; `-t` makes
+            // it independent of which session is current.
+            let mut cmds = Vec::new();
+            if let Some(sock) = &ozma_sock {
+                cmds.push(set_environment_in_session_command(&name, "OZMA_SOCK", sock));
+            }
+            cmds.push(switch_client_command(&name));
+            if let Some(window_id) = window {
+                cmds.push(select_window_command(window_id));
+            }
+            cmds
+        }
+        None => {
+            let mut server = build_server(configs);
+            if let Some(sock) = &ozma_sock {
+                server = server.env("OZMA_SOCK", sock);
+            }
             match server.create_detached_session() {
                 Ok(name) => vec![switch_client_command(&name)],
                 Err(e) => {


### PR DESCRIPTION
## Problem

A program launched inside a tmux pane that forked **before** ozma set `$OZMA_SOCK` — a pre-existing tmux session, or any pane opened before attach — cannot find the control socket. A running process's environment is fixed at `fork()` and cannot be changed from outside, so neither `new-session -e` nor `set-environment` reaches an already-running shell. The SDK's `Ozma::connect()` then fails with `NotInPane`, and webview mounts from those panes don't work.

## Solution

Resolve `$OZMA_SOCK` from tmux instead of relying solely on the inherited process environment, and make sure every session the client lands on actually carries it.

**SDK self-resolution (`sdk/ratatui-ozma`).** `Ozma::connect()` now falls back to tmux when `$OZMA_SOCK` is unset: it derives the server socket from `$TMUX` (always injected into every pane) and runs `tmux -S <socket> show-environment OZMA_SOCK`, which reads tmux's **live** session environment — including a value set *after* the pane forked. This needs no shell-rc hook and no `send-keys`. The pane identity already falls back to `$TMUX_PANE` when `$OZMA_TOKEN` is unset.

**Close the set-environment gaps (multiplexer backend).** For the fallback to find a value, the target session must have `$OZMA_SOCK` set. Session switches and chooser-created sessions previously missed it (`set-environment` is session-scoped, and the attach-time injector doesn't re-run on `switch-client`). `apply_switch` now sets it on the switched-to session (`set-environment -t`, sent **before** `switch-client` to avoid a post-switch spawn race) and on chooser-created sessions (`new-session -e`).

**Why this approach.** Global (`-g`) tmux env is **not** visible to a session-scoped `show-environment` read (verified against tmux 3.6b), so a single global set is incompatible with the SDK reader and would also pollute a user-owned server — session-scoped injection per landed session is the correct primitive. Modifying already-running shells from outside is impossible by OS design, so self-resolution (a pull at connect time) is the only non-destructive way to cover pre-existing panes.

Affected: `sdk/ratatui-ozma` (SDK), `crates/tmux_control` + `crates/tmux_session` (multiplexer backend), `src/tmux_picker` (binary), `docs/dyn-webview.md` + `examples/dyn_webview_client.rs` (docs/example).

### Tests

- **Unit:** `socket_from_tmux`, `parse_show_environment`, `set_environment_in_session_command`, `create_detached_session_argv` emitting `-e`.
- **Gated real-tmux (`-- --ignored`):** SDK end-to-end self-resolution from a pre-existing pane; `new-session -e` populates the session env; `set-environment -t` reaches only the target session, not the current one.

Not a breaking change: the existing `$OZMA_SOCK` env path is unchanged; the tmux lookup is a fallback added only for the previously-failing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
