### PR TITLE
fix(tmux): ignore foreign-session pane focus (no phantom "0:" window)

### DIFF
--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -349,20 +349,26 @@ pub(crate) fn detect_session_switch(
     None
 }
 
-/// True when the batch contains a `%session-window-changed` — the session's
-/// current window changed (`next-window` / `previous-window` / `select-window`).
+/// True when the batch contains a `%session-window-changed` for `current` — the
+/// own session's current window changed (`next-window` / `previous-window` /
+/// `select-window`). tmux broadcasts `%session-window-changed` to every control
+/// client server-wide, so a foreign session's switch (or `current == None`)
+/// returns false and does not trigger a needless active-pane re-query.
 ///
 /// NOTE: tmux emits *only* `%session-window-changed` for such a switch, never a
 /// `%window-pane-changed`, so the caller must re-query the active pane
 /// (`active_pane_command`) to move `ActiveWindow`/`ActivePane`. Without that the
 /// switch never reaches the projection and the UI stays on the old window.
-pub(crate) fn detect_window_switch(events: &[TransportEvent]) -> bool {
+pub(crate) fn detect_window_switch(events: &[TransportEvent], current: Option<SessionId>) -> bool {
+    let Some(current) = current else {
+        return false;
+    };
     events.iter().any(|event| {
         matches!(
             event,
             TransportEvent::Protocol(ClientEvent::Notification(
-                ControlEvent::SessionWindowChanged { .. }
-            ))
+                ControlEvent::SessionWindowChanged { session, .. }
+            )) if *session == current
         )
     })
 }
