### PR TITLE
feat(tmux): 1px pane dividers — collapse() tree layout, pixel-space hit-test, drag handles

### DIFF
--- a/crates/tmux_session/src/components.rs
+++ b/crates/tmux_session/src/components.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::Component;
 use bitflags::bitflags;
-use tmux_control_parser::{CellDims, Divider, PaneId, SessionId, WindowId};
+use tmux_control_parser::{CellDims, Divider, PaneId, SessionId, WindowId, WindowLayout};
 
 /// The projected tmux session entity, carrying the session id and name.
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
@@ -73,6 +73,10 @@ impl WindowFlags {
         flags
     }
 }
+
+/// The window's full tmux layout tree, retained for tree-driven pane sizing.
+#[derive(Component, Debug, Clone)]
+pub struct TmuxWindowLayout(pub WindowLayout);
 
 /// A projected tmux pane entity.
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/tmux_session/src/components.rs
+++ b/crates/tmux_session/src/components.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::Component;
 use bitflags::bitflags;
-use tmux_control_parser::{CellDims, Divider, PaneId, SessionId, WindowId, WindowLayout};
+use tmux_control_parser::{CellDims, PaneId, SessionId, WindowId, WindowLayout};
 
 /// The projected tmux session entity, carrying the session id and name.
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
@@ -31,10 +31,6 @@ pub struct TmuxWindow {
     /// Window name.
     pub name: String,
 }
-
-/// The active window's draggable dividers, projected for the mouse arbiter.
-#[derive(Component, Debug, Clone, Default, PartialEq, Eq)]
-pub struct TmuxDividers(pub Vec<Divider>);
 
 bitflags! {
     /// tmux per-window status flags, projected from `#{window_raw_flags}`.

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -6,7 +6,7 @@ use crate::enumerate::{WINDOW_FLAGS_SUBSCRIPTION, parse_window_rows};
 use crate::events::{
     TmuxActivePaneChanged, TmuxActiveWindowChanged, TmuxLayoutChanged, TmuxSessionChanged,
     TmuxWindowAdded, TmuxWindowClosed, TmuxWindowFlagsChanged, TmuxWindowRenamed,
-    TmuxWindowsRetained, pane_geoms,
+    TmuxWindowsRetained,
 };
 use crate::keybindings::{KeyBinding, ModeKeys, parse_list_keys, parse_prefix};
 use crate::output::PaneOutput;
@@ -15,7 +15,7 @@ use bevy::prelude::Commands;
 use crossbeam_channel::Receiver;
 use std::collections::{HashMap, HashSet};
 use tmux_control::{ClientEvent, CommandId, ControlEvent, TransportEvent};
-use tmux_control_parser::{PaneId, SessionId, WindowId, dividers};
+use tmux_control_parser::{PaneId, SessionId, WindowId};
 
 /// Upper bound on events drained per frame, so a pane flooding `%output`
 /// cannot stall the schedule with unbounded parse/apply work in one tick;
@@ -359,8 +359,7 @@ fn trigger_notification(commands: &mut Commands, event: &ControlEvent) {
         ControlEvent::LayoutChange { window, layout, .. } => {
             commands.trigger(TmuxLayoutChanged {
                 window: *window,
-                panes: pane_geoms(layout),
-                dividers: dividers(layout),
+                layout: layout.clone(),
             });
         }
         ControlEvent::WindowPaneChanged { window, pane } => {
@@ -405,8 +404,7 @@ fn trigger_seed(commands: &mut Commands, output: &[String]) {
         });
         commands.trigger(TmuxLayoutChanged {
             window: row.id,
-            panes: pane_geoms(&row.layout),
-            dividers: dividers(&row.layout),
+            layout: row.layout.clone(),
         });
         if row.active {
             commands.trigger(TmuxActiveWindowChanged { window: row.id });

--- a/crates/tmux_session/src/events.rs
+++ b/crates/tmux_session/src/events.rs
@@ -4,7 +4,7 @@
 
 use crate::components::WindowFlags;
 use bevy::prelude::Event;
-use tmux_control_parser::{Cell, CellDims, Divider, PaneId, SessionId, WindowId, WindowLayout};
+use tmux_control_parser::{Cell, CellDims, PaneId, SessionId, WindowId, WindowLayout};
 
 /// A pane's tmux id plus its cell geometry, carried in `TmuxLayoutChanged`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,12 +55,11 @@ pub(crate) struct TmuxWindowFlagsChanged {
     pub(crate) flags: WindowFlags,
 }
 
-/// `%layout-change` or a seed row: the window's full pane set.
+/// `%layout-change` or a seed row: the window's full layout tree.
 #[derive(Event, Debug, Clone)]
 pub(crate) struct TmuxLayoutChanged {
     pub(crate) window: WindowId,
-    pub(crate) panes: Vec<PaneGeom>,
-    pub(crate) dividers: Vec<Divider>,
+    pub(crate) layout: WindowLayout,
 }
 
 /// `%window-pane-changed`: the active pane (and its window).

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -21,7 +21,8 @@ mod select;
 mod state;
 
 pub use components::{
-    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, WindowFlags,
+    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout,
+    WindowFlags,
 };
 pub use connect::attach_or_create;
 pub use connection::TmuxConnection;

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -21,8 +21,7 @@ mod select;
 mod state;
 
 pub use components::{
-    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout,
-    WindowFlags,
+    ActivePane, ActiveWindow, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout, WindowFlags,
 };
 pub use connect::attach_or_create;
 pub use connection::TmuxConnection;

--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -2,16 +2,17 @@
 //! tmux-id -> entity index they resolve through.
 
 use crate::components::{
-    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, WindowFlags,
+    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout,
+    WindowFlags,
 };
 use crate::events::{
     PaneGeom, TmuxActivePaneChanged, TmuxActiveWindowChanged, TmuxConnectionReset,
     TmuxLayoutChanged, TmuxSessionChanged, TmuxWindowAdded, TmuxWindowClosed,
-    TmuxWindowFlagsChanged, TmuxWindowRenamed, TmuxWindowsRetained,
+    TmuxWindowFlagsChanged, TmuxWindowRenamed, TmuxWindowsRetained, pane_geoms,
 };
 use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
-use tmux_control_parser::{PaneId, WindowId};
+use tmux_control_parser::{PaneId, WindowId, dividers};
 
 /// Maps tmux ids to their projected entities. Internal routing state only.
 #[derive(Resource, Default)]
@@ -133,11 +134,16 @@ fn on_layout_changed(
     mut commands: Commands,
     mut index: ResMut<TmuxProjection>,
     active_panes: Query<Entity, With<ActivePane>>,
-    dividers: Query<&TmuxDividers>,
+    existing_dividers: Query<&TmuxDividers>,
 ) {
     let window = ensure_window(&mut commands, &mut index, ev.window);
 
-    let live: HashSet<PaneId> = ev.panes.iter().map(|p| p.id).collect();
+    commands
+        .entity(window)
+        .insert(TmuxWindowLayout(ev.layout.clone()));
+
+    let panes = pane_geoms(&ev.layout);
+    let live: HashSet<PaneId> = panes.iter().map(|p| p.id).collect();
     let stale: Vec<PaneId> = index
         .panes
         .iter()
@@ -149,19 +155,16 @@ fn on_layout_changed(
             commands.entity(e).despawn();
         }
     }
-
-    for geom in &ev.panes {
+    for geom in &panes {
         upsert_pane(&mut commands, &mut index, window, ev.window, geom);
     }
 
-    // NOTE: insert only when the divider set actually changed — `%layout-change`
-    // fires for events that leave dividers untouched (e.g. zoom), and an
-    // unconditional insert fires `Changed<TmuxDividers>` every time, churning the
-    // projected handle entities that reconcile against it.
-    if dividers.get(window).map_or(true, |d| d.0 != ev.dividers) {
-        commands
-            .entity(window)
-            .insert(TmuxDividers(ev.dividers.clone()));
+    // NOTE: insert only when the divider set actually changed — an unconditional
+    // insert fires `Changed<TmuxDividers>` every time, churning the projected
+    // handle entities that reconcile against it.
+    let divs = dividers(&ev.layout);
+    if existing_dividers.get(window).map_or(true, |d| d.0 != divs) {
+        commands.entity(window).insert(TmuxDividers(divs));
     }
 
     apply_pending_active_pane(&mut commands, &mut index, &active_panes);
@@ -308,8 +311,7 @@ fn set_marker<T: Component + Default>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::pane_geoms;
-    use tmux_control_parser::{SessionId, WindowLayout, dividers};
+    use tmux_control_parser::{SessionId, WindowLayout};
 
     fn app() -> App {
         let mut app = App::new();
@@ -332,8 +334,7 @@ mod tests {
         });
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&layout(b"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2}")),
-            dividers: vec![],
+            layout: layout(b"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2}"),
         });
         app.update();
 
@@ -360,8 +361,7 @@ mod tests {
 
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&layout(b"abcd,80x24,0,0,5")),
-            dividers: vec![],
+            layout: layout(b"abcd,80x24,0,0,5"),
         });
         app.update();
 
@@ -381,8 +381,7 @@ mod tests {
         });
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&layout(b"abcd,80x24,0,0,9")),
-            dividers: vec![],
+            layout: layout(b"abcd,80x24,0,0,9"),
         });
         app.update();
         app.world_mut().trigger(TmuxWindowClosed {
@@ -507,8 +506,7 @@ mod tests {
         });
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&layout(b"abcd,80x24,0,0,1")),
-            dividers: vec![],
+            layout: layout(b"abcd,80x24,0,0,1"),
         });
         app.update();
         app.world_mut().trigger(TmuxConnectionReset);
@@ -519,13 +517,35 @@ mod tests {
     }
 
     #[test]
