### PR TITLE
feat: ozmd — rich Markdown viewer TUI (+ fix inline webviews under the tmux backend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1873,6 +1873,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -2464,6 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -2518,7 +2536,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "mio",
+ "mio 1.2.1",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook 0.3.18",
@@ -2540,6 +2558,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctrlc"
@@ -2634,6 +2662,16 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -2876,6 +2914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,6 +3070,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,6 +3160,15 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3151,7 +3226,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
 dependencies = [
- "inotify",
+ "inotify 0.11.1",
  "js-sys",
  "libc",
  "libudev-sys",
@@ -3668,6 +3743,17 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
@@ -3869,6 +3955,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
 
 [[package]]
 name = "ktx2"
@@ -4091,6 +4197,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
@@ -4265,6 +4383,39 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7fd166739789c9ff169e654dc1501373db9d80a4c3f972817c8a4d7cf8f34e"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
+]
 
 [[package]]
 name = "ntapi"
@@ -4770,6 +4921,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ozmd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossbeam-channel",
+ "notify-debouncer-full",
+ "pulldown-cmark",
+ "ratatui",
+ "ratatui-ozma",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "ozmux-gui"
 version = "0.1.0"
 dependencies = [
@@ -5102,6 +5269,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.11.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5403,6 +5589,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,6 +5872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5715,7 +5946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.2.1",
  "signal-hook 0.3.18",
 ]
 
@@ -6429,10 +6660,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "typewit"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ workspace = true
 [workspace]
 resolver = "2"
 members = [
-  "crates/*", "sdk/ratatui-ozma",
+  "crates/*", "sdk/ratatui-ozma", "apps/ozmd",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build clean help fix-lint setup-cef
+.PHONY: run build clean help fix-lint setup-cef ozmd ozmd-web
 
 OZMUX_EXTENSION_ROOT := $(CURDIR)/extensions
 CARGO_BIN_DIR := $(if $(CARGO_HOME),$(CARGO_HOME)/bin,$(HOME)/.cargo/bin)
@@ -16,6 +16,8 @@ help:
 	@echo "  setup-cef      - Install the CEF framework + debug render process for ozmux-gui (macOS, one-time)"
 	@echo "  fix-lint       - clippy --fix + rustfmt + biome lint:fix"
 	@echo "  clean          - cargo clean (remove the workspace target dir)"
+	@echo "  ozmd           - Build the web bundle then the ozmd binary"
+	@echo "  ozmd-web       - Build the ozmd web bundle (esbuild)"
 
 run:
 	cargo run
@@ -36,3 +38,9 @@ fix-lint:
 
 clean:
 	cargo clean
+
+ozmd-web:
+	pnpm --filter @ozma/ozmd-web build
+
+ozmd: ozmd-web
+	cargo build -p ozmd

--- a/apps/ozmd/Cargo.toml
+++ b/apps/ozmd/Cargo.toml
@@ -21,6 +21,7 @@ pulldown-cmark = "0.12"
 notify-debouncer-full = "0.3"
 rust-embed = "8"
 tempfile = { workspace = true }
+crossbeam-channel = "0.5"
 
 [lints]
 workspace = true

--- a/apps/ozmd/Cargo.toml
+++ b/apps/ozmd/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ozmd"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "ozmd"
+path = "src/main.rs"
+
+[dependencies]
+ratatui-ozma = { path = "../../sdk/ratatui-ozma" }
+ratatui = "0.29"
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+pulldown-cmark = "0.12"
+notify-debouncer-full = "0.3"
+rust-embed = "8"
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/apps/ozmd/assets/.gitignore
+++ b/apps/ozmd/assets/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitkeep
+!.gitignore

--- a/apps/ozmd/build.mjs
+++ b/apps/ozmd/build.mjs
@@ -1,0 +1,31 @@
+import { build } from 'esbuild';
+import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = join(here, 'assets');
+
+await rm(out, { recursive: true, force: true });
+await mkdir(out, { recursive: true });
+
+// The full clean above wipes the checked-in placeholders, so restore them: the
+// build output must stay gitignored while the empty assets/ dir is preserved.
+await writeFile(join(out, '.gitignore'), '*\n!.gitkeep\n!.gitignore\n');
+await writeFile(join(out, '.gitkeep'), '');
+
+await build({
+  entryPoints: [join(here, 'web', 'main.ts')],
+  bundle: true,
+  format: 'esm',
+  splitting: true,
+  outdir: out,
+  entryNames: 'bundle',
+  chunkNames: 'chunks/[name]-[hash]',
+  loader: { '.woff2': 'file', '.woff': 'file', '.ttf': 'file' },
+  assetNames: 'fonts/[name]-[hash]',
+  minify: true,
+});
+
+await copyFile(join(here, 'web', 'index.html'), join(out, 'index.html'));
+console.log('ozmd web bundle written to assets/');

--- a/apps/ozmd/package.json
+++ b/apps/ozmd/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ozma/ozmd-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node ./build.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ozma/web": "workspace:*",
+    "marked": "catalog:",
+    "marked-highlight": "catalog:",
+    "marked-katex-extension": "catalog:",
+    "katex": "catalog:",
+    "mermaid": "catalog:",
+    "dompurify": "catalog:",
+    "highlight.js": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "esbuild": "catalog:",
+    "jsdom": "catalog:"
+  }
+}

