### PR TITLE
fix: connect ozmd from pre-existing tmux panes despite a stale $OZMA_SOCK

### DIFF
--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -20,7 +20,7 @@ use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use ratatui_ozma::{Ozma, OzmaBackend, RpcError, Webview, WebviewHandle};
+use ratatui_ozma::{Ozma, OzmaBackend, OzmaError, RpcError, Webview, WebviewHandle};
 use std::io::stdout;
 use std::path::Path;
 use std::sync::mpsc;
@@ -50,8 +50,10 @@ fn run() -> anyhow::Result<()> {
     let doc = document::load(&path)?;
     let shared = Arc::new(Mutex::new(doc));
 
-    let ozma =
-        Ozma::connect().map_err(|e| anyhow::anyhow!("{e}. Run ozmd inside an ozmux pane."))?;
+    let ozma = Ozma::connect().map_err(|e| match e {
+        OzmaError::NotInPane(_) => anyhow::anyhow!("{e}. Run ozmd inside an ozmux pane."),
+        _ => anyhow::anyhow!("{e}"),
+    })?;
 
     let asset_dir = assets::materialize()?;
 

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -192,6 +192,35 @@ impl TmuxServer {
         Ok(name)
     }
 
+    /// Runs a one-shot tmux command against this server (`tmux [socket] <args…>`,
+    /// plain subprocess, no control mode) and waits for it to finish.
+    ///
+    /// Used for fire-and-finish mutations whose effect must land before the
+    /// caller proceeds or exits — e.g. `set-environment` of `$OZMA_SOCK`, where
+    /// routing through the live `-CC` client would race the client's own
+    /// teardown at app exit (the buffered PTY write can be lost before tmux
+    /// forwards it). A blocking subprocess guarantees the server processed it.
+    /// `Ok(())` on a zero exit status; otherwise an error carrying tmux's stderr.
+    pub fn run_oneshot(&self, args: &[&str]) -> TmuxResult<()> {
+        let mut argv = self.socket_args();
+        argv.extend(args.iter().map(|s| s.to_string()));
+        let output = std::process::Command::new(&self.program)
+            .args(&argv)
+            .stdin(std::process::Stdio::null())
+            .output()
+            .map_err(TmuxError::Spawn)?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let message = if message.is_empty() {
+            "tmux command failed".to_string()
+        } else {
+            message
+        };
+        Err(TmuxError::Spawn(std::io::Error::other(message)))
+    }
+
     /// The argv (after the program) for `create_detached_session`.
     fn create_detached_session_argv(&self) -> Vec<String> {
         let mut argv = self.socket_args();
@@ -938,5 +967,67 @@ mod tests {
 
         let _ = client.handle().send("kill-server");
         drop(client);
+    }
+
+    #[test]
+    #[ignore = "requires a real tmux binary"]
+    fn real_tmux_run_oneshot_sets_env_per_session_and_global() {
+        let socket = format!("ozmux-oneshot-{}", std::process::id());
+        let server = TmuxServer::new().socket_name(&socket);
+
+        server
+            .run_oneshot(&["new-session", "-d", "-s", "alpha"])
+            .expect("create session alpha");
+        server
+            .run_oneshot(&["new-session", "-d", "-s", "beta"])
+            .expect("create session beta");
+
+        // The exact writes refresh_session_ozmux_sock performs: per-session on
+        // every existing session, plus the server-global environment.
+        let sock = "/run/ozma/live.sock";
+        for session in ["alpha", "beta"] {
+            server
+                .run_oneshot(&["set-environment", "-t", session, "OZMA_SOCK", sock])
+                .unwrap_or_else(|e| panic!("set on {session}: {e}"));
+        }
+        server
+            .run_oneshot(&["set-environment", "-g", "OZMA_SOCK", sock])
+            .expect("set global");
+
+        let show = |args: &[&str]| -> String {
+            let out = std::process::Command::new("tmux")
+                .arg("-L")
+                .arg(&socket)
+                .args(args)
+                .output()
+                .expect("run tmux show-environment");
+            String::from_utf8_lossy(&out.stdout).into_owned()
+        };
+        for session in ["alpha", "beta"] {
+            assert!(
+                show(&["show-environment", "-t", session, "OZMA_SOCK"])
+                    .contains(&format!("OZMA_SOCK={sock}")),
+                "session {session} must carry the live OZMA_SOCK"
+            );
+        }
+        assert!(
+            show(&["show-environment", "-g", "OZMA_SOCK"]).contains(&format!("OZMA_SOCK={sock}")),
+            "global env must carry the live OZMA_SOCK"
+        );
+
+        // The cleanup path: unset per-session + global, then confirm it is gone
+        // (a set value prints `OZMA_SOCK=…` on stdout; an unset one does not).
+        server
+            .run_oneshot(&["set-environment", "-t", "alpha", "-u", "OZMA_SOCK"])
+            .expect("unset on alpha");
+        server
+            .run_oneshot(&["set-environment", "-gu", "OZMA_SOCK"])
+            .expect("unset global");
+        assert!(
+            !show(&["show-environment", "-t", "alpha", "OZMA_SOCK"]).contains("OZMA_SOCK="),
+            "alpha OZMA_SOCK must be unset after cleanup"
+        );
+
+        let _ = server.run_oneshot(&["kill-server"]);
     }
 }

--- a/sdk/ratatui-ozma/src/error.rs
+++ b/sdk/ratatui-ozma/src/error.rs
@@ -17,6 +17,24 @@ pub enum OzmaError {
     #[error("control-socket io error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// The resolved control-socket path could not be reached — the file is gone
+    /// (`NotFound`) or nothing is listening on it (`ConnectionRefused`). This
+    /// means `$OZMA_SOCK` is stale: it points at a control socket whose ozmux has
+    /// exited. Distinct from [`OzmaError::Io`] so the caller can tell the user to
+    /// re-attach ozmux rather than print the misleading "not in a pane" hint.
+    #[error(
+        "control socket {path} is unavailable ({cause}); no ozmux is attached to this tmux session — attach ozmux and retry"
+    )]
+    SocketUnavailable {
+        /// The resolved socket path that could not be reached.
+        path: String,
+        /// The underlying connect error (`NotFound` / `ConnectionRefused`). Named
+        /// `cause`, not `source`: the message already renders it inline, and a
+        /// field literally named `source` would make `thiserror` also expose it
+        /// via `Error::source()`, double-printing it for chain-aware consumers.
+        cause: std::io::Error,
+    },
+
     /// The control plane rejected a `register` request.
     #[error("register rejected: {reason}")]
     Register {

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -8,7 +8,7 @@ use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
 use ratatui::layout::Rect;
 use std::collections::{HashMap, VecDeque};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
@@ -104,18 +104,24 @@ impl Ozma {
     /// Connects to the ozma control socket, performs the `hello` handshake, and
     /// spawns the background reader thread.
     ///
-    /// The socket path is `$OZMA_SOCK` when present; otherwise — in a pane that
-    /// forked before ozma set it — it is recovered from tmux's session
-    /// environment via `$TMUX` and `show-environment`, so no shell-rc hook is
-    /// required (see `resolve_ozma_sock`).
+    /// The socket path is resolved from an ordered candidate list (see
+    /// [`resolve_ozma_sock_candidates`]): the tmux session environment first — ozmux
+    /// rewrites it on every attach, so it names the currently-attached ozmux — then
+    /// the inherited `$OZMA_SOCK`, which can be a stale snapshot from an ozmux that
+    /// has since exited (the pane forked while that value was live). `connect()`
+    /// tries each in order via [`connect_first_reachable`] and uses the first that is
+    /// actually reachable, so a stale candidate cannot shadow the live one.
     pub fn connect() -> OzmaResult<Self> {
-        let sock = resolve_ozma_sock().ok_or(OzmaError::NotInPane("OZMA_SOCK"))?;
+        let candidates = resolve_ozma_sock_candidates();
+        if candidates.is_empty() {
+            return Err(OzmaError::NotInPane("OZMA_SOCK"));
+        }
         let token = pane_identity(
             std::env::var("OZMA_TOKEN").ok(),
             std::env::var("TMUX_PANE").ok(),
         )
         .ok_or(OzmaError::NotInPane("OZMA_TOKEN or TMUX_PANE"))?;
-        let stream = UnixStream::connect(sock)?;
+        let stream = connect_first_reachable(&candidates)?;
         let writer: SharedWriter = Arc::new(Mutex::new(stream.try_clone()?));
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
         let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
@@ -209,20 +215,37 @@ fn parse_show_environment<'a>(output: &'a str, key: &str) -> Option<&'a str> {
     output.lines().find_map(|line| line.strip_prefix(&prefix))
 }
 
-/// Resolves the control-socket path, falling back to tmux when the process did
-/// not inherit `$OZMA_SOCK`.
+/// The control-socket candidates to try, most-authoritative first.
 ///
-/// A pane that forked before ozma ran `set-environment` never received
-/// `$OZMA_SOCK`, and a running process's environment cannot be changed from
-/// outside. tmux does inject `$TMUX` into every pane, so reading the value back
-/// with `tmux -S <socket> show-environment OZMA_SOCK` recovers it without a
-/// shell-rc hook or `send-keys`. `None` when neither the env var nor a tmux
-/// lookup yields a value (outside tmux, or tmux unavailable / the variable
-/// unset on the session).
-fn resolve_ozma_sock() -> Option<String> {
-    if let Some(sock) = std::env::var("OZMA_SOCK").ok().filter(|s| !s.is_empty()) {
-        return Some(sock);
+/// The tmux session value (see [`resolve_from_tmux`]) comes first: ozmux rewrites
+/// it on every attach via `set-environment`, so it names the currently-attached
+/// ozmux. The inherited `$OZMA_SOCK` process env is second — it is the only source
+/// under the direct-PTY backend (no `$TMUX`), but in a tmux pane it can be a STALE
+/// snapshot from an ozmux that has since exited (the pane forked while that value
+/// was live), so it must not shadow the fresh tmux value. Deduped to avoid a
+/// redundant connect when the pane forked during the current ozmux (both equal).
+fn resolve_ozma_sock_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(sock) = resolve_from_tmux() {
+        candidates.push(sock);
     }
+    if let Some(sock) = std::env::var("OZMA_SOCK").ok().filter(|s| !s.is_empty())
+        && !candidates.contains(&sock)
+    {
+        candidates.push(sock);
+    }
+    candidates
+}
+
+/// Recovers `$OZMA_SOCK` from the tmux session environment via
+/// `tmux -S <socket> show-environment OZMA_SOCK`.
+///
+/// A pane that forked before ozma ran `set-environment` never inherited
+/// `$OZMA_SOCK`, and a running process's environment cannot be changed from
+/// outside; tmux injects `$TMUX` into every pane, so reading the value back
+/// recovers it without a shell-rc hook. `None` outside tmux, when tmux is
+/// unavailable, or when the variable is unset on the session.
+fn resolve_from_tmux() -> Option<String> {
     let tmux = std::env::var("TMUX").ok()?;
     let socket = socket_from_tmux(&tmux)?;
     let output = std::process::Command::new("tmux")
@@ -236,6 +259,31 @@ fn resolve_ozma_sock() -> Option<String> {
     parse_show_environment(&stdout, "OZMA_SOCK")
         .filter(|sock| !sock.is_empty())
         .map(str::to_owned)
+}
+
+/// Connects to the first reachable candidate, treating an unreachable one as a
+/// stale `$OZMA_SOCK` and moving on.
+///
+/// `NotFound` (the socket file is gone) and `ConnectionRefused` (the file exists
+/// but its ozmux has exited) mean a stale candidate — skip it. Any other IO error
+/// is surfaced as [`OzmaError::Io`]. When every candidate is stale, returns
+/// [`OzmaError::SocketUnavailable`] for the first (most-authoritative) one so the
+/// message points at the socket the caller most expected to reach.
+fn connect_first_reachable(candidates: &[String]) -> OzmaResult<UnixStream> {
+    let mut stale: Option<(String, std::io::Error)> = None;
+    for sock in candidates {
+        match UnixStream::connect(sock) {
+            Ok(stream) => return Ok(stream),
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::ConnectionRefused) => {
+                if stale.is_none() {
+                    stale = Some((sock.clone(), e));
+                }
+            }
+            Err(e) => return Err(OzmaError::Io(e)),
+        }
+    }
+    let (path, cause) = stale.expect("candidates is non-empty and every entry was stale");
+    Err(OzmaError::SocketUnavailable { path, cause })
 }
 
 /// Emits CUP + mount-inline for new/changed placements and unmount for vanished

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -16,16 +16,23 @@ fn with_env(sock: &std::path::Path, f: impl FnOnce()) {
     // A panicking test poisons the lock; recover the guard so it doesn't cascade
     // and mask the test that actually failed.
     let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // NOTE: clear $TMUX so resolve prefers ONLY the injected $OZMA_SOCK. connect()
+    // now consults the tmux session env first; if the test process is itself run
+    // inside tmux (CI/dev in a pane), an ambient $TMUX would otherwise hijack
+    // resolution to the real server instead of this test's FakeServer.
+    let prev_tmux = std::env::var_os("TMUX");
     // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
     unsafe {
         std::env::set_var("OZMA_SOCK", sock);
         std::env::set_var("OZMA_TOKEN", "test-token");
+        std::env::remove_var("TMUX");
     }
     f();
     unsafe {
         std::env::remove_var("OZMA_SOCK");
         std::env::remove_var("OZMA_TOKEN");
     }
+    set_or_remove("TMUX", prev_tmux);
 }
 
 #[derive(Clone)]
@@ -279,6 +286,164 @@ fn connect_resolves_ozma_sock_from_tmux_when_env_unset() {
     assert!(
         connected.is_ok(),
         "connect should resolve OZMA_SOCK via tmux show-environment: {:?}",
+        connected.err()
+    );
+}
+
+#[test]
+fn connect_reports_stale_socket_as_unavailable_not_io() {
+    // A stale $OZMA_SOCK (left in the tmux env by an exited ozmux) points at a
+    // removed control dir. connect must surface SocketUnavailable so the caller
+    // can tell the user to re-attach ozmux — not a bare Io error nor the
+    // misleading "not in a pane" hint (the user IS in a pane).
+    let dead = std::env::temp_dir().join(format!("ozma-dead-{}/control.sock", std::process::id()));
+    let _ = std::fs::remove_dir_all(dead.parent().unwrap());
+    with_env(&dead, || {
+        let connected = Ozma::connect();
+        assert!(
+            matches!(connected, Err(OzmaError::SocketUnavailable { .. })),
+            "a dead $OZMA_SOCK must report SocketUnavailable, got: {:?}",
+            connected.err()
+        );
+    });
+}
+
+#[test]
+#[ignore = "requires a real tmux binary"]
+fn connect_reports_stale_socket_resolved_from_tmux() {
+    // The exact user scenario: a pre-existing pane resolves OZMA_SOCK from the
+    // tmux session env, but the value is stale (the ozmux that set it has exited
+    // and its control dir is gone). The SDK must report SocketUnavailable.
+    let dead_sock = std::env::temp_dir()
+        .join(format!("ozma-stale-{}/control.sock", std::process::id()))
+        .to_string_lossy()
+        .into_owned();
+    let _ = std::fs::remove_dir_all(std::path::Path::new(&dead_sock).parent().unwrap());
+
+    let (_tmux, tmux_env) = tmux_with_ozma_sock("stale", &dead_sock);
+
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_sock = std::env::var_os("OZMA_SOCK");
+    let prev_token = std::env::var_os("OZMA_TOKEN");
+    let prev_tmux = std::env::var_os("TMUX");
+    // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
+    unsafe {
+        std::env::remove_var("OZMA_SOCK");
+        std::env::set_var("OZMA_TOKEN", "stale-token");
+        std::env::set_var("TMUX", &tmux_env);
+    }
+
+    let connected = Ozma::connect();
+
+    set_or_remove("OZMA_SOCK", prev_sock);
+    set_or_remove("OZMA_TOKEN", prev_token);
+    set_or_remove("TMUX", prev_tmux);
+
+    assert!(
+        matches!(connected, Err(OzmaError::SocketUnavailable { .. })),
+        "a stale tmux-resolved sock must report SocketUnavailable, got: {:?}",
+        connected.err()
+    );
+}
+
+// Starts a private tmux server with OZMA_SOCK=`value` on a detached session and
+// returns the guard plus the `$TMUX` string a pane in that session would carry.
+fn tmux_with_ozma_sock(label: &str, value: &str) -> (TmuxServerGuard, String) {
+    let tmux_socket =
+        std::env::temp_dir().join(format!("ozma-{label}-{}.tmuxsock", std::process::id()));
+    let _ = std::fs::remove_file(&tmux_socket);
+    let tmux = TmuxServerGuard {
+        socket: tmux_socket.clone(),
+    };
+    let created = tmux.run(&["new-session", "-d", "-s", "ozmasess"]);
+    assert!(
+        created.status.success(),
+        "tmux new-session failed: {}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let set = tmux.run(&["set-environment", "-t", "ozmasess", "OZMA_SOCK", value]);
+    assert!(
+        set.status.success(),
+        "set-environment failed: {}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+    let field = |f: &str| {
+        let out = tmux.run(&["display-message", "-p", "-t", "ozmasess", f]);
+        String::from_utf8_lossy(&out.stdout).trim().to_owned()
+    };
+    let sid = field("#{session_id}");
+    let sid = sid.trim_start_matches('$');
+    let pid = field("#{pid}");
+    (tmux, format!("{},{},{}", tmux_socket.display(), pid, sid))
+}
+
+#[test]
+#[ignore = "requires a real tmux binary"]
+fn connect_prefers_live_tmux_value_over_stale_env() {
+    // The reported bug: the pane inherited a STALE $OZMA_SOCK (an exited ozmux),
+    // while the attached ozmux refreshed the tmux session env to its LIVE socket.
+    // connect() must prefer/validate and reach the live socket, not the dead env.
+    let live = FakeServer::start("view-pref");
+    let live_sock = live.sock_path.to_string_lossy().into_owned();
+    let dead = std::env::temp_dir().join(format!("ozma-prefdead-{}/x.sock", std::process::id()));
+    let _ = std::fs::remove_dir_all(dead.parent().unwrap());
+    let (_tmux, tmux_env) = tmux_with_ozma_sock("pref", &live_sock);
+
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_sock = std::env::var_os("OZMA_SOCK");
+    let prev_token = std::env::var_os("OZMA_TOKEN");
+    let prev_tmux = std::env::var_os("TMUX");
+    // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
+    unsafe {
+        std::env::set_var("OZMA_SOCK", &dead);
+        std::env::set_var("OZMA_TOKEN", "pref-token");
+        std::env::set_var("TMUX", &tmux_env);
+    }
+
+    let connected = Ozma::connect();
+
+    set_or_remove("OZMA_SOCK", prev_sock);
+    set_or_remove("OZMA_TOKEN", prev_token);
+    set_or_remove("TMUX", prev_tmux);
+
+    assert!(
+        connected.is_ok(),
+        "must reach the live tmux socket despite a stale $OZMA_SOCK, got: {:?}",
+        connected.err()
+    );
+}
+
+#[test]
+#[ignore = "requires a real tmux binary"]
+fn connect_falls_back_to_live_env_when_tmux_value_dead() {
+    // Inverse: the tmux session value is dead but the inherited $OZMA_SOCK is live.
+    // try-each must skip the dead tmux candidate and reach the live env one.
+    let live = FakeServer::start("view-envlive");
+    let live_sock = live.sock_path.to_string_lossy().into_owned();
+    let dead = std::env::temp_dir().join(format!("ozma-tmuxdead-{}/x.sock", std::process::id()));
+    let _ = std::fs::remove_dir_all(dead.parent().unwrap());
+    let (_tmux, tmux_env) = tmux_with_ozma_sock("tmuxdead", &dead.to_string_lossy());
+
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_sock = std::env::var_os("OZMA_SOCK");
+    let prev_token = std::env::var_os("OZMA_TOKEN");
+    let prev_tmux = std::env::var_os("TMUX");
+    // SAFETY: ENV_LOCK serializes all callers; no other test thread touches these vars.
+    unsafe {
+        std::env::set_var("OZMA_SOCK", &live_sock);
+        std::env::set_var("OZMA_TOKEN", "envlive-token");
+        std::env::set_var("TMUX", &tmux_env);
+    }
+
+    let connected = Ozma::connect();
+
+    set_or_remove("OZMA_SOCK", prev_sock);
+    set_or_remove("OZMA_TOKEN", prev_token);
+    set_or_remove("TMUX", prev_tmux);
+
+    assert!(
+        connected.is_ok(),
+        "must fall back to the live $OZMA_SOCK when the tmux value is dead, got: {:?}",
         connected.err()
     );
 }

--- a/src/tmux_picker.rs
+++ b/src/tmux_picker.rs
@@ -12,7 +12,7 @@ use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 use ozmux_tmux::{
     AttachTarget, ConnectionState, TmuxConnection, attach_or_create, select_window_command,
-    set_environment_command, set_environment_in_session_command, switch_client_command,
+    set_environment_in_session_command, switch_client_command,
 };
 use tmux_control::{SessionInfo, TmuxServer, WindowEntry};
 
@@ -32,7 +32,11 @@ impl Plugin for OzmuxTmuxPickerPlugin {
             .add_systems(Update, refresh_picker_on_open)
             .add_systems(
                 Update,
-                inject_session_ozmux_sock.run_if(resource_exists_and_changed::<ConnectionState>),
+                refresh_session_ozmux_sock.run_if(resource_exists_and_changed::<ConnectionState>),
+            )
+            .add_systems(
+                Last,
+                cleanup_session_ozmux_sock.run_if(on_message::<AppExit>),
             )
             .add_systems(
                 PostUpdate,
@@ -490,29 +494,100 @@ fn apply_attach(
     }
 }
 
-/// Sets `$OZMA_SOCK` in the freshly-connected session's tmux environment so
-/// panes created after attach inherit it. Gated to run on every
-/// [`ConnectionState`] change; the body acts only on the `Attached` transition.
+/// Refreshes `$OZMA_SOCK` to this ozmux's live control socket across the whole
+/// tmux server on attach: session-scoped on every existing session (overwriting
+/// any stale value a previously-exited ozmux left behind) plus the server-global
+/// environment so sessions created later inherit it. Gated to run on every
+/// [`ConnectionState`] change; the body acts only while `Attached`.
 ///
-/// `new-session` already injects `$OZMA_SOCK` via `-e` (covering its initial
-/// pane), but attaching to a pre-existing session cannot — its panes are spawned
-/// by an already-running server. This session-scoped `set-environment` closes
-/// that gap for panes opened after attach (already-running shells are
-/// unreachable). No-op when the control plane is down.
-fn inject_session_ozmux_sock(
+/// A pre-existing pane never inherited `$OZMA_SOCK` in its own process env, so
+/// `ratatui-ozma` recovers it at connect time via `tmux show-environment`; that
+/// recovery only works when the stored value points at the live socket. Writes
+/// go through one-shot `tmux` subprocesses (not the live `-CC` client) so they
+/// are independent of the client and land synchronously. No-op when the control
+/// plane is down.
+fn refresh_session_ozmux_sock(
     state: Res<ConnectionState>,
-    connection: NonSend<TmuxConnection>,
+    configs: Res<OzmuxConfigsResource>,
     control: Option<Res<ControlPlaneHandle>>,
 ) {
     if !matches!(*state, ConnectionState::Attached) {
         return;
     }
-    let (Some(handle), Some(client)) = (control, connection.client()) else {
+    let Some(handle) = control else {
         return;
     };
-    let cmd = set_environment_command("OZMA_SOCK", &handle.sock_path.to_string_lossy());
-    if let Err(e) = client.handle().send(&cmd) {
-        tracing::warn!(?e, "failed to set $OZMA_SOCK in tmux session environment");
+    let sock = handle.sock_path.to_string_lossy().into_owned();
+    let server = build_server(&configs);
+    let sessions = match server.list_sessions() {
+        Ok(sessions) => sessions,
+        Err(e) => {
+            tracing::warn!(?e, "failed to list sessions while refreshing $OZMA_SOCK");
+            return;
+        }
+    };
+    for session in &sessions {
+        if let Err(e) = server.run_oneshot(&[
+            "set-environment",
+            "-t",
+            session.name.as_str(),
+            "OZMA_SOCK",
+            sock.as_str(),
+        ]) {
+            tracing::warn!(
+                ?e,
+                session = session.name.as_str(),
+                "failed to set $OZMA_SOCK"
+            );
+        }
+    }
+    if let Err(e) = server.run_oneshot(&["set-environment", "-g", "OZMA_SOCK", sock.as_str()]) {
+        tracing::warn!(?e, "failed to set global $OZMA_SOCK");
+    }
+}
+
+/// On app exit, removes `$OZMA_SOCK` from the tmux server environment and deletes
+/// this process's control runtime dir so a pre-existing pane's `ratatui-ozma`
+/// cannot later resolve a dead socket path.
+///
+/// Gated by `run_if(on_message::<AppExit>)` so it runs only on the exit frame
+/// (window close and the in-`DefaultPlugins` `TerminalCtrlCHandlerPlugin` Ctrl-C
+/// path both emit `AppExit`). The env unset is best-effort via one-shot `tmux`
+/// subprocesses, which flush before the process exits — unlike a write over the
+/// `-CC` client, which races its teardown. The runtime dir is removed explicitly
+/// here rather than relying solely on [`crate::control_plane`]'s `RuntimeRoot`
+/// `Drop`, which can be skipped when noisy CEF teardown ends the process before
+/// the world is dropped. A hard kill (SIGKILL / un-handled SIGTERM) skips all of
+/// this; the next attach overwrites every value via [`refresh_session_ozmux_sock`].
+fn cleanup_session_ozmux_sock(
+    configs: Res<OzmuxConfigsResource>,
+    control: Option<Res<ControlPlaneHandle>>,
+) {
+    let Some(handle) = control else {
+        return;
+    };
+    let server = build_server(&configs);
+    if let Ok(sessions) = server.list_sessions() {
+        for session in &sessions {
+            let _ = server.run_oneshot(&[
+                "set-environment",
+                "-t",
+                session.name.as_str(),
+                "-u",
+                "OZMA_SOCK",
+            ]);
+        }
+    }
+    let _ = server.run_oneshot(&["set-environment", "-gu", "OZMA_SOCK"]);
+    // NOTE: remove the runtime root (`<temp>/<pid>/control`, = sock_path's
+    // grandparent) but NOT its `<pid>` parent — sibling webview runtime roots can
+    // live under the same pid dir, so `remove_dir_all` on it would delete theirs.
+    if let Some(runtime_root) = handle
+        .sock_path
+        .parent()
+        .and_then(|sock_dir| sock_dir.parent())
+    {
+        let _ = std::fs::remove_dir_all(runtime_root);
     }
 }
 


### PR DESCRIPTION
## Problem

Running `ozmd` from a **pre-existing** pane of a tmux session that ozmux is attached to failed to connect — first with `control-socket io error: No such file or directory`, and after the partial fix in #131 by connecting to a dead socket and reporting it.

Root cause: a pre-existing pane's shell inherits `$OZMA_SOCK` into its process environment from whichever ozmux set it on the tmux **session** env *before that shell forked*. Once that ozmux exits, the value is stale (its per-PID control socket is gone). The SDK trusted the inherited `$OZMA_SOCK` whenever it was set, only consulting the live tmux session env when it was *unset* — so `ozmd` resolved the dead socket. (#131 handled "env unset"; the real-world case is "env set to a **stale** value".)

## Solution

**SDK (`sdk/ratatui-ozma`)** — `Ozma::connect()` now resolves an ordered, deduped candidate list and connects to the first **reachable** one:
- the tmux session value first (`tmux show-environment OZMA_SOCK` — ozmux refreshes it on every attach, so it names the currently-attached ozmux), then
- the inherited `$OZMA_SOCK` (the only source under the direct-PTY backend; a valid fast path when the pane forked during the current ozmux).
- Stale candidates (`NotFound` / `ConnectionRefused`) are skipped; when all are dead, `connect()` returns a new, actionable `OzmaError::SocketUnavailable` ("…attach ozmux and retry") instead of a cryptic io error. `ozmd` only appends the "Run ozmd inside an ozmux pane" hint for the genuine not-in-pane error.

**ozmux (`src/tmux_picker.rs`, `crates/tmux_control`)** — on attach, refresh `OZMA_SOCK` on **every session plus the server-global env** (so a pre-existing pane in any session resolves the live socket), via a new `TmuxServer::run_oneshot`; on `AppExit`, unset it (per-session + global) and remove the control runtime dir (cleanup gated by `run_if(on_message::<AppExit>)`).

Affected: `sdk/ratatui-ozma`, `crates/tmux_control`, `src/` (tmux picker), `apps/ozmd`.

### Testing
- SDK unit + integration tests, including gated real-tmux tests that reproduce the exact scenario (stale inherited `$OZMA_SOCK` + live tmux value → connects) and the inverse (dead tmux value + live env → falls back).
- `cargo clippy` + `cargo fmt` clean on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
