### PR TITLE
feat(shortcuts): make ozmux GUI keyboard shortcuts editable from config

### DIFF
--- a/crates/configs/src/shortcuts.rs
+++ b/crates/configs/src/shortcuts.rs
@@ -88,7 +88,9 @@ impl<'de> serde::Deserialize<'de> for Key {
 }
 
 /// Modifier flags accompanying a `Key`.
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug, Default)]
+#[derive(
+    Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, Default,
+)]
 #[serde(default)]
 pub struct Modifiers {
     /// `Ctrl` is held.

--- a/crates/configs/src/shortcuts.rs
+++ b/crates/configs/src/shortcuts.rs
@@ -503,8 +503,8 @@ impl Bindings {
 }
 
 /// Shortcut actions reachable under forward-only key routing. tmux owns the
-/// pane/window operations now, so only the two ozmux-local actions remain.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+/// pane/window operations now; these are the ozmux-local GUI actions.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum ShortcutAction {
     /// Paste the system clipboard into the active terminal.

--- a/crates/configs/src/shortcuts.rs
+++ b/crates/configs/src/shortcuts.rs
@@ -385,6 +385,12 @@ pub struct Bindings {
     /// Releases keyboard focus from a focused inline webview back to the terminal.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
     pub release_inline_focus: Option<KeyChord>,
+    /// Opens the tmux session/window picker overlay.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub open_picker: Option<KeyChord>,
+    /// Quits the ozmux application.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub quit: Option<KeyChord>,
     /// Deprecated and ignored: this binding was removed when surface/copy
     /// actions were dropped for the tmux backend. Accepted so existing
     /// configs carrying it still parse under `deny_unknown_fields`. Remove
@@ -442,6 +448,8 @@ impl Default for Bindings {
             focus_workspace_next: None,
             paste: Some(parse_default_chord("Cmd+V")),
             release_inline_focus: Some(parse_default_chord("Ctrl+Shift+Escape")),
+            open_picker: Some(parse_default_chord("Cmd+Shift+P")),
+            quit: Some(parse_default_chord("Cmd+Q")),
             close_surface: None,
             new_terminal_surface: None,
             focus_surface_prev: None,
@@ -467,6 +475,8 @@ impl Bindings {
                 &self.release_inline_focus,
                 ShortcutAction::ReleaseInlineFocus,
             ),
+            ("open-picker", &self.open_picker, ShortcutAction::OpenPicker),
+            ("quit", &self.quit, ShortcutAction::Quit),
         ]
         .into_iter()
     }
@@ -499,6 +509,10 @@ pub enum ShortcutAction {
     Paste,
     /// Releases keyboard focus from a focused inline webview back to the terminal.
     ReleaseInlineFocus,
+    /// Opens the tmux session/window picker overlay.
+    OpenPicker,
+    /// Quits the ozmux application.
+    Quit,
 }
 
 #[cfg(test)]
@@ -713,6 +727,8 @@ mod tests {
         let b = Bindings::default();
         assert!(b.paste.is_some());
         assert!(b.release_inline_focus.is_some());
+        assert!(b.open_picker.is_some());
+        assert!(b.quit.is_some());
     }
 
     #[test]
@@ -751,9 +767,9 @@ mod tests {
     }
 
     #[test]
-    fn iter_yields_2_entries() {
+    fn iter_yields_4_entries() {
         let b = Bindings::default();
-        assert_eq!(b.iter().count(), 2);
+        assert_eq!(b.iter().count(), 4);
     }
 
     #[test]
@@ -762,7 +778,7 @@ mod tests {
         // The Bindings struct serializes its fields in declaration order.
         // The kebab-case rename applies. Deprecated fields carry
         // `skip_serializing`, so only the active bindings appear here.
-        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-inline-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
+        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-inline-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}}}}"#;
         assert_eq!(json, expected);
     }
 
@@ -771,6 +787,24 @@ mod tests {
         let b = Bindings::default();
         let chord = b.paste.as_ref().unwrap();
         assert_eq!(chord.key, Key::Char('v'));
+        assert!(chord.modifiers.meta);
+        assert!(!chord.modifiers.ctrl && !chord.modifiers.shift && !chord.modifiers.alt);
+    }
+
+    #[test]
+    fn bindings_default_open_picker_is_cmd_shift_p() {
+        let b = Bindings::default();
+        let chord = b.open_picker.as_ref().unwrap();
+        assert_eq!(chord.key, Key::Char('p'));
+        assert!(chord.modifiers.meta && chord.modifiers.shift);
+        assert!(!chord.modifiers.ctrl && !chord.modifiers.alt);
+    }
+
+    #[test]
+    fn bindings_default_quit_is_cmd_q() {
+        let b = Bindings::default();
+        let chord = b.quit.as_ref().unwrap();
+        assert_eq!(chord.key, Key::Char('q'));
         assert!(chord.modifiers.meta);
         assert!(!chord.modifiers.ctrl && !chord.modifiers.shift && !chord.modifiers.alt);
     }
@@ -802,7 +836,7 @@ copy = \"Cmd+C\"
         let parsed: Shortcuts = toml::from_str(toml).expect("deprecated keys must still parse");
         assert_eq!(
             parsed.bindings.iter().count(),
-            2,
+            4,
             "ignored keys must not enter the active set"
         );
     }

