### PR TITLE
feat: configurable "Use Option as Meta key" (option_as_alt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,6 +4964,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "url",
+ "winit",
 ]
 
 [[package]]
@@ -7085,6 +7086,7 @@ checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
+ "once_cell",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ url = "2"
 [dev-dependencies]
 tempfile = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+winit = "0.30"
+
 [lints]
 workspace = true
 

--- a/crates/configs/src/keyboard.rs
+++ b/crates/configs/src/keyboard.rs
@@ -29,6 +29,7 @@ pub struct KeyboardConfig {
 /// Per-field-optional patch produced by parsing `[keyboard]` from
 /// `config.toml`. Missing keys fall through to the defaults.
 #[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct KeyboardPatch {
     pub(crate) option_as_alt: Option<OptionAsAlt>,
 }
@@ -85,5 +86,14 @@ mod tests {
     fn rejects_unknown_value() {
         let err = toml::from_str::<KeyboardPatch>(r#"option_as_alt = "meta""#).err();
         assert!(err.is_some(), "unknown enum value must be a parse error");
+    }
+
+    #[test]
+    fn rejects_unknown_field() {
+        let err = toml::from_str::<KeyboardPatch>(r#"option_as_alt2 = "both""#).err();
+        assert!(
+            err.is_some(),
+            "a misspelled key in [keyboard] must be a parse error, not silently ignored"
+        );
     }
 }

--- a/crates/configs/src/keyboard.rs
+++ b/crates/configs/src/keyboard.rs
@@ -1,0 +1,89 @@
+//! Keyboard input configuration: macOS Option-as-Meta behavior.
+
+use serde::{Deserialize, Serialize};
+
+/// Which Option/Alt key(s) macOS treats as Meta (Alt) instead of composing
+/// into special characters. Mirrors winit's `OptionAsAlt`; has no effect on
+/// non-macOS platforms, where Alt is always Meta.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OptionAsAlt {
+    /// Neither Option key acts as Meta; both compose normally (default).
+    #[default]
+    None,
+    /// Only the left Option key acts as Meta; the right one composes.
+    Left,
+    /// Only the right Option key acts as Meta; the left one composes.
+    Right,
+    /// Both Option keys act as Meta.
+    Both,
+}
+
+/// Fully-resolved `[keyboard]` config block.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct KeyboardConfig {
+    /// Which Option key(s) act as Meta on macOS.
+    pub option_as_alt: OptionAsAlt,
+}
+
+/// Per-field-optional patch produced by parsing `[keyboard]` from
+/// `config.toml`. Missing keys fall through to the defaults.
+#[derive(Deserialize, Default)]
+pub(crate) struct KeyboardPatch {
+    pub(crate) option_as_alt: Option<OptionAsAlt>,
+}
+
+impl KeyboardPatch {
+    pub(crate) fn apply_to(self, mut base: KeyboardConfig) -> KeyboardConfig {
+        if let Some(v) = self.option_as_alt {
+            base.option_as_alt = v;
+        }
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_none() {
+        assert_eq!(KeyboardConfig::default().option_as_alt, OptionAsAlt::None);
+    }
+
+    #[test]
+    fn parses_each_lowercase_value() {
+        for (s, expected) in [
+            ("none", OptionAsAlt::None),
+            ("left", OptionAsAlt::Left),
+            ("right", OptionAsAlt::Right),
+            ("both", OptionAsAlt::Both),
+        ] {
+            let patch: KeyboardPatch =
+                toml::from_str(&format!(r#"option_as_alt = "{s}""#)).unwrap();
+            assert_eq!(patch.option_as_alt, Some(expected));
+        }
+    }
+
+    #[test]
+    fn patch_overrides_present_field() {
+        let patch = KeyboardPatch {
+            option_as_alt: Some(OptionAsAlt::Both),
+        };
+        let merged = patch.apply_to(KeyboardConfig::default());
+        assert_eq!(merged.option_as_alt, OptionAsAlt::Both);
+    }
+
+    #[test]
+    fn empty_patch_keeps_default() {
+        let patch = KeyboardPatch::default();
+        let merged = patch.apply_to(KeyboardConfig::default());
+        assert_eq!(merged, KeyboardConfig::default());
+    }
+
+    #[test]
+    fn rejects_unknown_value() {
+        let err = toml::from_str::<KeyboardPatch>(r#"option_as_alt = "meta""#).err();
+        assert!(err.is_some(), "unknown enum value must be a parse error");
+    }
+}

--- a/crates/configs/src/lib.rs
+++ b/crates/configs/src/lib.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 pub mod error;
 pub mod font;
 pub mod inactive_pane;
+pub mod keyboard;
 pub mod mouse;
 pub mod osc_webview;
 pub mod path;
@@ -34,6 +35,8 @@ pub struct OzmuxConfigs {
     pub font: FontConfig,
     /// Mouse-input configuration.
     pub mouse: mouse::MouseConfig,
+    /// Keyboard-input configuration (macOS Option-as-Meta).
+    pub keyboard: keyboard::KeyboardConfig,
     /// Inactive-pane dimming configuration.
     pub inactive_pane: InactivePaneConfig,
     /// OSC-driven webview configuration.

--- a/crates/configs/src/raw.rs
+++ b/crates/configs/src/raw.rs
@@ -6,6 +6,7 @@ use crate::OzmuxConfigsError;
 use crate::OzmuxConfigsResult;
 use crate::font::FontPatch;
 use crate::inactive_pane::InactivePaneConfigPatch;
+use crate::keyboard::KeyboardPatch;
 use crate::mouse::MousePatch;
 use crate::osc_webview::OscWebviewPatch;
 use crate::shortcuts::Shortcuts;
@@ -22,6 +23,7 @@ pub(crate) struct RawConfigs {
     pub(crate) theme: Option<ThemePatch>,
     pub(crate) font: Option<FontPatch>,
     pub(crate) mouse: Option<MousePatch>,
+    pub(crate) keyboard: Option<KeyboardPatch>,
     pub(crate) inactive_pane: Option<InactivePaneConfigPatch>,
     pub(crate) osc_webview: Option<OscWebviewPatch>,
     pub(crate) tmux: Option<TmuxPatch>,
@@ -30,7 +32,7 @@ pub(crate) struct RawConfigs {
 impl RawConfigs {
     /// Applies any populated fields onto `base` and returns the merged result.
     /// Within the `shortcuts` section, `bindings` is full-replace when present.
-    /// The `theme`, `font`, `mouse`, `inactive_pane`, and `osc_webview`
+    /// The `theme`, `font`, `mouse`, `keyboard`, `inactive_pane`, and `osc_webview`
     /// sections use their respective `Patch::apply_to` for per-field merge.
     pub(crate) fn apply_to(self, mut base: OzmuxConfigs) -> OzmuxConfigs {
         if let Some(shortcuts) = self.shortcuts {
@@ -44,6 +46,9 @@ impl RawConfigs {
         }
         if let Some(patch) = self.mouse {
             base.mouse = patch.apply_to(base.mouse);
+        }
+        if let Some(patch) = self.keyboard {
+            base.keyboard = patch.apply_to(base.keyboard);
         }
         if let Some(patch) = self.inactive_pane {
             base.inactive_pane = patch.apply_to(base.inactive_pane);
@@ -224,5 +229,26 @@ release-inline-focus = "Cmd+V"
             }
             _ => panic!("expected DuplicateChords, got {err:?}"),
         }
+    }
+
+    #[test]
+    fn keyboard_section_merges_from_toml() {
+        let toml_str = r#"
+[keyboard]
+option_as_alt = "both"
+"#;
+        let raw: RawConfigs = toml::from_str(toml_str).unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(
+            merged.keyboard.option_as_alt,
+            crate::keyboard::OptionAsAlt::Both
+        );
+    }
+
+    #[test]
+    fn missing_keyboard_section_uses_defaults() {
+        let raw: RawConfigs = toml::from_str("").unwrap();
+        let merged = raw.apply_to(OzmuxConfigs::default());
+        assert_eq!(merged.keyboard, crate::keyboard::KeyboardConfig::default());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod hyperlink;
 pub(crate) mod ime;
+pub(crate) mod option_as_alt;
 
 use crate::system_set::OzmuxSystems;
 use bevy::prelude::*;

--- a/src/input/option_as_alt.rs
+++ b/src/input/option_as_alt.rs
@@ -61,7 +61,10 @@ mod macos {
 
         #[test]
         fn maps_each_variant_to_winit() {
-            assert!(matches!(to_winit(OptionAsAlt::None), WinitOptionAsAlt::None));
+            assert!(matches!(
+                to_winit(OptionAsAlt::None),
+                WinitOptionAsAlt::None
+            ));
             assert!(matches!(
                 to_winit(OptionAsAlt::Left),
                 WinitOptionAsAlt::OnlyLeft
@@ -70,7 +73,10 @@ mod macos {
                 to_winit(OptionAsAlt::Right),
                 WinitOptionAsAlt::OnlyRight
             ));
-            assert!(matches!(to_winit(OptionAsAlt::Both), WinitOptionAsAlt::Both));
+            assert!(matches!(
+                to_winit(OptionAsAlt::Both),
+                WinitOptionAsAlt::Both
+            ));
         }
     }
 }

--- a/src/input/option_as_alt.rs
+++ b/src/input/option_as_alt.rs
@@ -21,17 +21,18 @@ impl Plugin for OptionAsAltPlugin {
 #[cfg(target_os = "macos")]
 mod macos {
     use crate::configs::OzmuxConfigsResource;
+    use bevy::ecs::system::NonSendMarker;
     use bevy::prelude::*;
     use bevy::window::PrimaryWindow;
-    use bevy::winit::WinitWindows;
+    use bevy::winit::WINIT_WINDOWS;
     use ozmux_configs::keyboard::OptionAsAlt;
     use winit::platform::macos::{OptionAsAlt as WinitOptionAsAlt, WindowExtMacOS};
 
     pub(super) fn apply_option_as_alt(
         mut done: Local<bool>,
         configs: Res<OzmuxConfigsResource>,
-        winit_windows: NonSend<WinitWindows>,
         primary: Query<Entity, With<PrimaryWindow>>,
+        _non_send_marker: NonSendMarker,
     ) {
         if *done {
             return;
@@ -39,11 +40,15 @@ mod macos {
         let Ok(entity) = primary.single() else {
             return;
         };
-        let Some(window) = winit_windows.get_window(entity) else {
-            return;
-        };
-        window.set_option_as_alt(to_winit(configs.keyboard.option_as_alt));
-        *done = true;
+        // NOTE: Bevy 0.18 keeps WinitWindows in a main-thread thread-local, not a world
+        // non-send resource (bevy ECS #17667 workaround). NonSendMarker pins this system
+        // to the main thread so the borrow sees the populated instance, not an empty one.
+        WINIT_WINDOWS.with_borrow(|winit_windows| {
+            if let Some(window) = winit_windows.get_window(entity) {
+                window.set_option_as_alt(to_winit(configs.keyboard.option_as_alt));
+                *done = true;
+            }
+        });
     }
 
     fn to_winit(mode: OptionAsAlt) -> WinitOptionAsAlt {
@@ -77,6 +82,16 @@ mod macos {
                 to_winit(OptionAsAlt::Both),
                 WinitOptionAsAlt::Both
             ));
+        }
+
+        #[test]
+        fn system_validates_and_runs_without_winit() {
+            let mut app = App::new();
+            app.add_plugins(MinimalPlugins);
+            app.init_resource::<crate::configs::OzmuxConfigsResource>();
+            app.world_mut().spawn(PrimaryWindow);
+            app.add_systems(Update, apply_option_as_alt);
+            app.update();
         }
     }
 }

--- a/src/input/option_as_alt.rs
+++ b/src/input/option_as_alt.rs
@@ -1,0 +1,76 @@
+//! macOS "Option as Meta" support: applies the `[keyboard] option_as_alt`
+//! config to the native winit window via `WindowExtMacOS::set_option_as_alt`,
+//! so the configured Option side is delivered as Alt (Meta) below the IME
+//! layer instead of composing into special characters. No-op on non-macOS.
+
+use bevy::prelude::*;
+
+/// Bevy plugin that applies the configured macOS Option-as-Alt mode to the
+/// primary window. Empty on non-macOS targets.
+pub(crate) struct OptionAsAltPlugin;
+
+impl Plugin for OptionAsAltPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(target_os = "macos")]
+        app.add_systems(Update, macos::apply_option_as_alt);
+        #[cfg(not(target_os = "macos"))]
+        let _ = app;
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use crate::configs::OzmuxConfigsResource;
+    use bevy::prelude::*;
+    use bevy::window::PrimaryWindow;
+    use bevy::winit::WinitWindows;
+    use ozmux_configs::keyboard::OptionAsAlt;
+    use winit::platform::macos::{OptionAsAlt as WinitOptionAsAlt, WindowExtMacOS};
+
+    pub(super) fn apply_option_as_alt(
+        mut done: Local<bool>,
+        configs: Res<OzmuxConfigsResource>,
+        winit_windows: NonSend<WinitWindows>,
+        primary: Query<Entity, With<PrimaryWindow>>,
+    ) {
+        if *done {
+            return;
+        }
+        let Ok(entity) = primary.single() else {
+            return;
+        };
+        let Some(window) = winit_windows.get_window(entity) else {
+            return;
+        };
+        window.set_option_as_alt(to_winit(configs.keyboard.option_as_alt));
+        *done = true;
+    }
+
+    fn to_winit(mode: OptionAsAlt) -> WinitOptionAsAlt {
+        match mode {
+            OptionAsAlt::None => WinitOptionAsAlt::None,
+            OptionAsAlt::Left => WinitOptionAsAlt::OnlyLeft,
+            OptionAsAlt::Right => WinitOptionAsAlt::OnlyRight,
+            OptionAsAlt::Both => WinitOptionAsAlt::Both,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn maps_each_variant_to_winit() {
+            assert!(matches!(to_winit(OptionAsAlt::None), WinitOptionAsAlt::None));
+            assert!(matches!(
+                to_winit(OptionAsAlt::Left),
+                WinitOptionAsAlt::OnlyLeft
+            ));
+            assert!(matches!(
+                to_winit(OptionAsAlt::Right),
+                WinitOptionAsAlt::OnlyRight
+            ));
+            assert!(matches!(to_winit(OptionAsAlt::Both), WinitOptionAsAlt::Both));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use configs::OzmuxConfigsPlugin;
 use font::FontBridgePlugin;
 use input::OzmuxShortcutPlugin;
 use input::ime::ImePlugin;
+use input::option_as_alt::OptionAsAltPlugin;
 use ozma_tty_engine::TerminalHandlePlugin;
 use ozma_tty_renderer::TerminalRendererPlugin;
 use ozmux_tmux::TmuxSessionPlugin;
@@ -91,6 +92,7 @@ fn main() {
             HyperlinkInputPlugin,
             ImePlugin,
             ImeOverlayPlugin,
+            OptionAsAltPlugin,
             OzmuxOscWebviewPlugin,
             OzmuxInlineWebviewPlugin,
             OzmuxControlPlanePlugin::new(dyn_registry),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn powerline_glyphs_are_the_nerd_font_code_points() {
+    fn powerline_right_is_the_nerd_font_code_point() {
         assert_eq!(POWERLINE_RIGHT, "\u{e0b0}");
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -31,8 +31,6 @@ pub const SESSION_BG: Color = Color::srgb(0.200, 0.220, 0.282);
 pub const FLAG_WARN: Color = Color::srgb(0.878, 0.690, 0.302);
 /// Powerline right-pointing filled separator glyph (Nerd Font U+E0B0).
 pub const POWERLINE_RIGHT: &str = "\u{e0b0}";
-/// Powerline left-pointing filled separator glyph (Nerd Font U+E0B2).
-// pub const POWERLINE_LEFT: &str = "\u{e0b2}";
 /// Session-chooser selection bar — tmux choose-tree style amber.
 pub const SELECTION: Color = Color::srgb(0.847, 0.651, 0.341);
 /// Text on the SELECTION bar — near-black for contrast.
@@ -77,6 +75,5 @@ mod tests {
     #[test]
     fn powerline_glyphs_are_the_nerd_font_code_points() {
         assert_eq!(POWERLINE_RIGHT, "\u{e0b0}");
-        assert_eq!(POWERLINE_LEFT, "\u{e0b2}");
     }
 }

--- a/src/ui/tmux_window_bar.rs
+++ b/src/ui/tmux_window_bar.rs
@@ -547,10 +547,6 @@ mod tests {
             "active label: {texts:?}"
         );
         assert!(
-            texts.iter().any(|t| t == theme::POWERLINE_LEFT),
-            "left chevron: {texts:?}"
-        );
-        assert!(
             texts.iter().any(|t| t == theme::POWERLINE_RIGHT),
             "right chevron: {texts:?}"
         );


### PR DESCRIPTION
## Problem

On macOS, holding **Option** routes the key through the OS text-composition (IME) system, so a tmux config that binds window/pane actions to `Alt` (`M-`) — e.g. `bind -n M-e next-window` — does not work inside ozmux: pressing `Option+e` produces a composed dead-key accent (`´`) or glyph (`œ`, `π`, …) instead of sending `M-e` to tmux. ozmux had no equivalent of the common-terminal setting (kitty `macos_option_as_alt`, Alacritty `option_as_alt`, Terminal.app "Use Option as Meta key").

## Solution

Add a configurable `[keyboard] option_as_alt` setting and delegate to winit's native macOS Option-as-Alt support.

- **Config** (`crates/configs`): new `[keyboard]` section — `option_as_alt = "none" | "left" | "right" | "both"` (default `none`, opt-in), following the existing `[mouse]` section pattern. The configs crate stays std-only (no winit/bevy dependency).
- **macOS bridge** (`src/input/option_as_alt.rs`, registered in `src/main.rs`): a plugin maps the config enum to `winit::platform::macos::OptionAsAlt` and calls `WindowExtMacOS::set_option_as_alt` on the primary window. winit rewrites the Option-modified `NSEvent` **below the IME layer**, so the existing keyboard→tmux path (`bevy_key_to_tmux_name` + `physical_base_char`) produces `M-<base>` with **no changes to the IME path** (`read_ime_events`). Japanese IME (which never uses Option) is unaffected.
- `winit` is added as a **macOS-target-only** dependency.

Why winit-native over app-level IME gating: winit delivers no `KeyboardInput` during the IME preedit phase, so an app-level "suppress IME while Alt is held" approach cannot recover dead-key combos like `M-e`; the native setter fixes it below the IME layer and is the same mechanism Alacritty uses.

### Affected
- `crates/configs` (new `[keyboard]` config + wiring), `src/input` + `src/main.rs` (bridge + registration).
- Drive-by fix: removed stale `POWERLINE_LEFT` test references left by an earlier window-entry redesign that broke the binary crate's test build (`src/theme.rs`, `src/ui/tmux_window_bar.rs`); live rendering already used only `POWERLINE_RIGHT`.

### Notes
- Not a breaking change: default `none` preserves current behavior, and non-macOS is unaffected (Alt is already Meta there).
- Implementation detail: in Bevy 0.18 `WinitWindows` lives in a main-thread thread-local (`WINIT_WINDOWS`), not a world resource, so the apply system uses `NonSendMarker` + `WINIT_WINDOWS.with_borrow` — the pattern bevy_winit's own systems use.

### Testing
- `cargo test` — passing, incl. config parse/merge tests, the `to_winit` enum-mapping test, a `deny_unknown_fields` typo-rejection test, and a headless regression test guarding the winit-window access. `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.
- Manual macOS smoke test (`~/.config/ozmux/config.toml` → `[keyboard] option_as_alt = "both"`):
  - [ ] `Option+e` → next window (`M-e`), no `´` appears
  - [ ] `Option+q` / `Option+i` fire, no composed glyph
  - [ ] Japanese IME still composes/commits normally
  - [ ] `option_as_alt = "none"` restores composition; `"left"` → right-Option still composes
