### PR TITLE
feat(tmux): inline-webview mouse routing & focus (focus-based + pointer-gated wheel)

### DIFF
--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -528,5 +528,4 @@ mod tests {
             "window carries its layout tree after %layout-change",
         );
     }
-
 }

--- a/docs/superpowers/plans/2026-06-16-tmux-webview-mouse-focus.md
+++ b/docs/superpowers/plans/2026-06-16-tmux-webview-mouse-focus.md
@@ -1,0 +1,925 @@
+# tmux inline-webview mouse routing & focus — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an inline webview embedded in a tmux pane receive wheel/click/move (focus-based + pointer-gated), instead of the mouse wheel unconditionally entering tmux copy mode.
+
+**Architecture:** Mirror the proven native inline-routing path (`src/input/mouse_buttons.rs` `route_inline_left_click`, `src/input/mouse_wheel.rs` `resolve_inline_wheel_target`, `src/inline_webview.rs` `forward_inline_mouse_moves`) into the three tmux input systems, keyed off `TmuxPane` hosts instead of `SurfaceMarker + Slotted`. Focus lives in the existing `FocusedWebview` resource, granted by an ungated `Browsers::set_focus` before the first click and preserved under tmux by a focus-validator change. Geometry helpers (`inline_hit_at`, `inline_local_dip`, `focused_inline_of`, `TerminalOverlays` projection) are reused unchanged.
+
+**Tech Stack:** Rust 2024, Bevy 0.18 ECS, `bevy_cef` / `bevy_cef_core` (CEF webviews), `ozmux_tmux` (tmux control mode).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-tmux-webview-mouse-focus-design.md` — read it first.
+
+---
+
+## Reference reading (do this before Task 1)
+
+Read these so the adaptations below are unambiguous:
+
+- `src/input/mouse_buttons.rs`: `InlineRouteParams` (90-100), `resolve_pane_at_phys` (127), `phys_to_terminal_local` (159), `route_inline_left_click` (731-810), `inline_release_dip` (816-840).
+- `src/input/mouse_wheel.rs`: `InlineWheelTarget` (≈170), `InlineWheelParams` (≈74), `aggregate_wheel_delta` (≈190), `inline_wheel_delta` (≈230), `resolve_inline_wheel_target` (≈252).
+- `src/inline_webview.rs`: `focused_inline_of` (352), `InlineHit` + `inline_hit_at` (365-424), `inline_local_dip` (432), `forward_inline_mouse_moves` (563-609).
+- `src/tmux_mouse.rs`: `OzmuxTmuxMousePlugin` (43-48), `TmuxMouseGesture` (104-108), `pane_under_cursor` (135-143), the `arbiter` modal guard (227-244) and its `for ev in buttons.read()` press/release loop (266-415).
+- `src/tmux_input.rs`: `OzmuxTmuxInputPlugin` (32-46), `forward_wheel_to_tmux` (392-482).
+- `src/webview_render.rs`: `sync_focused_webview` (93-114).
+
+## File structure
+
+All changes are tmux-local; native path and shared helpers are untouched.
+
+- `src/webview_render.rs` — Task 1: tmux-aware focus preservation/GC in `sync_focused_webview`.
+- `src/tmux_mouse.rs` — Task 2: `tmux_pane_local_at` helper, `inline_press` field on `TmuxMouseGesture`, `TmuxInlineRouteParams`, `route_tmux_inline_left_click`, `tmux_inline_release_dip`, arbiter wiring, modal-guard change. Task 3: `forward_tmux_inline_mouse_moves` system + plugin registration.
+- `src/tmux_input.rs` — Task 4: `TmuxInlineWheelTarget`, `TmuxInlineWheelParams`, `resolve_tmux_inline_wheel_target`, `aggregate_tmux_wheel_cells`, `forward_wheel_to_tmux` rewrite.
+
+Run one crate's worth of tests with `cargo test --bin ozmux-gui <name>` (these systems live in the root binary, `ozmux-gui`).
+
+---
+
+## Task 1: tmux-aware focus validator
+
+`sync_focused_webview` clears `FocusedWebview` every frame unless the focused inline child's parent is the **old-multiplexer** active surface — which the tmux backend never populates, so a tmux-pane inline focus is clobbered one frame after a click sets it. Add a preservation arm: keep focus while it points at an inline child of a live `TmuxPane`. Despawn GC still works (the existing fall-through clears focus when the child entity is gone).
+
+**Files:**
+- Modify: `src/webview_render.rs:93-114` (`sync_focused_webview`)
+- Test: `src/webview_render.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/webview_render.rs` (it already uses `RunSystemOnce`; mirror the existing `focused_webview_follows_active_pane` test for setup of `FocusedWebview`, `InlineWebview`, and a parent entity). Use `ozmux_tmux::TmuxPane`.
+
+```rust
+#[test]
+fn tmux_pane_inline_focus_is_preserved() {
+    use ozmux_tmux::{PaneId, TmuxPane};
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(ozmux_multiplexer::MultiplexerPlugin);
+    app.init_resource::<FocusedWebview>();
+    app.add_systems(Update, sync_focused_webview);
+
+    // A TmuxPane host with an InlineWebview child; no old-mux active surface.
+    let pane = app.world_mut().spawn(TmuxPane::new(PaneId(1))).id();
+    let child = app
+        .world_mut()
+        .spawn((
+            ChildOf(pane),
+            InlineWebview { view_id: "v".into(), instance_id: None, slot: 0 },
+        ))
+        .id();
+    app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<FocusedWebview>().0,
+        Some(child),
+        "an inline child of a live TmuxPane must keep FocusedWebview across the per-frame sync",
+    );
+}
+
+#[test]
+fn tmux_pane_inline_focus_is_gc_on_despawn() {
+    use ozmux_tmux::{PaneId, TmuxPane};
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(ozmux_multiplexer::MultiplexerPlugin);
+    app.init_resource::<FocusedWebview>();
+    app.add_systems(Update, sync_focused_webview);
+
+    let pane = app.world_mut().spawn(TmuxPane::new(PaneId(1))).id();
+    let child = app
+        .world_mut()
+        .spawn((
+            ChildOf(pane),
+            InlineWebview { view_id: "v".into(), instance_id: None, slot: 0 },
+        ))
+        .id();
+    app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+    app.world_mut().entity_mut(child).despawn();
+
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<FocusedWebview>().0, None,
+        "a despawned inline child must be GC'd out of FocusedWebview",
+    );
+}
+```
+
+> NOTE: confirm `TmuxPane`'s constructor — if `TmuxPane::new(PaneId)` does not exist, build it the way the existing `tmux_mouse.rs`/`tmux_render.rs` tests construct a `TmuxPane` (grep `TmuxPane {` / `TmuxPane::`). The `InlineWebview` literal fields are `view_id`, `instance_id`, `slot` (see `src/inline_webview.rs:44-55`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --bin ozmux-gui tmux_pane_inline_focus -- --test-threads=1`
+Expected: FAIL — `tmux_pane_inline_focus_is_preserved` asserts `Some(child)` but the current sync clears it to `None`.
+
+- [ ] **Step 3: Implement the preservation arm**
+
+Add the import (in the existing top-of-file `use` block, no blank-line grouping):
+
+```rust
+use ozmux_tmux::TmuxPane;
+```
+
+Add a `tmux_panes` query parameter and the preservation arm at the top of `sync_focused_webview` (before the old-mux `active_surface` resolution). Mutable params stay first:
+
+```rust
+pub(crate) fn sync_focused_webview(
+    mut focused: ResMut<FocusedWebview>,
+    mux: MultiplexerCommands,
+    attached_workspace: Query<Entity, (With<WorkspaceMarker>, With<AttachedWorkspace>)>,
+    webviews: Query<(), With<WebviewSource>>,
+    non_interactive: Query<(), With<NonInteractive>>,
+    inline_parents: Query<&ChildOf, With<InlineWebview>>,
+    tmux_panes: Query<(), With<TmuxPane>>,
+) {
+    // Under the tmux backend FocusedWebview is click-driven, not active-pane
+    // driven: preserve it while it points at an inline child of a live TmuxPane.
+    // A despawned child fails `inline_parents.get` and falls through to the
+    // old-mux path below, which clears it (GC).
+    if let Some(child) = focused.0
+        && let Ok(parent) = inline_parents.get(child)
+        && tmux_panes.contains(parent.parent())
+    {
+        return;
+    }
+
+    let active_surface = attached_workspace
+        .iter()
+        .next()
+        .and_then(|workspace| mux.workspaces_active_pane(workspace))
+        .and_then(|pane| mux.panes_active_surface(pane));
+    if focused_inline_of(Some(&focused), &inline_parents, active_surface).is_some() {
+        return;
+    }
+    let active = active_surface
+        .filter(|surface| webviews.contains(*surface) && !non_interactive.contains(*surface));
+    if focused.0 != active {
+        focused.0 = active;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui tmux_pane_inline_focus -- --test-threads=1`
+Expected: PASS (both tests).
+Also run the existing regression: `cargo test --bin ozmux-gui focused_webview_follows_active_pane -- --test-threads=1` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/webview_render.rs
+git commit -m "feat(tmux): preserve click-driven inline-webview focus under the tmux backend"
+```
+
+---
+
+## Task 2: arbiter inline click routing + `inline_press` marker
+
+Route a left press inside an interactive inline rect to the webview (focus + click), consuming it so it never arms divider-drag/drag-select; route the matching release to the same child. Drop the blanket `focused_webview` drain from the modal guard (inline routing now owns focus).
+
+**Files:**
+- Modify: `src/tmux_mouse.rs` — add `tmux_pane_local_at`, `TmuxInlineRouteParams`, `route_tmux_inline_left_click`, `tmux_inline_release_dip`; add `inline_press` to `TmuxMouseGesture`; wire into `arbiter`; change the modal guard.
+- Test: `src/tmux_mouse.rs` `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Add imports + the `inline_press` field + the pane-local helper**
+
+Add to the top `use` block (no blank-line grouping). Mirror native import paths:
+
+```rust
+use crate::input::mouse_buttons::phys_to_terminal_local;
+use crate::inline_webview::{InlineHit, InlineWebview, inline_hit_at, inline_local_dip};
+use crate::osc_webview::NonInteractive;
+use bevy::ecs::system::SystemParam;
+use bevy_cef::prelude::{FocusedWebview, PointerButton};
+use bevy_cef_core::prelude::Browsers;
+use ozma_tty_renderer::prelude::TerminalOverlays;
+```
+
+> NOTE: `FocusedWebview` is already imported at `src/tmux_mouse.rs:31` — extend that line to `use bevy_cef::prelude::{FocusedWebview, PointerButton};` rather than adding a duplicate. Confirm `PointerButton` is re-exported from `bevy_cef::prelude` (it is the type `route_inline_left_click` uses in `mouse_buttons.rs`; match whatever path that file imports).
+
+Add the field to `TmuxMouseGesture` (`src/tmux_mouse.rs:104-108`):
+
+```rust
+#[derive(Resource, Default)]
+pub(crate) struct TmuxMouseGesture {
+    state: GestureState,
+    click: ClickTracker,
+    /// The in-flight inline-webview press (mirrors native
+    /// `MouseSelectionState.inline_press`): the child a left press inside an
+    /// interactive inline rect was forwarded to, so the matching release's
+    /// click-up routes to the SAME child even if the pointer drifted off-rect.
+    inline_press: Option<Entity>,
+}
+```
+
+Add the pane-local resolver (private helper, placed with the other free functions near `pane_under_cursor`):
+
+```rust
+/// Resolves the `TmuxPane` terminal entity under `cursor_phys` (physical px)
+/// and the pointer in that pane's terminal-local physical px, or `None` when
+/// no pane covers the point. The tmux analog of native `resolve_pane_at_phys`.
+fn tmux_pane_local_at(
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    cursor_phys: Vec2,
+) -> Option<(Entity, Vec2)> {
+    panes.iter().find_map(|(entity, _, node, transform)| {
+        if !node.contains_point(*transform, cursor_phys) {
+            return None;
+        }
+        let local = phys_to_terminal_local(node, transform, cursor_phys)?;
+        Some((entity, local))
+    })
+}
+```
+
+- [ ] **Step 2: Write the failing test (press inside rect focuses + consumes)**
+
+Add a fixture + test to `src/tmux_mouse.rs` tests. Model the fixture on `tmux_render.rs`/`mouse_wheel.rs` (`make_wheel_app`): a `TmuxPane` host at a known node, a `TerminalOverlays` with one rect, and an `InlineWebview` child. Build the `arbiter` app with the resources it reads (`TmuxMouseGesture`, `TmuxConnection`, `CopyModeQueries`, `SessionPicker`, `CopyPrompt`, `FocusedWebview`, metrics, a focused `PrimaryWindow`, `Time<Real>`), then drive a left press at a cursor inside the rect.
+
+```rust
+#[test]
+fn inline_press_focuses_child_and_consumes() {
+    let (mut app, _pane, child) = make_arbiter_inline_app(); // helper below
+    set_cursor(&mut app, Vec2::new(40.0, 48.0)); // inside the rect (see fixture)
+    write_button(&mut app, MouseButton::Left, ButtonState::Pressed);
+
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<FocusedWebview>().0, Some(child),
+        "a press inside an interactive inline rect must focus that child",
+    );
+    assert_eq!(
+        app.world().resource::<TmuxMouseGesture>().state,
+        GestureState::Idle,
+        "a consumed inline press must NOT arm a Pressed/Selecting gesture",
+    );
+}
+
+#[test]
+fn inline_off_rect_press_releases_focus_and_falls_through() {
+    let (mut app, pane, child) = make_arbiter_inline_app();
+    app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+    set_cursor(&mut app, Vec2::new(400.0, 400.0)); // inside the pane node, outside the rect
+
+    write_button(&mut app, MouseButton::Left, ButtonState::Pressed);
+    app.update();
+
+    assert_eq!(
+        app.world().resource::<FocusedWebview>().0, None,
+        "an off-rect press must release inline focus",
+    );
+    // The fall-through path focuses the pane: state becomes Pressed on that pane.
+    assert!(
+        matches!(
+            app.world().resource::<TmuxMouseGesture>().state,
+            GestureState::Pressed { pane: p, .. } if p == pane
+        ),
+        "an off-rect press must fall through to the normal pane gesture",
+    );
+}
+```
+
+The fixture (CEF-less: no `Browsers`, so state effects apply but no CEF forward) — add to the tests module:
+
+```rust
+fn make_arbiter_inline_app() -> (App, Entity, Entity) {
+    use crate::inline_webview::InlineWebview;
+    use ozma_tty_renderer::prelude::TerminalOverlays;
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_message::<MouseButtonInput>();
+    app.insert_non_send_resource(TmuxConnection::default());
+    app.init_resource::<TmuxMouseGesture>();
+    app.init_resource::<CopyModeQueries>();
+    app.init_resource::<SessionPicker>();
+    app.init_resource::<CopyPrompt>();
+    app.init_resource::<FocusedWebview>();
+    app.insert_resource(test_metrics()); // existing helper, 8x16 px cells
+    app.add_systems(Update, arbiter);
+
+    // Pane node: window-centered 800x600 at (400,300) → top-left (0,0), like make_wheel_app.
+    let pane = app
+        .world_mut()
+        .spawn((
+            tmux_pane_fixture(1, 100, 37), // see NOTE — width/height in cells
+            ComputedNode { size: Vec2::new(800.0, 600.0), ..ComputedNode::DEFAULT },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalOverlays::default(),
+        ))
+        .id();
+    // Rect rows 2..12, cols 3..43 → phys y 32..192, x 24..344 at 8x16 px.
+    app.world_mut().get_mut::<TerminalOverlays>(pane).unwrap().rects[0] =
+        IVec4::new(2, 3, 10, 40);
+    let child = app
+        .world_mut()
+        .spawn((
+            ChildOf(pane),
+            InlineWebview { view_id: "v".into(), instance_id: None, slot: 0 },
+        ))
+        .id();
+
+    app.world_mut().spawn((
+        Window { focused: true, resolution: WindowResolution::new(800, 600), ..default() },
+        PrimaryWindow,
+    ));
+    (app, pane, child)
+}
+
+fn set_cursor(app: &mut App, phys: Vec2) {
+    let win = app
+        .world_mut()
+        .query_filtered::<Entity, With<PrimaryWindow>>()
+        .single(app.world())
+        .unwrap();
+    app.world_mut()
+        .get_mut::<Window>(win)
+        .unwrap()
+        .set_physical_cursor_position(Some(bevy::math::DVec2::new(phys.x as f64, phys.y as f64)));
+}
+
+fn write_button(app: &mut App, button: MouseButton, state: ButtonState) {
+    app.world_mut()
+        .resource_mut::<bevy::ecs::message::Messages<MouseButtonInput>>()
+        .write(MouseButtonInput { button, state, window: Entity::PLACEHOLDER });
+}
+```
+
+> NOTE: `tmux_pane_fixture(id, w, h)` / `tmux_pane_fixture` is a placeholder — construct a `TmuxPane` with `dims.width`/`dims.height` set (so `cell_at_pane` and the fall-through pane-focus work) the same way the existing `tmux_mouse.rs` tests build one. Grep `TmuxPane {` in the test module; if there is no existing constructor, build the struct literal. The pane must carry `TmuxPane`, `ComputedNode`, `UiGlobalTransform`, and `TerminalOverlays` so both `pane_under_cursor` and `tmux_pane_local_at` resolve it.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test --bin ozmux-gui inline_press_focuses_child_and_consumes inline_off_rect -- --test-threads=1`
+Expected: FAIL — `arbiter` does not yet route inline clicks; `FocusedWebview` stays unchanged and the gesture arms `Pressed` on the in-rect press.
+
+- [ ] **Step 4: Add the route helpers + release-dip + wire the arbiter**
+
+Add the SystemParam bundle and helpers (private; place after `pane_under_cursor`). This mirrors native `InlineRouteParams` / `route_inline_left_click` / `inline_release_dip`:
+
+```rust
+/// Inline-routing params for the arbiter, bundled to stay within Bevy's
+/// system-parameter limit. `focused_webview` / `browsers` are optional so
+/// CEF-less tests construct the system (state effects still apply).
+#[derive(SystemParam)]
+struct TmuxInlineRouteParams<'w, 's> {
+    focused_webview: Option<ResMut<'w, FocusedWebview>>,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
+}
+
+/// Routes a left press/release through the inline-webview layer, returning
+/// `true` when the event was consumed and must NOT reach the tmux gesture
+/// pipeline. Mirrors native `route_inline_left_click`: a press inside an
+/// interactive rect sets `FocusedWebview`, issues the UNGATED `set_focus`
+/// BEFORE the gated `send_mouse_click` (CEF drops clicks to a browser with no
+/// `focused_frame()`, so the first click would otherwise be swallowed),
+/// forwards the press in DIP, and records the in-flight press; a press outside
+/// every rect clears an inline `FocusedWebview` and returns `false`. Release
+/// forwards the click-up to the recorded child (drift-tolerant) and clears.
+#[allow(clippy::too_many_arguments)]
+fn route_tmux_inline_left_click(
+    gesture: &mut TmuxMouseGesture,
+    route: &mut TmuxInlineRouteParams,
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    terminal: Entity,
+    local_phys: Vec2,
+    cursor_phys: Vec2,
+    button_state: ButtonState,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> bool {
+    match button_state {
+        ButtonState::Pressed => {
+            // A fresh press invalidates any stale in-flight marker (its release
+            // was lost, e.g. released off-window where the arbiter early-returns).
+            gesture.inline_press = None;
+            let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
+                inline_hit_at(
+                    &route.children, &route.inline, overlays, terminal,
+                    local_phys, cell_w_phys, cell_h_phys, scale,
+                )
+            });
+            let Some(hit) = hit else {
+                if let Some(focused) = route.focused_webview.as_deref_mut()
+                    && focused.0.is_some_and(|c| route.inline_parents.contains(c))
+                {
+                    focused.0 = None;
+                }
+                return false;
+            };
+            if let Some(focused) = route.focused_webview.as_deref_mut()
+                && focused.0 != Some(hit.child)
+            {
+                focused.0 = Some(hit.child);
+            }
+            if let Some(browsers) = route.browsers.as_deref() {
+                browsers.set_focus(&hit.child, true);
+                browsers.send_mouse_click(&hit.child, hit.local_dip, PointerButton::Primary, false);
+            }
+            gesture.inline_press = Some(hit.child);
+            true
+        }
+        ButtonState::Released => {
+            let Some(child) = gesture.inline_press.take() else {
+                return false;
+            };
+            if let Some(browsers) = route.browsers.as_deref()
+                && let Some(dip) = tmux_inline_release_dip(
+                    route, panes, child, cursor_phys, cell_w_phys, cell_h_phys, scale,
+                )
+            {
+                browsers.send_mouse_click(&child, dip, PointerButton::Primary, true);
+            }
+            true
+        }
+    }
+}
+
+/// Webview-local DIP for a release on `child`, WITHOUT containment (a pointer
+/// that drifted off the rect still produces a release position). `None` when
+/// the child/terminal/rect chain is gone. The tmux analog of native
+/// `inline_release_dip`.
+fn tmux_inline_release_dip(
+    route: &TmuxInlineRouteParams,
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    child: Entity,
+    cursor_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> Option<Vec2> {
+    let terminal = route.inline_parents.get(child).ok()?.parent();
+    let (_, _, node, transform) = panes.get(terminal).ok()?;
+    let local_phys = phys_to_terminal_local(node, transform, cursor_phys)?;
+    let (view, _) = route.inline.get(child).ok()?;
+    inline_local_dip(
+        route.overlay_rects.get(terminal).ok()?,
+        view.slot, local_phys, cell_w_phys, cell_h_phys, scale,
+    )
+}
+```
+
+Now wire it into `arbiter`. Add `mut inline_route: TmuxInlineRouteParams` to the signature and **replace** the `focused_webview: Res<FocusedWebview>` parameter (the bundle owns it now). Change the modal guard (lines 240-244) to drop the `focused_webview` term:
+
+```rust
+    // NOTE: a gesture behind a picker / copy-search prompt must not mutate
+    // tmux. The focused-webview case is NOT drained here — the inline click
+    // pre-step below owns focus (in-rect press keeps it, off-rect press
+    // releases it and drives tmux).
+    if picker.open || copy_prompt.open.is_some() {
+        buttons.clear();
+        gesture.state = GestureState::Idle;
+        return;
+    }
+```
+
+Inside `for ev in buttons.read()`, at the very top of the loop body (after the `if ev.button != Left { continue; }` guard, before the `match ev.state`), offer the event to the inline layer first:
+
+```rust
+        if ev.button != bevy::input::mouse::MouseButton::Left {
+            continue;
+        }
+        if let Some(cursor_phys) = window.cursor_position().map(|c| c * scale)
+            && let Some((terminal, local_phys)) = tmux_pane_local_at(&panes, cursor_phys)
+            && route_tmux_inline_left_click(
+                &mut gesture, &mut inline_route, &panes, terminal, local_phys,
+                cursor_phys, ev.state, cell_w, cell_h, scale,
+            )
+        {
+            continue; // consumed by the inline layer; skip the tmux gesture pipeline
+        }
+        match ev.state { /* ... existing Pressed / Released arms unchanged ... */ }
+```
+
+> NOTE: `gesture` is `ResMut<TmuxMouseGesture>`; pass `&mut gesture` (deref). The existing arms read `gesture.state` / `gesture.click` — borrow-checker: the inline call finishes (returns `bool`) before `match ev.state`, so there is no overlapping borrow. If the borrow checker complains about `gesture` being borrowed across the `for` body, hoist `cursor_phys`/`tmux_pane_local_at` results into locals computed before the call.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui inline_press_focuses_child_and_consumes inline_off_rect -- --test-threads=1`
+Expected: PASS (both).
+
+- [ ] **Step 6: Regression — existing arbiter tests still pass**
+
+Run: `cargo test --bin ozmux-gui --  --test-threads=1 tmux_mouse`
+(Or run the whole binary's tmux mouse tests.) Expected: existing tests (`gesture_state_default_is_idle`, divider hit-tests, click-count, `left_press_without_cursor_stays_idle`, multi-select) PASS unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tmux_mouse.rs
+git commit -m "feat(tmux): route inline-webview clicks (focus + CEF) in the mouse arbiter"
+```
+
+---
+
+## Task 3: tmux inline move/hover/drag forwarder
+
+A single stateless `CursorMoved`-driven system that forwards pointer motion over an interactive inline rect to CEF, forwarding whatever buttons are held (so hover and in-rect drag both work). Exact mirror of native `forward_inline_mouse_moves`, but over `TmuxPane` hosts.
+
+**Files:**
+- Modify: `src/tmux_mouse.rs` — add `forward_tmux_inline_mouse_moves`; register it in `OzmuxTmuxMousePlugin`.
+- Test: `src/tmux_mouse.rs` tests
+
+- [ ] **Step 1: Write the failing test (routing decision via hit-test)**
+
+Because CEF forwarding needs `Browsers` (absent in tests), assert the *resolution* the system performs — extract the resolution into a testable pure helper and test that.
+
+```rust
+#[test]
+fn move_resolves_inline_child_over_rect() {
+    let (mut app, _pane, child) = make_arbiter_inline_app();
+    let hit = app
+        .world_mut()
+        .run_system_once(move |
+            panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+            children: Query<&Children>,
+            inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+            overlays: Query<&TerminalOverlays>,
+        | {
+            let (terminal, local) = tmux_pane_local_at(&panes, Vec2::new(40.0, 48.0)).unwrap();
+            inline_hit_at(&children, &inline, overlays.get(terminal).unwrap(),
+                terminal, local, 8.0, 16.0, 1.0).map(|h| h.child)
+        })
+        .unwrap();
+    assert_eq!(hit, Some(child), "pointer over the rect must resolve the inline child");
+}
+
+#[test]
+fn move_resolves_nothing_off_rect() {
+    let (mut app, _pane, _child) = make_arbiter_inline_app();
+    let hit = app
+        .world_mut()
+        .run_system_once(|
+            panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+            children: Query<&Children>,
+            inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+            overlays: Query<&TerminalOverlays>,
+        | {
+            let (terminal, local) = tmux_pane_local_at(&panes, Vec2::new(400.0, 400.0)).unwrap();
+            inline_hit_at(&children, &inline, overlays.get(terminal).unwrap(),
+                terminal, local, 8.0, 16.0, 1.0).map(|h| h.child)
+        })
+        .unwrap();
+    assert_eq!(hit, None, "pointer over terminal text must resolve no inline child");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails (compile error — system not yet present / imports)**
+
+Run: `cargo test --bin ozmux-gui move_resolves -- --test-threads=1`
+Expected: FAIL to compile until `RunSystemOnce` is imported in the test module (`use bevy::ecs::system::RunSystemOnce;`) — add it; then the test compiles and (since `tmux_pane_local_at`/`inline_hit_at` already exist from Task 2) it should PASS. If it already passes, that is fine — these tests pin the resolution helper; proceed to add the system itself.
+
+- [ ] **Step 3: Implement the forwarder system**
+
+Add to `src/tmux_mouse.rs`. Mirror `forward_inline_mouse_moves` (`src/inline_webview.rs:563`). Read `CursorMoved`, skip while a modal owns input, resolve the pane + rect, forward held buttons:
+
+```rust
+/// Forwards pointer motion over an interactive inline rect of a tmux pane to
+/// the child's CEF browser (`send_mouse_move`, webview-local DIP), forwarding
+/// whatever mouse buttons are held so the one system serves both hover and an
+/// in-rect drag. The tmux analog of native `forward_inline_mouse_moves`:
+/// `CursorMoved`-driven (one forward per frame, latest position), and
+/// focus-gated inside `bevy_cef` so motion over an unfocused browser is
+/// dropped browser-side. `Browsers` is optional so CEF-less tests construct it.
+fn forward_tmux_inline_mouse_moves(
+    mut cursor_msg: MessageReader<CursorMoved>,
+    panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    children: Query<&Children>,
+    inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<&TerminalOverlays>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    metrics: Res<TerminalCellMetricsResource>,
+    mouse_buttons: Res<ButtonInput<MouseButton>>,
+    picker: Res<SessionPicker>,
+    copy_prompt: Res<CopyPrompt>,
+    browsers: Option<NonSend<Browsers>>,
+) {
+    let Some(moved) = cursor_msg.read().last() else {
+        return;
+    };
+    if picker.open || copy_prompt.open.is_some() {
+        return;
+    }
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    let scale = window.scale_factor();
+    let cursor_phys = moved.position * scale;
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let Some((terminal, local_phys)) = tmux_pane_local_at(&panes, cursor_phys) else {
+        return;
+    };
+    let Ok(overlays) = overlay_rects.get(terminal) else {
+        return;
+    };
+    let Some(hit) = inline_hit_at(
+        &children, &inline, overlays, terminal, local_phys, cell_w, cell_h, scale,
+    ) else {
+        return;
+    };
+    if let Some(browsers) = browsers.as_ref() {
+        browsers.send_mouse_move(&hit.child, mouse_buttons.get_pressed(), hit.local_dip, false);
+    }
+}
+```
+
+Register it in `OzmuxTmuxMousePlugin::build` (mirror native: `InputPhase::Hover`):
+
+```rust
+impl Plugin for OzmuxTmuxMousePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TmuxMouseGesture>();
+        app.add_systems(Update, arbiter.in_set(InputPhase::Dispatch));
+        app.add_systems(Update, forward_tmux_inline_mouse_moves.in_set(InputPhase::Hover));
+    }
+}
+```
+
+> NOTE: ensure `MouseButton`, `CursorMoved`, and `ButtonInput` are imported (the arbiter already uses `MouseButton`; add `bevy::input::mouse::CursorMoved` and `bevy::input::ButtonInput` if not in scope — grep the existing top imports).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui move_resolves -- --test-threads=1`
+Expected: PASS. Also `cargo build --bin ozmux-gui` to confirm the system registers and compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tmux_mouse.rs
+git commit -m "feat(tmux): forward hover/drag over inline-webview rects to CEF"
+```
+
+---
+
+## Task 4: pointer-gated inline wheel
+
+Forward the wheel to a focused inline webview only when the pointer is over its rect; otherwise run the existing tmux path. Remove the blanket `focused_webview.0.is_some()` early-return.
+
+**Files:**
+- Modify: `src/tmux_input.rs` — add `TmuxInlineWheelTarget`, `TmuxInlineWheelParams`, `resolve_tmux_inline_wheel_target`, `aggregate_tmux_wheel_cells`; rewrite the head of `forward_wheel_to_tmux`.
+- Test: `src/tmux_input.rs` tests
+
+- [ ] **Step 1: Add imports + the target type + params bundle + resolver**
+
+Add to the top `use` block of `src/tmux_input.rs` (extend the existing `use bevy_cef::prelude::FocusedWebview;` line and add the others):
+
+```rust
+use crate::input::mouse_buttons::phys_to_terminal_local;
+use crate::inline_webview::{InlineWebview, focused_inline_of, inline_hit_at};
+use crate::osc_webview::NonInteractive;
+use bevy::ecs::system::SystemParam;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy_cef::prelude::FocusedWebview;
+use bevy_cef_core::prelude::Browsers;
+use ozma_tty_renderer::prelude::TerminalOverlays;
+use ozmux_tmux::TmuxPane;
+```
+
+> NOTE: `tmux_pane_local_at` is private to `tmux_mouse.rs`. Either (a) make it `pub(crate)` in `tmux_mouse.rs` and import it here, or (b) duplicate the 6-line resolver locally. Prefer (a): change `fn tmux_pane_local_at` to `pub(crate) fn tmux_pane_local_at` in Task 2 and `use crate::tmux_mouse::tmux_pane_local_at;` here.
+
+Add the target + resolver (mirror native `InlineWheelTarget` / `resolve_inline_wheel_target` / `inline_wheel_delta`):
+
+```rust
+/// A focused inline webview claiming the wheel: the child to forward to and
+/// the pointer in its webview-local DIP.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct TmuxInlineWheelTarget {
+    child: Entity,
+    position_dip: Vec2,
+}
+
+/// Wheel-routing params bundled to stay within Bevy's system-parameter limit.
+#[derive(SystemParam)]
+struct TmuxInlineWheelParams<'w, 's> {
+    focused_webview: Res<'w, FocusedWebview>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    panes: Query<'w, 's, (Entity, &'static TmuxPane, &'static ComputedNode, &'static UiGlobalTransform)>,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
+}
+
+/// Resolves the focused inline webview under the pointer, or `None` (the tmux
+/// path runs). `Some` only when `FocusedWebview` holds an inline child of the
+/// pane under the pointer AND the pointer is over that child's rect — exactly
+/// native `resolve_inline_wheel_target`, over TmuxPane hosts.
+fn resolve_tmux_inline_wheel_target(
+    params: &TmuxInlineWheelParams,
+    cursor_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Option<TmuxInlineWheelTarget> {
+    let (terminal, local_phys) = crate::tmux_mouse::tmux_pane_local_at(&params.panes, cursor_phys)?;
+    let focused_child = focused_inline_of(Some(&params.focused_webview), &params.inline_parents, Some(terminal))?;
+    let overlays = params.overlay_rects.get(terminal).ok()?;
+    let hit = inline_hit_at(
+        &params.children, &params.inline, overlays, terminal,
+        local_phys, cell_w_phys, cell_h_phys, scale_factor,
+    )?;
+    (hit.child == focused_child).then_some(TmuxInlineWheelTarget {
+        child: hit.child,
+        position_dip: hit.local_dip,
+    })
+}
+
+/// Converts one `MouseWheel` event to the RAW CEF wheel delta (`Line → ×120`,
+/// `Pixel` unchanged, NO sign flip) — identical to native `inline_wheel_delta`.
+fn tmux_inline_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
+    match unit {
+        MouseScrollUnit::Line => Vec2::new(x, y) * 120.0,
+        MouseScrollUnit::Pixel => Vec2::new(x, y),
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test (target resolution)**
+
+Mirror `mouse_wheel.rs`'s `target_resolves_when_focused_inline_under_pointer` / `target_none_when_*`. Build a `TmuxPane` + `TerminalOverlays` + `InlineWebview` fixture (reuse the Task 2 fixture shape) and run `resolve_tmux_inline_wheel_target` via `RunSystemOnce`.
+
+```rust
+#[test]
+fn wheel_target_resolves_when_focused_inline_under_pointer() {
+    let (mut app, _pane, child) = make_tmux_wheel_app(); // fixture mirroring make_arbiter_inline_app
+    app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+    let target = run_resolve_wheel_target(&mut app, Vec2::new(40.0, 48.0));
+    assert_eq!(target.map(|t| t.child), Some(child));
+}
+
+#[test]
+fn wheel_target_none_off_rect() {
+    let (mut app, _pane, child) = make_tmux_wheel_app();
+    app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+    assert_eq!(run_resolve_wheel_target(&mut app, Vec2::new(400.0, 400.0)), None);
+}
+
+#[test]
+fn wheel_target_none_when_unfocused() {
+    let (mut app, _pane, _child) = make_tmux_wheel_app(); // FocusedWebview stays None
+    assert_eq!(run_resolve_wheel_target(&mut app, Vec2::new(40.0, 48.0)), None);
+}
+```
+
+`run_resolve_wheel_target` runs the resolver with the cursor set; provide cell metrics 8x16, scale 1:
+
+```rust
+fn run_resolve_wheel_target(app: &mut App, cursor_phys: Vec2) -> Option<TmuxInlineWheelTarget> {
+    app.world_mut()
+        .run_system_once(move |params: TmuxInlineWheelParams| {
+            resolve_tmux_inline_wheel_target(&params, cursor_phys, 8.0, 16.0, 1.0)
+        })
+        .unwrap()
+}
+```
+
+> NOTE: `make_tmux_wheel_app` is the same fixture as Task 2's `make_arbiter_inline_app` minus the `arbiter` system — factor the fixture into a shared test helper if both modules need it, or duplicate it in this module's tests.
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test --bin ozmux-gui wheel_target_ -- --test-threads=1`
+Expected: FAIL to compile (resolver/types not yet referenced by a test) → then FAIL/PASS as the resolver is added. After Step 1 they should compile; the assertions pass once the resolver is correct. If `wheel_target_none_when_unfocused` fails, check `focused_inline_of` is passed `Some(terminal)` as `active_surface`.
+
+- [ ] **Step 4: Rewrite the head of `forward_wheel_to_tmux`**
+
+Add `inline: TmuxInlineWheelParams` to the signature. At the top (after computing `dpr`, `cell_h_logical`, and physical cell metrics), resolve the target, forward inline events, and drop the `focused_webview` term from the modal guard. Replace the existing aggregate+guard prologue:
+
+```rust
+    let dpr = window.scale_factor().max(0.5);
+    let cell_h_logical = (metrics.metrics.line_height_phys.floor() / dpr).max(1.0);
+    let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cursor_phys = window.cursor_position().map(|c| c * dpr);
+
+    let target = cursor_phys.and_then(|c| {
+        resolve_tmux_inline_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr)
+    });
+
+    let Some(delta_cells) =
+        aggregate_tmux_wheel_cells(&mut wheel, target, inline.browsers.as_deref(), cell_h_logical)
+    else {
+        // Either the frame was empty or every event was forwarded inline.
+        if target.is_some() {
+            accumulator.residual_cells = 0.0;
+        }
+        return;
+    };
+    // NOTE: a background scroll must not mutate tmux; reset residual on every
+    // guarded return so momentum can't lurch on resume. (focused_webview is NOT
+    // a guard here — the pointer-gated target above handles webview scrolling.)
+    if !window.focused || picker.open || copy_prompt.open.is_some() {
+        accumulator.residual_cells = 0.0;
+        return;
+    }
+```
+
+Delete the old `aggregate_wheel_cells(&mut wheel, ...)` call and the old guard line that included `focused_webview.0.is_some()`. Remove the now-unused `focused_webview: Res<FocusedWebview>` parameter from `forward_wheel_to_tmux` (it moved into `TmuxInlineWheelParams`). Keep the rest of the body (active-pane resolution, `consume_wheel_notches`, the notch loop) unchanged.
+
+Add the inline-forking aggregate (mirror native `aggregate_wheel_delta`):
+
+```rust
+/// Drains the frame's `MouseWheel` into a signed cell-delta for the tmux path,
+/// forking inline-routed events to CEF first. Returns `None` when no
+/// terminal-bound events arrived (all forwarded inline, or empty). Identical
+/// shape to native `aggregate_wheel_delta`.
+fn aggregate_tmux_wheel_cells(
+    wheel: &mut MessageReader<MouseWheel>,
+    target: Option<TmuxInlineWheelTarget>,
+    browsers: Option<&Browsers>,
+    cell_h_logical: f32,
+) -> Option<f32> {
+    let mut delta = 0.0f32;
+    let mut had_terminal_input = false;
+    for ev in wheel.read() {
+        if let Some(target) = target {
+            if let Some(browsers) = browsers {
+                browsers.send_mouse_wheel(
+                    &target.child,
+                    target.position_dip,
+                    tmux_inline_wheel_delta(ev.unit, ev.x, ev.y),
+                );
+            }
+            continue;
+        }
+        had_terminal_input = true;
+        delta += match ev.unit {
+            MouseScrollUnit::Line => ev.y,
+            MouseScrollUnit::Pixel => ev.y / cell_h_logical,
+        };
+    }
+    had_terminal_input.then_some(delta)
+}
+```
+
+> NOTE: keep the existing `aggregate_wheel_cells` only if some other caller uses it; otherwise replace it with `aggregate_tmux_wheel_cells`. Grep for `aggregate_wheel_cells` — if `forward_wheel_to_tmux` was its sole caller, delete it and update its tests to call `aggregate_tmux_wheel_cells` with `target = None`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui wheel_target_ -- --test-threads=1`
+Expected: PASS.
+Run the existing wheel tests: `cargo test --bin ozmux-gui scroll_command consume_wheel aggregate -- --test-threads=1`
+Expected: PASS (update any `aggregate_wheel_cells` test to the new name/signature with `target = None`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tmux_input.rs src/tmux_mouse.rs
+git commit -m "feat(tmux): pointer-gate the wheel so a focused inline webview scrolls instead of copy mode"
+```
+
+---
+
+## Task 5: build, lint, full test, manual smoke
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full workspace build**
+
+Run: `cargo build`
+Expected: success, no errors.
+
+- [ ] **Step 2: Clippy + fmt**
+
+Run: `cargo clippy --workspace --all-targets 2>&1 | tail -40 && cargo fmt --check`
+Expected: no warnings in the changed files; fmt clean. Fix any `#[allow]` that should be `#[expect(..., reason = "...")]` per the repo rules.
+
+- [ ] **Step 3: Full test suite (single-threaded to avoid the known parallel-teardown SIGSEGV)**
+
+Run: `cargo test --bin ozmux-gui -- --test-threads=1`
+Expected: all green (modulo the pre-existing IME-test caveat noted in repo memory; if that one fails, it is unrelated — confirm it fails on `main` too).
+
+- [ ] **Step 4: Manual smoke (requires CEF; document the result)**
+
+Run `make setup-cef` once if needed, then `cargo run` under a tmux session that mounts an inline webview (e.g. the `ozmd` markdown viewer). Verify, and note pass/fail in the commit or PR body:
+1. Wheel over the webview rect scrolls the **webview** (not copy mode).
+2. Wheel over the terminal region of the same pane still enters/scrolls **tmux copy mode**.
+3. A single click on the webview focuses it AND activates the clicked element (link/button) — the first click is not swallowed.
+4. Clicking the terminal region releases webview focus and `select-pane`s.
+5. `Ctrl+Shift+Esc` releases focus; keyboard returns to tmux.
+6. Hover styling and in-rect text selection (press-drag) work inside the webview.
+
+- [ ] **Step 5: Commit any lint/fmt fixups**
+
+```bash
+git add -A
+git commit -m "chore(tmux): clippy/fmt cleanup for inline-webview mouse routing"
+```
+
+---
+
+## Self-review notes (already reconciled against the spec)
+
+- Spec §"State & focus lifecycle" → Tasks 1 (validator) + 2 (`inline_press`, ungated `set_focus` before click).
+- Spec §"Data flow / Click" → Task 2 (`route_tmux_inline_left_click`, modal-guard split-drop).
+- Spec §"Data flow / Move" → Task 3 (`forward_tmux_inline_mouse_moves`, stateless, held buttons).
+- Spec §"Data flow / Wheel" → Task 4 (`resolve_tmux_inline_wheel_target`, `aggregate_tmux_wheel_cells`, blanket early-return removed).
+- Spec §"Keyboard — unchanged" → no task (verified correct; `forward_keys_to_tmux` works once `FocusedWebview` is tmux-aware via Task 1).
+- Spec §"Testing" → tests embedded in Tasks 1-4 + Task 5 manual smoke.
+- Type consistency: `inline_press: Option<Entity>`, `tmux_pane_local_at(...) -> Option<(Entity, Vec2)>`, `TmuxInlineWheelTarget { child, position_dip }`, `tmux_inline_wheel_delta`, `aggregate_tmux_wheel_cells(..., target, browsers, cell_h)` are used consistently across tasks. `tmux_pane_local_at` is `pub(crate)` (Task 2) so Task 4 imports it.

--- a/docs/superpowers/specs/2026-06-16-tmux-webview-mouse-focus-design.md
+++ b/docs/superpowers/specs/2026-06-16-tmux-webview-mouse-focus-design.md
@@ -1,0 +1,390 @@
+# tmux inline-webview mouse routing & focus — design
+
+Date: 2026-06-16
+Branch: `webview-focus`
+Status: design (approved through brainstorming; pending spec review)
+
+## Problem
+
+Under the tmux backend, the mouse wheel **unconditionally enters tmux copy
+mode**, which makes an inline webview embedded in a tmux pane effectively
+**uninteractable with the mouse** (it cannot be scrolled, clicked, or
+hovered).
+
+Root cause, verified against the code:
+
+- The tmux wheel path `forward_wheel_to_tmux` (`src/tmux_input.rs`) is
+  **position-blind**. It aggregates the frame's wheel first, then early-returns
+  only when `focused_webview.0.is_some()` regardless of pointer position
+  (`src/tmux_input.rs:415`). When `FocusedWebview` is `None`, a scroll-up runs
+  the tmux `WheelUpPane` binding (`copy-mode -e`), which enters copy mode and
+  inserts `CopyModeState` (`src/tmux_input.rs:451`, `:329`).
+- `sync_focused_webview` (`src/webview_render.rs:93`) drives `FocusedWebview`
+  from the **old multiplexer's** active surface every frame. The tmux backend
+  does not populate the old multiplexer (production bootstrap no longer seeds an
+  old workspace — `src/bootstrap.rs`), so per the comment at
+  `src/tmux_input.rs:164-168`, `FocusedWebview` is "usually `None`" under tmux.
+  A click-granted focus is clobbered back to `None` on the next frame's sync.
+- Net effect under tmux: wheel-over-webview always falls through to copy-mode
+  entry; an inline webview can never hold focus, so its CEF browser never
+  receives mouse input.
+
+### Decisive technical constraint (bevy_cef is focus-gated)
+
+`bevy_cef`'s CEF input delivery is gated on a focused frame. All three input
+calls funnel through `get_focused_browser`, which requires
+`focused_frame().is_some()`:
+
+```rust
+// bevy_cef/crates/bevy_cef_core/src/browser_process/browsers.rs
+pub fn send_mouse_wheel(&self, webview: &Entity, position: Vec2, delta: Vec2) {
+    if let Some(browser) = self.get_focused_browser(webview) { ... }   // :265
+}
+pub fn send_mouse_move<'a>(&self, webview, buttons, position, mouse_leave) {
+    if let Some(browser) = self.get_focused_browser(webview) { ... }   // :213
+}
+pub fn send_mouse_click(&self, ...) {
+    if let Some(browser) = self.get_focused_browser(webview) { ... }   // :232
+    // NOTE: the internal `browser.host.set_focus(true)` runs INSIDE this gate,
+    // so it CANNOT bootstrap focus on a not-yet-focused browser.
+}
+fn get_focused_browser(&self, webview) -> Option<&WebviewBrowser> {
+    self.browsers.get(webview)
+        .and_then(|b| b.client.focused_frame().is_some().then_some(b))  // :641
+}
+pub fn set_focus(&self, webview: &Entity, focused: bool) { ... }        // :289
+// ^ the ONLY ungated path (a direct lookup, NOT get_focused_browser); the only
+//   call that can GRANT focus to a browser with no focused frame yet.
+```
+
+Consequence 1: **a pure hover model (deliver wheel to an unfocused webview) is
+impossible without modifying `bevy_cef`.** The interaction model must be
+focus-first. This is also why the existing native path
+(`resolve_inline_wheel_target` in `src/input/mouse_wheel.rs`) is gated on focus
+**and** pointer position.
+
+Consequence 2 (critical): focus must be granted by the **ungated**
+`Browsers::set_focus(&child, true)` (`browsers.rs:289`) BEFORE the first click is
+forwarded. `send_mouse_click` alone CANNOT establish focus — its body, including
+its own internal `set_focus(true)`, sits behind the `get_focused_browser` gate,
+so the very first click on a never-focused inline webview is silently dropped and
+focus never bootstraps (the exact failure this design must fix). The native path
+already uses the two-call idiom (`browsers.set_focus(&hit.child, true)` then
+`send_mouse_click`, `src/input/mouse_buttons.rs:781-783`, rationale at
+`:719-723`); the tmux path MUST replicate it. See the lifecycle table below.
+
+## Decisions (locked during brainstorming)
+
+1. **Backend scope:** tmux backend only. The native path
+   (`src/input/mouse_wheel.rs`, `src/input/mouse_buttons.rs`) is left unchanged;
+   it continues to serve old-multiplexer surfaces.
+2. **Routing model:** **Focus-based + pointer-gated wheel.** Click grants
+   keyboard/CEF focus; once focused, wheel/move route to the webview **only when
+   the pointer is over its rect**. Pure hover-wheel (wheel without focus) is
+   deferred to a future enhancement that would require patching `bevy_cef`.
+3. **Focus grant:** a left press inside an interactive inline rect focuses the
+   webview and forwards that same click to CEF (so links/buttons fire on one
+   click).
+4. **Focus release:** a left press on the terminal region (outside every inline
+   rect) clears focus and proceeds as a normal tmux gesture; **plus** the
+   existing `Ctrl+Shift+Esc` keyboard release.
+5. **In-webview drag & hover are in scope:** text selection / slider drag inside
+   the webview, and hover styling, are forwarded to CEF via `send_mouse_move`.
+
+## Goals / non-goals
+
+Goals:
+
+- Make `FocusedWebview` tmux-aware so an inline webview in a tmux pane can hold
+  focus.
+- Route wheel, click (press/release), and move (hover/drag) to a focused inline
+  webview when the pointer is over its rect, without breaking tmux copy-mode /
+  drag-select on the terminal regions.
+
+Non-goals:
+
+- Pure hover-wheel (wheel to an unfocused webview). Deferred; needs a `bevy_cef`
+  change.
+- Touching the native (old-multiplexer) input path.
+- Extracting a shared backend-agnostic inline-routing module (considered and
+  rejected as over-scoped; see "Alternatives").
+
+## Architecture
+
+Reuse the already-verified geometry helpers — they run for **any**
+`TerminalGrid`, and tmux panes carry `TerminalRenderBundle` (= `TerminalGrid`)
+with inline webviews mounted as `ChildOf(TmuxPane entity)`
+(`src/tmux_render.rs:86`). No helper changes are needed:
+
+- `inline_hit_at`, `inline_local_dip`, `focused_inline_of`, and the
+  `TerminalOverlays` projection (`src/inline_webview.rs`).
+- CEF forwarding through `bevy_cef_core::Browsers` (`send_mouse_wheel`,
+  `send_mouse_click`, `send_mouse_move`) — the same API the native path uses.
+
+The work is three pieces, all tmux-local:
+
+```
+ MouseButtonInput ─► tmux_mouse.rs::arbiter
+                       (new) inline left-click pre-step (mirrors native route_inline_left_click):
+                        press in rect  → FocusedWebview = child; ungated set_focus(child);
+                                         select-pane(host); send_mouse_click(down);
+                                         record inline_press = Some(child);
+                                         consume (do NOT arm divider/drag-select)
+                        press off rect → clear FocusedWebview (if it held an inline child);
+                                         fall through to existing divider/select-pane/drag
+                        release        → if inline_press == Some(child): send_mouse_click(up)
+                                         at the (drift-tolerant) release DIP; clear; consume
+                       (modal guard: keep picker/copy-prompt drain+reset; the
+                        focused_webview blanket-drain is REMOVED — inline routing owns it)
+
+ (CursorMoved)    ─► tmux_mouse.rs::forward_tmux_inline_mouse_moves  (new)
+                        on the latest CursorMoved, if the pointer is over an interactive
+                        inline rect of the pane under it → send_mouse_move(child,
+                        mouse_buttons.get_pressed(), dip). Stateless, event-driven, forwards
+                        held buttons (so a press-drag selects). ONE system for hover AND
+                        drag, exactly like native forward_inline_mouse_moves; bevy_cef gates
+                        delivery on focus internally; modal: skip.
+
+ MouseWheel       ─► tmux_input.rs::forward_wheel_to_tmux
+                        (new) resolve_tmux_inline_wheel_target():
+                          child = focused_inline_of(FocusedWebview, pane_under_pointer)
+                          require pointer in child's rect (inline_hit_at)
+                        if target: send_mouse_wheel(child, dip, raw_delta) per event;
+                                   reset residual; return (tmux untouched)
+                        else:      existing tmux path (copy-mode scroll / WheelUpPane)
+                        # the blanket `focused_webview.is_some()` early-return is removed
+
+ KeyboardInput    ─► tmux_input.rs::forward_keys_to_tmux  (unchanged)
+                        focused_webview.is_some() → webview owns keys; Ctrl+Shift+Esc
+                        releases. Already correct once FocusedWebview is tmux-aware.
+
+ (per frame)      ─► webview_render.rs focus validator  (modified / tmux-aware)
+                        keep FocusedWebview while it points at an inline child of a
+                        live TmuxPane; GC to None when that child despawns / pane gone.
+                        Does NOT drive focus from the active pane (focus is click-driven).
+```
+
+Files touched:
+
+- `src/tmux_mouse.rs` — inline click pre-step in the arbiter (mirrors native
+  `route_inline_left_click`); a new `inline_press: Option<Entity>` field on
+  `TmuxMouseGesture` (mirrors native `MouseSelectionState.inline_press`) to
+  route the release click-up to the same child; the modal guard keeps the
+  picker/copy-prompt drain+reset but DROPS the `focused_webview` blanket-drain
+  (inline routing now owns focus). New `CursorMoved`-driven
+  `forward_tmux_inline_mouse_moves` system (hover + drag, stateless). Reuse the
+  existing `pub(crate)` `pane_under_cursor` and `phys_to_terminal_local`.
+- `src/tmux_input.rs` — `forward_wheel_to_tmux`: pointer-gated inline wheel
+  target + per-event CEF forwarding (mirrors native `aggregate_wheel_delta`).
+  `forward_keys_to_tmux` unchanged.
+- `src/webview_render.rs` — make the focus source tmux-aware (preserve inline
+  focus for tmux-pane children; GC on despawn). The native old-multiplexer
+  preserve arm stays.
+- Shared helpers in `src/inline_webview.rs`: **no change**, reused.
+
+## State & focus lifecycle
+
+The single source of focus truth remains the existing `FocusedWebview`
+(bevy_cef resource) — "single focus source" (spec §7) extended to tmux. New
+persistent state is minimal: one added `inline_press: Option<Entity>` field on
+the existing `TmuxMouseGesture` resource (mirrors native
+`MouseSelectionState.inline_press`), holding the in-flight press so the release
+click-up routes to the same child even if the pointer drifted off the rect.
+There is no per-frame drag-capture state — move forwarding is stateless (see
+"Move").
+
+| Trigger | Action |
+| --- | --- |
+| press inside an interactive inline rect | `FocusedWebview = Some(child)`; **ungated `browsers.set_focus(&child, true)` (`browsers.rs:289`)** to grant CEF focus; `select-pane` the host pane; `send_mouse_click(down)`; record `inline_press = Some(child)`. The explicit `set_focus` is mandatory — `send_mouse_click` cannot bootstrap focus on its own (see "Decisive technical constraint", Consequence 2) |
+| press on terminal region (outside every rect) | `FocusedWebview = None` (→ CEF blur); proceed with the normal tmux gesture |
+| `Ctrl+Shift+Esc` | `FocusedWebview = None` (existing keyboard release) |
+| release while `inline_press == Some(child)` | `send_mouse_click(up)` at the drift-tolerant release DIP; clear `inline_press` |
+| focused inline child despawns / host pane gone | focus validator GCs `FocusedWebview` to `None` |
+
+CEF-focus consistency (critical invariant): setting `FocusedWebview = Some(child)`
+alone does not establish CEF focus, and `send_mouse_click` cannot establish it
+either (its body sits behind the `get_focused_browser` gate). The focusing press
+**must** call the ungated `browsers.set_focus(&child, true)` (`browsers.rs:289`)
+itself — ozmux owns the grant rather than relying on bevy_cef's deferred,
+unordered `apply_webview_focus` (a `Local`/`is_changed`-gated Update system).
+Order within the press: set `FocusedWebview` → `browsers.set_focus(true)` →
+`send_mouse_click(down)`.
+
+Same-frame caveat: `set_focus(true)` sets browser-process focus, but
+`focused_frame()` reflects renderer-process state updated via an async
+browser↔renderer IPC round-trip, so it does not flip to `Some` synchronously.
+The press bootstraps focus and it is reliably available on **subsequent** frames;
+a wheel event arriving in the very same frame as the first-ever focus grant may
+still find `focused_frame() == None` and be dropped. This fails **safe** (the
+event is silently dropped, never misrouted) and is not observable in practice
+(focus persists across frames; the press and the first wheel-over-rect are
+essentially never the same frame).
+
+## Data flow detail
+
+### Click — `tmux_mouse.rs::arbiter`
+
+For each **left** button event, before the existing divider/select-pane/
+drag-select logic:
+
+```
+press @ cursor_phys:
+  gesture.inline_press = None                          # a fresh press invalidates any stale marker
+  pane = pane_under_cursor(cursor_phys)
+  hit  = pane ? inline_hit_at(pane, local_phys)        # interactive slots only (excludes NonInteractive)
+  if hit:
+     FocusedWebview = Some(hit.child)
+     browsers.set_focus(hit.child, true)               # UNGATED grant — mandatory, MUST precede the click
+     send select-pane(host pane)
+     browsers.send_mouse_click(hit.child, hit.local_dip, Left, mouse_up=false)
+     gesture.inline_press = Some(hit.child)            # consumed; no divider/drag-select arm; no click-count bump
+  else:
+     if FocusedWebview holds an inline child: FocusedWebview = None   # off-rect click releases focus
+     # fall through to the existing Pressed / Resizing / select-pane flow
+
+release @ cursor_phys:
+  if gesture.inline_press.take() == Some(child):
+     dip = inline_release_dip(child, cursor_phys)       # inline_local_dip WITHOUT containment (drift-tolerant)
+     browsers.send_mouse_click(child, dip, Left, mouse_up=true)
+  else:
+     # existing Released flow (copy-selection, divider-click select-pane, ...)
+```
+
+The modal guard at `src/tmux_mouse.rs:240` currently drains ALL mouse events when
+`picker.open || copy_prompt.open.is_some() || focused_webview.0.is_some()` AND
+resets the gesture. **Keep** the `picker` / `copy_prompt` drain+reset unchanged (a
+modal still owns input — see the edge-case table), but **drop** the
+`focused_webview.0.is_some()` term entirely: the inline click pre-step above now
+owns focus (in-rect press keeps it, off-rect press releases it and drives tmux),
+so a focused webview must no longer blanket-drain mouse input.
+
+### Move (hover + drag) — `tmux_mouse.rs::forward_tmux_inline_mouse_moves` (new)
+
+A single stateless system, an exact mirror of the native `forward_inline_mouse_moves`
+(`src/inline_webview.rs:565`) but resolving the pane via `pane_under_cursor`
+(`TmuxPane` hosts) instead of the `SurfaceMarker + Slotted` host query. It is
+`CursorMoved`-driven (at most one forward per frame, at the latest position — NOT
+per-idle-frame), and forwards whatever buttons are held, so the same system serves
+both hover and an in-rect drag (text selection / slider):
+
+```
+moved = CursorMoved.last(); if none: return
+if modal open (picker / copy-search prompt): return
+(terminal, local_phys) = pane_under_cursor(moved.position * scale)   # TmuxPane host
+hit = inline_hit_at(terminal, local_phys)                            # interactive rects only
+if hit:
+   browsers.send_mouse_move(hit.child, mouse_buttons.get_pressed(), hit.local_dip, mouse_leave=false)
+```
+
+No drag-capture and no `mouse_leave` tracking — this matches native exactly: a drag
+that leaves the rect simply stops extending (its release click-up is still routed to
+the child by the arbiter's `inline_press` marker via `inline_release_dip`, so the
+selection completes at the last in-rect position). `bevy_cef`'s `send_mouse_move` is
+itself focus-gated, so hovers/drags over an unfocused browser are dropped
+browser-side, not here.
+
+### Wheel — `tmux_input.rs::forward_wheel_to_tmux`
+
+```
+target = resolve_tmux_inline_wheel_target():
+    child = focused_inline_of(FocusedWebview, pane_under_pointer)   # focus required
+    require pointer in child's rect (inline_hit_at)
+for ev in wheel:
+    if target: browsers.send_mouse_wheel(child, local_dip, raw_delta(ev))   # Line ×120, Pixel as-is, no sign flip
+    else:      existing tmux aggregate (copy-mode scroll / WheelUpPane → copy-mode entry)
+if target was Some: reset residual; return                          # tmux path untouched this frame
+```
+
+The blanket `focused_webview.is_some()` early-return is **removed**; gating is
+now pointer-position-aware exactly like the native `resolve_inline_wheel_target`.
+A focused webview no longer steals wheel events aimed at the terminal region.
+
+### Keyboard — unchanged
+
+`forward_keys_to_tmux`'s `focused_webview.0.is_some()` early-return is already
+correct: the webview owns the keyboard, `Ctrl+Shift+Esc` releases. It begins to
+function for real once `FocusedWebview` is tmux-aware.
+
+### Focus validator — `webview_render.rs` (per frame)
+
+Under tmux, do **not** drive focus from the active pane. Keep `FocusedWebview`
+while it points at an inline child (`ChildOf`) of a live `TmuxPane`; GC to `None`
+when that child despawns or its host pane is gone. The native old-multiplexer
+preserve arm is retained for the native backend.
+
+## Error handling & edge cases
+
+| Case | Handling |
+| --- | --- |
+| focused inline child despawns / host pane gone | validator GCs `FocusedWebview = None`; CEF forwards no-op via `get_focused_browser` → `None` |
+| `Browsers` (NonSend) absent (CEF-less tests) | `Option<NonSend<Browsers>>` like the native path; `None` → skip forward, run tmux path |
+| `NonInteractive` inline (display-only) | excluded by `inline_hit_at`; never focused/clicked/wheeled — tmux path as before |
+| multi-notch fling while focus changes | wheel resolves target once per frame → frame-consistent; residual reset on target switch |
+| modal (picker / copy-search) opens while webview focused | modal wins; arbiter + forwarder no-op; focus preserved, restored when modal closes |
+| off-rect press that releases focus | the same press both clears focus AND runs the normal tmux gesture (one click) |
+| pane resize / layout change mid-press | the `inline_press` marker is keyed to the child entity, so the release click-up still routes to that child (drift-tolerant `inline_release_dip`) even if its rect moved |
+| clicking an inline in a copy-mode pane | inline wins (focus + CEF); the pane's copy-mode state is independent (released via tmux as usual) |
+| drag starts in rect, pointer leaves rect while held | moves stop extending once off-rect (matches native); the release click-up is still routed to the child via `inline_press` + `inline_release_dip`, completing the selection at the last in-rect position |
+
+Invariant: every CEF forward is focus-gated, so any "`FocusedWebview` child ≠
+CEF focused frame" desync fails safe (dropped, never misrouted). The focusing
+press's explicit ungated `browsers.set_focus(&child, true)` (NOT
+`send_mouse_click`'s internal, gated `set_focus`) is what establishes focus.
+
+## Testing
+
+Mirror the native tests (`src/input/mouse_wheel.rs` `resolve_inline_wheel_target`
+suite: `target_resolves_when_focused_inline_under_pointer`,
+`target_none_when_pointer_off_the_rect`, `target_none_when_inline_not_focused`)
+for the tmux variant:
+
+- **Pure-function unit tests** — `resolve_tmux_inline_wheel_target`:
+  (a) focused inline under pointer → `Some`, (b) pointer off-rect → `None`,
+  (c) unfocused → `None`, (d) `NonInteractive` → `None`.
+- **Arbiter inline routing** (`RunSystemOnce` + `MinimalPlugins`, a
+  `TmuxPane` + `TerminalOverlays` + `InlineWebview` child fixture modeled on the
+  existing `make_wheel_app`): press in rect → `FocusedWebview` set to child;
+  press off rect → `FocusedWebview` cleared and the gesture proceeds to the
+  normal flow; a consumed press does not arm divider/drag-select.
+- **Move forwarder** (`forward_tmux_inline_mouse_moves`) — a `CursorMoved` over an
+  interactive inline rect resolves the child + DIP; over the terminal resolves
+  nothing. (CEF calls are not exercised when `Browsers` is absent; the routing
+  decision is asserted via the pure `inline_hit_at` resolution.) Mirror the native
+  forwarder's test shape.
+- **First-click focus bootstrap** — a press inside an inline rect on a
+  never-focused webview must record the ungated `set_focus(child, true)` BEFORE
+  the click (assert ordering and that the grant is not focus-gated), so the
+  first click is not swallowed and focus actually bootstraps.
+- **Focus validator** — focused child despawn → `FocusedWebview` GC'd to `None`.
+- **Regression** — a tmux pane with no inline webview still scrolls into
+  copy-mode / drag-selects exactly as before (the inline path yields no
+  false-positive target).
+
+CEF forwarding itself (`Browsers`) is not invoked in the `Option`-absent tests,
+matching the native convention; whether a forward happens is asserted through
+the pure target-resolution / gesture-state assertions.
+
+## Alternatives considered
+
+- **Generalize the native `mouse_buttons.rs` / `mouse_wheel.rs` to be
+  backend-agnostic** (one host query covering both `SurfaceMarker + Slotted` and
+  `TmuxPane`). Rejected: larger blast radius into the native path, which is tied
+  to old-multiplexer active-pane focus (`try_click_to_focus`,
+  `MultiplexerCommands`); against the "tmux priority, leave native alone" scope.
+  (Note: a *narrow* extraction of just the host-agnostic
+  `(terminal, local_phys) → inline_hit_at → send_mouse_*` tail — distinct from
+  this larger refactor — is a reasonable optional dedup with no native blast
+  radius; left to implementation discretion.)
+- **Minimal: fix only the focus source + wheel, rely on bevy_cef's own
+  `set_focus_on_press` for clicks.** Rejected: inline webviews render as overlay
+  textures on the pane grid, not as discrete bevy_cef-hit-tested UI nodes, so
+  bevy_cef would not see the rect and clicks would not focus/activate — likely
+  insufficient.
+
+## Future enhancement (out of scope)
+
+Pure hover-wheel (scroll the webview under the pointer without a prior click)
+requires extending `bevy_cef` so wheel can be delivered to a browser without a
+focused frame (or via transient focus). `bevy_cef` is a path dependency under
+the user's control, so this is feasible later, but it is deliberately excluded
+here to keep the change tmux-local and avoid an upstream-crate change.

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -170,9 +170,10 @@ fn forward_keys_to_tmux(
 
     // When an inline webview holds focus it owns the keyboard (bevy_cef routes
     // keystrokes to it); forwarding to tmux too would double-send. Ctrl+Shift+Esc
-    // releases focus back to the terminal. NOTE: in the current tmux backend the
-    // webview-focus machinery is old-multiplexer-driven, so FocusedWebview is
-    // usually None here; this handler is correct for when it is set.
+    // releases focus back to the terminal. NOTE: under the tmux backend a click
+    // on an interactive inline webview sets FocusedWebview (via the mouse
+    // arbiter's inline route), so this guard is load-bearing — removing it would
+    // double-send keystrokes to both the webview and the tmux active pane.
     if focused_webview.0.is_some() {
         for ev in events.read() {
             if ev.state == ButtonState::Pressed
@@ -494,14 +495,18 @@ fn forward_wheel_to_tmux(
     let Ok(window) = windows.single() else {
         return;
     };
-    let dpr = window.scale_factor().max(0.5);
-    let cell_h_logical = (metrics.metrics.line_height_phys.floor() / dpr).max(1.0);
+    let scale = window.scale_factor();
+    // NOTE: the .max(0.5) clamp guards ONLY the cell_h_logical division; the
+    // hit-test cursor and the inline DIP use the raw scale_factor so wheel
+    // events land at the same in-page coordinate as the click/move paths.
+    let cell_h_logical = (metrics.metrics.line_height_phys.floor() / scale.max(0.5)).max(1.0);
     let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
-    let cursor_phys = window.cursor_position().map(|c| c * dpr);
+    let cursor_phys = window.cursor_position().map(|c| c * scale);
 
-    let target = cursor_phys
-        .and_then(|c| resolve_tmux_inline_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr));
+    let target = cursor_phys.and_then(|c| {
+        resolve_tmux_inline_wheel_target(&inline, c, cell_w_phys, cell_h_phys, scale)
+    });
 
     let Some(delta_cells) = aggregate_tmux_wheel_cells(
         &mut wheel,

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -8,18 +8,25 @@
 
 use crate::clipboard::{Clipboard, build_paste_bytes};
 use crate::configs::OzmuxConfigsResource;
+use crate::inline_webview::{InlineWebview, focused_inline_of, inline_hit_at};
 use crate::input::InputPhase;
+use crate::osc_webview::NonInteractive;
+use crate::tmux_mouse::tmux_pane_local_at;
 use crate::tmux_picker::SessionPicker;
 use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
+use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
+use bevy_cef_core::prelude::Browsers;
 use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::prelude::TerminalOverlays;
 use ozmux_tmux::{
     ActivePane, CopyAction, CopyModeQueries, CopyQueryKind, Forwarded, KeyBindings, KeyMods,
     PromptKind, TmuxConnection, TmuxPane, bevy_key_to_tmux_name, copy_mode_dispatch, plan_forward,
@@ -373,13 +380,93 @@ struct TmuxWheelAccumulator {
     last_pane: Option<Entity>,
 }
 
+/// A focused inline webview claiming the wheel: the child to forward to and
+/// the pointer in its webview-local DIP.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct TmuxInlineWheelTarget {
+    child: Entity,
+    position_dip: Vec2,
+}
+
+/// Wheel-routing params bundled to stay within Bevy's system-parameter limit.
+/// `browsers` is optional so CEF-less tests construct the system.
+#[derive(SystemParam)]
+struct TmuxInlineWheelParams<'w, 's> {
+    focused_webview: Res<'w, FocusedWebview>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    panes: Query<
+        'w,
+        's,
+        (
+            Entity,
+            &'static TmuxPane,
+            &'static ComputedNode,
+            &'static UiGlobalTransform,
+        ),
+    >,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
+}
+
+/// Resolves the focused inline webview under the pointer, or `None` (the tmux
+/// path runs). `Some` only when `FocusedWebview` holds an inline child of the
+/// pane under the pointer AND the pointer is over that child's rect — the tmux
+/// analog of native `resolve_inline_wheel_target`.
+fn resolve_tmux_inline_wheel_target(
+    params: &TmuxInlineWheelParams,
+    cursor_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale_factor: f32,
+) -> Option<TmuxInlineWheelTarget> {
+    let (terminal, local_phys) = tmux_pane_local_at(&params.panes, cursor_phys)?;
+    let focused_child = focused_inline_of(
+        Some(&params.focused_webview),
+        &params.inline_parents,
+        Some(terminal),
+    )?;
+    let overlays = params.overlay_rects.get(terminal).ok()?;
+    let hit = inline_hit_at(
+        &params.children,
+        &params.inline,
+        overlays,
+        terminal,
+        local_phys,
+        cell_w_phys,
+        cell_h_phys,
+        scale_factor,
+    )?;
+    (hit.child == focused_child).then_some(TmuxInlineWheelTarget {
+        child: hit.child,
+        position_dip: hit.local_dip,
+    })
+}
+
+/// Converts one `MouseWheel` event to the RAW CEF wheel delta (`Line → ×120`,
+/// `Pixel` unchanged, NO sign flip) — identical to native `inline_wheel_delta`.
+fn tmux_inline_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
+    match unit {
+        MouseScrollUnit::Line => Vec2::new(x, y) * 120.0,
+        MouseScrollUnit::Pixel => Vec2::new(x, y),
+    }
+}
+
 /// Forwards mouse-wheel events to the active tmux pane.
 ///
-/// Events are accumulated into a cell-delta (`Pixel` units divided by the cell
-/// height, like the native terminal path) and quantized into integer notches
-/// against `mouse.cells_per_notch`, carrying the remainder across frames — so a
-/// macOS trackpad's stream of small `Pixel` events scrolls gently instead of
-/// firing a full notch per event.
+/// A focused inline webview under the pointer claims the wheel first
+/// (`resolve_tmux_inline_wheel_target`): each event is forwarded RAW to that
+/// child's CEF browser and dropped before the tmux accumulator, so the gesture
+/// scrolls the page instead of the terminal. Gating is pointer-driven, not the
+/// mere presence of `FocusedWebview` — a focused webview that the pointer is NOT
+/// over still scrolls the terminal pane.
+///
+/// Otherwise events are accumulated into a cell-delta (`Pixel` units divided by
+/// the cell height, like the native terminal path) and quantized into integer
+/// notches against `mouse.cells_per_notch`, carrying the remainder across frames
+/// — so a macOS trackpad's stream of small `Pixel` events scrolls gently instead
+/// of firing a full notch per event.
 ///
 /// In copy mode each notch sends a single pane-targeted `scroll_command`
 /// (`send-keys -X -t %id scroll-up|scroll-down`, `mouse.lines_per_notch` lines)
@@ -393,11 +480,11 @@ fn forward_wheel_to_tmux(
     mut commands: Commands,
     mut wheel: MessageReader<MouseWheel>,
     mut accumulator: ResMut<TmuxWheelAccumulator>,
+    inline: TmuxInlineWheelParams,
     connection: NonSend<TmuxConnection>,
     bindings: Res<KeyBindings>,
     picker: Res<SessionPicker>,
     copy_prompt: Res<CopyPrompt>,
-    focused_webview: Res<FocusedWebview>,
     configs: Res<OzmuxConfigsResource>,
     metrics: Res<TerminalCellMetricsResource>,
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
@@ -409,13 +496,33 @@ fn forward_wheel_to_tmux(
     };
     let dpr = window.scale_factor().max(0.5);
     let cell_h_logical = (metrics.metrics.line_height_phys.floor() / dpr).max(1.0);
-    let Some(delta_cells) = aggregate_wheel_cells(&mut wheel, cell_h_logical) else {
+    let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cursor_phys = window.cursor_position().map(|c| c * dpr);
+
+    let target = cursor_phys
+        .and_then(|c| resolve_tmux_inline_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr));
+
+    let Some(delta_cells) = aggregate_tmux_wheel_cells(
+        &mut wheel,
+        target,
+        inline.browsers.as_deref(),
+        cell_h_logical,
+    ) else {
+        // NOTE: an all-inline frame must reset the residual — leaving carried
+        // cells behind would let tmux momentum lurch when the wheel later resumes
+        // over the terminal. An empty frame (target None) leaves it intact.
+        if target.is_some() {
+            accumulator.residual_cells = 0.0;
+        }
         return;
     };
     // NOTE: a background scroll must not mutate tmux; mirror the keyboard path.
     // Reset any carried remainder on every guarded early-return so momentum
     // can't accumulate behind a modal / unfocused window and lurch on resume.
-    if !window.focused || picker.open || copy_prompt.open.is_some() || focused_webview.0.is_some() {
+    // focused_webview is NOT a guard here — the pointer-gated target above owns
+    // webview scrolling, so a focused webview must not steal terminal wheel.
+    if !window.focused || picker.open || copy_prompt.open.is_some() {
         accumulator.residual_cells = 0.0;
         return;
     }
@@ -485,25 +592,42 @@ fn forward_wheel_to_tmux(
 /// notch, so an uncapped fast fling would flood the control connection.
 const MAX_NOTCHES_PER_FRAME: usize = 10;
 
-/// Drains a frame's `MouseWheel` messages into a single signed cell-delta
-/// (positive = scroll up / toward older lines), or `None` when the frame held
-/// no wheel events. `Line` units contribute `ev.y` directly; `Pixel` units
-/// (macOS trackpads, high-resolution wheels) are divided by the cell height so
-/// a fixed pixel travel maps to a consistent number of lines.
-fn aggregate_wheel_cells(
+/// Drains the frame's `MouseWheel` into a signed cell-delta for the tmux path,
+/// forking inline-routed events to CEF first. Returns `None` when no
+/// terminal-bound events arrived (all forwarded inline, or empty). The tmux
+/// analog of native `aggregate_wheel_delta`.
+///
+/// Terminal-bound events: `Line` units contribute `ev.y` directly (positive =
+/// scroll up / toward older lines); `Pixel` units (macOS trackpads,
+/// high-resolution wheels) are divided by the cell height so a fixed pixel
+/// travel maps to a consistent number of lines. Inline-routed events are
+/// forwarded RAW to CEF via `tmux_inline_wheel_delta` (no sign flip).
+fn aggregate_tmux_wheel_cells(
     wheel: &mut MessageReader<MouseWheel>,
+    target: Option<TmuxInlineWheelTarget>,
+    browsers: Option<&Browsers>,
     cell_h_logical: f32,
 ) -> Option<f32> {
     let mut delta = 0.0f32;
-    let mut had_input = false;
+    let mut had_terminal_input = false;
     for ev in wheel.read() {
-        had_input = true;
+        if let Some(target) = target {
+            if let Some(browsers) = browsers {
+                browsers.send_mouse_wheel(
+                    &target.child,
+                    target.position_dip,
+                    tmux_inline_wheel_delta(ev.unit, ev.x, ev.y),
+                );
+            }
+            continue;
+        }
+        had_terminal_input = true;
         delta += match ev.unit {
             MouseScrollUnit::Line => ev.y,
             MouseScrollUnit::Pixel => ev.y / cell_h_logical,
         };
     }
-    had_input.then_some(delta)
+    had_terminal_input.then_some(delta)
 }
 
 /// Adds this frame's cell-delta to the accumulator and returns the signed
@@ -604,9 +728,12 @@ mod tests {
                 .write(*ev);
         }
         app.world_mut()
-            .run_system_once(move |mut reader: MessageReader<MouseWheel>| {
-                aggregate_wheel_cells(&mut reader, cell_h)
-            })
+            .run_system_once(
+                move |mut reader: MessageReader<MouseWheel>,
+                      browsers: Option<NonSend<Browsers>>| {
+                    aggregate_tmux_wheel_cells(&mut reader, None, browsers.as_deref(), cell_h)
+                },
+            )
             .unwrap()
     }
 
@@ -634,6 +761,99 @@ mod tests {
     #[test]
     fn aggregate_no_events_is_none() {
         assert_eq!(cells_from_events(16.0, &[]), None);
+    }
+
+    fn make_tmux_wheel_app() -> (App, Entity, Entity) {
+        use bevy::window::WindowResolution;
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<FocusedWebview>();
+
+        // Pane host node at window center (400, 300), size 800x600 → top-left
+        // at (0, 0). Rect rows 2..12, cols 3..43 → phys y 32..192, x 24..344 at
+        // 8x16 px.
+        let mut overlays = TerminalOverlays::default();
+        overlays.rects[0] = IVec4::new(2, 3, 10, 40);
+        let pane = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: ozmux_tmux::PaneId(1),
+                    dims: CellDims {
+                        width: 100,
+                        height: 37,
+                        xoff: 0,
+                        yoff: 0,
+                    },
+                },
+                ComputedNode {
+                    size: Vec2::new(800.0, 600.0),
+                    ..ComputedNode::DEFAULT
+                },
+                UiGlobalTransform::from_xy(400.0, 300.0),
+                overlays,
+            ))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(pane),
+                InlineWebview {
+                    view_id: "inline".into(),
+                    instance_id: None,
+                    slot: 0,
+                },
+            ))
+            .id();
+
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        (app, pane, child)
+    }
+
+    fn run_resolve_wheel_target(app: &mut App, cursor_phys: Vec2) -> Option<TmuxInlineWheelTarget> {
+        app.world_mut()
+            .run_system_once(move |params: TmuxInlineWheelParams| {
+                resolve_tmux_inline_wheel_target(&params, cursor_phys, 8.0, 16.0, 1.0)
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn wheel_target_resolves_when_focused_inline_under_pointer() {
+        let (mut app, _pane, child) = make_tmux_wheel_app();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        assert_eq!(
+            run_resolve_wheel_target(&mut app, Vec2::new(40.0, 48.0)).map(|t| t.child),
+            Some(child)
+        );
+    }
+
+    #[test]
+    fn wheel_target_none_off_rect() {
+        let (mut app, _pane, child) = make_tmux_wheel_app();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        assert_eq!(
+            run_resolve_wheel_target(&mut app, Vec2::new(400.0, 400.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn wheel_target_none_when_unfocused() {
+        let (mut app, _pane, _child) = make_tmux_wheel_app();
+        assert_eq!(
+            run_resolve_wheel_target(&mut app, Vec2::new(40.0, 48.0)),
+            None
+        );
     }
 
     #[test]

--- a/src/tmux_mouse.rs
+++ b/src/tmux_mouse.rs
@@ -32,7 +32,7 @@ use bevy::input::mouse::MouseButtonInput;
 use bevy::picking::pointer::PointerButton;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
-use bevy::window::PrimaryWindow;
+use bevy::window::{CursorMoved, PrimaryWindow};
 use bevy_cef::prelude::FocusedWebview;
 use bevy_cef_core::prelude::Browsers;
 use ozma_tty_renderer::TerminalCellMetricsResource;
@@ -51,6 +51,10 @@ impl Plugin for OzmuxTmuxMousePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TmuxMouseGesture>();
         app.add_systems(Update, arbiter.in_set(InputPhase::Dispatch));
+        app.add_systems(
+            Update,
+            forward_tmux_inline_mouse_moves.in_set(InputPhase::Hover),
+        );
     }
 }
 
@@ -778,6 +782,60 @@ fn tmux_inline_release_dip(
     )
 }
 
+/// Forwards pointer motion over an interactive inline rect of a tmux pane to
+/// the child's CEF browser (`send_mouse_move`, webview-local DIP), forwarding
+/// whatever mouse buttons are held so the one system serves both hover and an
+/// in-rect drag. The tmux analog of native `forward_inline_mouse_moves`:
+/// `CursorMoved`-driven (one forward per frame, latest position), and
+/// focus-gated inside `bevy_cef` so motion over an unfocused browser is
+/// dropped browser-side. `Browsers` is optional so CEF-less tests construct it.
+fn forward_tmux_inline_mouse_moves(
+    mut cursor_msg: MessageReader<CursorMoved>,
+    panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    children: Query<&Children>,
+    inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+    overlay_rects: Query<&TerminalOverlays>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    metrics: Res<TerminalCellMetricsResource>,
+    mouse_buttons: Res<ButtonInput<MouseButton>>,
+    picker: Res<SessionPicker>,
+    copy_prompt: Res<CopyPrompt>,
+    browsers: Option<NonSend<Browsers>>,
+) {
+    let Some(moved) = cursor_msg.read().last() else {
+        return;
+    };
+    if picker.open || copy_prompt.open.is_some() {
+        return;
+    }
+    let Ok(window) = windows.single() else {
+        return;
+    };
+    let scale = window.scale_factor();
+    let cursor_phys = moved.position * scale;
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let Some((terminal, local_phys)) = tmux_pane_local_at(&panes, cursor_phys) else {
+        return;
+    };
+    let Ok(overlays) = overlay_rects.get(terminal) else {
+        return;
+    };
+    let Some(hit) = inline_hit_at(
+        &children, &inline, overlays, terminal, local_phys, cell_w, cell_h, scale,
+    ) else {
+        return;
+    };
+    if let Some(browsers) = browsers.as_ref() {
+        browsers.send_mouse_move(
+            &hit.child,
+            mouse_buttons.get_pressed(),
+            hit.local_dip,
+            false,
+        );
+    }
+}
+
 /// Inserts `-t %<id>` into a `send-keys -X ...` copy-mode command so it targets
 /// a specific pane instead of the client's active pane. Non-`send-keys -X`
 /// commands are returned unchanged.
@@ -1108,6 +1166,75 @@ mod tests {
             app.world().resource::<TmuxMouseGesture>().state,
             GestureState::Idle,
             "a consumed inline press must NOT arm a Pressed/Selecting gesture"
+        );
+    }
+
+    #[test]
+    fn move_resolves_inline_child_over_rect() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let (mut app, _pane, child) = make_arbiter_inline_app();
+        let hit = app
+            .world_mut()
+            .run_system_once(
+                move |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+                      children: Query<&Children>,
+                      inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+                      overlays: Query<&TerminalOverlays>| {
+                    let (terminal, local) =
+                        tmux_pane_local_at(&panes, Vec2::new(40.0, 48.0)).unwrap();
+                    inline_hit_at(
+                        &children,
+                        &inline,
+                        overlays.get(terminal).unwrap(),
+                        terminal,
+                        local,
+                        8.0,
+                        16.0,
+                        1.0,
+                    )
+                    .map(|h| h.child)
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            hit,
+            Some(child),
+            "pointer over the rect must resolve the inline child"
+        );
+    }
+
+    #[test]
+    fn move_resolves_nothing_off_rect() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let (mut app, _pane, _child) = make_arbiter_inline_app();
+        let hit = app
+            .world_mut()
+            .run_system_once(
+                |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+                 children: Query<&Children>,
+                 inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+                 overlays: Query<&TerminalOverlays>| {
+                    let (terminal, local) =
+                        tmux_pane_local_at(&panes, Vec2::new(400.0, 400.0)).unwrap();
+                    inline_hit_at(
+                        &children,
+                        &inline,
+                        overlays.get(terminal).unwrap(),
+                        terminal,
+                        local,
+                        8.0,
+                        16.0,
+                        1.0,
+                    )
+                    .map(|h| h.child)
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            hit, None,
+            "pointer over terminal text must resolve no inline child"
         );
     }
 

--- a/src/tmux_mouse.rs
+++ b/src/tmux_mouse.rs
@@ -253,27 +253,50 @@ fn arbiter(
 ) {
     let Ok(window) = windows.single() else {
         buttons.clear();
+        // NOTE: no window means no cursor/scale to synthesize the CEF mouse-up,
+        // so just drop any in-flight inline press — leaving it set would let a
+        // later release act on a stale child.
+        gesture.inline_press = None;
         gesture.state = GestureState::Idle;
         return;
     };
+    let scale = window.scale_factor();
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let guard_cursor_phys = window.cursor_position().map(|c| c * scale);
     if !window.focused {
         buttons.clear();
+        release_inline_press(
+            &mut gesture,
+            &inline_route,
+            &panes,
+            guard_cursor_phys,
+            cell_w,
+            cell_h,
+            scale,
+        );
         gesture.state = GestureState::Idle;
         return;
     }
     // NOTE: a gesture behind a picker / copy-search prompt must not mutate
     // tmux. The focused-webview case is NOT drained here — the inline click
     // pre-step below owns focus (in-rect press keeps it, off-rect press
-    // releases it and drives tmux).
+    // releases it and drives tmux). An in-flight inline press IS released so
+    // the focused page does not stay logically pressed (no matching mouse-up).
     if picker.open || copy_prompt.open.is_some() {
         buttons.clear();
+        release_inline_press(
+            &mut gesture,
+            &inline_route,
+            &panes,
+            guard_cursor_phys,
+            cell_w,
+            cell_h,
+            scale,
+        );
         gesture.state = GestureState::Idle;
         return;
     }
-
-    let scale = window.scale_factor();
-    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
-    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
 
     let (grab_tol_logical, drag_threshold_logical, dbl_click_ms, click_drift) = configs
         .as_deref()
@@ -299,7 +322,8 @@ fn arbiter(
         }
         if let Some(cursor_phys) = window.cursor_position().map(|c| c * scale)
             && let Some((terminal, local_phys)) = tmux_pane_local_at(&panes, cursor_phys)
-            && route_tmux_inline_left_click(
+        {
+            let consumed = route_tmux_inline_left_click(
                 &mut gesture,
                 &mut inline_route,
                 &panes,
@@ -310,9 +334,23 @@ fn arbiter(
                 cell_w,
                 cell_h,
                 scale,
-            )
-        {
-            continue;
+            );
+            if consumed {
+                // NOTE: a press that focused an inline webview must also make its
+                // host pane the tmux-active pane (the native path runs
+                // try_click_to_focus BEFORE inline routing for this reason).
+                // ActivePane is the keyboard/paste target, so it has to follow
+                // the pane the user clicked into — without this, after focus is
+                // released keystrokes route to the previously-active pane.
+                if ev.state == ButtonState::Pressed
+                    && let Ok((_, pane, _, _)) = panes.get(terminal)
+                    && let Some(client) = connection.client()
+                    && let Err(e) = client.handle().send(&select_pane_command(pane.id))
+                {
+                    tracing::warn!(?e, pane = pane.id.0, "inline-press select-pane send failed");
+                }
+                continue;
+            }
         }
         match ev.state {
             ButtonState::Pressed => {
@@ -661,6 +699,38 @@ struct TmuxInlineRouteParams<'w, 's> {
     inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
+}
+
+/// Releases an in-flight inline-webview press to CEF (mouse-up at the last
+/// cursor) and clears the marker. Called when an arbiter guard drains the
+/// queued release (modal open / window unfocused) so the focused web page is
+/// not left logically pressed with no matching mouse-up.
+fn release_inline_press(
+    gesture: &mut TmuxMouseGesture,
+    route: &TmuxInlineRouteParams,
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    cursor_phys: Option<Vec2>,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) {
+    let Some(child) = gesture.inline_press.take() else {
+        return;
+    };
+    if let Some(cursor_phys) = cursor_phys
+        && let Some(browsers) = route.browsers.as_deref()
+        && let Some(dip) = tmux_inline_release_dip(
+            route,
+            panes,
+            child,
+            cursor_phys,
+            cell_w_phys,
+            cell_h_phys,
+            scale,
+        )
+    {
+        browsers.send_mouse_click(&child, dip, PointerButton::Primary, true);
+    }
 }
 
 /// Routes a left press/release through the inline-webview layer, returning

--- a/src/tmux_mouse.rs
+++ b/src/tmux_mouse.rs
@@ -18,18 +18,25 @@
 //! so they act on the pressed pane regardless of the client's active pane.
 
 use crate::configs::OzmuxConfigsResource;
+use crate::inline_webview::{InlineWebview, inline_hit_at, inline_local_dip};
 use crate::input::InputPhase;
+use crate::input::mouse_buttons::phys_to_terminal_local;
+use crate::osc_webview::NonInteractive;
 use crate::tmux_copy_mode::{CopyModeSnapshot, cell_at_pane, cursor_deltas};
 use crate::tmux_picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;
+use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
 use bevy::input::mouse::MouseButtonInput;
+use bevy::picking::pointer::PointerButton;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
+use bevy_cef_core::prelude::Browsers;
 use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::prelude::TerminalOverlays;
 use ozmux_tmux::{
     ActiveWindow, CopyModeQueries, CopyQueryKind, PaneId, TmuxConnection, TmuxDividers, TmuxPane,
     resize_pane_x_command, resize_pane_y_command, select_pane_command, show_buffer_command,
@@ -105,6 +112,11 @@ enum GestureState {
 pub(crate) struct TmuxMouseGesture {
     state: GestureState,
     click: ClickTracker,
+    /// The in-flight inline-webview press (mirrors native
+    /// `MouseSelectionState.inline_press`): the child a left press inside an
+    /// interactive inline rect was forwarded to, so the matching release's
+    /// click-up routes to the SAME child even if the pointer drifted off-rect.
+    inline_press: Option<Entity>,
 }
 
 /// Tracks consecutive-click count using a timeout + positional drift gate.
@@ -140,6 +152,22 @@ fn pane_under_cursor(
         .iter()
         .find(|(_, _, node, transform)| node.contains_point(**transform, cursor_phys))
         .map(|(entity, pane, _, _)| (entity, pane.id))
+}
+
+/// Resolves the `TmuxPane` terminal entity under `cursor_phys` (physical px)
+/// and the pointer in that pane's terminal-local physical px, or `None` when
+/// no pane covers the point. The tmux analog of native `resolve_pane_at_phys`.
+pub(crate) fn tmux_pane_local_at(
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    cursor_phys: Vec2,
+) -> Option<(Entity, Vec2)> {
+    panes.iter().find_map(|(entity, _, node, transform)| {
+        if !node.contains_point(*transform, cursor_phys) {
+            return None;
+        }
+        let local = phys_to_terminal_local(node, transform, cursor_phys)?;
+        Some((entity, local))
+    })
 }
 
 /// Returns the divider whose grab zone contains `cursor_phys` (physical px),
@@ -204,13 +232,20 @@ fn resize_target_size(near: i32, pointer_cell: i32) -> u32 {
 /// copied and bridged to the clipboard; a `Resizing` release that never dragged
 /// is treated as a click and focuses the pane under the cursor; any other
 /// release returns the state to `Idle`. When the primary window is not focused,
-/// or a modal (picker / copy-search prompt / webview) owns input, queued events
-/// are drained and the state is reset.
+/// or a modal (picker / copy-search prompt) owns input, queued events are
+/// drained and the state is reset.
+///
+/// Each left press/release is first offered to the inline-webview layer
+/// (`route_tmux_inline_left_click`): a press inside an interactive inline rect
+/// focuses + forwards to the child's CEF browser and never reaches the tmux
+/// gesture pipeline; a press outside every rect drops inline focus and falls
+/// through to the normal pane gesture.
 fn arbiter(
     mut gesture: ResMut<TmuxMouseGesture>,
     mut buttons: MessageReader<MouseButtonInput>,
     mut commands: Commands,
     mut queries: ResMut<CopyModeQueries>,
+    mut inline_route: TmuxInlineRouteParams,
     connection: NonSend<TmuxConnection>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     dividers_q: Query<&TmuxDividers, With<ActiveWindow>>,
@@ -218,7 +253,6 @@ fn arbiter(
     configs: Option<Res<OzmuxConfigsResource>>,
     picker: Res<SessionPicker>,
     copy_prompt: Res<CopyPrompt>,
-    focused_webview: Res<FocusedWebview>,
     copy_modes: Query<(), With<CopyModeState>>,
     snapshots: Query<&CopyModeSnapshot>,
     time: Res<Time<Real>>,
@@ -234,10 +268,11 @@ fn arbiter(
         gesture.state = GestureState::Idle;
         return;
     }
-    // NOTE: a gesture behind a modal must not mutate tmux; mirror the keyboard
-    // path. While a picker / copy-search prompt or a webview owns input, drain
-    // the events so they do not replay later, and reset the gesture.
-    if picker.open || copy_prompt.open.is_some() || focused_webview.0.is_some() {
+    // NOTE: a gesture behind a picker / copy-search prompt must not mutate
+    // tmux. The focused-webview case is NOT drained here — the inline click
+    // pre-step below owns focus (in-rect press keeps it, off-rect press
+    // releases it and drives tmux).
+    if picker.open || copy_prompt.open.is_some() {
         buttons.clear();
         gesture.state = GestureState::Idle;
         return;
@@ -265,6 +300,23 @@ fn arbiter(
 
     for ev in buttons.read() {
         if ev.button != bevy::input::mouse::MouseButton::Left {
+            continue;
+        }
+        if let Some(cursor_phys) = window.cursor_position().map(|c| c * scale)
+            && let Some((terminal, local_phys)) = tmux_pane_local_at(&panes, cursor_phys)
+            && route_tmux_inline_left_click(
+                &mut gesture,
+                &mut inline_route,
+                &panes,
+                terminal,
+                local_phys,
+                cursor_phys,
+                ev.state,
+                cell_w,
+                cell_h,
+                scale,
+            )
+        {
             continue;
         }
         match ev.state {
@@ -602,6 +654,130 @@ fn arbiter(
     }
 }
 
+/// Inline-routing params for the arbiter, bundled to stay within Bevy's
+/// system-parameter limit. `focused_webview` / `browsers` are optional so
+/// CEF-less tests construct the system (state effects still apply).
+#[derive(SystemParam)]
+struct TmuxInlineRouteParams<'w, 's> {
+    focused_webview: Option<ResMut<'w, FocusedWebview>>,
+    children: Query<'w, 's, &'static Children>,
+    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
+    browsers: Option<NonSend<'w, Browsers>>,
+}
+
+/// Routes a left press/release through the inline-webview layer, returning
+/// `true` when the event was consumed and must NOT reach the tmux gesture
+/// pipeline. Mirrors native `route_inline_left_click`: a press inside an
+/// interactive rect sets `FocusedWebview`, issues the UNGATED `set_focus`
+/// BEFORE the gated `send_mouse_click` (CEF drops clicks to a browser with no
+/// `focused_frame()`, so the first click would otherwise be swallowed),
+/// forwards the press in DIP, and records the in-flight press; a press outside
+/// every rect clears an inline `FocusedWebview` and returns `false`. Release
+/// forwards the click-up to the recorded child (drift-tolerant) and clears.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors native route_inline_left_click signature"
+)]
+fn route_tmux_inline_left_click(
+    gesture: &mut TmuxMouseGesture,
+    route: &mut TmuxInlineRouteParams,
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    terminal: Entity,
+    local_phys: Vec2,
+    cursor_phys: Vec2,
+    button_state: ButtonState,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> bool {
+    match button_state {
+        ButtonState::Pressed => {
+            gesture.inline_press = None;
+            let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
+                inline_hit_at(
+                    &route.children,
+                    &route.inline,
+                    overlays,
+                    terminal,
+                    local_phys,
+                    cell_w_phys,
+                    cell_h_phys,
+                    scale,
+                )
+            });
+            let Some(hit) = hit else {
+                if let Some(focused) = route.focused_webview.as_deref_mut()
+                    && focused
+                        .0
+                        .is_some_and(|current| route.inline_parents.contains(current))
+                {
+                    focused.0 = None;
+                }
+                return false;
+            };
+            if let Some(focused) = route.focused_webview.as_deref_mut()
+                && focused.0 != Some(hit.child)
+            {
+                focused.0 = Some(hit.child);
+            }
+            if let Some(browsers) = route.browsers.as_deref() {
+                browsers.set_focus(&hit.child, true);
+                browsers.send_mouse_click(&hit.child, hit.local_dip, PointerButton::Primary, false);
+            }
+            gesture.inline_press = Some(hit.child);
+            true
+        }
+        ButtonState::Released => {
+            let Some(child) = gesture.inline_press.take() else {
+                return false;
+            };
+            if let Some(browsers) = route.browsers.as_deref()
+                && let Some(dip) = tmux_inline_release_dip(
+                    route,
+                    panes,
+                    child,
+                    cursor_phys,
+                    cell_w_phys,
+                    cell_h_phys,
+                    scale,
+                )
+            {
+                browsers.send_mouse_click(&child, dip, PointerButton::Primary, true);
+            }
+            true
+        }
+    }
+}
+
+/// Webview-local DIP for a release on `child`, WITHOUT containment (a pointer
+/// that drifted off the rect still produces a release position). `None` when
+/// the child/terminal/rect chain is gone. The tmux analog of native
+/// `inline_release_dip`.
+fn tmux_inline_release_dip(
+    route: &TmuxInlineRouteParams,
+    panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
+    child: Entity,
+    cursor_phys: Vec2,
+    cell_w_phys: f32,
+    cell_h_phys: f32,
+    scale: f32,
+) -> Option<Vec2> {
+    let terminal = route.inline_parents.get(child).ok()?.parent();
+    let (_, _, node, transform) = panes.get(terminal).ok()?;
+    let local_phys = phys_to_terminal_local(node, transform, cursor_phys)?;
+    let (view, _) = route.inline.get(child).ok()?;
+    inline_local_dip(
+        route.overlay_rects.get(terminal).ok()?,
+        view.slot,
+        local_phys,
+        cell_w_phys,
+        cell_h_phys,
+        scale,
+    )
+}
+
 /// Inserts `-t %<id>` into a `send-keys -X ...` copy-mode command so it targets
 /// a specific pane instead of the client's active pane. Non-`send-keys -X`
 /// commands are returned unchanged.
@@ -822,6 +998,141 @@ mod tests {
         assert_eq!(
             target_copy_cmd(PaneId(2), "copy-mode -t %2"),
             "copy-mode -t %2",
+        );
+    }
+
+    fn make_arbiter_inline_app() -> (App, Entity, Entity) {
+        use bevy::window::WindowResolution;
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_message::<MouseButtonInput>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.init_resource::<TmuxMouseGesture>();
+        app.init_resource::<CopyModeQueries>();
+        app.init_resource::<SessionPicker>();
+        app.init_resource::<CopyPrompt>();
+        app.init_resource::<FocusedWebview>();
+        app.insert_resource(test_metrics());
+        app.add_systems(Update, arbiter);
+
+        // Pane host node at window center (400, 300), size 800x600 → top-left
+        // at (0, 0). Rect rows 2..12, cols 3..43 → phys y 32..192, x 24..344 at
+        // 8x16 px.
+        let mut overlays = TerminalOverlays::default();
+        overlays.rects[0] = IVec4::new(2, 3, 10, 40);
+        let pane = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: PaneId(1),
+                    dims: CellDims {
+                        width: 100,
+                        height: 37,
+                        xoff: 0,
+                        yoff: 0,
+                    },
+                },
+                ComputedNode {
+                    size: Vec2::new(800.0, 600.0),
+                    ..ComputedNode::DEFAULT
+                },
+                UiGlobalTransform::from_xy(400.0, 300.0),
+                overlays,
+            ))
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(pane),
+                InlineWebview {
+                    view_id: "inline".into(),
+                    instance_id: None,
+                    slot: 0,
+                },
+            ))
+            .id();
+
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        (app, pane, child)
+    }
+
+    fn set_cursor(app: &mut App, phys: Vec2) {
+        use bevy::math::DVec2;
+
+        let win = app
+            .world_mut()
+            .query_filtered::<Entity, With<PrimaryWindow>>()
+            .single(app.world())
+            .unwrap();
+        app.world_mut()
+            .get_mut::<Window>(win)
+            .unwrap()
+            .set_physical_cursor_position(Some(DVec2::new(phys.x as f64, phys.y as f64)));
+    }
+
+    fn write_button(app: &mut App, button: bevy::input::mouse::MouseButton, state: ButtonState) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseButtonInput>>()
+            .write(MouseButtonInput {
+                button,
+                state,
+                window: Entity::PLACEHOLDER,
+            });
+    }
+
+    #[test]
+    fn inline_press_focuses_child_and_consumes() {
+        let (mut app, _pane, child) = make_arbiter_inline_app();
+        set_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_button(
+            &mut app,
+            bevy::input::mouse::MouseButton::Left,
+            ButtonState::Pressed,
+        );
+        app.update();
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "a press inside an interactive inline rect must focus that child"
+        );
+        assert_eq!(
+            app.world().resource::<TmuxMouseGesture>().state,
+            GestureState::Idle,
+            "a consumed inline press must NOT arm a Pressed/Selecting gesture"
+        );
+    }
+
+    #[test]
+    fn inline_off_rect_press_releases_focus_and_falls_through() {
+        let (mut app, pane, child) = make_arbiter_inline_app();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        set_cursor(&mut app, Vec2::new(400.0, 400.0));
+        write_button(
+            &mut app,
+            bevy::input::mouse::MouseButton::Left,
+            ButtonState::Pressed,
+        );
+        app.update();
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "an off-rect press must release inline focus"
+        );
+        assert!(
+            matches!(
+                app.world().resource::<TmuxMouseGesture>().state,
+                GestureState::Pressed { pane: p, .. } if p == pane
+            ),
+            "an off-rect press must fall through to the normal pane gesture"
         );
     }
 }

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -1315,7 +1315,10 @@ mod tests {
         );
         assert_eq!(bbox, Vec2::new(640.0, 384.0));
         assert_eq!(dividers.len(), 2);
-        let outer = dividers.iter().find(|d| (d.pos_px - 320.0).abs() < 0.5).unwrap();
+        let outer = dividers
+            .iter()
+            .find(|d| (d.pos_px - 320.0).abs() < 0.5)
+            .unwrap();
         assert_eq!(outer.axis, DividerAxis::Vertical);
         assert_eq!(
             outer.primary,

--- a/src/webview_render.rs
+++ b/src/webview_render.rs
@@ -10,6 +10,7 @@ use crate::system_set::OzmuxSystems;
 use bevy::prelude::*;
 use bevy_cef::prelude::*;
 use ozmux_multiplexer::{AttachedWorkspace, MultiplexerCommands, WorkspaceMarker};
+use ozmux_tmux::TmuxPane;
 use ozmux_webview_host::DynAssetRegistry;
 use ozmux_webview_host::dyn_scheme::custom_dyn_scheme;
 use serde_json::Value;
@@ -90,6 +91,12 @@ impl Plugin for OzmuxWebviewRenderPlugin {
 /// clobber an inline focus one frame after it was set. Every other case — a
 /// different pane or surface becoming active, or the inline child despawning —
 /// keeps the drive-from-active-pane behavior above.
+///
+/// Under the tmux backend the active-surface resolution above is empty (the
+/// tmux projection populates `TmuxPane`, not the old multiplexer's
+/// active-pane chain), so `FocusedWebview` is click-driven there. A second
+/// preservation arm keeps it while it points at an inline child of a live
+/// `TmuxPane`; a despawned child falls through to the GC path below.
 pub(crate) fn sync_focused_webview(
     mut focused: ResMut<FocusedWebview>,
     mux: MultiplexerCommands,
@@ -97,7 +104,19 @@ pub(crate) fn sync_focused_webview(
     webviews: Query<(), With<WebviewSource>>,
     non_interactive: Query<(), With<NonInteractive>>,
     inline_parents: Query<&ChildOf, With<InlineWebview>>,
+    tmux_panes: Query<(), With<TmuxPane>>,
 ) {
+    // NOTE: a despawned inline child fails `inline_parents.get` here and so
+    // falls through to the old-mux path below, which clears it — that
+    // fall-through is the GC for tmux-pane inline focus; a later edit that
+    // short-circuits this arm before the despawn check would leak focus.
+    if let Some(child) = focused.0
+        && let Ok(parent) = inline_parents.get(child)
+        && tmux_panes.contains(parent.parent())
+    {
+        return;
+    }
+
     let active_surface = attached_workspace
         .iter()
         .next()
@@ -416,6 +435,97 @@ mod tests {
             app.world().resource::<FocusedWebview>().0,
             None,
             "inline focus must clear once a different pane/surface becomes active"
+        );
+    }
+
+    #[test]
+    fn tmux_pane_inline_focus_is_preserved() {
+        use ozmux_tmux::{PaneId, TmuxPane};
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(ozmux_multiplexer::MultiplexerPlugin);
+        app.init_resource::<FocusedWebview>();
+        app.add_systems(Update, sync_focused_webview);
+
+        let pane = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 80,
+                    height: 24,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(pane),
+                InlineWebview {
+                    view_id: "v".into(),
+                    instance_id: None,
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            Some(child),
+            "an inline child of a live TmuxPane must keep FocusedWebview across the per-frame sync",
+        );
+    }
+
+    #[test]
+    fn tmux_pane_inline_focus_is_gc_on_despawn() {
+        use ozmux_tmux::{PaneId, TmuxPane};
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(ozmux_multiplexer::MultiplexerPlugin);
+        app.init_resource::<FocusedWebview>();
+        app.add_systems(Update, sync_focused_webview);
+
+        let pane = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 80,
+                    height: 24,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        let child = app
+            .world_mut()
+            .spawn((
+                ChildOf(pane),
+                InlineWebview {
+                    view_id: "v".into(),
+                    instance_id: None,
+                    slot: 0,
+                },
+            ))
+            .id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
+        app.world_mut().entity_mut(child).despawn();
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<FocusedWebview>().0,
+            None,
+            "a despawned inline child must be GC'd out of FocusedWebview",
         );
     }
 


### PR DESCRIPTION
## Problem

Under the tmux backend, the mouse wheel **unconditionally enters tmux copy mode**, so an *interactive* inline webview embedded in a tmux pane can't be scrolled, clicked, or hovered — it is effectively uninteractable with the mouse.

Root cause: `bevy_cef`'s mouse input (`send_mouse_wheel` / `send_mouse_move` / `send_mouse_click`) is focus-gated (`get_focused_browser` → `focused_frame()`), and the `FocusedWebview` focus machinery (`sync_focused_webview`) was old-multiplexer-driven, which the tmux backend never populates — so a tmux-pane inline webview could never hold focus, and the wheel always fell through to copy-mode entry.

## Solution

Add **focus-based + pointer-gated** mouse routing for interactive inline webviews under the tmux backend, mirroring the proven native inline-routing path (`src/input/mouse_buttons.rs`, `src/input/mouse_wheel.rs`, `src/inline_webview.rs`) over `TmuxPane` hosts. Engine changes:

- **`src/webview_render.rs`** — `sync_focused_webview` is now tmux-aware: it preserves click-driven focus while `FocusedWebview` points at an inline child of a live `TmuxPane`, and GCs it on despawn.
- **`src/tmux_mouse.rs`** — arbiter inline click routing: an in-rect press grants CEF focus via the **ungated `Browsers::set_focus` *before* `send_mouse_click`** (avoids the first-click-swallow, since CEF drops clicks to a browser with no focused frame), forwards the click, records `inline_press`, and `select-pane`s the host pane; an off-rect press releases focus and falls through to the normal tmux gesture. New `CursorMoved`-driven `forward_tmux_inline_mouse_moves` handles hover and in-rect drag. Modal / unfocus drain guards release any in-flight press so the page is not left logically pressed.
- **`src/tmux_input.rs`** — `forward_wheel_to_tmux` is pointer-gated: a focused inline webview under the pointer scrolls the page (forwarded to CEF), otherwise the tmux path (copy-mode scroll / `WheelUpPane`) runs. The `forward_keys_to_tmux` keyboard guard now actually functions, since `FocusedWebview` is set under tmux.

Design + plan: `docs/superpowers/specs/2026-06-16-tmux-webview-mouse-focus-design.md`, `docs/superpowers/plans/2026-06-16-tmux-webview-mouse-focus.md`. Built feature-first (spec → review → plan → per-task TDD); 416 tests pass, `cargo fmt --check` clean.

### Notes / out of scope

- **Pure hover-wheel** (scroll without first focusing) is intentionally deferred: `bevy_cef` gates wheel delivery on a focused frame, so it would need an upstream `bevy_cef` change.
- **Display-only webviews** (registered `interactive(false)`, e.g. the `ozmd` viewer) are deliberately excluded — `inline_hit_at` skips `NonInteractive`; they stay TUI/keyboard-driven.
- Includes a merge of `main` to pick up #139 (1px pane dividers).