--- a/docs/superpowers/plans/2026-06-18-configurable-terminal-shortcuts.md
+++ b/docs/superpowers/plans/2026-06-18-configurable-terminal-shortcuts.md
@@ -1,0 +1,670 @@
+# Configurable terminal shortcuts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the four ozmux-GUI-owned shortcuts (paste, release-inline-focus, open-picker, quit) editable from `~/.config/ozmux/config.toml`, wiring the existing-but-unused config schema into the runtime key dispatcher.
+
+**Architecture:** Add `open-picker`/`quit` to the config `Bindings` schema. Resolve each configured logical chord to a physical `KeyCode` once at startup into a `ResolvedShortcuts` resource (translation lives in the binary so `ozmux_configs` stays bevy-free). The tmux keyboard dispatcher (`forward_keys_to_tmux`) matches incoming key events against that resolved table instead of the hardcoded `gui_chord()`.
+
+**Tech Stack:** Rust 2024 (toolchain 1.95), Bevy 0.18 ECS, serde/toml, `ozmux_configs` crate, `ozmux_tmux` crate.
+
+## Global Constraints
+
+- Edition 2024, toolchain pinned to 1.95.
+- No `mod.rs`: module files are `foo.rs` + `foo/bar.rs`.
+- Comments only `// TODO:` / `// NOTE:` (critical caveat) / `// SAFETY:`; all comments in English.
+- Doc comments (`///`) on every `pub` item; `//!` on every module file.
+- All `use` at top of file, single contiguous block, no blank lines between import groups.
+- Visibility minimized: items used only in their defining module are private; new resolution items are `pub(crate)` (consumed cross-module within the binary).
+- Item ordering: `pub`/`pub(crate)` items before private items in a module/impl.
+- Parameter ordering: mutable params before immutable (exception: the `interner` builder convention, not relevant here).
+- `ozmux_configs` MUST NOT depend on `bevy`. Logical→physical key translation lives in `src/`.
+- tmux key bindings (`crates/tmux_session/src/keybindings.rs`, `list-keys`) are NOT touched.
+- Matching is layout-stable: physical `KeyCode` + exact `Modifiers` equality (`meta` ⇔ `super`).
+- Load-at-startup only; no hot reload.
+
+**Known test caveat (this repo):** a pre-existing IME test failure and a parallel-teardown SIGSEGV mean the *full* suite needs `cargo test -- --test-threads=1 --skip <flaky>` for a green run. Per-task commands below target specific crates/filters to stay fast and unaffected.
+
+---
+
+### Task 1: Add `open-picker` and `quit` to the shortcut config schema
+
+**Files:**
+- Modify: `crates/configs/src/shortcuts.rs` (`Bindings` struct, `Bindings::iter`, `Bindings::default`, `ShortcutAction` enum, tests)
+
+**Interfaces:**
+- Consumes: existing `KeyChord`, `parse_default_chord`, `deser_chord_or_unbind`.
+- Produces:
+  - `Bindings.open_picker: Option<KeyChord>` (default `Cmd+Shift+P`)
+  - `Bindings.quit: Option<KeyChord>` (default `Cmd+Q`)
+  - `ShortcutAction::OpenPicker`, `ShortcutAction::Quit`
+  - `Bindings::iter()` yields 4 tuples `(&'static str, &Option<KeyChord>, ShortcutAction)`.
+
+- [ ] **Step 1: Update the JSON snapshot test to expect four bindings (failing test first)**
+
+In `crates/configs/src/shortcuts.rs`, replace the `expected` string inside `default_shortcuts_json_snapshot` with:
+
+```rust
+        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-inline-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}}}}"#;
+```
+
+Also rename `iter_yields_2_entries` to `iter_yields_4_entries` and update its body:
+
+```rust
+    #[test]
+    fn iter_yields_4_entries() {
+        let b = Bindings::default();
+        assert_eq!(b.iter().count(), 4);
+    }
+```
+
+Add two new default-value tests after `bindings_default_paste_is_cmd_v`:
+
+```rust
+    #[test]
+    fn bindings_default_open_picker_is_cmd_shift_p() {
+        let b = Bindings::default();
+        let chord = b.open_picker.as_ref().unwrap();
+        assert_eq!(chord.key, Key::Char('p'));
+        assert!(chord.modifiers.meta && chord.modifiers.shift);
+        assert!(!chord.modifiers.ctrl && !chord.modifiers.alt);
+    }
+
+    #[test]
+    fn bindings_default_quit_is_cmd_q() {
+        let b = Bindings::default();
+        let chord = b.quit.as_ref().unwrap();
+        assert_eq!(chord.key, Key::Char('q'));
+        assert!(chord.modifiers.meta);
+        assert!(!chord.modifiers.ctrl && !chord.modifiers.shift && !chord.modifiers.alt);
+    }
+```
+
+And extend `bindings_default_has_active_fields_some`:
+
+```rust
+    #[test]
+    fn bindings_default_has_active_fields_some() {
+        let b = Bindings::default();
+        assert!(b.paste.is_some());
+        assert!(b.release_inline_focus.is_some());
+        assert!(b.open_picker.is_some());
+        assert!(b.quit.is_some());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p ozmux_configs shortcuts`
+Expected: FAIL — `no field open_picker on type Bindings` / `no variant OpenPicker` (compile errors), and `iter_yields_4_entries` count mismatch.
+
+- [ ] **Step 3: Add the two fields to `Bindings`**
+
+In `crates/configs/src/shortcuts.rs`, immediately AFTER the `pub release_inline_focus: Option<KeyChord>,` field (and its doc comment) and BEFORE the deprecated `close_surface` block, insert:
+
+```rust
+    /// Opens the tmux session/window picker overlay.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub open_picker: Option<KeyChord>,
+    /// Quits the ozmux application.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub quit: Option<KeyChord>,
+```
+
+- [ ] **Step 4: Seed the defaults in `Bindings::default`**
+
+In the `impl Default for Bindings` block, immediately AFTER the `release_inline_focus: Some(parse_default_chord("Ctrl+Shift+Escape")),` line, insert:
+
+```rust
+            open_picker: Some(parse_default_chord("Cmd+Shift+P")),
+            quit: Some(parse_default_chord("Cmd+Q")),
+```
+
+- [ ] **Step 5: Add the two `ShortcutAction` variants**
+
+In `enum ShortcutAction`, after the `ReleaseInlineFocus,` variant, insert:
+
+```rust
+    /// Opens the tmux session/window picker overlay.
+    OpenPicker,
+    /// Quits the ozmux application.
+    Quit,
+```
+
+- [ ] **Step 6: Extend `Bindings::iter` to yield all four**
+
+Replace the array literal in `Bindings::iter` with:
+
+```rust
+        [
+            ("paste", &self.paste, ShortcutAction::Paste),
+            (
+                "release-inline-focus",
+                &self.release_inline_focus,
+                ShortcutAction::ReleaseInlineFocus,
+            ),
+            ("open-picker", &self.open_picker, ShortcutAction::OpenPicker),
+            ("quit", &self.quit, ShortcutAction::Quit),
+        ]
+        .into_iter()
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cargo test -p ozmux_configs shortcuts`
+Expected: PASS (all shortcut tests, including the updated snapshot, count, conflict, and new default tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/configs/src/shortcuts.rs
+git commit -m "feat(configs): add open-picker and quit shortcut actions"
+```
+
+---
+
+### Task 2: Add the logical→physical resolution layer
+
+**Files:**
+- Create: `src/input/shortcuts.rs`
+- Modify: `src/input.rs` (declare the module)
+
+**Interfaces:**
+- Consumes: `ozmux_configs::shortcuts::{Bindings, Key, Modifiers, ShortcutAction}`, `Bindings::iter`, `KeyChord` Display, `bevy::prelude::KeyCode`, `crate::configs::OzmuxConfigsResource`.
+- Produces:
+  - `pub(crate) struct ResolvedShortcut { keycode: KeyCode, modifiers: Modifiers, action: ShortcutAction }`
+  - `pub(crate) struct ResolvedShortcuts(pub(crate) Vec<ResolvedShortcut>)` (Bevy `Resource`, `Default`)
+  - `ResolvedShortcuts::match_gui_action(&self, KeyCode, Modifiers) -> Option<ShortcutAction>` (excludes `ReleaseInlineFocus`)
+  - `ResolvedShortcuts::is_release_inline_focus(&self, KeyCode, Modifiers) -> bool`
+  - `pub(crate) fn resolve_from_bindings(&Bindings) -> Vec<ResolvedShortcut>`
+
+> NOTE: `bevy::prelude` and `ozmux_configs::shortcuts` both export a type named `Key`. This module aliases the config one to `ConfigKey` to avoid the clash, since `bevy::prelude::*` is the established import idiom across `src/`.
+
+- [ ] **Step 1: Declare the module in `src/input.rs`**
+
+In `src/input.rs`, after the line `pub(crate) mod option_as_alt;`, add:
+
+```rust
+pub(crate) mod shortcuts;
+```
+
+- [ ] **Step 2: Write the new module with its failing tests**
+
+Create `src/input/shortcuts.rs` with this exact content:
+
+```rust
+//! Resolves configured shortcut chords (logical keys) into physical
+//! `KeyCode`-based entries the runtime input dispatcher matches against.
+//! The translation lives here (not in `ozmux_configs`) so the config crate
+//! stays free of any `bevy` dependency.
+
+use crate::configs::OzmuxConfigsResource;
+use bevy::prelude::*;
+use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
+
+/// One configured shortcut resolved to a physical key: the `KeyCode` to match,
+/// the exact modifier set required, and the action to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedShortcut {
+    pub(crate) keycode: KeyCode,
+    pub(crate) modifiers: Modifiers,
+    pub(crate) action: ShortcutAction,
+}
+
+/// The startup-resolved ozmux shortcut table. Built once from
+/// `OzmuxConfigsResource`; consumed by the tmux keyboard dispatcher.
+#[derive(Resource, Default, Debug, Clone)]
+pub(crate) struct ResolvedShortcuts(pub(crate) Vec<ResolvedShortcut>);
+
+impl ResolvedShortcuts {
+    /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
+    /// `ReleaseInlineFocus`, which is meaningful only while an inline webview
+    /// holds focus and is matched separately via `is_release_inline_focus`.
+    pub(crate) fn match_gui_action(
+        &self,
+        keycode: KeyCode,
+        mods: Modifiers,
+    ) -> Option<ShortcutAction> {
+        self.0
+            .iter()
+            .filter(|s| s.action != ShortcutAction::ReleaseInlineFocus)
+            .find(|s| s.keycode == keycode && s.modifiers == mods)
+            .map(|s| s.action.clone())
+    }
+
+    /// True when `(keycode, mods)` matches the configured release-inline-focus
+    /// chord.
+    pub(crate) fn is_release_inline_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool {
+        self.0.iter().any(|s| {
+            s.action == ShortcutAction::ReleaseInlineFocus
+                && s.keycode == keycode
+                && s.modifiers == mods
+        })
+    }
+}
+
+/// Resolves every bound chord in `bindings` to a `ResolvedShortcut`, skipping
+/// (with a warning) any chord whose logical key has no physical `KeyCode`.
+pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut> {
+    let mut out = Vec::new();
+    for (label, bound, action) in bindings.iter() {
+        let Some(chord) = bound else { continue };
+        match key_to_keycode(&chord.key) {
+            Some(keycode) => out.push(ResolvedShortcut {
+                keycode,
+                modifiers: chord.modifiers.clone(),
+                action,
+            }),
+            None => tracing::warn!(
+                label,
+                chord = %chord,
+                "shortcut key has no physical KeyCode mapping; ignoring binding"
+            ),
+        }
+    }
+    out
+}
+
+/// Maps a config logical `Key` to the physical `KeyCode` ozmux matches on.
+/// Returns `None` for keys with no stable physical mapping (`Plus`, `Other`,
+/// non-alphanumeric chars).
+fn key_to_keycode(key: &ConfigKey) -> Option<KeyCode> {
+    Some(match key {
+        ConfigKey::Char(c) => match c.to_ascii_lowercase() {
+            'a' => KeyCode::KeyA,
+            'b' => KeyCode::KeyB,
+            'c' => KeyCode::KeyC,
+            'd' => KeyCode::KeyD,
+            'e' => KeyCode::KeyE,
+            'f' => KeyCode::KeyF,
+            'g' => KeyCode::KeyG,
+            'h' => KeyCode::KeyH,
+            'i' => KeyCode::KeyI,
+            'j' => KeyCode::KeyJ,
+            'k' => KeyCode::KeyK,
+            'l' => KeyCode::KeyL,
+            'm' => KeyCode::KeyM,
+            'n' => KeyCode::KeyN,
+            'o' => KeyCode::KeyO,
+            'p' => KeyCode::KeyP,
+            'q' => KeyCode::KeyQ,
+            'r' => KeyCode::KeyR,
+            's' => KeyCode::KeyS,
+            't' => KeyCode::KeyT,
+            'u' => KeyCode::KeyU,
+            'v' => KeyCode::KeyV,
+            'w' => KeyCode::KeyW,
+            'x' => KeyCode::KeyX,
+            'y' => KeyCode::KeyY,
+            'z' => KeyCode::KeyZ,
+            '0' => KeyCode::Digit0,
+            '1' => KeyCode::Digit1,
+            '2' => KeyCode::Digit2,
+            '3' => KeyCode::Digit3,
+            '4' => KeyCode::Digit4,
+            '5' => KeyCode::Digit5,
+            '6' => KeyCode::Digit6,
+            '7' => KeyCode::Digit7,
+            '8' => KeyCode::Digit8,
+            '9' => KeyCode::Digit9,
+            _ => return None,
+        },
+        ConfigKey::Escape => KeyCode::Escape,
+        ConfigKey::Space => KeyCode::Space,
+        ConfigKey::Enter => KeyCode::Enter,
+        ConfigKey::Tab => KeyCode::Tab,
+        ConfigKey::Backspace => KeyCode::Backspace,
+        ConfigKey::ArrowUp => KeyCode::ArrowUp,
+        ConfigKey::ArrowDown => KeyCode::ArrowDown,
+        ConfigKey::ArrowLeft => KeyCode::ArrowLeft,
+        ConfigKey::ArrowRight => KeyCode::ArrowRight,
+        ConfigKey::Plus => return None,
+        ConfigKey::Other(_) => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mods(ctrl: bool, shift: bool, alt: bool, meta: bool) -> Modifiers {
+        Modifiers {
+            ctrl,
+            shift,
+            alt,
+            meta,
+        }
+    }
+
+    #[test]
+    fn char_letter_maps_to_keycode_case_insensitive() {
+        assert_eq!(key_to_keycode(&ConfigKey::Char('v')), Some(KeyCode::KeyV));
+        assert_eq!(key_to_keycode(&ConfigKey::Char('P')), Some(KeyCode::KeyP));
+    }
+
+    #[test]
+    fn digit_maps_to_keycode() {
+        assert_eq!(key_to_keycode(&ConfigKey::Char('1')), Some(KeyCode::Digit1));
+    }
+
+    #[test]
+    fn named_keys_map() {
+        assert_eq!(key_to_keycode(&ConfigKey::Escape), Some(KeyCode::Escape));
+        assert_eq!(key_to_keycode(&ConfigKey::ArrowUp), Some(KeyCode::ArrowUp));
+    }
+
+    #[test]
+    fn unmappable_keys_are_none() {
+        assert_eq!(key_to_keycode(&ConfigKey::Plus), None);
+        assert_eq!(key_to_keycode(&ConfigKey::Other("f12".into())), None);
+    }
+
+    #[test]
+    fn default_bindings_resolve_to_four() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(r.0.len(), 4);
+    }
+
+    #[test]
+    fn match_gui_action_resolves_defaults() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyV, mods(false, false, false, true)),
+            Some(ShortcutAction::Paste)
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyP, mods(false, true, false, true)),
+            Some(ShortcutAction::OpenPicker)
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyQ, mods(false, false, false, true)),
+            Some(ShortcutAction::Quit)
+        );
+    }
+
+    #[test]
+    fn match_gui_action_requires_exact_modifiers() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyV, mods(false, true, false, true)),
+            None
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyQ, mods(false, true, false, true)),
+            None
+        );
+    }
+
+    #[test]
+    fn match_gui_action_excludes_release_inline_focus() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::Escape, mods(true, true, false, false)),
+            None
+        );
+    }
+
+    #[test]
+    fn unmatched_chord_is_none() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyH, mods(false, false, false, true)),
+            None
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyA, mods(false, false, false, false)),
+            None
+        );
+    }
+
+    #[test]
+    fn is_release_inline_focus_matches_default_chord() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert!(r.is_release_inline_focus(KeyCode::Escape, mods(true, true, false, false)));
+        assert!(!r.is_release_inline_focus(KeyCode::KeyV, mods(false, false, false, true)));
+    }
+}
+```
+
+- [ ] **Step 3: Run the new module's tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui input::shortcuts`
+Expected: PASS (all `input::shortcuts::tests::*`). Compiles the GUI binary's test harness; requires CEF provisioned (`make setup-cef`).
+
+> NOTE: `build_resolved_shortcuts` is intentionally NOT defined here yet — it would be unused (dead code) until Task 3 registers it. The pure logic above is fully exercised by the tests in this task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/input.rs src/input/shortcuts.rs
+git commit -m "feat(input): add startup shortcut resolution layer (logical key -> KeyCode)"
+```
+
+---
+
+### Task 3: Wire the resolved table into the runtime dispatcher
+
+**Files:**
+- Modify: `src/input/shortcuts.rs` (add the `build_resolved_shortcuts` startup system)
+- Modify: `src/input.rs` (`OzmuxShortcutPlugin::build` — init resource + register startup system)
+- Modify: `src/tmux_input.rs` (consume `ResolvedShortcuts`, replace both dispatch sites, delete `gui_chord`/`GuiChord` and their tests)
+
+**Interfaces:**
+- Consumes: `ResolvedShortcuts`, `ResolvedShortcuts::match_gui_action`, `ResolvedShortcuts::is_release_inline_focus`, `resolve_from_bindings` (Task 2); `ShortcutAction`, `Modifiers` (Task 1); `crate::configs::OzmuxConfigsResource`.
+- Produces: `pub(crate) fn build_resolved_shortcuts(Commands, Res<OzmuxConfigsResource>)` (Bevy `Startup` system).
+
+- [ ] **Step 1: Add the startup system to `src/input/shortcuts.rs`**
+
+Insert this function immediately AFTER `resolve_from_bindings` and BEFORE `fn key_to_keycode` (keeps `pub(crate)` items above the private helper):
+
+```rust
+/// `Startup` system: resolves the configured shortcut bindings into
+/// `ResolvedShortcuts`, replacing the empty default inserted at plugin build.
+pub(crate) fn build_resolved_shortcuts(
+    mut commands: Commands,
+    configs: Res<OzmuxConfigsResource>,
+) {
+    commands.insert_resource(ResolvedShortcuts(resolve_from_bindings(
+        &configs.shortcuts.bindings,
+    )));
+}
+```
+
+- [ ] **Step 2: Register the resource and startup system in `OzmuxShortcutPlugin`**
+
+In `src/input.rs`, replace the body of `impl Plugin for OzmuxShortcutPlugin`'s `build` so it reads:
+
+```rust
+    fn build(&self, app: &mut App) {
+        app.init_resource::<shortcuts::ResolvedShortcuts>()
+            .add_systems(Startup, shortcuts::build_resolved_shortcuts)
+            .configure_sets(
+                Update,
+                (
+                    InputPhase::Hover,
+                    InputPhase::Dispatch,
+                    InputPhase::FocusedKey,
+                )
+                    .chain()
+                    .in_set(OzmuxSystems::Input),
+            );
+    }
+```
+
+- [ ] **Step 3: Add imports to `src/tmux_input.rs`**
+
+In the top import block of `src/tmux_input.rs`, add (keep the block contiguous, no blank lines between groups):
+
+```rust
+use crate::input::shortcuts::ResolvedShortcuts;
+```
+
+and add `ShortcutAction` + `Modifiers` from the config crate:
+
+```rust
+use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
+```
+
+- [ ] **Step 4: Add the `resolved` param to `forward_keys_to_tmux`**
+
+In the parameter list of `fn forward_keys_to_tmux`, add the following line immediately after `bindings: Res<KeyBindings>,` (it is an immutable `Res`, so it belongs in the immutable group):
+
+```rust
+    resolved: Res<ResolvedShortcuts>,
+```
+
+- [ ] **Step 5: Derive the config `Modifiers` once per frame**
+
+In `forward_keys_to_tmux`, immediately AFTER the `let mods = KeyMods { ... };` block (the one ending `};` around the `super_:` line), insert:
+
+```rust
+    let cfg_mods = Modifiers {
+        ctrl: mods.ctrl,
+        shift: mods.shift,
+        alt: mods.alt,
+        meta: mods.super_,
+    };
+```
+
+- [ ] **Step 6: Replace the release-inline-focus condition**
+
+In the `if focused_webview.0.is_some()` branch, replace the inner `if` condition:
+
+```rust
+            if ev.state == ButtonState::Pressed
+                && ev.key_code == KeyCode::Escape
+                && mods.ctrl
+                && mods.shift
+            {
+```
+
+with:
+
+```rust
+            if ev.state == ButtonState::Pressed
+                && resolved.is_release_inline_focus(ev.key_code, cfg_mods)
+            {
+```
+
+- [ ] **Step 7: Replace the GUI-chord dispatch in the main key loop**
+
+In the `for ev in events.read()` loop, replace the whole block that begins `if let Some(chord) = gui_chord(&ev.key_code, mods) {` and ends with its closing `}` + `continue;` (the `match chord { ... }` block) with:
+
+```rust
+        if let Some(action) = resolved.match_gui_action(ev.key_code, cfg_mods) {
+            // A GUI action abandons any pending tmux prefix sequence.
+            *prefix_pending = false;
+            match action {
+                ShortcutAction::OpenPicker => picker.open = true,
+                ShortcutAction::Quit => {
+                    exit.write(AppExit::Success);
+                }
+                ShortcutAction::Paste => {
+                    let Some(text) = clipboard.read() else {
+                        continue;
+                    };
+                    if text.is_empty() {
+                        continue;
+                    }
+                    let (Some(target), Some(client)) = (target.as_deref(), connection.client())
+                    else {
+                        continue;
+                    };
+                    let bytes = build_paste_bytes(&text, false);
+                    for chunk in bytes.chunks(PASTE_CHUNK_BYTES) {
+                        if let Err(e) = client.handle().send(&send_bytes_command(target, chunk)) {
+                            tracing::warn!(?e, "paste send failed");
+                            break;
+                        }
+                    }
+                }
+                ShortcutAction::ReleaseInlineFocus => {}
+            }
+            continue;
+        }
+        // Any Cmd/Super-modified key that matched no ozmux shortcut is swallowed:
+        // tmux/PTY has no Super modifier, so it must never be forwarded.
+        if mods.super_ {
+            *prefix_pending = false;
+            continue;
+        }
+```
+
+- [ ] **Step 8: Delete the now-dead `gui_chord` function and `GuiChord` enum**
+
+Delete the `enum GuiChord { ... }` definition (the `OpenPicker / Quit / Paste / Other` enum near the top of the file) and the entire `fn gui_chord(key_code: &KeyCode, mods: KeyMods) -> Option<GuiChord> { ... }` function.
+
+- [ ] **Step 9: Delete the obsolete `gui_chord` tests and the `m()` helper**
+
+In the `#[cfg(test)] mod tests` block of `src/tmux_input.rs`, delete the helper `fn m(shift: bool, super_: bool) -> KeyMods { ... }` and these five tests (their behavior is now covered by `input::shortcuts::tests`): `cmd_shift_p_opens_picker`, `cmd_q_quits`, `cmd_v_is_paste`, `other_super_chord_is_swallowed`, `non_super_key_is_not_a_chord`.
+
+- [ ] **Step 10: Build and run the affected tests**
+
+Run: `cargo build --bin ozmux-gui`
+Expected: SUCCESS, no `gui_chord`/`GuiChord` unresolved references, no unused-import warnings.
+
+Run: `cargo test --bin ozmux-gui input::shortcuts && cargo test --bin ozmux-gui tmux_input`
+Expected: PASS (resolution-layer tests and the remaining tmux_input tests).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/input.rs src/input/shortcuts.rs src/tmux_input.rs
+git commit -m "feat(input): drive ozmux GUI shortcuts from config instead of hardcoding"
+```
+
+---
+
+### Task 4: Final integration verification
+
+**Files:** none (verification only)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Workspace lint + format**
+
+Run: `cargo clippy --workspace --all-targets && cargo fmt --check`
+Expected: clippy clean (no warnings on changed crates), fmt reports no diffs.
+
+- [ ] **Step 2: Config crate full tests**
+
+Run: `cargo test -p ozmux_configs`
+Expected: PASS.
+
+- [ ] **Step 3: Binary unit tests (serialized to dodge the known SIGSEGV/IME flakiness)**
+
+Run: `cargo test --bin ozmux-gui -- --test-threads=1`
+Expected: PASS, except the pre-existing IME failure documented in the repo memory. If that single known failure appears, re-run skipping it; no NEW failures are acceptable.
+
+- [ ] **Step 4: Manual GUI smoke (human-run; cannot be automated here)**
+
+Document for the reviewer to verify in a real session:
+1. Default config: `Cmd+V` pastes, `Cmd+Shift+P` opens the picker, `Cmd+Q` quits, `Ctrl+Shift+Escape` releases inline-webview focus — all unchanged.
+2. Edit `~/.config/ozmux/config.toml`:
+   ```toml
+   [shortcuts.bindings]
+   quit = "Cmd+Shift+Q"
+   open-picker = "Cmd+K"
+   ```
+   Restart ozmux. Confirm the new chords work and the old ones (`Cmd+Q`, `Cmd+Shift+P`) no longer trigger those actions (`Cmd+Q` is swallowed, not forwarded to tmux).
+3. Set `quit = ""` (unbind), restart, confirm `Cmd+Q` no longer quits.
+4. Introduce a duplicate (`quit = "Cmd+V"`), restart, confirm ozmux exits with code 2 and prints the duplicate-chord error.
+
+- [ ] **Step 5: Final confirmation**
+
+No code changes in this task. If Steps 1–3 are green, the feature is complete; flag the manual smoke (Step 4) as the remaining human gate.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Config schema (`open-picker`, `quit`, `ShortcutAction`, `iter`, defaults, conflict validation) → Task 1.
+- Resolution layer (`key_to_keycode`, `ResolvedShortcuts`, matchers, `resolve_from_bindings`) → Task 2.
+- Runtime wiring (`build_resolved_shortcuts` startup system, `match_gui_action` in the main loop, `is_release_inline_focus` in the webview branch, Cmd-swallow safety net, delete `gui_chord`) → Task 3.
+- Non-goals (no hot reload, no tmux-conflict detection, no new actions, layout-stable matching preserved) → respected; verified in Task 4 manual smoke.
+- `Plus`/`Other` resolve to `None` (skipped) → Task 2 `key_to_keycode` + `unmappable_keys_are_none` test.
+
+**Placeholder scan:** No TBD/TODO; all code blocks are complete (including all 26 letter + 10 digit arms).
+
+**Type consistency:** `match_gui_action`/`is_release_inline_focus`/`resolve_from_bindings`/`build_resolved_shortcuts`/`ResolvedShortcuts` names and signatures are identical across Tasks 2–3. `Modifiers` field order (`ctrl, shift, alt, meta`) matches `ozmux_configs::shortcuts::Modifiers`. `ShortcutAction` variants (`Paste`, `ReleaseInlineFocus`, `OpenPicker`, `Quit`) are matched exhaustively in Task 3 Step 7.

--- a/docs/superpowers/specs/2026-06-18-configurable-terminal-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-06-18-configurable-terminal-shortcuts-design.md
@@ -118,8 +118,11 @@ Contents:
   enum to a physical `bevy::KeyCode`:
   - `Char('a'..='z')` → `KeyA..KeyZ`
   - `Char('0'..='9')` → `Digit0..Digit9`
-  - `Escape/Space/Enter/Tab/Backspace/ArrowUp/Down/Left/Right/Plus` → the
-    matching `KeyCode`
+  - `Escape/Space/Enter/Tab/Backspace/ArrowUp/Down/Left/Right` → the matching
+    `KeyCode`
+  - `Plus`: no dedicated physical `KeyCode` exists (`+` is Shift+Equal on US
+    layouts); it has no clean layout-stable mapping and is not used by any
+    default shortcut, so it resolves to `None` (skipped) in v1
   - anything else (e.g. `Key::Other`, unmapped punctuation) → `None`
 - `ResolvedShortcuts(Vec<ResolvedShortcut>)` Bevy `Resource`, where
   `ResolvedShortcut { keycode: KeyCode, modifiers: Modifiers, action: ShortcutAction }`.
@@ -223,7 +226,7 @@ config.toml
 `src/input/shortcuts.rs`:
 
 - `key_to_keycode`: `Char('v')→KeyV`, `Char('1')→Digit1`, `Escape→Escape`,
-  arrows, `Plus`; `Key::Other(..)` → `None`.
+  arrows; `Key::Plus` and `Key::Other(..)` → `None`.
 - `match_gui_action`: exact modifier equality (e.g. `Cmd+Q` does not match when
   Shift is also held); `Cmd+V` resolves to `Paste`; `ReleaseInlineFocus` is
   never returned.

--- a/docs/superpowers/specs/2026-06-18-configurable-terminal-shortcuts-design.md
+++ b/docs/superpowers/specs/2026-06-18-configurable-terminal-shortcuts-design.md
@@ -1,0 +1,257 @@
+# Configurable terminal shortcuts (ozmux-owned keys)
+
+Date: 2026-06-18
+Branch: `terminal-shortcuts`
+Status: design approved, pending spec review
+
+## Problem
+
+ozmux already ships a complete shortcut-config schema
+(`crates/configs/src/shortcuts.rs`): a `Bindings` table, a `"Cmd+V"`-shape
+chord parser, and cross-action conflict validation. But that schema is **not
+wired into the runtime**. The actual GUI-chord dispatch in
+`src/tmux_input.rs::gui_chord()` is hardcoded:
+
+- `Cmd+Shift+P` → open session picker
+- `Cmd+Q` → quit
+- `Cmd+V` → paste
+- (`Ctrl+Shift+Escape` → release inline-webview focus, hardcoded separately at
+  the `focused_webview` branch around `tmux_input.rs:191`)
+
+Because the hardcoded defaults coincide with the config defaults, the
+disconnect has gone unnoticed. Editing `~/.config/ozmux/config.toml` has no
+effect on these keys today.
+
+Furthermore, `open-picker` and `quit` are not even present in the config
+schema — only `paste` and `release-inline-focus` are active fields (the
+pane/window/surface entries are deprecated and ignored because tmux owns
+them).
+
+## Goal
+
+Make the four ozmux-GUI-owned shortcuts editable from
+`~/.config/ozmux/config.toml`:
+
+- `paste`
+- `release-inline-focus`
+- `open-picker` (new schema field)
+- `quit` (new schema field)
+
+tmux-side key bindings continue to be read from tmux via `list-keys`
+(`crates/tmux_session/src/keybindings.rs`) — **unchanged**. This change
+concerns only the chords ozmux intercepts before forwarding to tmux.
+
+## Non-goals
+
+- Hot reload of shortcuts. Load-at-startup only (restart to apply), consistent
+  with every other ozmux config section.
+- Conflict detection between an ozmux shortcut and a tmux binding. ozmux
+  intercepts first and wins; documented, not enforced.
+- Adding new *actions* (pane/window/surface operations stay owned by tmux).
+- Changing the layout-stable (physical-key) matching semantics ozmux uses
+  today.
+
+## Central design decision: bridging logical config keys to physical runtime keys
+
+The config `KeyChord` is **logical** (`Key::Char('v')` + `Modifiers`). The
+runtime `KeyboardInput` event carries a **physical** `KeyCode` (`KeyCode::KeyV`)
+plus modifier state. Today's `gui_chord()` matches on the physical `KeyCode`
+deliberately — its doc comment calls this "layout-stable".
+
+Chosen approach (**A**): resolve each configured logical `Key` to a physical
+`KeyCode` **once at startup**, then match on exact `(KeyCode, Modifiers)`
+equality at runtime. This preserves the existing layout-stable behavior, keeps
+the `ozmux_configs` crate free of any `bevy` dependency (the translation lives
+in the binary), and is cheap (a linear scan over at most four entries per key
+event).
+
+Rejected alternatives:
+
+- **B — match the event's `logical_key`.** Avoids a `Key → KeyCode` table but
+  flips behavior to layout-dependent, and the logical key shifts under
+  Shift/Alt, making the modifier match awkward.
+- **C — resolve per frame inside the dispatch system.** No extra resource, but
+  re-resolves every frame (wasteful) and further bloats the already-large
+  `forward_keys_to_tmux` system; violates the repo's "compute once" preference.
+
+## Design
+
+### 1. Config schema — `crates/configs/src/shortcuts.rs`
+
+Add two active fields to `Bindings`:
+
+```toml
+[shortcuts.bindings]
+paste                = "Cmd+V"              # existing
+release-inline-focus = "Ctrl+Shift+Escape"  # existing
+open-picker          = "Cmd+Shift+P"        # new
+quit                 = "Cmd+Q"              # new
+```
+
+- New fields: `open_picker: Option<KeyChord>` (default `Cmd+Shift+P`),
+  `quit: Option<KeyChord>` (default `Cmd+Q`). Both use the existing
+  `#[serde(deserialize_with = "deser_chord_or_unbind")]` attribute so `""`
+  means unbind.
+- New `ShortcutAction` variants: `OpenPicker`, `Quit`.
+- `Bindings::iter()` yields all four `(label, &Option<KeyChord>, ShortcutAction)`
+  tuples.
+- `Bindings::default()` seeds the two new fields with their default chords.
+- `validate_no_conflicts()` already detects duplicate chords across all fields
+  reported by `iter()`; with four active actions it now guards all four. The
+  default set (`Cmd+V`, `Cmd+Shift+P`, `Cmd+Q`, `Ctrl+Shift+Escape`) is
+  conflict-free. Conflicts remain fatal via the existing `exit(2)` path in
+  `src/configs.rs`.
+
+Unbinding semantics: a `None` field contributes no entry to the resolved table,
+so e.g. `quit = ""` disables the GUI quit chord entirely (the user closes the
+window through the OS).
+
+### 2. Resolution layer — new `src/input/shortcuts.rs`
+
+`ozmux_configs` must not depend on `bevy`, so the logical→physical translation
+and the resolved table live in the binary. Declared from `src/input.rs` as
+`pub(crate) mod shortcuts;` (no `mod.rs`, per repo rules).
+
+Contents:
+
+- `fn key_to_keycode(key: &Key) -> Option<KeyCode>` — maps the config `Key`
+  enum to a physical `bevy::KeyCode`:
+  - `Char('a'..='z')` → `KeyA..KeyZ`
+  - `Char('0'..='9')` → `Digit0..Digit9`
+  - `Escape/Space/Enter/Tab/Backspace/ArrowUp/Down/Left/Right/Plus` → the
+    matching `KeyCode`
+  - anything else (e.g. `Key::Other`, unmapped punctuation) → `None`
+- `ResolvedShortcuts(Vec<ResolvedShortcut>)` Bevy `Resource`, where
+  `ResolvedShortcut { keycode: KeyCode, modifiers: Modifiers, action: ShortcutAction }`.
+- `fn build_resolved_shortcuts(...)` — a `Startup` system that reads
+  `Res<OzmuxConfigsResource>`, walks `bindings.iter()`, resolves each bound
+  chord's `Key` to a `KeyCode` (logging and skipping any chord whose key has no
+  `KeyCode` mapping), and inserts `ResolvedShortcuts`.
+- Two query helpers on `ResolvedShortcuts`:
+  - `fn match_gui_action(&self, keycode: KeyCode, mods: Modifiers) -> Option<ShortcutAction>`
+    — exact `(keycode, modifiers)` match, **excluding** `ReleaseInlineFocus`
+    (that action is meaningful only while a webview holds focus).
+  - `fn is_release_inline_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool`
+    — exact match against the `ReleaseInlineFocus` entry only.
+
+Modifier comparison reuses the existing `crate::input::current_modifiers()`,
+which already converts `ButtonInput<KeyCode>` into an
+`ozmux_configs::shortcuts::Modifiers` with `meta = super` (so `Cmd` ↔ the
+config's `meta`). Matching is **exact modifier equality**, which preserves the
+current behavior precisely — e.g. `Cmd+Q` requires Shift to be *up*, matching
+the old `!mods.shift && super_` check.
+
+`OzmuxShortcutPlugin` (`src/input.rs`) registers `build_resolved_shortcuts` in
+`Startup`. Ordering is safe: `OzmuxConfigsPlugin` inserts `OzmuxConfigsResource`
+in its `Plugin::build` (added before `OzmuxShortcutPlugin` in `main.rs`), so the
+resource exists before any `Startup` system runs.
+
+### 3. Runtime wiring — `src/tmux_input.rs`
+
+- Delete `gui_chord()` and the `GuiChord` enum.
+- Add `resolved: Res<ResolvedShortcuts>` to `forward_keys_to_tmux`'s params.
+- Replace the per-event chord branch in the key loop with:
+
+  ```text
+  let mods = current_modifiers(&keys);            // Modifiers, meta = super
+  if let Some(action) = resolved.match_gui_action(ev.key_code, mods) {
+      *prefix_pending = false;                    // a GUI action abandons a pending prefix
+      match action {
+          OpenPicker        => picker.open = true,
+          Quit              => exit.write(AppExit::Success),
+          Paste             => { /* existing paste body verbatim */ }
+          ReleaseInlineFocus => {}                // unreachable here (excluded from match_gui_action)
+      }
+      continue;
+  }
+  if mods.meta {                                  // Cmd held, no ozmux chord matched
+      *prefix_pending = false;
+      continue;                                   // swallow — tmux/PTY has no Super; never leak
+  }
+  if let Some(name) = bevy_key_to_tmux_name(...) { key_names.push(name); }
+  ```
+
+  The `mods.meta` swallow preserves the old `GuiChord::Other` safety net (any
+  unhandled Cmd-modified key is dropped, never forwarded to tmux).
+
+- Replace the hardcoded `Ctrl+Shift+Escape` test in the `focused_webview`
+  branch (~`tmux_input.rs:191`) with
+  `resolved.is_release_inline_focus(ev.key_code, mods)`. Behavior when no
+  webview is focused is unchanged: the general loop excludes
+  `ReleaseInlineFocus`, so the release chord (default `Ctrl+Shift+Escape`,
+  no Cmd) falls through to `bevy_key_to_tmux_name` and forwards to tmux exactly
+  as today.
+
+### 4. Data flow
+
+```
+config.toml
+  → OzmuxConfigs::load_blocking()            (startup, existing)
+  → OzmuxConfigsResource                     (existing Resource)
+  → [Startup] build_resolved_shortcuts       (logical Key → physical KeyCode, resolved once)
+  → ResolvedShortcuts                         (new Resource)
+  → forward_keys_to_tmux:
+        match_gui_action → run action
+        else Cmd held    → swallow (safety net)
+        else             → forward to tmux (unchanged)
+     focused_webview branch:
+        is_release_inline_focus → release focus
+```
+
+## Error handling
+
+- A bound chord whose `Key` has no `KeyCode` mapping is logged
+  (`tracing::warn!`) and skipped during resolution — it behaves as unbound
+  rather than crashing. In practice the config `Key` set is already constrained
+  to the mappable letters/digits/named keys, so this is a defensive guard for
+  forward-compat `Key::Other`.
+- Duplicate-chord conflicts across the four actions remain fatal (`exit(2)`),
+  surfaced by the existing `OzmuxConfigsPlugin` path.
+- Parse/IO errors fall back to defaults with a warning, as today.
+
+## Testing
+
+`crates/configs/src/shortcuts.rs`:
+
+- `open-picker`/`quit` defaults are `Cmd+Shift+P` / `Cmd+Q`.
+- `Bindings::iter()` yields four entries (update `iter_yields_2_entries`).
+- Default-shortcuts JSON snapshot updated to include the two new fields.
+- `validate_no_conflicts` detects a user-introduced conflict among the four
+  actions; the default set stays conflict-free.
+- `""` unbinds `quit` / `open-picker`.
+
+`src/input/shortcuts.rs`:
+
+- `key_to_keycode`: `Char('v')→KeyV`, `Char('1')→Digit1`, `Escape→Escape`,
+  arrows, `Plus`; `Key::Other(..)` → `None`.
+- `match_gui_action`: exact modifier equality (e.g. `Cmd+Q` does not match when
+  Shift is also held); `Cmd+V` resolves to `Paste`; `ReleaseInlineFocus` is
+  never returned.
+- `is_release_inline_focus`: true only for the configured release chord.
+- `build_resolved_shortcuts`: from default config produces the four expected
+  entries; a chord with an unmappable key is skipped.
+
+`src/tmux_input.rs`:
+
+- Migrate the existing `gui_chord` tests (`cmd_shift_p_opens_picker`,
+  `cmd_q_quits`, `cmd_v_is_paste`, `other_super_chord_is_swallowed`,
+  `non_super_key_is_not_a_chord`) to drive the new matcher against a
+  default-built `ResolvedShortcuts`.
+
+## Files affected
+
+- `crates/configs/src/shortcuts.rs` — schema (fields, `ShortcutAction`,
+  `iter`, `Default`) + tests.
+- `src/input.rs` — declare `pub(crate) mod shortcuts;`, register the
+  `Startup` system in `OzmuxShortcutPlugin`.
+- `src/input/shortcuts.rs` — **new**: `key_to_keycode`, `ResolvedShortcuts`,
+  `build_resolved_shortcuts`, matchers + tests.
+- `src/tmux_input.rs` — remove `gui_chord`/`GuiChord`, consume
+  `Res<ResolvedShortcuts>`, swap the two dispatch sites; migrate tests.
+- `src/configs.rs` — unaffected (conflict-fatal path already covers four
+  actions).
+
+## Open questions
+
+None blocking. (Documenting the four config keys in any user-facing config
+reference is a minor follow-up if such a doc exists.)

--- a/src/input.rs
+++ b/src/input.rs
@@ -30,16 +30,18 @@ pub struct OzmuxShortcutPlugin;
 
 impl Plugin for OzmuxShortcutPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(
-            Update,
-            (
-                InputPhase::Hover,
-                InputPhase::Dispatch,
-                InputPhase::FocusedKey,
-            )
-                .chain()
-                .in_set(OzmuxSystems::Input),
-        );
+        app.init_resource::<shortcuts::ResolvedShortcuts>()
+            .add_systems(Startup, shortcuts::build_resolved_shortcuts)
+            .configure_sets(
+                Update,
+                (
+                    InputPhase::Hover,
+                    InputPhase::Dispatch,
+                    InputPhase::FocusedKey,
+                )
+                    .chain()
+                    .in_set(OzmuxSystems::Input),
+            );
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,6 +5,7 @@
 pub(crate) mod hyperlink;
 pub(crate) mod ime;
 pub(crate) mod option_as_alt;
+pub(crate) mod shortcuts;
 
 use crate::system_set::OzmuxSystems;
 use bevy::prelude::*;

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -5,6 +5,7 @@
 
 use bevy::prelude::*;
 use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
+use crate::configs::OzmuxConfigsResource;
 
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
 /// the exact modifier set required, and the action to run.
@@ -67,6 +68,17 @@ pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut
         }
     }
     out
