### PR TITLE
fix(tmux): restore pane cursor position on attach

### DIFF
--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -4,7 +4,7 @@ use crate::components::WindowFlags;
 use crate::input::quote;
 use crate::keybindings::PromptKind;
 use bevy::prelude::Resource;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tmux_control::CommandId;
 use tmux_control_parser::{PaneId, WindowId, WindowLayout};
 
@@ -198,6 +198,17 @@ pub(crate) fn capture_pane_command(id: PaneId) -> String {
     format!("capture-pane -p -e -t %{}", id.0)
 }
 
+/// Builds `display-message -p -t %<id> '#{cursor_x} #{cursor_y}'` to query the
+/// real cursor position of a pane.
+///
+/// Sent immediately after [`capture_pane_command`] for the same pane. Because
+/// tmux CC-mode replies are FIFO-ordered, this reply always arrives after the
+/// capture reply, so the capture content can be held until both are available and
+/// a cursor-positioning escape appended before the `PaneOutput` is emitted.
+pub(crate) fn cursor_query_command(id: PaneId) -> String {
+    format!("display-message -p -t %{} '#{{cursor_x}} #{{cursor_y}}'", id.0)
+}
+
 /// The tab-separated `display-message -F` format ozmux reads each refresh while
 /// a pane is in copy mode. Field order is fixed; `parse_copy_state` depends on it.
 const COPY_STATE_FORMAT: &str = "#{pane_in_mode}\t#{scroll_position}\t#{pane_height}\t#{history_size}\t#{copy_cursor_x}\t#{copy_cursor_y}\t#{selection_present}\t#{rectangle_toggle}\t#{selection_start_x}\t#{selection_start_y}\t#{selection_end_x}\t#{selection_end_y}";
@@ -348,6 +359,17 @@ pub(crate) struct EnumerationState {
     pub(crate) mode_keys_pending: Option<CommandId>,
     /// In-flight `capture-pane` commands → the pane each reply seeds.
     pub(crate) capture_pending: HashMap<CommandId, PaneId>,
+    /// In-flight cursor-position `display-message` queries → the pane.
+    ///
+    /// Replies arrive after the paired `capture-pane` reply (FIFO). When both
+    /// have been received the cursor-positioning escape is appended to the
+    /// captured content before the `PaneOutput` is emitted.
+    pub(crate) cursor_pending: HashMap<CommandId, PaneId>,
+    /// Panes whose cursor query is still in-flight; used for O(1) lookup when
+    /// the capture reply arrives to decide whether to cache or emit immediately.
+    pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
+    /// Captured screen lines held while the cursor reply has not yet arrived.
+    pub(crate) capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
 }
 
 #[cfg(test)]

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -118,16 +118,21 @@ pub(crate) fn take_client_name(
     None
 }
 
-/// Drains matching `capture-pane` replies from `events`, returning a
-/// [`PaneOutput`] seeding each captured pane's initial screen.
+/// Drains matching `capture-pane` replies from `events`.
 ///