--- a/apps/ozmd/src/app.rs
+++ b/apps/ozmd/src/app.rs
@@ -1,0 +1,307 @@
+//! The pure App state machine. `on_action` is the single entry point; it
+//! returns the side-effect [`Cmd`]s for `main.rs` to execute. No SDK or I/O here.
+
+use crate::keymap::{Action, Mode};
+use crate::outline::Heading;
+use crate::protocol::{ScrollAction, SearchDir};
+
+/// A side effect for `main.rs` to perform after `on_action`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Cmd {
+    /// Scroll the page.
+    Scroll(ScrollAction),
+    /// Scroll heading `index` (the `id="h{index}"` anchor) into view.
+    ScrollToHeading(usize),
+    /// Run an in-page search for `query`.
+    Search(String),
+    /// Navigate to the next/previous search match.
+    SearchNav(SearchDir),
+    /// Clear the in-page search highlight.
+    ClearSearch,
+    /// Re-read the file from disk and push new content.
+    Reload,
+    /// Exit the app.
+    Quit,
+}
+
+/// Whole-app state.
+#[derive(Debug, Default)]
+pub(crate) struct App {
+    mode: Mode,
+    pending_prefix: Option<char>,
+    outline: Vec<Heading>,
+    outline_open: bool,
+    outline_selected: usize,
+    current_heading_index: Option<usize>,
+    search_query: String,
+    search_active: bool,
+}
+
+impl App {
+    /// The current input mode.
+    pub(crate) fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// Whether the outline panel is open.
+    pub(crate) fn outline_open(&self) -> bool {
+        self.outline_open
+    }
+
+    /// The selected outline index.
+    pub(crate) fn selected(&self) -> usize {
+        self.outline_selected
+    }
+
+    /// The current search query buffer.
+    pub(crate) fn query(&self) -> &str {
+        &self.search_query
+    }
+
+    /// The headings to draw in the outline panel.
+    pub(crate) fn outline(&self) -> &[Heading] {
+        &self.outline
+    }
+
+    /// Replaces the outline (called after a (re)load), clamping the selection.
+    pub(crate) fn set_outline(&mut self, outline: Vec<Heading>) {
+        self.outline = outline;
+        if self.outline_selected >= self.outline.len() {
+            self.outline_selected = self.outline.len().saturating_sub(1);
+        }
+    }
+
+    /// Records the heading index nearest the viewport top (from `scrollState`).
+    pub(crate) fn set_current_heading_index(&mut self, index: Option<usize>) {
+        self.current_heading_index = index;
+    }
+
+    /// Processes an [`Action`], returning the side effects to perform.
+    pub(crate) fn on_action(&mut self, action: Action) -> Vec<Cmd> {
+        if let Some(prefix) = self.pending_prefix.take()
+            && let Action::Prefix(c) = action
+            && c == prefix
+        {
+            return self.resolve_chord(c);
+        }
+
+        match action {
+            Action::Prefix(c) => {
+                self.pending_prefix = Some(c);
+                vec![]
+            }
+            Action::Quit => vec![Cmd::Quit],
+            Action::Reload => vec![Cmd::Reload],
+            Action::ScrollLineDown => vec![Cmd::Scroll(ScrollAction::Down)],
+            Action::ScrollLineUp => vec![Cmd::Scroll(ScrollAction::Up)],
+            Action::ScrollHalfDown => vec![Cmd::Scroll(ScrollAction::HalfDown)],
+            Action::ScrollHalfUp => vec![Cmd::Scroll(ScrollAction::HalfUp)],
+            Action::ScrollPageDown => vec![Cmd::Scroll(ScrollAction::PageDown)],
+            Action::ScrollPageUp => vec![Cmd::Scroll(ScrollAction::PageUp)],
+            Action::GoBottom => vec![Cmd::Scroll(ScrollAction::Bottom)],
+            Action::ToggleOutline => {
+                self.outline_open = !self.outline_open;
+                self.mode = if self.outline_open { Mode::Outline } else { Mode::Normal };
+                vec![]
+            }
+            Action::OutlineMoveDown => {
+                if self.outline_selected + 1 < self.outline.len() {
+                    self.outline_selected += 1;
+                }
+                vec![]
+            }
+            Action::OutlineMoveUp => {
+                self.outline_selected = self.outline_selected.saturating_sub(1);
+                vec![]
+            }
+            Action::OutlineConfirm => {
+                if self.outline.is_empty() {
+                    vec![]
+                } else {
+                    vec![Cmd::ScrollToHeading(self.outline_selected)]
+                }
+            }
+            Action::EnterSearch => {
+                self.mode = Mode::Search;
+                self.search_query.clear();
+                vec![]
+            }
+            Action::SearchChar(c) => {
+                self.search_query.push(c);
+                vec![]
+            }
+            Action::SearchBackspace => {
+                self.search_query.pop();
+                vec![]
+            }
+            Action::SearchConfirm => {
+                self.mode = Mode::Normal;
+                self.search_active = true;
+                vec![Cmd::Search(self.search_query.clone())]
+            }
+            Action::SearchNext if self.search_active => vec![Cmd::SearchNav(SearchDir::Next)],
+            Action::SearchPrev if self.search_active => vec![Cmd::SearchNav(SearchDir::Prev)],
+            Action::SearchNext | Action::SearchPrev => vec![],
+            Action::Escape => {
+                self.outline_open = false;
+                self.mode = Mode::Normal;
+                if self.search_active {
+                    self.search_active = false;
+                    self.search_query.clear();
+                    vec![Cmd::ClearSearch]
+                } else {
+                    vec![]
+                }
+            }
+            Action::Ignore => vec![],
+        }
+    }
+
+    fn resolve_chord(&mut self, c: char) -> Vec<Cmd> {
+        match c {
+            'g' => vec![Cmd::Scroll(ScrollAction::Top)],
+            ']' => self.heading_jump(true),
+            '[' => self.heading_jump(false),
+            _ => vec![],
+        }
+    }
+
+    fn heading_jump(&self, forward: bool) -> Vec<Cmd> {
+        if self.outline.is_empty() {
+            return vec![];
+        }
+        let last = self.outline.len() - 1;
+        let target = match (self.current_heading_index, forward) {
+            (None, _) => 0,
+            (Some(i), true) => (i + 1).min(last),
+            (Some(i), false) => i.saturating_sub(1),
+        };
+        if Some(target) == self.current_heading_index {
+            return vec![];
+        }
+        vec![Cmd::ScrollToHeading(target)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app_with_outline(n: usize) -> App {
+        let mut app = App::default();
+        app.set_outline((0..n).map(|i| Heading { level: 1, text: format!("h{i}") }).collect());
+        app
+    }
+
+    #[test]
+    fn gg_chord_scrolls_to_top() {
+        let mut app = App::default();
+        assert_eq!(app.on_action(Action::Prefix('g')), vec![]);
+        assert_eq!(app.on_action(Action::Prefix('g')), vec![Cmd::Scroll(ScrollAction::Top)]);
+    }
+
+    #[test]
+    fn dangling_prefix_then_other_key_is_cleared() {
+        let mut app = App::default();
+        assert_eq!(app.on_action(Action::Prefix('g')), vec![]);
+        assert_eq!(app.on_action(Action::ScrollLineDown), vec![Cmd::Scroll(ScrollAction::Down)]);
+    }
+
+    #[test]
+    fn bracket_chord_navigates_headings_from_current() {
+        let mut app = app_with_outline(3);
+        app.set_current_heading_index(Some(0));
+        app.on_action(Action::Prefix(']'));
+        assert_eq!(app.on_action(Action::Prefix(']')), vec![Cmd::ScrollToHeading(1)]);
+        app.set_current_heading_index(Some(2));
+        app.on_action(Action::Prefix('['));
+        assert_eq!(app.on_action(Action::Prefix('[')), vec![Cmd::ScrollToHeading(1)]);
+    }
+
+    #[test]
+    fn next_heading_from_none_goes_to_first() {
+        let mut app = app_with_outline(3);
+        app.on_action(Action::Prefix(']'));
+        assert_eq!(app.on_action(Action::Prefix(']')), vec![Cmd::ScrollToHeading(0)]);
+    }
+
+    #[test]
+    fn search_flow_enters_types_confirms_returns_to_normal() {
+        let mut app = App::default();
+        app.on_action(Action::EnterSearch);
+        assert_eq!(app.mode(), Mode::Search);
+        app.on_action(Action::SearchChar('f'));
+        app.on_action(Action::SearchChar('o'));
+        assert_eq!(app.on_action(Action::SearchConfirm), vec![Cmd::Search("fo".into())]);
+        assert_eq!(app.mode(), Mode::Normal);
+    }
+
+    #[test]
+    fn n_navigates_only_when_search_active() {
+        let mut app = App::default();
+        assert_eq!(app.on_action(Action::SearchNext), vec![]);
+        app.on_action(Action::EnterSearch);
+        app.on_action(Action::SearchChar('x'));
+        app.on_action(Action::SearchConfirm);
+        assert_eq!(app.on_action(Action::SearchNext), vec![Cmd::SearchNav(SearchDir::Next)]);
+    }
+
+    #[test]
+    fn escape_clears_active_search() {
+        let mut app = App::default();
+        app.on_action(Action::EnterSearch);
+        app.on_action(Action::SearchChar('x'));
+        app.on_action(Action::SearchConfirm);
+        assert_eq!(app.on_action(Action::Escape), vec![Cmd::ClearSearch]);
+    }
+
+    #[test]
+    fn outline_toggle_move_and_confirm() {
+        let mut app = app_with_outline(3);
+        app.on_action(Action::ToggleOutline);
+        assert_eq!(app.mode(), Mode::Outline);
+        assert!(app.outline_open());
+        app.on_action(Action::OutlineMoveDown);
+        app.on_action(Action::OutlineMoveDown);
+        assert_eq!(app.on_action(Action::OutlineConfirm), vec![Cmd::ScrollToHeading(2)]);
+    }
+
+    #[test]
+    fn outline_move_is_clamped() {
+        let mut app = app_with_outline(2);
+        app.on_action(Action::ToggleOutline);
+        app.on_action(Action::OutlineMoveUp);
+        assert_eq!(app.selected(), 0);
+        app.on_action(Action::OutlineMoveDown);
+        app.on_action(Action::OutlineMoveDown);
+        assert_eq!(app.selected(), 1);
+    }
+
+    #[test]
+    fn quit_and_reload_passthrough() {
+        let mut app = App::default();
+        assert_eq!(app.on_action(Action::Quit), vec![Cmd::Quit]);
+        assert_eq!(app.on_action(Action::Reload), vec![Cmd::Reload]);
+    }
+
+    #[test]
+    fn escape_in_outline_mode_closes_panel() {
+        let mut app = app_with_outline(3);
+        app.on_action(Action::ToggleOutline);
+        assert!(app.outline_open());
+        assert_eq!(app.on_action(Action::Escape), vec![]);
+        assert!(!app.outline_open());
+        assert_eq!(app.mode(), Mode::Normal);
+    }
+
+    #[test]
+    fn heading_jump_is_noop_at_boundaries() {
+        let mut app = app_with_outline(3);
+        app.set_current_heading_index(Some(2));
+        app.on_action(Action::Prefix(']'));
+        assert_eq!(app.on_action(Action::Prefix(']')), vec![]);
+        app.set_current_heading_index(Some(0));
+        app.on_action(Action::Prefix('['));
+        assert_eq!(app.on_action(Action::Prefix('[')), vec![]);
+    }
+}

--- a/apps/ozmd/src/app.rs
+++ b/apps/ozmd/src/app.rs
@@ -101,7 +101,11 @@ impl App {
             Action::GoBottom => vec![Cmd::Scroll(ScrollAction::Bottom)],
             Action::ToggleOutline => {
                 self.outline_open = !self.outline_open;
-                self.mode = if self.outline_open { Mode::Outline } else { Mode::Normal };
+                self.mode = if self.outline_open {
+                    Mode::Outline
+                } else {
+                    Mode::Normal
+                };
                 vec![]
             }
             Action::OutlineMoveDown => {
@@ -189,7 +193,14 @@ mod tests {
 
     fn app_with_outline(n: usize) -> App {
         let mut app = App::default();
-        app.set_outline((0..n).map(|i| Heading { level: 1, text: format!("h{i}") }).collect());
+        app.set_outline(
+            (0..n)
+                .map(|i| Heading {
+                    level: 1,
+                    text: format!("h{i}"),
+                })
+                .collect(),
+        );
         app
     }
 
@@ -197,14 +208,20 @@ mod tests {
     fn gg_chord_scrolls_to_top() {
         let mut app = App::default();
         assert_eq!(app.on_action(Action::Prefix('g')), vec![]);
-        assert_eq!(app.on_action(Action::Prefix('g')), vec![Cmd::Scroll(ScrollAction::Top)]);
+        assert_eq!(
+            app.on_action(Action::Prefix('g')),
+            vec![Cmd::Scroll(ScrollAction::Top)]
+        );
     }
 
     #[test]
     fn dangling_prefix_then_other_key_is_cleared() {
         let mut app = App::default();
         assert_eq!(app.on_action(Action::Prefix('g')), vec![]);
-        assert_eq!(app.on_action(Action::ScrollLineDown), vec![Cmd::Scroll(ScrollAction::Down)]);
+        assert_eq!(
+            app.on_action(Action::ScrollLineDown),
+            vec![Cmd::Scroll(ScrollAction::Down)]
+        );
     }
 
     #[test]
@@ -212,17 +229,26 @@ mod tests {
         let mut app = app_with_outline(3);
         app.set_current_heading_index(Some(0));
         app.on_action(Action::Prefix(']'));
-        assert_eq!(app.on_action(Action::Prefix(']')), vec![Cmd::ScrollToHeading(1)]);
+        assert_eq!(
+            app.on_action(Action::Prefix(']')),
+            vec![Cmd::ScrollToHeading(1)]
+        );
         app.set_current_heading_index(Some(2));
         app.on_action(Action::Prefix('['));
-        assert_eq!(app.on_action(Action::Prefix('[')), vec![Cmd::ScrollToHeading(1)]);
+        assert_eq!(
+            app.on_action(Action::Prefix('[')),
+            vec![Cmd::ScrollToHeading(1)]
+        );
     }
 
     #[test]
     fn next_heading_from_none_goes_to_first() {
         let mut app = app_with_outline(3);
         app.on_action(Action::Prefix(']'));
-        assert_eq!(app.on_action(Action::Prefix(']')), vec![Cmd::ScrollToHeading(0)]);
+        assert_eq!(
+            app.on_action(Action::Prefix(']')),
+            vec![Cmd::ScrollToHeading(0)]
+        );
     }
 
     #[test]
@@ -232,7 +258,10 @@ mod tests {
         assert_eq!(app.mode(), Mode::Search);
         app.on_action(Action::SearchChar('f'));
         app.on_action(Action::SearchChar('o'));
-        assert_eq!(app.on_action(Action::SearchConfirm), vec![Cmd::Search("fo".into())]);
+        assert_eq!(
+            app.on_action(Action::SearchConfirm),
+            vec![Cmd::Search("fo".into())]
+        );
         assert_eq!(app.mode(), Mode::Normal);
     }
 
@@ -243,7 +272,10 @@ mod tests {
         app.on_action(Action::EnterSearch);
         app.on_action(Action::SearchChar('x'));
         app.on_action(Action::SearchConfirm);
-        assert_eq!(app.on_action(Action::SearchNext), vec![Cmd::SearchNav(SearchDir::Next)]);
+        assert_eq!(
+            app.on_action(Action::SearchNext),
+            vec![Cmd::SearchNav(SearchDir::Next)]
+        );
     }
 
     #[test]
@@ -263,7 +295,10 @@ mod tests {
         assert!(app.outline_open());
         app.on_action(Action::OutlineMoveDown);
         app.on_action(Action::OutlineMoveDown);
-        assert_eq!(app.on_action(Action::OutlineConfirm), vec![Cmd::ScrollToHeading(2)]);
+        assert_eq!(
+            app.on_action(Action::OutlineConfirm),
+            vec![Cmd::ScrollToHeading(2)]
+        );
     }
 
     #[test]

--- a/apps/ozmd/src/app.rs
+++ b/apps/ozmd/src/app.rs
@@ -76,6 +76,11 @@ impl App {
         self.current_heading_index = index;
     }
 
+    /// Whether a search is active (matches highlighted, awaiting clear).
+    pub(crate) fn search_active(&self) -> bool {
+        self.search_active
+    }
+
     /// Processes an [`Action`], returning the side effects to perform.
     pub(crate) fn on_action(&mut self, action: Action) -> Vec<Cmd> {
         if let Some(prefix) = self.pending_prefix.take()
@@ -327,6 +332,18 @@ mod tests {
         assert_eq!(app.on_action(Action::Escape), vec![]);
         assert!(!app.outline_open());
         assert_eq!(app.mode(), Mode::Normal);
+    }
+
+    #[test]
+    fn search_active_reflects_lifecycle() {
+        let mut app = App::default();
+        assert!(!app.search_active());
+        app.on_action(Action::EnterSearch);
+        app.on_action(Action::SearchChar('x'));
+        app.on_action(Action::SearchConfirm);
+        assert!(app.search_active());
+        app.on_action(Action::Escape);
+        assert!(!app.search_active());
     }
 
     #[test]

--- a/apps/ozmd/src/assets.rs
+++ b/apps/ozmd/src/assets.rs
@@ -1,0 +1,31 @@
+//! Embeds the built web bundle and materializes it to a temp directory at
+//! runtime so it can be served through `Webview::dir`.
+
+use rust_embed::RustEmbed;
+use std::fs;
+use tempfile::TempDir;
+
+/// The built web bundle, embedded at compile time from `assets/`.
+#[derive(RustEmbed)]
+#[folder = "assets/"]
+struct Assets;
+
+/// Writes every embedded asset into a fresh temp directory and returns it.
+///
+/// Keep the returned [`TempDir`] alive for the lifetime of the app; dropping it
+/// deletes the materialized files.
+///
+/// # Errors
+/// Returns an error if the temp dir or any file cannot be written.
+pub(crate) fn materialize() -> std::io::Result<TempDir> {
+    let dir = tempfile::tempdir()?;
+    for name in Assets::iter() {
+        let file = Assets::get(name.as_ref()).expect("embedded asset listed by iter() must exist");
+        let dest = dir.path().join(name.as_ref());
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&dest, file.data.as_ref())?;
+    }
+    Ok(dir)
+}

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -8,18 +8,18 @@ use std::time::SystemTime;
 
 /// A loaded Markdown document and its derived outline.
 #[derive(Debug, Clone)]
-pub struct Document {
+pub(crate) struct Document {
     /// Raw Markdown source.
-    pub text: String,
+    pub(crate) text: String,
     /// Absolute parent directory of the source file.
-    pub base_dir: PathBuf,
+    pub(crate) base_dir: PathBuf,
     /// Headings parsed from `text`, in document order.
-    pub outline: Vec<Heading>,
+    pub(crate) outline: Vec<Heading>,
 }
 
 /// A cheap change fingerprint: file length plus mtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Fingerprint {
+pub(crate) struct Fingerprint {
     len: u64,
     mtime: Option<SystemTime>,
 }
@@ -27,7 +27,7 @@ pub struct Fingerprint {
 impl Document {
     /// Builds a document from source text and the file's parent directory,
     /// parsing the outline from `text`.
-    pub fn from_source(text: String, base_dir: PathBuf) -> Self {
+    fn from_source(text: String, base_dir: PathBuf) -> Self {
         let outline = outline::parse(&text);
         Self { text, base_dir, outline }
     }
@@ -37,7 +37,7 @@ impl Document {
 ///
 /// # Errors
 /// Returns an error if the path does not exist or is not a regular file.
-pub fn resolve_path(arg: &str) -> io::Result<PathBuf> {
+pub(crate) fn resolve_path(arg: &str) -> io::Result<PathBuf> {
     let path = fs::canonicalize(arg)?;
     if !path.is_file() {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"));
@@ -46,14 +46,14 @@ pub fn resolve_path(arg: &str) -> io::Result<PathBuf> {
 }
 
 /// Reads and parses the Markdown file at `path` into a [`Document`].
-pub fn load(path: &Path) -> io::Result<Document> {
+pub(crate) fn load(path: &Path) -> io::Result<Document> {
     let text = fs::read_to_string(path)?;
     let base_dir = path.parent().map(Path::to_path_buf).unwrap_or_default();
     Ok(Document::from_source(text, base_dir))
 }
 
 /// Reads the change fingerprint (length + mtime) for `path`.
-pub fn fingerprint(path: &Path) -> io::Result<Fingerprint> {
+pub(crate) fn fingerprint(path: &Path) -> io::Result<Fingerprint> {
     let meta = fs::metadata(path)?;
     Ok(Fingerprint { len: meta.len(), mtime: meta.modified().ok() })
 }

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -1,0 +1,102 @@
+//! The in-memory Markdown document plus path resolution and change detection.
+
+use crate::outline::{self, Heading};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// A loaded Markdown document and its derived outline.
+#[derive(Debug, Clone)]
+pub struct Document {
+    /// Raw Markdown source.
+    pub text: String,
+    /// Absolute parent directory of the source file.
+    pub base_dir: PathBuf,
+    /// Headings parsed from `text`, in document order.
+    pub outline: Vec<Heading>,
+}
+
+/// A cheap change fingerprint: file length plus mtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fingerprint {
+    len: u64,
+    mtime: Option<SystemTime>,
+}
+
+impl Document {
+    /// Builds a document from source text and the file's parent directory,
+    /// parsing the outline from `text`.
+    pub fn from_source(text: String, base_dir: PathBuf) -> Self {
+        let outline = outline::parse(&text);
+        Self { text, base_dir, outline }
+    }
+}
+
+/// Resolves a user-supplied path to an absolute, canonical regular-file path.
+///
+/// # Errors
+/// Returns an error if the path does not exist or is not a regular file.
+pub fn resolve_path(arg: &str) -> io::Result<PathBuf> {
+    let path = fs::canonicalize(arg)?;
+    if !path.is_file() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"));
+    }
+    Ok(path)
+}
+
+/// Reads and parses the Markdown file at `path` into a [`Document`].
+pub fn load(path: &Path) -> io::Result<Document> {
+    let text = fs::read_to_string(path)?;
+    let base_dir = path.parent().map(Path::to_path_buf).unwrap_or_default();
+    Ok(Document::from_source(text, base_dir))
+}
+
+/// Reads the change fingerprint (length + mtime) for `path`.
+pub fn fingerprint(path: &Path) -> io::Result<Fingerprint> {
+    let meta = fs::metadata(path)?;
+    Ok(Fingerprint { len: meta.len(), mtime: meta.modified().ok() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(name: &str, body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn load_reads_text_outline_and_base_dir() {
+        let (_dir, path) = write_temp("doc.md", "# A\n\ntext\n## B\n");
+        let doc = load(&path).unwrap();
+        assert_eq!(doc.text, "# A\n\ntext\n## B\n");
+        assert_eq!(doc.outline.len(), 2);
+        assert_eq!(doc.base_dir, path.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_path_rejects_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve_path(dir.path().to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn resolve_path_rejects_missing() {
+        assert!(resolve_path("/no/such/file/ozmd-xyz.md").is_err());
+    }
+
+    #[test]
+    fn fingerprint_changes_with_content_length() {
+        let (_dir, path) = write_temp("doc.md", "short");
+        let fp1 = fingerprint(&path).unwrap();
+        fs::write(&path, "a much longer body than before").unwrap();
+        let fp2 = fingerprint(&path).unwrap();
+        assert_ne!(fp1, fp2);
+    }
+}

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -29,7 +29,11 @@ impl Document {
     /// parsing the outline from `text`.
     fn from_source(text: String, base_dir: PathBuf) -> Self {
         let outline = outline::parse(&text);
-        Self { text, base_dir, outline }
+        Self {
+            text,
+            base_dir,
+            outline,
+        }
     }
 }
 
@@ -40,7 +44,10 @@ impl Document {
 pub(crate) fn resolve_path(arg: &str) -> io::Result<PathBuf> {
     let path = fs::canonicalize(arg)?;
     if !path.is_file() {
-        return Err(io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "not a regular file",
+        ));
     }
     Ok(path)
 }
@@ -55,7 +62,10 @@ pub(crate) fn load(path: &Path) -> io::Result<Document> {
 /// Reads the change fingerprint (length + mtime) for `path`.
 pub(crate) fn fingerprint(path: &Path) -> io::Result<Fingerprint> {
     let meta = fs::metadata(path)?;
-    Ok(Fingerprint { len: meta.len(), mtime: meta.modified().ok() })
+    Ok(Fingerprint {
+        len: meta.len(),
+        mtime: meta.modified().ok(),
+    })
 }
 
 #[cfg(test)]

--- a/apps/ozmd/src/keymap.rs
+++ b/apps/ozmd/src/keymap.rs
@@ -1,0 +1,153 @@
+//! Maps a (mode, key) pair to a high-level [`Action`]. Pure and stateless;
+//! two-key chords (`gg`, `]]`, `[[`) emit a [`Action::Prefix`] that `App`
+//! completes.
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// The current input mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum Mode {
+    /// Scrolling / navigation.
+    #[default]
+    Normal,
+    /// Outline panel is open and focused.
+    Outline,
+    /// Search query is being typed.
+    Search,
+}
+
+/// A high-level action produced by a key in some mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Action {
+    Quit,
+    Reload,
+    ScrollLineDown,
+    ScrollLineUp,
+    ScrollHalfDown,
+    ScrollHalfUp,
+    ScrollPageDown,
+    ScrollPageUp,
+    GoBottom,
+    /// First key of a two-key chord (`g`, `]`, `[`).
+    Prefix(char),
+    ToggleOutline,
+    OutlineMoveDown,
+    OutlineMoveUp,
+    OutlineConfirm,
+    EnterSearch,
+    SearchChar(char),
+    SearchBackspace,
+    SearchConfirm,
+    SearchNext,
+    SearchPrev,
+    Escape,
+    Ignore,
+}
+
+/// Maps a key event in `mode` to an [`Action`].
+pub(crate) fn map(mode: Mode, key: KeyEvent) -> Action {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match mode {
+        Mode::Search => match key.code {
+            KeyCode::Esc => Action::Escape,
+            KeyCode::Enter => Action::SearchConfirm,
+            KeyCode::Backspace => Action::SearchBackspace,
+            KeyCode::Char(c) => Action::SearchChar(c),
+            _ => Action::Ignore,
+        },
+        Mode::Outline => match key.code {
+            KeyCode::Esc => Action::Escape,
+            KeyCode::Tab => Action::ToggleOutline,
+            KeyCode::Enter => Action::OutlineConfirm,
+            KeyCode::Char('o') => Action::ToggleOutline,
+            KeyCode::Char('j') | KeyCode::Down => Action::OutlineMoveDown,
+            KeyCode::Char('k') | KeyCode::Up => Action::OutlineMoveUp,
+            KeyCode::Char('q') if !ctrl => Action::Quit,
+            KeyCode::Char('c') if ctrl => Action::Quit,
+            _ => Action::Ignore,
+        },
+        Mode::Normal => map_normal(ctrl, key.code),
+    }
+}
+
+fn map_normal(ctrl: bool, code: KeyCode) -> Action {
+    match code {
+        KeyCode::Char('c') if ctrl => Action::Quit,
+        KeyCode::Char('d') if ctrl => Action::ScrollHalfDown,
+        KeyCode::Char('u') if ctrl => Action::ScrollHalfUp,
+        KeyCode::Char('f') if ctrl => Action::ScrollPageDown,
+        KeyCode::Char('b') if ctrl => Action::ScrollPageUp,
+        _ if ctrl => Action::Ignore,
+        KeyCode::Char('q') => Action::Quit,
+        KeyCode::Char('r') => Action::Reload,
+        KeyCode::Char('j') | KeyCode::Down => Action::ScrollLineDown,
+        KeyCode::Char('k') | KeyCode::Up => Action::ScrollLineUp,
+        KeyCode::Char(' ') | KeyCode::PageDown => Action::ScrollPageDown,
+        KeyCode::PageUp => Action::ScrollPageUp,
+        KeyCode::Char('G') => Action::GoBottom,
+        KeyCode::Char('g') => Action::Prefix('g'),
+        KeyCode::Char(']') => Action::Prefix(']'),
+        KeyCode::Char('[') => Action::Prefix('['),
+        KeyCode::Char('o') | KeyCode::Tab => Action::ToggleOutline,
+        KeyCode::Char('/') => Action::EnterSearch,
+        KeyCode::Char('n') => Action::SearchNext,
+        KeyCode::Char('N') => Action::SearchPrev,
+        _ => Action::Ignore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+    fn ctrl(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn normal_scrolling() {
+        assert_eq!(map(Mode::Normal, key('j')), Action::ScrollLineDown);
+        assert_eq!(map(Mode::Normal, key('k')), Action::ScrollLineUp);
+        assert_eq!(map(Mode::Normal, ctrl('d')), Action::ScrollHalfDown);
+        assert_eq!(map(Mode::Normal, ctrl('u')), Action::ScrollHalfUp);
+    }
+
+    #[test]
+    fn normal_prefixes_and_bottom() {
+        assert_eq!(map(Mode::Normal, key('g')), Action::Prefix('g'));
+        assert_eq!(map(Mode::Normal, key('G')), Action::GoBottom);
+        assert_eq!(map(Mode::Normal, key(']')), Action::Prefix(']'));
+        assert_eq!(map(Mode::Normal, key('[')), Action::Prefix('['));
+    }
+
+    #[test]
+    fn normal_search_nav_and_modes() {
+        assert_eq!(map(Mode::Normal, key('/')), Action::EnterSearch);
+        assert_eq!(map(Mode::Normal, key('n')), Action::SearchNext);
+        assert_eq!(map(Mode::Normal, key('N')), Action::SearchPrev);
+        assert_eq!(map(Mode::Normal, key('o')), Action::ToggleOutline);
+        assert_eq!(map(Mode::Normal, key('q')), Action::Quit);
+        assert_eq!(map(Mode::Normal, ctrl('c')), Action::Quit);
+        assert_eq!(map(Mode::Normal, key('r')), Action::Reload);
+    }
+
+    #[test]
+    fn search_mode_typing() {
+        assert_eq!(map(Mode::Search, key('a')), Action::SearchChar('a'));
+        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)), Action::SearchConfirm);
+        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)), Action::SearchBackspace);
+        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)), Action::Escape);
+    }
+
+    #[test]
+    fn outline_mode_navigation() {
+        assert_eq!(map(Mode::Outline, key('j')), Action::OutlineMoveDown);
+        assert_eq!(map(Mode::Outline, key('k')), Action::OutlineMoveUp);
+        assert_eq!(map(Mode::Outline, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)), Action::OutlineConfirm);
+        assert_eq!(map(Mode::Outline, key('o')), Action::ToggleOutline);
+        assert_eq!(map(Mode::Outline, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)), Action::Escape);
+    }
+}

--- a/apps/ozmd/src/keymap.rs
+++ b/apps/ozmd/src/keymap.rs
@@ -137,17 +137,47 @@ mod tests {
     #[test]
     fn search_mode_typing() {
         assert_eq!(map(Mode::Search, key('a')), Action::SearchChar('a'));
-        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)), Action::SearchConfirm);
-        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)), Action::SearchBackspace);
-        assert_eq!(map(Mode::Search, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)), Action::Escape);
+        assert_eq!(
+            map(
+                Mode::Search,
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+            ),
+            Action::SearchConfirm
+        );
+        assert_eq!(
+            map(
+                Mode::Search,
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)
+            ),
+            Action::SearchBackspace
+        );
+        assert_eq!(
+            map(
+                Mode::Search,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+            ),
+            Action::Escape
+        );
     }
 
     #[test]
     fn outline_mode_navigation() {
         assert_eq!(map(Mode::Outline, key('j')), Action::OutlineMoveDown);
         assert_eq!(map(Mode::Outline, key('k')), Action::OutlineMoveUp);
-        assert_eq!(map(Mode::Outline, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)), Action::OutlineConfirm);
+        assert_eq!(
+            map(
+                Mode::Outline,
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+            ),
+            Action::OutlineConfirm
+        );
         assert_eq!(map(Mode::Outline, key('o')), Action::ToggleOutline);
-        assert_eq!(map(Mode::Outline, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)), Action::Escape);
+        assert_eq!(
+            map(
+                Mode::Outline,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+            ),
+            Action::Escape
+        );
     }
 }

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,6 +1,7 @@
 //! ozmd — a rich Markdown viewer TUI for ozmux panes.
 
 mod app;
