### PR TITLE
feat: distinguish inactive panes (iTerm2-style grey background + dimmed webviews)

### DIFF
--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -72,32 +72,26 @@ impl InactivePaneConfigPatch {
         if let Some(v) = self.enabled {
             base.enabled = v;
         }
-        if let Some(v) = self.dim
-            && !v.is_nan()
-        {
-            base.dim = v.clamp(0.0, 1.0);
-        }
+        apply_unit(&mut base.dim, self.dim);
         if let Some(v) = self.tint_color
             && parse_hex_rgb(&v).is_some()
         {
             base.tint_color = v.to_ascii_lowercase();
         }
-        if let Some(v) = self.tint
-            && !v.is_nan()
-        {
-            base.tint = v.clamp(0.0, 1.0);
-        }
-        if let Some(v) = self.webview_dim
-            && !v.is_nan()
-        {
-            base.webview_dim = v.clamp(0.0, 1.0);
-        }
-        if let Some(v) = self.webview_desaturate
-            && !v.is_nan()
-        {
-            base.webview_desaturate = v.clamp(0.0, 1.0);
-        }
+        apply_unit(&mut base.tint, self.tint);
+        apply_unit(&mut base.webview_dim, self.webview_dim);
+        apply_unit(&mut base.webview_desaturate, self.webview_desaturate);
         base
+    }
+}
+
+/// Overwrites `dst` with `src` clamped to `0.0..=1.0`. A `None` or `NaN` `src`
+/// leaves `dst` unchanged (the base value is kept).
+fn apply_unit(dst: &mut f32, src: Option<f32>) {
+    if let Some(v) = src
+        && !v.is_nan()
+    {
+        *dst = v.clamp(0.0, 1.0);
     }
 }
 

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -1,30 +1,47 @@
-//! Inactive-pane treatment configuration: per-pane brightness `dim` and
-//! desaturation `desaturate` that the terminal renderer applies to every
-//! pane that is not its workspace's active pane.
+//! Inactive-pane treatment configuration: a per-pane background tint toward a
+//! configurable grey (`tint_color` at strength `tint`) plus an optional
+//! brightness `dim`, applied by the terminal renderer to every pane that is
+//! not its workspace's active pane.
 
 use serde::{Deserialize, Serialize};
 
-/// Fully-resolved `[inactive_pane]` config block. The terminal renderer dims
-/// (brightness) and desaturates (toward grey) every inactive pane.
+/// Fully-resolved `[inactive_pane]` config block. The terminal renderer blends
+/// each inactive pane's background toward `tint_color` by `tint`, and multiplies
+/// brightness by `dim`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct InactivePaneConfig {
-    /// Whether inactive panes are treated (dimmed + desaturated) at all.
+    /// Whether inactive panes are treated (tinted + dimmed) at all.
     pub enabled: bool,
     /// Inactive-pane brightness multiplier in `0.0..=1.0` (lower = dimmer);
     /// `1.0` leaves brightness untouched.
     pub dim: f32,
-    /// Inactive-pane desaturation in `0.0..=1.0`: `0.0` keeps full color,
-    /// `1.0` is fully grey. Applied in the terminal shader alongside `dim`.
-    pub desaturate: f32,
+    /// Background-tint target color as a `#RRGGBB` hex string. Inactive-pane
+    /// backgrounds blend toward this color by `tint`. Case-insensitive on
+    /// input, stored normalized to lowercase.
+    pub tint_color: String,
+    /// Background-tint strength in `0.0..=1.0`: `0.0` keeps the real background,
+    /// `1.0` replaces it with `tint_color`. Only the background is tinted; text
+    /// and overlays are untouched.
+    pub tint: f32,
 }
 
 impl Default for InactivePaneConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            dim: 0.5,
-            desaturate: 0.7,
+            dim: 1.0,
+            tint_color: "#3a3b45".to_string(),
+            tint: 0.85,
         }
+    }
+}
+
+impl InactivePaneConfig {
+    /// Returns the tint target's `(r, g, b)` byte components parsed from the
+    /// `#RRGGBB` `tint_color` string, falling back to black on a malformed
+    /// value.
+    pub fn tint_color_rgb(&self) -> (u8, u8, u8) {
+        parse_hex_rgb(&self.tint_color).unwrap_or((0, 0, 0))
     }
 }
 