-/// For every `CommandComplete` whose id is in `capture_pending`, the entry is
-/// removed and (on success) its body lines are joined with CRLF into VT bytes
-/// fed to the pane like ordinary `%output`. tmux `-CC` does not replay existing
-/// content on attach, so this seeds the first paint; the live `%output` stream
-/// keeps it current thereafter.
+/// For every `CommandComplete` whose id is in `capture_pending`:
+/// - If the pane has a cursor-position query in-flight (`panes_with_cursor_pending`),
+///   the captured lines are stored in `capture_awaiting_cursor` and emitted later
+///   by [`take_cursor_positions`] once the cursor reply arrives.
+/// - Otherwise the pane is emitted immediately as a [`PaneOutput`] (original
+///   behaviour when cursor querying is unavailable or already drained).
+///
+/// tmux `-CC` does not replay existing content on attach, so this seeds the
+/// first paint; the live `%output` stream keeps it current thereafter.
 pub(crate) fn take_pane_captures(
     capture_pending: &mut HashMap<CommandId, PaneId>,
+    capture_awaiting_cursor: &mut HashMap<PaneId, Vec<String>>,
+    panes_with_cursor_pending: &HashSet<PaneId>,
     events: &[TransportEvent],
 ) -> Vec<PaneOutput> {
     let mut out = Vec::new();
@@ -136,16 +141,64 @@ pub(crate) fn take_pane_captures(
             && let Some(pane) = capture_pending.remove(id)
         {
             if *ok {
-                out.push(PaneOutput {
-                    pane,
-                    data: capture_to_bytes(output),
-                });
+                if panes_with_cursor_pending.contains(&pane) {
+                    capture_awaiting_cursor.insert(pane, output.clone());
+                } else {
+                    out.push(PaneOutput {
+                        pane,
+                        data: capture_to_bytes(output),
+                    });
+                }
             } else {
                 tracing::warn!(pane = pane.0, "capture-pane command failed");
             }
         }
     }
     out
+}
+
+/// Drains matching cursor-position `display-message` replies from `events`,
+/// pairing each with its cached capture content and returning the combined
+/// [`PaneOutput`] with the real cursor position restored.
+///
+/// FIFO ordering guarantees the capture reply arrives before this cursor reply,
+/// so `capture_awaiting_cursor` should always contain the entry. If it does not
+/// (e.g. capture failed), the cursor reply is silently dropped.
+pub(crate) fn take_cursor_positions(
+    cursor_pending: &mut HashMap<CommandId, PaneId>,
+    panes_with_cursor_pending: &mut HashSet<PaneId>,
+    capture_awaiting_cursor: &mut HashMap<PaneId, Vec<String>>,
+    events: &[TransportEvent],
+) -> Vec<PaneOutput> {
+    let mut out = Vec::new();
+    for event in events {
+        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
+            && let Some(pane) = cursor_pending.remove(id)
+        {
+            panes_with_cursor_pending.remove(&pane);
+            let Some(lines) = capture_awaiting_cursor.remove(&pane) else {
+                continue;
+            };
+            let (cx, cy) = if *ok {
+                parse_cursor_pos(output).unwrap_or((0, 0))
+            } else {
+                tracing::warn!(pane = pane.0, "cursor-position query failed");
+                (0, 0)
+            };
+            out.push(PaneOutput {
+                pane,
+                data: capture_to_bytes_with_cursor(&lines, cx, cy),
+            });
+        }
+    }
+    out
+}
+
+/// Parses a `'#{cursor_x} #{cursor_y}'` reply line into `(col, row)`.
+fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
+    let line = output.first()?;
+    let (x, y) = line.trim().split_once(' ')?;
+    Some((x.parse().ok()?, y.parse().ok()?))
 }
 
 /// Joins `capture-pane -p -e` reply lines into VT bytes for seeding a pane's
@@ -156,6 +209,15 @@ pub(crate) fn take_pane_captures(
 fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
     let mut bytes = b"\x1b[H\x1b[2J".to_vec();
     bytes.extend_from_slice(lines.join("\r\n").as_bytes());
+    bytes
+}
+
+/// Like [`capture_to_bytes`] but appends a CSI cursor-position escape (`ESC[row;colH`,
+/// 1-origin) so the rendered cursor matches the real tmux pane cursor after the
+/// snapshot is painted.
+fn capture_to_bytes_with_cursor(lines: &[String], cx: u16, cy: u16) -> Vec<u8> {
+    let mut bytes = capture_to_bytes(lines);
+    bytes.extend_from_slice(format!("\x1b[{};{}H", cy + 1, cx + 1).as_bytes());
     bytes
 }
 
@@ -478,7 +540,9 @@ mod tests {
             output: vec!["line one".to_string(), "line two".to_string()],
         })];
         let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
-        let out = take_pane_captures(&mut capture_pending, &events);
+        let no_cursor_pending = HashSet::new();
+        let mut awaiting = HashMap::new();
+        let out = take_pane_captures(&mut capture_pending, &mut awaiting, &no_cursor_pending, &events);
         assert_eq!(
             out,
             vec![PaneOutput {
@@ -487,6 +551,7 @@ mod tests {
             }]
         );
         assert!(capture_pending.is_empty());
+        assert!(awaiting.is_empty());
     }
 
     #[test]
@@ -514,12 +579,57 @@ mod tests {
             output: vec![],
         })];
         let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
-        let out = take_pane_captures(&mut capture_pending, &events);
+        let no_cursor_pending = HashSet::new();
+        let mut awaiting = HashMap::new();
+        let out = take_pane_captures(&mut capture_pending, &mut awaiting, &no_cursor_pending, &events);
         assert!(out.is_empty());