+    fn layout_change_attaches_window_layout_component() {
+        use crate::components::TmuxWindowLayout;
+        let mut app = app();
+        app.world_mut().trigger(TmuxWindowAdded {
+            window: WindowId(1),
+            index: 0,
+            name: "w".into(),
+        });
+        app.world_mut().trigger(TmuxLayoutChanged {
+            window: WindowId(1),
+            layout: layout(b"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2}"),
+        });
+        app.update();
+
+        let index = app.world().resource::<TmuxProjection>();
+        let window_e = index.windows[&WindowId(1)];
+        assert!(
+            app.world().get::<TmuxWindowLayout>(window_e).is_some(),
+            "window carries its layout tree after %layout-change",
+        );
+    }
+
+    #[test]
     fn layout_changed_projects_dividers_onto_window_entity() {
         let mut app = app();
         let l = layout(b"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2}");
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&l),
-            dividers: dividers(&l),
+            layout: l,
         });
         app.update();
 

--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -2,8 +2,7 @@
 //! tmux-id -> entity index they resolve through.
 
 use crate::components::{
-    ActivePane, ActiveWindow, TmuxDividers, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout,
-    WindowFlags,
+    ActivePane, ActiveWindow, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout, WindowFlags,
 };
 use crate::events::{
     PaneGeom, TmuxActivePaneChanged, TmuxActiveWindowChanged, TmuxConnectionReset,
@@ -12,7 +11,7 @@ use crate::events::{
 };
 use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
-use tmux_control_parser::{PaneId, WindowId, dividers};
+use tmux_control_parser::{PaneId, WindowId};
 
 /// Maps tmux ids to their projected entities. Internal routing state only.
 #[derive(Resource, Default)]
@@ -134,7 +133,6 @@ fn on_layout_changed(
     mut commands: Commands,
     mut index: ResMut<TmuxProjection>,
     active_panes: Query<Entity, With<ActivePane>>,
-    existing_dividers: Query<&TmuxDividers>,
 ) {
     let window = ensure_window(&mut commands, &mut index, ev.window);
 
@@ -157,14 +155,6 @@ fn on_layout_changed(
     }
     for geom in &panes {
         upsert_pane(&mut commands, &mut index, window, ev.window, geom);
-    }
-
-    // NOTE: insert only when the divider set actually changed — an unconditional
-    // insert fires `Changed<TmuxDividers>` every time, churning the projected
-    // handle entities that reconcile against it.
-    let divs = dividers(&ev.layout);
-    if existing_dividers.get(window).map_or(true, |d| d.0 != divs) {
-        commands.entity(window).insert(TmuxDividers(divs));
     }
 
     apply_pending_active_pane(&mut commands, &mut index, &active_panes);
@@ -539,19 +529,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn layout_changed_projects_dividers_onto_window_entity() {
-        let mut app = app();
-        let l = layout(b"abcd,80x24,0,0{40x24,0,0,1,39x24,41,0,2}");
-        app.world_mut().trigger(TmuxLayoutChanged {
-            window: WindowId(1),
-            layout: l,
-        });
-        app.update();
-
-        let index = app.world().resource::<TmuxProjection>();
-        let window_e = index.windows[&WindowId(1)];
-        let td = app.world().get::<TmuxDividers>(window_e).unwrap();
-        assert_eq!(td.0.len(), 1);
-    }
 }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn empty_windows_retained_clears_windows_and_panes_keeps_session() {
         use crate::events::{
-            TmuxLayoutChanged, TmuxSessionChanged, TmuxWindowAdded, TmuxWindowsRetained, pane_geoms,
+            TmuxLayoutChanged, TmuxSessionChanged, TmuxWindowAdded, TmuxWindowsRetained,
         };
         use tmux_control_parser::{SessionId, WindowId, WindowLayout};
 
@@ -304,8 +304,7 @@ mod tests {
         });
         app.world_mut().trigger(TmuxLayoutChanged {
             window: WindowId(1),
-            panes: pane_geoms(&WindowLayout::parse(b"abcd,80x24,0,0,1").unwrap()),
-            dividers: vec![],
+            layout: WindowLayout::parse(b"abcd,80x24,0,0,1").unwrap(),
         });
         app.update();
         app.world_mut().trigger(TmuxWindowsRetained {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -49,6 +49,9 @@ pub const SURFACE_TERMINAL: Color = Color::srgb(0.094, 0.094, 0.110);
 
 /// Pane border thickness.
 pub const PANE_BORDER_PX: f32 = 1.0;
+/// Gap in logical px between packed panes. The grey window container bleeds
+/// through this gap as the 1px divider line.
+pub const PANE_GAP_PX: f32 = 1.0;
 /// Camera clear color — shows through tmux's reserved-cell gaps between panes.
 /// Black matches the terminal background; retint here to recolor the gaps.
 pub const PANE_GAP: Color = Color::BLACK;

--- a/src/tmux_mouse.rs
+++ b/src/tmux_mouse.rs
@@ -21,6 +21,7 @@ use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
 use crate::tmux_copy_mode::{CopyModeSnapshot, cell_at_pane, cursor_deltas};
 use crate::tmux_picker::SessionPicker;
+use crate::tmux_render::{DividerPixelRect, PackedTmuxLayout};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;
 use bevy::input::ButtonState;
@@ -31,11 +32,11 @@ use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozmux_tmux::{
-    ActiveWindow, CopyModeQueries, CopyQueryKind, PaneId, TmuxConnection, TmuxDividers, TmuxPane,
+    ActiveWindow, CopyModeQueries, CopyQueryKind, PaneId, TmuxConnection, TmuxPane,
     resize_pane_x_command, resize_pane_y_command, select_pane_command, show_buffer_command,
 };
 use std::time::Duration;
-use tmux_control_parser::{Divider, DividerAxis};
+use tmux_control_parser::DividerAxis;
 
 /// Bevy plugin that registers the tmux mouse gesture arbiter.
 pub(crate) struct OzmuxTmuxMousePlugin;
@@ -87,7 +88,7 @@ enum GestureState {
     },
     /// Dragging a divider to resize its primary pane.
     Resizing {
-        divider: Divider,
+        divider: DividerPixelRect,
         /// The primary pane's fixed near edge (xoff for vertical, yoff for horizontal), cells.
         near: i32,
         /// Last absolute size (cells) we issued a resize for.
@@ -142,39 +143,27 @@ fn pane_under_cursor(
         .map(|(entity, pane, _, _)| (entity, pane.id))
 }
 
-/// Returns the divider whose grab zone contains `cursor_phys` (physical px),
-/// given physical cell metrics and a tolerance in physical px. The grab zone is
-/// the divider's reserved gap cell (`[pos, pos+1)` on the major axis) expanded by
-/// `tol_phys` on each side, intersected with the divider's span on the
-/// perpendicular axis. This matches the visible handle bar (which fills the gap
-/// cell) so the handle, the resize grab, and the hover cursor coincide.
+/// Returns the divider whose grab zone contains `cursor` (logical px), given a
+/// tolerance in logical px. The grab zone is the 1px gap at `[pos_px, pos_px+1)`
+/// on the major axis expanded by `tol` on each side, intersected with the
+/// divider's span on the perpendicular axis.
 pub(crate) fn divider_at(
-    dividers: &[Divider],
-    cursor_phys: Vec2,
-    cell_w: f32,
-    cell_h: f32,
-    tol_phys: f32,
-) -> Option<Divider> {
+    dividers: &[DividerPixelRect],
+    cursor: Vec2,
+    tol: f32,
+) -> Option<DividerPixelRect> {
     dividers.iter().copied().find(|d| match d.axis {
         DividerAxis::Vertical => {
-            let gap0 = d.pos as f32 * cell_w;
-            let gap1 = (d.pos + 1) as f32 * cell_w;
-            let span0 = d.span_start as f32 * cell_h;
-            let span1 = d.span_end as f32 * cell_h;
-            cursor_phys.x >= gap0 - tol_phys
-                && cursor_phys.x <= gap1 + tol_phys
-                && cursor_phys.y >= span0
-                && cursor_phys.y < span1
+            cursor.x >= d.pos_px - tol
+                && cursor.x <= d.pos_px + 1.0 + tol
+                && cursor.y >= d.span_start_px
+                && cursor.y < d.span_end_px
         }
         DividerAxis::Horizontal => {
-            let gap0 = d.pos as f32 * cell_h;
-            let gap1 = (d.pos + 1) as f32 * cell_h;
-            let span0 = d.span_start as f32 * cell_w;
-            let span1 = d.span_end as f32 * cell_w;
-            cursor_phys.y >= gap0 - tol_phys
-                && cursor_phys.y <= gap1 + tol_phys
-                && cursor_phys.x >= span0
-                && cursor_phys.x < span1
+            cursor.y >= d.pos_px - tol
+                && cursor.y <= d.pos_px + 1.0 + tol
+                && cursor.x >= d.span_start_px
+                && cursor.x < d.span_end_px
         }
     })
 }
@@ -213,7 +202,7 @@ fn arbiter(
     mut queries: ResMut<CopyModeQueries>,
     connection: NonSend<TmuxConnection>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
-    dividers_q: Query<&TmuxDividers, With<ActiveWindow>>,
+    packed_q: Query<&PackedTmuxLayout, With<ActiveWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
     configs: Option<Res<OzmuxConfigsResource>>,
     picker: Res<SessionPicker>,
@@ -258,10 +247,12 @@ fn arbiter(
             )
         })
         .unwrap_or((4.0, 4.0, 400, 8.0));
-    let tol_phys = grab_tol_logical * scale;
     let drag_threshold_phys = drag_threshold_logical * scale;
 
-    let dividers: &[Divider] = dividers_q.single().map(|d| d.0.as_slice()).unwrap_or(&[]);
+    let packed_dividers: &[DividerPixelRect] = packed_q
+        .single()
+        .map(|p| p.dividers.as_slice())
+        .unwrap_or(&[]);
 
     for ev in buttons.read() {
         if ev.button != bevy::input::mouse::MouseButton::Left {
@@ -277,8 +268,9 @@ fn arbiter(
                 // A divider whose primary pane has no projected geometry yet
                 // cannot be resized, so it falls through to a pane focus rather
                 // than entering Resizing with a bogus (0) baseline.
+                let cursor_logical = cursor_phys / scale;
                 let resize =
-                    divider_at(dividers, cursor_phys, cell_w, cell_h, tol_phys).and_then(|d| {
+                    divider_at(packed_dividers, cursor_logical, grab_tol_logical).and_then(|d| {
                         panes
                             .iter()
                             .find(|(_, p, _, _)| p.id == d.primary)
@@ -646,44 +638,40 @@ mod tests {
         assert_eq!(GestureState::default(), GestureState::Idle);
     }
 
-    fn vdiv(primary: u32, pos: i32, s: i32, e: i32) -> Divider {
-        Divider {
+    fn pixel_vdiv(pos: f32, span_start: f32, span_end: f32) -> DividerPixelRect {
+        DividerPixelRect {
             axis: DividerAxis::Vertical,
-            primary: PaneId(primary),
-            pos,
-            span_start: s,
-            span_end: e,
+            primary: PaneId(1),
+            pos_px: pos,
+            span_start_px: span_start,
+            span_end_px: span_end,
         }
     }
 
     #[test]
-    fn hit_test_grabs_vertical_divider_within_tolerance() {
-        let ds = [vdiv(1, 40, 0, 24)];
-        let hit = divider_at(&ds, Vec2::new(322.0, 100.0), 8.0, 16.0, 4.0);
+    fn pixel_hit_test_within_tolerance() {
+        let d = pixel_vdiv(320.0, 0.0, 384.0);
+        let hit = divider_at(&[d], Vec2::new(322.0, 100.0), 4.0);
         assert!(hit.is_some());
         assert_eq!(hit.unwrap().primary, PaneId(1));
     }
 
     #[test]
-    fn hit_test_misses_outside_tolerance() {
-        let ds = [vdiv(1, 40, 0, 24)];
-        assert!(divider_at(&ds, Vec2::new(360.0, 100.0), 8.0, 16.0, 4.0).is_none());
+    fn pixel_hit_test_outside_tolerance() {
+        let d = pixel_vdiv(320.0, 0.0, 384.0);
+        assert!(divider_at(&[d], Vec2::new(330.0, 100.0), 4.0).is_none());
     }
 
     #[test]
-    fn hit_test_misses_outside_span() {
-        let ds = [vdiv(1, 40, 0, 12)];
-        assert!(divider_at(&ds, Vec2::new(320.0, 208.0), 8.0, 16.0, 4.0).is_none());
+    fn pixel_hit_test_outside_span() {
+        let d = pixel_vdiv(320.0, 0.0, 192.0);
+        assert!(divider_at(&[d], Vec2::new(320.0, 200.0), 4.0).is_none());
     }
 
     #[test]
-    fn hit_test_grabs_far_side_of_gap() {
-        // Gap cell is column 40 = px [320, 328); the far side (x=327) is on the
-        // visible handle and must grab even though it is >tol from the gap's
-        // leading edge (320) — the zone spans the whole gap cell, not ±tol.
-        let ds = [vdiv(1, 40, 0, 24)];
-        let hit = divider_at(&ds, Vec2::new(327.0, 100.0), 8.0, 16.0, 4.0);
-        assert_eq!(hit.map(|d| d.primary), Some(PaneId(1)));
+    fn pixel_hit_test_far_side_of_tolerance() {
+        let d = pixel_vdiv(320.0, 0.0, 384.0);
+        assert!(divider_at(&[d], Vec2::new(324.0, 100.0), 4.0).is_some());
     }
 
     #[test]

--- a/src/tmux_mouse.rs
+++ b/src/tmux_mouse.rs
@@ -269,8 +269,8 @@ fn arbiter(
                 // cannot be resized, so it falls through to a pane focus rather
                 // than entering Resizing with a bogus (0) baseline.
                 let cursor_logical = cursor_phys / scale;
-                let resize =
-                    divider_at(packed_dividers, cursor_logical, grab_tol_logical).and_then(|d| {
+                let resize = divider_at(packed_dividers, cursor_logical, grab_tol_logical)
+                    .and_then(|d| {
                         panes
                             .iter()
                             .find(|(_, p, _, _)| p.id == d.primary)

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -35,9 +35,6 @@ pub struct OzmuxTmuxRenderPlugin;
 impl Plugin for OzmuxTmuxRenderPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LastClientSize>();
-        // NOTE: the camera clear color bleeds through the 1px gaps between panes
-        // (panes are opaque; window containers are grey). Adjust `theme::PANE_GAP`
-        // to retint those gaps.
         app.insert_resource(ClearColor(theme::PANE_GAP));
         app.add_systems(
             Update,
@@ -240,14 +237,14 @@ fn place(
     match cell {
         Cell::Leaf { dims, pane_id } => {
             let size = Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h);
+            let node_size = Vec2::new(available.x.max(size.x), available.y.max(size.y));
             if let Some(id) = pane_id {
-                let node_size = Vec2::new(available.x.max(size.x), available.y.max(size.y));
                 panes.insert(
                     PaneId(*id),
                     Rect::from_corners(origin.round(), (origin + node_size).round()),
                 );
             }
-            size
+            node_size
         }
         Cell::Split {
             dir: SplitDir::LeftRight,
@@ -276,7 +273,7 @@ fn place(
                 if i < last {
                     dividers.push(DividerPixelRect {
                         axis: DividerAxis::Vertical,
-                        primary: first_pane_id(child).unwrap_or(PaneId(0)),
+                        primary: last_pane_id(child).unwrap_or(PaneId(0)),
                         pos_px: x,
                         span_start_px: origin.y,
                         span_end_px: origin.y + available.y,
@@ -313,7 +310,7 @@ fn place(
                 if i < last {
                     dividers.push(DividerPixelRect {
                         axis: DividerAxis::Horizontal,
-                        primary: first_pane_id(child).unwrap_or(PaneId(0)),
+                        primary: last_pane_id(child).unwrap_or(PaneId(0)),
                         pos_px: y,
                         span_start_px: origin.x,
                         span_end_px: origin.x + available.x,
@@ -348,6 +345,16 @@ fn first_pane_id(cell: &Cell) -> Option<PaneId> {
         } => Some(PaneId(*id)),
         Cell::Leaf { pane_id: None, .. } => None,
         Cell::Split { children, .. } => children.iter().find_map(first_pane_id),
+    }
+}
+
+fn last_pane_id(cell: &Cell) -> Option<PaneId> {
+    match cell {
+        Cell::Leaf {
+            pane_id: Some(id), ..
+        } => Some(PaneId(*id)),
+        Cell::Leaf { pane_id: None, .. } => None,
+        Cell::Split { children, .. } => children.iter().rev().find_map(last_pane_id),
     }
 }
 
@@ -1239,6 +1246,82 @@ mod tests {
             Rect::from_corners(Vec2::new(321.0, 193.0), Vec2::new(640.0, 384.0)),
         );
         assert_eq!(bbox, Vec2::new(640.0, 384.0));
+    }
+
+    #[test]
+    fn collapse_compound_non_last_child_no_overlap() {
+        let inner_lr = Cell::Split {
+            dims: CellDims {
+                width: 40,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
+            dir: SplitDir::LeftRight,
+            children: vec![
+                Cell::Leaf {
+                    dims: CellDims {
+                        width: 20,
+                        height: 24,
+                        xoff: 0,
+                        yoff: 0,
+                    },
+                    pane_id: Some(1),
+                },
+                Cell::Leaf {
+                    dims: CellDims {
+                        width: 19,
+                        height: 24,
+                        xoff: 21,
+                        yoff: 0,
+                    },
+                    pane_id: Some(2),
+                },
+            ],
+        };
+        let root = Cell::Split {
+            dims: CellDims {
+                width: 80,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
+            dir: SplitDir::LeftRight,
+            children: vec![
+                inner_lr,
+                Cell::Leaf {
+                    dims: CellDims {
+                        width: 39,
+                        height: 24,
+                        xoff: 41,
+                        yoff: 0,
+                    },
+                    pane_id: Some(3),
+                },
+            ],
+        };
+        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0);
+        assert_eq!(
+            rects[&PaneId(1)],
+            Rect::from_corners(Vec2::ZERO, Vec2::new(160.0, 384.0))
+        );
+        assert_eq!(
+            rects[&PaneId(2)],
+            Rect::from_corners(Vec2::new(161.0, 0.0), Vec2::new(320.0, 384.0)),
+        );
+        assert_eq!(
+            rects[&PaneId(3)],
+            Rect::from_corners(Vec2::new(321.0, 0.0), Vec2::new(640.0, 384.0)),
+        );
+        assert_eq!(bbox, Vec2::new(640.0, 384.0));
+        assert_eq!(dividers.len(), 2);
+        let outer = dividers.iter().find(|d| (d.pos_px - 320.0).abs() < 0.5).unwrap();
+        assert_eq!(outer.axis, DividerAxis::Vertical);
+        assert_eq!(
+            outer.primary,
+            PaneId(2),
+            "outer divider primary must be the rightmost pane of the before-child",
+        );
     }
 
     #[test]

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -6,6 +6,7 @@ use crate::osc_webview::OscWebviewGate;
 use crate::theme;
 use crate::ui::WorkspaceUiRoot;
 use bevy::ecs::message::MessageReader;
+use bevy::math::Rect;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ozma_tty_engine::{TerminalHandle, TerminalTitle};
@@ -20,6 +21,7 @@ use ozmux_tmux::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use tmux_control_parser::{Cell, DividerAxis, PaneId, SplitDir};
 
 #[derive(Resource, Default)]
 struct LastClientSize {
@@ -174,6 +176,148 @@ fn route_tmux_output(
     }
 }
 
+/// Pixel-space position of a 1px inter-pane gap. Positions are in logical px
+/// (the same coordinate space as Bevy `Node` rects).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct DividerPixelRect {
+    pub(crate) axis: DividerAxis,
+    /// Pane on the "before" side; used to identify the resize target.
+    pub(crate) primary: PaneId,
+    /// Logical-px leading edge of the 1px gap on the major axis.
+    pub(crate) pos_px: f32,
+    pub(crate) span_start_px: f32,
+    pub(crate) span_end_px: f32,
+}
+
+/// Pixel-space layout derived from a `TmuxWindowLayout` tree, stored on the
+/// window entity by `layout_tmux_panes`.
+#[derive(Component, Clone, Default, PartialEq)]
+pub(crate) struct PackedTmuxLayout {
+    pub(crate) panes: HashMap<PaneId, Rect>,
+    pub(crate) dividers: Vec<DividerPixelRect>,
+    /// Total available size in logical px (equals root cell dims × cell size).
+    pub(crate) bbox: Vec2,
+}
+
+/// Computes packed pixel rects, 1px-gap divider positions, and the total bbox
+/// for a layout tree. Returns `(pane rects, dividers, bbox)`.
+///
+/// The last child in each split fills the remaining available space so no blank
+/// strip appears at window edges.
+fn collapse(
+    root: &Cell,
+    cell_w: f32,
+    cell_h: f32,
+    gap: f32,
+) -> (HashMap<PaneId, Rect>, Vec<DividerPixelRect>, Vec2) {
+    let dims = root.dims();
+    let available = Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h);
+    let mut panes = HashMap::new();
+    let mut dividers = Vec::new();
+    place(&mut panes, &mut dividers, root, Vec2::ZERO, available, cell_w, cell_h, gap);
+    (panes, dividers, available)
+}
+
+fn place(
+    panes: &mut HashMap<PaneId, Rect>,
+    dividers: &mut Vec<DividerPixelRect>,
+    cell: &Cell,
+    origin: Vec2,
+    available: Vec2,
+    cell_w: f32,
+    cell_h: f32,
+    gap: f32,
+) -> Vec2 {
+    match cell {
+        Cell::Leaf { dims, pane_id } => {
+            let size = Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h);
+            if let Some(id) = pane_id {
+                let node_size = Vec2::new(available.x.max(size.x), available.y.max(size.y));
+                panes.insert(
+                    PaneId(*id),
+                    Rect::from_corners(origin.round(), (origin + node_size).round()),
+                );
+            }
+            size
+        }
+        Cell::Split { dir: SplitDir::LeftRight, children, .. } => {
+            let last = children.len().saturating_sub(1);
+            let mut x = origin.x;
+            for (i, child) in children.iter().enumerate() {
+                let child_avail_w = if i == last {
+                    available.x - (x - origin.x)
+                } else {
+                    child.dims().width as f32 * cell_w
+                };
+                let csz = place(
+                    panes, dividers, child,
+                    Vec2::new(x, origin.y),
+                    Vec2::new(child_avail_w, available.y),
+                    cell_w, cell_h, gap,
+                );
+                x += csz.x;
+                if i < last {
+                    dividers.push(DividerPixelRect {
+                        axis: DividerAxis::Vertical,
+                        primary: first_pane_id(child).unwrap_or(PaneId(0)),
+                        pos_px: x,
+                        span_start_px: origin.y,
+                        span_end_px: origin.y + available.y,
+                    });
+                    x += gap;
+                }
+            }
+            Vec2::new(x - origin.x, available.y)
+        }
+        Cell::Split { dir: SplitDir::TopBottom, children, .. } => {
+            let last = children.len().saturating_sub(1);
+            let mut y = origin.y;
+            for (i, child) in children.iter().enumerate() {
+                let child_avail_h = if i == last {
+                    available.y - (y - origin.y)
+                } else {
+                    child.dims().height as f32 * cell_h
+                };
+                let csz = place(
+                    panes, dividers, child,
+                    Vec2::new(origin.x, y),
+                    Vec2::new(available.x, child_avail_h),
+                    cell_w, cell_h, gap,
+                );
+                y += csz.y;
+                if i < last {
+                    dividers.push(DividerPixelRect {
+                        axis: DividerAxis::Horizontal,
+                        primary: first_pane_id(child).unwrap_or(PaneId(0)),
+                        pos_px: y,
+                        span_start_px: origin.x,
+                        span_end_px: origin.x + available.x,
+                    });
+                    y += gap;
+                }
+            }
+            Vec2::new(available.x, y - origin.y)
+        }
+        Cell::Split { dir: SplitDir::Floating, children, dims } => {
+            for child in children {
+                let d = child.dims();
+                let lit_origin = Vec2::new(d.xoff as f32 * cell_w, d.yoff as f32 * cell_h);
+                let lit_avail = Vec2::new(d.width as f32 * cell_w, d.height as f32 * cell_h);
+                place(panes, dividers, child, lit_origin, lit_avail, cell_w, cell_h, gap);
+            }
+            Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h)
+        }
+    }
+}
+
+fn first_pane_id(cell: &Cell) -> Option<PaneId> {
+    match cell {
+        Cell::Leaf { pane_id: Some(id), .. } => Some(PaneId(*id)),
+        Cell::Leaf { pane_id: None, .. } => None,
+        Cell::Split { children, .. } => children.iter().find_map(first_pane_id),
+    }
+}
+
 /// Converts tmux cell dims (`u32`) to an alacritty grid size, clamping into
 /// `1..=u16::MAX` so a pathological width/height cannot truncate to 0 (a 0-col
 /// `Term::resize` would panic).
@@ -318,9 +462,10 @@ fn sync_active_pane_outline(mut panes: Query<(Has<ActivePane>, &mut Outline), Wi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::math::{Rect, Vec2};
     use ozma_tty_renderer::prelude::TerminalGridPlugin;
     use ozmux_tmux::PaneOutput;
-    use tmux_control_parser::{CellDims, PaneId};
+    use tmux_control_parser::{Cell, CellDims, SplitDir};
 
     #[test]
     fn rows_for_panes_reserves_one_row_for_the_bar() {
@@ -897,5 +1042,106 @@ mod tests {
             pane_rect(dims.xoff, dims.yoff, dims.width, dims.height, 8.0, 16.0),
             (16.0, 16.0, 80.0, 64.0),
         );
+    }
+
+    #[test]
+    fn collapse_single_pane_fills_available() {
+        let root = Cell::Leaf {
+            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            pane_id: Some(0),
+        };
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0);
+        assert_eq!(rects[&PaneId(0)], Rect::from_corners(Vec2::ZERO, Vec2::new(640.0, 384.0)));
+        assert_eq!(bbox, Vec2::new(640.0, 384.0));
+    }
+
+    #[test]
+    fn collapse_left_right_produces_one_px_gap() {
+        let root = Cell::Split {
+            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dir: SplitDir::LeftRight,
+            children: vec![
+                Cell::Leaf {
+                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    pane_id: Some(1),
+                },
+                Cell::Leaf {
+                    dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+                    pane_id: Some(2),
+                },
+            ],
+        };
+        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0);
+        assert_eq!(rects[&PaneId(1)], Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0)));
+        assert_eq!(
+            rects[&PaneId(2)],
+            Rect::from_corners(Vec2::new(321.0, 0.0), Vec2::new(640.0, 384.0)),
+        );
+        assert_eq!(bbox, Vec2::new(640.0, 384.0));
+        assert_eq!(dividers.len(), 1);
+        assert_eq!(dividers[0].axis, DividerAxis::Vertical);
+        assert!((dividers[0].pos_px - 320.0).abs() < 0.5);
+        assert_eq!(dividers[0].primary, PaneId(1));
+    }
+
+    #[test]
+    fn collapse_nested_split_fills_without_blank_strips() {
+        let right_child = Cell::Split {
+            dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+            dir: SplitDir::TopBottom,
+            children: vec![
+                Cell::Leaf {
+                    dims: CellDims { width: 39, height: 12, xoff: 41, yoff: 0 },
+                    pane_id: Some(2),
+                },
+                Cell::Leaf {
+                    dims: CellDims { width: 39, height: 11, xoff: 41, yoff: 13 },
+                    pane_id: Some(3),
+                },
+            ],
+        };
+        let root = Cell::Split {
+            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dir: SplitDir::LeftRight,
+            children: vec![
+                Cell::Leaf {
+                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    pane_id: Some(1),
+                },
+                right_child,
+            ],
+        };
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0);
+        assert_eq!(rects[&PaneId(1)], Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0)));
+        assert_eq!(
+            rects[&PaneId(2)],
+            Rect::from_corners(Vec2::new(321.0, 0.0), Vec2::new(640.0, 192.0)),
+        );
+        assert_eq!(
+            rects[&PaneId(3)],
+            Rect::from_corners(Vec2::new(321.0, 193.0), Vec2::new(640.0, 384.0)),
+        );
+        assert_eq!(bbox, Vec2::new(640.0, 384.0));
+    }
+
+    #[test]
+    fn collapse_skips_leaf_without_pane_id() {
+        let root = Cell::Split {
+            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dir: SplitDir::LeftRight,
+            children: vec![
+                Cell::Leaf {
+                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    pane_id: None,
+                },
+                Cell::Leaf {
+                    dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+                    pane_id: Some(2),
+                },
+            ],
+        };
+        let (rects, _, _) = collapse(&root, 8.0, 16.0, 1.0);
+        assert_eq!(rects.len(), 1, "pane_id:None leaf is not placed");
+        assert!(rects.contains_key(&PaneId(2)));
     }
 }

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -1024,7 +1024,6 @@ mod tests {
                 .chain(),
         );
 
-        // Frame 1: emit once so first_emit flips to false (matching production state).
         app.update();
         let hits_after_first = app.world().resource::<SnapHits>().0;
         assert!(
@@ -1032,7 +1031,6 @@ mod tests {
             "first flush_emit must fire a FrameSnapshot (first_emit path)"
         );
 
-        // Now change pane dims so layout_tmux_panes will resize.
         app.world_mut()
             .entity_mut(entity)
             .get_mut::<TmuxPane>()
@@ -1044,8 +1042,6 @@ mod tests {
             yoff: 0,
         };
 
-        // Frame 2: layout_tmux_panes sees the dim change, calls resize_grid_only +
-        // emit_pending — must fire a NEW FrameSnapshot even though first_emit is now false.
         app.update();
         let hits_after_resize = app.world().resource::<SnapHits>().0;
 

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -16,7 +16,7 @@ use ozma_tty_renderer::prelude::TerminalRenderBundle;
 use ozma_tty_renderer::schema::TerminalGrid;
 use ozmux_tmux::{
     ActivePane, ActiveWindow, PaneOutput, TmuxConnection, TmuxPane, TmuxProjectionSet, TmuxWindow,
-    refresh_client_command,
+    TmuxWindowLayout, refresh_client_command,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -67,12 +67,10 @@ fn attach_tmux_window_container(
     for window in windows.iter() {
         commands.entity(window).insert((
             Node {
-                display: Display::Flex,
                 position_type: PositionType::Absolute,
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
                 ..default()
             },
+            BackgroundColor(theme::BORDER),
             ChildOf(root),
         ));
     }
@@ -328,31 +326,17 @@ fn grid_dims(width: u32, height: u32) -> (u16, u16) {
     (clamp(width), clamp(height))
 }
 
-fn pane_rect(
-    xoff: i32,
-    yoff: i32,
-    width: u32,
-    height: u32,
-    cell_w: f32,
-    cell_h: f32,
-) -> (f32, f32, f32, f32) {
-    (
-        xoff as f32 * cell_w,
-        yoff as f32 * cell_h,
-        width as f32 * cell_w,
-        height as f32 * cell_h,
-    )
-}
 
 fn layout_tmux_panes(
     mut commands: Commands,
-    mut panes: Query<(
-        Entity,
-        &TmuxPane,
-        &mut Node,
-        &mut TerminalHandle,
-        &mut TerminalGrid,
-    )>,
+    mut windows: Query<
+        (Entity, &TmuxWindowLayout, &mut Node, &Children, Option<&PackedTmuxLayout>),
+        With<TmuxWindow>,
+    >,
+    mut panes: Query<
+        (&TmuxPane, &mut Node, &mut TerminalHandle, &mut TerminalGrid),
+        Without<TmuxWindow>,
+    >,
     metrics: Res<TerminalCellMetricsResource>,
     window: Query<&Window, With<PrimaryWindow>>,
 ) {
@@ -362,30 +346,54 @@ fn layout_tmux_panes(
     let dpr = window.scale_factor().max(0.5);
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0) / dpr;
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0) / dpr;
-    for (entity, pane, mut node, mut handle, mut grid) in panes.iter_mut() {
-        let d = pane.dims;
-        let (left, top, width, height) =
-            pane_rect(d.xoff, d.yoff, d.width, d.height, cell_w, cell_h);
+
+    for (window_entity, layout, mut container, children, maybe_packed) in windows.iter_mut() {
+        let (rects, dividers, bbox) = collapse(&layout.0.root, cell_w, cell_h, theme::PANE_GAP_PX);
+
         // NOTE: only write the Node fields when they actually change — writing
-        // through `Mut<Node>` every frame would mark the component changed and
-        // force a full UI relayout pass each tick even when nothing moved.
-        if node.left != Val::Px(left)
-            || node.top != Val::Px(top)
-            || node.width != Val::Px(width)
-            || node.height != Val::Px(height)
-        {
-            node.left = Val::Px(left);
-            node.top = Val::Px(top);
-            node.width = Val::Px(width);
-            node.height = Val::Px(height);
+        // through `Mut<Node>` every frame marks the component changed and forces
+        // a full UI relayout pass each tick even when nothing moved.
+        if container.width != Val::Px(bbox.x) || container.height != Val::Px(bbox.y) {
+            container.width = Val::Px(bbox.x);
+            container.height = Val::Px(bbox.y);
         }
-        let (cols, rows) = grid_dims(pane.dims.width, pane.dims.height);
-        let (cur_cols, cur_rows, _) = handle.read_geometry();
-        if (cur_cols, cur_rows) != (cols, rows) {
-            handle.resize_grid_only(cols, rows);
-            grid.cols = cols;
-            grid.rows = rows;
-            handle.emit_pending(&mut commands, entity);
+
+        let packed_changed = maybe_packed.map_or(true, |p| {
+            p.panes != rects || p.dividers != dividers || p.bbox != bbox
+        });
+        if packed_changed {
+            commands
+                .entity(window_entity)
+                .insert(PackedTmuxLayout { panes: rects.clone(), dividers: dividers.clone(), bbox });
+        }
+
+        for child in children.iter() {
+            let Ok((pane, mut node, mut handle, mut grid)) = panes.get_mut(child) else {
+                continue;
+            };
+            let Some(rect) = rects.get(&pane.id) else {
+                continue;
+            };
+            let (left, top, width, height) =
+                (rect.min.x, rect.min.y, rect.width(), rect.height());
+            if node.left != Val::Px(left)
+                || node.top != Val::Px(top)
+                || node.width != Val::Px(width)
+                || node.height != Val::Px(height)
+            {
+                node.left = Val::Px(left);
+                node.top = Val::Px(top);
+                node.width = Val::Px(width);
+                node.height = Val::Px(height);
+            }
+            let (cols, rows) = grid_dims(pane.dims.width, pane.dims.height);
+            let (cur_cols, cur_rows, _) = handle.read_geometry();
+            if (cur_cols, cur_rows) != (cols, rows) {
+                handle.resize_grid_only(cols, rows);
+                grid.cols = cols;
+                grid.rows = rows;
+                handle.emit_pending(&mut commands, child);
+            }
         }
     }
 }
@@ -766,6 +774,18 @@ mod tests {
         };
         window.resolution.set_scale_factor(1.0);
         app.world_mut().spawn((window, PrimaryWindow));
+
+        use ozmux_tmux::{TmuxWindow, TmuxWindowLayout};
+        use tmux_control_parser::{WindowId, WindowLayout};
+
+        let window_e = app
+            .world_mut()
+            .spawn((
+                TmuxWindow { id: WindowId(1), index: 0, name: String::new() },
+                TmuxWindowLayout(WindowLayout::parse(b"0000,40x10,0,0,1").unwrap()),
+                Node::default(),
+            ))
+            .id();
         let entity = app
             .world_mut()
             .spawn((
@@ -781,6 +801,7 @@ mod tests {
                 Node::default(),
                 TerminalHandle::detached(20, 5, Arc::new(AtomicBool::new(false))),
                 TerminalGrid::default(),
+                ChildOf(window_e),
             ))
             .id();
 
@@ -958,7 +979,18 @@ mod tests {
         window.resolution.set_scale_factor(1.0);
         app.world_mut().spawn((window, PrimaryWindow));
 
+        use ozmux_tmux::{TmuxWindow, TmuxWindowLayout};
+        use tmux_control_parser::{WindowId, WindowLayout};
+
         let pane_id = PaneId(2);
+        let window_e = app
+            .world_mut()
+            .spawn((
+                TmuxWindow { id: WindowId(1), index: 0, name: String::new() },
+                TmuxWindowLayout(WindowLayout::parse(b"0000,20x5,0,0,2").unwrap()),
+                Node::default(),
+            ))
+            .id();
         let entity = app
             .world_mut()
             .spawn((
@@ -974,6 +1006,7 @@ mod tests {
                 Node::default(),
                 TerminalHandle::detached(20, 5, Arc::new(AtomicBool::new(false))),
                 TerminalGrid::default(),
+                ChildOf(window_e),
             ))
             .id();
 
@@ -1029,20 +1062,6 @@ mod tests {
             hits_after_resize > hits_after_first,
             "resize must fire a fresh FrameSnapshot when first_emit is already false \
              (got {hits_after_resize} total, was {hits_after_first} before resize)",
-        );
-    }
-
-    #[test]
-    fn pane_rect_scales_cell_dims_to_pixels() {
-        let dims = CellDims {
-            width: 10,
-            height: 4,
-            xoff: 2,
-            yoff: 1,
-        };
-        assert_eq!(
-            pane_rect(dims.xoff, dims.yoff, dims.width, dims.height, 8.0, 16.0),
-            (16.0, 16.0, 80.0, 64.0),
         );
     }
 

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -35,9 +35,9 @@ pub struct OzmuxTmuxRenderPlugin;
 impl Plugin for OzmuxTmuxRenderPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LastClientSize>();
-        // The camera clear color shows through tmux's reserved-cell gaps between
-        // panes (panes are opaque; the UI roots and pane container are
-        // transparent). Adjust `theme::PANE_GAP` to retint those gaps.
+        // NOTE: the camera clear color bleeds through the 1px gaps between panes
+        // (panes are opaque; window containers are grey). Adjust `theme::PANE_GAP`
+        // to retint those gaps.
         app.insert_resource(ClearColor(theme::PANE_GAP));
         app.add_systems(
             Update,
@@ -54,6 +54,31 @@ impl Plugin for OzmuxTmuxRenderPlugin {
         );
         app.add_systems(Update, sync_client_size.after(TmuxProjectionSet));
     }
+}
+
+/// Pixel-space position of a 1px inter-pane gap. Positions are in logical px
+/// (the same coordinate space as Bevy `Node` rects).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct DividerPixelRect {
+    pub(crate) axis: DividerAxis,
+    /// Pane on the "before" side; used to identify the resize target.
+    pub(crate) primary: PaneId,
+    /// Logical-px leading edge of the 1px gap on the major axis.
+    pub(crate) pos_px: f32,
+    /// Orthogonal-axis start of the divider line in logical px.
+    pub(crate) span_start_px: f32,
+    /// Orthogonal-axis end of the divider line in logical px.
+    pub(crate) span_end_px: f32,
+}
+
+/// Pixel-space layout derived from a `TmuxWindowLayout` tree, stored on the
+/// window entity by `layout_tmux_panes`.
+#[derive(Component, Clone, Default, PartialEq)]
+pub(crate) struct PackedTmuxLayout {
+    pub(crate) panes: HashMap<PaneId, Rect>,
+    pub(crate) dividers: Vec<DividerPixelRect>,
+    /// Total available size in logical px (equals root cell dims × cell size).
+    pub(crate) bbox: Vec2,
 }
 
 fn attach_tmux_window_container(
@@ -172,31 +197,6 @@ fn route_tmux_output(
         // history recall). Draining still matters: the reply channel is unbounded.
         let _ = handle.take_replies();
     }
-}
-
-/// Pixel-space position of a 1px inter-pane gap. Positions are in logical px
-/// (the same coordinate space as Bevy `Node` rects).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct DividerPixelRect {
-    pub(crate) axis: DividerAxis,
-    /// Pane on the "before" side; used to identify the resize target.
-    pub(crate) primary: PaneId,
-    /// Logical-px leading edge of the 1px gap on the major axis.
-    pub(crate) pos_px: f32,
-    /// Orthogonal-axis start of the divider line in logical px.
-    pub(crate) span_start_px: f32,
-    /// Orthogonal-axis end of the divider line in logical px.
-    pub(crate) span_end_px: f32,
-}
-
-/// Pixel-space layout derived from a `TmuxWindowLayout` tree, stored on the
-/// window entity by `layout_tmux_panes`.
-#[derive(Component, Clone, Default, PartialEq)]
-pub(crate) struct PackedTmuxLayout {
-    pub(crate) panes: HashMap<PaneId, Rect>,
-    pub(crate) dividers: Vec<DividerPixelRect>,
-    /// Total available size in logical px (equals root cell dims × cell size).
-    pub(crate) bbox: Vec2,
 }
 
 /// Computes packed pixel rects, 1px-gap divider positions, and the total bbox

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -214,7 +214,16 @@ fn collapse(
     let available = Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h);
     let mut panes = HashMap::new();
     let mut dividers = Vec::new();
-    place(&mut panes, &mut dividers, root, Vec2::ZERO, available, cell_w, cell_h, gap);
+    place(
+        &mut panes,
+        &mut dividers,
+        root,
+        Vec2::ZERO,
+        available,
+        cell_w,
+        cell_h,
+        gap,
+    );
     (panes, dividers, available)
 }
 
@@ -240,7 +249,11 @@ fn place(
             }
             size
         }
-        Cell::Split { dir: SplitDir::LeftRight, children, .. } => {
+        Cell::Split {
+            dir: SplitDir::LeftRight,
+            children,
+            ..
+        } => {
             let last = children.len().saturating_sub(1);
             let mut x = origin.x;
             for (i, child) in children.iter().enumerate() {
@@ -250,10 +263,14 @@ fn place(
                     child.dims().width as f32 * cell_w
                 };
                 let csz = place(
-                    panes, dividers, child,
+                    panes,
+                    dividers,
+                    child,
                     Vec2::new(x, origin.y),
                     Vec2::new(child_avail_w, available.y),
-                    cell_w, cell_h, gap,
+                    cell_w,
+                    cell_h,
+                    gap,
                 );
                 x += csz.x;
                 if i < last {
@@ -269,7 +286,11 @@ fn place(
             }
             Vec2::new(x - origin.x, available.y)
         }
-        Cell::Split { dir: SplitDir::TopBottom, children, .. } => {
+        Cell::Split {
+            dir: SplitDir::TopBottom,
+            children,
+            ..
+        } => {
             let last = children.len().saturating_sub(1);
             let mut y = origin.y;
             for (i, child) in children.iter().enumerate() {
@@ -279,10 +300,14 @@ fn place(
                     child.dims().height as f32 * cell_h
                 };
                 let csz = place(
-                    panes, dividers, child,
+                    panes,
+                    dividers,
+                    child,
                     Vec2::new(origin.x, y),
                     Vec2::new(available.x, child_avail_h),
-                    cell_w, cell_h, gap,
+                    cell_w,
+                    cell_h,
+                    gap,
                 );
                 y += csz.y;
                 if i < last {
@@ -298,12 +323,18 @@ fn place(
             }
             Vec2::new(available.x, y - origin.y)
         }
-        Cell::Split { dir: SplitDir::Floating, children, dims } => {
+        Cell::Split {
+            dir: SplitDir::Floating,
+            children,
+            dims,
+        } => {
             for child in children {
                 let d = child.dims();
                 let lit_origin = Vec2::new(d.xoff as f32 * cell_w, d.yoff as f32 * cell_h);
                 let lit_avail = Vec2::new(d.width as f32 * cell_w, d.height as f32 * cell_h);
-                place(panes, dividers, child, lit_origin, lit_avail, cell_w, cell_h, gap);
+                place(
+                    panes, dividers, child, lit_origin, lit_avail, cell_w, cell_h, gap,
+                );
             }
             Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h)
         }
@@ -312,7 +343,9 @@ fn place(
 
 fn first_pane_id(cell: &Cell) -> Option<PaneId> {
     match cell {
-        Cell::Leaf { pane_id: Some(id), .. } => Some(PaneId(*id)),
+        Cell::Leaf {
+            pane_id: Some(id), ..
+        } => Some(PaneId(*id)),
         Cell::Leaf { pane_id: None, .. } => None,
         Cell::Split { children, .. } => children.iter().find_map(first_pane_id),
     }
@@ -326,11 +359,16 @@ fn grid_dims(width: u32, height: u32) -> (u16, u16) {
     (clamp(width), clamp(height))
 }
 
-
 fn layout_tmux_panes(
     mut commands: Commands,
     mut windows: Query<
-        (Entity, &TmuxWindowLayout, &mut Node, &Children, Option<&PackedTmuxLayout>),
+        (
+            Entity,
+            &TmuxWindowLayout,
+            &mut Node,
+            &Children,
+            Option<&PackedTmuxLayout>,
+        ),
         With<TmuxWindow>,
     >,
     mut panes: Query<
@@ -358,13 +396,14 @@ fn layout_tmux_panes(
             container.height = Val::Px(bbox.y);
         }
 
-        let packed_changed = maybe_packed.map_or(true, |p| {
-            p.panes != rects || p.dividers != dividers || p.bbox != bbox
-        });
+        let packed_changed = maybe_packed
+            .is_none_or(|p| p.panes != rects || p.dividers != dividers || p.bbox != bbox);
         if packed_changed {
-            commands
-                .entity(window_entity)
-                .insert(PackedTmuxLayout { panes: rects.clone(), dividers: dividers.clone(), bbox });
+            commands.entity(window_entity).insert(PackedTmuxLayout {
+                panes: rects.clone(),
+                dividers: dividers.clone(),
+                bbox,
+            });
         }
 
         for child in children.iter() {
@@ -374,8 +413,7 @@ fn layout_tmux_panes(
             let Some(rect) = rects.get(&pane.id) else {
                 continue;
             };
-            let (left, top, width, height) =
-                (rect.min.x, rect.min.y, rect.width(), rect.height());
+            let (left, top, width, height) = (rect.min.x, rect.min.y, rect.width(), rect.height());
             if node.left != Val::Px(left)
                 || node.top != Val::Px(top)
                 || node.width != Val::Px(width)
@@ -781,7 +819,11 @@ mod tests {
         let window_e = app
             .world_mut()
             .spawn((
-                TmuxWindow { id: WindowId(1), index: 0, name: String::new() },
+                TmuxWindow {
+                    id: WindowId(1),
+                    index: 0,
+                    name: String::new(),
+                },
                 TmuxWindowLayout(WindowLayout::parse(b"0000,40x10,0,0,1").unwrap()),
                 Node::default(),
             ))
@@ -986,7 +1028,11 @@ mod tests {
         let window_e = app
             .world_mut()
             .spawn((
-                TmuxWindow { id: WindowId(1), index: 0, name: String::new() },
+                TmuxWindow {
+                    id: WindowId(1),
+                    index: 0,
+                    name: String::new(),
+                },
                 TmuxWindowLayout(WindowLayout::parse(b"0000,20x5,0,0,2").unwrap()),
                 Node::default(),
             ))
@@ -1064,32 +1110,58 @@ mod tests {
     #[test]
     fn collapse_single_pane_fills_available() {
         let root = Cell::Leaf {
-            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dims: CellDims {
+                width: 80,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
             pane_id: Some(0),
         };
         let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0);
-        assert_eq!(rects[&PaneId(0)], Rect::from_corners(Vec2::ZERO, Vec2::new(640.0, 384.0)));
+        assert_eq!(
+            rects[&PaneId(0)],
+            Rect::from_corners(Vec2::ZERO, Vec2::new(640.0, 384.0))
+        );
         assert_eq!(bbox, Vec2::new(640.0, 384.0));
     }
 
     #[test]
     fn collapse_left_right_produces_one_px_gap() {
         let root = Cell::Split {
-            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dims: CellDims {
+                width: 80,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
             dir: SplitDir::LeftRight,
             children: vec![
                 Cell::Leaf {
-                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    dims: CellDims {
+                        width: 40,
+                        height: 24,
+                        xoff: 0,
+                        yoff: 0,
+                    },
                     pane_id: Some(1),
                 },
                 Cell::Leaf {
-                    dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+                    dims: CellDims {
+                        width: 39,
+                        height: 24,
+                        xoff: 41,
+                        yoff: 0,
+                    },
                     pane_id: Some(2),
                 },
             ],
         };
         let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0);
-        assert_eq!(rects[&PaneId(1)], Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0)));
+        assert_eq!(
+            rects[&PaneId(1)],
+            Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0))
+        );
         assert_eq!(
             rects[&PaneId(2)],
             Rect::from_corners(Vec2::new(321.0, 0.0), Vec2::new(640.0, 384.0)),
@@ -1104,32 +1176,60 @@ mod tests {
     #[test]
     fn collapse_nested_split_fills_without_blank_strips() {
         let right_child = Cell::Split {
-            dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+            dims: CellDims {
+                width: 39,
+                height: 24,
+                xoff: 41,
+                yoff: 0,
+            },
             dir: SplitDir::TopBottom,
             children: vec![
                 Cell::Leaf {
-                    dims: CellDims { width: 39, height: 12, xoff: 41, yoff: 0 },
+                    dims: CellDims {
+                        width: 39,
+                        height: 12,
+                        xoff: 41,
+                        yoff: 0,
+                    },
                     pane_id: Some(2),
                 },
                 Cell::Leaf {
-                    dims: CellDims { width: 39, height: 11, xoff: 41, yoff: 13 },
+                    dims: CellDims {
+                        width: 39,
+                        height: 11,
+                        xoff: 41,
+                        yoff: 13,
+                    },
                     pane_id: Some(3),
                 },
             ],
         };
         let root = Cell::Split {
-            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dims: CellDims {
+                width: 80,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
             dir: SplitDir::LeftRight,
             children: vec![
                 Cell::Leaf {
-                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    dims: CellDims {
+                        width: 40,
+                        height: 24,
+                        xoff: 0,
+                        yoff: 0,
+                    },
                     pane_id: Some(1),
                 },
                 right_child,
             ],
         };
         let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0);
-        assert_eq!(rects[&PaneId(1)], Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0)));
+        assert_eq!(
+            rects[&PaneId(1)],
+            Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0))
+        );
         assert_eq!(
             rects[&PaneId(2)],
             Rect::from_corners(Vec2::new(321.0, 0.0), Vec2::new(640.0, 192.0)),
@@ -1144,15 +1244,30 @@ mod tests {
     #[test]
     fn collapse_skips_leaf_without_pane_id() {
         let root = Cell::Split {
-            dims: CellDims { width: 80, height: 24, xoff: 0, yoff: 0 },
+            dims: CellDims {
+                width: 80,
+                height: 24,
+                xoff: 0,
+                yoff: 0,
+            },
             dir: SplitDir::LeftRight,
             children: vec![
                 Cell::Leaf {
-                    dims: CellDims { width: 40, height: 24, xoff: 0, yoff: 0 },
+                    dims: CellDims {
+                        width: 40,
+                        height: 24,
+                        xoff: 0,
+                        yoff: 0,
+                    },
                     pane_id: None,
                 },
                 Cell::Leaf {
-                    dims: CellDims { width: 39, height: 24, xoff: 41, yoff: 0 },
+                    dims: CellDims {
+                        width: 39,
+                        height: 24,
+                        xoff: 41,
+                        yoff: 0,
+                    },
                     pane_id: Some(2),
                 },
             ],

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -185,7 +185,9 @@ pub(crate) struct DividerPixelRect {
     pub(crate) primary: PaneId,
     /// Logical-px leading edge of the 1px gap on the major axis.
     pub(crate) pos_px: f32,
+    /// Orthogonal-axis start of the divider line in logical px.
     pub(crate) span_start_px: f32,
+    /// Orthogonal-axis end of the divider line in logical px.
     pub(crate) span_end_px: f32,
 }
 

--- a/src/ui/tmux_divider_handle.rs
+++ b/src/ui/tmux_divider_handle.rs
@@ -45,10 +45,18 @@ struct DividerHandle {
 /// Logical-px rect `(left, top, width, height)` for a divider's handle node.
 fn handle_node_rect(d: &DividerPixelRect) -> (f32, f32, f32, f32) {
     match d.axis {
-        DividerAxis::Vertical => (d.pos_px, d.span_start_px, 1.0, d.span_end_px - d.span_start_px),
-        DividerAxis::Horizontal => {
-            (d.span_start_px, d.pos_px, d.span_end_px - d.span_start_px, 1.0)
-        }
+        DividerAxis::Vertical => (
+            d.pos_px,
+            d.span_start_px,
+            1.0,
+            d.span_end_px - d.span_start_px,
+        ),
+        DividerAxis::Horizontal => (
+            d.span_start_px,
+            d.pos_px,
+            d.span_end_px - d.span_start_px,
+            1.0,
+        ),
     }
 }
 
@@ -198,13 +206,11 @@ mod tests {
             "handles belong to the dividers' window",
         );
 
-        app.world_mut()
-            .entity_mut(window)
-            .insert(PackedTmuxLayout {
-                panes: HashMap::new(),
-                dividers: vec![vdiv(200.0)],
-                bbox: Vec2::new(640.0, 384.0),
-            });
+        app.world_mut().entity_mut(window).insert(PackedTmuxLayout {
+            panes: HashMap::new(),
+            dividers: vec![vdiv(200.0)],
+            bbox: Vec2::new(640.0, 384.0),
+        });
         app.update();
         assert_eq!(count(&mut app), 1, "reconciled to the new divider set");
 

--- a/src/ui/tmux_divider_handle.rs
+++ b/src/ui/tmux_divider_handle.rs
@@ -1,22 +1,22 @@
 //! Visible drag handles in tmux's reserved inter-pane gap, plus the resize
 //! mouse cursor while hovering them.
 //!
-//! For each `Divider` projected onto a window (`TmuxDividers`), one handle node
-//! fills the 1-cell gap the divider occupies (subtle grey, brightening to the
-//! accent color on hover). A hover system reuses the arbiter's `divider_at`
-//! hit-test so the visible handle, the resize grab zone, and the cursor all
-//! coincide, and sets a `ColResize` / `RowResize` cursor on the primary window
-//! while the pointer is over a divider.
+//! For each `DividerPixelRect` stored on a window (`PackedTmuxLayout`), one
+//! handle node fills the 1px gap the divider occupies (subtle grey, brightening
+//! to the accent color on hover). A hover system reuses the arbiter's
+//! `divider_at` hit-test so the visible handle, the resize grab zone, and the
+//! cursor all coincide, and sets a `ColResize` / `RowResize` cursor on the
+//! primary window while the pointer is over a divider.
 
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
 use crate::theme;
 use crate::tmux_mouse::divider_at;
+use crate::tmux_render::{DividerPixelRect, PackedTmuxLayout};
 use bevy::prelude::*;
 use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
-use ozma_tty_renderer::TerminalCellMetricsResource;
-use ozmux_tmux::{ActiveWindow, TmuxDividers, TmuxProjectionSet};
-use tmux_control_parser::{Divider, DividerAxis};
+use ozmux_tmux::{ActiveWindow, TmuxProjectionSet};
+use tmux_control_parser::DividerAxis;
 
 /// Registers the divider-handle visuals and the resize hover cursor.
 pub(crate) struct OzmuxTmuxDividerHandlePlugin;
@@ -27,7 +27,6 @@ impl Plugin for OzmuxTmuxDividerHandlePlugin {
             Update,
             (
                 reconcile_divider_handles.after(TmuxProjectionSet),
-                position_divider_handles.after(reconcile_divider_handles),
                 divider_hover_feedback.after(InputPhase::Hover),
             ),
         );
@@ -35,70 +34,43 @@ impl Plugin for OzmuxTmuxDividerHandlePlugin {
 }
 
 /// A visual bar filling one divider's reserved gap. `window` is the owning
-/// `TmuxWindow` entity (the handle's `ChildOf` parent), stored so a layout
-/// change can despawn this window's handles before respawning the new set.
+/// `TmuxWindow` entity; stored so a layout change can despawn this window's
+/// handles before respawning the new set.
 #[derive(Component)]
 struct DividerHandle {
-    divider: Divider,
+    divider: DividerPixelRect,
     window: Entity,
 }
 
-/// Logical-px rect `(left, top, width, height)` for a divider's handle, filling
-/// its reserved gap cell and spanning the shared edge. `cell_w` / `cell_h` are
-/// logical px per cell.
-fn handle_rect(divider: Divider, cell_w: f32, cell_h: f32) -> (f32, f32, f32, f32) {
-    let span = (divider.span_end - divider.span_start).max(0) as f32;
-    match divider.axis {
-        DividerAxis::Vertical => (
-            divider.pos as f32 * cell_w,
-            divider.span_start as f32 * cell_h,
-            cell_w,
-            span * cell_h,
-        ),
-        DividerAxis::Horizontal => (
-            divider.span_start as f32 * cell_w,
-            divider.pos as f32 * cell_h,
-            span * cell_w,
-            cell_h,
-        ),
+/// Logical-px rect `(left, top, width, height)` for a divider's handle node.
+fn handle_node_rect(d: &DividerPixelRect) -> (f32, f32, f32, f32) {
+    match d.axis {
+        DividerAxis::Vertical => (d.pos_px, d.span_start_px, 1.0, d.span_end_px - d.span_start_px),
+        DividerAxis::Horizontal => {
+            (d.span_start_px, d.pos_px, d.span_end_px - d.span_start_px, 1.0)
+        }
     }
 }
 
-/// Logical px per cell from the renderer's physical metrics and the window DPR.
-fn logical_cell_size(metrics: &TerminalCellMetricsResource, dpr: f32) -> (f32, f32) {
-    (
-        metrics.metrics.advance_phys.floor().max(1.0) / dpr,
-        metrics.metrics.line_height_phys.floor().max(1.0) / dpr,
-    )
-}
-
-/// Despawns and respawns a window's handle bars whenever its `TmuxDividers`
-/// change (first projection + every `%layout-change`). Spawns each handle with
-/// its gap rect already set so it appears in place without a one-frame stutter;
-/// `position_divider_handles` keeps it in sync afterward.
+/// Despawns and respawns a window's handle bars whenever its `PackedTmuxLayout`
+/// changes (first projection + every `%layout-change`). Spawns each handle with
+/// its gap rect already set so it appears in place without a one-frame stutter.
 fn reconcile_divider_handles(
     mut commands: Commands,
-    changed: Query<(Entity, &TmuxDividers), Changed<TmuxDividers>>,
+    changed: Query<(Entity, &PackedTmuxLayout), Changed<PackedTmuxLayout>>,
     handles: Query<(Entity, &DividerHandle)>,
-    metrics: Res<TerminalCellMetricsResource>,
-    window: Query<&Window, With<PrimaryWindow>>,
 ) {
     if changed.is_empty() {
         return;
     }
-    let dpr = window
-        .single()
-        .map(|w| w.scale_factor().max(0.5))
-        .unwrap_or(1.0);
-    let (cell_w, cell_h) = logical_cell_size(&metrics, dpr);
-    for (window_entity, dividers) in changed.iter() {
+    for (window_entity, packed) in changed.iter() {
         for (handle, handle_data) in handles.iter() {
             if handle_data.window == window_entity {
                 commands.entity(handle).despawn();
             }
         }
-        for divider in &dividers.0 {
-            let (left, top, w, h) = handle_rect(*divider, cell_w, cell_h);
+        for divider in &packed.dividers {
+            let (left, top, w, h) = handle_node_rect(divider);
             commands.spawn((
                 DividerHandle {
                     divider: *divider,
@@ -119,34 +91,6 @@ fn reconcile_divider_handles(
     }
 }
 
-/// Keeps each handle's gap rect in sync with the current cell metrics / DPR
-/// (font or monitor changes), mirroring `layout_tmux_panes`. Writes the `Node`
-/// only when it actually changes to avoid forcing a relayout every frame.
-fn position_divider_handles(
-    mut handles: Query<(&DividerHandle, &mut Node)>,
-    metrics: Res<TerminalCellMetricsResource>,
-    window: Query<&Window, With<PrimaryWindow>>,
-) {
-    let Ok(window) = window.single() else {
-        return;
-    };
-    let dpr = window.scale_factor().max(0.5);
-    let (cell_w, cell_h) = logical_cell_size(&metrics, dpr);
-    for (handle, mut node) in handles.iter_mut() {
-        let (left, top, w, h) = handle_rect(handle.divider, cell_w, cell_h);
-        if node.left != Val::Px(left)
-            || node.top != Val::Px(top)
-            || node.width != Val::Px(w)
-            || node.height != Val::Px(h)
-        {
-            node.left = Val::Px(left);
-            node.top = Val::Px(top);
-            node.width = Val::Px(w);
-            node.height = Val::Px(h);
-        }
-    }
-}
-
 /// Brightens the hovered divider's handle to the accent color and sets a
 /// `ColResize` / `RowResize` cursor on the primary window. Runs after
 /// `InputPhase::Hover` so it overrides the hyperlink baseline cursor; when no
@@ -154,30 +98,29 @@ fn position_divider_handles(
 fn divider_hover_feedback(
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
     mut handles: Query<(&DividerHandle, &mut BackgroundColor)>,
-    dividers_q: Query<&TmuxDividers, With<ActiveWindow>>,
-    metrics: Res<TerminalCellMetricsResource>,
+    packed_q: Query<&PackedTmuxLayout, With<ActiveWindow>>,
     configs: Option<Res<OzmuxConfigsResource>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     let Ok(window) = windows.single() else {
         return;
     };
-    let scale = window.scale_factor();
-    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
-    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
     let tol = configs
         .as_deref()
         .map(|c| c.mouse.divider_grab_tolerance_px)
-        .unwrap_or(4.0)
-        * scale;
-    let dividers: &[Divider] = dividers_q.single().map(|d| d.0.as_slice()).unwrap_or(&[]);
+        .unwrap_or(4.0);
+    let dividers: &[DividerPixelRect] = packed_q
+        .single()
+        .map(|p| p.dividers.as_slice())
+        .unwrap_or(&[]);
     let hovered = window
         .cursor_position()
-        .map(|c| c * scale)
-        .and_then(|cursor_phys| divider_at(dividers, cursor_phys, cell_w, cell_h, tol));
+        .and_then(|cursor| divider_at(dividers, cursor, tol));
 
     for (handle, mut bg) in handles.iter_mut() {
-        let want = if Some(handle.divider) == hovered {
+        let want = if hovered
+            .is_some_and(|h| h.axis == handle.divider.axis && h.primary == handle.divider.primary)
+        {
             theme::ACCENT
         } else {
             theme::BORDER
@@ -204,39 +147,39 @@ fn divider_hover_feedback(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ozma_tty_renderer::CellMetrics;
-    use tmux_control_parser::PaneId;
-
-    fn test_metrics() -> TerminalCellMetricsResource {
-        TerminalCellMetricsResource {
-            metrics: CellMetrics {
-                advance_phys: 8.0,
-                line_height_phys: 16.0,
-                ascent_phys: 12.0,
-                descent_phys: 4.0,
-                underline_position_phys: -2.0,
-                underline_thickness_phys: 1.0,
-                max_overflow_phys: 0.0,
-            },
-            phys_font_size: 16,
-        }
-    }
+    use crate::tmux_render::{DividerPixelRect, PackedTmuxLayout};
+    use bevy::math::Vec2;
+    use std::collections::HashMap;
+    use tmux_control_parser::{DividerAxis, PaneId};
 
     #[test]
     fn reconcile_tracks_one_handle_per_divider() {
+        let vdiv = |pos: f32| DividerPixelRect {
+            axis: DividerAxis::Vertical,
+            primary: PaneId(1),
+            pos_px: pos,
+            span_start_px: 0.0,
+            span_end_px: 384.0,
+        };
+        let hdiv = |pos: f32| DividerPixelRect {
+            axis: DividerAxis::Horizontal,
+            primary: PaneId(1),
+            pos_px: pos,
+            span_start_px: 0.0,
+            span_end_px: 640.0,
+        };
+
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(test_metrics());
         app.add_systems(Update, reconcile_divider_handles);
-        app.world_mut().spawn((
-            Window {
-                ..Default::default()
-            },
-            PrimaryWindow,
-        ));
+
         let window = app
             .world_mut()
-            .spawn(TmuxDividers(vec![vdiv(40, 0, 24), hdiv(12, 0, 80)]))
+            .spawn(PackedTmuxLayout {
+                panes: HashMap::new(),
+                dividers: vec![vdiv(320.0), hdiv(192.0)],
+                bbox: Vec2::new(640.0, 384.0),
+            })
             .id();
         app.update();
 
@@ -255,53 +198,20 @@ mod tests {
             "handles belong to the dividers' window",
         );
 
-        // A layout change to a single divider despawns the stale handles and
-        // respawns the new set.
         app.world_mut()
             .entity_mut(window)
-            .insert(TmuxDividers(vec![vdiv(20, 0, 24)]));
+            .insert(PackedTmuxLayout {
+                panes: HashMap::new(),
+                dividers: vec![vdiv(200.0)],
+                bbox: Vec2::new(640.0, 384.0),
+            });
         app.update();
         assert_eq!(count(&mut app), 1, "reconciled to the new divider set");
 
-        // Collapsing to a single pane (no dividers) removes all handles.
         app.world_mut()
             .entity_mut(window)
-            .insert(TmuxDividers(vec![]));
+            .insert(PackedTmuxLayout::default());
         app.update();
         assert_eq!(count(&mut app), 0, "no dividers -> no handles");
-    }
-
-    fn vdiv(pos: i32, s: i32, e: i32) -> Divider {
-        Divider {
-            axis: DividerAxis::Vertical,
-            primary: PaneId(1),
-            pos,
-            span_start: s,
-            span_end: e,
-        }
-    }
-
-    fn hdiv(pos: i32, s: i32, e: i32) -> Divider {
-        Divider {
-            axis: DividerAxis::Horizontal,
-            primary: PaneId(1),
-            pos,
-            span_start: s,
-            span_end: e,
-        }
-    }
-
-    #[test]
-    fn vertical_handle_fills_gap_column_over_its_span() {
-        // pos=40 gap column, rows 2..10, 8x16 logical cells.
-        let (left, top, w, h) = handle_rect(vdiv(40, 2, 10), 8.0, 16.0);
-        assert_eq!((left, top, w, h), (320.0, 32.0, 8.0, 128.0));
-    }
-
-    #[test]
-    fn horizontal_handle_fills_gap_row_over_its_span() {
-        // pos=12 gap row, columns 0..80, 8x16 logical cells.
-        let (left, top, w, h) = handle_rect(hdiv(12, 0, 80), 8.0, 16.0);
-        assert_eq!((left, top, w, h), (0.0, 192.0, 640.0, 16.0));
     }
 }


### PR DESCRIPTION
## Problem

Tmux pane dividers rendered as full-cell-width grey bands (~8–16 px) instead of 1 px lines. Root cause: tmux allocates 1 cell per divider; ozmux rendered the entire cell as a grey gap. This also left blank strips at window edges because compressing the divider freed `cell_h - 1` px per split that had nowhere to go.

## Solution

Replaced the flat cell-coordinate pane layout with a recursive `collapse()` tree walk that compresses each divider gap to exactly 1 px and absorbs the freed space into the last child of each split ("last-fills-remaining"):

**`crates/tmux_session`**
- `TmuxLayoutChanged` now carries the full `WindowLayout` tree instead of a flat `Vec<PaneGeom>` + `Vec<Divider>`
- `TmuxWindowLayout(WindowLayout)` component retained on the window entity for downstream systems
- Removed `TmuxDividers` (dead after this PR — all consumers migrated to `PackedTmuxLayout`)

**`src/tmux_render.rs`**
- `collapse(root, cell_w, cell_h, gap)` — pure tree-walk returning `(HashMap<PaneId, Rect>, Vec<DividerPixelRect>, bbox)` in logical px
- `place()` recursive inner function; last child fills remaining available space to prevent blank edges
- `PackedTmuxLayout` component inserted on each window entity; change-gated to avoid spurious UI relayout passes
- Window container gets `BackgroundColor(theme::BORDER)` — 1 px pane gaps expose the backdrop colour
- Bug fix: `place()` Leaf now returns `node_size` (available space) instead of `size` (tmux dims); old code caused divider misalignment in nested splits where an inner split's last child received `available > dims*cell_size`
- Bug fix: divider `primary` now uses `last_pane_id()` (DFS-last leaf = the pane whose far edge touches the divider) instead of `first_pane_id()`; fixes resize-pane targeting wrong pane for compound before-children

**`src/ui/tmux_divider_handle.rs`**
- Reconcile reads `PackedTmuxLayout` instead of `TmuxDividers`; handles sized from `DividerPixelRect` pixel coords, no cell-size arithmetic
- `position_divider_handles` system removed (position is set at spawn from pixel rects)
- Hover feedback and drag handles both operate in logical px

**`src/tmux_mouse.rs`**
- `divider_at(dividers, cursor_logical, tol)` operates in logical px matching `DividerPixelRect.pos_px`; hit-test uses `[pos_px - tol, pos_px + 1 + tol]` on the major axis
- `GestureState::Resizing` stores `DividerPixelRect` instead of the old cell-space `Divider`

**`src/theme.rs`**
- `PANE_GAP_PX: f32 = 1.0` constant

<details><summary>Screenshots</summary>

Before: full-cell grey bands between panes  
After: 1 px grey lines, no blank strips at edges

</details>