### PR TITLE
fix(renderer): mount tmux pane grid on the pane entity so inline webviews render

### DIFF
--- a/src/tmux_copy_mode.rs
+++ b/src/tmux_copy_mode.rs
@@ -14,7 +14,6 @@
 //! stashed [`CopyModeSnapshot`] / handle the `Buffer` reply later.
 
 use crate::clipboard::Clipboard;
-use crate::tmux_render::TerminalRenderRef;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
@@ -106,13 +105,12 @@ fn on_copy_mode_exit(
     ev: On<Remove, CopyModeState>,
     mut commands: Commands,
     mut refresh: ResMut<CopyRefreshState>,
-    mut live_handles: Query<(&mut TerminalHandle, Option<&TerminalRenderRef>)>,
+    mut live_handles: Query<&mut TerminalHandle>,
     panes: Query<&TmuxPane>,
 ) {
     let entity = ev.entity;
-    if let Ok((mut handle, maybe_ref)) = live_handles.get_mut(entity) {
-        let target = maybe_ref.map(|r| r.0).unwrap_or(entity);
-        handle.repaint_full(&mut commands, target);
+    if let Ok(mut handle) = live_handles.get_mut(entity) {
+        handle.repaint_full(&mut commands, entity);
     }
     commands
         .entity(entity)
@@ -176,16 +174,13 @@ fn consume_copy_reply(
     mut clipboard: ResMut<Clipboard>,
     mut render_handles: Query<&mut CopyRenderHandle>,
     connection: NonSend<TmuxConnection>,
-    panes: Query<(Entity, &TmuxPane, Option<&TerminalRenderRef>)>,
+    panes: Query<(Entity, &TmuxPane)>,
     copy_modes: Query<(), With<CopyModeState>>,
     snapshots: Query<&CopyModeSnapshot>,
 ) {
-    let entity_of: HashMap<PaneId, (Entity, Option<Entity>)> = panes
-        .iter()
-        .map(|(e, p, r)| (p.id, (e, r.map(|rr| rr.0))))
-        .collect();
+    let entity_of: HashMap<PaneId, Entity> = panes.iter().map(|(e, p)| (p.id, e)).collect();
     for reply in replies.read() {
-        let Some(&(entity, maybe_render)) = entity_of.get(&reply.pane) else {
+        let Some(&entity) = entity_of.get(&reply.pane) else {
             continue;
         };
         match reply.kind {
@@ -215,14 +210,7 @@ fn consume_copy_reply(
                 if copy_modes.get(entity).is_err() {
                     continue;
                 }
-                let render_target = maybe_render.unwrap_or(entity);
-                apply_capture_reply(
-                    &mut commands,
-                    &mut render_handles,
-                    entity,
-                    render_target,
-                    reply,
-                );
+                apply_capture_reply(&mut commands, &mut render_handles, entity, reply);
             }
             CopyQueryKind::Buffer => {
                 if reply.ok {
@@ -285,13 +273,11 @@ fn apply_state_reply(
 /// Handles a `Capture` reply: feeds the captured bytes into the pane's
 /// `CopyRenderHandle` (created/resized to the pane on demand) and emits, so the
 /// pane's `TerminalGrid` shows the scrolled copy-mode view. `pane_entity` holds
-/// `CopyRenderHandle`; `render_target` is the entity carrying `TerminalGrid`
-/// (the `TerminalRenderRef` child, or the pane itself in tests without one).
+/// both the `CopyRenderHandle` and the `TerminalGrid` the emit targets.
 fn apply_capture_reply(
     commands: &mut Commands,
     render_handles: &mut Query<&mut CopyRenderHandle>,
     pane_entity: Entity,
-    render_target: Entity,
     reply: &CopyModeReply,
 ) {
     if !reply.ok {
@@ -305,12 +291,12 @@ fn apply_capture_reply(
             render.0.resize_grid_only(cols, rows);
         }
         render.0.advance(&bytes);
-        render.0.flush_emit(commands, render_target);
+        render.0.flush_emit(commands, pane_entity);
         return;
     }
     let mut handle = TerminalHandle::detached(cols, rows, Arc::new(AtomicBool::new(false)));
     handle.advance(&bytes);
-    handle.flush_emit(commands, render_target);
+    handle.flush_emit(commands, pane_entity);
     commands
         .entity(pane_entity)
         .insert(CopyRenderHandle(handle));
@@ -340,9 +326,8 @@ fn capture_dims(lines: &[String]) -> (u16, u16) {
 /// `TerminalGrid`. Runs each frame while any pane has a `CopyModeSnapshot`,
 /// ordered after `consume_copy_reply`.
 ///
-/// `CopyModeSnapshot` lives on the `TmuxPane` entity; `TerminalGrid` lives on
-/// the `TerminalRenderRef` child. The two queries are split so each entity is
-/// addressed at the correct level.
+/// `CopyModeSnapshot` and `TerminalGrid` both live on the `TmuxPane` entity, so
+/// a single query addresses them together.
 ///
 /// # Ordering
 ///
@@ -354,18 +339,8 @@ fn capture_dims(lines: &[String]) -> (u16, u16) {
 // unconditionally marks the grid changed and triggers downstream repaint. If the
 // guard is removed the renderer will repaint every frame even in steady state,
 // defeating Bevy's change-detection optimizations for the glyph pipeline.
-fn apply_copy_overlay(
-    mut grids: Query<&mut TerminalGrid>,
-    panes: Query<(&CopyModeSnapshot, Option<&TerminalRenderRef>)>,
-) {
-    for (snapshot, maybe_ref) in panes.iter() {
-        let render_entity = maybe_ref.map(|r| r.0);
-        let Some(target) = render_entity else {
-            continue;
-        };
-        let Ok(mut grid) = grids.get_mut(target) else {
-            continue;
-        };
+fn apply_copy_overlay(mut panes: Query<(&CopyModeSnapshot, &mut TerminalGrid)>) {
+    for (snapshot, mut grid) in panes.iter_mut() {
         let (vi_cursor, selection) = build_overlay(&snapshot.0);
         let want_cursor = Some(vi_cursor);
         if grid.vi_cursor != want_cursor {
@@ -646,7 +621,6 @@ mod tests {
         app.add_plugins(OzmuxTmuxCopyModePlugin);
 
         let pane_id = PaneId(1);
-        let render_child = app.world_mut().spawn(TerminalGrid::default()).id();
         let entity = app
             .world_mut()
             .spawn((
@@ -659,8 +633,8 @@ mod tests {
                         yoff: 0,
                     },
                 },
+                TerminalGrid::default(),
                 TerminalHandle::detached(20, 3, Arc::new(AtomicBool::new(false))),
-                TerminalRenderRef(render_child),
                 CopyModeState,
             ))
             .id();
@@ -675,12 +649,12 @@ mod tests {
                     live.advance(b"LIVE");
                     let mut cap = TerminalHandle::detached(20, 3, Arc::new(AtomicBool::new(false)));
                     cap.advance(b"CAP");
-                    cap.flush_emit(&mut commands, render_child);
+                    cap.flush_emit(&mut commands, entity);
                 },
             )
             .unwrap();
         app.update();
-        let before: String = app.world().get::<TerminalGrid>(render_child).unwrap().cells[0]
+        let before: String = app.world().get::<TerminalGrid>(entity).unwrap().cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -709,7 +683,7 @@ mod tests {
         app.world_mut().entity_mut(entity).remove::<CopyModeState>();
         app.update();
 
-        let after: String = app.world().get::<TerminalGrid>(render_child).unwrap().cells[0]
+        let after: String = app.world().get::<TerminalGrid>(entity).unwrap().cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -1191,15 +1165,9 @@ mod tests {
 
         // Evaluate overlay assertions while still in copy mode.
         let snapshot_ok = got_snapshot;
-        let render_child_entity = app
+        let vi_cursor_present = app
             .world()
-            .get::<TerminalRenderRef>(pane_entity)
-            .map(|r| r.0);
-        let vi_cursor_present = render_child_entity
-            .and_then(|e| {
-                app.world()
-                    .get::<ozma_tty_renderer::schema::TerminalGrid>(e)
-            })
+            .get::<ozma_tty_renderer::schema::TerminalGrid>(pane_entity)
             .map(|g| g.vi_cursor.is_some())
             .unwrap_or(false);
         let selection_present = app

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -79,16 +79,6 @@ pub(crate) struct PackedTmuxLayout {
     pub(crate) bbox: Vec2,
 }
 
-/// Links a `TmuxPane` container entity to its `TerminalRenderChild` (the entity
-/// that owns `TerminalGrid` and `MaterialNode<TerminalUiMaterial>`). Inserted by
-/// `attach_tmux_pane_terminal` alongside `TerminalHandle`.
-///
-/// Required because `flush_emit` / `emit_pending` must target the entity that
-/// carries `TerminalGrid` (where `apply_snapshot` / `apply_delta` observers look),
-/// and that entity is the child, not the `TmuxPane` container.
-#[derive(Component)]
-pub(crate) struct TerminalRenderRef(pub Entity);
-
 fn attach_tmux_window_container(
     mut commands: Commands,
     windows: Query<Entity, (With<TmuxWindow>, Without<Node>)>,
@@ -109,10 +99,11 @@ fn attach_tmux_window_container(
     }
 }
 
-/// Attaches a detached `TerminalHandle` and a column-flex container `Node` to
-/// each `TmuxPane` that lacks a `TerminalHandle`. Spawns a `TerminalRenderBundle`
-/// child that owns the GPU grid and records it in `TerminalRenderRef` so
-/// `flush_emit` and observers target the right entity.
+/// Attaches a detached `TerminalHandle`, a `TerminalRenderBundle`, and a
+/// placeholder absolute `Node` to each `TmuxPane` that lacks a `TerminalHandle`.
+/// The `TerminalGrid` lives on the pane entity itself, so `flush_emit` /
+/// `emit_pending` and the inline-webview overlay projection all target it
+/// directly (an inline webview mounts as a `ChildOf` the pane).
 ///
 /// Runs every frame but targets each pane exactly once. `ChildOf` is NOT set
 /// here — the projection observers already establish the correct
@@ -138,28 +129,12 @@ fn attach_tmux_pane_terminal(
         commands.entity(entity).insert((
             handle,
             TerminalTitle::default(),
+            TerminalRenderBundle::new(material),
             Node {
                 position_type: PositionType::Absolute,
-                flex_direction: FlexDirection::Column,
                 ..default()
             },
         ));
-
-        let render_child = commands
-            .spawn((
-                TerminalRenderBundle::new(material),
-                Node {
-                    flex_grow: 1.0,
-                    width: Val::Percent(100.0),
-                    ..default()
-                },
-                ChildOf(entity),
-            ))
-            .id();
-
-        commands
-            .entity(entity)
-            .insert(TerminalRenderRef(render_child));
     }
 }
 
@@ -182,7 +157,7 @@ fn attach_tmux_pane_terminal(
 fn route_tmux_output(
     mut commands: Commands,
     mut reader: MessageReader<PaneOutput>,
-    mut handles: Query<(&mut TerminalHandle, &mut TerminalTitle, &TerminalRenderRef)>,
+    mut handles: Query<(&mut TerminalHandle, &mut TerminalTitle)>,
     panes: Query<(Entity, &TmuxPane)>,
     copy_modes: Query<(), With<crate::ui::copy_mode::CopyModeState>>,
 ) {
@@ -198,7 +173,7 @@ fn route_tmux_output(
         let Some(&entity) = entity_of.get(&pane) else {
             continue;
         };
-        let Ok((mut handle, mut title, render_ref)) = handles.get_mut(entity) else {
+        let Ok((mut handle, mut title)) = handles.get_mut(entity) else {
             continue;
         };
         handle.advance(&data);
@@ -212,7 +187,7 @@ fn route_tmux_output(
         // the captured scrollback onto the grid, and a late %output delta must not
         // overwrite it. The exit observer forces a full repaint on return.
         if copy_modes.get(entity).is_err() {
-            handle.flush_emit(&mut commands, render_ref.0);
+            handle.flush_emit(&mut commands, entity);
         }
         // NOTE: drain and DISCARD — never forward these replies to tmux. The
         // handle is a display-only renderer; tmux already answered the program's
@@ -234,7 +209,6 @@ fn collapse(
     cell_w: f32,
     cell_h: f32,
     gap: f32,
-    pane_title_h: f32,
     workspace_h: f32,
 ) -> (HashMap<PaneId, Rect>, Vec<DividerPixelRect>, Vec2) {
     let dims = root.dims();
@@ -250,7 +224,6 @@ fn collapse(
         cell_w,
         cell_h,
         gap,
-        pane_title_h,
     );
     let actual_h = panes.values().map(|r| r.max.y).fold(0.0f32, f32::max);
     let bbox = Vec2::new(available.x, actual_h.max(available.y));
@@ -266,13 +239,12 @@ fn place(
     cell_w: f32,
     cell_h: f32,
     gap: f32,
-    pane_title_h: f32,
 ) -> Vec2 {
     match cell {
         Cell::Leaf { dims, pane_id } => {
             let node_size = Vec2::new(
                 available.x.max(dims.width as f32 * cell_w),
-                available.y.max(dims.height as f32 * cell_h + pane_title_h),
+                available.y.max(dims.height as f32 * cell_h),
             );
             if let Some(id) = pane_id {
                 panes.insert(
@@ -304,7 +276,6 @@ fn place(
                     cell_w,
                     cell_h,
                     gap,
-                    pane_title_h,
                 );
                 x += csz.x;
                 if i < last {
@@ -330,7 +301,7 @@ fn place(
             let gaps_total = last as f32 * gap;
             let natural_h: f32 = children
                 .iter()
-                .map(|c| c.dims().height as f32 * cell_h + pane_title_h)
+                .map(|c| c.dims().height as f32 * cell_h)
                 .sum();
             let slack = (available.y - natural_h - gaps_total).max(0.0);
             let mut y = origin.y;
@@ -340,7 +311,7 @@ fn place(
                 } else {
                     let extra = (slack * (i + 1) as f32 / n as f32).round()
                         - (slack * i as f32 / n as f32).round();
-                    child.dims().height as f32 * cell_h + pane_title_h + extra
+                    child.dims().height as f32 * cell_h + extra
                 };
                 let csz = place(
                     panes,
@@ -351,7 +322,6 @@ fn place(
                     cell_w,
                     cell_h,
                     gap,
-                    pane_title_h,
                 );
                 y += csz.y;
                 if i < last {
@@ -385,7 +355,6 @@ fn place(
                     cell_w,
                     cell_h,
                     gap,
-                    pane_title_h,
                 );
             }
             Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h)
@@ -428,11 +397,10 @@ fn layout_tmux_panes(
             &TmuxPane,
             &mut Node,
             &mut TerminalHandle,
-            &TerminalRenderRef,
+            Option<&mut TerminalGrid>,
         ),
         Without<TmuxWindow>,
     >,
-    mut grids: Query<&mut TerminalGrid>,
     metrics: Res<TerminalCellMetricsResource>,
     window: Query<&Window, With<PrimaryWindow>>,
 ) {
@@ -442,7 +410,6 @@ fn layout_tmux_panes(
     let dpr = window.scale_factor().max(0.5);
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0) / dpr;
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0) / dpr;
-    let pane_title_h = 0.0_f32;
     let workspace_h = (window.resolution.physical_height() as f32 / dpr - cell_h).max(cell_h);
 
     for (window_entity, layout, mut container, children, maybe_packed) in windows.iter_mut() {
@@ -451,7 +418,6 @@ fn layout_tmux_panes(
             cell_w,
             cell_h,
             theme::PANE_GAP_PX,
-            pane_title_h,
             workspace_h,
         );
 
@@ -474,7 +440,7 @@ fn layout_tmux_panes(
         }
 
         for child in children.iter() {
-            let Ok((pane, mut node, mut handle, render_ref)) = panes.get_mut(child) else {
+            let Ok((pane, mut node, mut handle, grid)) = panes.get_mut(child) else {
                 continue;
             };
             let Some(rect) = rects.get(&pane.id) else {
@@ -495,11 +461,11 @@ fn layout_tmux_panes(
             let (cur_cols, cur_rows, _) = handle.read_geometry();
             if (cur_cols, cur_rows) != (cols, rows) {
                 handle.resize_grid_only(cols, rows);
-                if let Ok(mut grid) = grids.get_mut(render_ref.0) {
+                if let Some(mut grid) = grid {
                     grid.cols = cols;
                     grid.rows = rows;
                 }
-                handle.emit_pending(&mut commands, render_ref.0);
+                handle.emit_pending(&mut commands, child);
             }
         }
     }
@@ -638,14 +604,10 @@ mod tests {
             });
         app.update();
 
-        let render_ref = app
-            .world()
-            .get::<TerminalRenderRef>(pane_entity)
-            .expect("pane has TerminalRenderRef");
         let grid = app
             .world()
-            .get::<TerminalGrid>(render_ref.0)
-            .expect("render child has TerminalGrid");
+            .get::<TerminalGrid>(pane_entity)
+            .expect("pane has TerminalGrid");
         let row0: String = grid.cells[0].iter().map(|c| c.text.as_str()).collect();
         assert!(
             row0.starts_with("hi"),
@@ -691,11 +653,11 @@ mod tests {
                 data: b"hi".to_vec(),
             });
         app.update();
-        let baseline: String = {
-            let rr = app.world().get::<TerminalRenderRef>(pane_entity).unwrap();
-            app.world().get::<TerminalGrid>(rr.0).unwrap()
-        }
-        .cells[0]
+        let baseline: String = app
+            .world()
+            .get::<TerminalGrid>(pane_entity)
+            .unwrap()
+            .cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -713,11 +675,11 @@ mod tests {
                 data: b"\r\nXY".to_vec(),
             });
         app.update();
-        let gated: String = {
-            let rr = app.world().get::<TerminalRenderRef>(pane_entity).unwrap();
-            app.world().get::<TerminalGrid>(rr.0).unwrap()
-        }
-        .cells[0]
+        let gated: String = app
+            .world()
+            .get::<TerminalGrid>(pane_entity)
+            .unwrap()
+            .cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -739,11 +701,11 @@ mod tests {
                 data: Vec::new(),
             });
         app.update();
-        let resumed: String = {
-            let rr = app.world().get::<TerminalRenderRef>(pane_entity).unwrap();
-            app.world().get::<TerminalGrid>(rr.0).unwrap()
-        }
-        .cells[1]
+        let resumed: String = app
+            .world()
+            .get::<TerminalGrid>(pane_entity)
+            .unwrap()
+            .cells[1]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -856,30 +818,32 @@ mod tests {
                 Node::default(),
             ))
             .id();
-        let render_child = app.world_mut().spawn(TerminalGrid::default()).id();
-        app.world_mut().spawn((
-            TmuxPane {
-                id: PaneId(1),
-                dims: CellDims {
-                    width: 40,
-                    height: 10,
-                    xoff: 0,
-                    yoff: 0,
+        let pane = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: PaneId(1),
+                    dims: CellDims {
+                        width: 40,
+                        height: 10,
+                        xoff: 0,
+                        yoff: 0,
+                    },
                 },
-            },
-            Node::default(),
-            TerminalHandle::detached(20, 5, Arc::new(AtomicBool::new(false))),
-            TerminalRenderRef(render_child),
-            ChildOf(window_e),
-        ));
+                Node::default(),
+                TerminalGrid::default(),
+                TerminalHandle::detached(20, 5, Arc::new(AtomicBool::new(false))),
+                ChildOf(window_e),
+            ))
+            .id();
 
         app.add_systems(Update, layout_tmux_panes);
         app.update();
 
         let grid = app
             .world()
-            .get::<TerminalGrid>(render_child)
-            .expect("render child has TerminalGrid");
+            .get::<TerminalGrid>(pane)
+            .expect("pane has TerminalGrid");
         assert_eq!(
             (grid.cols, grid.rows),
             (40, 10),
@@ -1063,7 +1027,6 @@ mod tests {
                 Node::default(),
             ))
             .id();
-        let render_child = app.world_mut().spawn(TerminalGrid::default()).id();
         let entity = app
             .world_mut()
             .spawn((
@@ -1077,8 +1040,8 @@ mod tests {
                     },
                 },
                 Node::default(),
+                TerminalGrid::default(),
                 TerminalHandle::detached(20, 5, Arc::new(AtomicBool::new(false))),
-                TerminalRenderRef(render_child),
                 ChildOf(window_e),
             ))
             .id();
@@ -1086,11 +1049,10 @@ mod tests {
         app.add_systems(
             Update,
             (
-                |mut commands: Commands,
-                 mut q: Query<(Entity, &mut TerminalHandle, &TerminalRenderRef)>| {
-                    for (_, mut h, render_ref) in q.iter_mut() {
+                |mut commands: Commands, mut q: Query<(Entity, &mut TerminalHandle)>| {
+                    for (e, mut h) in q.iter_mut() {
                         h.advance(b"x");
-                        h.flush_emit(&mut commands, render_ref.0);
+                        h.flush_emit(&mut commands, e);
                     }
                 },
                 layout_tmux_panes,
@@ -1121,8 +1083,8 @@ mod tests {
 
         let grid = app
             .world()
-            .get::<TerminalGrid>(render_child)
-            .expect("render child has TerminalGrid");
+            .get::<TerminalGrid>(entity)
+            .expect("pane has TerminalGrid");
         assert_eq!(
             (grid.cols, grid.rows),
             (40, 10),
@@ -1146,7 +1108,7 @@ mod tests {
             },
             pane_id: Some(0),
         };
-        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 0.0, 384.0);
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 384.0);
         assert_eq!(
             rects[&PaneId(0)],
             Rect::from_corners(Vec2::ZERO, Vec2::new(640.0, 384.0))
@@ -1185,7 +1147,7 @@ mod tests {
                 },
             ],
         };
-        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0, 0.0, 384.0);
+        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0, 384.0);
         assert_eq!(
             rects[&PaneId(1)],
             Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0))
@@ -1253,10 +1215,10 @@ mod tests {
                 right_child,
             ],
         };
-        // pane_title_h=0, natural_h=192+176=368, gap=1, slack=384-368-1=15
+        // natural_h=192+176=368, gap=1, slack=384-368-1=15
         // slack distributed: pane2 gets round(15/2)=8px, pane3 (last) gets remaining 7px
         // pane2: 12*16+8=200, pane3: 384-200-1=183 (11*16+7=183)
-        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 0.0, 384.0);
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 384.0);
         assert_eq!(
             rects[&PaneId(1)],
             Rect::from_corners(Vec2::ZERO, Vec2::new(320.0, 384.0))
@@ -1324,7 +1286,7 @@ mod tests {
                 },
             ],
         };
-        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0, 0.0, 384.0);
+        let (rects, dividers, bbox) = collapse(&root, 8.0, 16.0, 1.0, 384.0);
         assert_eq!(
             rects[&PaneId(1)],
             Rect::from_corners(Vec2::ZERO, Vec2::new(160.0, 384.0))
@@ -1382,57 +1344,9 @@ mod tests {
                 },
             ],
         };
-        let (rects, _, _) = collapse(&root, 8.0, 16.0, 1.0, 0.0, 384.0);
+        let (rects, _, _) = collapse(&root, 8.0, 16.0, 1.0, 384.0);
         assert_eq!(rects.len(), 1, "pane_id:None leaf is not placed");
         assert!(rects.contains_key(&PaneId(2)));
-    }
-
-    #[test]
-    fn collapse_with_title_h_adds_t_to_every_leaf() {
-        let root = Cell::Split {
-            dims: CellDims {
-                width: 80,
-                height: 22,
-                xoff: 0,
-                yoff: 0,
-            },
-            dir: SplitDir::TopBottom,
-            children: vec![
-                Cell::Leaf {
-                    dims: CellDims {
-                        width: 80,
-                        height: 11,
-                        xoff: 0,
-                        yoff: 0,
-                    },
-                    pane_id: Some(1),
-                },
-                Cell::Leaf {
-                    dims: CellDims {
-                        width: 80,
-                        height: 10,
-                        xoff: 0,
-                        yoff: 12,
-                    },
-                    pane_id: Some(2),
-                },
-            ],
-        };
-        // cell_h = 16.0, pane_title_h = 16.0, gap = 1.0, workspace_h = 22*16 = 352
-        // pane1: dims.height*cell_h + pane_title_h = 11*16 + 16 = 192 px tall
-        // pane2: available.y - consumed = 352 - 192 - 1 = 159 available
-        //        max(159, 10*16+16) = max(159, 176) = 176 px tall
-        // pane2 starts at y = 192+1 = 193
-        let (rects, _, _) = collapse(&root, 8.0, 16.0, 1.0, 16.0, 352.0);
-        let r1 = rects[&PaneId(1)];
-        let r2 = rects[&PaneId(2)];
-        assert_eq!(r1, Rect::from_corners(Vec2::ZERO, Vec2::new(640.0, 192.0)));
-        assert_eq!(
-            r2,
-            Rect::from_corners(Vec2::new(0.0, 193.0), Vec2::new(640.0, 369.0))
-        );
-        assert_eq!(r1.height(), 192.0, "11 rows + 1 title bar row = 192px");
-        assert_eq!(r2.height(), 176.0, "10 rows + 1 title bar row = 176px");
     }
 
     #[test]
@@ -1446,9 +1360,10 @@ mod tests {
             },
             pane_id: Some(1),
         };
-        // workspace_h = 5*16 + 16 (title) + 8 (slack) = 104px
-        let workspace_h = 5.0 * 16.0 + 16.0 + 8.0;
-        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 16.0, workspace_h);
+        // workspace_h = 5*16 (natural) + 24 (slack) = 104px; the single leaf
+        // stretches to fill the whole workspace height.
+        let workspace_h = 5.0 * 16.0 + 24.0;
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, workspace_h);
         assert_eq!(
             rects[&PaneId(1)].height(),
             workspace_h,
@@ -1497,11 +1412,11 @@ mod tests {
                 },
             ],
         };
-        // cell_h=16, pane_title_h=16, gap=1
-        // natural_h = 3*(8*16+16) = 432, gaps = 2, slack = 6
-        // each pane gets 2px extra: 144+16+2 = 162? No: 8*16+16+2 = 146
+        // cell_h=16, gap=1
+        // natural_h = 3*(8*16) = 384, gaps = 2, slack = 440-384-2 = 54
+        // each pane gets 18px extra: 8*16+18 = 146
         // pane1: y=0..146, pane2: y=147..293, pane3: y=294..440
-        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 16.0, 440.0);
+        let (rects, _, bbox) = collapse(&root, 8.0, 16.0, 1.0, 440.0);
         assert_eq!(
             rects[&PaneId(1)].height(),
             146.0,

--- a/src/ui/tmux_pane_focus.rs
+++ b/src/ui/tmux_pane_focus.rs
@@ -6,7 +6,6 @@
 //! gesture arbiter (`tmux_mouse::OzmuxTmuxMousePlugin`).
 
 use crate::configs::OzmuxConfigsResource;
-use crate::tmux_render::TerminalRenderRef;
 use bevy::prelude::*;
 use bevy::ui::FocusPolicy;
 use ozma_tty_engine::TerminalHandle;
@@ -58,30 +57,25 @@ fn pane_active_state_changed(
         || removed_active.read().next().is_some()
 }
 
-/// Sets each pane's [`PaneDim`] brightness on the `TerminalRenderChild` entity:
-/// `1.0` for the pane carrying `ActivePane` (or for all panes when no pane is
-/// active), the configured dim factor otherwise. Only inserts when the value
-/// changes. Panes without a `TerminalRenderRef` (not yet attached) are skipped.
+/// Sets each pane's [`PaneDim`] brightness on the `TmuxPane` entity (which owns
+/// the `TerminalGrid` / material): `1.0` for the pane carrying `ActivePane` (or
+/// for all panes when no pane is active), the configured dim factor otherwise.
+/// Only inserts when the value changes.
 fn sync_pane_dim(
     mut commands: Commands,
-    panes: Query<(Has<ActivePane>, Option<&TerminalRenderRef>), With<TmuxPane>>,
-    render_dims: Query<Option<&PaneDim>>,
+    panes: Query<(Entity, Has<ActivePane>, Option<&PaneDim>), With<TmuxPane>>,
     configs: Option<Res<OzmuxConfigsResource>>,
 ) {
     let dim_factor = inactive_dim_factor(configs.as_deref());
-    let any_active = panes.iter().any(|(active, _)| active);
-    for (active, maybe_ref) in panes.iter() {
-        let Some(render_ref) = maybe_ref else {
-            continue;
-        };
+    let any_active = panes.iter().any(|(_, active, _)| active);
+    for (entity, active, current) in panes.iter() {
         let want = if active || !any_active {
             1.0
         } else {
             dim_factor
         };
-        let current = render_dims.get(render_ref.0).ok().flatten();
         if current.map(|d| d.0) != Some(want) {
-            commands.entity(render_ref.0).insert(PaneDim(want));
+            commands.entity(entity).insert(PaneDim(want));
         }
     }
 }
@@ -122,7 +116,6 @@ mod tests {
         app.insert_resource(OzmuxConfigsResource::default());
         let h = || TerminalHandle::detached(10, 5, Arc::new(AtomicBool::new(false)));
 
-        let rc1 = app.world_mut().spawn(()).id();
         let p1 = app
             .world_mut()
             .spawn((
@@ -132,11 +125,9 @@ mod tests {
                 },
                 h(),
                 ActivePane,
-                crate::tmux_render::TerminalRenderRef(rc1),
             ))
             .id();
 
-        let rc2 = app.world_mut().spawn(()).id();
         let p2 = app
             .world_mut()
             .spawn((
@@ -145,38 +136,27 @@ mod tests {
                     dims: dims(),
                 },
                 h(),
-                crate::tmux_render::TerminalRenderRef(rc2),
             ))
             .id();
 
         let dim = |app: &App, e| app.world().get::<PaneDim>(e).map(|d| d.0);
 
         app.update();
-        assert_eq!(
-            dim(&app, rc1),
-            Some(1.0),
-            "active pane render child full-bright"
-        );
-        assert_eq!(
-            dim(&app, rc2),
-            Some(0.5),
-            "inactive pane render child dimmed"
-        );
-        assert_eq!(dim(&app, p1), None);
-        assert_eq!(dim(&app, p2), None);
+        assert_eq!(dim(&app, p1), Some(1.0), "active pane full-bright");
+        assert_eq!(dim(&app, p2), Some(0.5), "inactive pane dimmed");
 
         // Move ActivePane to p2.
         app.world_mut().entity_mut(p1).remove::<ActivePane>();
         app.world_mut().entity_mut(p2).insert(ActivePane);
         app.update();
-        assert_eq!(dim(&app, rc1), Some(0.5));
-        assert_eq!(dim(&app, rc2), Some(1.0));
+        assert_eq!(dim(&app, p1), Some(0.5));
+        assert_eq!(dim(&app, p2), Some(1.0));
 
         // No active pane: both full-bright.
         app.world_mut().entity_mut(p2).remove::<ActivePane>();
         app.update();
-        assert_eq!(dim(&app, rc1), Some(1.0));
-        assert_eq!(dim(&app, rc2), Some(1.0));
+        assert_eq!(dim(&app, p1), Some(1.0));
+        assert_eq!(dim(&app, p2), Some(1.0));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Inline webviews stopped rendering inside tmux panes. The webview would mount
(the CEF browser is created and begins loading) but never appears on screen.

Root cause is a regression from #145. To host the (now-removed) pane
title-tab bar, #145 turned each `TmuxPane` into a flex container and moved
`TerminalRenderBundle` (`TerminalGrid` + `MaterialNode`) onto a child
`render_child` entity, referenced via a new `TerminalRenderRef` component.
But an inline webview mounts as a `ChildOf` the **pane**, while
`project_inline_overlays` walks the `Children` of the entity that carries
`TerminalGrid` to find webviews. After #145 those are two different entities
(grid on `render_child`, webview on the pane), so projection could never
discover the webview — no overlay texture reached the terminal shader and
nothing rendered. The `mount_inline` doc comment
(`src/inline_webview.rs:201-206`) still documented the now-violated invariant
that the grid and the webview's `ChildOf` parent are the same entity.

## Solution

The title-tab bar no longer exists, so the pane container is unnecessary.
Restore the pre-#145 structure and remove the indirection (engine renderer
layer — `src/`):

- `attach_tmux_pane_terminal`: insert `TerminalRenderBundle` directly on the
  `TmuxPane` entity; drop the `render_child` spawn and the
  `flex_direction: Column` container `Node`.
- Delete the `TerminalRenderRef` component and update every consumer to
  target the pane entity directly — `flush_emit` / `emit_pending` /
  `repaint_full` (`tmux_render`, `tmux_copy_mode`) and `PaneDim`
  (`tmux_pane_focus`). `apply_copy_overlay` and `sync_pane_dim` collapse to a
  single query since their components now co-locate on the pane.
- Drop the always-zero `pane_title_h` parameter threaded through
  `collapse`/`place`, and fold the now-vestigial separate `TerminalGrid`
  query in `layout_tmux_panes` into the `panes` tuple.

This makes the unchanged `inline_webview` projection invariant true again, so
a webview mounted on a tmux pane is found and composited.

Net: **106 insertions / 243 deletions** across `tmux_render.rs`,
`tmux_copy_mode.rs`, `tmux_pane_focus.rs`.

### Verification

- `cargo build` clean; `cargo clippy --all-features` clean.
- Affected unit tests green: 14 `tmux_render`, plus `tmux_copy_mode` /
  `tmux_pane_focus` / `inline_webview` (87 total, 2 ignored real-tmux).
- CEF rendering can't be exercised by unit tests; a manual GUI smoke test
  (`RUST_LOG="info,ozmux_gui=debug,bevy_cef=debug" cargo run --features debug`,
  mount a webview in a pane) is still recommended to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