-        assert!(
-            capture_pending.is_empty(),
-            "failed capture is still cleared"
+        assert!(capture_pending.is_empty(), "failed capture is still cleared");
+        assert!(awaiting.is_empty(), "failed capture must not populate awaiting");
+    }
+
+    #[test]
+    fn take_pane_captures_caches_when_cursor_pending() {
+        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(5),
+            number: 0,
+            ok: true,
+            output: vec!["line one".to_string()],
+        })];
+        let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
+        let cursor_pending = HashSet::from([PaneId(88)]);
+        let mut awaiting = HashMap::new();
+        let out = take_pane_captures(&mut capture_pending, &mut awaiting, &cursor_pending, &events);
+        assert!(out.is_empty(), "should cache, not emit");
+        assert_eq!(awaiting.get(&PaneId(88)), Some(&vec!["line one".to_string()]));
+    }
+
+    #[test]
+    fn take_cursor_positions_emits_with_cursor_escape() {
+        let cursor_event = TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(6),
+            number: 0,
+            ok: true,
+            output: vec!["3 5".to_string()],
+        });
+        let mut cursor_pending = HashMap::from([(CommandId(6), PaneId(88))]);
+        let mut panes_with_cursor = HashSet::from([PaneId(88)]);
+        let mut awaiting = HashMap::from([(PaneId(88), vec!["hello".to_string()])]);
+        let out = take_cursor_positions(
+            &mut cursor_pending,
+            &mut panes_with_cursor,
+            &mut awaiting,
+            &[cursor_event],
         );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].pane, PaneId(88));
+        // ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4, 1-origin)
+        assert_eq!(
+            out[0].data,
+            b"\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec()
+        );
+        assert!(cursor_pending.is_empty());
+        assert!(panes_with_cursor.is_empty());
+        assert!(awaiting.is_empty());
     }
 
     #[test]

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -6,12 +6,12 @@ use crate::connection::TmuxConnection;
 use crate::copy_queries::{CopyModeQueries, CopyModeReply, drain_copy_replies};
 use crate::enumerate::{
     EnumerationState, active_pane_command, capture_pane_command, client_name_command,
-    list_windows_command, mode_keys_command, subscribe_window_flags_command,
+    cursor_query_command, list_windows_command, mode_keys_command, subscribe_window_flags_command,
 };
 use crate::event_pump::{
     advance_state, detect_session_switch, detect_window_added, detect_window_switch,
-    drain_transport, take_active_pane, take_client_name, take_keybindings, take_mode_keys,
-    take_pane_captures, take_prefix_keys, trigger_events,
+    drain_transport, take_active_pane, take_client_name, take_cursor_positions, take_keybindings,
+    take_mode_keys, take_pane_captures, take_prefix_keys, trigger_events,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxConnectionReset, TmuxWindowsRetained};
 use crate::keybindings::{KeyBindings, list_keys_command, prefix_options_command};
@@ -54,12 +54,13 @@ impl Plugin for TmuxSessionPlugin {
     }
 }
 