@@ -429,6 +435,7 @@ fn trigger_notification(commands: &mut Commands, event: &ControlEvent) {
             commands.trigger(TmuxActivePaneChanged {
                 window: *window,
                 pane: *pane,
+                from_notification: true,
             });
         }
         ControlEvent::SubscriptionChanged {
@@ -753,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    fn detect_window_switch_flags_session_window_changed() {
+    fn detect_window_switch_flags_own_session_window_changed() {
         use tmux_control_parser::{SessionId, WindowId};
         let switched = vec![TransportEvent::Protocol(ClientEvent::Notification(
             ControlEvent::SessionWindowChanged {
@@ -761,8 +768,13 @@ mod tests {
                 window: WindowId(4),
             },
         ))];
-        assert!(detect_window_switch(&switched));
-        assert!(!detect_window_switch(&[]));
+        // Own session's window switch is detected.
+        assert!(detect_window_switch(&switched, Some(SessionId(1))));
+        // A foreign session's broadcast %session-window-changed is ignored.
+        assert!(!detect_window_switch(&switched, Some(SessionId(2))));
+        // No current session yet → nothing to switch.
+        assert!(!detect_window_switch(&switched, None));
+        assert!(!detect_window_switch(&[], Some(SessionId(1))));
 
         let session_changed = vec![TransportEvent::Protocol(ClientEvent::Notification(
             ControlEvent::SessionChanged {
@@ -770,7 +782,7 @@ mod tests {
                 name: "b".to_string(),
             },
         ))];
-        assert!(!detect_window_switch(&session_changed));
+        assert!(!detect_window_switch(&session_changed, Some(SessionId(2))));
     }
 
     #[test]

--- a/crates/tmux_session/src/events.rs
+++ b/crates/tmux_session/src/events.rs
@@ -67,6 +67,11 @@ pub(crate) struct TmuxLayoutChanged {
 pub(crate) struct TmuxActivePaneChanged {
     pub(crate) window: WindowId,
     pub(crate) pane: PaneId,
+    /// True when sourced from a live `%window-pane-changed` notification (which
+    /// tmux broadcasts to every control client server-wide, possibly for a
+    /// foreign session); false when from the trusted own-session
+    /// `active_pane_command` reply.
+    pub(crate) from_notification: bool,
 }
 
 /// A seed row's active flag: this window is the active one.

--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -167,6 +167,14 @@ fn on_active_pane_changed(
     active_windows: Query<Entity, With<ActiveWindow>>,
     active_panes: Query<Entity, With<ActivePane>>,
 ) {
+    // NOTE: tmux broadcasts %window-pane-changed to ALL control clients
+    // server-wide (no session guard), so a foreign client's pane focus in
+    // another session must not spawn a phantom window here. Only the trusted
+    // own-session active-pane query reply (from_notification == false) may seed
+    // a window; an unknown window from a live notification is foreign — ignore it.
+    if ev.from_notification && !index.windows.contains_key(&ev.window) {
+        return;
+    }
     let window = ensure_window(&mut commands, &mut index, ev.window);
     set_marker::<ActiveWindow>(&mut commands, &active_windows, window);
 
@@ -342,6 +350,7 @@ mod tests {
         app.world_mut().trigger(TmuxActivePaneChanged {
             window: WindowId(1),
             pane: PaneId(5),
+            from_notification: false,
         });
         app.update();
         assert_eq!(
@@ -359,6 +368,36 @@ mod tests {
         assert_eq!(index.pending_active_pane, None);
         let (pane_e, _) = index.panes[&PaneId(5)];
         assert!(app.world().get::<ActivePane>(pane_e).is_some());
+    }
+
+    #[test]
+    fn foreign_notification_active_pane_does_not_spawn_window() {
+        let mut app = app();
+        // A live %window-pane-changed (from_notification: true) for a window not
+        // in this session's projection is foreign (tmux broadcasts it
+        // server-wide) and must be ignored: no phantom window, no ActiveWindow
+        // hijack, no pending active pane.
+        app.world_mut().trigger(TmuxActivePaneChanged {
+            window: WindowId(7),
+            pane: PaneId(3),
+            from_notification: true,
+        });
+        app.update();
+
+        let index = app.world().resource::<TmuxProjection>();
+        assert!(
+            index.windows.is_empty(),
+            "foreign notification must not spawn a window"
+        );
+        assert_eq!(index.pending_active_pane, None);
+        let mut active = app
+            .world_mut()
+            .query_filtered::<Entity, With<ActiveWindow>>();
+        assert_eq!(
+            active.iter(app.world()).count(),
+            0,
+            "foreign notification must not set the ActiveWindow marker"
+        );
     }
 
     #[test]

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -146,7 +146,7 @@ fn drain_tmux_events(
                 Err(error) => tracing::warn!(?error, "failed to re-enumerate on window-add"),
             }
         }
-        if detect_window_switch(&events) {
+        if detect_window_switch(&events, current_session) {
             match client.handle().send(&active_pane_command()) {
                 Ok(id) => enumeration.active_pane_pending = Some(id),
                 Err(error) => {
@@ -207,7 +207,11 @@ fn drain_tmux_events(
         if let Some((window, pane)) =
             take_active_pane(&mut enumeration.active_pane_pending, &events)
         {
-            commands.trigger(TmuxActivePaneChanged { window, pane });
+            commands.trigger(TmuxActivePaneChanged {
+                window,
+                pane,
+                from_notification: false,
+            });
         }
         // NOTE: deref once so the borrow checker can see these as distinct
         // field borrows rather than overlapping borrows through DerefMut.

--- a/crates/tmux_session/tests/real_tmux_pane_focus.rs
+++ b/crates/tmux_session/tests/real_tmux_pane_focus.rs
@@ -1,0 +1,136 @@
+//! Gated end-to-end test against a real tmux `-CC`: a foreign client focusing a
+//! pane in ANOTHER session must not spawn a phantom window in ozmux's projection.
+//!
+//! tmux's `control_notify_window_pane_changed` has no session guard — it
+//! broadcasts `%window-pane-changed @win %pane` to every control client on the
+//! server. So ozmux (attached to session A) receives a foreign session B's pane
+//! focus. Without the fix, `on_active_pane_changed` would `ensure_window` the
+//! foreign window id, spawning a `TmuxWindow { index: 0, name: "" }` (a "0:" tab)
+//! and moving the `ActiveWindow` marker onto it — hiding ozmux's real window and
+//! blanking the pane. The fix gates the live-notification path on `index.windows`
+//! membership, so a foreign window is ignored.
+//!
+//! Run with:
+//! ```text
+//! cargo test -p ozmux_tmux --test real_tmux_pane_focus -- --ignored --test-threads=1
+//! ```
+
+use bevy::prelude::*;
+use ozmux_tmux::{
+    ActiveWindow, ConnectionState, TmuxConnection, TmuxPane, TmuxSessionPlugin, TmuxWindow,
+    WindowId,
+};
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+use tmux_control::TmuxServer;
+
+fn pump_until(app: &mut App, secs: u64, mut done: impl FnMut(&mut App) -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        app.update();
+        if done(app) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+fn teardown(app: &mut App) {
+    if let Some(client) = app
+        .world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .unwrap()
+        .take()
+    {
+        client.handle().send("kill-server").ok();
+    }
+}
+
+fn attach_and_wait(tag: &str) -> App {
+    let socket = format!("ozmux-pf-{}-{}", std::process::id(), tag);
+    let server = TmuxServer::new().socket_name(&socket);
+    let client = server.new_session().expect("spawn tmux -CC new-session");
+
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    app.world_mut()
+        .get_non_send_resource_mut::<TmuxConnection>()
+        .expect("TmuxConnection inserted by the plugin")
+        .set(client);
+
+    let mut pane_q = app.world_mut().query::<&TmuxPane>();
+    let ready = pump_until(&mut app, 5, |app| {
+        *app.world().resource::<ConnectionState>() == ConnectionState::Attached
+            && pane_q.iter(app.world()).next().is_some()
+    });
+    assert!(ready, "tmux should attach and project a pane within 5 s");
+    app
+}
+
+fn window_ids(app: &mut App) -> HashSet<WindowId> {
+    app.world_mut()
+        .query::<&TmuxWindow>()
+        .iter(app.world())
+        .map(|w| w.id)
+        .collect()
+}
+
+fn active_window_id(app: &mut App) -> Option<WindowId> {
+    app.world_mut()
+        .query_filtered::<&TmuxWindow, With<ActiveWindow>>()
+        .iter(app.world())
+        .next()
+        .map(|w| w.id)
+}
+
+#[test]
+#[ignore = "requires a real tmux binary and a controlling PTY"]
+fn foreign_pane_focus_does_not_spawn_phantom_window() {
+    let mut app = attach_and_wait("panefocus");
+    let foreign = format!("ozmux-pf-foreign-{}", std::process::id());
+
+    let handle = app
+        .world()
+        .get_non_send_resource::<TmuxConnection>()
+        .unwrap()
+        .client()
+        .unwrap()
+        .handle();
+    // Foreign session B with two panes in its window.
+    handle
+        .send(&format!("new-session -d -s {foreign}"))
+        .expect("new-session -d");
+    handle
+        .send(&format!("split-window -t {foreign}:"))
+        .expect("split-window");
+
+    // Let the foreign-session setup notifications settle, then capture ozmux's own
+    // window-id set (foreign windows are not projected) and active window.
+    let _ = pump_until(&mut app, 2, |_| false);
+    let baseline_ids = window_ids(&mut app);
+    let active_before = active_window_id(&mut app);
+
+    // Foreign client focuses the other pane in session B → tmux broadcasts
+    // %window-pane-changed to ozmux's control client.
+    handle
+        .send(&format!("select-pane -t {foreign}:.+"))
+        .expect("select-pane");
+
+    let _ = pump_until(&mut app, 2, |_| false);
+
+    let post_ids = window_ids(&mut app);
+    let active_after = active_window_id(&mut app);
+    teardown(&mut app);
+
+    assert_eq!(
+        post_ids, baseline_ids,
+        "a foreign session's pane focus must not add a window to ozmux's projection \
+         (no phantom \"0:\" tab); baseline={baseline_ids:?} after={post_ids:?}"
+    );
+    assert_eq!(
+        active_after, active_before,
+        "a foreign session's pane focus must not move ozmux's ActiveWindow marker; \
+         before={active_before:?} after={active_after:?}"
+    );
+}


### PR DESCRIPTION
## Problem

When ozmux is attached to one tmux session and a **separate** client (e.g. iTerm2)
is attached to a **different** session on the same server, focusing a pane in that
other session makes ozmux spawn a phantom window tab named **`0:`** and blank its
pane area.

Root cause: tmux's `control_notify_window_pane_changed` (`control-notify.c`) has
**no session guard** — it broadcasts `%window-pane-changed @win %pane` to every
control client on the server. ozmux's `on_active_pane_changed` then ran
`ensure_window()` for the foreign window id, spawning a
`TmuxWindow { index: 0, name: "" }` (rendered `0:`) and moving the `ActiveWindow`
marker onto it; `sync_active_window` hid ozmux's real window and showed the empty
foreign one → black pane.

## Solution

Affected: `crates/tmux_session`.

- Add `TmuxActivePaneChanged.from_notification` to distinguish the **trusted**
  own-session `active_pane_command` reply (`false`) from the broadcast
  `%window-pane-changed` notification (`true`). `on_active_pane_changed` ignores a
  notification-sourced event whose window is **not already in the projection**
  (`index.windows`); the trusted reply keeps seeding, so the same-batch
  initial-attach active-pane ordering is unchanged.
- Gate `detect_window_switch` on the own session id so a foreign, server-wide
  `%session-window-changed` no longer triggers a needless `active_pane_command`
  re-query.

`%layout-change` and `%window-add` are already session-scoped by tmux
(`winlink_find_by_window_id`; a foreign new window arrives as
`%unlinked-window-add`, which ozmux ignores), so `index.windows` only ever holds
own-session windows — that invariant is what makes the membership gate sound.

### Testing

- Crate unit tests pass; clippy + rustfmt clean (for the changed files).
- New observer unit test (foreign notification ignored) + `detect_window_switch`
  session-gate unit tests.
- Gated real-tmux acceptance test
  (`cargo test -p ozmux_tmux --test real_tmux_pane_focus -- --ignored --test-threads=1`)
  passes against tmux 3.6a: a foreign session's pane focus adds no window to
  ozmux's projection and does not move its `ActiveWindow` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