+}
+
+/// `Startup` system: resolves the configured shortcut bindings into
+/// `ResolvedShortcuts`, replacing the empty default inserted at plugin build.
+pub(crate) fn build_resolved_shortcuts(
+    mut commands: Commands,
+    configs: Res<OzmuxConfigsResource>,
+) {
+    commands.insert_resource(ResolvedShortcuts(resolve_from_bindings(
+        &configs.shortcuts.bindings,
+    )));
 }
 
 /// Maps a config logical `Key` to the physical `KeyCode` ozmux matches on.

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -3,9 +3,9 @@
 //! The translation lives here (not in `ozmux_configs`) so the config crate
 //! stays free of any `bevy` dependency.
 
+use crate::configs::OzmuxConfigsResource;
 use bevy::prelude::*;
 use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
-use crate::configs::OzmuxConfigsResource;
 
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
 /// the exact modifier set required, and the action to run.
@@ -72,10 +72,7 @@ pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut
 
 /// `Startup` system: resolves the configured shortcut bindings into
 /// `ResolvedShortcuts`, replacing the empty default inserted at plugin build.
-pub(crate) fn build_resolved_shortcuts(
-    mut commands: Commands,
-    configs: Res<OzmuxConfigsResource>,
-) {
+pub(crate) fn build_resolved_shortcuts(mut commands: Commands, configs: Res<OzmuxConfigsResource>) {
     commands.insert_resource(ResolvedShortcuts(resolve_from_bindings(
         &configs.shortcuts.bindings,
     )));

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -57,7 +57,7 @@ pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut
         match key_to_keycode(&chord.key) {
             Some(keycode) => out.push(ResolvedShortcut {
                 keycode,
-                modifiers: chord.modifiers.clone(),
+                modifiers: chord.modifiers,
                 action,
             }),
             None => tracing::warn!(

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -10,16 +10,16 @@ use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAc
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
 /// the exact modifier set required, and the action to run.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ResolvedShortcut {
-    pub(crate) keycode: KeyCode,
-    pub(crate) modifiers: Modifiers,
-    pub(crate) action: ShortcutAction,
+struct ResolvedShortcut {
+    keycode: KeyCode,
+    modifiers: Modifiers,
+    action: ShortcutAction,
 }
 
 /// The startup-resolved ozmux shortcut table. Built once from
 /// `OzmuxConfigsResource`; consumed by the tmux keyboard dispatcher.
 #[derive(Resource, Default, Debug, Clone)]
-pub(crate) struct ResolvedShortcuts(pub(crate) Vec<ResolvedShortcut>);
+pub(crate) struct ResolvedShortcuts(Vec<ResolvedShortcut>);
 
 impl ResolvedShortcuts {
     /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
@@ -32,9 +32,12 @@ impl ResolvedShortcuts {
     ) -> Option<ShortcutAction> {
         self.0
             .iter()
-            .filter(|s| s.action != ShortcutAction::ReleaseInlineFocus)
-            .find(|s| s.keycode == keycode && s.modifiers == mods)
-            .map(|s| s.action.clone())
+            .find(|s| {
+                s.action != ShortcutAction::ReleaseInlineFocus
+                    && s.keycode == keycode
+                    && s.modifiers == mods
+            })
+            .map(|s| s.action)
     }
 
     /// True when `(keycode, mods)` matches the configured release-inline-focus
@@ -50,7 +53,7 @@ impl ResolvedShortcuts {
 
 /// Resolves every bound chord in `bindings` to a `ResolvedShortcut`, skipping
 /// (with a warning) any chord whose logical key has no physical `KeyCode`.
-pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut> {
+fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut> {
     let mut out = Vec::new();
     for (label, bound, action) in bindings.iter() {
         let Some(chord) = bound else { continue };
@@ -72,10 +75,16 @@ pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut
 
 /// `Startup` system: resolves the configured shortcut bindings into
 /// `ResolvedShortcuts`, replacing the empty default inserted at plugin build.
-pub(crate) fn build_resolved_shortcuts(mut commands: Commands, configs: Res<OzmuxConfigsResource>) {
-    commands.insert_resource(ResolvedShortcuts(resolve_from_bindings(
-        &configs.shortcuts.bindings,
-    )));
+///
+/// Writes through `ResMut` (an immediate change, unlike a deferred
+/// `Commands::insert_resource`) so the table is populated the moment this
+/// system runs, with no window in which a same-schedule reader could observe
+/// the empty default.
+pub(crate) fn build_resolved_shortcuts(
+    mut resolved: ResMut<ResolvedShortcuts>,
+    configs: Res<OzmuxConfigsResource>,
+) {
+    resolved.0 = resolve_from_bindings(&configs.shortcuts.bindings);
 }
 
 /// Maps a config logical `Key` to the physical `KeyCode` ozmux matches on.

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -1,0 +1,230 @@
+//! Resolves configured shortcut chords (logical keys) into physical
+//! `KeyCode`-based entries the runtime input dispatcher matches against.
+//! The translation lives here (not in `ozmux_configs`) so the config crate
+//! stays free of any `bevy` dependency.
+
+use bevy::prelude::*;
+use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
+
+/// One configured shortcut resolved to a physical key: the `KeyCode` to match,
+/// the exact modifier set required, and the action to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedShortcut {
+    pub(crate) keycode: KeyCode,
+    pub(crate) modifiers: Modifiers,
+    pub(crate) action: ShortcutAction,
+}
+
+/// The startup-resolved ozmux shortcut table. Built once from
+/// `OzmuxConfigsResource`; consumed by the tmux keyboard dispatcher.
+#[derive(Resource, Default, Debug, Clone)]
+pub(crate) struct ResolvedShortcuts(pub(crate) Vec<ResolvedShortcut>);
+
+impl ResolvedShortcuts {
+    /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
+    /// `ReleaseInlineFocus`, which is meaningful only while an inline webview
+    /// holds focus and is matched separately via `is_release_inline_focus`.
+    pub(crate) fn match_gui_action(
+        &self,
+        keycode: KeyCode,
+        mods: Modifiers,
+    ) -> Option<ShortcutAction> {
+        self.0
+            .iter()
+            .filter(|s| s.action != ShortcutAction::ReleaseInlineFocus)
+            .find(|s| s.keycode == keycode && s.modifiers == mods)
+            .map(|s| s.action.clone())
+    }
+
+    /// True when `(keycode, mods)` matches the configured release-inline-focus
+    /// chord.
+    pub(crate) fn is_release_inline_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool {
+        self.0.iter().any(|s| {
+            s.action == ShortcutAction::ReleaseInlineFocus
+                && s.keycode == keycode
+                && s.modifiers == mods
+        })
+    }
+}
+
+/// Resolves every bound chord in `bindings` to a `ResolvedShortcut`, skipping
+/// (with a warning) any chord whose logical key has no physical `KeyCode`.
+pub(crate) fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut> {
+    let mut out = Vec::new();
+    for (label, bound, action) in bindings.iter() {
+        let Some(chord) = bound else { continue };
+        match key_to_keycode(&chord.key) {
+            Some(keycode) => out.push(ResolvedShortcut {
+                keycode,
+                modifiers: chord.modifiers.clone(),
+                action,
+            }),
+            None => tracing::warn!(
+                label,
+                chord = %chord,
+                "shortcut key has no physical KeyCode mapping; ignoring binding"
+            ),
+        }
+    }
+    out
+}
+
+/// Maps a config logical `Key` to the physical `KeyCode` ozmux matches on.
+/// Returns `None` for keys with no stable physical mapping (`Plus`, `Other`,
+/// non-alphanumeric chars).
+fn key_to_keycode(key: &ConfigKey) -> Option<KeyCode> {
+    Some(match key {
+        ConfigKey::Char(c) => match c.to_ascii_lowercase() {
+            'a' => KeyCode::KeyA,
+            'b' => KeyCode::KeyB,
+            'c' => KeyCode::KeyC,
+            'd' => KeyCode::KeyD,
+            'e' => KeyCode::KeyE,
+            'f' => KeyCode::KeyF,
+            'g' => KeyCode::KeyG,
+            'h' => KeyCode::KeyH,
+            'i' => KeyCode::KeyI,
+            'j' => KeyCode::KeyJ,
+            'k' => KeyCode::KeyK,
+            'l' => KeyCode::KeyL,
+            'm' => KeyCode::KeyM,
+            'n' => KeyCode::KeyN,
+            'o' => KeyCode::KeyO,
+            'p' => KeyCode::KeyP,
+            'q' => KeyCode::KeyQ,
+            'r' => KeyCode::KeyR,
+            's' => KeyCode::KeyS,
+            't' => KeyCode::KeyT,
+            'u' => KeyCode::KeyU,
+            'v' => KeyCode::KeyV,
+            'w' => KeyCode::KeyW,
+            'x' => KeyCode::KeyX,
+            'y' => KeyCode::KeyY,
+            'z' => KeyCode::KeyZ,
+            '0' => KeyCode::Digit0,
+            '1' => KeyCode::Digit1,
+            '2' => KeyCode::Digit2,
+            '3' => KeyCode::Digit3,
+            '4' => KeyCode::Digit4,
+            '5' => KeyCode::Digit5,
+            '6' => KeyCode::Digit6,
+            '7' => KeyCode::Digit7,
+            '8' => KeyCode::Digit8,
+            '9' => KeyCode::Digit9,
+            _ => return None,
+        },
+        ConfigKey::Escape => KeyCode::Escape,
+        ConfigKey::Space => KeyCode::Space,
+        ConfigKey::Enter => KeyCode::Enter,
+        ConfigKey::Tab => KeyCode::Tab,
+        ConfigKey::Backspace => KeyCode::Backspace,
+        ConfigKey::ArrowUp => KeyCode::ArrowUp,
+        ConfigKey::ArrowDown => KeyCode::ArrowDown,
+        ConfigKey::ArrowLeft => KeyCode::ArrowLeft,
+        ConfigKey::ArrowRight => KeyCode::ArrowRight,
+        ConfigKey::Plus => return None,
+        ConfigKey::Other(_) => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mods(ctrl: bool, shift: bool, alt: bool, meta: bool) -> Modifiers {
+        Modifiers {
+            ctrl,
+            shift,
+            alt,
+            meta,
+        }
+    }
+
+    #[test]
+    fn char_letter_maps_to_keycode_case_insensitive() {
+        assert_eq!(key_to_keycode(&ConfigKey::Char('v')), Some(KeyCode::KeyV));
+        assert_eq!(key_to_keycode(&ConfigKey::Char('P')), Some(KeyCode::KeyP));
+    }
+
+    #[test]
+    fn digit_maps_to_keycode() {
+        assert_eq!(key_to_keycode(&ConfigKey::Char('1')), Some(KeyCode::Digit1));
+    }
+
+    #[test]
+    fn named_keys_map() {
+        assert_eq!(key_to_keycode(&ConfigKey::Escape), Some(KeyCode::Escape));
+        assert_eq!(key_to_keycode(&ConfigKey::ArrowUp), Some(KeyCode::ArrowUp));
+    }
+
+    #[test]
+    fn unmappable_keys_are_none() {
+        assert_eq!(key_to_keycode(&ConfigKey::Plus), None);
+        assert_eq!(key_to_keycode(&ConfigKey::Other("f12".into())), None);
+    }
+
+    #[test]
+    fn default_bindings_resolve_to_four() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(r.0.len(), 4);
+    }
+
+    #[test]
+    fn match_gui_action_resolves_defaults() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyV, mods(false, false, false, true)),
+            Some(ShortcutAction::Paste)
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyP, mods(false, true, false, true)),
+            Some(ShortcutAction::OpenPicker)
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyQ, mods(false, false, false, true)),
+            Some(ShortcutAction::Quit)
+        );
+    }
+
+    #[test]
+    fn match_gui_action_requires_exact_modifiers() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyV, mods(false, true, false, true)),
+            None
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyQ, mods(false, true, false, true)),
+            None
+        );
+    }
+
+    #[test]
+    fn match_gui_action_excludes_release_inline_focus() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::Escape, mods(true, true, false, false)),
+            None
+        );
+    }
+
+    #[test]
+    fn unmatched_chord_is_none() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyH, mods(false, false, false, true)),
+            None
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyA, mods(false, false, false, false)),
+            None
+        );
+    }
+
+    #[test]
+    fn is_release_inline_focus_matches_default_chord() {
+        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        assert!(r.is_release_inline_focus(KeyCode::Escape, mods(true, true, false, false)));
+        assert!(!r.is_release_inline_focus(KeyCode::KeyV, mods(false, false, false, true)));
+    }
+}

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -254,8 +254,8 @@ fn forward_keys_to_tmux(
             }
             continue;
         }