+mod assets;
 mod document;
 mod keymap;
 mod outline;

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,5 +1,6 @@
 //! ozmd — a rich Markdown viewer TUI for ozmux panes.
 
+mod app;
 mod document;
 mod keymap;
 mod outline;

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,0 +1,5 @@
+//! ozmd — a rich Markdown viewer TUI for ozmux panes.
+
+fn main() {
+    println!("ozmd");
+}

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -6,6 +6,7 @@ mod document;
 mod keymap;
 mod outline;
 mod protocol;
+mod ui;
 mod watcher;
 
 fn main() {

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,6 +1,7 @@
 //! ozmd — a rich Markdown viewer TUI for ozmux panes.
 
 mod document;
+mod keymap;
 mod outline;
 mod protocol;
 

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -10,16 +10,16 @@ mod ui;
 mod watcher;
 
 use crate::app::{App, Cmd};
-use crate::protocol::{Content, Scroll, Search, SearchCount, SearchNav, ScrollState};
+use crate::protocol::{Content, Scroll, ScrollState, Search, SearchCount, SearchNav};
 use crate::ui::LiveStatus;
 use crossbeam_channel::{Receiver, Sender};
+use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{self, Event};
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use ratatui::Terminal;
 use ratatui_ozma::{Ozma, OzmaBackend, RpcError, Webview, WebviewHandle};
 use std::io::stdout;
 use std::path::Path;
@@ -44,12 +44,14 @@ fn run() -> anyhow::Result<()> {
     let arg = std::env::args()
         .nth(1)
         .ok_or_else(|| anyhow::anyhow!("usage: ozmd <markdown-file>"))?;
-    let path = document::resolve_path(&arg).map_err(|e| anyhow::anyhow!("cannot open {arg}: {e}"))?;
+    let path =
+        document::resolve_path(&arg).map_err(|e| anyhow::anyhow!("cannot open {arg}: {e}"))?;
 
     let doc = document::load(&path)?;
     let shared = Arc::new(Mutex::new(doc));
 
-    let ozma = Ozma::connect().map_err(|e| anyhow::anyhow!("{e}. Run ozmd inside an ozmux pane."))?;
+    let ozma =
+        Ozma::connect().map_err(|e| anyhow::anyhow!("{e}. Run ozmd inside an ozmux pane."))?;
 
     let asset_dir = assets::materialize()?;
 
@@ -92,14 +94,20 @@ fn register_view(
                     base_dir: doc.base_dir.display().to_string(),
                 })
             })
