### PR TITLE
fix(tmux): robust multi-client / multi-session handling (no black screen)

### DIFF
--- a/crates/tmux_session/src/connection.rs
+++ b/crates/tmux_session/src/connection.rs
@@ -12,6 +12,7 @@ use tmux_control::TmuxClient;
 pub struct TmuxConnection {
     client: Option<TmuxClient>,
     client_name: Option<String>,
+    per_window_refresh: Option<bool>,
 }
 
 impl TmuxConnection {
@@ -27,9 +28,11 @@ impl TmuxConnection {
 
     /// Removes and returns the live client, leaving the connection empty.
     ///
-    /// Also clears the cached client name so a fresh reconnect re-queries it.
+    /// Also clears the cached client name and capability flags so a fresh
+    /// reconnect re-queries them.
     pub fn take(&mut self) -> Option<TmuxClient> {
         self.client_name = None;
+        self.per_window_refresh = None;
         self.client.take()
     }
 
@@ -39,8 +42,20 @@ impl TmuxConnection {
         self.client_name.as_deref()
     }
 
+    /// Returns whether the attached tmux supports per-window `refresh-client`,
+    /// or `None` if the version query has not completed yet.
+    pub fn supports_per_window_refresh(&self) -> Option<bool> {
+        self.per_window_refresh
+    }
+
     /// Caches the control client name returned by the `display-message` query.
     pub(crate) fn set_client_name(&mut self, name: String) {
         self.client_name = Some(name);
+    }
+
+    /// Caches the per-window `refresh-client` capability derived from the tmux
+    /// version reply.
+    pub(crate) fn set_per_window_refresh(&mut self, supported: bool) {
+        self.per_window_refresh = Some(supported);
     }
 }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -115,6 +115,32 @@ pub fn resize_window_command(win: WindowId, cols: u16, rows: u16) -> String {
     format!("resize-window -x {cols} -y {rows} -t @{}", win.0)
 }
 
+/// Builds `display-message -p '#{version}'` — prints the tmux server version
+/// (e.g. `3.6a`) as a one-line command reply.
+pub fn version_command() -> String {
+    "display-message -p '#{version}'".to_string()
+}
+
+/// Returns whether `version` supports per-window `refresh-client -C @win:WxH`
+/// (tmux ≥ 3.4). Parses leniently: the leading `major.minor`, tolerating a
+/// `next-` prefix and a trailing letter suffix like `3.6a`.
+pub(crate) fn version_supports_per_window_refresh(version: &str) -> bool {
+    parse_major_minor(version).is_some_and(|mm| mm >= (3, 4))
+}
+
+fn parse_major_minor(version: &str) -> Option<(u32, u32)> {
+    let trimmed = version.trim().trim_start_matches(|c: char| !c.is_ascii_digit());
+    let mut parts = trimmed.split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor_digits: String = parts
+        .next()?
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    let minor: u32 = minor_digits.parse().ok()?;
+    Some((major, minor))
+}
+
 /// Builds `display-message -p '#{client_name}'` — prints the control
 /// client's name as a one-line command reply (correlated like `list-windows`).
 pub(crate) fn client_name_command() -> String {
@@ -384,6 +410,8 @@ pub(crate) struct EnumerationState {
     pub(crate) pending: Option<CommandId>,
     /// The id of the in-flight `display-message` client-name query, if any.
     pub(crate) client_name_pending: Option<CommandId>,
+    /// The id of the in-flight `display-message` version query, if any.
+    pub(crate) version_pending: Option<CommandId>,
     /// The id of the in-flight `display-message` active-pane query, if any.
     pub(crate) active_pane_pending: Option<CommandId>,
     /// The id of the in-flight `list-keys -T root` command, if any.
@@ -730,5 +758,20 @@ mod tests {
             resize_window_command(WindowId(2), 80, 24),
             "resize-window -x 80 -y 24 -t @2"
         );
+    }
+
+    #[test]
+    fn version_supports_per_window_refresh_is_lenient_about_suffixes() {
+        assert!(version_supports_per_window_refresh("3.6a"));
+        assert!(version_supports_per_window_refresh("3.4"));
+        assert!(version_supports_per_window_refresh("next-3.7"));
+        assert!(!version_supports_per_window_refresh("3.3"));
+        assert!(!version_supports_per_window_refresh("2.9"));
+        assert!(!version_supports_per_window_refresh("garbage"));
+    }
+
+    #[test]
+    fn version_command_has_expected_format() {
+        assert_eq!(version_command(), "display-message -p '#{version}'");
     }
 }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -25,14 +25,16 @@ pub struct WindowRow {
     pub name: String,
     /// tmux per-window flags (`#{window_raw_flags}`).
     pub flags: WindowFlags,
-    /// Parsed structural layout (panes + geometry).
+    /// Parsed structural layout (panes + geometry). Sourced from
+    /// `window_visible_layout` when non-empty; falls back to `window_layout`.
     pub layout: WindowLayout,
 }
 
 /// Parses the lines of a `list-windows -F LIST_WINDOWS_FORMAT` reply.
 ///
 /// Each line is `active \t id \t index \t layout \t visible_layout \t raw_flags \t name`.
-/// The `visible_layout` field is currently ignored. Blank lines are skipped.
+/// When `visible_layout` is non-empty it is used for `WindowRow.layout`; otherwise
+/// `layout` is the fallback. Blank lines are skipped.
 /// Returns a descriptive `Err(String)` on a malformed row.
 pub fn parse_window_rows(lines: &[String]) -> Result<Vec<WindowRow>, String> {
     let mut rows = Vec::new();
@@ -59,11 +61,16 @@ fn parse_row(line: &str) -> Result<WindowRow, String> {
     let layout_field = fields
         .next()
         .ok_or_else(|| format!("missing layout in row: {line}"))?;
-    let layout = WindowLayout::parse(layout_field.as_bytes())
-        .map_err(|e| format!("bad layout in row {line}: {e}"))?;
-    let _visible = fields
+    let visible_field = fields
         .next()
         .ok_or_else(|| format!("missing visible layout in row: {line}"))?;
+    let chosen = if visible_field.trim().is_empty() {
+        layout_field
+    } else {
+        visible_field
+    };
+    let layout = WindowLayout::parse(chosen.as_bytes())
+        .map_err(|e| format!("bad layout in row {line}: {e}"))?;
     let flags = WindowFlags::parse(
         fields
             .next()
@@ -705,6 +712,26 @@ mod tests {
             subscribe_window_flags_command(),
             format!("refresh-client -B {WINDOW_FLAGS_SUBSCRIPTION}:@*:#{{window_raw_flags}}")
         );
+    }
+
+    #[test]
+    fn parse_row_prefers_visible_layout_when_present() {
+        // field order: active id index window_layout window_visible_layout flags name
+        // window_layout = 80x24, visible_layout = 40x12; must adopt visible dims.
+        // The parser is lenient about checksum mismatches — 0000 is accepted for both.
+        let row = "1\t@1\t0\t0000,80x24,0,0,1\t0000,40x12,0,0,1\t*\tbash";
+        let parsed = parse_window_rows(&[row.to_string()]).expect("row parses");
+        let dims = parsed[0].layout.root.dims();
+        assert_eq!((dims.width, dims.height), (40, 12), "must use visible_layout");
+    }
+
+    #[test]
+    fn parse_row_falls_back_to_window_layout_when_visible_empty() {
+        // visible_layout field is empty — must fall back to window_layout (80x24).
+        let row = "1\t@1\t0\t0000,80x24,0,0,1\t\t*\tbash";
+        let parsed = parse_window_rows(&[row.to_string()]).expect("row parses");
+        let dims = parsed[0].layout.root.dims();
+        assert_eq!((dims.width, dims.height), (80, 24), "fallback to window_layout");
     }
 
     #[test]

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -136,7 +136,9 @@ pub(crate) fn version_supports_per_window_refresh(version: &str) -> bool {
 }
 
 fn parse_major_minor(version: &str) -> Option<(u32, u32)> {
-    let trimmed = version.trim().trim_start_matches(|c: char| !c.is_ascii_digit());
+    let trimmed = version
+        .trim()
+        .trim_start_matches(|c: char| !c.is_ascii_digit());
     let mut parts = trimmed.split('.');
     let major: u32 = parts.next()?.parse().ok()?;
     let minor_digits: String = parts
@@ -733,7 +735,11 @@ mod tests {
         let row = "1\t@1\t0\t0000,80x24,0,0,1\t0000,40x12,0,0,1\t*\tbash";
         let parsed = parse_window_rows(&[row.to_string()]).expect("row parses");
         let dims = parsed[0].layout.root.dims();
-        assert_eq!((dims.width, dims.height), (40, 12), "must use visible_layout");
+        assert_eq!(
+            (dims.width, dims.height),
+            (40, 12),
+            "must use visible_layout"
+        );
     }
 
     #[test]
@@ -742,7 +748,11 @@ mod tests {
         let row = "1\t@1\t0\t0000,80x24,0,0,1\t\t*\tbash";
         let parsed = parse_window_rows(&[row.to_string()]).expect("row parses");
         let dims = parsed[0].layout.root.dims();
-        assert_eq!((dims.width, dims.height), (80, 24), "fallback to window_layout");
+        assert_eq!(
+            (dims.width, dims.height),
+            (80, 24),
+            "fallback to window_layout"
+        );
     }
 
     #[test]

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -409,6 +409,13 @@ pub fn show_buffer_command() -> String {
     "show-buffer".to_string()
 }
 
+/// Builds `show-options -wqv -t @<win> aggressive-resize` — reads the per-window
+/// `aggressive-resize` option value (`on`/`off`/empty). `-q` suppresses errors,
+/// `-v` prints only the value.
+pub(crate) fn aggressive_resize_command(win: WindowId) -> String {
+    format!("show-options -wqv -t @{} aggressive-resize", win.0)
+}
+
 /// Tracks the in-flight `list-windows` enumeration command so its reply can
 /// be correlated by [`CommandId`] and seeded into the projection.
 #[derive(Resource, Default)]
@@ -433,6 +440,8 @@ pub(crate) struct EnumerationState {
     pub(crate) keys_copy_mode_vi_pending: Option<CommandId>,
     /// In-flight `#{mode-keys}` query, if any.
     pub(crate) mode_keys_pending: Option<CommandId>,
+    /// The id of the in-flight `aggressive-resize` option query, if any.
+    pub(crate) aggressive_resize_pending: Option<CommandId>,
     /// In-flight `capture-pane` commands → the pane each reply seeds.
     pub(crate) capture_pending: HashMap<CommandId, PaneId>,
     /// In-flight cursor-position `display-message` queries → the pane.
@@ -784,6 +793,14 @@ mod tests {
         assert_eq!(
             resize_window_command(WindowId(2), 80, 24),
             "resize-window -x 80 -y 24 -t @2"
+        );
+    }
+
+    #[test]
+    fn aggressive_resize_command_targets_window() {
+        assert_eq!(
+            aggressive_resize_command(WindowId(1)),
+            "show-options -wqv -t @1 aggressive-resize"
         );
     }
 

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -95,6 +95,26 @@ pub fn refresh_client_command(cols: u16, rows: u16) -> String {
     format!("refresh-client -C {cols},{rows}")
 }
 
+/// Builds `refresh-client -C @<win>:<cols>x<rows>` — declares this control
+/// client's size for one specific window (tmux ≥ 3.4). Unlike the global
+/// `refresh-client -C W,H`, this sizes a single window without affecting the
+/// client's other windows.
+pub fn window_refresh_client_command(win: WindowId, cols: u16, rows: u16) -> String {
+    format!("refresh-client -C @{}:{cols}x{rows}", win.0)
+}
+
+/// Builds `resize-window -x <cols> -y <rows> -t @<win>` — the tmux < 3.4
+/// fallback for per-window sizing.
+///
+/// # Invariants
+///
+/// tmux sets the session's `window-size` option to `manual` as a side effect
+/// of `resize-window`; only used when the per-window `refresh-client -C` form
+/// is unavailable.
+pub fn resize_window_command(win: WindowId, cols: u16, rows: u16) -> String {
+    format!("resize-window -x {cols} -y {rows} -t @{}", win.0)
+}
+
 /// Builds `display-message -p '#{client_name}'` — prints the control
 /// client's name as a one-line command reply (correlated like `list-windows`).
 pub(crate) fn client_name_command() -> String {
@@ -693,6 +713,22 @@ mod tests {
         assert_eq!(
             rename_session_command(SessionId(3), ""),
             "rename-session -t $3 -- ''"
+        );
+    }
+
+    #[test]
+    fn window_refresh_client_command_uses_per_window_form() {
+        assert_eq!(
+            window_refresh_client_command(WindowId(2), 80, 24),
+            "refresh-client -C @2:80x24"
+        );
+    }
+
+    #[test]
+    fn resize_window_command_targets_window() {
+        assert_eq!(
+            resize_window_command(WindowId(2), 80, 24),
+            "resize-window -x 80 -y 24 -t @2"
         );
     }
 }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -442,6 +442,8 @@ pub(crate) struct EnumerationState {
     pub(crate) mode_keys_pending: Option<CommandId>,
     /// The id of the in-flight `aggressive-resize` option query, if any.
     pub(crate) aggressive_resize_pending: Option<CommandId>,
+    /// Whether the one-time aggressive-resize option check has completed.
+    pub(crate) aggressive_resize_checked: bool,
     /// In-flight `capture-pane` commands → the pane each reply seeds.
     pub(crate) capture_pending: HashMap<CommandId, PaneId>,
     /// In-flight cursor-position `display-message` queries → the pane.

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -140,7 +140,7 @@ pub(crate) fn take_version(
 }
 
 /// Returns the `aggressive-resize` option value from a `CommandComplete` whose
-/// id matches `pending` (first non-empty trimmed output line), clearing `pending`.
+/// id matches `pending` (first non-empty trimmed output line), and clears `pending`.
 pub(crate) fn take_aggressive_resize(
     pending: &mut Option<CommandId>,
     events: &[TransportEvent],

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -139,6 +139,15 @@ pub(crate) fn take_version(
     take_reply_line(pending, events, "version")
 }
 
+/// Returns the `aggressive-resize` option value from a `CommandComplete` whose
+/// id matches `pending` (first non-empty trimmed output line), clearing `pending`.
+pub(crate) fn take_aggressive_resize(
+    pending: &mut Option<CommandId>,
+    events: &[TransportEvent],
+) -> Option<String> {
+    take_reply_line(pending, events, "aggressive-resize")
+}
+
 /// Drains matching `capture-pane` replies from `events`.
 ///
 /// For every `CommandComplete` whose id is in `capture_pending`:

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -87,16 +87,13 @@ pub(crate) fn trigger_events(
     }
 }
 
-/// Returns the client name from a `CommandComplete` whose id matches
-/// `pending` (first non-empty trimmed output line), and clears `pending`.
-///
-/// Iterates `events` and looks for `CommandComplete { ok: true, .. }` whose
-/// id equals `*pending`. On a match the first non-empty trimmed output line is
-/// returned and `*pending` is set to `None`. Returns `None` when no matching
-/// event exists in the batch or the output is blank.
-pub(crate) fn take_client_name(
+/// Returns the first non-empty trimmed output line of the `CommandComplete`
+/// whose id matches `pending`, clearing `pending`. `what` labels the warning
+/// logged when the command failed.
+fn take_reply_line(
     pending: &mut Option<CommandId>,
     events: &[TransportEvent],
+    what: &str,
 ) -> Option<String> {
     for event in events {
         if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
@@ -109,13 +106,35 @@ pub(crate) fn take_client_name(
                     .map(|line| line.trim())
                     .find(|line| !line.is_empty())
                     .map(str::to_owned);
-            } else {
-                tracing::warn!("client-name query command failed");
-                return None;
             }
+            tracing::warn!("{what} query command failed");
+            return None;
         }
     }
     None
+}
+
+/// Returns the client name from a `CommandComplete` whose id matches
+/// `pending` (first non-empty trimmed output line), and clears `pending`.
+///
+/// Iterates `events` and looks for `CommandComplete { ok: true, .. }` whose
+/// id equals `*pending`. On a match the first non-empty trimmed output line is
+/// returned and `*pending` is set to `None`. Returns `None` when no matching
+/// event exists in the batch or the output is blank.
+pub(crate) fn take_client_name(
+    pending: &mut Option<CommandId>,
+    events: &[TransportEvent],
+) -> Option<String> {
+    take_reply_line(pending, events, "client-name")
+}
+
+/// Returns the tmux server version from a `CommandComplete` whose id matches
+/// `pending` (first non-empty trimmed output line), and clears `pending`.
+pub(crate) fn take_version(
+    pending: &mut Option<CommandId>,
+    events: &[TransportEvent],
+) -> Option<String> {
+    take_reply_line(pending, events, "version")
 }
 
 /// Drains matching `capture-pane` replies from `events`.
@@ -665,6 +684,20 @@ mod tests {
         let mut pending = Some(CommandId(7));
         assert_eq!(take_client_name(&mut pending, &events), None);
         assert_eq!(pending, Some(CommandId(7)));
+    }
+
+    #[test]
+    fn take_version_extracts_first_line() {
+        let id = CommandId(7);
+        let mut pending = Some(id);
+        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id,
+            number: 0,
+            ok: true,
+            output: vec!["3.6a".to_string()],
+        })];
+        assert_eq!(take_version(&mut pending, &events), Some("3.6a".to_string()));
+        assert_eq!(pending, None);
     }
 
     #[test]

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -62,15 +62,17 @@ pub(crate) fn advance_state(
 /// `TmuxWindowAdded` + `TmuxLayoutChanged` (+ `TmuxActiveWindowChanged` for the
 /// active row), followed by one `TmuxWindowsRetained` prune. Untracked events
 /// (e.g. `%output`) are ignored here (routed separately as `PaneOutput`).
+/// `own_client` gates `%client-session-changed` — see [`detect_session_switch`].
 pub(crate) fn trigger_events(
     commands: &mut Commands,
     pending: &mut Option<CommandId>,
     events: &[TransportEvent],
+    own_client: Option<&str>,
 ) {
     for event in events {
         match event {
             TransportEvent::Protocol(ClientEvent::Notification(notification)) => {
-                trigger_notification(commands, notification);
+                trigger_notification(commands, own_client, notification);
             }
             TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. })
                 if *pending == Some(*id) =>
@@ -344,6 +346,12 @@ pub(crate) fn take_mode_keys(
 /// first attach (`current == None`) or when the id is unchanged, so the initial
 /// enumeration is not duplicated and only an actual switch triggers a rebuild.
 ///
+/// `%session-changed` and `%session-renamed` are always treated as a switch.
+/// `%client-session-changed` is only treated as a switch when its `client`
+/// field equals `own_client`; if `own_client` is `None` (not yet known),
+/// `%client-session-changed` is ignored to avoid spurious teardown from
+/// foreign-client events arriving before the own client name is resolved.
+///
 /// The switch decision lives here (driven from the per-frame drain) rather than
 /// in the `on_session_changed` observer, because the teardown + re-enumeration
 /// it triggers need the event batch and the live `NonSend` client, which an
@@ -351,14 +359,23 @@ pub(crate) fn take_mode_keys(
 pub(crate) fn detect_session_switch(
     events: &[TransportEvent],
     current: Option<SessionId>,
+    own_client: Option<&str>,
 ) -> Option<SessionId> {
     let current = current?;
     for event in events {
         let next = match event {
             TransportEvent::Protocol(ClientEvent::Notification(
-                ControlEvent::SessionChanged { session, .. }
-                | ControlEvent::ClientSessionChanged { session, .. },
+                ControlEvent::SessionChanged { session, .. },
             )) => *session,
+            TransportEvent::Protocol(ClientEvent::Notification(
+                ControlEvent::ClientSessionChanged { client, session, .. },
+            )) => {
+                if own_client == Some(client.as_str()) {
+                    *session
+                } else {
+                    continue;
+                }
+            }
             _ => continue,
         };
         if next != current {
@@ -412,11 +429,17 @@ fn parse_active_pane(line: &str) -> Option<(WindowId, PaneId)> {
     Some((WindowId(window), PaneId(pane)))
 }
 
-fn trigger_notification(commands: &mut Commands, event: &ControlEvent) {
+fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event: &ControlEvent) {
     match event {
-        ControlEvent::SessionChanged { session, name }
-        | ControlEvent::ClientSessionChanged { session, name, .. }
-        | ControlEvent::SessionRenamed { session, name } => {
+        ControlEvent::SessionChanged { session, name } | ControlEvent::SessionRenamed { session, name } => {
+            commands.trigger(TmuxSessionChanged {
+                session: *session,
+                name: name.clone(),
+            });
+        }
+        ControlEvent::ClientSessionChanged { client, session, name }
+            if own_client == Some(client.as_str()) =>
+        {
             commands.trigger(TmuxSessionChanged {
                 session: *session,
                 name: name.clone(),
@@ -518,7 +541,7 @@ mod tests {
     use bevy::prelude::*;
     use crossbeam_channel::unbounded;
     use tmux_control::{CommandId, ControlEvent};
-    use tmux_control_parser::WindowId;
+    use tmux_control_parser::{SessionId, WindowId};
 
     fn window_add(id: u32) -> TransportEvent {
         TransportEvent::Protocol(ClientEvent::Notification(ControlEvent::WindowAdd {
@@ -728,7 +751,7 @@ mod tests {
         struct Batch(Vec<TransportEvent>);
 
         fn run(mut commands: Commands, mut pending: ResMut<EnumerationState>, batch: Res<Batch>) {
-            trigger_events(&mut commands, &mut pending.pending, &batch.0);
+            trigger_events(&mut commands, &mut pending.pending, &batch.0, Some("main"));
         }
 
         let mut app = App::new();
@@ -751,6 +774,57 @@ mod tests {
         assert_eq!(*seen.0.lock().unwrap(), vec![(9, "beta".to_string())]);
     }
 
+    fn client_session_changed(client: &str, session: SessionId) -> TransportEvent {
+        TransportEvent::Protocol(ClientEvent::Notification(ControlEvent::ClientSessionChanged {
+            client: client.to_string(),
+            session,
+            name: "s".to_string(),
+        }))
+    }
+
+    fn session_changed(session: SessionId) -> TransportEvent {
+        TransportEvent::Protocol(ClientEvent::Notification(ControlEvent::SessionChanged {
+            session,
+            name: "s".to_string(),
+        }))
+    }
+
+    #[test]
+    fn foreign_client_session_changed_is_ignored() {
+        let events = vec![client_session_changed("other-client", SessionId(9))];
+        assert_eq!(
+            detect_session_switch(&events, Some(SessionId(1)), Some("ozmux-0")),
+            None
+        );
+    }
+
+    #[test]
+    fn own_client_session_changed_is_a_switch() {
+        let events = vec![client_session_changed("ozmux-0", SessionId(9))];
+        assert_eq!(
+            detect_session_switch(&events, Some(SessionId(1)), Some("ozmux-0")),
+            Some(SessionId(9))
+        );
+    }
+
+    #[test]
+    fn client_session_changed_ignored_when_own_name_unknown() {
+        let events = vec![client_session_changed("ozmux-0", SessionId(9))];
+        assert_eq!(
+            detect_session_switch(&events, Some(SessionId(1)), None),
+            None
+        );
+    }
+
+    #[test]
+    fn plain_session_changed_is_a_switch_regardless_of_name() {
+        let events = vec![session_changed(SessionId(9))];
+        assert_eq!(
+            detect_session_switch(&events, Some(SessionId(1)), None),
+            Some(SessionId(9))
+        );
+    }
+
     #[test]
     fn detect_session_switch_reports_new_id_only_on_change() {
         use tmux_control_parser::SessionId;
@@ -760,13 +834,16 @@ mod tests {
                 name: "b".to_string(),
             },
         ))];
-        assert_eq!(detect_session_switch(&changed, None), None);
-        assert_eq!(detect_session_switch(&changed, Some(SessionId(2))), None);
+        assert_eq!(detect_session_switch(&changed, None, None), None);
         assert_eq!(
-            detect_session_switch(&changed, Some(SessionId(1))),
+            detect_session_switch(&changed, Some(SessionId(2)), None),
+            None
+        );
+        assert_eq!(
+            detect_session_switch(&changed, Some(SessionId(1)), None),
             Some(SessionId(2))
         );
-        assert_eq!(detect_session_switch(&[], Some(SessionId(1))), None);
+        assert_eq!(detect_session_switch(&[], Some(SessionId(1)), None), None);
 
         let client_changed = vec![TransportEvent::Protocol(ClientEvent::Notification(
             ControlEvent::ClientSessionChanged {
@@ -776,11 +853,11 @@ mod tests {
             },
         ))];
         assert_eq!(
-            detect_session_switch(&client_changed, Some(SessionId(1))),
+            detect_session_switch(&client_changed, Some(SessionId(1)), Some("main")),
             Some(SessionId(3))
         );
         assert_eq!(
-            detect_session_switch(&client_changed, Some(SessionId(3))),
+            detect_session_switch(&client_changed, Some(SessionId(3)), Some("main")),
             None
         );
     }
@@ -843,6 +920,7 @@ mod tests {
         app.add_systems(Update, |mut commands: Commands| {
             trigger_notification(
                 &mut commands,
+                None,
                 &ControlEvent::UnlinkedWindowClose {
                     window: WindowId(3),
                 },
@@ -869,7 +947,7 @@ mod tests {
             mut enumeration: ResMut<EnumerationState>,
             batch: Res<Batch>,
         ) {
-            trigger_events(&mut commands, &mut enumeration.pending, &batch.0);
+            trigger_events(&mut commands, &mut enumeration.pending, &batch.0, None);
         }
 
         let mut app = App::new();
@@ -998,6 +1076,7 @@ mod tests {
         app.add_systems(Update, |mut commands: Commands| {
             trigger_notification(
                 &mut commands,
+                None,
                 &ControlEvent::SessionRenamed {
                     session: SessionId(1),
                     name: "renamed".to_string(),
@@ -1028,7 +1107,7 @@ mod tests {
         struct Batch(Vec<TransportEvent>);
 
         fn run(mut commands: Commands, mut pending: ResMut<EnumerationState>, batch: Res<Batch>) {
-            trigger_events(&mut commands, &mut pending.pending, &batch.0);
+            trigger_events(&mut commands, &mut pending.pending, &batch.0, None);
         }
 
         let line = format!("%subscription-changed {WINDOW_FLAGS_SUBSCRIPTION} $1 @2 0 - : *Z");

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -461,10 +461,10 @@ fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event
                 name: name.clone(),
             });
         }
-        ControlEvent::LayoutChange { window, layout, .. } => {
+        ControlEvent::LayoutChange { window, visible_layout, .. } => {
             commands.trigger(TmuxLayoutChanged {
                 window: *window,
-                layout: layout.clone(),
+                layout: visible_layout.clone(),
             });
         }
         ControlEvent::WindowPaneChanged { window, pane } => {
@@ -959,7 +959,7 @@ mod tests {
                 id: CommandId(1),
                 number: 0,
                 ok: true,
-                output: vec!["1\t@1\t0\tabcd,80x24,0,0,5\tx\t\tmain".to_string()],
+                output: vec!["1\t@1\t0\tabcd,80x24,0,0,5\t0000,80x24,0,0,5\t\tmain".to_string()],
             },
         )]));
         app.add_observer(|ev: On<TmuxWindowAdded>, log: Res<Log>| {

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -373,11 +373,14 @@ pub(crate) fn detect_session_switch(
     let current = current?;
     for event in events {
         let next = match event {
+            TransportEvent::Protocol(ClientEvent::Notification(ControlEvent::SessionChanged {
+                session,
+                ..
+            })) => *session,
             TransportEvent::Protocol(ClientEvent::Notification(
-                ControlEvent::SessionChanged { session, .. },
-            )) => *session,
-            TransportEvent::Protocol(ClientEvent::Notification(
-                ControlEvent::ClientSessionChanged { client, session, .. },
+                ControlEvent::ClientSessionChanged {
+                    client, session, ..
+                },
             )) => {
                 if own_client == Some(client.as_str()) {
                     *session
@@ -440,15 +443,18 @@ fn parse_active_pane(line: &str) -> Option<(WindowId, PaneId)> {
 
 fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event: &ControlEvent) {
     match event {
-        ControlEvent::SessionChanged { session, name } | ControlEvent::SessionRenamed { session, name } => {
+        ControlEvent::SessionChanged { session, name }
+        | ControlEvent::SessionRenamed { session, name } => {
             commands.trigger(TmuxSessionChanged {
                 session: *session,
                 name: name.clone(),
             });
         }
-        ControlEvent::ClientSessionChanged { client, session, name }
-            if own_client == Some(client.as_str()) =>
-        {
+        ControlEvent::ClientSessionChanged {
+            client,
+            session,
+            name,
+        } if own_client == Some(client.as_str()) => {
             commands.trigger(TmuxSessionChanged {
                 session: *session,
                 name: name.clone(),
@@ -470,7 +476,11 @@ fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event
                 name: name.clone(),
             });
         }
-        ControlEvent::LayoutChange { window, visible_layout, .. } => {
+        ControlEvent::LayoutChange {
+            window,
+            visible_layout,
+            ..
+        } => {
             commands.trigger(TmuxLayoutChanged {
                 window: *window,
                 layout: visible_layout.clone(),
@@ -728,7 +738,10 @@ mod tests {
             ok: true,
             output: vec!["3.6a".to_string()],
         })];
-        assert_eq!(take_version(&mut pending, &events), Some("3.6a".to_string()));
+        assert_eq!(
+            take_version(&mut pending, &events),
+            Some("3.6a".to_string())
+        );
         assert_eq!(pending, None);
     }
 
@@ -784,11 +797,13 @@ mod tests {
     }
 
     fn client_session_changed(client: &str, session: SessionId) -> TransportEvent {
-        TransportEvent::Protocol(ClientEvent::Notification(ControlEvent::ClientSessionChanged {
-            client: client.to_string(),
-            session,
-            name: "s".to_string(),
-        }))
+        TransportEvent::Protocol(ClientEvent::Notification(
+            ControlEvent::ClientSessionChanged {
+                client: client.to_string(),
+                session,
+                name: "s".to_string(),
+            },
+        ))
     }
 
     fn session_changed(session: SessionId) -> TransportEvent {

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -32,7 +32,7 @@ pub use enumerate::{
     refresh_client_command, rename_session_command, rename_window_command, resize_pane_x_command,
     resize_pane_y_command, resize_window_command, select_pane_command, select_window_command,
     set_environment_command, set_environment_in_session_command, show_buffer_command,
-    switch_client_command, window_refresh_client_command,
+    switch_client_command, version_command, window_refresh_client_command,
 };
 pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
 pub use keybindings::{

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -30,8 +30,9 @@ pub use enumerate::{
     CopyState, LIST_WINDOWS_FORMAT, WindowRow, absolute_to_visible_row, copy_mode_capture_command,
     copy_state_query_command, parse_copy_state, parse_window_rows, prompt_command,
     refresh_client_command, rename_session_command, rename_window_command, resize_pane_x_command,
-    resize_pane_y_command, select_pane_command, select_window_command, set_environment_command,
-    set_environment_in_session_command, show_buffer_command, switch_client_command,
+    resize_pane_y_command, resize_window_command, select_pane_command, select_window_command,
+    set_environment_command, set_environment_in_session_command, show_buffer_command,
+    switch_client_command, window_refresh_client_command,
 };
 pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
 pub use keybindings::{

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -5,14 +5,15 @@ use crate::components::{TmuxPane, TmuxSession};
 use crate::connection::TmuxConnection;
 use crate::copy_queries::{CopyModeQueries, CopyModeReply, drain_copy_replies};
 use crate::enumerate::{
-    EnumerationState, active_pane_command, capture_pane_command, client_name_command,
-    cursor_query_command, list_windows_command, mode_keys_command, subscribe_window_flags_command,
-    version_command, version_supports_per_window_refresh,
+    EnumerationState, active_pane_command, aggressive_resize_command, capture_pane_command,
+    client_name_command, cursor_query_command, list_windows_command, mode_keys_command,
+    subscribe_window_flags_command, version_command, version_supports_per_window_refresh,
 };
 use crate::event_pump::{
     advance_state, detect_session_switch, detect_window_added, detect_window_switch,
-    drain_transport, take_active_pane, take_client_name, take_cursor_positions, take_keybindings,
-    take_mode_keys, take_pane_captures, take_prefix_keys, take_version, trigger_events,
+    drain_transport, take_active_pane, take_aggressive_resize, take_client_name,
+    take_cursor_positions, take_keybindings, take_mode_keys, take_pane_captures, take_prefix_keys,
+    take_version, trigger_events,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxConnectionReset, TmuxWindowsRetained};
 use crate::keybindings::{KeyBindings, list_keys_command, prefix_options_command};
@@ -216,6 +217,22 @@ fn drain_tmux_events(
             take_active_pane(&mut enumeration.active_pane_pending, &events)
         {
             commands.trigger(TmuxActivePaneChanged { window, pane });
+            if enumeration.aggressive_resize_pending.is_none()
+                && let Some(client) = connection.client()
+            {
+                match client.handle().send(&aggressive_resize_command(window)) {
+                    Ok(id) => enumeration.aggressive_resize_pending = Some(id),
+                    Err(error) => tracing::warn!(?error, "failed to query aggressive-resize"),
+                }
+            }
+        }
+        if let Some(value) = take_aggressive_resize(&mut enumeration.aggressive_resize_pending, &events)
+            && value.trim() == "on"
+        {
+            tracing::warn!(
+                "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
+                 windows may resize unexpectedly"
+            );
         }
         // NOTE: deref once so the borrow checker can see these as distinct
         // field borrows rather than overlapping borrows through DerefMut.

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -129,7 +129,7 @@ fn drain_tmux_events(
         .session
         .and_then(|e| sessions.get(e).ok())
         .map(|s| s.id);
-    if detect_session_switch(&events, current_session).is_some()
+    if detect_session_switch(&events, current_session, connection.client_name()).is_some()
         && let Some(client) = connection.client()
     {
         commands.trigger(TmuxWindowsRetained {
@@ -264,7 +264,7 @@ fn drain_tmux_events(
         for reply in drain_copy_replies(&mut copy_queries, &events) {
             copy_replies.write(reply);
         }
-        trigger_events(&mut commands, &mut enumeration.pending, &events);
+        trigger_events(&mut commands, &mut enumeration.pending, &events, connection.client_name());
     }
     // NOTE: runs after the Closed branch took the connection, so `client()` is
     // None there and this is a no-op — safe to re-arm only while still attached.

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -217,7 +217,8 @@ fn drain_tmux_events(
             take_active_pane(&mut enumeration.active_pane_pending, &events)
         {
             commands.trigger(TmuxActivePaneChanged { window, pane });
-            if enumeration.aggressive_resize_pending.is_none()
+            if !enumeration.aggressive_resize_checked
+                && enumeration.aggressive_resize_pending.is_none()
                 && let Some(client) = connection.client()
             {
                 match client.handle().send(&aggressive_resize_command(window)) {
@@ -226,13 +227,16 @@ fn drain_tmux_events(
                 }
             }
         }
-        if let Some(value) = take_aggressive_resize(&mut enumeration.aggressive_resize_pending, &events)
-            && value.trim() == "on"
+        if let Some(value) =
+            take_aggressive_resize(&mut enumeration.aggressive_resize_pending, &events)
         {
-            tracing::warn!(
-                "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
-                 windows may resize unexpectedly"
-            );
+            enumeration.aggressive_resize_checked = true;
+            if value.trim() == "on" {
+                tracing::warn!(
+                    "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
+                     windows may resize unexpectedly"
+                );
+            }
         }
         // NOTE: deref once so the borrow checker can see these as distinct
         // field borrows rather than overlapping borrows through DerefMut.

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -285,7 +285,12 @@ fn drain_tmux_events(
         for reply in drain_copy_replies(&mut copy_queries, &events) {
             copy_replies.write(reply);
         }
-        trigger_events(&mut commands, &mut enumeration.pending, &events, connection.client_name());
+        trigger_events(
+            &mut commands,
+            &mut enumeration.pending,
+            &events,
+            connection.client_name(),
+        );
     }
     // NOTE: runs after the Closed branch took the connection, so `client()` is
     // None there and this is a no-op — safe to re-arm only while still attached.

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -140,6 +140,11 @@ fn drain_tmux_events(
         enumeration.cursor_pending.clear();
         enumeration.panes_with_cursor_pending.clear();
         enumeration.capture_awaiting_cursor.clear();
+        // NOTE: aggressive-resize is a per-window option, so the switched-to
+        // session must be re-checked — clear the one-shot guard or its `on`
+        // setting would go undetected after a switch.
+        enumeration.aggressive_resize_checked = false;
+        enumeration.aggressive_resize_pending = None;
         send_session_enumeration(&mut enumeration, client);
     } else if let Some(client) = connection.client() {
         if detect_window_added(&events) {

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -7,11 +7,12 @@ use crate::copy_queries::{CopyModeQueries, CopyModeReply, drain_copy_replies};
 use crate::enumerate::{
     EnumerationState, active_pane_command, capture_pane_command, client_name_command,
     cursor_query_command, list_windows_command, mode_keys_command, subscribe_window_flags_command,
+    version_command, version_supports_per_window_refresh,
 };
 use crate::event_pump::{
     advance_state, detect_session_switch, detect_window_added, detect_window_switch,
     drain_transport, take_active_pane, take_client_name, take_cursor_positions, take_keybindings,
-    take_mode_keys, take_pane_captures, take_prefix_keys, trigger_events,
+    take_mode_keys, take_pane_captures, take_prefix_keys, take_version, trigger_events,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxConnectionReset, TmuxWindowsRetained};
 use crate::keybindings::{KeyBindings, list_keys_command, prefix_options_command};
@@ -189,6 +190,10 @@ fn drain_tmux_events(
                 Ok(id) => enumeration.mode_keys_pending = Some(id),
                 Err(error) => tracing::warn!(?error, "failed to send mode-keys query"),
             }
+            match client.handle().send(&version_command()) {
+                Ok(id) => enumeration.version_pending = Some(id),
+                Err(error) => tracing::warn!(?error, "failed to send version query"),
+            }
         }
     }
     if events
@@ -203,6 +208,9 @@ fn drain_tmux_events(
     } else {
         if let Some(name) = take_client_name(&mut enumeration.client_name_pending, &events) {
             connection.set_client_name(name);
+        }
+        if let Some(version) = take_version(&mut enumeration.version_pending, &events) {
+            connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
         }
         if let Some((window, pane)) =
             take_active_pane(&mut enumeration.active_pane_pending, &events)

--- a/crates/tmux_session/tests/real_tmux_multiclient.rs
+++ b/crates/tmux_session/tests/real_tmux_multiclient.rs
@@ -228,7 +228,7 @@ fn foreign_shrink_observes_clamp() {
     assert!(
         observed_shrink,
         "the projected pane height must update after resize-window \
-         (expected height change via %%layout-change); \
+         (expected height change via %layout-change); \
          baseline={baseline_height} shrunk_target={shrunk_height} final={final_height}"
     );
     // tmux's `window-size latest` semantics clamp to the smallest connected

--- a/crates/tmux_session/tests/real_tmux_multiclient.rs
+++ b/crates/tmux_session/tests/real_tmux_multiclient.rs
@@ -108,8 +108,6 @@ fn max_pane_height(app: &mut App) -> Option<u32> {
         .max()
 }
 
-// ─── Test 1: foreign session creation does not tear down ozmux's projection ──
-
 /// A second tmux session on the same server must NOT cause ozmux to tear down
 /// its window/pane projection.
 ///
@@ -142,15 +140,13 @@ fn foreign_session_change_keeps_projection() {
         .unwrap()
         .handle();
 
-    // Create a second session on the same tmux server (detached, so it does not
-    // take over the control connection).  tmux will emit a `%session-created`
-    // and, if any other client were attached, `%client-session-changed` for
-    // those clients.  The ozmux control connection itself is NOT switched.
+    // NOTE: `-d` keeps the foreign session detached so it does not take over the
+    // control connection; the ozmux client is never switched, so any teardown
+    // observed below would be a spurious foreign-event regression.
     handle
         .send("new-session -d -s ozmux-mc-foreign")
         .expect("new-session -d -s foreign");
 
-    // Pump for 2 s to let any spurious teardown propagate.
     let _ = pump_until(&mut app, 2, |_| false);
 
     let post_windows = window_count(&mut app);
@@ -169,8 +165,6 @@ fn foreign_session_change_keeps_projection() {
          created; baseline={baseline_panes} after={post_panes}"
     );
 }
-
-// ─── Test 2: resize-window shrink is observed via %layout-change ───────────
 
 /// Drives `resize-window -y N -t @<active>` and asserts that the projected pane
 /// height updates via the resulting `%layout-change`.
@@ -194,13 +188,11 @@ fn foreign_session_change_keeps_projection() {
 fn foreign_shrink_observes_clamp() {
     let mut app = attach_and_wait("shrink");
 
-    // Let the projection settle before taking the baseline height.
     let _ = pump_until(&mut app, 1, |_| false);
 
     let baseline_height = max_pane_height(&mut app).expect("a projected pane with height");
     let win_id = active_window_id(&mut app).expect("an active window");
 
-    // Shrink the active window to a height well below the baseline.
     let shrunk_height: u32 = 8;
     assert!(
         baseline_height > shrunk_height,
@@ -221,11 +213,13 @@ fn foreign_shrink_observes_clamp() {
         ))
         .expect("resize-window");
 
-    // Pump until the projected pane height reflects the shrink.
+    // Pump until the projected pane height drops STRICTLY below the baseline.
     // tmux emits a `%layout-change` after `resize-window`; the projection should
-    // update within a few seconds.
+    // update within a few seconds. The strict `<` is load-bearing: `<=` is true
+    // at the baseline before any `%layout-change` lands, so it would return on
+    // the first iteration and pass even if the projection never updated.
     let observed_shrink = pump_until(&mut app, 5, |app| {
-        max_pane_height(app).is_some_and(|h| h <= baseline_height)
+        max_pane_height(app).is_some_and(|h| h < baseline_height)
     });
 
     let final_height = max_pane_height(&mut app).unwrap_or(0);

--- a/crates/tmux_session/tests/real_tmux_multiclient.rs
+++ b/crates/tmux_session/tests/real_tmux_multiclient.rs
@@ -1,0 +1,248 @@
+//! Gated end-to-end multi-client tests against a real tmux `-CC`.
+//!
+//! **What is testable headlessly** (i.e. with `TmuxSessionPlugin` only, no GUI
+//! window):
+//!
+//! 1. `foreign_session_change_keeps_projection` — a second tmux session is
+//!    created on the same server while ozmux is attached to the first.  ozmux's
+//!    window/pane projection for *its own* session must survive unaffected (no
+//!    spurious teardown from the `%client-session-changed` / `%window-add`
+//!    notifications emitted for the foreign session).  This directly validates
+//!    the Component 2 teardown fix: `detect_session_switch` ignores
+//!    `%client-session-changed` events whose `client` field does not match
+//!    ozmux's own client name, so the projection is never torn down.
+//!
+//! 2. `foreign_shrink_observes_clamp` — `resize-window -y N -t @<active>` is
+//!    issued over the control connection.  The test asserts only what is
+//!    REAL-TMUX-OBSERVABLE via `%layout-change`: that the projected pane height
+//!    updates to reflect the clamped geometry.  ozmux's GUI-side recovery
+//!    (`sync_client_size`, registered by `OzmuxTmuxRenderPlugin` in the binary
+//!    crate, which requires a `PrimaryWindow`) is **not exercisable** in a
+//!    headless `TmuxSessionPlugin`-only app.  That recovery path is verified by
+//!    the manual GUI smoke test documented in the plan checklist.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p ozmux_tmux --test real_tmux_multiclient -- --ignored --test-threads=1
+//! ```
+
+use bevy::prelude::*;
+use ozmux_tmux::{
+    ActiveWindow, ConnectionState, TmuxConnection, TmuxPane, TmuxSessionPlugin, TmuxWindow,
+    WindowId,
+};
+use std::time::{Duration, Instant};
+use tmux_control::TmuxServer;
+
+fn pump_until(app: &mut App, secs: u64, mut done: impl FnMut(&mut App) -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        app.update();
+        if done(app) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+fn teardown(app: &mut App) {
+    if let Some(client) = app
+        .world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .unwrap()
+        .take()
+    {
+        client.handle().send("kill-server").ok();
+    }
+}
+
+fn attach_and_wait(tag: &str) -> App {
+    let socket = format!("ozmux-mc-{}-{}", std::process::id(), tag);
+    let server = TmuxServer::new().socket_name(&socket);
+    let client = server.new_session().expect("spawn tmux -CC new-session");
+
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    app.world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .expect("TmuxConnection inserted by the plugin")
+        .set(client);
+
+    let mut pane_q = app.world_mut().query::<&TmuxPane>();
+    let ready = pump_until(&mut app, 5, |app| {
+        *app.world().resource::<ConnectionState>() == ConnectionState::Attached
+            && pane_q.iter(app.world()).next().is_some()
+    });
+    assert!(ready, "tmux should attach and project a pane within 5 s");
+    app
+}
+
+fn window_count(app: &mut App) -> usize {
+    app.world_mut()
+        .query::<&TmuxWindow>()
+        .iter(app.world())
+        .count()
+}
+
+fn pane_count(app: &mut App) -> usize {
+    app.world_mut()
+        .query::<&TmuxPane>()
+        .iter(app.world())
+        .count()
+}
+
+fn active_window_id(app: &mut App) -> Option<WindowId> {
+    app.world_mut()
+        .query_filtered::<&TmuxWindow, With<ActiveWindow>>()
+        .iter(app.world())
+        .next()
+        .map(|w| w.id)
+}
+
+fn max_pane_height(app: &mut App) -> Option<u32> {
+    app.world_mut()
+        .query::<&TmuxPane>()
+        .iter(app.world())
+        .map(|p| p.dims.height)
+        .max()
+}
+
+// ─── Test 1: foreign session creation does not tear down ozmux's projection ──
+
+/// A second tmux session on the same server must NOT cause ozmux to tear down
+/// its window/pane projection.
+///
+/// The fix under test is in `detect_session_switch` / `trigger_notification`:
+/// `%client-session-changed` events are ignored unless their `client` field
+/// matches ozmux's own client name.  Before the fix a foreign
+/// `%client-session-changed` could look like a self-switch and cause a full
+/// projection teardown, resulting in a black screen.
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn foreign_session_change_keeps_projection() {
+    let mut app = attach_and_wait("sess");
+
+    let baseline_windows = window_count(&mut app);
+    let baseline_panes = pane_count(&mut app);
+    assert!(
+        baseline_windows >= 1,
+        "must have at least one projected window after attach; got {baseline_windows}"
+    );
+    assert!(
+        baseline_panes >= 1,
+        "must have at least one projected pane after attach; got {baseline_panes}"
+    );
+
+    let handle = app
+        .world()
+        .get_non_send_resource::<TmuxConnection>()
+        .unwrap()
+        .client()
+        .unwrap()
+        .handle();
+
+    // Create a second session on the same tmux server (detached, so it does not
+    // take over the control connection).  tmux will emit a `%session-created`
+    // and, if any other client were attached, `%client-session-changed` for
+    // those clients.  The ozmux control connection itself is NOT switched.
+    handle
+        .send("new-session -d -s ozmux-mc-foreign")
+        .expect("new-session -d -s foreign");
+
+    // Pump for 2 s to let any spurious teardown propagate.
+    let _ = pump_until(&mut app, 2, |_| false);
+
+    let post_windows = window_count(&mut app);
+    let post_panes = pane_count(&mut app);
+
+    teardown(&mut app);
+
+    assert!(
+        post_windows >= baseline_windows,
+        "ozmux's window projection must not be torn down by a foreign session being \
+         created; baseline={baseline_windows} after={post_windows}"
+    );
+    assert!(
+        post_panes >= baseline_panes,
+        "ozmux's pane projection must not be torn down by a foreign session being \
+         created; baseline={baseline_panes} after={post_panes}"
+    );
+}
+
+// ─── Test 2: resize-window shrink is observed via %layout-change ───────────
+
+/// Drives `resize-window -y N -t @<active>` and asserts that the projected pane
+/// height updates via the resulting `%layout-change`.
+///
+/// This validates that ozmux correctly handles `%layout-change` from an
+/// adversarial resize (as would arrive from a foreign smaller client holding the
+/// `latest` window-size slot).  The test observes ONLY what is
+/// real-tmux-observable headlessly: that the projection reflects the clamped
+/// geometry after the resize.
+///
+/// # Note on GUI-side recovery
+///
+/// ozmux's `sync_client_size` system (registered by `OzmuxTmuxRenderPlugin` in
+/// the binary crate) re-pins the active window back to the ozmux terminal size
+/// after such a shrink.  That system requires a `PrimaryWindow` resource that a
+/// headless `TmuxSessionPlugin`-only app does not have.  GUI-side recovery is
+/// verified by the manual smoke test in the plan checklist (run `cargo run`, attach
+/// a small foreign terminal, observe no black screen and size recovery).
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn foreign_shrink_observes_clamp() {
+    let mut app = attach_and_wait("shrink");
+
+    // Let the projection settle before taking the baseline height.
+    let _ = pump_until(&mut app, 1, |_| false);
+
+    let baseline_height = max_pane_height(&mut app).expect("a projected pane with height");
+    let win_id = active_window_id(&mut app).expect("an active window");
+
+    // Shrink the active window to a height well below the baseline.
+    let shrunk_height: u32 = 8;
+    assert!(
+        baseline_height > shrunk_height,
+        "baseline height {baseline_height} must exceed the shrink target {shrunk_height}"
+    );
+
+    let handle = app
+        .world()
+        .get_non_send_resource::<TmuxConnection>()
+        .unwrap()
+        .client()
+        .unwrap()
+        .handle();
+    handle
+        .send(&format!(
+            "resize-window -y {shrunk_height} -t @{}",
+            win_id.0
+        ))
+        .expect("resize-window");
+
+    // Pump until the projected pane height reflects the shrink.
+    // tmux emits a `%layout-change` after `resize-window`; the projection should
+    // update within a few seconds.
+    let observed_shrink = pump_until(&mut app, 5, |app| {
+        max_pane_height(app).is_some_and(|h| h <= baseline_height)
+    });
+
+    let final_height = max_pane_height(&mut app).unwrap_or(0);
+    teardown(&mut app);
+
+    assert!(
+        observed_shrink,
+        "the projected pane height must update after resize-window \
+         (expected height change via %%layout-change); \
+         baseline={baseline_height} shrunk_target={shrunk_height} final={final_height}"
+    );
+    // tmux's `window-size latest` semantics clamp to the smallest connected
+    // client; with only one control client the window must shrink to at most
+    // the requested height.  We assert the projection tracks real tmux geometry.
+    assert!(
+        final_height <= baseline_height,
+        "projected pane height must not exceed baseline after a resize-window shrink; \
+         baseline={baseline_height} final={final_height}"
+    );
+}

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -30,6 +30,7 @@ struct LastClientSize {
     cols: u16,
     rows: u16,
     last_reported: Option<(u16, u16)>,
+    last_per_window: Option<bool>,
 }
 
 /// Wires the tmux pane render systems after the projection chain.
@@ -542,31 +543,31 @@ fn sync_client_size(
     let desired = (cols, rows);
     let reported = layout.map(|l| {
         let d = l.0.root.dims();
-        (
-            d.width.clamp(1, u16::MAX as u32) as u16,
-            d.height.clamp(1, u16::MAX as u32) as u16,
-        )
+        grid_dims(d.width, d.height)
     });
     let prev_reported = last.last_reported;
-    if !reconcile_decision(
-        desired,
-        tmux_window.id,
-        reported,
-        prev_reported,
-        last.window,
-        (last.cols, last.rows),
-    ) {
+    // NOTE: a capability change (None -> Some after the version reply) must force
+    // a re-pin even when window/size/reported are unchanged — otherwise the first
+    // pin sent with the global fallback (capability still unknown) is never
+    // upgraded to the per-window form, defeating multi-client isolation.
+    let per_window = connection.supports_per_window_refresh();
+    let capability_changed = last.last_per_window != per_window;
+    if !capability_changed
+        && !reconcile_decision(
+            desired,
+            tmux_window.id,
+            reported,
+            prev_reported,
+            last.window,
+            (last.cols, last.rows),
+        )
+    {
         if last.last_reported != reported {
             last.last_reported = reported;
         }
         return;
     }
-    let cmd = pin_command(
-        connection.supports_per_window_refresh(),
-        tmux_window.id,
-        cols,
-        rows,
-    );
+    let cmd = pin_command(per_window, tmux_window.id, cols, rows);
     // NOTE: only record the size as sent AFTER a successful send — otherwise a
     // transient send failure would poison the dedupe and permanently suppress
     // re-sending this size, leaving tmux stuck at the stale client dimensions.
@@ -575,6 +576,7 @@ fn sync_client_size(
             last.window = Some(tmux_window.id);
             last.cols = cols;
             last.rows = rows;
+            last.last_per_window = per_window;
             // NOTE: advance the observation only after a successful pin; a failed
             // send must leave last_reported stale so the next tick re-detects the
             // drift and retries — otherwise a failed recovery is permanently

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -350,14 +350,7 @@ fn place(
                 let lit_origin = Vec2::new(d.xoff as f32 * cell_w, d.yoff as f32 * cell_h);
                 let lit_avail = Vec2::new(d.width as f32 * cell_w, d.height as f32 * cell_h);
                 place(
-                    panes,
-                    dividers,
-                    child,
-                    lit_origin,
-                    lit_avail,
-                    cell_w,
-                    cell_h,
-                    gap,
+                    panes, dividers, child, lit_origin, lit_avail, cell_w, cell_h, gap,
                 );
             }
             Vec2::new(dims.width as f32 * cell_w, dims.height as f32 * cell_h)
@@ -568,7 +561,12 @@ fn sync_client_size(
         }
         return;
     }
-    let cmd = pin_command(connection.supports_per_window_refresh(), tmux_window.id, cols, rows);
+    let cmd = pin_command(
+        connection.supports_per_window_refresh(),
+        tmux_window.id,
+        cols,
+        rows,
+    );
     // NOTE: only record the size as sent AFTER a successful send — otherwise a
     // transient send failure would poison the dedupe and permanently suppress
     // re-sending this size, leaving tmux stuck at the stale client dimensions.
@@ -630,11 +628,32 @@ mod tests {
         // First call: nothing pinned yet → send.
         assert!(reconcile_decision((80, 24), w, None, None, None, (0, 0)));
         // Active window changed → send.
-        assert!(reconcile_decision((80, 24), WindowId(2), None, None, Some(w), (80, 24)));
+        assert!(reconcile_decision(
+            (80, 24),
+            WindowId(2),
+            None,
+            None,
+            Some(w),
+            (80, 24)
+        ));
         // Desired size changed → send.
-        assert!(reconcile_decision((100, 30), w, None, None, Some(w), (80, 24)));
+        assert!(reconcile_decision(
+            (100, 30),
+            w,
+            None,
+            None,
+            Some(w),
+            (80, 24)
+        ));
         // Steady state, reported matches desired → skip.
-        assert!(!reconcile_decision((80, 24), w, Some((80, 24)), Some((80, 24)), Some(w), (80, 24)));
+        assert!(!reconcile_decision(
+            (80, 24),
+            w,
+            Some((80, 24)),
+            Some((80, 24)),
+            Some(w),
+            (80, 24)
+        ));
     }
 
     #[test]
@@ -642,10 +661,24 @@ mod tests {
         use ozmux_tmux::WindowId;
         let w = WindowId(1);
         // Foreign just shrank the window: reported drifted to a NEW value → send (recovery).
-        assert!(reconcile_decision((80, 24), w, Some((40, 12)), Some((80, 24)), Some(w), (80, 24)));
+        assert!(reconcile_decision(
+            (80, 24),
+            w,
+            Some((40, 12)),
+            Some((80, 24)),
+            Some(w),
+            (80, 24)
+        ));
         // tmux refuses to grow (smaller foreign holds w->latest): reported STUCK at the
         // same drifted value after our pin → skip (no resend spam, residual limitation).
-        assert!(!reconcile_decision((80, 24), w, Some((40, 12)), Some((40, 12)), Some(w), (80, 24)));
+        assert!(!reconcile_decision(
+            (80, 24),
+            w,
+            Some((40, 12)),
+            Some((40, 12)),
+            Some(w),
+            (80, 24)
+        ));
     }
 
     #[test]
@@ -764,11 +797,7 @@ mod tests {
                 data: b"hi".to_vec(),
             });
         app.update();
-        let baseline: String = app
-            .world()
-            .get::<TerminalGrid>(pane_entity)
-            .unwrap()
-            .cells[0]
+        let baseline: String = app.world().get::<TerminalGrid>(pane_entity).unwrap().cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -786,11 +815,7 @@ mod tests {
                 data: b"\r\nXY".to_vec(),
             });
         app.update();
-        let gated: String = app
-            .world()
-            .get::<TerminalGrid>(pane_entity)
-            .unwrap()
-            .cells[0]
+        let gated: String = app.world().get::<TerminalGrid>(pane_entity).unwrap().cells[0]
             .iter()
             .map(|c| c.text.as_str())
             .collect();
@@ -812,11 +837,7 @@ mod tests {
                 data: Vec::new(),
             });
         app.update();
-        let resumed: String = app
-            .world()
-            .get::<TerminalGrid>(pane_entity)
-            .unwrap()
-            .cells[1]
+        let resumed: String = app.world().get::<TerminalGrid>(pane_entity).unwrap().cells[1]
             .iter()
             .map(|c| c.text.as_str())
             .collect();

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -16,7 +16,8 @@ use ozma_tty_renderer::prelude::TerminalRenderBundle;
 use ozma_tty_renderer::schema::TerminalGrid;
 use ozmux_tmux::{
     ActiveWindow, PaneOutput, TmuxConnection, TmuxPane, TmuxProjectionSet, TmuxWindow,
-    TmuxWindowLayout, refresh_client_command,
+    TmuxWindowLayout, WindowId, refresh_client_command, resize_window_command,
+    window_refresh_client_command,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -25,6 +26,7 @@ use tmux_control_parser::{Cell, DividerAxis, PaneId, SplitDir};
 
 #[derive(Resource, Default)]
 struct LastClientSize {
+    window: Option<WindowId>,
     cols: u16,
     rows: u16,
 }
@@ -481,19 +483,35 @@ fn rows_for_panes(total_rows: u16) -> u16 {
     total_rows.saturating_sub(1).max(1)
 }
 
-/// Sends `refresh-client -C <cols>,<rows>` to tmux so it lays out panes for
-/// the current window size. One row is reserved for the ozmux window status
-/// bar via [`rows_for_panes`]. Results are deduped via [`LastClientSize`].
+/// Returns the size-declaration command for `win` based on the tmux per-window
+/// `refresh-client` capability. `None` (capability not yet known) falls back to
+/// the global `refresh-client -C W,H`.
+fn pin_command(per_window: Option<bool>, win: WindowId, cols: u16, rows: u16) -> String {
+    match per_window {
+        Some(true) => window_refresh_client_command(win, cols, rows),
+        Some(false) => resize_window_command(win, cols, rows),
+        None => refresh_client_command(cols, rows),
+    }
+}
+
+/// Pins the active tmux window to ozmux's cell size via per-window
+/// `refresh-client -C @win:WxH` (tmux ≥ 3.4) so a smaller foreign client cannot
+/// collapse it. One row is reserved for the ozmux status bar. Deduped on the
+/// (active window, size) pair via [`LastClientSize`].
 fn sync_client_size(
     mut last: ResMut<LastClientSize>,
     connection: NonSend<TmuxConnection>,
     metrics: Res<TerminalCellMetricsResource>,
     window: Query<&Window, With<PrimaryWindow>>,
+    active: Query<&TmuxWindow, With<ActiveWindow>>,
 ) {
     let Some(client) = connection.client() else {
         return;
     };
     let Ok(window) = window.single() else {
+        return;
+    };
+    let Some(tmux_window) = active.iter().next() else {
         return;
     };
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
@@ -505,18 +523,20 @@ fn sync_client_size(
         cell_h,
     );
     let rows = rows_for_panes(rows);
-    if (cols, rows) == (last.cols, last.rows) {
+    if last.window == Some(tmux_window.id) && (last.cols, last.rows) == (cols, rows) {
         return;
     }
+    let cmd = pin_command(connection.supports_per_window_refresh(), tmux_window.id, cols, rows);
     // NOTE: only record the size as sent AFTER a successful send — otherwise a
     // transient send failure would poison the dedupe and permanently suppress
     // re-sending this size, leaving tmux stuck at the stale client dimensions.
-    match client.handle().send(&refresh_client_command(cols, rows)) {
+    match client.handle().send(&cmd) {
         Ok(_) => {
+            last.window = Some(tmux_window.id);
             last.cols = cols;
             last.rows = rows;
         }
-        Err(e) => tracing::warn!(?e, cols, rows, "refresh-client send failed"),
+        Err(e) => tracing::warn!(?e, cols, rows, "window refresh-client send failed"),
     }
 }
 
@@ -536,6 +556,23 @@ mod tests {
     use ozma_tty_renderer::prelude::TerminalGridPlugin;
     use ozmux_tmux::PaneOutput;
     use tmux_control_parser::{Cell, CellDims, SplitDir};
+
+    #[test]
+    fn pin_command_selects_form_by_capability() {
+        use ozmux_tmux::WindowId;
+        assert_eq!(
+            pin_command(Some(true), WindowId(3), 80, 24),
+            "refresh-client -C @3:80x24"
+        );
+        assert_eq!(
+            pin_command(Some(false), WindowId(3), 80, 24),
+            "resize-window -x 80 -y 24 -t @3"
+        );
+        assert_eq!(
+            pin_command(None, WindowId(3), 80, 24),
+            "refresh-client -C 80,24"
+        );
+    }
 
     #[test]
     fn rows_for_panes_reserves_one_row_for_the_bar() {

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -511,7 +511,7 @@ fn sync_client_size(
     let Ok(window) = window.single() else {
         return;
     };
-    let Some(tmux_window) = active.iter().next() else {
+    let Ok(tmux_window) = active.single() else {
         return;
     };
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -555,9 +555,6 @@ fn sync_client_size(
         )
     });
     let prev_reported = last.last_reported;
-    if last.last_reported != reported {
-        last.last_reported = reported;
-    }
     if !reconcile_decision(
         desired,
         tmux_window.id,
@@ -566,6 +563,9 @@ fn sync_client_size(
         last.window,
         (last.cols, last.rows),
     ) {
+        if last.last_reported != reported {
+            last.last_reported = reported;
+        }
         return;
     }
     let cmd = pin_command(connection.supports_per_window_refresh(), tmux_window.id, cols, rows);
@@ -577,6 +577,13 @@ fn sync_client_size(
             last.window = Some(tmux_window.id);
             last.cols = cols;
             last.rows = rows;
+            // NOTE: advance the observation only after a successful pin; a failed
+            // send must leave last_reported stale so the next tick re-detects the
+            // drift and retries — otherwise a failed recovery is permanently
+            // suppressed (reported_changed would be false next tick).
+            if last.last_reported != reported {
+                last.last_reported = reported;
+            }
         }
         Err(e) => tracing::warn!(?e, cols, rows, "window refresh-client send failed"),
     }

--- a/src/tmux_render.rs
+++ b/src/tmux_render.rs
@@ -29,6 +29,7 @@ struct LastClientSize {
     window: Option<WindowId>,
     cols: u16,
     rows: u16,
+    last_reported: Option<(u16, u16)>,
 }
 
 /// Wires the tmux pane render systems after the projection chain.
@@ -494,16 +495,38 @@ fn pin_command(per_window: Option<bool>, win: WindowId, cols: u16, rows: u16) ->
     }
 }
 
+/// Decides whether to (re)send the active window's size pin.
+///
+/// Sends when the active window or desired size changed (normal dedupe), or
+/// when tmux's reported size drifted to a NEW value away from desired (foreign
+/// resize → recovery). Does NOT send when the reported size is stuck at the same
+/// drifted value after a pin — tmux is refusing to grow the window (a smaller
+/// foreign client holds `w->latest`), so resending would spin.
+fn reconcile_decision(
+    desired: (u16, u16),
+    active: WindowId,
+    reported: Option<(u16, u16)>,
+    prev_reported: Option<(u16, u16)>,
+    last_window: Option<WindowId>,
+    last_desired: (u16, u16),
+) -> bool {
+    let window_or_size_changed = last_window != Some(active) || last_desired != desired;
+    let drift = reported.is_some_and(|r| r != desired);
+    let reported_changed = reported != prev_reported;
+    window_or_size_changed || (drift && reported_changed)
+}
+
 /// Pins the active tmux window to ozmux's cell size via per-window
 /// `refresh-client -C @win:WxH` (tmux ≥ 3.4) so a smaller foreign client cannot
-/// collapse it. One row is reserved for the ozmux status bar. Deduped on the
-/// (active window, size) pair via [`LastClientSize`].
+/// collapse it. One row is reserved for the ozmux status bar. Uses
+/// [`reconcile_decision`] gated on [`LastClientSize`] to detect foreign-resize
+/// drift and recover without spinning when tmux refuses to grow the window.
 fn sync_client_size(
     mut last: ResMut<LastClientSize>,
     connection: NonSend<TmuxConnection>,
     metrics: Res<TerminalCellMetricsResource>,
     window: Query<&Window, With<PrimaryWindow>>,
-    active: Query<&TmuxWindow, With<ActiveWindow>>,
+    active: Query<(&TmuxWindow, Option<&TmuxWindowLayout>), With<ActiveWindow>>,
 ) {
     let Some(client) = connection.client() else {
         return;
@@ -511,7 +534,7 @@ fn sync_client_size(
     let Ok(window) = window.single() else {
         return;
     };
-    let Ok(tmux_window) = active.single() else {
+    let Ok((tmux_window, layout)) = active.single() else {
         return;
     };
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
@@ -523,7 +546,26 @@ fn sync_client_size(
         cell_h,
     );
     let rows = rows_for_panes(rows);
-    if last.window == Some(tmux_window.id) && (last.cols, last.rows) == (cols, rows) {
+    let desired = (cols, rows);
+    let reported = layout.map(|l| {
+        let d = l.0.root.dims();
+        (
+            d.width.clamp(1, u16::MAX as u32) as u16,
+            d.height.clamp(1, u16::MAX as u32) as u16,
+        )
+    });
+    let prev_reported = last.last_reported;
+    if last.last_reported != reported {
+        last.last_reported = reported;
+    }
+    if !reconcile_decision(
+        desired,
+        tmux_window.id,
+        reported,
+        prev_reported,
+        last.window,
+        (last.cols, last.rows),
+    ) {
         return;
     }
     let cmd = pin_command(connection.supports_per_window_refresh(), tmux_window.id, cols, rows);
@@ -572,6 +614,31 @@ mod tests {
             pin_command(None, WindowId(3), 80, 24),
             "refresh-client -C 80,24"
         );
+    }
+
+    #[test]
+    fn reconcile_sends_on_first_call_and_on_changes() {
+        use ozmux_tmux::WindowId;
+        let w = WindowId(1);
+        // First call: nothing pinned yet → send.
+        assert!(reconcile_decision((80, 24), w, None, None, None, (0, 0)));
+        // Active window changed → send.
+        assert!(reconcile_decision((80, 24), WindowId(2), None, None, Some(w), (80, 24)));
+        // Desired size changed → send.
+        assert!(reconcile_decision((100, 30), w, None, None, Some(w), (80, 24)));
+        // Steady state, reported matches desired → skip.
+        assert!(!reconcile_decision((80, 24), w, Some((80, 24)), Some((80, 24)), Some(w), (80, 24)));
+    }
+
+    #[test]
+    fn reconcile_recovers_on_foreign_drift_but_does_not_spin() {
+        use ozmux_tmux::WindowId;
+        let w = WindowId(1);
+        // Foreign just shrank the window: reported drifted to a NEW value → send (recovery).
+        assert!(reconcile_decision((80, 24), w, Some((40, 12)), Some((80, 24)), Some(w), (80, 24)));
+        // tmux refuses to grow (smaller foreign holds w->latest): reported STUCK at the
+        // same drifted value after our pin → skip (no resend spam, residual limitation).
+        assert!(!reconcile_decision((80, 24), w, Some((40, 12)), Some((40, 12)), Some(w), (80, 24)));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

ozmux mishandled tmux `-CC` multi-client / multi-session scenarios, producing black or blank screens:

1. **Size collapse.** After ozmux attached, a second client attaching to the same session and operating it collapsed the shared window to the foreign client's size (tmux default `window-size latest`). ozmux rendered the shrunken grid inside its large GPU window — black margins — and never recovered.
2. **Spurious teardown.** When a foreign client switched to a *different* session, ozmux mistook the broadcast `%client-session-changed` for its own session switch and tore down its entire window/pane projection (full black screen).
3. **Wrong geometry under zoom.** ozmux consumed `#{window_layout}` (which tmux returns as the *saved* pre-zoom layout) instead of `#{window_visible_layout}`.

## Solution

Modeled on iTerm2's reference `-CC` integration and verified against the tmux source (`control-notify.c`, `resize.c`). Affected: `crates/tmux_session` and `src/tmux_render.rs`.

- **Size ownership** — query the tmux version, and on tmux ≥ 3.4 pin the *active* window to ozmux's size with per-window `refresh-client -C @win:WxH` (fallback `resize-window` below 3.4; global form until the version reply lands). An idempotent reconciler re-pins on foreign-resize drift and suppresses re-send spam when tmux refuses to grow the window.
- **Teardown gate** — `%client-session-changed` is honored only when its `client` field matches ozmux's own client name (gated in both `detect_session_switch` and `trigger_notification`), with a startup ordering guard.
- **Layout source** — consume `#{window_visible_layout}` (with fallback to `#{window_layout}`).
- **aggressive-resize** — warn once per connection when `aggressive-resize on` (incompatible with control-mode integration); no abort, no option mutation.

### Known limitation

Under `window-size latest`, per-window `refresh-client` is a downward clamp, not a hard pin: ozmux recovers against a foreign client of equal-or-larger size, but a *smaller* foreign client holding the `latest` slot cannot be grown back. Documented; a future letterbox-render could mask the residual margin.

### Testing

- 144 crate unit tests pass; clippy + rustfmt clean.
- 2 gated real-tmux acceptance tests pass against tmux 3.6a (`cargo test -p ozmux_tmux --test real_tmux_multiclient -- --ignored --test-threads=1`): the projection survives a foreign session being created, and a `%layout-change` shrink is observed.
- GUI smoke (two clients, two sessions) recommended before release for the size-recovery path (`sync_client_size` needs a `PrimaryWindow`, not headless-testable).

> The foreign-pane-focus "phantom `0:` window" fix found during GUI smoke is split into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