-        // Any Cmd/Super-modified key that matched no ozmux shortcut is swallowed:
-        // tmux/PTY has no Super modifier, so it must never be forwarded.
+        // NOTE: tmux/PTY has no Super modifier, so a Cmd-modified key that
+        // matched no ozmux shortcut must be swallowed here, never forwarded.
         if mods.super_ {
             *prefix_pending = false;
             continue;

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -10,6 +10,8 @@ use crate::clipboard::{Clipboard, build_paste_bytes};
 use crate::configs::OzmuxConfigsResource;
 use crate::inline_webview::{InlineWebview, focused_inline_of, inline_hit_at};
 use crate::input::InputPhase;
+use crate::input::shortcuts::ResolvedShortcuts;
+use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
 use crate::osc_webview::NonInteractive;
 use crate::tmux_pane_hit::tmux_pane_at_phys;
 use crate::tmux_picker::SessionPicker;
@@ -52,14 +54,6 @@ impl Plugin for OzmuxTmuxInputPlugin {
             ),
         );
     }
-}
-
-/// A GUI-level chord ozmux handles itself (never forwarded to tmux).
-enum GuiChord {
-    OpenPicker,
-    Quit,
-    Paste,
-    Other,
 }
 
 const PASTE_CHUNK_BYTES: usize = 256;