-/// Sends `capture-pane` once for each newly-projected pane so its current screen
-/// seeds the first paint. tmux `-CC` does not replay existing content on attach
-/// (it only streams new `%output`), so without this a quiescent pane stays blank
-/// until its program writes again. Gated on `Added<TmuxPane>` — runs once per
-/// pane. The reply is consumed by [`take_pane_captures`] and routed as
-/// `PaneOutput`.
+/// Sends `capture-pane` and a companion cursor-position `display-message` once
+/// for each newly-projected pane so its current screen seeds the first paint
+/// with the cursor at the correct position. tmux `-CC` does not replay existing
+/// content on attach (it only streams new `%output`), so without this a
+/// quiescent pane stays blank until its program writes again. Gated on
+/// `Added<TmuxPane>` — runs once per pane. Replies are consumed by
+/// [`take_pane_captures`] / [`take_cursor_positions`] and routed as `PaneOutput`.
 fn request_pane_captures(
     mut enumeration: ResMut<EnumerationState>,
     connection: NonSend<TmuxConnection>,
@@ -70,8 +71,17 @@ fn request_pane_captures(
     };
     for pane in new_panes.iter() {
         match client.handle().send(&capture_pane_command(pane.id)) {
-            Ok(id) => {
-                enumeration.capture_pending.insert(id, pane.id);
+            Ok(cap_id) => {
+                enumeration.capture_pending.insert(cap_id, pane.id);
+                match client.handle().send(&cursor_query_command(pane.id)) {
+                    Ok(cur_id) => {
+                        enumeration.cursor_pending.insert(cur_id, pane.id);
+                        enumeration.panes_with_cursor_pending.insert(pane.id);
+                    }
+                    Err(error) => {
+                        tracing::warn!(?error, pane = pane.id.0, "failed to send cursor query");
+                    }
+                }
             }
             Err(error) => {
                 tracing::warn!(?error, pane = pane.id.0, "failed to send capture-pane")
@@ -124,6 +134,10 @@ fn drain_tmux_events(
         commands.trigger(TmuxWindowsRetained {
             windows: Vec::new(),
         });
+        enumeration.capture_pending.clear();
+        enumeration.cursor_pending.clear();
+        enumeration.panes_with_cursor_pending.clear();
+        enumeration.capture_awaiting_cursor.clear();
         send_session_enumeration(&mut enumeration, client);
     } else if let Some(client) = connection.client() {
         if detect_window_added(&events) {
@@ -182,16 +196,7 @@ fn drain_tmux_events(
         .any(|event| matches!(event, TransportEvent::Closed { .. }))
     {
         connection.take();
-        enumeration.pending = None;
-        enumeration.client_name_pending = None;
-        enumeration.active_pane_pending = None;
-        enumeration.capture_pending.clear();
-        enumeration.keys_root_pending = None;
-        enumeration.keys_prefix_pending = None;
-        enumeration.prefix_keys_pending = None;
-        enumeration.keys_copy_mode_pending = None;
-        enumeration.keys_copy_mode_vi_pending = None;
-        enumeration.mode_keys_pending = None;
+        *enumeration = EnumerationState::default();
         keybindings.clear();
         copy_queries.clear();
         commands.trigger(TmuxConnectionReset);
@@ -204,7 +209,28 @@ fn drain_tmux_events(
         {
             commands.trigger(TmuxActivePaneChanged { window, pane });
         }
-        for output in take_pane_captures(&mut enumeration.capture_pending, &events) {
+        // NOTE: deref once so the borrow checker can see these as distinct
+        // field borrows rather than overlapping borrows through DerefMut.
+        // NOTE: take_pane_captures MUST run before take_cursor_positions: when
+        // both a capture reply and its paired cursor reply arrive in the same
+        // event batch, captures populates capture_awaiting_cursor first, then
+        // cursor_positions drains it. Swapping the calls silently drops cursor
+        // fixes on same-batch arrivals.
+        let e = &mut *enumeration;
+        for output in take_pane_captures(
+            &mut e.capture_pending,
+            &mut e.capture_awaiting_cursor,
+            &e.panes_with_cursor_pending,
+            &events,
+        ) {
+            pane_output.write(output);
+        }
+        for output in take_cursor_positions(
+            &mut e.cursor_pending,
+            &mut e.panes_with_cursor_pending,
+            &mut e.capture_awaiting_cursor,
+            &events,
+        ) {
             pane_output.write(output);
         }
         if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, &events) {


### PR DESCRIPTION
## Problem

When ozmux attaches to a tmux session, quiescent panes (e.g. a shell waiting at a prompt) display the cursor at the **bottom row** of the pane instead of at the real cursor position. The cursor stays wrong until the running program emits new output.

Root cause: `capture-pane -p -e` returns all `pane_height` lines joined with `\r\n`. After the `\x1b[H\x1b[2J` prefix, the VT emulator lands at row `height-1` regardless of where the program's cursor actually is. `capture-pane` does not include cursor position in its output.

## Solution

After each `capture-pane` command, immediately send a companion `display-message -p -t %N '#{cursor_x} #{cursor_y}'` query. tmux CC-mode replies are FIFO-ordered, so the cursor reply always arrives after the capture reply. The capture lines are cached until both replies are in hand, then `capture_to_bytes_with_cursor` appends `ESC[row;colH` (1-origin CSI cursor position) before emitting the `PaneOutput`.

**Affected crate:** `crates/tmux_session` (enumerate, event\_pump, plugin).

Changes:
- `enumerate.rs` — new `cursor_query_command()`, three new `EnumerationState` fields (`cursor_pending`, `panes_with_cursor_pending`, `capture_awaiting_cursor`)
- `event_pump.rs` — `take_pane_captures` now caches content when a cursor query is in-flight; new `take_cursor_positions` drains cursor replies and emits the combined output; new `capture_to_bytes_with_cursor` and `parse_cursor_pos` helpers; four updated/added unit tests
- `plugin.rs` — `request_pane_captures` sends both commands; `drain_tmux_events` calls both drain functions (in the correct FIFO order, documented with a NOTE); session-switch path now clears the new maps; `Closed` branch simplified to `*enumeration = EnumerationState::default()`