-            .on("searchCount", move |c: SearchCount| -> Result<(), RpcError> {
-                let _ = count_tx.send(PageMsg::SearchCount(c));
-                Ok(())
-            })
-            .on("scrollState", move |s: ScrollState| -> Result<(), RpcError> {
-                let _ = state_tx.send(PageMsg::ScrollState(s));
-                Ok(())
-            }),
+            .on(
+                "searchCount",
+                move |c: SearchCount| -> Result<(), RpcError> {
+                    let _ = count_tx.send(PageMsg::SearchCount(c));
+                    Ok(())
+                },
+            )
+            .on(
+                "scrollState",
+                move |s: ScrollState| -> Result<(), RpcError> {
+                    let _ = state_tx.send(PageMsg::ScrollState(s));
+                    Ok(())
+                },
+            ),
     )?;
     Ok(view)
 }
@@ -148,7 +156,7 @@ fn event_loop(
         terminal.draw(|f| {
             ui::draw(
                 f,
-                &mut *ozma.frame(),
+                &mut ozma.frame(),
                 &state,
                 view.id(),
                 &file_name,
@@ -172,7 +180,8 @@ fn event_loop(
                         let _ = view.emit("scroll", &Scroll { action });
                     }
                     Cmd::ScrollToHeading(index) => {
-                        let _ = view.emit("scrollToHeading", &serde_json::json!({ "index": index }));
+                        let _ =
+                            view.emit("scrollToHeading", &serde_json::json!({ "index": index }));
                     }
                     Cmd::Search(query) => {
                         let _ = view.emit("search", &Search { query });
@@ -224,7 +233,9 @@ fn apply_reload(
         base_dir: doc.base_dir.display().to_string(),
     };
     {
-        let mut guard = shared.lock().map_err(|_| anyhow::anyhow!("state poisoned"))?;
+        let mut guard = shared
+            .lock()
+            .map_err(|_| anyhow::anyhow!("state poisoned"))?;
         *guard = doc;
     }
     let _ = view.emit("content", &content);

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -89,10 +89,7 @@ fn register_view(
             .interactive(false)
             .on("ready", move |(): ()| -> Result<Content, RpcError> {
                 let doc = ready_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
-                Ok(Content {
-                    markdown: doc.text.clone(),
-                    base_dir: doc.base_dir.display().to_string(),
-                })
+                Ok(content_of(&doc))
             })
             .on(
                 "searchCount",
@@ -207,17 +204,15 @@ fn apply_reload(
     shared: &Arc<Mutex<document::Document>>,
     path: &Path,
 ) -> anyhow::Result<()> {
-    match document::fingerprint(path) {
-        Ok(fp) => {
-            if Some(fp) == *last_fp {
-                return Ok(());
-            }
-            *last_fp = Some(fp);
-        }
+    let fp = match document::fingerprint(path) {
+        Ok(fp) => fp,
         Err(_) => {
             *live = LiveStatus::Missing;
             return Ok(());
         }
+    };
+    if Some(fp) == *last_fp {
+        return Ok(());
     }
     let doc = match document::load(path) {
         Ok(d) => d,
@@ -226,12 +221,13 @@ fn apply_reload(
             return Ok(());
         }
     };
+    // NOTE: record the fingerprint only after a successful load — setting it
+    // before would let a transient read failure poison the skip-check and
+    // permanently suppress a later reload with the same fingerprint.
+    *last_fp = Some(fp);
     *live = LiveStatus::Watching;
     state.set_outline(doc.outline.clone());
-    let content = Content {
-        markdown: doc.text.clone(),
-        base_dir: doc.base_dir.display().to_string(),
-    };
+    let content = content_of(&doc);
     {
         let mut guard = shared
             .lock()
@@ -240,6 +236,13 @@ fn apply_reload(
     }
     let _ = view.emit("content", &content);
     Ok(())
+}
+
+fn content_of(doc: &document::Document) -> Content {
+    Content {
+        markdown: doc.text.clone(),
+        base_dir: doc.base_dir.display().to_string(),
+    }
 }
 
 fn install_panic_hook() {

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -5,6 +5,7 @@ mod document;
 mod keymap;
 mod outline;
 mod protocol;
+mod watcher;
 
 fn main() {
     println!("ozmd");

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,5 +1,6 @@
 //! ozmd — a rich Markdown viewer TUI for ozmux panes.
 
+mod document;
 mod outline;
 
 fn main() {

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -1,5 +1,7 @@
 //! ozmd — a rich Markdown viewer TUI for ozmux panes.
 
+mod outline;
+
 fn main() {
     println!("ozmd");
 }

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -2,6 +2,7 @@
 
 mod document;
 mod outline;
+mod protocol;
 
 fn main() {
     println!("ozmd");

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -9,6 +9,233 @@ mod protocol;
 mod ui;
 mod watcher;
 
+use crate::app::{App, Cmd};
+use crate::protocol::{Content, Scroll, Search, SearchCount, SearchNav, ScrollState};
+use crate::ui::LiveStatus;
+use crossbeam_channel::{Receiver, Sender};
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::Terminal;
+use ratatui_ozma::{Ozma, OzmaBackend, RpcError, Webview, WebviewHandle};
+use std::io::stdout;
+use std::path::Path;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Messages forwarded from page→controller `.on` handlers to the main loop.
+enum PageMsg {
+    SearchCount(SearchCount),
+    ScrollState(ScrollState),
+}
+
 fn main() {
-    println!("ozmd");
+    if let Err(e) = run() {
+        eprintln!("ozmd: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let arg = std::env::args()
+        .nth(1)
+        .ok_or_else(|| anyhow::anyhow!("usage: ozmd <markdown-file>"))?;
+    let path = document::resolve_path(&arg).map_err(|e| anyhow::anyhow!("cannot open {arg}: {e}"))?;
+
+    let doc = document::load(&path)?;
+    let shared = Arc::new(Mutex::new(doc));
+
+    let ozma = Ozma::connect().map_err(|e| anyhow::anyhow!("{e}. Run ozmd inside an ozmux pane."))?;
+
+    let asset_dir = assets::materialize()?;
+
+    let (page_tx, page_rx) = crossbeam_channel::unbounded::<PageMsg>();
+    let view = register_view(&ozma, &asset_dir, Arc::clone(&shared), page_tx)?;
+
+    let (reload_tx, reload_rx) = mpsc::channel::<()>();
+    let _watcher = watcher::watch(&path, reload_tx)?;
+
+    enable_raw_mode()?;
+    if let Err(e) = execute!(stdout(), EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(e.into());
+    }
+    install_panic_hook();
+
+    let result = event_loop(&ozma, &view, &shared, &path, &page_rx, &reload_rx);
+
+    let _ = disable_raw_mode();
+    let _ = execute!(stdout(), LeaveAlternateScreen);
+    result
+}
+
+fn register_view(
+    ozma: &Ozma,
+    asset_dir: &tempfile::TempDir,
+    shared: Arc<Mutex<document::Document>>,
+    page_tx: Sender<PageMsg>,
+) -> anyhow::Result<WebviewHandle> {
+    let ready_doc = Arc::clone(&shared);
+    let count_tx = page_tx.clone();
+    let state_tx = page_tx;
+    let view = ozma.register(
+        Webview::dir(asset_dir.path(), "index.html")
+            .interactive(false)
+            .on("ready", move |(): ()| -> Result<Content, RpcError> {
+                let doc = ready_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
+                Ok(Content {
+                    markdown: doc.text.clone(),
+                    base_dir: doc.base_dir.display().to_string(),
+                })
+            })
+            .on("searchCount", move |c: SearchCount| -> Result<(), RpcError> {
+                let _ = count_tx.send(PageMsg::SearchCount(c));
+                Ok(())
+            })
+            .on("scrollState", move |s: ScrollState| -> Result<(), RpcError> {
+                let _ = state_tx.send(PageMsg::ScrollState(s));
+                Ok(())
+            }),
+    )?;
+    Ok(view)
+}
+
+fn event_loop(
+    ozma: &Ozma,
+    view: &WebviewHandle,
+    shared: &Arc<Mutex<document::Document>>,
+    path: &Path,
+    page_rx: &Receiver<PageMsg>,
+    reload_rx: &mpsc::Receiver<()>,
+) -> anyhow::Result<()> {
+    let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), ozma);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut state = App::default();
+    state.set_outline(shared.lock().unwrap().outline.clone());
+    let mut live = LiveStatus::Watching;
+    let mut scroll_percent: u16 = 0;
+    let mut last_fp = document::fingerprint(path).ok();
+    let mut search_status: Option<SearchCount> = None;
+    let file_name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    loop {
+        while let Ok(msg) = page_rx.try_recv() {
+            match msg {
+                PageMsg::SearchCount(c) => search_status = Some(c),
+                PageMsg::ScrollState(s) => {
+                    scroll_percent = (s.ratio.clamp(0.0, 1.0) * 100.0).round() as u16;
+                    state.set_current_heading_index(s.current_heading_index);
+                }
+            }
+        }
+
+        let mut reload = false;
+        while reload_rx.try_recv().is_ok() {
+            reload = true;
+        }
+        if reload {
+            apply_reload(&mut state, &mut live, &mut last_fp, view, shared, path)?;
+        }
+
+        terminal.draw(|f| {
+            ui::draw(
+                f,
+                &mut *ozma.frame(),
+                &state,
+                view.id(),
+                &file_name,
+                live,
+                scroll_percent,
+                search_status,
+            );
+        })?;
+
+        if event::poll(Duration::from_millis(33))?
+            && let Event::Key(key) = event::read()?
+        {
+            let action = keymap::map(state.mode(), key);
+            for cmd in state.on_action(action) {
+                match cmd {
+                    Cmd::Quit => return Ok(()),
+                    Cmd::Reload => {
+                        apply_reload(&mut state, &mut live, &mut last_fp, view, shared, path)?;
+                    }
+                    Cmd::Scroll(action) => {
+                        let _ = view.emit("scroll", &Scroll { action });
+                    }
+                    Cmd::ScrollToHeading(index) => {
+                        let _ = view.emit("scrollToHeading", &serde_json::json!({ "index": index }));
+                    }
+                    Cmd::Search(query) => {
+                        let _ = view.emit("search", &Search { query });
+                    }
+                    Cmd::SearchNav(dir) => {
+                        let _ = view.emit("searchNav", &SearchNav { dir });
+                    }
+                    Cmd::ClearSearch => {
+                        search_status = None;
+                        let _ = view.emit("clearSearch", &());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn apply_reload(
+    state: &mut App,
+    live: &mut LiveStatus,
+    last_fp: &mut Option<document::Fingerprint>,
+    view: &WebviewHandle,
+    shared: &Arc<Mutex<document::Document>>,
+    path: &Path,
+) -> anyhow::Result<()> {
+    match document::fingerprint(path) {
+        Ok(fp) => {
+            if Some(fp) == *last_fp {
+                return Ok(());
+            }
+            *last_fp = Some(fp);
+        }
+        Err(_) => {
+            *live = LiveStatus::Missing;
+            return Ok(());
+        }
+    }
+    let doc = match document::load(path) {
+        Ok(d) => d,
+        Err(_) => {
+            *live = LiveStatus::Missing;
+            return Ok(());
+        }
+    };
+    *live = LiveStatus::Watching;
+    state.set_outline(doc.outline.clone());
+    let content = Content {
+        markdown: doc.text.clone(),
+        base_dir: doc.base_dir.display().to_string(),
+    };
+    {
+        let mut guard = shared.lock().map_err(|_| anyhow::anyhow!("state poisoned"))?;
+        *guard = doc;
+    }
+    let _ = view.emit("content", &content);
+    Ok(())
+}
+
+fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), LeaveAlternateScreen);
+        prev(info);
+    }));
 }

--- a/apps/ozmd/src/outline.rs
+++ b/apps/ozmd/src/outline.rs
@@ -61,9 +61,18 @@ mod tests {
         assert_eq!(
             parse(md),
             vec![
-                Heading { level: 1, text: "Title".into() },
-                Heading { level: 2, text: "Setup".into() },
-                Heading { level: 3, text: "Deep".into() },
+                Heading {
+                    level: 1,
+                    text: "Title".into()
+                },
+                Heading {
+                    level: 2,
+                    text: "Setup".into()
+                },
+                Heading {
+                    level: 3,
+                    text: "Deep".into()
+                },
             ]
         );
     }
@@ -71,7 +80,13 @@ mod tests {
     #[test]
     fn strips_inline_markup_but_keeps_code_text() {
         let md = "# Hello `world` and **bold**\n";
-        assert_eq!(parse(md), vec![Heading { level: 1, text: "Hello world and bold".into() }]);
+        assert_eq!(
+            parse(md),
+            vec![Heading {
+                level: 1,
+                text: "Hello world and bold".into()
+            }]
+        );
     }
 
     #[test]
@@ -80,8 +95,14 @@ mod tests {
         assert_eq!(
             parse(md),
             vec![
-                Heading { level: 1, text: "Real".into() },
-                Heading { level: 2, text: "Also real".into() },
+                Heading {
+                    level: 1,
+                    text: "Real".into()
+                },
+                Heading {
+                    level: 2,
+                    text: "Also real".into()
+                },
             ]
         );
     }

--- a/apps/ozmd/src/outline.rs
+++ b/apps/ozmd/src/outline.rs
@@ -4,11 +4,11 @@ use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
 
 /// A single heading in the document outline.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Heading {
+pub(crate) struct Heading {
     /// Heading level, 1..=6.
-    pub level: u8,
+    pub(crate) level: u8,
     /// Plain-text content of the heading (inline markup stripped).
-    pub text: String,
+    pub(crate) text: String,
 }
 
 /// Parses the Markdown source into an ordered list of headings.
@@ -16,7 +16,7 @@ pub struct Heading {
 /// Enumerates only Markdown headings (ATX/Setext) in document order; raw-HTML
 /// `<h2>` blocks are not counted, so the indices line up one-to-one with the
 /// `id="h{n}"` anchors the renderer page injects.
-pub fn parse(source: &str) -> Vec<Heading> {
+pub(crate) fn parse(source: &str) -> Vec<Heading> {
     let mut headings = Vec::new();
     let mut current: Option<(u8, String)> = None;
     for event in Parser::new(source) {

--- a/apps/ozmd/src/outline.rs
+++ b/apps/ozmd/src/outline.rs
@@ -1,0 +1,93 @@
+//! Parses the heading outline from Markdown source.
+
+use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
+
+/// A single heading in the document outline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Heading {
+    /// Heading level, 1..=6.
+    pub level: u8,
+    /// Plain-text content of the heading (inline markup stripped).
+    pub text: String,
+}
+
+/// Parses the Markdown source into an ordered list of headings.
+///
+/// Enumerates only Markdown headings (ATX/Setext) in document order; raw-HTML
+/// `<h2>` blocks are not counted, so the indices line up one-to-one with the
+/// `id="h{n}"` anchors the renderer page injects.
+pub fn parse(source: &str) -> Vec<Heading> {
+    let mut headings = Vec::new();
+    let mut current: Option<(u8, String)> = None;
+    for event in Parser::new(source) {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                current = Some((level_to_u8(level), String::new()));
+            }
+            Event::Text(t) | Event::Code(t) => {
+                if let Some((_, text)) = current.as_mut() {
+                    text.push_str(&t);
+                }
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some((level, text)) = current.take() {
+                    headings.push(Heading { level, text });
+                }
+            }
+            _ => {}
+        }
+    }
+    headings
+}
+
+fn level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_levels_and_text_in_order() {
+        let md = "# Title\n\nbody\n\n## Setup\n\ntext\n\n### Deep\n";
+        assert_eq!(
+            parse(md),
+            vec![
+                Heading { level: 1, text: "Title".into() },
+                Heading { level: 2, text: "Setup".into() },
+                Heading { level: 3, text: "Deep".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_inline_markup_but_keeps_code_text() {
+        let md = "# Hello `world` and **bold**\n";
+        assert_eq!(parse(md), vec![Heading { level: 1, text: "Hello world and bold".into() }]);
+    }
+
+    #[test]
+    fn ignores_raw_html_headings_to_preserve_index_alignment() {
+        let md = "# Real\n\n<h2>Raw HTML heading</h2>\n\n## Also real\n";
+        assert_eq!(
+            parse(md),
+            vec![
+                Heading { level: 1, text: "Real".into() },
+                Heading { level: 2, text: "Also real".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_source_has_no_headings() {
+        assert!(parse("").is_empty());
+    }
+}

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// A scroll command sent to the page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub enum ScrollAction {
+pub(crate) enum ScrollAction {
     Down,
     Up,
     HalfDown,
@@ -20,7 +20,7 @@ pub enum ScrollAction {
 /// A search-navigation direction sent to the page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub enum SearchDir {
+pub(crate) enum SearchDir {
     Next,
     Prev,
 }
@@ -28,31 +28,31 @@ pub enum SearchDir {
 /// The full document content pushed to the page (and returned from `ready`).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Content {
+pub(crate) struct Content {
     /// Raw Markdown source.
-    pub markdown: String,
+    pub(crate) markdown: String,
     /// Absolute parent directory (string form) of the source file.
-    pub base_dir: String,
+    pub(crate) base_dir: String,
 }
 
 /// Search-result counts the page reports back (`searchCount` call).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SearchCount {
+pub(crate) struct SearchCount {
     /// Total matches in the document.
-    pub total: usize,
+    pub(crate) total: usize,
     /// 1-based index of the current match (0 when none).
-    pub current: usize,
+    pub(crate) current: usize,
 }
 
 /// Viewport state the page reports back (`scrollState` call).
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ScrollState {
+pub(crate) struct ScrollState {
     /// Vertical scroll position as a 0.0..=1.0 ratio.
-    pub ratio: f64,
+    pub(crate) ratio: f64,
     /// Index of the `id="h{n}"` anchor nearest the top, or `None`.
-    pub current_heading_index: Option<usize>,
+    pub(crate) current_heading_index: Option<usize>,
 }
 
 #[cfg(test)]

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -83,19 +83,32 @@ mod tests {
 
     #[test]
     fn scroll_action_is_camel_case() {
-        assert_eq!(serde_json::to_value(ScrollAction::HalfDown).unwrap(), json!("halfDown"));
-        assert_eq!(serde_json::to_value(ScrollAction::Top).unwrap(), json!("top"));
+        assert_eq!(
+            serde_json::to_value(ScrollAction::HalfDown).unwrap(),
+            json!("halfDown")
+        );
+        assert_eq!(
+            serde_json::to_value(ScrollAction::Top).unwrap(),
+            json!("top")
+        );
     }
 
     #[test]
     fn content_renames_base_dir() {
-        let c = Content { markdown: "# x".into(), base_dir: "/tmp".into() };
-        assert_eq!(serde_json::to_value(&c).unwrap(), json!({"markdown": "# x", "baseDir": "/tmp"}));
+        let c = Content {
+            markdown: "# x".into(),
+            base_dir: "/tmp".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&c).unwrap(),
+            json!({"markdown": "# x", "baseDir": "/tmp"})
+        );
     }
 
     #[test]
     fn scroll_state_reads_camel_case_and_null_index() {
-        let s: ScrollState = serde_json::from_value(json!({"ratio": 0.5, "currentHeadingIndex": null})).unwrap();
+        let s: ScrollState =
+            serde_json::from_value(json!({"ratio": 0.5, "currentHeadingIndex": null})).unwrap();
         assert_eq!(s.ratio, 0.5);
         assert_eq!(s.current_heading_index, None);
     }
@@ -103,6 +116,12 @@ mod tests {
     #[test]
     fn search_count_reads_camel_case() {
         let s: SearchCount = serde_json::from_value(json!({"total": 12, "current": 3})).unwrap();
-        assert_eq!(s, SearchCount { total: 12, current: 3 });
+        assert_eq!(
+            s,
+            SearchCount {
+                total: 12,
+                current: 3
+            }
+        );
     }
 }

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -55,6 +55,27 @@ pub(crate) struct ScrollState {
     pub(crate) current_heading_index: Option<usize>,
 }
 
+/// A scroll command payload (`scroll` emit).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(crate) struct Scroll {
+    /// Which way to scroll.
+    pub(crate) action: ScrollAction,
+}
+
+/// A search request payload (`search` emit).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Search {
+    /// The query string to highlight.
+    pub(crate) query: String,
+}
+
+/// A search-navigation payload (`searchNav` emit).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(crate) struct SearchNav {
+    /// Direction to move within the match set.
+    pub(crate) dir: SearchDir,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -1,0 +1,87 @@
+//! Wire types for the controller↔page protocol. Emit payloads serialize; call
+//! params deserialize. All field names are camelCase on the wire.
+
+use serde::{Deserialize, Serialize};
+
+/// A scroll command sent to the page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ScrollAction {
+    Down,
+    Up,
+    HalfDown,
+    HalfUp,
+    PageDown,
+    PageUp,
+    Top,
+    Bottom,
+}
+
+/// A search-navigation direction sent to the page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SearchDir {
+    Next,
+    Prev,
+}
+
+/// The full document content pushed to the page (and returned from `ready`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Content {
+    /// Raw Markdown source.
+    pub markdown: String,
+    /// Absolute parent directory (string form) of the source file.
+    pub base_dir: String,
+}
+
+/// Search-result counts the page reports back (`searchCount` call).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchCount {
+    /// Total matches in the document.
+    pub total: usize,
+    /// 1-based index of the current match (0 when none).
+    pub current: usize,
+}
+
+/// Viewport state the page reports back (`scrollState` call).
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollState {
+    /// Vertical scroll position as a 0.0..=1.0 ratio.
+    pub ratio: f64,
+    /// Index of the `id="h{n}"` anchor nearest the top, or `None`.
+    pub current_heading_index: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn scroll_action_is_camel_case() {
+        assert_eq!(serde_json::to_value(ScrollAction::HalfDown).unwrap(), json!("halfDown"));
+        assert_eq!(serde_json::to_value(ScrollAction::Top).unwrap(), json!("top"));
+    }
+
+    #[test]
+    fn content_renames_base_dir() {
+        let c = Content { markdown: "# x".into(), base_dir: "/tmp".into() };
+        assert_eq!(serde_json::to_value(&c).unwrap(), json!({"markdown": "# x", "baseDir": "/tmp"}));
+    }
+
+    #[test]
+    fn scroll_state_reads_camel_case_and_null_index() {
+        let s: ScrollState = serde_json::from_value(json!({"ratio": 0.5, "currentHeadingIndex": null})).unwrap();
+        assert_eq!(s.ratio, 0.5);
+        assert_eq!(s.current_heading_index, None);
+    }
+
+    #[test]
+    fn search_count_reads_camel_case() {
+        let s: SearchCount = serde_json::from_value(json!({"total": 12, "current": 3})).unwrap();
+        assert_eq!(s, SearchCount { total: 12, current: 3 });
+    }
+}

--- a/apps/ozmd/src/ui.rs
+++ b/apps/ozmd/src/ui.rs
@@ -3,11 +3,11 @@
 use crate::app::App;
 use crate::keymap::Mode;
 use crate::protocol::SearchCount;
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
-use ratatui::Frame;
 use ratatui_ozma::{FramePlacements, WebviewWidget};
 
 /// Whether live-reload is currently healthy.

--- a/apps/ozmd/src/ui.rs
+++ b/apps/ozmd/src/ui.rs
@@ -1,0 +1,112 @@
+//! Native ratatui chrome around the webview preview.
+
+use crate::app::App;
+use crate::keymap::Mode;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+use ratatui_ozma::{FramePlacements, WebviewWidget};
+
+/// Whether live-reload is currently healthy.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LiveStatus {
+    /// Watching the file; updates flowing.
+    Watching,
+    /// The file is missing (deleted); last content retained.
+    Missing,
+}
+
+/// Draws the whole frame: status line, optional outline panel + webview, and the
+/// optional search line.
+pub(crate) fn draw(
+    frame: &mut Frame<'_>,
+    placements: &mut FramePlacements,
+    app: &App,
+    handle_id: &str,
+    file_name: &str,
+    live: LiveStatus,
+    scroll_percent: u16,
+) {
+    let search_open = app.mode() == Mode::Search;
+    let vchunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(if search_open { 1 } else { 0 }),
+        ])
+        .split(frame.area());
+
+    draw_status(frame, vchunks[0], file_name, live, scroll_percent);
+    draw_body(frame, placements, vchunks[1], app, handle_id);
+    if search_open {
+        draw_search(frame, vchunks[2], app);
+    }
+}
+
+fn draw_status(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    file_name: &str,
+    live: LiveStatus,
+    scroll_percent: u16,
+) {
+    let dot = match live {
+        LiveStatus::Watching => "● live",
+        LiveStatus::Missing => "○ missing",
+    };
+    let line = Line::from(format!("ozmd · {file_name}    {dot}    {scroll_percent}%"));
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().add_modifier(Modifier::REVERSED)),
+        area,
+    );
+}
+
+fn draw_body(
+    frame: &mut Frame<'_>,
+    placements: &mut FramePlacements,
+    area: Rect,
+    app: &App,
+    handle_id: &str,
+) {
+    let webview_area = if app.outline_open() {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(28), Constraint::Min(1)])
+            .split(area);
+        draw_outline(frame, cols[0], app);
+        cols[1]
+    } else {
+        area
+    };
+    frame.render_stateful_widget(
+        WebviewWidget::new(handle_id).fallback(Block::bordered().title("loading…")),
+        webview_area,
+        placements,
+    );
+}
+
+fn draw_outline(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let items: Vec<ListItem> = app
+        .outline()
+        .iter()
+        .map(|h| {
+            let indent = "  ".repeat(h.level.saturating_sub(1) as usize);
+            ListItem::new(format!("{indent}{}", h.text))
+        })
+        .collect();
+    let mut state = ListState::default();
+    if !app.outline().is_empty() {
+        state.select(Some(app.selected()));
+    }
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::RIGHT).title("Outline"))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_search(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    frame.render_widget(Paragraph::new(format!("/{}", app.query())), area);
+}

--- a/apps/ozmd/src/ui.rs
+++ b/apps/ozmd/src/ui.rs
@@ -31,7 +31,7 @@ pub(crate) fn draw(
     scroll_percent: u16,
     search: Option<SearchCount>,
 ) {
-    let search_open = app.mode() == Mode::Search;
+    let search_open = app.mode() == Mode::Search || app.search_active();
     let vchunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/apps/ozmd/src/ui.rs
+++ b/apps/ozmd/src/ui.rs
@@ -2,6 +2,7 @@
 
 use crate::app::App;
 use crate::keymap::Mode;
+use crate::protocol::SearchCount;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
@@ -28,6 +29,7 @@ pub(crate) fn draw(
     file_name: &str,
     live: LiveStatus,
     scroll_percent: u16,
+    search: Option<SearchCount>,
 ) {
     let search_open = app.mode() == Mode::Search;
     let vchunks = Layout::default()
@@ -42,7 +44,7 @@ pub(crate) fn draw(
     draw_status(frame, vchunks[0], file_name, live, scroll_percent);
     draw_body(frame, placements, vchunks[1], app, handle_id);
     if search_open {
-        draw_search(frame, vchunks[2], app);
+        draw_search(frame, vchunks[2], app, search);
     }
 }
 
@@ -107,6 +109,10 @@ fn draw_outline(frame: &mut Frame<'_>, area: Rect, app: &App) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
-fn draw_search(frame: &mut Frame<'_>, area: Rect, app: &App) {
-    frame.render_widget(Paragraph::new(format!("/{}", app.query())), area);
+fn draw_search(frame: &mut Frame<'_>, area: Rect, app: &App, search: Option<SearchCount>) {
+    let count = match search {
+        Some(c) if c.total > 0 => format!("   {}/{}", c.current, c.total),
+        _ => String::new(),
+    };
+    frame.render_widget(Paragraph::new(format!("/{}{count}", app.query())), area);
 }

--- a/apps/ozmd/src/watcher.rs
+++ b/apps/ozmd/src/watcher.rs
@@ -1,0 +1,48 @@
+//! Debounced file watcher. Watches the target file's parent directory (so
+//! atomic save = write-temp-then-rename is caught) and sends a reload signal on
+//! the channel whenever an event references the target path.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Sender;
+use std::time::Duration;
+use notify_debouncer_full::notify::{RecursiveMode, Watcher};
+use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, FileIdMap};
+
+/// A live watcher; dropping it stops the background thread.
+pub(crate) struct FileWatcher {
+    _debouncer: Debouncer<notify_debouncer_full::notify::RecommendedWatcher, FileIdMap>,
+}
+
+/// Starts watching `path` (via its parent directory). Sends `()` on `tx` after a
+/// debounced settle whenever an event references `path`.
+///
+/// # Errors
+/// Returns an error if the watcher cannot be created or the parent cannot be watched.
+pub(crate) fn watch(path: &Path, tx: Sender<()>) -> anyhow::Result<FileWatcher> {
+    let target: PathBuf = path.to_path_buf();
+    let parent = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(150),
+        None,
+        move |res: DebounceEventResult| {
+            if let Ok(events) = res {
+                if events.iter().any(|e| e.paths.iter().any(|p| p == &target)) {
+                    let _ = tx.send(());
+                }
+            }
+        },
+    )?;
+    debouncer
+        .watcher()
+        .watch(&parent, RecursiveMode::NonRecursive)?;
+    debouncer
+        .cache()
+        .add_root(&parent, RecursiveMode::NonRecursive);
+    Ok(FileWatcher {
+        _debouncer: debouncer,
+    })
+}

--- a/apps/ozmd/src/watcher.rs
+++ b/apps/ozmd/src/watcher.rs
@@ -2,11 +2,11 @@
 //! atomic save = write-temp-then-rename is caught) and sends a reload signal on
 //! the channel whenever an event references the target path.
 
+use notify_debouncer_full::notify::{RecursiveMode, Watcher};
+use notify_debouncer_full::{DebounceEventResult, Debouncer, FileIdMap, new_debouncer};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 use std::time::Duration;
-use notify_debouncer_full::notify::{RecursiveMode, Watcher};
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, FileIdMap};
 
 /// A live watcher; dropping it stops the background thread.
 pub(crate) struct FileWatcher {
@@ -29,10 +29,10 @@ pub(crate) fn watch(path: &Path, tx: Sender<()>) -> anyhow::Result<FileWatcher> 
         Duration::from_millis(150),
         None,
         move |res: DebounceEventResult| {
-            if let Ok(events) = res {
-                if events.iter().any(|e| e.paths.iter().any(|p| p == &target)) {
-                    let _ = tx.send(());
-                }
+            if let Ok(events) = res
+                && events.iter().any(|e| e.paths.iter().any(|p| p == &target))
+            {
+                let _ = tx.send(());
             }
         },
     )?;

--- a/apps/ozmd/tsconfig.json
+++ b/apps/ozmd/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"]

--- a/apps/ozmd/tsconfig.json
+++ b/apps/ozmd/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["web"]
+}

--- a/apps/ozmd/vitest.config.ts
+++ b/apps/ozmd/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['web/**/*.test.ts'],
+  },
+});

--- a/apps/ozmd/web/css.d.ts
+++ b/apps/ozmd/web/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/apps/ozmd/web/index.html
+++ b/apps/ozmd/web/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="bundle.css" />
+    <style>
+      :root { color-scheme: dark; }
+      body { margin: 0; padding: 24px; background: #0d1117; color: #c9d1d9;
+             font: 16px/1.6 -apple-system, system-ui, sans-serif; }
+      #content { max-width: 900px; margin: 0 auto; }
+      pre { background: #161b22; padding: 12px; border-radius: 6px; overflow: auto; }
+      code { font-family: ui-monospace, monospace; }
+      mark.ozmd-match { background: #ffd33d55; color: inherit; }
+      mark.ozmd-current { background: #ffd33d; color: #000; }
+      table { border-collapse: collapse; }
+      th, td { border: 1px solid #30363d; padding: 6px 12px; }
+    </style>
+  </head>
+  <body>
+    <div id="content"></div>
+    <script type="module" src="bundle.js"></script>
+  </body>
+</html>

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -120,4 +120,7 @@ ozma.on('clearSearch', () => {
 
 window.addEventListener('scroll', reportScrollState, { passive: true });
 
-void ozma.call<ContentPayload>('ready').then((doc) => setContent(doc)).catch(console.error);
+void ozma
+  .call<ContentPayload>('ready')
+  .then((doc) => setContent(doc))
+  .catch(console.error);

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -1,0 +1,123 @@
+import 'katex/dist/katex.min.css';
+import 'highlight.js/styles/github-dark.css';
+import { ozma } from '@ozma/web';
+import DOMPurify from 'dompurify';
+import mermaid from 'mermaid';
+import { renderMarkdown } from './render';
+import { Search } from './search';
+
+mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'dark' });
+
+const content = document.getElementById('content') as HTMLElement;
+const search = new Search();
+
+interface ContentPayload {
+  markdown: string;
+  baseDir: string;
+}
+
+function headingEls(): HTMLElement[] {
+  return Array.from(content.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6')).filter((h) =>
+    /^h\d+$/.test(h.id),
+  );
+}
+
+function reportScrollState(): void {
+  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const ratio = max > 0 ? window.scrollY / max : 0;
+  const heads = headingEls();
+  let currentHeadingIndex: number | null = null;
+  for (let i = 0; i < heads.length; i++) {
+    if (heads[i].getBoundingClientRect().top <= 1) {
+      currentHeadingIndex = i;
+    }
+  }
+  void ozma.call('scrollState', { ratio, currentHeadingIndex });
+}
+
+async function renderMermaid(): Promise<void> {
+  const blocks = Array.from(content.querySelectorAll('pre code.language-mermaid'));
+  for (let i = 0; i < blocks.length; i++) {
+    const pre = blocks[i].parentElement;
+    if (pre === null) {
+      continue;
+    }
+    try {
+      const { svg } = await mermaid.render(`ozmd-mermaid-${i}`, blocks[i].textContent ?? '');
+      // NOTE: mermaid source is attacker-controllable; strict mode sanitizes, and
+      // this DOMPurify pass (allowing SVG foreignObject) is defense-in-depth.
+      pre.outerHTML = DOMPurify.sanitize(svg, {
+        USE_PROFILES: { svg: true, svgFilters: true, html: true },
+        ADD_TAGS: ['foreignObject'],
+      });
+    } catch {
+      // NOTE: a malformed diagram must not abort the whole render — leave the
+      // original fenced code block visible as the fallback.
+    }
+  }
+}
+
+async function setContent(payload: ContentPayload): Promise<void> {
+  content.innerHTML = renderMarkdown(payload.markdown);
+  await renderMermaid();
+  reportScrollState();
+}
+
+function scrollByAction(action: string): void {
+  const page = window.innerHeight;
+  const line = 60;
+  switch (action) {
+    case 'down':
+      window.scrollBy({ top: line });
+      break;
+    case 'up':
+      window.scrollBy({ top: -line });
+      break;
+    case 'halfDown':
+      window.scrollBy({ top: page / 2 });
+      break;
+    case 'halfUp':
+      window.scrollBy({ top: -page / 2 });
+      break;
+    case 'pageDown':
+      window.scrollBy({ top: page });
+      break;
+    case 'pageUp':
+      window.scrollBy({ top: -page });
+      break;
+    case 'top':
+      window.scrollTo({ top: 0 });
+      break;
+    case 'bottom':
+      window.scrollTo({ top: document.documentElement.scrollHeight });
+      break;
+  }
+  reportScrollState();
+}
+
+ozma.on('content', (p) => {
+  void setContent(p as ContentPayload).catch(console.error);
+});
+ozma.on('scroll', (p) => {
+  scrollByAction((p as { action: string }).action);
+});
+ozma.on('scrollToHeading', (p) => {
+  const { index } = p as { index: number };
+  document.getElementById(`h${index}`)?.scrollIntoView({ block: 'start' });
+  reportScrollState();
+});
+ozma.on('search', (p) => {
+  const { query } = p as { query: string };
+  void ozma.call('searchCount', search.run(content, query));
+});
+ozma.on('searchNav', (p) => {
+  const { dir } = p as { dir: 'next' | 'prev' };
+  void ozma.call('searchCount', search.navigate(dir));
+});
+ozma.on('clearSearch', () => {
+  search.clear(content);
+});
+
+window.addEventListener('scroll', reportScrollState, { passive: true });
+
+void ozma.call<ContentPayload>('ready').then((doc) => setContent(doc)).catch(console.error);

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -11,6 +11,9 @@ mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'dark' 
 const content = document.getElementById('content') as HTMLElement;
 const search = new Search();
 
+let mermaidSeq = 0;
+let renderGeneration = 0;
+
 interface ContentPayload {
   markdown: string;
   baseDir: string;
@@ -20,6 +23,10 @@ function headingEls(): HTMLElement[] {
   return Array.from(content.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6')).filter((h) =>
     /^h\d+$/.test(h.id),
   );
+}
+
+function scrollMax(): number {
+  return document.documentElement.scrollHeight - window.innerHeight;
 }
 
 interface ScrollAnchor {
@@ -41,7 +48,7 @@ function captureScrollAnchor(): ScrollAnchor {
       break;
     }
   }
-  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const max = scrollMax();
   const ratio = max > 0 ? window.scrollY / max : 0;
   return { id, offset, ratio };
 }
@@ -54,12 +61,12 @@ function restoreScrollAnchor(anchor: ScrollAnchor): void {
       return;
     }
   }
-  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const max = scrollMax();
   window.scrollTo({ top: max > 0 ? anchor.ratio * max : 0 });
 }
 
 function reportScrollState(): void {
-  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const max = scrollMax();
   const ratio = max > 0 ? window.scrollY / max : 0;
   const heads = headingEls();
   let currentHeadingIndex: number | null = null;
@@ -79,7 +86,10 @@ async function renderMermaid(): Promise<void> {
       continue;
     }
     try {
-      const { svg } = await mermaid.render(`ozmd-mermaid-${i}`, blocks[i].textContent ?? '');
+      const { svg } = await mermaid.render(
+        `ozmd-mermaid-${mermaidSeq++}`,
+        blocks[i].textContent ?? '',
+      );
       // NOTE: mermaid source is attacker-controllable; strict mode sanitizes, and
       // this DOMPurify pass (allowing SVG foreignObject) is defense-in-depth.
       pre.outerHTML = DOMPurify.sanitize(svg, {
@@ -94,9 +104,16 @@ async function renderMermaid(): Promise<void> {
 }
 
 async function setContent(payload: ContentPayload): Promise<void> {
+  const generation = ++renderGeneration;
   const anchor = captureScrollAnchor();
   content.innerHTML = renderMarkdown(payload.markdown);
   await renderMermaid();
+  // NOTE: a newer setContent superseded this one during the await (rapid reloads
+  // race) — skip the stale scroll restore so only the latest render positions the
+  // viewport.
+  if (generation !== renderGeneration) {
+    return;
+  }
   restoreScrollAnchor(anchor);
   reportScrollState();
 }
@@ -127,7 +144,7 @@ function scrollByAction(action: string): void {
       window.scrollTo({ top: 0 });
       break;
     case 'bottom':
-      window.scrollTo({ top: document.documentElement.scrollHeight });
+      window.scrollTo({ top: scrollMax() });
       break;
   }
   reportScrollState();

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -22,6 +22,42 @@ function headingEls(): HTMLElement[] {
   );
 }
 
+interface ScrollAnchor {
+  id: string | null;
+  offset: number;
+  ratio: number;
+}
+
+function captureScrollAnchor(): ScrollAnchor {
+  const heads = headingEls();
+  let id: string | null = null;
+  let offset = 0;
+  for (const h of heads) {
+    const top = h.getBoundingClientRect().top;
+    if (top <= 1) {
+      id = h.id;
+      offset = top;
+    } else {
+      break;
+    }
+  }
+  const max = document.documentElement.scrollHeight - window.innerHeight;
+  const ratio = max > 0 ? window.scrollY / max : 0;
+  return { id, offset, ratio };
+}
+
+function restoreScrollAnchor(anchor: ScrollAnchor): void {
+  if (anchor.id !== null) {
+    const el = document.getElementById(anchor.id);
+    if (el !== null) {
+      window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - anchor.offset });
+      return;
+    }
+  }
+  const max = document.documentElement.scrollHeight - window.innerHeight;
+  window.scrollTo({ top: max > 0 ? anchor.ratio * max : 0 });
+}
+
 function reportScrollState(): void {
   const max = document.documentElement.scrollHeight - window.innerHeight;
   const ratio = max > 0 ? window.scrollY / max : 0;
@@ -58,8 +94,10 @@ async function renderMermaid(): Promise<void> {
 }
 
 async function setContent(payload: ContentPayload): Promise<void> {
+  const anchor = captureScrollAnchor();
   content.innerHTML = renderMarkdown(payload.markdown);
   await renderMermaid();
+  restoreScrollAnchor(anchor);
   reportScrollState();
 }
 

--- a/apps/ozmd/web/render.test.ts
+++ b/apps/ozmd/web/render.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from './render';
+
+describe('renderMarkdown', () => {
+  it('tags each markdown heading with a sequential id in document order', () => {
+    const html = renderMarkdown('# A\n\n## B\n\n### C\n');
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const ids = Array.from(doc.querySelectorAll('h1,h2,h3')).map((h) => h.id);
+    expect(ids).toEqual(['h0', 'h1', 'h2']);
+  });
+
+  it('does not tag raw-html headings (index alignment with the Rust outline)', () => {
+    const html = renderMarkdown('# Real\n\n<h2>Raw</h2>\n\n## Second\n');
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const tagged = Array.from(doc.querySelectorAll('h1,h2,h3,h4,h5,h6'))
+      .map((h) => h.id)
+      .filter((id) => /^h\d+$/.test(id));
+    expect(tagged).toEqual(['h0', 'h1']);
+  });
+
+  it('adds highlight.js classes to fenced code', () => {
+    const html = renderMarkdown('```js\nconst x = 1;\n```\n');
+    expect(html).toContain('hljs');
+  });
+
+  it('strips script tags from untrusted html', () => {
+    const html = renderMarkdown('hello <script>alert(1)</script> world');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('strips event-handler attributes', () => {
+    expect(renderMarkdown('<img src="x" onerror="alert(1)">')).not.toContain('onerror');
+  });
+
+  it('strips javascript: urls in links', () => {
+    expect(renderMarkdown('[x](javascript:alert(1))')).not.toContain('javascript:');
+  });
+
+  it('resets heading ids between calls', () => {
+    renderMarkdown('# first\n');
+    const html = renderMarkdown('# again\n');
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    expect(doc.querySelector('h1')?.id).toBe('h0');
+  });
+});

--- a/apps/ozmd/web/render.ts
+++ b/apps/ozmd/web/render.ts
@@ -1,0 +1,40 @@
+import DOMPurify from 'dompurify';
+import hljs from 'highlight.js';
+import { Marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import markedKatex from 'marked-katex-extension';
+
+let headingIndex = 0;
+
+const marked = new Marked(
+  markedHighlight({
+    emptyLangClass: 'hljs',
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }),
+  markedKatex({ throwOnError: false, output: 'html' }),
+);
+
+marked.use({
+  renderer: {
+    heading(text: string, level: number): string {
+      const id = `h${headingIndex++}`;
+      return `<h${level} id="${id}">${text}</h${level}>\n`;
+    },
+  },
+});
+
+/** Renders Markdown to sanitized HTML with sequential `id="h{n}"` heading anchors. */
+export function renderMarkdown(source: string): string {
+  // NOTE: rendering is synchronous and single-threaded, so resetting this
+  // module-level counter at the start of each call is reentrancy-safe.
+  headingIndex = 0;
+  // NOTE: marked 12's Marked#parse has no async:false overload, so its return type
+  // is string|Promise<string>; passing async:false guarantees a synchronous string.
+  // Keep this synchronous — do not await it.
+  const raw = marked.parse(source, { async: false }) as string;
+  return DOMPurify.sanitize(raw);
+}

--- a/apps/ozmd/web/search.test.ts
+++ b/apps/ozmd/web/search.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Search } from './search';
+
+function container(html: string): HTMLElement {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  document.body.replaceChildren(el);
+  return el;
+}
+
+describe('Search', () => {
+  let search: Search;
+  beforeEach(() => {
+    search = new Search();
+  });
+
+  it('counts case-insensitive matches and wraps them in marks', () => {
+    const el = container('<p>foo Foo FOO bar</p>');
+    const { total, current } = search.run(el, 'foo');
+    expect(total).toBe(3);
+    expect(current).toBe(1);
+    expect(el.querySelectorAll('mark.ozmd-match').length).toBe(3);
+  });
+
+  it('navigates next and wraps around', () => {
+    const el = container('<p>x x x</p>');
+    search.run(el, 'x');
+    expect(search.navigate('next').current).toBe(2);
+    expect(search.navigate('next').current).toBe(3);
+    expect(search.navigate('next').current).toBe(1);
+  });
+
+  it('navigates prev and wraps around', () => {
+    const el = container('<p>x x x</p>');
+    search.run(el, 'x');
+    expect(search.navigate('prev').current).toBe(3);
+  });
+
+  it('clear removes all marks', () => {
+    const el = container('<p>aaa</p>');
+    search.run(el, 'a');
+    search.clear(el);
+    expect(el.querySelectorAll('mark.ozmd-match').length).toBe(0);
+  });
+
+  it('empty query yields zero matches', () => {
+    const el = container('<p>anything</p>');
+    expect(search.run(el, '').total).toBe(0);
+  });
+
+  it('matches across multiple elements', () => {
+    const el = container('<p>cat</p><div><span>cat</span></div>');
+    expect(search.run(el, 'cat').total).toBe(2);
+  });
+
+  it('re-running clears the previous query before highlighting the new one', () => {
+    const el = container('<p>foo bar</p>');
+    search.run(el, 'foo');
+    const result = search.run(el, 'bar');
+    expect(result.total).toBe(1);
+    const marks = el.querySelectorAll('mark.ozmd-match');
+    expect(marks.length).toBe(1);
+    expect(marks[0].textContent).toBe('bar');
+  });
+
+  it('clear restores the original text', () => {
+    const el = container('<p>aaa</p>');
+    search.run(el, 'a');
+    search.clear(el);
+    expect(el.textContent).toBe('aaa');
+  });
+});

--- a/apps/ozmd/web/search.ts
+++ b/apps/ozmd/web/search.ts
@@ -1,0 +1,96 @@
+/** Result counts of an in-page search. */
+export interface SearchResult {
+  /** Total matches. */
+  total: number;
+  /** 1-based index of the current match (0 when none). */
+  current: number;
+}
+
+/**
+ * In-page text search: highlights matches, tracks the current one, scrolls to it.
+ *
+ * All `run` / `navigate` / `clear` calls must operate on the SAME root element;
+ * the instance does not track which root its marks belong to, so switching roots
+ * would leave stale highlights in the previous one.
+ */
+export class Search {
+  private marks: HTMLElement[] = [];
+  private index = 0;
+
+  /** Highlights every case-insensitive occurrence of `query` under `root`. */
+  run(root: HTMLElement, query: string): SearchResult {
+    this.clear(root);
+    if (query.length === 0) {
+      return { total: 0, current: 0 };
+    }
+    const needle = query.toLowerCase();
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const textNodes: Text[] = [];
+    for (let n = walker.nextNode(); n !== null; n = walker.nextNode()) {
+      textNodes.push(n as Text);
+    }
+    for (const node of textNodes) {
+      this.markNode(node, needle);
+    }
+    this.index = 0;
+    this.focusCurrent();
+    return { total: this.marks.length, current: this.marks.length === 0 ? 0 : 1 };
+  }
+
+  /** Moves to the next/previous match (wrapping) and scrolls it into view. */
+  navigate(dir: 'next' | 'prev'): SearchResult {
+    if (this.marks.length === 0) {
+      return { total: 0, current: 0 };
+    }
+    const n = this.marks.length;
+    this.index = dir === 'next' ? (this.index + 1) % n : (this.index - 1 + n) % n;
+    this.focusCurrent();
+    return { total: n, current: this.index + 1 };
+  }
+
+  /** Removes all highlight marks under `root`. */
+  clear(root: HTMLElement): void {
+    for (const mark of root.querySelectorAll('mark.ozmd-match')) {
+      const text = document.createTextNode(mark.textContent ?? '');
+      mark.replaceWith(text);
+    }
+    root.normalize();
+    this.marks = [];
+    this.index = 0;
+  }
+
+  private markNode(node: Text, needle: string): void {
+    const value = node.nodeValue ?? '';
+    const lower = value.toLowerCase();
+    let from = lower.indexOf(needle);
+    if (from === -1) {
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    let cursor = 0;
+    while (from !== -1) {
+      if (from > cursor) {
+        frag.append(document.createTextNode(value.slice(cursor, from)));
+      }
+      const mark = document.createElement('mark');
+      mark.className = 'ozmd-match';
+      mark.textContent = value.slice(from, from + needle.length);
+      frag.append(mark);
+      this.marks.push(mark);
+      cursor = from + needle.length;
+      from = lower.indexOf(needle, cursor);
+    }
+    if (cursor < value.length) {
+      frag.append(document.createTextNode(value.slice(cursor)));
+    }
+    node.replaceWith(frag);
+  }
+
+  private focusCurrent(): void {
+    this.marks.forEach((m, i) => m.classList.toggle('ozmd-current', i === this.index));
+    const current = this.marks[this.index];
+    if (current?.scrollIntoView) {
+      current.scrollIntoView({ block: 'center' });
+    }
+  }
+}

--- a/apps/ozmd/web/search.ts
+++ b/apps/ozmd/web/search.ts
@@ -87,7 +87,9 @@ export class Search {
   }
 
   private focusCurrent(): void {
-    this.marks.forEach((m, i) => m.classList.toggle('ozmd-current', i === this.index));
+    for (let i = 0; i < this.marks.length; i++) {
+      this.marks[i].classList.toggle('ozmd-current', i === this.index);
+    }
     const current = this.marks[this.index];
     if (current?.scrollIntoView) {
       current.scrollIntoView({ block: 'center' });

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "files": {
-    "includes": ["sdk/**", "!**/node_modules", "!**/dist", "!**/target"],
+    "includes": ["sdk/**", "apps/ozmd/web/**", "!**/node_modules", "!**/dist", "!**/target"],
     "ignoreUnknown": true
   },
   "vcs": {

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -658,7 +658,7 @@ impl TerminalHandle {
     /// Clipboard) and emits the corresponding `EntityEvent`s on this
     /// `entity`. Updates the supplied `TerminalTitle` Component as a
     /// side-effect of `Title` / `ResetTitle`.
-    pub(crate) fn drain_control_events(
+    pub fn drain_control_events(
         &self,
         commands: &mut Commands,
         entity: Entity,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,33 @@ catalogs:
     '@types/node':
       specifier: ^24.12.2
       version: 24.12.2
+    dompurify:
+      specifier: ^3.1.6
+      version: 3.4.10
+    esbuild:
+      specifier: ^0.27.0
+      version: 0.27.7
+    highlight.js:
+      specifier: ^11.0.0
+      version: 11.11.1
+    jsdom:
+      specifier: ^25.0.0
+      version: 25.0.1
+    katex:
+      specifier: ^0.16.11
+      version: 0.16.47
+    marked:
+      specifier: ^12.0.0
+      version: 12.0.2
+    marked-highlight:
+      specifier: ^2.1.4
+      version: 2.2.4
+    marked-katex-extension:
+      specifier: ^5.1.1
+      version: 5.1.10
+    mermaid:
+      specifier: ^11.0.0
+      version: 11.15.0
     typescript:
       specifier: ~6.0.3
       version: 6.0.3
@@ -27,6 +54,49 @@ importers:
         specifier: 'catalog:'
         version: 24.12.2
 
+  apps/ozmd:
+    dependencies:
+      '@ozma/web':
+        specifier: workspace:*
+        version: link:../../sdk/ozma-web
+      dompurify:
+        specifier: 'catalog:'
+        version: 3.4.10
+      highlight.js:
+        specifier: 'catalog:'
+        version: 11.11.1
+      katex:
+        specifier: 'catalog:'
+        version: 0.16.47
+      marked:
+        specifier: 'catalog:'
+        version: 12.0.2
+      marked-highlight:
+        specifier: 'catalog:'
+        version: 2.2.4(marked@12.0.2)
+      marked-katex-extension:
+        specifier: 'catalog:'
+        version: 5.1.10(katex@0.16.47)(marked@12.0.2)
+      mermaid:
+        specifier: 'catalog:'
+        version: 11.15.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.7
+      jsdom:
+        specifier: 'catalog:'
+        version: 25.0.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+
   sdk/ozma-web:
     devDependencies:
       '@types/node':
@@ -40,6 +110,12 @@ importers:
         version: 4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -113,13 +189,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-calc@3.2.0':
     resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
@@ -128,12 +221,25 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-color-parser@4.1.0':
     resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -148,6 +254,10 @@ packages:
     peerDependenciesMeta:
       css-tree:
         optional: true
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -327,8 +437,17 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -449,14 +568,116 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -492,41 +713,283 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.1:
+    resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -555,17 +1018,81 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -573,6 +1100,15 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -582,6 +1118,19 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -657,6 +1206,12 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
@@ -664,23 +1219,74 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  marked-highlight@2.2.4:
+    resolution: {integrity: sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==}
+    peerDependencies:
+      marked: '>=4 <19'
+
+  marked-katex-extension@5.1.10:
+    resolution: {integrity: sha512-TuqrzguLeXXm6iBaf16leL3+dVmMj8KrBdunMVVzxMS/bwcjtQ0YG0sNytl1j7uUo8yClsXJqBbVjH1yOPurwQ==}
+    peerDependencies:
+      katex: '>=0.16 <0.18'
+      marked: '>=4 <19'
+
+  marked@12.0.2:
+    resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -691,6 +1297,12 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
@@ -707,10 +1319,28 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -733,6 +1363,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -751,8 +1384,15 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.30:
     resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.30:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
@@ -762,13 +1402,25 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -789,6 +1441,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -878,13 +1534,30 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -895,6 +1568,18 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -903,6 +1588,19 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -963,19 +1661,37 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.14':
     optional: true
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
     optional: true
 
+  '@chevrotain/types@11.1.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
   '@csstools/color-helpers@6.0.2':
     optional: true
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
     optional: true
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -984,6 +1700,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
     optional: true
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -994,6 +1714,8 @@ snapshots:
     optionalDependencies:
       css-tree: 3.2.1
     optional: true
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@csstools/css-tokenizer@4.0.0':
     optional: true
@@ -1095,7 +1817,19 @@ snapshots:
   '@exodus/bytes@1.15.0':
     optional: true
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1172,13 +1906,140 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1224,7 +2085,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
     optional: true
 
   '@vitest/utils@4.1.5':
@@ -1233,22 +2094,241 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  agent-base@7.1.4: {}
+
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
     optional: true
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   chai@6.2.2: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
     optional: true
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-urls@7.0.0:
     dependencies:
@@ -1258,15 +2338,55 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  decimal.js@10.6.0:
-    optional: true
+  dayjs@1.11.21: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  entities@6.0.1: {}
 
   entities@8.0.0:
     optional: true
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  es-toolkit@1.47.1: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1296,7 +2416,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
-    optional: true
 
   estree-walker@3.0.3:
     dependencies:
@@ -1314,13 +2433,61 @@ snapshots:
   flatted@3.4.2:
     optional: true
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  gopd@1.2.0: {}
+
+  hachure-fill@0.5.2: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  highlight.js@11.11.1: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -1329,11 +2496,62 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-meta-resolve@4.2.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   jiti@2.6.1:
     optional: true
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@29.1.1:
     dependencies:
@@ -1361,6 +2579,16 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1411,6 +2639,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash-es@4.18.1: {}
+
+  lru-cache@10.4.3: {}
+
   lru-cache@11.3.6:
     optional: true
 
@@ -1418,20 +2650,77 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked-highlight@2.2.4(marked@12.0.2):
+    dependencies:
+      marked: 12.0.2
+
+  marked-katex-extension@5.1.10(katex@0.16.47)(marked@12.0.2):
+    dependencies:
+      katex: 0.16.47
+      marked: 12.0.2
+
+  marked@12.0.2: {}
+
+  marked@16.4.2: {}
+
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1:
     optional: true
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.10
+      es-toolkit: 1.47.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.0
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mrmime@2.0.1:
     optional: true
 
+  ms@2.1.3: {}
+
   nanoid@3.3.12: {}
 
+  nwsapi@2.2.24: {}
+
   obug@2.1.1: {}
+
+  package-manager-detector@1.6.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
     optional: true
+
+  path-data-parser@0.1.0: {}
 
   pathe@2.0.3: {}
 
@@ -1439,20 +2728,28 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+
   postcss@8.5.13:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  punycode@2.3.1:
-    optional: true
+  punycode@2.3.1: {}
 
   require-from-string@2.0.2:
     optional: true
 
   resolve-pkg-maps@1.0.0:
     optional: true
+
+  robust-predicates@3.0.3: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -1475,10 +2772,24 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   siginfo@2.0.0: {}
 
@@ -1495,8 +2806,9 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
+  stylis@4.4.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
 
@@ -1509,8 +2821,14 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.30:
     optional: true
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.30:
     dependencies:
@@ -1520,15 +2838,25 @@ snapshots:
   totalist@3.0.1:
     optional: true
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
     optional: true
 
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1:
     optional: true
@@ -1548,6 +2876,8 @@ snapshots:
   undici@7.25.0:
     optional: true
 
+  uuid@14.0.0: {}
+
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -1561,6 +2891,35 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+
+  vitest@4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.5(@types/node@24.12.2)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
@@ -1594,13 +2953,25 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
+
+  webidl-conversions@7.0.0: {}
 
   webidl-conversions@8.0.1:
     optional: true
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-mimetype@5.0.0:
     optional: true
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1:
     dependencies:
@@ -1616,8 +2987,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  xml-name-validator@5.0.0:
-    optional: true
+  ws@8.21.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,13 @@
 packages:
   - sdk/*
+  - apps/*
 
 catalog:
   '@types/node': ^24.12.2
   typescript: ~6.0.3
   vitest: ^4.1.5
   zod: ^4.4.3
-  esbuild: ^0.25.0
+  esbuild: ^0.27.0
   react: ^19.0.0
   react-dom: ^19.0.0
   '@types/react': ^19.0.0
@@ -17,5 +18,12 @@ catalog:
   remark-gfm: ^4.0.0
   rehype-highlight: ^7.0.0
   highlight.js: ^11.0.0
+  marked: ^12.0.0
+  marked-highlight: ^2.1.4
+  marked-katex-extension: ^5.1.1
+  katex: ^0.16.11
+  mermaid: ^11.0.0
+  dompurify: ^3.1.6
+  jsdom: ^25.0.0
 
 catalogMode: strict

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -2,11 +2,12 @@
 //! GPU render bundle to each projected `TmuxPane`, then routes tmux `%output`
 //! into the handle. Lives in the binary so `ozmux_tmux` stays renderer-free.
 
+use crate::osc_webview::OscWebviewGate;
 use crate::ui::WorkspaceUiRoot;
 use bevy::ecs::message::MessageReader;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
-use ozma_tty_engine::TerminalHandle;
+use ozma_tty_engine::{TerminalHandle, TerminalTitle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::material::TerminalUiMaterial;
 use ozma_tty_renderer::prelude::TerminalRenderBundle;
@@ -79,14 +80,23 @@ fn attach_tmux_window_container(
 fn attach_tmux_pane_terminal(
     mut commands: Commands,
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
+    gate: Option<Res<OscWebviewGate>>,
     panes: Query<(Entity, &TmuxPane), Without<TerminalHandle>>,
 ) {
+    // NOTE: clone the SHARED OscWebviewGate so a tmux pane captures OSC 5379 when
+    // the feature is enabled; a fresh `false` atomic would leave inline-webview
+    // capture permanently off for tmux panes. The fallback is only reached in
+    // tests that do not install the gate resource.
+    let gate = gate
+        .map(|g| g.0.clone())
+        .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
     for (entity, pane) in panes.iter() {
         let (cols, rows) = grid_dims(pane.dims.width, pane.dims.height);
-        let handle = TerminalHandle::detached(cols, rows, Arc::new(AtomicBool::new(false)));
+        let handle = TerminalHandle::detached(cols, rows, gate.clone());
         let material = materials.add(TerminalUiMaterial::default());
         commands.entity(entity).insert((
             handle,
+            TerminalTitle::default(),
             TerminalRenderBundle::new(material),
             Node {
                 position_type: PositionType::Absolute,
@@ -106,7 +116,7 @@ fn attach_tmux_pane_terminal(
 fn route_tmux_output(
     mut commands: Commands,
     mut reader: MessageReader<PaneOutput>,
-    mut handles: Query<&mut TerminalHandle>,
+    mut handles: Query<(&mut TerminalHandle, &mut TerminalTitle)>,
     panes: Query<(Entity, &TmuxPane)>,
 ) {
     let mut by_pane: HashMap<_, Vec<u8>> = HashMap::new();
@@ -121,10 +131,16 @@ fn route_tmux_output(
         let Some(&entity) = entity_of.get(&pane) else {
             continue;
         };
-        let Ok(mut handle) = handles.get_mut(entity) else {
+        let Ok((mut handle, mut title)) = handles.get_mut(entity) else {
             continue;
         };
         handle.advance(&data);
+        // NOTE: drain captured control frames — crucially the OSC 5379
+        // mount/unmount verbs — into observer triggers. The engine's own control
+        // drain runs only for PtyHandle-backed terminals; tmux panes have no
+        // PtyHandle, so without this call a pane program's inline-webview mount
+        // OSC is parsed and then silently dropped (no webview ever mounts).
+        handle.drain_control_events(&mut commands, entity, &mut title);
         handle.flush_emit(&mut commands, entity);
         // NOTE: drain and DISCARD — never forward these replies to tmux. The
         // handle is a display-only renderer; tmux already answered the program's
@@ -361,6 +377,59 @@ mod tests {
         assert!(
             row0.starts_with("hi"),
             "rendered grid row 0 should start with 'hi', got {row0:?}",
+        );
+    }
+
+    #[test]
+    fn mount_inline_osc_from_pane_triggers_webview_request() {
+        use ozma_tty_engine::OscWebviewRequest;
+
+        #[derive(Resource, Default)]
+        struct Seen(u32);
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(TerminalGridPlugin);
+        app.init_resource::<Assets<TerminalUiMaterial>>();
+        app.add_message::<PaneOutput>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.insert_resource(OscWebviewGate(Arc::new(AtomicBool::new(true))));
+        app.init_resource::<Seen>();
+        app.add_observer(|_ev: On<OscWebviewRequest>, mut seen: ResMut<Seen>| {
+            seen.0 += 1;
+        });
+
+        let pane_id = PaneId(1);
+        app.world_mut().spawn(TmuxPane {
+            id: pane_id,
+            dims: dims(),
+        });
+
+        app.add_systems(
+            Update,
+            (
+                attach_tmux_pane_terminal,
+                route_tmux_output.run_if(on_message::<PaneOutput>),
+            )
+                .chain(),
+        );
+
+        // Frame 1: attach the handle + TerminalTitle (no output yet).
+        app.update();
+
+        // Frame 2: deliver a mount-inline OSC and route it.
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<PaneOutput>>()
+            .write(PaneOutput {
+                pane: pane_id,
+                data: b"\x1b]5379;mount-inline;memo;3;10\x1b\\".to_vec(),
+            });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Seen>().0,
+            1,
+            "a mount-inline OSC from a tmux pane must trigger exactly one OscWebviewRequest",
         );
     }
 


### PR DESCRIPTION
## Problem

ozmux has the Tier 1 dynamic inline-webview path but no real, non-example app exercising it end to end. We want a practical, keyboard-driven TUI that shows the path off: a rich Markdown viewer.

While building it, inline webviews turned out to **not mount at all under the tmux control-mode backend** (a regression from the tmux migration) — so the `ratatui-ozma` examples and any inline webview were broken, not just this app.

## Solution

A new app plus a host-side fix that makes inline webviews work under tmux.

### `apps/ozmd` — the Markdown viewer (built on `ratatui-ozma`)

- **Controller/view split.** The Rust controller owns the terminal, keyboard, file watcher, and a native ratatui chrome (status line, toggleable outline panel, search line). The webview is **display-only** and does only the preview: render Markdown → DOM, scroll, and in-page search highlight.
- **Offline web bundle (`@ozma/ozmd-web`).** `marked` + `marked-highlight`/`highlight.js` + `KaTeX` + `mermaid` + `DOMPurify`, bundled by esbuild, embedded via `rust-embed`, served as `kind:"dir"`.
- **Live updates.** `notify-debouncer-full` watches the file (parent-dir, fingerprint-skip); content is pushed over the `window.ozma` back-channel; scroll position is preserved by anchoring to the top visible heading.
- **Structure & navigation.** The outline is parsed Rust-side (`pulldown-cmark`); heading jumps use sequential `id="h{n}"` anchors that stay index-aligned with the outline. Vim keys: `j`/`k`, `Ctrl-d`/`Ctrl-u`, `gg`/`G`, `]]`/`[[`, `o` (outline), `/` + `n`/`N` (search), `r`, `q`.
- **Security.** Markdown is sanitized with the default DOMPurify profile (KaTeX as `output:'html'`); mermaid runs `securityLevel:'strict'` with a scoped second DOMPurify pass for its SVG.

### Host fix — inline webviews under the tmux backend (engine + binary)

Two regressions from the tmux migration meant a pane program's `mount-inline` OSC was parsed and then silently dropped:

1. tmux panes built their `TerminalHandle` with a fresh `AtomicBool::new(false)` instead of the shared `OscWebviewGate`, so OSC 5379 capture was permanently off. Now clones the shared gate (matching the direct-PTY path).
2. `route_tmux_output` advanced the VT parser but never called `drain_control_events`, the only place a captured verb becomes an `OscWebviewRequest`. The engine's own drain runs only for `PtyHandle`-backed terminals, which tmux panes lack. It now drains control events (panes carry a `TerminalTitle` for it); `drain_control_events` is made `pub`.

This fixes **all** inline webviews under tmux (the `ratatui-ozma` examples too), not just ozmd.

### Affected

- New `apps/ozmd` (Rust crate + `web/` TS bundle).
- Workspace wiring: root `Cargo.toml` `members`, `pnpm-workspace.yaml` (`apps/*` + catalog entries), `Makefile` (`ozmd`/`ozmd-web` targets).
- Engine `crates/ozma_tty_engine` (`drain_control_events` → `pub`) and binary `src/tmux_render.rs`.

### Tests

- Rust unit: outline, document, protocol (serde), keymap, and the pure `App` state machine. vitest: render pipeline + in-page search. Plus a `tmux_render` regression test (a pane `mount-inline` OSC triggers exactly one `OscWebviewRequest`).
- Green: `cargo test -p ozmd` (30), `pnpm --filter @ozma/ozmd-web test` (15), `cargo clippy`/`cargo fmt`/`biome` clean.
- Note: the full in-app GUI E2E (CEF) is verified manually; automated coverage stops at the unit/integration level.

### Known v1 limitation

Relative **local images** in the Markdown don't render — the `ozma-dyn://` origin is `DISPLAY_ISOLATED`, so `file://` is blocked. A local-asset proxy is deferred. (Bundled assets — KaTeX fonts, JS/CSS — load fine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)