### PR TITLE
fix(tmux): forward Alt+punctuation as the base key (Alt+. → M-.)

### DIFF
--- a/crates/tmux_session/src/input.rs
+++ b/crates/tmux_session/src/input.rs
@@ -40,8 +40,11 @@ pub struct KeyMods {
 /// which tmux cannot map to its `M-p` bindings (it types `<ffffffff>`); tmux
 /// `M-` bindings are defined on the base key, so `Alt` acts as Meta here. `Shift`
 /// is folded into the base by uppercasing it (Alt+Shift+p → `M-P`), matching the
-/// `Key::Character` convention. Only letter/digit keys have a physical base;
-/// other Alt-modified keys fall through to the logical glyph below.
+/// `Key::Character` convention. Letter, digit, and ASCII-punctuation keys have a
+/// physical base (so Alt+. → `M-.` despite macOS composing Option+. into `≥`);
+/// other Alt-modified keys fall through to the logical glyph below. Punctuation
+/// has no ASCII uppercase, so the Shift fold leaves it unchanged (Alt+Shift+. →
+/// `M-.`).
 pub fn bevy_key_to_tmux_name(key: &Key, code: KeyCode, mods: KeyMods) -> Option<String> {
     if mods.super_ {
         return None;
@@ -127,8 +130,9 @@ pub fn send_pane_keys_command(pane: &str, names: &[String]) -> String {
     cmd
 }
 
-/// Returns the base character a letter/digit physical key produces, ignoring
-/// any layout composition (e.g. macOS Option). `None` for non-character keys.
+/// Returns the base character a letter/digit/ASCII-punctuation physical key
+/// produces, ignoring any layout composition (e.g. macOS Option). `None` for
+/// non-character keys.
 fn physical_base_char(code: KeyCode) -> Option<char> {
     Some(match code {
         KeyCode::KeyA => 'a',
@@ -167,6 +171,17 @@ fn physical_base_char(code: KeyCode) -> Option<char> {
         KeyCode::Digit7 => '7',
         KeyCode::Digit8 => '8',
         KeyCode::Digit9 => '9',
+        KeyCode::Backquote => '`',
+        KeyCode::Minus => '-',
+        KeyCode::Equal => '=',
+        KeyCode::BracketLeft => '[',
+        KeyCode::BracketRight => ']',
+        KeyCode::Backslash => '\\',
+        KeyCode::Semicolon => ';',
+        KeyCode::Quote => '\'',
+        KeyCode::Comma => ',',
+        KeyCode::Period => '.',
+        KeyCode::Slash => '/',
         _ => return None,
     })
 }
@@ -270,6 +285,30 @@ mod tests {
                 m(false, true, false, false)
             ),
             Some("M-i".to_string())
+        );
+    }
+
+    #[test]
+    fn alt_punctuation_uses_physical_key_not_composed_glyph() {
+        // macOS Option+. yields logical "≥" (Option+, → "≤"); tmux needs M-.
+        // (the base key) to match its `M-.` binding — otherwise it types
+        // <ffffffff>. The base comes from the physical key, layout composition
+        // notwithstanding.
+        assert_eq!(
+            bevy_key_to_tmux_name(
+                &Key::Character("≥".into()),
+                KeyCode::Period,
+                m(false, true, false, false)
+            ),
+            Some("M-.".to_string())
+        );
+        assert_eq!(
+            bevy_key_to_tmux_name(
+                &Key::Character("≤".into()),
+                KeyCode::Comma,
+                m(false, true, false, false)
+            ),
+            Some("M-,".to_string())
         );
     }
 


### PR DESCRIPTION
## Problem

Setting a tmux resize keybinding to `Alt+.` (e.g. `bind -n M-. ...`) did not work — pressing it printed the literal text `<ffffffff>` in the terminal instead of triggering the binding. The `Alt` modifier was handled correctly; only the `.` failed.

`<ffffffff>` is tmux's own rendering of a key name it cannot map (its internal `-1` / `KEYC_UNKNOWN`). On macOS, `Option+.` composes into the glyph `≥` (`Option+,` → `≤`), so ozmux was forwarding `M-≥`, which tmux can't resolve.

The root cause: when `Alt` is held, `bevy_key_to_tmux_name` derives the base key from the physical key via `physical_base_char`, but that function only mapped letters `A–Z` and digits `0–9`. Punctuation keys like `Period` fell through to the macOS-composed logical glyph. This is the same Option-composition bug already solved for letters (`Option+p → π` → `M-p`); punctuation was just never covered.

## Solution

Extended `physical_base_char` (`crates/tmux_session/src/input.rs`) to map the ASCII-punctuation physical keys (`` ` `` `-` `=` `[` `]` `\` `;` `'` `,` `.` `/`) to their base characters, so `Alt+.` → `M-.` and `Alt+,` → `M-,` regardless of layout composition.

- Added a reproducing unit test (`alt_punctuation_uses_physical_key_not_composed_glyph`) — confirmed it produced `M-≥` before the fix, `M-.` after.
- Updated the doc comments on `bevy_key_to_tmux_name` and `physical_base_char` to reflect punctuation coverage.
- All 81 `ozmux_tmux` lib tests pass; `clippy` and `fmt` clean.

Known limitation (documented in code, unchanged behavior class): ASCII punctuation has no uppercase, so the Shift fold leaves it as-is (`Alt+Shift+.` → `M-.`), consistent with how digit keys already behave — and still strictly better than the previous `<ffffffff>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)