@@ -124,9 +118,12 @@ fn forward_keys_to_tmux(
     mut copy_queries: ResMut<CopyModeQueries>,
     mut prefix_pending: Local<bool>,
     connection: NonSend<TmuxConnection>,
-    keys: Res<ButtonInput<KeyCode>>,
-    ime: Res<crate::input::ime::ImeState>,
-    bindings: Res<KeyBindings>,
+    (keys, ime, bindings, resolved): (
+        Res<ButtonInput<KeyCode>>,
+        Res<crate::input::ime::ImeState>,
+        Res<KeyBindings>,
+        Res<ResolvedShortcuts>,
+    ),
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     copy_modes: Query<(), With<CopyModeState>>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -180,6 +177,12 @@ fn forward_keys_to_tmux(
         shift: keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight),
         super_: keys.pressed(KeyCode::SuperLeft) || keys.pressed(KeyCode::SuperRight),
     };
+    let cfg_mods = Modifiers {
+        ctrl: mods.ctrl,
+        shift: mods.shift,
+        alt: mods.alt,
+        meta: mods.super_,
+    };
 
     // When an inline webview holds focus it owns the keyboard (bevy_cef routes
     // keystrokes to it); forwarding to tmux too would double-send. Ctrl+Shift+Esc
@@ -191,9 +194,7 @@ fn forward_keys_to_tmux(
     if focused_webview.0.is_some() {
         for ev in events.read() {
             if ev.state == ButtonState::Pressed
-                && ev.key_code == KeyCode::Escape
-                && mods.ctrl
-                && mods.shift
+                && resolved.is_release_inline_focus(ev.key_code, cfg_mods.clone())
             {
                 focused_webview.0 = None;
                 break;
@@ -222,15 +223,15 @@ fn forward_keys_to_tmux(
         if ev.state != ButtonState::Pressed {
             continue;
         }
-        if let Some(chord) = gui_chord(&ev.key_code, mods) {
+        if let Some(action) = resolved.match_gui_action(ev.key_code, cfg_mods.clone()) {
             // A GUI action abandons any pending tmux prefix sequence.
             *prefix_pending = false;
-            match chord {
-                GuiChord::OpenPicker => picker.open = true,
-                GuiChord::Quit => {
+            match action {
+                ShortcutAction::OpenPicker => picker.open = true,
+                ShortcutAction::Quit => {
                     exit.write(AppExit::Success);
                 }
-                GuiChord::Paste => {
+                ShortcutAction::Paste => {
                     let Some(text) = clipboard.read() else {
                         continue;
                     };
@@ -249,8 +250,14 @@ fn forward_keys_to_tmux(
                         }
                     }
                 }
-                GuiChord::Other => {}
+                ShortcutAction::ReleaseInlineFocus => {}
             }
+            continue;
+        }
+        // Any Cmd/Super-modified key that matched no ozmux shortcut is swallowed:
+        // tmux/PTY has no Super modifier, so it must never be forwarded.
+        if mods.super_ {
+            *prefix_pending = false;
             continue;
         }
         if let Some(name) = bevy_key_to_tmux_name(&ev.logical_key, ev.key_code, mods) {
@@ -716,25 +723,6 @@ fn consume_wheel_notches(
     notches
 }
 
-/// Classifies a key event as a GUI chord (matched on physical `key_code` + the
-/// `Super`/Cmd modifier — layout-stable). Any other `Super`-modified key is
-/// swallowed (`Other`) so it is never forwarded (tmux has no Super modifier).
-fn gui_chord(key_code: &KeyCode, mods: KeyMods) -> Option<GuiChord> {
-    if !mods.super_ {
-        return None;
-    }
-    if mods.shift && *key_code == KeyCode::KeyP {
-        return Some(GuiChord::OpenPicker);
-    }
-    if !mods.shift && *key_code == KeyCode::KeyQ {
-        return Some(GuiChord::Quit);
-    }
-    if !mods.shift && *key_code == KeyCode::KeyV {
-        return Some(GuiChord::Paste);
-    }
-    Some(GuiChord::Other)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1049,53 +1037,4 @@ mod tests {
         assert!(!is_copy_mode_entry("send-keys -X scroll-up"));
     }
 
-    fn m(shift: bool, super_: bool) -> KeyMods {
-        KeyMods {
-            ctrl: false,
-            alt: false,
-            shift,
-            super_,
-        }
-    }
-
-    #[test]
-    fn cmd_shift_p_opens_picker() {
-        assert!(matches!(
-            gui_chord(&KeyCode::KeyP, m(true, true)),
-            Some(GuiChord::OpenPicker)
-        ));
-    }
-
-    #[test]
-    fn cmd_q_quits() {
-        assert!(matches!(
-            gui_chord(&KeyCode::KeyQ, m(false, true)),
-            Some(GuiChord::Quit)
-        ));
-    }
-
-    #[test]
-    fn cmd_v_is_paste() {
-        assert!(matches!(
-            gui_chord(&KeyCode::KeyV, m(false, true)),
-            Some(GuiChord::Paste)
-        ));
-        assert!(matches!(
-            gui_chord(&KeyCode::KeyV, m(true, true)),
-            Some(GuiChord::Other)
-        ));
-    }
-
-    #[test]
-    fn other_super_chord_is_swallowed() {
-        assert!(matches!(
-            gui_chord(&KeyCode::KeyH, m(false, true)),
-            Some(GuiChord::Other)
-        ));
-    }
-
-    #[test]
-    fn non_super_key_is_not_a_chord() {
-        assert!(gui_chord(&KeyCode::KeyA, m(false, false)).is_none());
-    }
 }

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -185,8 +185,8 @@ fn forward_keys_to_tmux(
     };
 
     // When an inline webview holds focus it owns the keyboard (bevy_cef routes
-    // keystrokes to it); forwarding to tmux too would double-send. Ctrl+Shift+Esc
-    // releases focus back to the terminal. NOTE: under the tmux backend
+    // keystrokes to it); forwarding to tmux too would double-send. The configured
+    // release-inline-focus chord releases focus back to the terminal. NOTE: under the tmux backend
     // `FocusedWebview` is live (set by the inline-click router, the control-plane
     // `SetFocus` op, and the focus-preservation arm in `sync_focused_webview`),
     // so this drain is load-bearing whenever an inline webview is focused —
@@ -194,7 +194,7 @@ fn forward_keys_to_tmux(
     if focused_webview.0.is_some() {
         for ev in events.read() {
             if ev.state == ButtonState::Pressed
-                && resolved.is_release_inline_focus(ev.key_code, cfg_mods.clone())
+                && resolved.is_release_inline_focus(ev.key_code, cfg_mods)
             {
                 focused_webview.0 = None;
                 break;
@@ -217,13 +217,13 @@ fn forward_keys_to_tmux(
     };
 
     // Collect forwardable tmux key names in event order. Super-modified keys are
-    // handled as GUI chords (Paste/Quit/Picker) or swallowed; none reach tmux.
+    // matched against the configured ozmux shortcuts or swallowed; none reach tmux.
     let mut key_names: Vec<String> = Vec::new();
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
         }
-        if let Some(action) = resolved.match_gui_action(ev.key_code, cfg_mods.clone()) {
+        if let Some(action) = resolved.match_gui_action(ev.key_code, cfg_mods) {
             // A GUI action abandons any pending tmux prefix sequence.
             *prefix_pending = false;
             match action {

--- a/src/tmux_input.rs
+++ b/src/tmux_input.rs
@@ -11,7 +11,6 @@ use crate::configs::OzmuxConfigsResource;
 use crate::inline_webview::{InlineWebview, focused_inline_of, inline_hit_at};
 use crate::input::InputPhase;
 use crate::input::shortcuts::ResolvedShortcuts;
-use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
 use crate::osc_webview::NonInteractive;
 use crate::tmux_pane_hit::tmux_pane_at_phys;
 use crate::tmux_picker::SessionPicker;
@@ -30,6 +29,7 @@ use bevy_cef::prelude::FocusedWebview;
 use bevy_cef_core::prelude::Browsers;
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::prelude::TerminalOverlays;
+use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
 use ozmux_tmux::{
     ActivePane, ActiveWindow, CopyAction, CopyModeQueries, CopyQueryKind, Forwarded, KeyBindings,
     KeyMods, PromptKind, TmuxConnection, TmuxPane, TmuxSession, TmuxWindow, bevy_key_to_tmux_name,
@@ -1036,5 +1036,4 @@ mod tests {
         assert!(!is_copy_mode_entry("send-keys -M"));
         assert!(!is_copy_mode_entry("send-keys -X scroll-up"));
     }
-
 }


### PR DESCRIPTION
## Problem

ozmux already shipped a shortcut-config schema (`crates/configs/src/shortcuts.rs`) — a `Bindings` table, a `"Cmd+V"`-style chord parser, and conflict validation — but it was **never wired into the runtime**. The GUI-chord dispatch in `tmux_input.rs::gui_chord()` was hardcoded (`Cmd+Shift+P` → picker, `Cmd+Q` → quit, `Cmd+V` → paste, `Ctrl+Shift+Escape` → release inline-webview focus), so editing `~/.config/ozmux/config.toml` had no effect on these keys. `open-picker` and `quit` weren't even present in the schema. tmux's own key bindings (`list-keys`) are read separately and stay unchanged.

## Solution

Make all four ozmux-GUI-owned shortcuts editable from `[shortcuts.bindings]`, leaving tmux keybindings exactly as before.

- **configs** (`crates/configs`): add `open-picker` (default `Cmd+Shift+P`) and `quit` (default `Cmd+Q`) to `Bindings` and `ShortcutAction`; `iter()` and duplicate-chord validation now cover all four actions. `""` unbinds an action; a duplicate chord across actions remains a fatal load error (exit 2).
- **resolution layer** (`src/input/shortcuts.rs`, new): a `Startup` system resolves each logical config `Key` to a physical Bevy `KeyCode` once into a `ResolvedShortcuts` resource. The translation lives in the binary so `ozmux_configs` stays free of any Bevy dependency. Matching is layout-stable — physical `KeyCode` + exact `Modifiers` equality (`meta` ⇔ macOS Cmd/Super).
- **runtime** (`src/tmux_input.rs`): `forward_keys_to_tmux` replaces the hardcoded `gui_chord()` with config-driven `match_gui_action` (paste / open-picker / quit) and `is_release_inline_focus` (the inline-webview focus branch). The prior safety net — any unmatched Cmd/Super-modified key is swallowed, never forwarded to tmux — is preserved.

Affected areas: the `configs` crate, `src/input`, and `src/tmux_input`. Load-at-startup only (restart to apply), consistent with every other ozmux config section. Out of scope by design: hot reload, new actions (pane/window stay owned by tmux), and ozmux↔tmux chord-conflict detection (ozmux intercepts first).

### Testing

- `ozmux_configs` 113/113, `input::shortcuts` 10/10, `tmux_input` 24/24; `cargo clippy` clean; `cargo fmt` clean for changed files.
- Reviewed with a max-effort multi-angle pass (`/code-review max --fix`): tightened item visibility, derived `Copy` on `ShortcutAction`, and hardened the startup write to `ResMut`.
- ⚠️ **Manual GUI/CEF smoke pending** (human gate): default chords unchanged; reconfigured chords take effect after restart while old ones go inert; `""` disables a chord; the configured release chord releases a focused inline webview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xadjnw4xarwRw92XLDnc2g