@@ -34,7 +51,8 @@ impl Default for InactivePaneConfig {
 pub(crate) struct InactivePaneConfigPatch {
     pub(crate) enabled: Option<bool>,
     pub(crate) dim: Option<f32>,
-    pub(crate) desaturate: Option<f32>,
+    pub(crate) tint_color: Option<String>,
+    pub(crate) tint: Option<f32>,
 }
 
 impl InactivePaneConfigPatch {
@@ -47,13 +65,34 @@ impl InactivePaneConfigPatch {
         {
             base.dim = v.clamp(0.0, 1.0);
         }
-        if let Some(v) = self.desaturate
+        if let Some(v) = self.tint_color
+            && parse_hex_rgb(&v).is_some()
+        {
+            base.tint_color = v.to_ascii_lowercase();
+        }
+        if let Some(v) = self.tint
             && !v.is_nan()
         {
-            base.desaturate = v.clamp(0.0, 1.0);
+            base.tint = v.clamp(0.0, 1.0);
         }
         base
     }
+}
+
+/// Parses a `#RRGGBB` hex string into `(r, g, b)` bytes; returns `None` for
+/// any other shape (missing `#`, wrong length, non-hex digits).
+fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
+    let hex = s.strip_prefix('#')?;
+    // NOTE: `!hex.is_ascii()` is load-bearing — the byte-index slices below
+    // panic on a 6-BYTE non-ASCII string (e.g. "#中文") whose offsets 2/4
+    // fall on a non-char-boundary. Drop this and config loading crashes.
+    if hex.len() != 6 || !hex.is_ascii() {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some((r, g, b))
 }
 
 #[cfg(test)]
@@ -64,20 +103,23 @@ mod tests {
     fn defaults_match_expected_values() {
         let cfg = InactivePaneConfig::default();
         assert!(cfg.enabled);
-        assert_eq!(cfg.dim, 0.5);
-        assert_eq!(cfg.desaturate, 0.7);
+        assert_eq!(cfg.dim, 1.0);
+        assert_eq!(cfg.tint_color, "#3a3b45");
+        assert_eq!(cfg.tint, 0.85);
+        assert_eq!(cfg.tint_color_rgb(), (0x3a, 0x3b, 0x45));
     }
 
     #[test]
     fn patch_overrides_only_present_fields() {
         let patch = InactivePaneConfigPatch {
-            desaturate: Some(0.3),
+            tint: Some(0.3),
             ..Default::default()
         };
         let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.desaturate, 0.3);
+        assert_eq!(merged.tint, 0.3);
         assert!(merged.enabled);
-        assert_eq!(merged.dim, 0.5);
+        assert_eq!(merged.dim, 1.0);
+        assert_eq!(merged.tint_color, "#3a3b45");
     }
 
     #[test]
@@ -98,48 +140,86 @@ mod tests {
     }
 
     #[test]
-    fn desaturate_clamps_into_unit_range() {
+    fn tint_clamps_into_unit_range() {
         let high = InactivePaneConfigPatch {
-            desaturate: Some(4.0),
+            tint: Some(4.0),
             ..Default::default()
         }
         .apply_to(InactivePaneConfig::default());
-        assert_eq!(high.desaturate, 1.0);
+        assert_eq!(high.tint, 1.0);
 
         let low = InactivePaneConfigPatch {
-            desaturate: Some(-1.0),
+            tint: Some(-1.0),
             ..Default::default()
         }
         .apply_to(InactivePaneConfig::default());
-        assert_eq!(low.desaturate, 0.0);
+        assert_eq!(low.tint, 0.0);
     }
 
     #[test]
     fn nan_dim_is_rejected_and_keeps_base() {
         let patch: InactivePaneConfigPatch = toml::from_str("dim = nan").unwrap();
         let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.dim, 0.5, "NaN dim must fall back to base");
+        assert_eq!(merged.dim, 1.0, "NaN dim must fall back to base");
         assert!(merged.dim.is_finite());
     }
 
     #[test]
-    fn nan_desaturate_is_rejected_and_keeps_base() {
-        let patch: InactivePaneConfigPatch = toml::from_str("desaturate = nan").unwrap();
+    fn nan_tint_is_rejected_and_keeps_base() {
+        let patch: InactivePaneConfigPatch = toml::from_str("tint = nan").unwrap();
         let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(
-            merged.desaturate, 0.7,
-            "NaN desaturate must fall back to base"
-        );
-        assert!(merged.desaturate.is_finite());
+        assert_eq!(merged.tint, 0.85, "NaN tint must fall back to base");
+        assert!(merged.tint.is_finite());
+    }
+
+    #[test]
+    fn invalid_tint_color_falls_back_to_base() {
+        let merged = InactivePaneConfigPatch {
+            tint_color: Some("not-a-color".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.tint_color, "#3a3b45");
+    }
+
+    #[test]
+    fn uppercase_tint_color_is_normalized_and_parsed() {
+        let merged = InactivePaneConfigPatch {
+            tint_color: Some("#FF00AB".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.tint_color, "#ff00ab");
+        assert_eq!(merged.tint_color_rgb(), (0xff, 0x00, 0xab));
+    }
+
+    #[test]
+    fn non_ascii_six_byte_tint_color_is_rejected_without_panic() {
+        // "中文" is 6 UTF-8 bytes; byte-slicing it would panic at a
+        // non-char-boundary if parse_hex_rgb did not guard on is_ascii.
+        let merged = InactivePaneConfigPatch {
+            tint_color: Some("#中文".to_string()),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.tint_color, "#3a3b45", "non-ASCII must fall back");
+
+        let cfg = InactivePaneConfig {
+            tint_color: "#中文".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(cfg.tint_color_rgb(), (0, 0, 0), "rgb() must not panic");
     }
 
     #[test]
     fn patch_parses_from_toml() {
         let patch: InactivePaneConfigPatch =
-            toml::from_str("enabled = false\ndim = 0.3\ndesaturate = 0.9").unwrap();
+            toml::from_str("enabled = false\ndim = 0.3\ntint_color = \"#112233\"\ntint = 0.9")
+                .unwrap();
         assert_eq!(patch.enabled, Some(false));
         assert_eq!(patch.dim, Some(0.3));
-        assert_eq!(patch.desaturate, Some(0.9));
+        assert_eq!(patch.tint_color.as_deref(), Some("#112233"));
+        assert_eq!(patch.tint, Some(0.9));
     }
 
     #[test]
@@ -150,10 +230,10 @@ mod tests {
     }
 
     #[test]
-    fn stale_veil_keys_are_ignored_without_error() {
+    fn stale_keys_are_ignored_without_error() {
         let patch: InactivePaneConfigPatch =
-            toml::from_str("dim = 0.4\nopacity = 0.6\ncolor = \"#112233\"").unwrap();
+            toml::from_str("dim = 0.4\ndesaturate = 0.7\nopacity = 0.6").unwrap();
         assert_eq!(patch.dim, Some(0.4));
-        assert_eq!(patch.desaturate, None);
+        assert_eq!(patch.tint, None);
     }
 }

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -1,44 +1,30 @@
-//! Inactive-pane dimming configuration: the translucent veil drawn over
-//! every pane that is not its workspace's active pane.
+//! Inactive-pane treatment configuration: per-pane brightness `dim` and
+//! desaturation `desaturate` that the terminal renderer applies to every
+//! pane that is not its workspace's active pane.
 
 use serde::{Deserialize, Serialize};
 
-/// Fully-resolved `[inactive_pane]` config block. The UI layer draws a
-/// veil over each inactive pane using `color` (RGB) at `opacity` (alpha).
+/// Fully-resolved `[inactive_pane]` config block. The terminal renderer dims
+/// (brightness) and desaturates (toward grey) every inactive pane.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct InactivePaneConfig {
-    /// Whether inactive panes are dimmed at all.
+    /// Whether inactive panes are treated (dimmed + desaturated) at all.
     pub enabled: bool,
-    /// Veil alpha in `0.0..=1.0`. Higher = darker inactive panes.
-    pub opacity: f32,
-    /// Veil color as a `#RRGGBB` hex string. Alpha comes from `opacity`,
-    /// not from this string. Hex is case-insensitive on input and stored
-    /// normalized to lowercase. `opacity`/`color` dim non-terminal panes
-    /// (e.g. the webview); terminal panes use `dim`.
-    pub color: String,
-    /// Inactive-terminal brightness multiplier in `0.0..=1.0`. The terminal
-    /// renderer multiplies an inactive pane's rendered content by this
-    /// (lower = dimmer); `1.0` leaves it full-bright. Separate from `opacity`
-    /// because a darkening veil is invisible on a black terminal background.
+    /// Inactive-pane brightness multiplier in `0.0..=1.0` (lower = dimmer);
+    /// `1.0` leaves brightness untouched.
     pub dim: f32,
+    /// Inactive-pane desaturation in `0.0..=1.0`: `0.0` keeps full color,
+    /// `1.0` is fully grey. Applied in the terminal shader alongside `dim`.
+    pub desaturate: f32,
 }
 
 impl Default for InactivePaneConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            opacity: 0.5,
-            color: "#000000".to_string(),
             dim: 0.5,
+            desaturate: 0.7,
         }
-    }
-}
-
-impl InactivePaneConfig {
-    /// Returns the veil color's `(r, g, b)` byte components parsed from the
-    /// `#RRGGBB` `color` string, falling back to black on a malformed value.
-    pub fn rgb(&self) -> (u8, u8, u8) {
-        parse_hex_rgb(&self.color).unwrap_or((0, 0, 0))
     }
 }
 
@@ -47,9 +33,8 @@ impl InactivePaneConfig {
 #[derive(Deserialize, Default)]
 pub(crate) struct InactivePaneConfigPatch {
     pub(crate) enabled: Option<bool>,
-    pub(crate) opacity: Option<f32>,
-    pub(crate) color: Option<String>,
     pub(crate) dim: Option<f32>,
+    pub(crate) desaturate: Option<f32>,
 }
 
 impl InactivePaneConfigPatch {
@@ -57,39 +42,18 @@ impl InactivePaneConfigPatch {
         if let Some(v) = self.enabled {
             base.enabled = v;
         }
-        if let Some(v) = self.opacity
-            && !v.is_nan()
-        {
-            base.opacity = v.clamp(0.0, 1.0);
-        }
-        if let Some(v) = self.color
-            && parse_hex_rgb(&v).is_some()
-        {
-            base.color = v.to_ascii_lowercase();
-        }
         if let Some(v) = self.dim
             && !v.is_nan()
         {
             base.dim = v.clamp(0.0, 1.0);
         }
+        if let Some(v) = self.desaturate
+            && !v.is_nan()
+        {
+            base.desaturate = v.clamp(0.0, 1.0);
+        }
         base
     }
-}
-
-/// Parses a `#RRGGBB` hex string into `(r, g, b)` bytes; returns `None` for
-/// any other shape (missing `#`, wrong length, non-hex digits).
-fn parse_hex_rgb(s: &str) -> Option<(u8, u8, u8)> {
-    let hex = s.strip_prefix('#')?;
-    // NOTE: `!hex.is_ascii()` is load-bearing — the byte-index slices below
-    // panic on a 6-BYTE non-ASCII string (e.g. "#中文") whose offsets 2/4
-    // fall on a non-char-boundary. Drop this and config loading crashes.
-    if hex.len() != 6 || !hex.is_ascii() {
-        return None;
-    }
-    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-    Some((r, g, b))
 }
 
 #[cfg(test)]
@@ -100,134 +64,20 @@ mod tests {
     fn defaults_match_expected_values() {
         let cfg = InactivePaneConfig::default();
         assert!(cfg.enabled);
-        assert_eq!(cfg.opacity, 0.5);
-        assert_eq!(cfg.color, "#000000");
-        assert_eq!(cfg.rgb(), (0, 0, 0));
         assert_eq!(cfg.dim, 0.5);
-    }
-
-    #[test]
-    fn rgb_parses_hex() {
-        let cfg = InactivePaneConfig {
-            enabled: true,
-            opacity: 0.5,
-            color: "#1a2b3c".to_string(),
-            dim: 0.5,
-        };
-        assert_eq!(cfg.rgb(), (0x1a, 0x2b, 0x3c));
+        assert_eq!(cfg.desaturate, 0.7);
     }
 
     #[test]
     fn patch_overrides_only_present_fields() {
         let patch = InactivePaneConfigPatch {
-            opacity: Some(0.8),
+            desaturate: Some(0.3),
             ..Default::default()
         };
         let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.opacity, 0.8);
+        assert_eq!(merged.desaturate, 0.3);
         assert!(merged.enabled);
-        assert_eq!(merged.color, "#000000");
-    }
-
-    #[test]
-    fn opacity_clamps_into_unit_range() {
-        let high = InactivePaneConfigPatch {
-            opacity: Some(5.0),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(high.opacity, 1.0);
-
-        let low = InactivePaneConfigPatch {
-            opacity: Some(-2.0),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(low.opacity, 0.0);
-    }
-
-    #[test]
-    fn invalid_color_falls_back_to_base() {
-        let merged = InactivePaneConfigPatch {
-            color: Some("not-a-color".to_string()),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.color, "#000000");
-    }
-
-    #[test]
-    fn patch_parses_from_toml() {
-        let patch: InactivePaneConfigPatch =
-            toml::from_str("enabled = false\nopacity = 0.6\ncolor = \"#112233\"\ndim = 0.3")
-                .unwrap();
-        assert_eq!(patch.enabled, Some(false));
-        assert_eq!(patch.opacity, Some(0.6));
-        assert_eq!(patch.color.as_deref(), Some("#112233"));
-        assert_eq!(patch.dim, Some(0.3));
-    }
-
-    #[test]
-    fn uppercase_color_is_normalized_and_parsed() {
-        let merged = InactivePaneConfigPatch {
-            color: Some("#FF00AB".to_string()),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.color, "#ff00ab");
-        assert_eq!(merged.rgb(), (0xff, 0x00, 0xab));
-    }
-
-    #[test]
-    fn empty_patch_leaves_base_unchanged() {
-        let patch = InactivePaneConfigPatch::default();
-        let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged, InactivePaneConfig::default());
-    }
-
-    #[test]
-    fn non_ascii_six_byte_color_is_rejected_without_panic() {
-        // "中文" is 6 UTF-8 bytes; byte-slicing it would panic at a
-        // non-char-boundary if parse_hex_rgb did not guard on is_ascii.
-        let merged = InactivePaneConfigPatch {
-            color: Some("#中文".to_string()),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(
-            merged.color, "#000000",
-            "non-ASCII color must fall back to base"
-        );
-
-        let cfg = InactivePaneConfig {
-            enabled: true,
-            opacity: 0.5,
-            color: "#中文".to_string(),
-            dim: 0.5,
-        };
-        assert_eq!(
-            cfg.rgb(),
-            (0, 0, 0),
-            "rgb() must not panic on a non-ASCII color"
-        );
-    }
-
-    #[test]
-    fn nan_opacity_is_rejected_and_keeps_base() {
-        let patch: InactivePaneConfigPatch = toml::from_str("opacity = nan").unwrap();
-        let merged = patch.apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.opacity, 0.5, "NaN opacity must fall back to base");
-        assert!(merged.opacity.is_finite(), "stored opacity must be finite");
-    }
-
-    #[test]
-    fn infinite_opacity_clamps_to_unit_range() {
-        let merged = InactivePaneConfigPatch {
-            opacity: Some(f32::INFINITY),
-            ..Default::default()
-        }
-        .apply_to(InactivePaneConfig::default());
-        assert_eq!(merged.opacity, 1.0, "+inf opacity clamps to 1.0");
+        assert_eq!(merged.dim, 0.5);
     }
 
     #[test]
@@ -248,10 +98,62 @@ mod tests {
     }
 
     #[test]
+    fn desaturate_clamps_into_unit_range() {
+        let high = InactivePaneConfigPatch {
+            desaturate: Some(4.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(high.desaturate, 1.0);
+
+        let low = InactivePaneConfigPatch {
+            desaturate: Some(-1.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(low.desaturate, 0.0);
+    }
+
+    #[test]
     fn nan_dim_is_rejected_and_keeps_base() {
         let patch: InactivePaneConfigPatch = toml::from_str("dim = nan").unwrap();
         let merged = patch.apply_to(InactivePaneConfig::default());
         assert_eq!(merged.dim, 0.5, "NaN dim must fall back to base");
         assert!(merged.dim.is_finite());
+    }
+
+    #[test]
+    fn nan_desaturate_is_rejected_and_keeps_base() {
+        let patch: InactivePaneConfigPatch = toml::from_str("desaturate = nan").unwrap();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(
+            merged.desaturate, 0.7,
+            "NaN desaturate must fall back to base"
+        );
+        assert!(merged.desaturate.is_finite());
+    }
+
+    #[test]
+    fn patch_parses_from_toml() {
+        let patch: InactivePaneConfigPatch =
+            toml::from_str("enabled = false\ndim = 0.3\ndesaturate = 0.9").unwrap();
+        assert_eq!(patch.enabled, Some(false));
+        assert_eq!(patch.dim, Some(0.3));
+        assert_eq!(patch.desaturate, Some(0.9));
+    }
+
+    #[test]
+    fn empty_patch_leaves_base_unchanged() {
+        let patch = InactivePaneConfigPatch::default();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged, InactivePaneConfig::default());
+    }
+
+    #[test]
+    fn stale_veil_keys_are_ignored_without_error() {
+        let patch: InactivePaneConfigPatch =
+            toml::from_str("dim = 0.4\nopacity = 0.6\ncolor = \"#112233\"").unwrap();
+        assert_eq!(patch.dim, Some(0.4));
+        assert_eq!(patch.desaturate, None);
     }
 }

--- a/crates/configs/src/inactive_pane.rs
+++ b/crates/configs/src/inactive_pane.rs
@@ -23,6 +23,14 @@ pub struct InactivePaneConfig {
     /// `1.0` replaces it with `tint_color`. Only the background is tinted; text
     /// and overlays are untouched.
     pub tint: f32,
+    /// Inactive-webview brightness multiplier in `0.0..=1.0` (lower = darker);
+    /// `1.0` leaves brightness untouched. Applied to inline-webview overlays
+    /// only, so the background tint can stay background-only.
+    pub webview_dim: f32,
+    /// Inactive-webview desaturation in `0.0..=1.0`: `0.0` keeps full color,
+    /// `1.0` is fully grey. Applied to inline-webview overlays alongside
+    /// `webview_dim`.
+    pub webview_desaturate: f32,
 }
 
 impl Default for InactivePaneConfig {
@@ -32,6 +40,8 @@ impl Default for InactivePaneConfig {
             dim: 1.0,
             tint_color: "#3a3b45".to_string(),
             tint: 0.85,
+            webview_dim: 0.55,
+            webview_desaturate: 0.6,
         }
     }
 }
@@ -53,6 +63,8 @@ pub(crate) struct InactivePaneConfigPatch {
     pub(crate) dim: Option<f32>,
     pub(crate) tint_color: Option<String>,
     pub(crate) tint: Option<f32>,
+    pub(crate) webview_dim: Option<f32>,
+    pub(crate) webview_desaturate: Option<f32>,
 }
 
 impl InactivePaneConfigPatch {
@@ -74,6 +86,16 @@ impl InactivePaneConfigPatch {
             && !v.is_nan()
         {
             base.tint = v.clamp(0.0, 1.0);
+        }
+        if let Some(v) = self.webview_dim
+            && !v.is_nan()
+        {
+            base.webview_dim = v.clamp(0.0, 1.0);
+        }
+        if let Some(v) = self.webview_desaturate
+            && !v.is_nan()
+        {
+            base.webview_desaturate = v.clamp(0.0, 1.0);
         }
         base
     }
@@ -107,6 +129,8 @@ mod tests {
         assert_eq!(cfg.tint_color, "#3a3b45");
         assert_eq!(cfg.tint, 0.85);
         assert_eq!(cfg.tint_color_rgb(), (0x3a, 0x3b, 0x45));
+        assert_eq!(cfg.webview_dim, 0.55);
+        assert_eq!(cfg.webview_desaturate, 0.6);
     }
 
     #[test]
@@ -173,6 +197,31 @@ mod tests {
     }
 
     #[test]
+    fn webview_fields_clamp_into_unit_range() {
+        let merged = InactivePaneConfigPatch {
+            webview_dim: Some(4.0),
+            webview_desaturate: Some(-1.0),
+            ..Default::default()
+        }
+        .apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.webview_dim, 1.0);
+        assert_eq!(merged.webview_desaturate, 0.0);
+    }
+
+    #[test]
+    fn nan_webview_fields_are_rejected_and_keep_base() {
+        let patch: InactivePaneConfigPatch =
+            toml::from_str("webview_dim = nan\nwebview_desaturate = nan").unwrap();
+        let merged = patch.apply_to(InactivePaneConfig::default());
+        assert_eq!(merged.webview_dim, 0.55, "NaN webview_dim falls back");
+        assert_eq!(
+            merged.webview_desaturate, 0.6,
+            "NaN webview_desaturate falls back"
+        );
+        assert!(merged.webview_dim.is_finite() && merged.webview_desaturate.is_finite());
+    }
+
+    #[test]
     fn invalid_tint_color_falls_back_to_base() {
         let merged = InactivePaneConfigPatch {
             tint_color: Some("not-a-color".to_string()),
@@ -213,13 +262,16 @@ mod tests {
 
     #[test]
     fn patch_parses_from_toml() {
-        let patch: InactivePaneConfigPatch =
-            toml::from_str("enabled = false\ndim = 0.3\ntint_color = \"#112233\"\ntint = 0.9")
-                .unwrap();
+        let patch: InactivePaneConfigPatch = toml::from_str(
+            "enabled = false\ndim = 0.3\ntint_color = \"#112233\"\ntint = 0.9\nwebview_dim = 0.4\nwebview_desaturate = 0.7",
+        )
+        .unwrap();
         assert_eq!(patch.enabled, Some(false));
         assert_eq!(patch.dim, Some(0.3));
         assert_eq!(patch.tint_color.as_deref(), Some("#112233"));
         assert_eq!(patch.tint, Some(0.9));
+        assert_eq!(patch.webview_dim, Some(0.4));
+        assert_eq!(patch.webview_desaturate, Some(0.7));
     }
 
     #[test]

--- a/crates/configs/src/raw.rs
+++ b/crates/configs/src/raw.rs
@@ -153,13 +153,16 @@ resize-pane-down = "Cmd+Shift+J"
         let toml_str = r#"
 [inactive_pane]
 enabled = false
-opacity = 2.0
+desaturate = 2.0
 "#;
         let raw: RawConfigs = toml::from_str(toml_str).unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert!(!merged.inactive_pane.enabled);
-        assert_eq!(merged.inactive_pane.opacity, 1.0, "opacity clamps to 1.0");
-        assert_eq!(merged.inactive_pane.color, "#000000", "color keeps default");
+        assert_eq!(
+            merged.inactive_pane.desaturate, 1.0,
+            "desaturate clamps to 1.0"
+        );
+        assert_eq!(merged.inactive_pane.dim, 0.5, "dim keeps default");
     }
 
     #[test]

--- a/crates/configs/src/raw.rs
+++ b/crates/configs/src/raw.rs
@@ -150,19 +150,18 @@ resize-pane-down = "Cmd+Shift+J"
 
     #[test]
     fn inactive_pane_section_merges_and_clamps() {
-        let toml_str = r#"
+        let toml_str = r##"
 [inactive_pane]
 enabled = false
-desaturate = 2.0
-"#;
+tint = 2.0
+tint_color = "#102030"
+"##;
         let raw: RawConfigs = toml::from_str(toml_str).unwrap();
         let merged = raw.apply_to(OzmuxConfigs::default());
         assert!(!merged.inactive_pane.enabled);
-        assert_eq!(
-            merged.inactive_pane.desaturate, 1.0,
-            "desaturate clamps to 1.0"
-        );
-        assert_eq!(merged.inactive_pane.dim, 0.5, "dim keeps default");
+        assert_eq!(merged.inactive_pane.tint, 1.0, "tint clamps to 1.0");
+        assert_eq!(merged.inactive_pane.tint_color, "#102030");
+        assert_eq!(merged.inactive_pane.dim, 1.0, "dim keeps default");
     }
 
     #[test]

--- a/crates/ozma_tty_renderer/src/lib.rs
+++ b/crates/ozma_tty_renderer/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
     pub use crate::TerminalRendererPlugin;
     pub use crate::bundle::TerminalRenderBundle;
     pub use crate::grid::TerminalGridPlugin;
-    pub use crate::material::{OVERLAY_SLOTS, PaneDim, TerminalOverlays};
+    pub use crate::material::{OVERLAY_SLOTS, PaneInactiveStyle, TerminalOverlays};
     pub use crate::schema::*;
 }
 

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -260,7 +260,7 @@ struct TerminalParams {
     dim: f32,
     /// Per-pane desaturation toward Rec.709 luminance, applied to the final
     /// fragment RGB after `dim`. `0.0` = full color (active / no-op); `1.0` =
-    /// fully grey. Fills the 4-byte slot encase previously padded after `dim`,
+    /// fully grey. Fills the 4-byte slot encase would otherwise pad after `dim`,
     /// so the uniform stays 176 bytes. `Default` (below) sets this to `0.0`.
     desaturate: f32,
     /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -106,26 +106,28 @@ impl TerminalUiMaterial {
     }
 }
 
-/// Per-pane inactive-pane treatment for the terminal renderer: brightness
-/// `dim` and desaturation `desaturate`, both applied in the fragment shader to
-/// the final composited color (terminal content + any inline-webview overlay).
-/// The consumer (e.g. ozmux-gui) sets this on a terminal host from its
-/// active-pane state; `update_terminal_material` bakes both into the uniform
-/// each frame. An absent component is treated as `{ dim: 1.0, desaturate: 0.0 }`
-/// (full-bright, full-color / active).
+/// Per-pane inactive-pane treatment for the terminal renderer: a background
+/// `tint` (rgb = target color in LINEAR space, `a` = blend amount) and a
+/// brightness `dim`. The shader blends each background source toward `tint.rgb`
+/// by `tint.a` before glyphs/overlays paint (background only), then multiplies
+/// the final color by `dim`. The consumer (e.g. ozmux-gui) sets this on a
+/// terminal host from its active-pane state; `update_terminal_material` bakes
+/// both into the uniform each frame. An absent component is treated as
+/// `{ dim: 1.0, tint: ZERO }` (full-bright, untinted / active).
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
 pub struct PaneInactiveStyle {
     /// Brightness multiplier in `0.0..=1.0`; `1.0` = full-bright.
     pub dim: f32,
-    /// Desaturation in `0.0..=1.0`; `0.0` = full color, `1.0` = grey.
-    pub desaturate: f32,
+    /// Background tint: rgb = target color (linear), `a` = blend amount in
+    /// `0.0..=1.0` (`0.0` = no tint / active).
+    pub tint: Vec4,
 }
 
 impl Default for PaneInactiveStyle {
     fn default() -> Self {
         Self {
             dim: 1.0,
-            desaturate: 0.0,
+            tint: Vec4::ZERO,
         }
     }
 }
@@ -190,10 +192,10 @@ impl Default for TerminalOverlays {
 ///
 /// Field offsets in bytes. `max_overflow_phys` fills the 4-byte padding slot
 /// at offset 76 that encase would otherwise insert before `bg_padding_color`
-/// (Vec4 needs 16-byte alignment, lands at offset 80). `overlay_rects`
-/// (`array<vec4<i32>, 4>`) also needs 16-byte alignment; `desaturate` fills the
-/// 4-byte slot encase would otherwise pad after `dim`, so `overlay_rects` lands
-/// at offset 112 (total 176 bytes, 16-byte aligned):
+/// (Vec4 needs 16-byte alignment, lands at offset 80). `inactive_tint` is also
+/// a Vec4 (16-byte alignment), so encase pads the 4 bytes after `dim` and lands
+/// it at offset 112; `overlay_rects` (`array<vec4<i32>, 4>`) follows at offset
+/// 128 (total 192 bytes, 16-byte aligned):
 ///
 /// | Offset | Field                       |
 /// |--------|-----------------------------|
@@ -217,8 +219,8 @@ impl Default for TerminalOverlays {
 /// | 96     | `hover_hyperlink_id`        |
 /// | 100    | `hover_active`              |
 /// | 104    | `dim`                       |
-/// | 108    | `desaturate`                |
-/// | 112    | `overlay_rects`             |
+/// | 112    | `inactive_tint`             |
+/// | 128    | `overlay_rects`             |
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -258,11 +260,12 @@ struct TerminalParams {
     /// hand-written `Default` below sets this to `1.0` so an un-updated
     /// material never renders dark (a derived `Default` would give `0.0`).
     dim: f32,
-    /// Per-pane desaturation toward Rec.709 luminance, applied to the final
-    /// fragment RGB after `dim`. `0.0` = full color (active / no-op); `1.0` =
-    /// fully grey. Fills the 4-byte slot encase would otherwise pad after `dim`,
-    /// so the uniform stays 176 bytes. `Default` (below) sets this to `0.0`.
-    desaturate: f32,
+    /// Per-pane background tint: `rgb` = target color (LINEAR), `a` = blend
+    /// amount in `0.0..=1.0`. The shader blends each background source toward
+    /// `rgb` by `a` BEFORE glyphs/overlays paint (background only). `a == 0`
+    /// (active / no-op) leaves the background untouched; `Default` (below) sets
+    /// this to `Vec4::ZERO`. A Vec4, so encase pads the 4 bytes after `dim`.
+    inactive_tint: Vec4,
     /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell
     /// coords; `row` may be negative; `rows == 0` = inactive slot sentinel.
     overlay_rects: [IVec4; OVERLAY_SLOTS],
@@ -291,7 +294,7 @@ impl Default for TerminalParams {
             hover_hyperlink_id: 0,
             hover_active: 0,
             dim: 1.0,
-            desaturate: 0.0,
+            inactive_tint: Vec4::ZERO,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
@@ -322,7 +325,7 @@ impl TerminalParams {
         hover_hyperlink_id: u32,
         hover_active: u32,
         dim: f32,
-        desaturate: f32,
+        inactive_tint: Vec4,
     ) -> Self {
         let cols = u32::from(grid.cols);
         let rows = u32::from(grid.rows);
@@ -364,7 +367,7 @@ impl TerminalParams {
             hover_hyperlink_id,
             hover_active,
             dim,
-            desaturate,
+            inactive_tint,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
@@ -589,8 +592,11 @@ fn update_terminal_material(
             _ => (0, 0),
         };
 
-        let (dim, desaturate) = pane_style.map_or((1.0, 0.0), |s| {
-            (s.dim.clamp(0.0, 1.0), s.desaturate.clamp(0.0, 1.0))
+        let (dim, inactive_tint) = pane_style.map_or((1.0, Vec4::ZERO), |s| {
+            (
+                s.dim.clamp(0.0, 1.0),
+                s.tint.with_w(s.tint.w.clamp(0.0, 1.0)),
+            )
         });
         if let Some(mat) = materials.get_mut(&handle.0) {
             let mut params = TerminalParams::new(
@@ -607,7 +613,7 @@ fn update_terminal_material(
                 hover_hyperlink_id,
                 hover_active,
                 dim,
-                desaturate,
+                inactive_tint,
             );
             match overlays {
                 Some(o) => {
@@ -857,20 +863,20 @@ mod tests {
 
     #[test]
     fn terminal_params_uniform_size_includes_overlay_rects() {
-        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 176);
+        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 192);
     }
 
     #[test]
-    fn terminal_params_default_desaturate_is_zero() {
-        assert_eq!(TerminalParams::default().desaturate, 0.0);
+    fn terminal_params_default_inactive_tint_is_zero() {
+        assert_eq!(TerminalParams::default().inactive_tint, Vec4::ZERO);
     }
 
     #[test]
     fn terminal_params_field_offsets_are_pinned() {
-        // `dim` fills offset 104; `desaturate` fills the 4-byte pad encase
-        // previously inserted at 108; `overlay_rects` stays at 112 — so the
-        // uniform size is unchanged (176, asserted separately). Field indices
-        // are 0-based in declaration order.
+        // `dim` is at offset 104; `inactive_tint` (a Vec4, 16-byte aligned)
+        // lands at 112 after encase pads the 4 bytes following `dim`;
+        // `overlay_rects` follows at 128 (total 192 bytes). Field indices are
+        // 0-based in declaration order.
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(19),
             104,
@@ -878,13 +884,13 @@ mod tests {
         );
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(20),
-            108,
-            "desaturate fills the former pad slot"
+            112,
+            "inactive_tint (Vec4) after the pad following dim"
         );
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(21),
-            112,
-            "overlay_rects unchanged"
+            128,
+            "overlay_rects after inactive_tint"
         );
     }
 }

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -106,16 +106,27 @@ impl TerminalUiMaterial {
     }
 }
 
-/// Per-pane brightness multiplier for the terminal renderer. The consumer
-/// (e.g. ozmux-gui) sets this on a terminal host from its active-pane state;
-/// `update_terminal_material` bakes it into the material's `dim` uniform
-/// each frame. An absent component is treated as `1.0` (full-bright / active).
-#[derive(Component, Clone, Copy, Debug)]
-pub struct PaneDim(pub f32);
+/// Per-pane inactive-pane treatment for the terminal renderer: brightness
+/// `dim` and desaturation `desaturate`, both applied in the fragment shader to
+/// the final composited color (terminal content + any inline-webview overlay).
+/// The consumer (e.g. ozmux-gui) sets this on a terminal host from its
+/// active-pane state; `update_terminal_material` bakes both into the uniform
+/// each frame. An absent component is treated as `{ dim: 1.0, desaturate: 0.0 }`
+/// (full-bright, full-color / active).
+#[derive(Component, Clone, Copy, Debug, PartialEq)]
+pub struct PaneInactiveStyle {
+    /// Brightness multiplier in `0.0..=1.0`; `1.0` = full-bright.
+    pub dim: f32,
+    /// Desaturation in `0.0..=1.0`; `0.0` = full color, `1.0` = grey.
+    pub desaturate: f32,
+}
 
-impl Default for PaneDim {
+impl Default for PaneInactiveStyle {
     fn default() -> Self {
-        Self(1.0)
+        Self {
+            dim: 1.0,
+            desaturate: 0.0,
+        }
     }
 }
 
@@ -438,7 +449,7 @@ fn update_terminal_material(
         &MaterialNode<TerminalUiMaterial>,
         &mut TerminalMaterialState,
         &TerminalGrid,
-        Option<&PaneDim>,
+        Option<&PaneInactiveStyle>,
         Option<&TerminalOverlays>,
     )>,
     fonts: Res<TerminalFonts>,
@@ -477,7 +488,7 @@ fn update_terminal_material(
     let dpr = window.scale_factor();
     let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
 
-    for (entity, handle, mut state, grid, pane_dim, overlays) in terminals.iter_mut() {
+    for (entity, handle, mut state, grid, pane_style, overlays) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;
         let cols = grid.cols as u32;
         let rows = grid.rows as u32;
@@ -578,7 +589,9 @@ fn update_terminal_material(
             _ => (0, 0),
         };
 
-        let dim = pane_dim.map_or(1.0, |d| d.0).clamp(0.0, 1.0);
+        let (dim, desaturate) = pane_style.map_or((1.0, 0.0), |s| {
+            (s.dim.clamp(0.0, 1.0), s.desaturate.clamp(0.0, 1.0))
+        });
         if let Some(mat) = materials.get_mut(&handle.0) {
             let mut params = TerminalParams::new(
                 grid,
@@ -594,7 +607,7 @@ fn update_terminal_material(
                 hover_hyperlink_id,
                 hover_active,
                 dim,
-                0.0,
+                desaturate,
             );
             match overlays {
                 Some(o) => {

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -180,9 +180,9 @@ impl Default for TerminalOverlays {
 /// Field offsets in bytes. `max_overflow_phys` fills the 4-byte padding slot
 /// at offset 76 that encase would otherwise insert before `bg_padding_color`
 /// (Vec4 needs 16-byte alignment, lands at offset 80). `overlay_rects`
-/// (`array<vec4<i32>, 4>`) also needs 16-byte alignment, so encase pads
-/// 4 bytes after `dim` and lands it at offset 112 (total 176 bytes,
-/// 16-byte aligned):
+/// (`array<vec4<i32>, 4>`) also needs 16-byte alignment; `desaturate` fills the
+/// 4-byte slot encase would otherwise pad after `dim`, so `overlay_rects` lands
+/// at offset 112 (total 176 bytes, 16-byte aligned):
 ///
 /// | Offset | Field                       |
 /// |--------|-----------------------------|
@@ -206,6 +206,7 @@ impl Default for TerminalOverlays {
 /// | 96     | `hover_hyperlink_id`        |
 /// | 100    | `hover_active`              |
 /// | 104    | `dim`                       |
+/// | 108    | `desaturate`                |
 /// | 112    | `overlay_rects`             |
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
@@ -246,6 +247,11 @@ struct TerminalParams {
     /// hand-written `Default` below sets this to `1.0` so an un-updated
     /// material never renders dark (a derived `Default` would give `0.0`).
     dim: f32,
+    /// Per-pane desaturation toward Rec.709 luminance, applied to the final
+    /// fragment RGB after `dim`. `0.0` = full color (active / no-op); `1.0` =
+    /// fully grey. Fills the 4-byte slot encase previously padded after `dim`,
+    /// so the uniform stays 176 bytes. `Default` (below) sets this to `0.0`.
+    desaturate: f32,
     /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell
     /// coords; `row` may be negative; `rows == 0` = inactive slot sentinel.
     overlay_rects: [IVec4; OVERLAY_SLOTS],
@@ -274,6 +280,7 @@ impl Default for TerminalParams {
             hover_hyperlink_id: 0,
             hover_active: 0,
             dim: 1.0,
+            desaturate: 0.0,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
@@ -304,6 +311,7 @@ impl TerminalParams {
         hover_hyperlink_id: u32,
         hover_active: u32,
         dim: f32,
+        desaturate: f32,
     ) -> Self {
         let cols = u32::from(grid.cols);
         let rows = u32::from(grid.rows);
@@ -345,6 +353,7 @@ impl TerminalParams {
             hover_hyperlink_id,
             hover_active,
             dim,
+            desaturate,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
         }
     }
@@ -585,6 +594,7 @@ fn update_terminal_material(
                 hover_hyperlink_id,
                 hover_active,
                 dim,
+                0.0,
             );
             match overlays {
                 Some(o) => {
@@ -835,5 +845,33 @@ mod tests {
     #[test]
     fn terminal_params_uniform_size_includes_overlay_rects() {
         assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 176);
+    }
+
+    #[test]
+    fn terminal_params_default_desaturate_is_zero() {
+        assert_eq!(TerminalParams::default().desaturate, 0.0);
+    }
+
+    #[test]
+    fn terminal_params_field_offsets_are_pinned() {
+        // `dim` fills offset 104; `desaturate` fills the 4-byte pad encase
+        // previously inserted at 108; `overlay_rects` stays at 112 — so the
+        // uniform size is unchanged (176, asserted separately). Field indices
+        // are 0-based in declaration order.
+        assert_eq!(
+            <TerminalParams as ShaderType>::METADATA.offset(19),
+            104,
+            "dim"
+        );
+        assert_eq!(
+            <TerminalParams as ShaderType>::METADATA.offset(20),
+            108,
+            "desaturate fills the former pad slot"
+        );
+        assert_eq!(
+            <TerminalParams as ShaderType>::METADATA.offset(21),
+            112,
+            "overlay_rects unchanged"
+        );
     }
 }

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -121,6 +121,12 @@ pub struct PaneInactiveStyle {
     /// Background tint: rgb = target color (linear), `a` = blend amount in
     /// `0.0..=1.0` (`0.0` = no tint / active).
     pub tint: Vec4,
+    /// Inline-overlay (webview) brightness multiplier in `0.0..=1.0`; `1.0` =
+    /// full-bright. Applied to overlay samples only, independent of `tint`.
+    pub overlay_dim: f32,
+    /// Inline-overlay (webview) desaturation in `0.0..=1.0`; `0.0` = full color,
+    /// `1.0` = grey.
+    pub overlay_desaturate: f32,
 }
 
 impl Default for PaneInactiveStyle {
@@ -128,6 +134,8 @@ impl Default for PaneInactiveStyle {
         Self {
             dim: 1.0,
             tint: Vec4::ZERO,
+            overlay_dim: 1.0,
+            overlay_desaturate: 0.0,
         }
     }
 }
@@ -195,7 +203,8 @@ impl Default for TerminalOverlays {
 /// (Vec4 needs 16-byte alignment, lands at offset 80). `inactive_tint` is also
 /// a Vec4 (16-byte alignment), so encase pads the 4 bytes after `dim` and lands
 /// it at offset 112; `overlay_rects` (`array<vec4<i32>, 4>`) follows at offset
-/// 128 (total 192 bytes, 16-byte aligned):
+/// 128. The trailing `overlay_dim` / `overlay_desaturate` scalars sit at 192/196
+/// and the struct rounds up to its 16-byte alignment (total 208 bytes):
 ///
 /// | Offset | Field                       |
 /// |--------|-----------------------------|
@@ -221,6 +230,8 @@ impl Default for TerminalOverlays {
 /// | 104    | `dim`                       |
 /// | 112    | `inactive_tint`             |
 /// | 128    | `overlay_rects`             |
+/// | 192    | `overlay_dim`               |
+/// | 196    | `overlay_desaturate`        |
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -269,6 +280,12 @@ struct TerminalParams {
     /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell
     /// coords; `row` may be negative; `rows == 0` = inactive slot sentinel.
     overlay_rects: [IVec4; OVERLAY_SLOTS],
+    /// Inline-overlay (webview) brightness multiplier applied to overlay samples
+    /// before they blend over the background. `1.0` = active / no-op.
+    overlay_dim: f32,
+    /// Inline-overlay (webview) desaturation toward Rec.709 luminance applied to
+    /// overlay samples. `0.0` = active / no-op.
+    overlay_desaturate: f32,
 }
 
 impl Default for TerminalParams {
@@ -296,6 +313,8 @@ impl Default for TerminalParams {
             dim: 1.0,
             inactive_tint: Vec4::ZERO,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
+            overlay_dim: 1.0,
+            overlay_desaturate: 0.0,
         }
     }
 }
@@ -326,6 +345,8 @@ impl TerminalParams {
         hover_active: u32,
         dim: f32,
         inactive_tint: Vec4,
+        overlay_dim: f32,
+        overlay_desaturate: f32,
     ) -> Self {
         let cols = u32::from(grid.cols);
         let rows = u32::from(grid.rows);
@@ -369,6 +390,8 @@ impl TerminalParams {
             dim,
             inactive_tint,
             overlay_rects: [IVec4::ZERO; OVERLAY_SLOTS],
+            overlay_dim,
+            overlay_desaturate,
         }
     }
 }
@@ -592,12 +615,15 @@ fn update_terminal_material(
             _ => (0, 0),
         };
 
-        let (dim, inactive_tint) = pane_style.map_or((1.0, Vec4::ZERO), |s| {
-            (
-                s.dim.clamp(0.0, 1.0),
-                s.tint.with_w(s.tint.w.clamp(0.0, 1.0)),
-            )
-        });
+        let (dim, inactive_tint, overlay_dim, overlay_desaturate) =
+            pane_style.map_or((1.0, Vec4::ZERO, 1.0, 0.0), |s| {
+                (
+                    s.dim.clamp(0.0, 1.0),
+                    s.tint.with_w(s.tint.w.clamp(0.0, 1.0)),
+                    s.overlay_dim.clamp(0.0, 1.0),
+                    s.overlay_desaturate.clamp(0.0, 1.0),
+                )
+            });
         if let Some(mat) = materials.get_mut(&handle.0) {
             let mut params = TerminalParams::new(
                 grid,
@@ -614,6 +640,8 @@ fn update_terminal_material(
                 hover_active,
                 dim,
                 inactive_tint,
+                overlay_dim,
+                overlay_desaturate,
             );
             match overlays {
                 Some(o) => {
@@ -863,20 +891,24 @@ mod tests {
 
     #[test]
     fn terminal_params_uniform_size_includes_overlay_rects() {
-        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 192);
+        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 208);
     }
 
     #[test]
-    fn terminal_params_default_inactive_tint_is_zero() {
-        assert_eq!(TerminalParams::default().inactive_tint, Vec4::ZERO);
+    fn terminal_params_default_inactive_treatment_is_noop() {
+        let p = TerminalParams::default();
+        assert_eq!(p.inactive_tint, Vec4::ZERO);
+        assert_eq!(p.overlay_dim, 1.0);
+        assert_eq!(p.overlay_desaturate, 0.0);
     }
 
     #[test]
     fn terminal_params_field_offsets_are_pinned() {
         // `dim` is at offset 104; `inactive_tint` (a Vec4, 16-byte aligned)
         // lands at 112 after encase pads the 4 bytes following `dim`;
-        // `overlay_rects` follows at 128 (total 192 bytes). Field indices are
-        // 0-based in declaration order.
+        // `overlay_rects` follows at 128; the trailing scalars `overlay_dim` /
+        // `overlay_desaturate` sit at 192/196 (total 208 bytes). Field indices
+        // are 0-based in declaration order.
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(19),
             104,
@@ -891,6 +923,16 @@ mod tests {
             <TerminalParams as ShaderType>::METADATA.offset(21),
             128,
             "overlay_rects after inactive_tint"
+        );
+        assert_eq!(
+            <TerminalParams as ShaderType>::METADATA.offset(22),
+            192,
+            "overlay_dim after overlay_rects"
+        );
+        assert_eq!(
+            <TerminalParams as ShaderType>::METADATA.offset(23),
+            196,
+            "overlay_desaturate after overlay_dim"
         );
     }
 }

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -28,6 +28,8 @@ struct TerminalParams {
     dim: f32,
     inactive_tint: vec4<f32>,
     overlay_rects: array<vec4<i32>, 4>,
+    overlay_dim: f32,
+    overlay_desaturate: f32,
 };
 
 struct Cell {
@@ -394,6 +396,17 @@ fn is_in_selection_uniform(
 // is partially scrolled above the viewport), so partial visibility never
 // distorts the image; grid-edge clipping is inherent because only in-grid
 // fragments reach paint_grid_cell.
+// Applies the inactive-pane treatment to one overlay (webview) sample before it
+// blends over the background: desaturate toward Rec.709 luminance, then dim.
+// `s` is premultiplied-alpha and linear, so both are correct on `s.rgb`
+// (luma(a*c) = a*luma(c); a scalar multiply distributes through premultiply).
+// Active pane => overlay_dim == 1.0 && overlay_desaturate == 0.0 (no-op).
+fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
+    let luma = dot(s.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+    let desat = mix(s.rgb, vec3<f32>(luma), params.overlay_desaturate);
+    return vec4<f32>(desat * params.overlay_dim, s.a);
+}
+
 fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     var color = base;
     let p_px = vec2<f32>(f32(hit.col), f32(hit.row)) * params.cell_size_px + hit.in_cell_px;
@@ -403,28 +416,28 @@ fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     {
         let uv = overlay_uv(params.overlay_rects[0], p_px, hit);
         if uv.x >= 0.0 {
-            let s = textureSampleLevel(overlay0_tex, overlay0_samp, uv, 0.0);
+            let s = treat_overlay(textureSampleLevel(overlay0_tex, overlay0_samp, uv, 0.0));
             color = blend_premultiplied_over(color, s);
         }
     }
     {
         let uv = overlay_uv(params.overlay_rects[1], p_px, hit);
         if uv.x >= 0.0 {
-            let s = textureSampleLevel(overlay1_tex, overlay1_samp, uv, 0.0);
+            let s = treat_overlay(textureSampleLevel(overlay1_tex, overlay1_samp, uv, 0.0));
             color = blend_premultiplied_over(color, s);
         }
     }
     {
         let uv = overlay_uv(params.overlay_rects[2], p_px, hit);
         if uv.x >= 0.0 {
-            let s = textureSampleLevel(overlay2_tex, overlay2_samp, uv, 0.0);
+            let s = treat_overlay(textureSampleLevel(overlay2_tex, overlay2_samp, uv, 0.0));
             color = blend_premultiplied_over(color, s);
         }
     }
     {
         let uv = overlay_uv(params.overlay_rects[3], p_px, hit);
         if uv.x >= 0.0 {
-            let s = textureSampleLevel(overlay3_tex, overlay3_samp, uv, 0.0);
+            let s = treat_overlay(textureSampleLevel(overlay3_tex, overlay3_samp, uv, 0.0));
             color = blend_premultiplied_over(color, s);
         }
     }

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -26,7 +26,7 @@ struct TerminalParams {
     hover_hyperlink_id: u32,
     hover_active: u32,
     dim: f32,
-    desaturate: f32,
+    inactive_tint: vec4<f32>,
     overlay_rects: array<vec4<i32>, 4>,
 };
 
@@ -101,12 +101,23 @@ const GLYPH_NONE: u32 = 0xFFFFFFFFu;
 // Fragment entrypoint
 // ============================================================================
 
+// Blends a BACKGROUND color toward the inactive-pane tint target. `rgb`
+// blends toward `params.inactive_tint.rgb` by `params.inactive_tint.a`; alpha
+// is preserved. Active pane => `inactive_tint.a == 0.0` (no-op). Applied only
+// at background-establishment points (before glyphs/overlays paint), so text
+// and inline-webview overlays keep their full color. Runs in LINEAR space —
+// `inactive_tint.rgb` is uploaded pre-linearized by the host.
+fn tint_bg(c: vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(mix(c.rgb, params.inactive_tint.rgb, params.inactive_tint.a), c.a);
+}
+
 @fragment
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // Out-of-grid fragments (degenerate grid, or the right/bottom padding
     // strip) fall back to bg_padding_color so the surrounding band blends
-    // with the terminal background instead of opaque black.
-    let fallback = params.bg_padding_color;
+    // with the terminal background instead of opaque black. The padding is a
+    // background region, so it receives the inactive-pane tint too.
+    let fallback = tint_bg(params.bg_padding_color);
 
     var color: vec4<f32>;
     if params.grid_size.x == 0u || params.grid_size.y == 0u {
@@ -124,16 +135,12 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
         }
     }
 
-    // Pane-level treatment on the final composited color (terminal content +
-    // any inline-webview overlay): desaturate toward Rec.709 luminance, then
-    // multiply brightness. Active pane => desaturate == 0.0 && dim == 1.0
-    // (no-op). RGB only; alpha preserved so the opaque-padding and overlay
-    // premultiplied-blend contracts are unchanged. Composes with the per-cell
-    // SGR STYLE_DIM independently. Runs in LINEAR space (cells uploaded via
-    // to_linear, overlays linearized on read), where Rec.709 luma is correct.
-    let luma = dot(color.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
-    let grey = mix(color.rgb, vec3<f32>(luma), params.desaturate);
-    return vec4<f32>(grey * params.dim, color.a);
+    // Pane-level brightness: active pane => params.dim == 1.0 (no-op); inactive
+    // pane => params.dim <= 1.0. RGB only; alpha is preserved so blending and
+    // the opaque-padding contract are unchanged. The inactive-pane background
+    // tint is applied earlier (tint_bg, at the background stage). Composes with
+    // the per-cell SGR STYLE_DIM independently.
+    return vec4<f32>(color.rgb * params.dim, color.a);
 }
 
 // ============================================================================
@@ -145,7 +152,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 // cursor → selection.
 fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
     let colors = resolve_cell_colors(hit.cell);
-    var color = colors.bg;
+    var color = tint_bg(colors.bg);
     color = paint_inline_overlays(hit, color);
     color = paint_primary_glyph(hit, colors.fg, color);
     color = paint_left_overdraw(hit, color);
@@ -186,7 +193,7 @@ fn paint_right_strip(p_px: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
         p_px.y - f32(row) * params.cell_size_px.y,
     );
     let colors = resolve_cell_colors(strip_cell);
-    var color = colors.bg;
+    var color = tint_bg(colors.bg);
     // NOTE: paint_cell_glyph (NOT paint_primary_glyph). strip_local.x is
     // in [cell_pitch.x, cell_pitch.x + max_overflow_phys) — already in
     // the right-half coordinate space of any STYLE_WIDE_RIGHT_HALF wide

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -385,6 +385,17 @@ fn is_in_selection_uniform(
 // Inline-overlay compositing
 // ============================================================================
 
+// Applies the inactive-pane treatment to one overlay (webview) sample before it
+// blends over the background: desaturate toward Rec.709 luminance, then dim.
+// `s` is premultiplied-alpha and linear, so both are correct on `s.rgb`
+// (luma(a*c) = a*luma(c); a scalar multiply distributes through premultiply).
+// Active pane => overlay_dim == 1.0 && overlay_desaturate == 0.0 (no-op).
+fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
+    let luma = dot(s.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+    let desat = mix(s.rgb, vec3<f32>(luma), params.overlay_desaturate);
+    return vec4<f32>(desat * params.overlay_dim, s.a);
+}
+
 // Inline-overlay compositing (spec §6.2): samples each ACTIVE overlay slot
 // whose cell-rect contains this fragment and composites it OVER the cell
 // background. Source is premultiplied alpha (CEF convention, spec §6.3);
@@ -396,16 +407,6 @@ fn is_in_selection_uniform(
 // is partially scrolled above the viewport), so partial visibility never
 // distorts the image; grid-edge clipping is inherent because only in-grid
 // fragments reach paint_grid_cell.
-// Applies the inactive-pane treatment to one overlay (webview) sample before it
-// blends over the background: desaturate toward Rec.709 luminance, then dim.
-// `s` is premultiplied-alpha and linear, so both are correct on `s.rgb`
-// (luma(a*c) = a*luma(c); a scalar multiply distributes through premultiply).
-// Active pane => overlay_dim == 1.0 && overlay_desaturate == 0.0 (no-op).
-fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
-    let luma = dot(s.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
-    let desat = mix(s.rgb, vec3<f32>(luma), params.overlay_desaturate);
-    return vec4<f32>(desat * params.overlay_dim, s.a);
-}
 
 fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     var color = base;

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -26,6 +26,7 @@ struct TerminalParams {
     hover_hyperlink_id: u32,
     hover_active: u32,
     dim: f32,
+    desaturate: f32,
     overlay_rects: array<vec4<i32>, 4>,
 };
 
@@ -123,11 +124,16 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
         }
     }
 
-    // Pane-level dim: active pane => params.dim == 1.0 (no-op); inactive pane
-    // => params.dim < 1.0. RGB only; alpha is preserved so blending and the
-    // opaque-padding contract are unchanged. Composes with the per-cell SGR
-    // STYLE_DIM independently.
-    return vec4<f32>(color.rgb * params.dim, color.a);
+    // Pane-level treatment on the final composited color (terminal content +
+    // any inline-webview overlay): desaturate toward Rec.709 luminance, then
+    // multiply brightness. Active pane => desaturate == 0.0 && dim == 1.0
+    // (no-op). RGB only; alpha preserved so the opaque-padding and overlay
+    // premultiplied-blend contracts are unchanged. Composes with the per-cell
+    // SGR STYLE_DIM independently. Runs in LINEAR space (cells uploaded via
+    // to_linear, overlays linearized on read), where Rec.709 luma is correct.
+    let luma = dot(color.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+    let grey = mix(color.rgb, vec3<f32>(luma), params.desaturate);
+    return vec4<f32>(grey * params.dim, color.a);
 }
 
 // ============================================================================

--- a/src/ui/tmux_pane_focus.rs
+++ b/src/ui/tmux_pane_focus.rs
@@ -1,9 +1,10 @@
-//! Pane augmentation and dim: gives each tmux pane a `Button` click target
-//! with `FocusPolicy::Block` (load-bearing: stops pane clicks reaching webview
-//! surfaces), and dims and desaturates every inactive pane at the renderer via
-//! `PaneInactiveStyle` (brightness + grey-out the terminal shader applies)
-//! rather than an opaque overlay veil. `select-pane` on press is now owned by
-//! the tmux mouse gesture arbiter (`tmux_mouse::OzmuxTmuxMousePlugin`).
+//! Pane augmentation and inactive-pane styling: gives each tmux pane a `Button`
+//! click target with `FocusPolicy::Block` (load-bearing: stops pane clicks
+//! reaching webview surfaces), and tints the background of (and optionally dims)
+//! every inactive pane at the renderer via `PaneInactiveStyle` (the terminal
+//! shader blends inactive backgrounds toward a configured grey). `select-pane`
+//! on press is owned by the tmux mouse gesture arbiter
+//! (`tmux_mouse::OzmuxTmuxMousePlugin`).
 
 use crate::configs::OzmuxConfigsResource;
 use bevy::prelude::*;
@@ -59,22 +60,22 @@ fn pane_active_state_changed(
 
 /// Sets each pane's [`PaneInactiveStyle`] on the `TmuxPane` entity (which owns
 /// the `TerminalGrid` / material): the active pane (or every pane when none is
-/// active) gets the default no-op `{ dim: 1.0, desaturate: 0.0 }`; inactive
-/// panes get the configured `(dim, desaturate)`. Only inserts when the value
-/// changes. Gated by `pane_active_state_changed`, so it does not observe live
-/// config edits — a config reload re-applies on the next active-pane change.
+/// active) gets the default no-op `{ dim: 1.0, tint: ZERO }`; inactive panes get
+/// the configured `(dim, tint)`. Only inserts when the value changes. Gated by
+/// `pane_active_state_changed`, so it does not observe live config edits — a
+/// config reload re-applies on the next active-pane change.
 fn sync_inactive_pane_style(
     mut commands: Commands,
     panes: Query<(Entity, Has<ActivePane>, Option<&PaneInactiveStyle>), With<TmuxPane>>,
     configs: Option<Res<OzmuxConfigsResource>>,
 ) {
-    let (dim, desaturate) = inactive_style(configs.as_deref());
+    let (dim, tint) = inactive_style(configs.as_deref());
     let any_active = panes.iter().any(|(_, active, _)| active);
     for (entity, active, current) in panes.iter() {
         let want = if active || !any_active {
             PaneInactiveStyle::default()
         } else {
-            PaneInactiveStyle { dim, desaturate }
+            PaneInactiveStyle { dim, tint }
         };
         if current.copied() != Some(want) {
             commands.entity(entity).insert(want);
@@ -82,15 +83,21 @@ fn sync_inactive_pane_style(
     }
 }
 
-/// Returns the `(dim, desaturate)` applied to inactive panes: the configured
-/// values when the inactive-pane treatment is enabled, otherwise the no-op
-/// `(1.0, 0.0)`.
-fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> (f32, f32) {
+/// Returns the `(dim, tint)` applied to inactive panes when the treatment is
+/// enabled: the configured brightness and a background-tint `Vec4` (rgb in
+/// LINEAR space, `w` = blend amount). Disabled or absent config yields the
+/// no-op `(1.0, Vec4::ZERO)`.
+fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> (f32, Vec4) {
     match configs {
         Some(cfg) if cfg.inactive_pane.enabled => {
-            (cfg.inactive_pane.dim, cfg.inactive_pane.desaturate)
+            let (r, g, b) = cfg.inactive_pane.tint_color_rgb();
+            let lin = Color::srgb_u8(r, g, b).to_linear();
+            (
+                cfg.inactive_pane.dim,
+                Vec4::new(lin.red, lin.green, lin.blue, cfg.inactive_pane.tint),
+            )
         }
-        _ => (1.0, 0.0),
+        _ => (1.0, Vec4::ZERO),
     }
 }
 
@@ -145,36 +152,34 @@ mod tests {
             .id();
 
         let style = |app: &App, e| app.world().get::<PaneInactiveStyle>(e).copied();
+        // Expected inactive value from the default config (#3a3b45 @ 0.85,
+        // dim 1.0), built the same way as the production `inactive_style`.
+        let lin = Color::srgb_u8(0x3a, 0x3b, 0x45).to_linear();
+        let inactive = PaneInactiveStyle {
+            dim: 1.0,
+            tint: Vec4::new(lin.red, lin.green, lin.blue, 0.85),
+        };
 
         app.update();
         assert_eq!(
             style(&app, p1),
             Some(PaneInactiveStyle::default()),
-            "active pane: full-bright, full-color"
+            "active pane: untinted, full-bright"
         );
         assert_eq!(
             style(&app, p2),
-            Some(PaneInactiveStyle {
-                dim: 0.5,
-                desaturate: 0.7
-            }),
-            "inactive pane: dimmed + desaturated"
+            Some(inactive),
+            "inactive pane: background-tinted"
         );
 
         // Move ActivePane to p2.
         app.world_mut().entity_mut(p1).remove::<ActivePane>();
         app.world_mut().entity_mut(p2).insert(ActivePane);
         app.update();
-        assert_eq!(
-            style(&app, p1),
-            Some(PaneInactiveStyle {
-                dim: 0.5,
-                desaturate: 0.7
-            })
-        );
+        assert_eq!(style(&app, p1), Some(inactive));
         assert_eq!(style(&app, p2), Some(PaneInactiveStyle::default()));
 
-        // No active pane: both full-bright, full-color.
+        // No active pane: both untinted.
         app.world_mut().entity_mut(p2).remove::<ActivePane>();
         app.update();
         assert_eq!(style(&app, p1), Some(PaneInactiveStyle::default()));

--- a/src/ui/tmux_pane_focus.rs
+++ b/src/ui/tmux_pane_focus.rs
@@ -1,15 +1,15 @@
 //! Pane augmentation and dim: gives each tmux pane a `Button` click target
 //! with `FocusPolicy::Block` (load-bearing: stops pane clicks reaching webview
-//! surfaces), and dims every inactive pane at the renderer via `PaneDim` (a
-//! brightness multiplier the terminal shader applies) rather than an opaque
-//! overlay veil. `select-pane` on press is now owned by the tmux mouse
-//! gesture arbiter (`tmux_mouse::OzmuxTmuxMousePlugin`).
+//! surfaces), and dims and desaturates every inactive pane at the renderer via
+//! `PaneInactiveStyle` (brightness + grey-out the terminal shader applies)
+//! rather than an opaque overlay veil. `select-pane` on press is now owned by
+//! the tmux mouse gesture arbiter (`tmux_mouse::OzmuxTmuxMousePlugin`).
 
 use crate::configs::OzmuxConfigsResource;
 use bevy::prelude::*;
 use bevy::ui::FocusPolicy;
 use ozma_tty_engine::TerminalHandle;
-use ozma_tty_renderer::material::PaneDim;
+use ozma_tty_renderer::material::PaneInactiveStyle;
 use ozmux_tmux::{ActivePane, TmuxPane, TmuxProjectionSet};
 
 /// Registers the pane augmentation (adds `Button` + `FocusPolicy::Block`) and
@@ -22,7 +22,7 @@ impl Plugin for OzmuxTmuxPaneFocusPlugin {
             Update,
             (
                 augment_tmux_pane.after(TmuxProjectionSet),
-                sync_pane_dim.run_if(pane_active_state_changed),
+                sync_inactive_pane_style.run_if(pane_active_state_changed),
             ),
         );
     }
@@ -57,35 +57,40 @@ fn pane_active_state_changed(
         || removed_active.read().next().is_some()
 }
 
-/// Sets each pane's [`PaneDim`] brightness on the `TmuxPane` entity (which owns
-/// the `TerminalGrid` / material): `1.0` for the pane carrying `ActivePane` (or
-/// for all panes when no pane is active), the configured dim factor otherwise.
-/// Only inserts when the value changes.
-fn sync_pane_dim(
+/// Sets each pane's [`PaneInactiveStyle`] on the `TmuxPane` entity (which owns
+/// the `TerminalGrid` / material): the active pane (or every pane when none is
+/// active) gets the default no-op `{ dim: 1.0, desaturate: 0.0 }`; inactive
+/// panes get the configured `(dim, desaturate)`. Only inserts when the value
+/// changes. Gated by `pane_active_state_changed`, so it does not observe live
+/// config edits — a config reload re-applies on the next active-pane change.
+fn sync_inactive_pane_style(
     mut commands: Commands,
-    panes: Query<(Entity, Has<ActivePane>, Option<&PaneDim>), With<TmuxPane>>,
+    panes: Query<(Entity, Has<ActivePane>, Option<&PaneInactiveStyle>), With<TmuxPane>>,
     configs: Option<Res<OzmuxConfigsResource>>,
 ) {
-    let dim_factor = inactive_dim_factor(configs.as_deref());
+    let (dim, desaturate) = inactive_style(configs.as_deref());
     let any_active = panes.iter().any(|(_, active, _)| active);
     for (entity, active, current) in panes.iter() {
         let want = if active || !any_active {
-            1.0
+            PaneInactiveStyle::default()
         } else {
-            dim_factor
+            PaneInactiveStyle { dim, desaturate }
         };
-        if current.map(|d| d.0) != Some(want) {
-            commands.entity(entity).insert(PaneDim(want));
+        if current.copied() != Some(want) {
+            commands.entity(entity).insert(want);
         }
     }
 }
 
-/// Returns the brightness multiplier applied to inactive panes: the configured
-/// `inactive_pane.dim` when dimming is enabled, otherwise `1.0` (no dim).
-fn inactive_dim_factor(configs: Option<&OzmuxConfigsResource>) -> f32 {
+/// Returns the `(dim, desaturate)` applied to inactive panes: the configured
+/// values when the inactive-pane treatment is enabled, otherwise the no-op
+/// `(1.0, 0.0)`.
+fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> (f32, f32) {
     match configs {
-        Some(cfg) if cfg.inactive_pane.enabled => cfg.inactive_pane.dim,
-        _ => 1.0,
+        Some(cfg) if cfg.inactive_pane.enabled => {
+            (cfg.inactive_pane.dim, cfg.inactive_pane.desaturate)
+        }
+        _ => (1.0, 0.0),
     }
 }
 
@@ -139,24 +144,85 @@ mod tests {
             ))
             .id();
 
-        let dim = |app: &App, e| app.world().get::<PaneDim>(e).map(|d| d.0);
+        let style = |app: &App, e| app.world().get::<PaneInactiveStyle>(e).copied();
 
         app.update();
-        assert_eq!(dim(&app, p1), Some(1.0), "active pane full-bright");
-        assert_eq!(dim(&app, p2), Some(0.5), "inactive pane dimmed");
+        assert_eq!(
+            style(&app, p1),
+            Some(PaneInactiveStyle::default()),
+            "active pane: full-bright, full-color"
+        );
+        assert_eq!(
+            style(&app, p2),
+            Some(PaneInactiveStyle {
+                dim: 0.5,
+                desaturate: 0.7
+            }),
+            "inactive pane: dimmed + desaturated"
+        );
 
         // Move ActivePane to p2.
         app.world_mut().entity_mut(p1).remove::<ActivePane>();
         app.world_mut().entity_mut(p2).insert(ActivePane);
         app.update();
-        assert_eq!(dim(&app, p1), Some(0.5));
-        assert_eq!(dim(&app, p2), Some(1.0));
+        assert_eq!(
+            style(&app, p1),
+            Some(PaneInactiveStyle {
+                dim: 0.5,
+                desaturate: 0.7
+            })
+        );
+        assert_eq!(style(&app, p2), Some(PaneInactiveStyle::default()));
 
-        // No active pane: both full-bright.
+        // No active pane: both full-bright, full-color.
         app.world_mut().entity_mut(p2).remove::<ActivePane>();
         app.update();
-        assert_eq!(dim(&app, p1), Some(1.0));
-        assert_eq!(dim(&app, p2), Some(1.0));
+        assert_eq!(style(&app, p1), Some(PaneInactiveStyle::default()));
+        assert_eq!(style(&app, p2), Some(PaneInactiveStyle::default()));
+    }
+
+    #[test]
+    fn disabled_config_leaves_every_pane_untreated() {
+        use ozmux_tmux::ActivePane;
+
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, OzmuxTmuxPaneFocusPlugin));
+        app.insert_non_send_resource(ozmux_tmux::TmuxConnection::default());
+        let mut configs = OzmuxConfigsResource::default();
+        configs.0.inactive_pane.enabled = false;
+        app.insert_resource(configs);
+        let h = || TerminalHandle::detached(10, 5, Arc::new(AtomicBool::new(false)));
+
+        let p1 = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: PaneId(1),
+                    dims: dims(),
+                },
+                h(),
+                ActivePane,
+            ))
+            .id();
+        let p2 = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: PaneId(2),
+                    dims: dims(),
+                },
+                h(),
+            ))
+            .id();
+
+        app.update();
+        let style = |app: &App, e| app.world().get::<PaneInactiveStyle>(e).copied();
+        assert_eq!(style(&app, p1), Some(PaneInactiveStyle::default()));
+        assert_eq!(
+            style(&app, p2),
+            Some(PaneInactiveStyle::default()),
+            "enabled=false: inactive pane is untreated"
+        );
     }
 
     #[test]

--- a/src/ui/tmux_pane_focus.rs
+++ b/src/ui/tmux_pane_focus.rs
@@ -60,22 +60,22 @@ fn pane_active_state_changed(
 
 /// Sets each pane's [`PaneInactiveStyle`] on the `TmuxPane` entity (which owns
 /// the `TerminalGrid` / material): the active pane (or every pane when none is
-/// active) gets the default no-op `{ dim: 1.0, tint: ZERO }`; inactive panes get
-/// the configured `(dim, tint)`. Only inserts when the value changes. Gated by
-/// `pane_active_state_changed`, so it does not observe live config edits — a
-/// config reload re-applies on the next active-pane change.
+/// active) gets the default no-op; inactive panes get the configured style
+/// (background tint + overlay dim/desaturate). Only inserts when the value
+/// changes. Gated by `pane_active_state_changed`, so it does not observe live
+/// config edits — a config reload re-applies on the next active-pane change.
 fn sync_inactive_pane_style(
     mut commands: Commands,
     panes: Query<(Entity, Has<ActivePane>, Option<&PaneInactiveStyle>), With<TmuxPane>>,
     configs: Option<Res<OzmuxConfigsResource>>,
 ) {
-    let (dim, tint) = inactive_style(configs.as_deref());
+    let inactive = inactive_style(configs.as_deref());
     let any_active = panes.iter().any(|(_, active, _)| active);
     for (entity, active, current) in panes.iter() {
         let want = if active || !any_active {
             PaneInactiveStyle::default()
         } else {
-            PaneInactiveStyle { dim, tint }
+            inactive
         };
         if current.copied() != Some(want) {
             commands.entity(entity).insert(want);
@@ -83,21 +83,23 @@ fn sync_inactive_pane_style(
     }
 }
 
-/// Returns the `(dim, tint)` applied to inactive panes when the treatment is
-/// enabled: the configured brightness and a background-tint `Vec4` (rgb in
-/// LINEAR space, `w` = blend amount). Disabled or absent config yields the
-/// no-op `(1.0, Vec4::ZERO)`.
-fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> (f32, Vec4) {
+/// Returns the [`PaneInactiveStyle`] applied to inactive panes when the
+/// treatment is enabled: background tint (`tint_color` linearized + `tint`
+/// amount) and the inline-webview overlay treatment (`webview_dim` /
+/// `webview_desaturate`). Disabled or absent config yields the no-op default.
+fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> PaneInactiveStyle {
     match configs {
         Some(cfg) if cfg.inactive_pane.enabled => {
             let (r, g, b) = cfg.inactive_pane.tint_color_rgb();
             let lin = Color::srgb_u8(r, g, b).to_linear();
-            (
-                cfg.inactive_pane.dim,
-                Vec4::new(lin.red, lin.green, lin.blue, cfg.inactive_pane.tint),
-            )
+            PaneInactiveStyle {
+                dim: cfg.inactive_pane.dim,
+                tint: Vec4::new(lin.red, lin.green, lin.blue, cfg.inactive_pane.tint),
+                overlay_dim: cfg.inactive_pane.webview_dim,
+                overlay_desaturate: cfg.inactive_pane.webview_desaturate,
+            }
         }
-        _ => (1.0, Vec4::ZERO),
+        _ => PaneInactiveStyle::default(),
     }
 }
 
@@ -153,11 +155,13 @@ mod tests {
 
         let style = |app: &App, e| app.world().get::<PaneInactiveStyle>(e).copied();
         // Expected inactive value from the default config (#3a3b45 @ 0.85,
-        // dim 1.0), built the same way as the production `inactive_style`.
+        // dim 1.0, webview 0.55/0.6), built the same way as `inactive_style`.
         let lin = Color::srgb_u8(0x3a, 0x3b, 0x45).to_linear();
         let inactive = PaneInactiveStyle {
             dim: 1.0,
             tint: Vec4::new(lin.red, lin.green, lin.blue, 0.85),
+            overlay_dim: 0.55,
+            overlay_desaturate: 0.6,
         };
 
         app.update();


### PR DESCRIPTION
## Problem

Inactive panes were hard to distinguish from the active one. ozmux only dimmed
brightness slightly, and on the common case — empty/dark panes — that reads as
almost no change (desaturating a near-black background stays near-black). iTerm2's
tmux mode makes this obvious by giving inactive panes a visibly **grey background**;
ozmux had no equivalent. Panes hosting an inline webview were worse: the webview is
opaque, so nothing distinguished an inactive webview pane from the active one.

## Solution

A per-pane "inactive style" applied entirely in the terminal fragment shader, gated
by active-pane state and a config toggle. Two independent treatments:

- **Terminal background tint.** Inactive pane backgrounds blend toward a configurable
  grey (`tint_color` at strength `tint`) *at the background stage*, before glyphs and
  overlays paint — so an empty dark pane visibly lightens to grey like iTerm2 while
  text stays crisp and full-color. (This is a real "blend toward a fixed grey", which
  — unlike desaturation — is what actually shows on a dark background.)
- **Inline-webview dim + desaturate.** Because webviews composite as opaque overlays
  over the (tinted) background, the background tint can't reach them. So inactive
  panes' webview overlays are separately dimmed + desaturated (`webview_dim`,
  `webview_desaturate`) in `treat_overlay`, applied to the premultiplied sample before
  it blends. The active pane is an exact no-op.

**Affected code:**
- `crates/ozma_tty_renderer` — `terminal_ui_material.wgsl` (`tint_bg`, `treat_overlay`,
  final `* dim`); `material.rs` (`TerminalParams` uniform gains `inactive_tint: Vec4`
  + `overlay_dim`/`overlay_desaturate`, 176→208 bytes with offsets pinned by test;
  new public `PaneInactiveStyle` component replacing `PaneDim`).
- `crates/configs` — `[inactive_pane]` config: `enabled`, `dim`, `tint_color`, `tint`,
  `webview_dim`, `webview_desaturate`.
- binary (`src/ui/tmux_pane_focus.rs`) — `sync_inactive_pane_style` drives the
  component from config + active-pane state.

**Verification:** `cargo test -p ozmux_configs -p ozma_tty_renderer` and the
`tmux_pane_focus` suite pass; clippy + fmt clean. The shader output itself is not
unit-testable — a manual GUI smoke (split panes ± an inline webview, toggle focus)
is the visual check; `tint_color`/`tint`/`webview_*` defaults are tunable in
`config.toml`. iTerm2 reference for the target look:

<details><summary>Screenshots</summary>

Before/after of ozmux split panes to be attached. Reference (iTerm2 inactive panes
= grey background): the `iterm.png` shared during design.

</details>

### Breaking Changes

The `[inactive_pane]` config schema changed:
- **Removed** `opacity` and `color` (a "veil" that was defined but never wired) and the
  interim `desaturate` field.
- **Added** `tint_color`, `tint`, `webview_dim`, `webview_desaturate`.
- **Default `dim` changed `0.5` → `1.0`** — the new look *lightens* inactive panes
  (background tint) rather than darkening, so brightness-dim defaults off and stays
  available as an opt-in.

Existing configs do not break: unknown/stale keys under `[inactive_pane]` are silently
ignored (covered by a test). Users who relied on the old default brightness dimming
should set `dim` explicitly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
