### PR TITLE
fix(ratatui-ozma): transparent reconnect for inline webviews on ozmux re-attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,6 +5409,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -157,7 +157,7 @@ fn event_loop(
                 f,
                 &mut ozma.frame(),
                 &state,
-                view.id(),
+                &view.id(),
                 &file_name,
                 live,
                 scroll_percent,

--- a/sdk/ratatui-ozma/Cargo.toml
+++ b/sdk/ratatui-ozma/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 crossbeam-channel = "0.5"
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/sdk/ratatui-ozma/examples/focus_grid.rs
+++ b/sdk/ratatui-ozma/examples/focus_grid.rs
@@ -184,14 +184,14 @@ fn draw(
     // webviews — calling it twice would drop the first placement.
     let mut frame = ozma.frame();
     f.render_stateful_widget(
-        WebviewWidget::new(ne.id())
+        WebviewWidget::new(&ne.id())
             .focused(focused == "ne")
             .fallback(focus_block("NE (webview)", focused == "ne")),
         ne_area,
         &mut *frame,
     );
     f.render_stateful_widget(
-        WebviewWidget::new(sw.id())
+        WebviewWidget::new(&sw.id())
             .focused(focused == "sw")
             .fallback(focus_block("SW (webview)", focused == "sw")),
         sw_area,

--- a/sdk/ratatui-ozma/examples/ratatui_remote_url.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_remote_url.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
                 f.render_widget(Paragraph::new("remote url demo · q to quit"), rows[0]);
                 f.render_stateful_widget(
-                    WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                    WebviewWidget::new(&view.id()).fallback(Block::bordered().title("loading…")),
                     rows[1],
                     &mut *ozma.frame(),
                 );

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -89,7 +89,7 @@ fn run(
                 rows[0],
             );
             f.render_stateful_widget(
-                WebviewWidget::new(view.id())
+                WebviewWidget::new(&view.id())
                     .focused(web_focused)
                     .fallback(Block::bordered().title("loading…")),
                 rows[1],

--- a/sdk/ratatui-ozma/src/backend.rs
+++ b/sdk/ratatui-ozma/src/backend.rs
@@ -1,13 +1,15 @@
 //! A ratatui `Backend` wrapper that emits webview OSC during `terminal.draw()`.
 
 use crate::error::OzmaError;
-use crate::session::{FlushState, FramePlacements, Ozma};
+use crate::session::{FlushState, FramePlacements, Ozma, ReconnectHandle};
 use crate::webview::SharedWriter;
 use ratatui::backend::{Backend, ClearType, WindowSize};
 use ratatui::buffer::Cell;
 use ratatui::layout::{Position, Size};
 use std::io::{self, Write};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 /// A ratatui [`Backend`] that wraps another backend and emits ozmux webview
 /// mount/unmount OSC (and the control-plane focus op) after each frame's cell
@@ -33,6 +35,9 @@ pub struct OzmaBackend<B> {
     frame: Arc<Mutex<FramePlacements>>,
     writer: SharedWriter,
     flush_state: FlushState,
+    reconnect: ReconnectHandle,
+    last_gen: u64,
+    last_attempt: Option<Instant>,
 }
 
 impl<B> OzmaBackend<B> {
@@ -43,6 +48,9 @@ impl<B> OzmaBackend<B> {
             frame: ozma.frame_handle(),
             writer: ozma.writer_handle(),
             flush_state: FlushState::default(),
+            reconnect: ozma.reconnect_handle(),
+            last_gen: 0,
+            last_attempt: None,
         }
     }
 }
@@ -52,11 +60,31 @@ impl<B: Backend + Write> Backend for OzmaBackend<B> {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
+        let current_gen = self.reconnect.generation.load(Ordering::Relaxed);
+        if current_gen != self.last_gen {
+            self.flush_state.reset();
+            self.last_gen = current_gen;
+        }
+
         self.inner.draw(content)?;
+
         let frame = self.frame.lock().unwrap_or_else(|e| e.into_inner());
         self.flush_state
             .emit_frame(&mut self.inner, &self.writer, &frame)
-            .map_err(to_io)
+            .map_err(to_io)?;
+        drop(frame);
+
+        if self.reconnect.disconnected.load(Ordering::Relaxed) {
+            let should_retry = self
+                .last_attempt
+                .is_none_or(|t| t.elapsed() >= Duration::from_secs(2));
+            if should_retry {
+                let _ = self.reconnect.reconnect_tx.try_send(());
+                self.last_attempt = Some(Instant::now());
+            }
+        }
+
+        Ok(())
     }
 
     fn hide_cursor(&mut self) -> io::Result<()> {
@@ -102,4 +130,100 @@ impl<B: Backend + Write> Backend for OzmaBackend<B> {
 
 fn to_io(e: OzmaError) -> io::Error {
     io::Error::other(e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    struct WritableTestBackend(ratatui::backend::TestBackend);
+
+    impl io::Write for WritableTestBackend {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Backend for WritableTestBackend {
+        fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+        where
+            I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+        {
+            self.0.draw(content)
+        }
+
+        fn hide_cursor(&mut self) -> io::Result<()> {
+            self.0.hide_cursor()
+        }
+
+        fn show_cursor(&mut self) -> io::Result<()> {
+            self.0.show_cursor()
+        }
+
+        fn get_cursor_position(&mut self) -> io::Result<Position> {
+            self.0.get_cursor_position()
+        }
+
+        fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+            self.0.set_cursor_position(position)
+        }
+
+        fn clear(&mut self) -> io::Result<()> {
+            self.0.clear()
+        }
+
+        fn size(&self) -> io::Result<Size> {
+            self.0.size()
+        }
+
+        fn window_size(&mut self) -> io::Result<WindowSize> {
+            self.0.window_size()
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Backend::flush(&mut self.0)
+        }
+    }
+
+    #[test]
+    fn generation_change_resets_flush_state() {
+        use std::os::unix::net::UnixStream;
+        use std::sync::{Arc, Mutex};
+        let flush = FlushState::default();
+        let disconnected = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let generation = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (tx, _rx) = crossbeam_channel::bounded::<()>(1);
+        let reconnect = ReconnectHandle {
+            disconnected: disconnected.clone(),
+            generation: generation.clone(),
+            reconnect_tx: tx,
+        };
+        let mut backend = OzmaBackend {
+            inner: WritableTestBackend(ratatui::backend::TestBackend::new(80, 24)),
+            frame: Arc::new(Mutex::new(crate::session::FramePlacements::default())),
+            writer: Arc::new(Mutex::new(UnixStream::pair().unwrap().0)),
+            flush_state: flush,
+            reconnect,
+            last_gen: 0,
+            last_attempt: None,
+        };
+        backend
+            .flush_state
+            .last
+            .insert("h1".into(), ratatui::layout::Rect::new(0, 0, 10, 5));
+        generation.store(1, Ordering::Relaxed);
+        use ratatui::backend::Backend;
+        let no_cells: Vec<(u16, u16, &ratatui::buffer::Cell)> = Vec::new();
+        Backend::draw(&mut backend, no_cells.into_iter()).unwrap();
+        assert!(
+            backend.flush_state.last.is_empty(),
+            "flush_state should be reset after generation change"
+        );
+        assert_eq!(backend.last_gen, 1);
+    }
 }

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -44,7 +44,7 @@ pub(crate) enum ClientMsg {
 }
 
 /// The content variants of a `register` request.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub(crate) enum RegisterKind {
     /// A full inline HTML document.

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -70,7 +70,7 @@ impl FramePlacements {
 /// Last-emitted geometry per handle, for diff-driven flush.
 #[derive(Debug, Default)]
 pub(crate) struct FlushState {
-    last: HashMap<String, Rect>,
+    pub(crate) last: HashMap<String, Rect>,
     last_focused: Option<String>,
 }
 

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -70,7 +70,10 @@ impl FramePlacements {
 /// Last-emitted geometry per handle, for diff-driven flush.
 #[derive(Debug, Default)]
 pub(crate) struct FlushState {
+    #[cfg(test)]
     pub(crate) last: HashMap<String, Rect>,
+    #[cfg(not(test))]
+    last: HashMap<String, Rect>,
     last_focused: Option<String>,
 }
 

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -3,13 +3,14 @@
 use crate::error::{OzmaError, OzmaResult};
 use crate::handler::BoxedHandler;
 use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline, valid_handle};
-use crate::protocol::{ClientMsg, IncomingCall, RegisterReply};
+use crate::protocol::{ClientMsg, IncomingCall, RegisterKind, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
 use ratatui::layout::Rect;
 use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 
@@ -92,6 +93,11 @@ impl FlushState {
         let mut w = socket.lock()?;
         flush_focus(&mut *w, &mut self.last_focused, &frame.focused)
     }
+
+    pub(crate) fn reset(&mut self) {
+        self.last.clear();
+        self.last_focused = None;
+    }
 }
 
 type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
@@ -105,6 +111,20 @@ struct PendingRegister {
 }
 
 type PendingCompositing = Arc<Mutex<HashMap<String, bool>>>;
+
+/// A saved webview registration for replay on reconnect.
+struct Registration {
+    kind: RegisterKind,
+    handle_slot: Arc<Mutex<String>>,
+    handlers: Arc<HashMap<String, BoxedHandler>>,
+}
+
+/// The minimal shared state passed to [`OzmaBackend`] for reconnect signalling.
+pub(crate) struct ReconnectHandle {
+    pub(crate) disconnected: Arc<AtomicBool>,
+    pub(crate) generation: Arc<AtomicU64>,
+    pub(crate) reconnect_tx: Sender<()>,
+}
 
 /// An ozmux session: owns the control-socket connection and reader thread.
 pub struct Ozma {
@@ -577,6 +597,19 @@ mod tests {
     #[test]
     fn parse_show_environment_none_when_key_absent() {
         assert_eq!(parse_show_environment("OTHER=/x\n", "OZMA_SOCK"), None);
+    }
+
+    #[test]
+    fn flush_state_reset_clears_placements_and_focus() {
+        let mut state = FlushState::default();
+        state.last.insert("h1".into(), rect(0, 0, 10, 5));
+        state.last_focused = Some("h1".into());
+        state.reset();
+        assert!(state.last.is_empty(), "last should be empty after reset");
+        assert_eq!(
+            state.last_focused, None,
+            "last_focused should be None after reset"
+        );
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -666,8 +666,8 @@ fn attempt_reconnect(
         let old = reg
             .handle_slot
             .lock()
-            .map(|g| g.clone())
-            .unwrap_or_default();
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         if let Ok(mut map) = handlers.lock() {
             map.remove(&old);
             map.insert(new_handle.clone(), reg.handlers.clone());

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -10,7 +10,7 @@ use ratatui::layout::Rect;
 use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::os::unix::net::UnixStream;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 
@@ -132,6 +132,12 @@ pub struct Ozma {
     pending: PendingRegisters,
     frame: Arc<Mutex<FramePlacements>>,
     pending_compositing: PendingCompositing,
+    handlers: HandlerRegistry,
+    disconnected: Arc<AtomicBool>,
+    generation: Arc<AtomicU64>,
+    registrations: Arc<Mutex<Vec<Registration>>>,
+    reconnect_tx: crossbeam_channel::Sender<()>,
+    token: String,
 }
 
 impl Ozma {
@@ -160,9 +166,15 @@ impl Ozma {
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
         let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
         let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
+        let disconnected: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let generation: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+        let registrations: Arc<Mutex<Vec<Registration>>> = Arc::new(Mutex::new(Vec::new()));
+        let (reconnect_tx, reconnect_rx) = crossbeam_channel::bounded::<()>(1);
 
         {
-            let line = serde_json::to_string(&ClientMsg::Hello { token })?;
+            let line = serde_json::to_string(&ClientMsg::Hello {
+                token: token.clone(),
+            })?;
             let mut w = writer.lock()?;
             writeln!(w, "{line}")?;
             w.flush()?;
@@ -174,21 +186,54 @@ impl Ozma {
             handlers.clone(),
             pending.clone(),
             pending_compositing.clone(),
+            disconnected.clone(),
         );
+
+        {
+            let writer2 = writer.clone();
+            let handlers2 = handlers.clone();
+            let pending2 = pending.clone();
+            let pending_compositing2 = pending_compositing.clone();
+            let disconnected2 = disconnected.clone();
+            let generation2 = generation.clone();
+            let registrations2 = registrations.clone();
+            let token2 = token.clone();
+            thread::spawn(move || {
+                while let Ok(()) = reconnect_rx.recv() {
+                    attempt_reconnect(
+                        &writer2,
+                        &handlers2,
+                        &pending2,
+                        &pending_compositing2,
+                        &disconnected2,
+                        &generation2,
+                        &registrations2,
+                        &token2,
+                    );
+                }
+            });
+        }
 
         Ok(Self {
             writer,
             pending,
             frame: Arc::new(Mutex::new(FramePlacements::default())),
             pending_compositing,
+            handlers,
+            disconnected,
+            generation,
+            registrations,
+            reconnect_tx,
+            token,
         })
     }
 
     /// Registers a webview, blocking until the control plane mints its handle.
     pub fn register(&self, webview: Webview) -> OzmaResult<WebviewHandle> {
         let Webview { kind, handlers } = webview;
+        let handlers = Arc::new(handlers);
         let (tx, rx) = bounded(1);
-        let line = serde_json::to_string(&ClientMsg::Register(kind))?;
+        let line = serde_json::to_string(&ClientMsg::Register(kind.clone()))?;
         {
             let mut w = self.writer.lock()?;
             // NOTE: push the pending entry while holding the writer lock so the
@@ -196,7 +241,7 @@ impl Ozma {
             // so concurrent registrants would otherwise mismatch their handles.
             self.pending.lock()?.push_back(PendingRegister {
                 reply: tx,
-                handlers: Arc::new(handlers),
+                handlers: handlers.clone(),
             });
             if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
                 // The register never went out, so no reply will arrive for this
@@ -207,7 +252,15 @@ impl Ozma {
         }
 
         let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
-        Ok(WebviewHandle::new(handle, self.writer.clone()))
+        let handle_slot = Arc::new(Mutex::new(handle));
+        if let Ok(mut regs) = self.registrations.lock() {
+            regs.push(Registration {
+                kind,
+                handle_slot: handle_slot.clone(),
+                handlers: handlers.clone(),
+            });
+        }
+        Ok(WebviewHandle::new_shared(handle_slot, self.writer.clone()))
     }
 
     /// Locks and clears the per-frame placement collector for `render_stateful_widget`.
@@ -236,6 +289,15 @@ impl Ozma {
 
     pub(crate) fn writer_handle(&self) -> SharedWriter {
         self.writer.clone()
+    }
+
+    /// Returns a handle to the reconnect machinery for use by [`crate::OzmaBackend`].
+    pub(crate) fn reconnect_handle(&self) -> ReconnectHandle {
+        ReconnectHandle {
+            disconnected: self.disconnected.clone(),
+            generation: self.generation.clone(),
+            reconnect_tx: self.reconnect_tx.clone(),
+        }
     }
 }
 
@@ -402,6 +464,7 @@ fn spawn_reader(
     handlers: HandlerRegistry,
     pending: PendingRegisters,
     pending_compositing: PendingCompositing,
+    disconnected: Arc<AtomicBool>,
 ) {
     thread::spawn(move || {
         let mut reader = BufReader::new(stream);
@@ -463,6 +526,7 @@ fn spawn_reader(
         if let Ok(mut q) = pending.lock() {
             q.clear();
         }
+        disconnected.store(true, Ordering::Relaxed);
     });
 }
 
@@ -496,6 +560,126 @@ fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: Incomi
         let _ = writeln!(w, "{line}");
         let _ = w.flush();
     }
+}
+
+fn attempt_reconnect(
+    writer: &SharedWriter,
+    handlers: &HandlerRegistry,
+    pending: &PendingRegisters,
+    pending_compositing: &PendingCompositing,
+    disconnected: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
+    registrations: &Arc<Mutex<Vec<Registration>>>,
+    token: &str,
+) {
+    let candidates = resolve_ozma_sock_candidates();
+    if candidates.is_empty() {
+        tracing::debug!("reconnect: no OZMA_SOCK candidates, will retry on next signal");
+        return;
+    }
+    let new_stream = match connect_first_reachable(&candidates) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!("reconnect: socket unavailable: {e}");
+            return;
+        }
+    };
+    let cloned = match new_stream.try_clone() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!("reconnect: try_clone failed: {e}");
+            return;
+        }
+    };
+    {
+        let Ok(mut w) = writer.lock() else { return };
+        *w = cloned;
+    }
+    {
+        let line = match serde_json::to_string(&ClientMsg::Hello {
+            token: token.to_owned(),
+        }) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::debug!("reconnect: serialize hello failed: {e}");
+                return;
+            }
+        };
+        let Ok(mut w) = writer.lock() else { return };
+        if writeln!(w, "{line}").and_then(|()| w.flush()).is_err() {
+            tracing::debug!("reconnect: hello write failed");
+            return;
+        }
+    }
+    disconnected.store(false, Ordering::Relaxed);
+    spawn_reader(
+        new_stream,
+        writer.clone(),
+        handlers.clone(),
+        pending.clone(),
+        pending_compositing.clone(),
+        disconnected.clone(),
+    );
+    let Ok(regs) = registrations.lock() else {
+        return;
+    };
+    let Ok(mut w) = writer.lock() else { return };
+    for reg in regs.iter() {
+        let (tx, rx) = bounded::<OzmaResult<String>>(1);
+        {
+            let Ok(mut pq) = pending.lock() else {
+                disconnected.store(true, Ordering::Relaxed);
+                return;
+            };
+            pq.push_back(PendingRegister {
+                reply: tx,
+                handlers: reg.handlers.clone(),
+            });
+        }
+        let line = match serde_json::to_string(&ClientMsg::Register(reg.kind.clone())) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::debug!("reconnect: serialize register failed: {e}");
+                disconnected.store(true, Ordering::Relaxed);
+                return;
+            }
+        };
+        if writeln!(w, "{line}").and_then(|()| w.flush()).is_err() {
+            tracing::debug!("reconnect: register write failed");
+            disconnected.store(true, Ordering::Relaxed);
+            return;
+        }
+        // NOTE: release writer lock while awaiting the reader-thread reply so
+        // the reader can write focus/emit responses without deadlocking.
+        drop(w);
+        let new_handle = match rx.recv().unwrap_or(Err(OzmaError::Disconnected)) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!("reconnect: re-registration failed: {e}");
+                disconnected.store(true, Ordering::Relaxed);
+                return;
+            }
+        };
+        let old = reg
+            .handle_slot
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        if let Ok(mut map) = handlers.lock() {
+            map.remove(&old);
+            map.insert(new_handle.clone(), reg.handlers.clone());
+        }
+        if let Ok(mut slot) = reg.handle_slot.lock() {
+            *slot = new_handle;
+        }
+        w = match writer.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+    }
+    drop(w);
+    generation.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!("reconnect: completed successfully");
 }
 
 #[cfg(test)]
@@ -777,6 +961,7 @@ mod tests {
             handlers,
             pending,
             pending_compositing.clone(),
+            Arc::new(AtomicBool::new(false)),
         );
 
         use std::io::Write;
@@ -817,6 +1002,7 @@ mod tests {
             handlers,
             pending,
             pending_compositing.clone(),
+            Arc::new(AtomicBool::new(false)),
         );
 
         use std::io::Write;

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -124,24 +124,32 @@ impl Webview {
 /// A registered webview handle: emit events to the page, read its id.
 #[derive(Clone, Debug)]
 pub struct WebviewHandle {
-    id: String,
+    id: Arc<Mutex<String>>,
     writer: SharedWriter,
 }
 
 impl PartialEq for WebviewHandle {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.id() == other.id()
     }
 }
 
 impl WebviewHandle {
     pub(crate) fn new(id: String, writer: SharedWriter) -> Self {
+        Self::new_shared(Arc::new(Mutex::new(id)), writer)
+    }
+
+    /// Creates a handle from a pre-existing shared ID slot.
+    ///
+    /// Used by the reconnect path (Task 5) so the reconnect thread can update
+    /// the ID in place while the caller retains an always-current view.
+    pub(crate) fn new_shared(id: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
         Self { id, writer }
     }
 
     /// Returns the opaque handle id minted by the control plane.
-    pub fn id(&self) -> &str {
-        &self.id
+    pub fn id(&self) -> String {
+        self.id.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
     /// Pushes an event to the currently-mounted page(s) of this handle.
@@ -149,7 +157,7 @@ impl WebviewHandle {
     /// Mount-scoped: a no-op (still `Ok`) when nothing is mounted.
     pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> OzmaResult<()> {
         let msg = ClientMsg::Emit {
-            handle: self.id.clone(),
+            handle: self.id(),
             event: event.to_owned(),
             payload: serde_json::to_value(payload)?,
         };
@@ -283,5 +291,16 @@ mod tests {
         let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
         assert_eq!(v["kind"], "url");
         assert_eq!(v["passthrough"][0]["key"], "h");
+    }
+
+    #[test]
+    fn id_reflects_slot_update() {
+        let slot = Arc::new(Mutex::new("old-id".to_owned()));
+        let (a, _b) = std::os::unix::net::UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(a));
+        let handle = WebviewHandle::new_shared(slot.clone(), writer);
+        assert_eq!(handle.id(), "old-id");
+        *slot.lock().unwrap() = "new-id".to_owned();
+        assert_eq!(handle.id(), "new-id");
     }
 }

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -135,18 +135,6 @@ impl PartialEq for WebviewHandle {
 }
 
 impl WebviewHandle {
-    pub(crate) fn new(id: String, writer: SharedWriter) -> Self {
-        Self::new_shared(Arc::new(Mutex::new(id)), writer)
-    }
-
-    /// Creates a handle from a pre-existing shared ID slot.
-    ///
-    /// Used by the reconnect path (Task 5) so the reconnect thread can update
-    /// the ID in place while the caller retains an always-current view.
-    pub(crate) fn new_shared(id: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
-        Self { id, writer }
-    }
-
     /// Returns the opaque handle id minted by the control plane.
     pub fn id(&self) -> String {
         self.id.lock().unwrap_or_else(|e| e.into_inner()).clone()
@@ -166,6 +154,16 @@ impl WebviewHandle {
         writeln!(w, "{line}")?;
         w.flush()?;
         Ok(())
+    }
+
+    /// Creates a handle from a pre-existing shared ID slot for callers that need
+    /// to share the ID slot across threads.
+    pub(crate) fn new_shared(id: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
+        Self { id, writer }
+    }
+
+    pub(crate) fn new(id: String, writer: SharedWriter) -> Self {
+        Self::new_shared(Arc::new(Mutex::new(id)), writer)
     }
 }
 

--- a/sdk/ratatui-ozma/src/widget.rs
+++ b/sdk/ratatui-ozma/src/widget.rs
@@ -10,18 +10,18 @@ use ratatui::widgets::{Clear, StatefulWidget, Widget};
 /// Blanks its cells (the webview composites under the text) and records its rect
 /// into the frame the [`crate::OzmaBackend`] emits on the next draw. Optionally
 /// paints a fallback under-layer (shown on non-macOS or before the page composites).
-pub struct WebviewWidget<'a, W = WebviewDefaultPlaceholder> {
-    handle: &'a str,
+pub struct WebviewWidget<W = WebviewDefaultPlaceholder> {
+    handle: String,
     fallback: W,
     focused: bool,
-    on_compositing_change: Option<Box<dyn Fn(bool) + 'a>>,
+    on_compositing_change: Option<Box<dyn Fn(bool) + 'static>>,
 }
 
-impl<'a> WebviewWidget<'a, WebviewDefaultPlaceholder> {
+impl WebviewWidget<WebviewDefaultPlaceholder> {
     /// Creates a widget for the given webview handle id.
-    pub fn new(handle: &'a str) -> Self {
+    pub fn new(handle: impl Into<String>) -> Self {
         Self {
-            handle,
+            handle: handle.into(),
             fallback: WebviewDefaultPlaceholder,
             focused: false,
             on_compositing_change: None,
@@ -29,9 +29,9 @@ impl<'a> WebviewWidget<'a, WebviewDefaultPlaceholder> {
     }
 }
 
-impl<'a, W> WebviewWidget<'a, W> {
+impl<W> WebviewWidget<W> {
     /// Sets a fallback widget painted into the cells under the webview.
-    pub fn fallback<W2: Widget>(self, widget: W2) -> WebviewWidget<'a, W2> {
+    pub fn fallback<W2: Widget>(self, widget: W2) -> WebviewWidget<W2> {
         WebviewWidget {
             handle: self.handle,
             fallback: widget,
@@ -45,7 +45,7 @@ impl<'a, W> WebviewWidget<'a, W> {
     ///
     /// The callback receives `true` when the webview starts compositing (the
     /// page is live and painting) and `false` when it stops.
-    pub fn on_compositing_change(mut self, f: impl Fn(bool) + 'a) -> Self {
+    pub fn on_compositing_change(mut self, f: impl Fn(bool) + 'static) -> Self {
         self.on_compositing_change = Some(Box::new(f));
         self
     }
@@ -69,7 +69,7 @@ impl<'a, W> WebviewWidget<'a, W> {
     }
 }
 
-impl<W: Widget> StatefulWidget for WebviewWidget<'_, W> {
+impl<W: Widget> StatefulWidget for WebviewWidget<W> {
     type State = FramePlacements;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
@@ -78,11 +78,11 @@ impl<W: Widget> StatefulWidget for WebviewWidget<'_, W> {
         }
         Clear.render(area, buf);
         self.fallback.render(area, buf);
-        state.record(self.handle.to_owned(), area);
+        state.record(self.handle.clone(), area);
         if self.focused {
-            state.set_focused(self.handle.to_owned());
+            state.set_focused(self.handle.clone());
         }
-        if let Some(active) = state.take_compositing(self.handle)
+        if let Some(active) = state.take_compositing(&self.handle)
             && let Some(cb) = &self.on_compositing_change
         {
             cb(active);
@@ -192,6 +192,7 @@ mod tests {
     #[test]
     fn on_compositing_change_fires_when_pending() {
         use std::cell::Cell;
+        use std::rc::Rc;
         let area = Rect {
             x: 0,
             y: 0,
@@ -202,12 +203,14 @@ mod tests {
         let mut state = FramePlacements::default();
         state.pending_compositing.insert("v".into(), true);
 
-        let fired = Cell::new(false);
-        let fired_val = Cell::new(false);
+        let fired = Rc::new(Cell::new(false));
+        let fired_val = Rc::new(Cell::new(false));
+        let fired2 = fired.clone();
+        let fired_val2 = fired_val.clone();
         WebviewWidget::new("v")
-            .on_compositing_change(|active| {
-                fired.set(true);
-                fired_val.set(active);
+            .on_compositing_change(move |active| {
+                fired2.set(true);
+                fired_val2.set(active);
             })
             .render(area, &mut buf, &mut state);
 
@@ -217,6 +220,7 @@ mod tests {
 
     #[test]
     fn on_compositing_change_not_fired_when_absent() {
+        use std::rc::Rc;
         let area = Rect {
             x: 0,
             y: 0,
@@ -226,17 +230,22 @@ mod tests {
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
 
-        let fired = std::cell::Cell::new(false);
+        let fired = Rc::new(std::cell::Cell::new(false));
+        let fired2 = fired.clone();
         WebviewWidget::new("v")
-            .on_compositing_change(|_| fired.set(true))
+            .on_compositing_change(move |_| fired2.set(true))
             .render(area, &mut buf, &mut state);
 
-        assert!(!fired.get(), "callback must not fire when no pending compositing");
+        assert!(
+            !fired.get(),
+            "callback must not fire when no pending compositing"
+        );
     }
 
     #[test]
     fn on_compositing_change_fires_false() {
         use std::cell::Cell;
+        use std::rc::Rc;
         let area = Rect {
             x: 0,
             y: 0,
@@ -247,10 +256,11 @@ mod tests {
         let mut state = FramePlacements::default();
         state.pending_compositing.insert("v".into(), false);
 
-        let fired_val = Cell::new(true);
+        let fired_val = Rc::new(Cell::new(true));
+        let fired_val2 = fired_val.clone();
         WebviewWidget::new("v")
-            .on_compositing_change(|active| {
-                fired_val.set(active);
+            .on_compositing_change(move |active| {
+                fired_val2.set(active);
             })
             .render(area, &mut buf, &mut state);
 
@@ -270,7 +280,7 @@ mod tests {
         state.pending_compositing.insert("v".into(), true);
 
         WebviewWidget::new("v")
-            .on_compositing_change(|_| {})
+            .on_compositing_change(move |_| {})
             .render(area, &mut buf, &mut state);
 
         assert!(
@@ -283,6 +293,7 @@ mod tests {
     fn on_compositing_change_survives_fallback_builder() {
         use ratatui::text::Text;
         use std::cell::Cell;
+        use std::rc::Rc;
         let area = Rect {
             x: 0,
             y: 0,
@@ -293,12 +304,16 @@ mod tests {
         let mut state = FramePlacements::default();
         state.pending_compositing.insert("v".into(), true);
 
-        let fired = Cell::new(false);
+        let fired = Rc::new(Cell::new(false));
+        let fired2 = fired.clone();
         WebviewWidget::new("v")
-            .on_compositing_change(|_| fired.set(true))
+            .on_compositing_change(move |_| fired2.set(true))
             .fallback(Text::raw("x"))
             .render(area, &mut buf, &mut state);
 
-        assert!(fired.get(), "callback should survive .fallback() builder call");
+        assert!(
+            fired.get(),
+            "callback should survive .fallback() builder call"
+        );
     }
 }

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -63,7 +63,7 @@ fn backend_draw_emits_mount_osc_and_focus_op() {
         {
             let mut scratch = Buffer::empty(Rect::new(0, 0, 80, 40));
             let mut frame = ozma.frame();
-            WebviewWidget::new(handle.id()).focused(true).render(
+            WebviewWidget::new(&handle.id()).focused(true).render(
                 Rect::new(2, 3, 48, 12),
                 &mut scratch,
                 &mut *frame,

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -186,6 +186,53 @@ fn panicking_handler_does_not_kill_reader() {
     });
 }
 
+#[test]
+fn reconnect_updates_handle_id_and_reregisters() {
+    use std::time::Duration;
+    let pair = support::ReconnectPair::start("view-rc1", "view-rc2");
+    with_env(&pair.first.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma.register(Webview::inline("<h1>rc</h1>")).unwrap();
+        assert_eq!(
+            handle.id(),
+            "view-rc1",
+            "initial registration must get first handle"
+        );
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &ozma);
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        // Drop first server: _close_tx drops → shutdown watcher drops stream clone →
+        // client reader sees EOF → disconnected=true.
+        drop(pair.first);
+
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Update $OZMA_SOCK so the reconnect thread finds the second server.
+        // NOTE: ENV_LOCK is held by with_env, serializing all env var accesses.
+        unsafe { std::env::set_var("OZMA_SOCK", &pair.second.sock_path) };
+
+        // Draw again: disconnected=true + last_attempt=None bypasses the 2s rate
+        // limit, fires reconnect_tx.try_send(), and the reconnect thread picks it up.
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while handle.id() == "view-rc1" {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reconnect did not complete within 5 seconds"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert_eq!(
+            handle.id(),
+            "view-rc2",
+            "handle ID must update to second server's handle after reconnect"
+        );
+    });
+}
+
 // A private tmux server for the gated fallback test: kills the server and
 // removes its socket on drop so a panicking assertion cannot leak it.
 struct TmuxServerGuard {

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -203,18 +203,13 @@ fn reconnect_updates_handle_id_and_reregisters() {
         let mut backend = OzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &ozma);
         Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
 
-        // Drop first server: _close_tx drops → shutdown watcher drops stream clone →
-        // client reader sees EOF → disconnected=true.
         drop(pair.first);
 
         std::thread::sleep(Duration::from_millis(200));
 
-        // Update $OZMA_SOCK so the reconnect thread finds the second server.
         // NOTE: ENV_LOCK is held by with_env, serializing all env var accesses.
         unsafe { std::env::set_var("OZMA_SOCK", &pair.second.sock_path) };
 
-        // Draw again: disconnected=true + last_attempt=None bypasses the 2s rate
-        // limit, fires reconnect_tx.try_send(), and the reconnect thread picks it up.
         Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
 
         let deadline = std::time::Instant::now() + Duration::from_secs(5);

--- a/sdk/ratatui-ozma/tests/support/mod.rs
+++ b/sdk/ratatui-ozma/tests/support/mod.rs
@@ -11,11 +11,16 @@ use std::thread;
 ///
 /// `start` is non-blocking: it binds the socket and spawns the accept/reader and
 /// writer threads, then returns immediately so the client can connect afterward.
+///
+/// Dropping a `FakeServer` closes the connection: the internal `_close_tx` drops,
+/// causing the shutdown-watcher thread to close the cloned stream, which makes the
+/// client's reader see EOF.
 pub struct FakeServer {
     pub sock_path: std::path::PathBuf,
     received: Receiver<Value>,
     to_client: Sender<Value>,
     _dir: tempfile::TempDir,
+    _close_tx: std::sync::mpsc::SyncSender<()>,
 }
 
 impl FakeServer {
@@ -28,6 +33,7 @@ impl FakeServer {
         let (to_client, client_rx) = mpsc::channel::<Value>();
         let reply_tx = to_client.clone();
         let handle = handle.to_owned();
+        let (close_tx, close_rx) = mpsc::sync_channel::<()>(0);
 
         thread::spawn(move || {
             let (stream, _) = listener.accept().unwrap();
@@ -39,6 +45,16 @@ impl FakeServer {
                     }
                     let _ = write_half.flush();
                 }
+            });
+
+            // NOTE: dropping FakeServer drops _close_tx, which causes close_rx.recv()
+            // to return Err here; we then shut down the socket, which closes the
+            // connection from the server side and causes the client reader to see EOF
+            // regardless of how many dup'd fds are still open.
+            let stream_for_close = stream.try_clone().unwrap();
+            thread::spawn(move || {
+                let _ = close_rx.recv();
+                let _ = stream_for_close.shutdown(std::net::Shutdown::Both);
             });
 
             let mut reader = BufReader::new(stream);
@@ -64,6 +80,7 @@ impl FakeServer {
             received,
             to_client,
             _dir: dir,
+            _close_tx: close_tx,
         }
     }
 
@@ -76,6 +93,7 @@ impl FakeServer {
         let listener = UnixListener::bind(&sock_path).unwrap();
         let (_recv_tx, received) = mpsc::channel::<Value>();
         let (to_client, _client_rx) = mpsc::channel::<Value>();
+        let (close_tx, _close_rx) = mpsc::sync_channel::<()>(0);
 
         thread::spawn(move || {
             let (stream, _) = listener.accept().unwrap();
@@ -99,6 +117,7 @@ impl FakeServer {
             received,
             to_client,
             _dir: dir,
+            _close_tx: close_tx,
         }
     }
 
@@ -114,6 +133,27 @@ impl FakeServer {
             if v["op"] != "hello" && v["op"] != "register" {
                 return v;
             }
+        }
+    }
+}
+
+/// A pair of fake servers for testing the reconnect path.
+///
+/// `first` accepts a client connection and auto-replies with `handle1`. Dropping
+/// `first` closes the connection from the server side — the client reader sees EOF
+/// and sets `disconnected=true`. `second` waits for the reconnect client and
+/// auto-replies with `handle2`.
+pub struct ReconnectPair {
+    pub first: FakeServer,
+    pub second: FakeServer,
+}
+
+impl ReconnectPair {
+    /// Starts two fake servers at separate temp paths and returns them as a pair.
+    pub fn start(handle1: &str, handle2: &str) -> Self {
+        Self {
+            first: FakeServer::start(handle1),
+            second: FakeServer::start(handle2),
         }
     }
 }

--- a/src/inline_webview.rs
+++ b/src/inline_webview.rs
@@ -2221,21 +2221,22 @@ mod tests {
             .world_mut()
             .resource_mut::<Assets<Image>>()
             .add(Image::default());
-        app.world_mut().spawn((
-            ChildOf(terminal),
-            InlineWebview {
-                view_id: format!("view-{slot}"),
-                instance_id: None,
-                slot,
-            },
-            placement,
-            WebviewTextureTarget(image_handle.clone()),
-            WebviewOwner {
-                connection_id,
-                handle: handle.to_string(),
-            },
-        ))
-        .id()
+        app.world_mut()
+            .spawn((
+                ChildOf(terminal),
+                InlineWebview {
+                    view_id: format!("view-{slot}"),
+                    instance_id: None,
+                    slot,
+                },
+                placement,
+                WebviewTextureTarget(image_handle.clone()),
+                WebviewOwner {
+                    connection_id,
+                    handle: handle.to_string(),
+                },
+            ))
+            .id()
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When ozmux re-attaches to an existing tmux session, inline webviews mounted by `ratatui-ozma` apps (e.g. `ozmd`) are not restored — the webview content never loads.

Five conditions combine to produce the failure:
1. `ozmd` calls `Ozma::connect()` and `register()` once at startup with no reconnect path
2. `ozmd` uses `interactive(false)` and never changes focus, so socket writes never occur — when ozmux exits and the socket is removed, no IO error surfaces
3. `FlushState.last` caches the last-emitted webview positions diff-style; subsequent frames see no change and skip re-emitting the `mount-inline` OSC
4. A new ozmux process starts with an empty `DynamicRegistry`; the old scrollback `mount-inline;H1` OSC is silently dropped
5. ozmux updates `$OZMA_SOCK` on re-attach, but the SDK only reads it at initial `Ozma::connect()` time

## Solution

Adds transparent SDK-level reconnect in `sdk/ratatui-ozma` only — no changes to the ozmux binary or `apps/ozmd` application logic.

**Signal flow:**
1. Reader thread detects EOF on control socket → sets `disconnected=true`
2. `OzmaBackend::draw()` detects `disconnected=true` → fires `reconnect_tx.try_send()` (rate-limited to 2s)
3. Background reconnect thread: resolves updated `$OZMA_SOCK` → connects new socket → sends hello → re-registers all webviews under new handle IDs → increments `generation`
4. Next `draw()`: detects `generation` change → calls `flush_state.reset()` → re-emits `mount-inline` with new handle IDs → ozmux mounts the webview ✓

**Affected packages:** `sdk/ratatui-ozma` only

### Changes

- `webview.rs`: `WebviewHandle.id` changed from `String` to `Arc<Mutex<String>>` so the reconnect thread can update it in-place without app code changes
- `widget.rs`: `WebviewWidget<'a, W>` → `WebviewWidget<W>` (lifetime removed; `handle` becomes owned `String`)
- `session.rs`: `Registration` struct for replay, `ReconnectHandle` for backend integration, reconnect thread in `Ozma::connect()`, `FlushState::reset()`
- `backend.rs`: generation-change detection and reconnect signalling in `OzmaBackend::draw()`
- `tests/`: `FakeServer` gains a drop-triggered shutdown mechanism; integration test `reconnect_updates_handle_id_and_reregisters` verifies the full reconnect cycle end-to-end