### PR TITLE
feat(ozma_mode): add ozma_mode crate with AppMode State and plugin

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -98,6 +98,28 @@ Forbidden:
 
 Note on preludes: a module that *defines* a prelude (i.e., re-exports curated names for downstream consumers) may itself use `pub use foo::*;` inside its own definition. The rule above forbids glob imports in **consumer** code.
 
+Required — import, don't inline:
+
+- Prefer `use` imports over inline fully-qualified paths. If a type is used in a function signature or system body, it belongs in the `use` block at the top of the file, not written out inline as `some_crate::some_module::Type` at the call site.
+
+| Pattern | Example | Fix |
+| --- | --- | --- |
+| Inline path in signature / body | `fn f(x: foo::bar::Baz)` | Add `use foo::bar::Baz;` and write `fn f(x: Baz)` |
+| Inline path in `run_if` or type parameter | `.add_message::<bevy::window::WindowResized>()` | `use bevy::window::WindowResized;` then `.add_message::<WindowResized>()` |
+
+## Naming — Query parameters
+
+Bevy `Query` system parameters must not use a `_q` suffix. Use a descriptive noun instead:
+
+- Singular (`window`, `terminal`) when the query is expected to return one result and the system calls `.single()` / `.single_mut()`.
+- Plural (`windows`, `terminals`) when the query is iterated or used with `.get()` over an arbitrary entity.
+
+Forbidden:
+
+| Pattern | Example | Fix |
+| --- | --- | --- |
+| `_q` suffix on any `Query` parameter | `window_q: Query<&Window, …>` | `window: Query<&Window, …>` |
+
 ## Visibility — minimize scope
 
 Every item (functions, types, fields, modules, constants, traits) starts
@@ -389,6 +411,8 @@ Not tool-enforced — review-time check required. The following rules cannot cur
 - Parameter ordering — mutable parameters declared before immutable ones in function signatures (see "Parameter ordering — mutable parameters first")
 - System optimization — whole-system resource change/added guards expressed as in-body early returns must be `run_if` run conditions instead (see "System optimization — gate with `run_if`, not in-body change checks")
 - Change detection — no manual `set_changed()` / `bypass_change_detection()`-then-`set_changed()` notification; mutate conditionally so normal `DerefMut` drives change detection (see "Change detection — let mutation drive it, don't force it manually")
+- Imports — no inline fully-qualified paths in signatures, bodies, or type parameters; add a `use` at the top instead (see "Imports — import, don't inline")
+- Naming — `Query` parameters must not use a `_q` suffix; use a descriptive singular or plural noun (see "Naming — Query parameters")
 
 If you add a tool or script that detects any of these, move the corresponding entry into the tool-enforced list above.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,6 +4888,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ozma_mode"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bevy",
+ "ozma_tty_engine",
+ "ozma_tty_renderer",
+ "ozmux_configs",
+ "tracing",
+]
+
+[[package]]
 name = "ozma_tty_engine"
 version = "0.1.0"
 dependencies = [

--- a/crates/configs/src/lib.rs
+++ b/crates/configs/src/lib.rs
@@ -18,6 +18,7 @@ pub mod inactive_pane;
 pub mod keyboard;
 pub mod mouse;
 pub mod osc_webview;
+pub mod ozma;
 pub mod path;
 mod raw;
 pub mod shortcuts;
@@ -43,6 +44,8 @@ pub struct OzmuxConfigs {
     pub osc_webview: OscWebviewConfig,
     /// tmux backend configuration.
     pub tmux: tmux::TmuxConfig,
+    /// Ozma single-terminal mode configuration.
+    pub ozma: ozma::OzmaConfig,
 }
 
 impl OzmuxConfigs {

--- a/crates/configs/src/ozma.rs
+++ b/crates/configs/src/ozma.rs
@@ -1,0 +1,70 @@
+//! Configuration for the Ozma single-terminal mode.
+
+use serde::Deserialize;
+
+/// Resolved Ozma mode settings.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OzmaConfig {
+    /// Shell program to launch. `None` means "resolve at runtime via `$SHELL`".
+    pub shell: Option<String>,
+}
+
+/// Per-field-optional `[ozma]` view for TOML deserialization.
+#[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OzmaPatch {
+    /// Optional shell override.
+    pub shell: Option<String>,
+}
+
+impl OzmaPatch {
+    /// Applies this patch over `base`, keeping `base`'s value where unset.
+    pub(crate) fn apply_to(self, base: OzmaConfig) -> OzmaConfig {
+        OzmaConfig {
+            shell: self.shell.or(base.shell),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_shell_is_none() {
+        assert!(OzmaConfig::default().shell.is_none());
+    }
+
+    #[test]
+    fn patch_overrides_shell() {
+        let patched = OzmaPatch {
+            shell: Some("/bin/fish".to_string()),
+        }
+        .apply_to(OzmaConfig::default());
+        assert_eq!(patched.shell.as_deref(), Some("/bin/fish"));
+    }
+
+    #[test]
+    fn empty_patch_keeps_base() {
+        let patched = OzmaPatch::default().apply_to(OzmaConfig::default());
+        assert_eq!(patched, OzmaConfig::default());
+    }
+
+    #[test]
+    fn ozma_section_parses_from_toml() {
+        let toml_str = r#"
+[ozma]
+shell = "/usr/bin/zsh"
+"#;
+        let raw: crate::raw::RawConfigs = toml::from_str(toml_str).unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert_eq!(merged.ozma.shell.as_deref(), Some("/usr/bin/zsh"));
+    }
+
+    #[test]
+    fn missing_ozma_section_uses_defaults() {
+        let raw: crate::raw::RawConfigs = toml::from_str("").unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert!(merged.ozma.shell.is_none());
+    }
+}

--- a/crates/configs/src/ozma.rs
+++ b/crates/configs/src/ozma.rs
@@ -13,8 +13,7 @@ pub struct OzmaConfig {
 #[derive(Deserialize, Default, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct OzmaPatch {
-    /// Optional shell override.
-    pub shell: Option<String>,
+    shell: Option<String>,
 }
 
 impl OzmaPatch {

--- a/crates/configs/src/raw.rs
+++ b/crates/configs/src/raw.rs
@@ -9,6 +9,7 @@ use crate::inactive_pane::InactivePaneConfigPatch;
 use crate::keyboard::KeyboardPatch;
 use crate::mouse::MousePatch;
 use crate::osc_webview::OscWebviewPatch;
+use crate::ozma::OzmaPatch;
 use crate::shortcuts::Shortcuts;
 use crate::theme::ThemePatch;
 use crate::tmux::TmuxPatch;
@@ -27,6 +28,7 @@ pub(crate) struct RawConfigs {
     pub(crate) inactive_pane: Option<InactivePaneConfigPatch>,
     pub(crate) osc_webview: Option<OscWebviewPatch>,
     pub(crate) tmux: Option<TmuxPatch>,
+    pub(crate) ozma: Option<OzmaPatch>,
 }
 
 impl RawConfigs {
@@ -58,6 +60,9 @@ impl RawConfigs {
         }
         if let Some(patch) = self.tmux {
             base.tmux = patch.apply_to(base.tmux);
+        }
+        if let Some(patch) = self.ozma {
+            base.ozma = patch.apply_to(base.ozma);
         }
         base
     }

--- a/crates/ozma_mode/Cargo.toml
+++ b/crates/ozma_mode/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ozma_mode"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[dependencies]
+bevy              = { workspace = true }
+ozma_tty_engine   = { path = "../ozma_tty_engine" }
+ozma_tty_renderer = { path = "../ozma_tty_renderer" }
+ozmux_configs     = { path = "../configs" }
+tracing           = { workspace = true }
+anyhow            = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ozma_mode/src/exit.rs
+++ b/crates/ozma_mode/src/exit.rs
@@ -15,9 +15,9 @@ impl Plugin for ExitPlugin {
 fn on_child_exit(
     ev: On<TerminalChildExit>,
     mut exit: MessageWriter<AppExit>,
-    terminal_q: Query<(), With<OzmaTerminal>>,
+    terminals: Query<(), With<OzmaTerminal>>,
 ) {
-    if terminal_q.get(ev.event_target()).is_ok() {
+    if terminals.get(ev.event_target()).is_ok() {
         exit.write(AppExit::Success);
     }
 }

--- a/crates/ozma_mode/src/exit.rs
+++ b/crates/ozma_mode/src/exit.rs
@@ -1,0 +1,9 @@
+//! Child-process exit observer: sends `AppExit` when the shell quits.
+
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalChildExit;
+
+/// Observer fired when the PTY child exits. Sends `AppExit::Success`.
+pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: MessageWriter<AppExit>) {
+    exit.write(AppExit::Success);
+}

--- a/crates/ozma_mode/src/exit.rs
+++ b/crates/ozma_mode/src/exit.rs
@@ -1,20 +1,28 @@
 //! Child-process exit observer: sends `AppExit` when the shell quits.
 
+use crate::spawn::OzmaTerminal;
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalChildExit;
 
 /// Observer fired when the PTY child process exits.
 ///
-/// Sends `AppExit::Success` regardless of the exit code — the user
-/// closed their shell, so the application should quit.
-pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: MessageWriter<AppExit>) {
-    exit.write(AppExit::Success);
+/// Sends `AppExit::Success` only when the exiting terminal is the Ozma
+/// terminal — ignores exits from any other terminal entity in the world.
+pub(crate) fn on_child_exit(
+    ev: On<TerminalChildExit>,
+    mut exit: MessageWriter<AppExit>,
+    terminal_q: Query<(), With<OzmaTerminal>>,
+) {
+    if terminal_q.get(ev.event_target()).is_ok() {
+        exit.write(AppExit::Success);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use bevy::ecs::message::MessageReader;
+    use crate::spawn::OzmaTerminal;
     use ozma_tty_engine::TerminalChildExit;
 
     #[test]
@@ -34,7 +42,7 @@ mod tests {
         app.init_resource::<GotExit>();
         app.add_systems(Update, capture);
 
-        let entity = app.world_mut().spawn_empty().id();
+        let entity = app.world_mut().spawn(OzmaTerminal).id();
         app.world_mut().trigger(TerminalChildExit {
             entity,
             code: Some(0),

--- a/crates/ozma_mode/src/exit.rs
+++ b/crates/ozma_mode/src/exit.rs
@@ -4,11 +4,15 @@ use crate::spawn::OzmaTerminal;
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalChildExit;
 
-/// Observer fired when the PTY child process exits.
-///
-/// Sends `AppExit::Success` only when the exiting terminal is the Ozma
-/// terminal — ignores exits from any other terminal entity in the world.
-pub(crate) fn on_child_exit(
+pub(crate) struct ExitPlugin;
+
+impl Plugin for ExitPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_child_exit);
+    }
+}
+
+fn on_child_exit(
     ev: On<TerminalChildExit>,
     mut exit: MessageWriter<AppExit>,
     terminal_q: Query<(), With<OzmaTerminal>>,

--- a/crates/ozma_mode/src/exit.rs
+++ b/crates/ozma_mode/src/exit.rs
@@ -3,7 +3,47 @@
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalChildExit;
 
-/// Observer fired when the PTY child exits. Sends `AppExit::Success`.
+/// Observer fired when the PTY child process exits.
+///
+/// Sends `AppExit::Success` regardless of the exit code — the user
+/// closed their shell, so the application should quit.
 pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: MessageWriter<AppExit>) {
     exit.write(AppExit::Success);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::message::MessageReader;
+    use ozma_tty_engine::TerminalChildExit;
+
+    #[test]
+    fn child_exit_sends_app_exit() {
+        #[derive(Resource, Default)]
+        struct GotExit(bool);
+
+        fn capture(mut reader: MessageReader<AppExit>, mut flag: ResMut<GotExit>) {
+            if reader.read().next().is_some() {
+                flag.0 = true;
+            }
+        }
+
+        let mut app = App::new();
+        app.add_message::<AppExit>();
+        app.add_observer(on_child_exit);
+        app.init_resource::<GotExit>();
+        app.add_systems(Update, capture);
+
+        let entity = app.world_mut().spawn_empty().id();
+        app.world_mut().trigger(TerminalChildExit {
+            entity,
+            code: Some(0),
+        });
+        app.update();
+
+        assert!(
+            app.world().resource::<GotExit>().0,
+            "AppExit should have been sent on TerminalChildExit",
+        );
+    }
 }

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -17,11 +17,10 @@ impl Plugin for LayoutPlugin {
                 Update,
                 resize_to_window
                     .run_if(in_state(crate::AppMode::Ozma))
+                    .run_if(resource_exists::<TerminalCellMetricsResource>)
                     .run_if(
                         resource_exists_and_changed::<OzmaLastSize>
-                            .or(resource_exists_and_changed::<
-                                ozma_tty_renderer::TerminalCellMetricsResource,
-                            >)
+                            .or(resource_exists_and_changed::<TerminalCellMetricsResource>)
                             .or(on_message::<bevy::window::WindowResized>),
                     ),
             );
@@ -42,12 +41,9 @@ fn resize_to_window(
         (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
         With<OzmaTerminal>,
     >,
-    metrics: Option<Res<TerminalCellMetricsResource>>,
+    metrics: Res<TerminalCellMetricsResource>,
     window_q: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Some(metrics) = metrics else {
-        return;
-    };
     let Ok(window) = window_q.single() else {
         return;
     };

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -6,22 +6,36 @@ use bevy::window::PrimaryWindow;
 use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 
-/// Tracks the last (cols, rows) sent to the terminal to guard against
-/// redundant resize calls.
-#[derive(Resource, Default)]
-pub(crate) struct OzmaLastSize(Option<(u16, u16)>);
+pub(crate) struct LayoutPlugin;
 
-/// Resets the cached terminal size on Ozma mode entry so `resize_to_window`
-/// fires on the first frame even when font metrics and window size are stable.
-pub(crate) fn reset_last_size(mut last_size: ResMut<OzmaLastSize>) {
+impl Plugin for LayoutPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<OzmaLastSize>()
+            .add_message::<bevy::window::WindowResized>()
+            .add_systems(OnEnter(crate::AppMode::Ozma), reset_last_size)
+            .add_systems(
+                Update,
+                resize_to_window
+                    .run_if(in_state(crate::AppMode::Ozma))
+                    .run_if(
+                        resource_exists_and_changed::<OzmaLastSize>
+                            .or(resource_exists_and_changed::<
+                                ozma_tty_renderer::TerminalCellMetricsResource,
+                            >)
+                            .or(on_message::<bevy::window::WindowResized>),
+                    ),
+            );
+    }
+}
+
+#[derive(Resource, Default)]
+struct OzmaLastSize(Option<(u16, u16)>);
+
+fn reset_last_size(mut last_size: ResMut<OzmaLastSize>) {
     last_size.0 = None;
 }
 
-/// Resizes the Ozma terminal to fill the primary window.
-///
-/// Gated by `run_if` at registration — only runs when `OzmaLastSize`,
-/// `TerminalCellMetricsResource`, or `WindowResized` changes.
-pub(crate) fn resize_to_window(
+fn resize_to_window(
     mut commands: Commands,
     mut last_size: ResMut<OzmaLastSize>,
     mut terminal_q: Query<

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -12,15 +12,53 @@ use ozma_tty_renderer::TerminalCellMetricsResource;
 pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
 
 /// Resizes the Ozma terminal to fill the primary window.
+///
+/// Gated by `run_if` at registration — only runs on
+/// `TerminalCellMetricsResource` change or `WindowResized`.
 pub(crate) fn resize_to_window(
-    mut _commands: Commands,
-    mut _last_size: ResMut<OzmaLastSize>,
-    mut _terminal_q: Query<
+    mut commands: Commands,
+    mut last_size: ResMut<OzmaLastSize>,
+    mut terminal_q: Query<
         (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
         With<OzmaTerminal>,
     >,
-    _metrics: Option<Res<TerminalCellMetricsResource>>,
-    _window_q: Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    window_q: Query<&Window, With<PrimaryWindow>>,
 ) {
-    // TODO: implement in Task 5
+    let Some(metrics) = metrics else {
+        return;
+    };
+    let Ok(window) = window_q.single() else {
+        return;
+    };
+    let Ok((entity, mut handle, mut pty, mut coalescer)) = terminal_q.single_mut() else {
+        return;
+    };
+
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cols = ((window.resolution.physical_width() as f32 / cell_w).floor() as u16).max(1);
+    let rows = ((window.resolution.physical_height() as f32 / cell_h).floor() as u16).max(1);
+
+    if last_size.0 == Some((cols, rows)) {
+        return;
+    }
+
+    match handle.resize(&mut pty, &mut coalescer, cols, rows) {
+        Ok(()) => {
+            last_size.0 = Some((cols, rows));
+            handle.emit_pending(&mut commands, entity);
+        }
+        Err(e) => tracing::warn!(?e, cols, rows, "failed to resize ozma terminal"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_size_starts_none() {
+        assert!(OzmaLastSize::default().0.is_none());
+    }
 }

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -9,7 +9,7 @@ use ozma_tty_renderer::TerminalCellMetricsResource;
 /// Tracks the last (cols, rows) sent to the terminal to guard against
 /// redundant resize calls.
 #[derive(Resource, Default)]
-pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
+pub(crate) struct OzmaLastSize(Option<(u16, u16)>);
 
 /// Resets the cached terminal size on Ozma mode entry so `resize_to_window`
 /// fires on the first frame even when font metrics and window size are stable.
@@ -19,8 +19,8 @@ pub(crate) fn reset_last_size(mut last_size: ResMut<OzmaLastSize>) {
 
 /// Resizes the Ozma terminal to fill the primary window.
 ///
-/// Gated by `run_if` at registration — only runs on
-/// `TerminalCellMetricsResource` change or `WindowResized`.
+/// Gated by `run_if` at registration — only runs when `OzmaLastSize`,
+/// `TerminalCellMetricsResource`, or `WindowResized` changes.
 pub(crate) fn resize_to_window(
     mut commands: Commands,
     mut last_size: ResMut<OzmaLastSize>,
@@ -43,8 +43,12 @@ pub(crate) fn resize_to_window(
 
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
-    let cols = ((window.resolution.physical_width() as f32 / cell_w).floor() as u16).max(1);
-    let rows = ((window.resolution.physical_height() as f32 / cell_h).floor() as u16).max(1);
+    let (cols, rows) = crate::spawn::cells_for(
+        window.resolution.physical_width(),
+        window.resolution.physical_height(),
+        cell_w,
+        cell_h,
+    );
 
     if last_size.0 == Some((cols, rows)) {
         return;

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -1,10 +1,10 @@
 //! Window-fill resize system for the Ozma terminal.
 
+use crate::spawn::OzmaTerminal;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
-use crate::spawn::OzmaTerminal;
 
 /// Tracks the last (cols, rows) sent to the terminal to guard against
 /// redundant resize calls.

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -11,6 +11,12 @@ use ozma_tty_renderer::TerminalCellMetricsResource;
 #[derive(Resource, Default)]
 pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
 
+/// Resets the cached terminal size on Ozma mode entry so `resize_to_window`
+/// fires on the first frame even when font metrics and window size are stable.
+pub(crate) fn reset_last_size(mut last_size: ResMut<OzmaLastSize>) {
+    last_size.0 = None;
+}
+
 /// Resizes the Ozma terminal to fill the primary window.
 ///
 /// Gated by `run_if` at registration — only runs on

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -1,0 +1,27 @@
+//! Window-fill resize system for the Ozma terminal.
+
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+
+use crate::spawn::OzmaTerminal;
+
+/// Tracks the last (cols, rows) sent to the terminal to guard against
+/// redundant resize calls.
+#[derive(Resource, Default)]
+pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
+
+/// Resizes the Ozma terminal to fill the primary window.
+pub(crate) fn resize_to_window(
+    mut _commands: Commands,
+    mut _last_size: ResMut<OzmaLastSize>,
+    mut _terminal_q: Query<
+        (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
+        With<OzmaTerminal>,
+    >,
+    _metrics: Option<Res<TerminalCellMetricsResource>>,
+    _window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    // TODO: implement in Task 5
+}

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
-
 use crate::spawn::OzmaTerminal;
 
 /// Tracks the last (cols, rows) sent to the terminal to guard against

--- a/crates/ozma_mode/src/layout.rs
+++ b/crates/ozma_mode/src/layout.rs
@@ -2,7 +2,7 @@
 
 use crate::spawn::OzmaTerminal;
 use bevy::prelude::*;
-use bevy::window::PrimaryWindow;
+use bevy::window::{PrimaryWindow, WindowResized};
 use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 
@@ -11,7 +11,7 @@ pub(crate) struct LayoutPlugin;
 impl Plugin for LayoutPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<OzmaLastSize>()
-            .add_message::<bevy::window::WindowResized>()
+            .add_message::<WindowResized>()
             .add_systems(OnEnter(crate::AppMode::Ozma), reset_last_size)
             .add_systems(
                 Update,
@@ -21,7 +21,7 @@ impl Plugin for LayoutPlugin {
                     .run_if(
                         resource_exists_and_changed::<OzmaLastSize>
                             .or(resource_exists_and_changed::<TerminalCellMetricsResource>)
-                            .or(on_message::<bevy::window::WindowResized>),
+                            .or(on_message::<WindowResized>),
                     ),
             );
     }
@@ -37,17 +37,17 @@ fn reset_last_size(mut last_size: ResMut<OzmaLastSize>) {
 fn resize_to_window(
     mut commands: Commands,
     mut last_size: ResMut<OzmaLastSize>,
-    mut terminal_q: Query<
+    mut terminal: Query<
         (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
         With<OzmaTerminal>,
     >,
     metrics: Res<TerminalCellMetricsResource>,
-    window_q: Query<&Window, With<PrimaryWindow>>,
+    window: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Ok(window) = window_q.single() else {
+    let Ok(window) = window.single() else {
         return;
     };
-    let Ok((entity, mut handle, mut pty, mut coalescer)) = terminal_q.single_mut() else {
+    let Ok((entity, mut handle, mut pty, mut coalescer)) = terminal.single_mut() else {
         return;
     };
 

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -53,7 +53,10 @@ impl Plugin for OzmaModePlugin {
                 shell: self.config_shell.clone(),
             })
             .add_observer(exit::on_child_exit)
-            .add_systems(OnEnter(AppMode::Ozma), spawn::spawn_terminal)
+            .add_systems(
+                OnEnter(AppMode::Ozma),
+                (spawn::spawn_terminal, layout::reset_last_size),
+            )
             .add_systems(
                 Update,
                 layout::resize_to_window

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -40,29 +40,10 @@ impl OzmaModePlugin {
 impl Plugin for OzmaModePlugin {
     fn build(&self, app: &mut App) {
         app.init_state::<AppMode>()
-            .init_resource::<layout::OzmaLastSize>()
-            .add_message::<bevy::window::WindowResized>()
             .insert_resource(OzmaModeConfig {
                 shell: self.config_shell.clone(),
             })
-            .add_observer(exit::on_child_exit)
-            .add_systems(
-                OnEnter(AppMode::Ozma),
-                (spawn::spawn_terminal, layout::reset_last_size),
-            )
-            .add_systems(
-                Update,
-                layout::resize_to_window
-                    .run_if(in_state(AppMode::Ozma))
-                    .run_if(
-                        resource_exists_and_changed::<layout::OzmaLastSize>
-                            .or(resource_exists_and_changed::<
-                                ozma_tty_renderer::TerminalCellMetricsResource,
-                            >)
-                            .or(on_message::<bevy::window::WindowResized>),
-                    ),
-            )
-            .add_systems(OnExit(AppMode::Ozma), spawn::despawn_terminal);
+            .add_plugins((exit::ExitPlugin, layout::LayoutPlugin, spawn::SpawnPlugin));
     }
 }
 

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -73,15 +73,20 @@ impl Plugin for OzmaModePlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::asset::AssetPlugin;
+    use ozma_tty_renderer::material::TerminalUiMaterial;
 
     #[test]
     fn plugin_registers_state_and_defaults_to_ozma() {
         let mut app = App::new();
         app.add_plugins((
             MinimalPlugins,
+            AssetPlugin::default(),
             bevy::state::app::StatesPlugin,
             OzmaModePlugin::new(None),
         ));
+        app.world_mut()
+            .init_resource::<bevy::asset::Assets<TerminalUiMaterial>>();
         app.update();
         assert_eq!(
             app.world().resource::<State<AppMode>>().get(),

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -1,0 +1,91 @@
+//! Ozma single-terminal mode: owns `AppMode` State and the `OzmaModePlugin`.
+
+mod exit;
+mod layout;
+mod spawn;
+
+use bevy::prelude::*;
+
+/// Application mode. `Ozma` is the default (single PTY, no tmux).
+/// `Ozmux` activates the tmux multiplexer backend.
+///
+/// Owned here and re-exported so other crates can depend on this crate
+/// for the shared state type rather than duplicating it.
+#[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum AppMode {
+    /// Single PTY terminal, Alacritty VT emulation, no tmux.
+    #[default]
+    Ozma,
+    /// tmux backend, multiplexer layout.
+    Ozmux,
+}
+
+/// Internal resource storing the constructor-injected shell override.
+/// `None` means "fall back to `$SHELL` at spawn time".
+#[derive(Resource)]
+pub(crate) struct OzmaModeConfig {
+    pub(crate) shell: Option<String>,
+}
+
+/// Bevy plugin implementing Ozma mode: spawns a single PTY terminal on
+/// `OnEnter(AppMode::Ozma)`, resizes it to fill the window, and sends
+/// `AppExit` when the shell process exits.
+pub struct OzmaModePlugin {
+    config_shell: Option<String>,
+}
+
+impl OzmaModePlugin {
+    /// Constructs the plugin with the shell override from config.
+    ///
+    /// Pass `OzmuxConfigs.ozma.shell` here; the plugin resolves
+    /// `$SHELL` and `/bin/sh` fallbacks at spawn time.
+    pub fn new(config_shell: Option<String>) -> Self {
+        Self { config_shell }
+    }
+}
+
+impl Plugin for OzmaModePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_state::<AppMode>()
+            .init_resource::<layout::OzmaLastSize>()
+            .add_message::<bevy::window::WindowResized>()
+            .insert_resource(OzmaModeConfig {
+                shell: self.config_shell.clone(),
+            })
+            .add_observer(exit::on_child_exit)
+            .add_systems(OnEnter(AppMode::Ozma), spawn::spawn_terminal)
+            .add_systems(
+                Update,
+                layout::resize_to_window
+                    .run_if(in_state(AppMode::Ozma))
+                    .run_if(
+                        resource_exists_and_changed::<layout::OzmaLastSize>
+                            .or(resource_exists_and_changed::<
+                                ozma_tty_renderer::TerminalCellMetricsResource,
+                            >)
+                            .or(on_message::<bevy::window::WindowResized>),
+                    ),
+            )
+            .add_systems(OnExit(AppMode::Ozma), spawn::despawn_terminal);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_registers_state_and_defaults_to_ozma() {
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins,
+            bevy::state::app::StatesPlugin,
+            OzmaModePlugin::new(None),
+        ));
+        app.update();
+        assert_eq!(
+            app.world().resource::<State<AppMode>>().get(),
+            &AppMode::Ozma,
+        );
+    }
+}

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -20,13 +20,6 @@ pub enum AppMode {
     Ozmux,
 }
 
-/// Internal resource storing the constructor-injected shell override.
-/// `None` means "fall back to `$SHELL` at spawn time".
-#[derive(Resource)]
-pub(crate) struct OzmaModeConfig {
-    pub(crate) shell: Option<String>,
-}
-
 /// Bevy plugin implementing Ozma mode: spawns a single PTY terminal on
 /// `OnEnter(AppMode::Ozma)`, resizes it to fill the window, and sends
 /// `AppExit` when the shell process exits.
@@ -71,6 +64,13 @@ impl Plugin for OzmaModePlugin {
             )
             .add_systems(OnExit(AppMode::Ozma), spawn::despawn_terminal);
     }
+}
+
+/// Internal resource storing the constructor-injected shell override.
+/// `None` means "fall back to `$SHELL` at spawn time".
+#[derive(Resource)]
+pub(crate) struct OzmaModeConfig {
+    pub(crate) shell: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/ozma_mode/src/lib.rs
+++ b/crates/ozma_mode/src/lib.rs
@@ -4,6 +4,7 @@ mod exit;
 mod layout;
 mod spawn;
 
+use crate::{exit::ExitPlugin, layout::LayoutPlugin, spawn::SpawnPlugin};
 use bevy::prelude::*;
 
 /// Application mode. `Ozma` is the default (single PTY, no tmux).
@@ -43,7 +44,7 @@ impl Plugin for OzmaModePlugin {
             .insert_resource(OzmaModeConfig {
                 shell: self.config_shell.clone(),
             })
-            .add_plugins((exit::ExitPlugin, layout::LayoutPlugin, spawn::SpawnPlugin));
+            .add_plugins((ExitPlugin, LayoutPlugin, SpawnPlugin));
     }
 }
 

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -1,22 +1,115 @@
 //! Terminal spawn and despawn for Ozma mode.
-
+use crate::OzmaModeConfig;
 use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use ozma_tty_engine::{SpawnOptions, TerminalBundle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::material::TerminalUiMaterial;
+use ozma_tty_renderer::prelude::TerminalRenderBundle;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 /// Marker component identifying the single Ozma terminal entity.
 #[derive(Component)]
 pub(crate) struct OzmaTerminal;
 
-/// Spawns the Ozma PTY terminal on mode entry.
-pub(crate) fn spawn_terminal(_commands: Commands) {
-    // TODO: implement in Task 3
+/// Spawns the Ozma PTY terminal on `OnEnter(AppMode::Ozma)`.
+///
+/// Reads `OzmaModeConfig.shell` for the configured shell override;
+/// falls back to `$SHELL` then `/bin/sh`. Initial terminal dimensions
+/// are derived from the primary window and font metrics if available,
+/// otherwise default to 80×24.
+pub(crate) fn spawn_terminal(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<TerminalUiMaterial>>,
+    config: Res<OzmaModeConfig>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    let (cols, rows) = metrics
+        .as_ref()
+        .zip(window_q.single().ok())
+        .map(|(m, w)| {
+            let cell_w = m.metrics.advance_phys.floor().max(1.0);
+            let cell_h = m.metrics.line_height_phys.floor().max(1.0);
+            cells_for(
+                w.resolution.physical_width(),
+                w.resolution.physical_height(),
+                cell_w,
+                cell_h,
+            )
+        })
+        .unwrap_or((80, 24));
+
+    let shell = resolve_shell(
+        config.shell.as_deref(),
+        std::env::var("SHELL").ok().as_deref(),
+    );
+
+    let opts = SpawnOptions {
+        cols,
+        rows,
+        shell,
+        cwd: None,
+        env: Vec::new(),
+        osc_webview_gate: Arc::new(AtomicBool::new(false)),
+    };
+
+    match TerminalBundle::spawn(opts) {
+        Ok(bundle) => {
+            let material = materials.add(TerminalUiMaterial::default());
+            commands.spawn((bundle, TerminalRenderBundle::new(material), OzmaTerminal));
+        }
+        Err(e) => tracing::error!(?e, "failed to spawn ozma terminal"),
+    }
 }
 
-/// Despawns the Ozma terminal on mode exit.
+/// Despawns the Ozma terminal on `OnExit(AppMode::Ozma)`.
 pub(crate) fn despawn_terminal(
     mut commands: Commands,
     terminal_q: Query<Entity, With<OzmaTerminal>>,
 ) {
     for entity in terminal_q.iter() {
         commands.entity(entity).despawn();
+    }
+}
+
+fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
+    let cols = ((w_px as f32 / cell_w).floor() as u16).max(1);
+    let rows = ((h_px as f32 / cell_h).floor() as u16).max(1);
+    (cols, rows)
+}
+
+fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {
+    config.or(env_shell).unwrap_or("/bin/sh").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_resolution_uses_config() {
+        assert_eq!(
+            resolve_shell(Some("/bin/fish"), Some("/bin/zsh")),
+            "/bin/fish"
+        );
+    }
+
+    #[test]
+    fn shell_resolution_falls_back_to_env() {
+        assert_eq!(resolve_shell(None, Some("/bin/zsh")), "/bin/zsh");
+    }
+
+    #[test]
+    fn shell_resolution_falls_back_to_sh() {
+        assert_eq!(resolve_shell(None, None), "/bin/sh");
+    }
+
+    #[test]
+    fn cells_for_divides_and_floors() {
+        assert_eq!(cells_for(800, 600, 8.0, 16.0), (100, 37));
+        assert_eq!(cells_for(0, 0, 8.0, 16.0), (1, 1));
+        assert_eq!(cells_for(807, 607, 8.0, 16.0), (100, 37));
     }
 }

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -1,0 +1,22 @@
+//! Terminal spawn and despawn for Ozma mode.
+
+use bevy::prelude::*;
+
+/// Marker component identifying the single Ozma terminal entity.
+#[derive(Component)]
+pub(crate) struct OzmaTerminal;
+
+/// Spawns the Ozma PTY terminal on mode entry.
+pub(crate) fn spawn_terminal(_commands: Commands) {
+    // TODO: implement in Task 3
+}
+
+/// Despawns the Ozma terminal on mode exit.
+pub(crate) fn despawn_terminal(
+    mut commands: Commands,
+    terminal_q: Query<Entity, With<OzmaTerminal>>,
+) {
+    for entity in terminal_q.iter() {
+        commands.entity(entity).despawn();
+    }
+}

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -22,6 +22,7 @@ pub(crate) struct OzmaTerminal;
 pub(crate) fn spawn_terminal(
     mut commands: Commands,
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
+    mut exit: MessageWriter<AppExit>,
     config: Res<OzmaModeConfig>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
     window_q: Query<&Window, With<PrimaryWindow>>,
@@ -72,7 +73,10 @@ pub(crate) fn spawn_terminal(
                 },
             ));
         }
-        Err(e) => tracing::error!(?e, "failed to spawn ozma terminal"),
+        Err(e) => {
+            tracing::error!(?e, "failed to spawn ozma terminal");
+            exit.write(AppExit::Success);
+        }
     }
 }
 
@@ -86,14 +90,18 @@ pub(crate) fn despawn_terminal(
     }
 }
 
-fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
+pub(crate) fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
     let cols = ((w_px as f32 / cell_w).floor() as u16).max(1);
     let rows = ((h_px as f32 / cell_h).floor() as u16).max(1);
     (cols, rows)
 }
 
 fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {
-    config.or(env_shell).unwrap_or("/bin/sh").to_string()
+    config
+        .filter(|s| !s.is_empty())
+        .or_else(|| env_shell.filter(|s| !s.is_empty()))
+        .unwrap_or("/bin/sh")
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -13,13 +13,22 @@ use std::sync::atomic::AtomicBool;
 #[derive(Component)]
 pub(crate) struct OzmaTerminal;
 
-/// Spawns the Ozma PTY terminal on `OnEnter(AppMode::Ozma)`.
-///
-/// Reads `OzmaModeConfig.shell` for the configured shell override;
-/// falls back to `$SHELL` then `/bin/sh`. Initial terminal dimensions
-/// are derived from the primary window and font metrics if available,
-/// otherwise default to 80×24.
-pub(crate) fn spawn_terminal(
+pub(crate) struct SpawnPlugin;
+
+impl Plugin for SpawnPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(OnEnter(crate::AppMode::Ozma), spawn_terminal)
+            .add_systems(OnExit(crate::AppMode::Ozma), despawn_terminal);
+    }
+}
+
+pub(crate) fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
+    let cols = ((w_px as f32 / cell_w).floor() as u16).max(1);
+    let rows = ((h_px as f32 / cell_h).floor() as u16).max(1);
+    (cols, rows)
+}
+
+fn spawn_terminal(
     mut commands: Commands,
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
     mut exit: MessageWriter<AppExit>,
@@ -80,20 +89,13 @@ pub(crate) fn spawn_terminal(
     }
 }
 
-/// Despawns the Ozma terminal on `OnExit(AppMode::Ozma)`.
-pub(crate) fn despawn_terminal(
+fn despawn_terminal(
     mut commands: Commands,
     terminal_q: Query<Entity, With<OzmaTerminal>>,
 ) {
     for entity in terminal_q.iter() {
         commands.entity(entity).despawn();
     }
-}
-
-pub(crate) fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
-    let cols = ((w_px as f32 / cell_w).floor() as u16).max(1);
-    let rows = ((h_px as f32 / cell_h).floor() as u16).max(1);
-    (cols, rows)
 }
 
 fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -58,7 +58,19 @@ pub(crate) fn spawn_terminal(
     match TerminalBundle::spawn(opts) {
         Ok(bundle) => {
             let material = materials.add(TerminalUiMaterial::default());
-            commands.spawn((bundle, TerminalRenderBundle::new(material), OzmaTerminal));
+            commands.spawn((
+                bundle,
+                TerminalRenderBundle::new(material),
+                OzmaTerminal,
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(0.0),
+                    top: Val::Px(0.0),
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    ..default()
+                },
+            ));
         }
         Err(e) => tracing::error!(?e, "failed to spawn ozma terminal"),
     }

--- a/crates/ozma_mode/src/spawn.rs
+++ b/crates/ozma_mode/src/spawn.rs
@@ -34,11 +34,11 @@ fn spawn_terminal(
     mut exit: MessageWriter<AppExit>,
     config: Res<OzmaModeConfig>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
-    window_q: Query<&Window, With<PrimaryWindow>>,
+    window: Query<&Window, With<PrimaryWindow>>,
 ) {
     let (cols, rows) = metrics
         .as_ref()
-        .zip(window_q.single().ok())
+        .zip(window.single().ok())
         .map(|(m, w)| {
             let cell_w = m.metrics.advance_phys.floor().max(1.0);
             let cell_h = m.metrics.line_height_phys.floor().max(1.0);
@@ -91,9 +91,9 @@ fn spawn_terminal(
 
 fn despawn_terminal(
     mut commands: Commands,
-    terminal_q: Query<Entity, With<OzmaTerminal>>,
+    terminals: Query<Entity, With<OzmaTerminal>>,
 ) {
-    for entity in terminal_q.iter() {
+    for entity in terminals.iter() {
         commands.entity(entity).despawn();
     }
 }

--- a/docs/superpowers/plans/2026-06-18-ozma-mode-crate.md
+++ b/docs/superpowers/plans/2026-06-18-ozma-mode-crate.md
@@ -1,0 +1,1048 @@
+# ozma_mode Crate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `crates/ozma_mode` — a Bevy plugin crate that owns `AppMode` State and implements Ozma mode (single PTY terminal, no tmux), plus the `[ozma]` config section in `crates/configs`.
+
+**Architecture:** `OzmaModePlugin` registers `AppMode` State, inserts `OzmaModeConfig` from constructor args, and adds four lifecycle hooks: `OnEnter` spawns the terminal, an `Update` system resizes it to fill the window, a Bevy observer sends `AppExit` on shell exit, and `OnExit` despawns. Config is extended with a new `[ozma]` TOML section (`shell` field, `OzmaConfig`/`OzmaPatch`) wired into `RawConfigs`.
+
+**Tech Stack:** Rust edition 2024, Bevy 0.18, `ozma_tty_engine` (PTY + VT), `ozma_tty_renderer` (`TerminalRenderBundle`, `TerminalCellMetricsResource`, `TerminalUiMaterial`), `ozmux_configs`.
+
+## Global Constraints
+
+- Edition 2024, toolchain pinned to 1.95 (`rust-toolchain.toml`).
+- No `mod.rs` files — use `foo.rs` + `foo/bar.rs` layout.
+- Comments: only `// TODO:`, `// NOTE:`, `// SAFETY:`. No narrative comments.
+- Doc comments (`///`) required on every `pub` item.
+- Mutable parameters first in function signatures.
+- `run_if` for whole-system resource/event gates — no in-body early returns.
+- `#[expect(..., reason = "...")]` over `#[allow(...)]` for lint suppressions.
+- Lint: `cargo clippy --workspace --fix --allow-dirty --allow-staged && cargo fmt` (or `make fix-lint`).
+- Test command: `cargo test -p ozmux_configs` (Task 1), `cargo test -p ozma_mode` (Tasks 2–5).
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `crates/configs/src/ozma.rs` | CREATE | `OzmaConfig`, `OzmaPatch`, per-field tests |
+| `crates/configs/src/lib.rs` | MODIFY | Add `pub mod ozma;`, `pub ozma: OzmaConfig` field to `OzmuxConfigs` |
+| `crates/configs/src/raw.rs` | MODIFY | Add `ozma: Option<OzmaPatch>` to `RawConfigs`, arm in `apply_to` |
+| `crates/ozma_mode/Cargo.toml` | CREATE | Crate metadata + deps |
+| `crates/ozma_mode/src/lib.rs` | CREATE | `AppMode`, `OzmaModeConfig`, `OzmaModePlugin` |
+| `crates/ozma_mode/src/spawn.rs` | CREATE | `resolve_shell`, `OzmaTerminal` marker, `spawn_terminal` system |
+| `crates/ozma_mode/src/layout.rs` | CREATE | `OzmaLastSize` resource, `resize_to_window` system |
+| `crates/ozma_mode/src/exit.rs` | CREATE | `on_child_exit` observer |
+
+---
+
+### Task 1: Add `[ozma]` config section to `crates/configs`
+
+**Files:**
+- Create: `crates/configs/src/ozma.rs`
+- Modify: `crates/configs/src/lib.rs` (lines ~20–45 for mod/struct)
+- Modify: `crates/configs/src/raw.rs` (RawConfigs struct + apply_to)
+
+**Interfaces:**
+- Produces: `ozmux_configs::ozma::OzmaConfig { pub shell: Option<String> }` — read by Task 2's `OzmaModePlugin::new`.
+
+- [ ] **Step 1: Write failing tests in `crates/configs/src/ozma.rs`**
+
+Create the file with tests only (no implementation yet):
+
+```rust
+//! Configuration for the Ozma single-terminal mode.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_shell_is_none() {
+        assert!(OzmaConfig::default().shell.is_none());
+    }
+
+    #[test]
+    fn patch_overrides_shell() {
+        let patched = OzmaPatch {
+            shell: Some("/bin/fish".to_string()),
+        }
+        .apply_to(OzmaConfig::default());
+        assert_eq!(patched.shell.as_deref(), Some("/bin/fish"));
+    }
+
+    #[test]
+    fn empty_patch_keeps_base() {
+        let patched = OzmaPatch::default().apply_to(OzmaConfig::default());
+        assert_eq!(patched, OzmaConfig::default());
+    }
+
+    #[test]
+    fn ozma_section_parses_from_toml() {
+        let toml_str = r#"
+[ozma]
+shell = "/usr/bin/zsh"
+"#;
+        let raw: crate::raw::RawConfigs = toml::from_str(toml_str).unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert_eq!(merged.ozma.shell.as_deref(), Some("/usr/bin/zsh"));
+    }
+
+    #[test]
+    fn missing_ozma_section_uses_defaults() {
+        let raw: crate::raw::RawConfigs = toml::from_str("").unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert!(merged.ozma.shell.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cargo test -p ozmux_configs 2>&1 | grep -E "error|FAILED|cannot find"
+```
+
+Expected: compile errors — `OzmaConfig`, `OzmaPatch` not found.
+
+- [ ] **Step 3: Implement `crates/configs/src/ozma.rs`**
+
+Replace the file with the full implementation + tests:
+
+```rust
+//! Configuration for the Ozma single-terminal mode.
+
+use serde::Deserialize;
+
+/// Resolved Ozma mode settings.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OzmaConfig {
+    /// Shell program to launch. `None` means "resolve at runtime via `$SHELL`".
+    pub shell: Option<String>,
+}
+
+/// Per-field-optional `[ozma]` view for TOML deserialization.
+#[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OzmaPatch {
+    /// Optional shell override.
+    pub shell: Option<String>,
+}
+
+impl OzmaPatch {
+    /// Applies this patch over `base`, keeping `base`'s value where unset.
+    pub(crate) fn apply_to(self, base: OzmaConfig) -> OzmaConfig {
+        OzmaConfig {
+            shell: self.shell.or(base.shell),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_shell_is_none() {
+        assert!(OzmaConfig::default().shell.is_none());
+    }
+
+    #[test]
+    fn patch_overrides_shell() {
+        let patched = OzmaPatch {
+            shell: Some("/bin/fish".to_string()),
+        }
+        .apply_to(OzmaConfig::default());
+        assert_eq!(patched.shell.as_deref(), Some("/bin/fish"));
+    }
+
+    #[test]
+    fn empty_patch_keeps_base() {
+        let patched = OzmaPatch::default().apply_to(OzmaConfig::default());
+        assert_eq!(patched, OzmaConfig::default());
+    }
+
+    #[test]
+    fn ozma_section_parses_from_toml() {
+        let toml_str = r#"
+[ozma]
+shell = "/usr/bin/zsh"
+"#;
+        let raw: crate::raw::RawConfigs = toml::from_str(toml_str).unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert_eq!(merged.ozma.shell.as_deref(), Some("/usr/bin/zsh"));
+    }
+
+    #[test]
+    fn missing_ozma_section_uses_defaults() {
+        let raw: crate::raw::RawConfigs = toml::from_str("").unwrap();
+        let merged = raw.apply_to(crate::OzmuxConfigs::default());
+        assert!(merged.ozma.shell.is_none());
+    }
+}
+```
+
+- [ ] **Step 4: Add `pub mod ozma;` and `pub ozma: OzmaConfig` to `crates/configs/src/lib.rs`**
+
+In the module declaration block (after `pub mod tmux;`), add:
+
+```rust
+pub mod ozma;
+```
+
+In the `OzmuxConfigs` struct, add the field after `pub tmux: tmux::TmuxConfig,`:
+
+```rust
+    /// Ozma single-terminal mode configuration.
+    pub ozma: ozma::OzmaConfig,
+```
+
+The `Default` derive already handles `OzmaConfig::default()` — no `impl Default` change needed.
+
+- [ ] **Step 5: Add `ozma: Option<OzmaPatch>` to `crates/configs/src/raw.rs`**
+
+In `RawConfigs`, add after `pub(crate) tmux: Option<TmuxPatch>,`:
+
+```rust
+    pub(crate) ozma: Option<crate::ozma::OzmaPatch>,
+```
+
+In `RawConfigs::apply_to`, add after the `tmux` arm:
+
+```rust
+        if let Some(patch) = self.ozma {
+            base.ozma = patch.apply_to(base.ozma);
+        }
+```
+
+Also add the import at the top of `raw.rs` (already uses `use crate::tmux::TmuxPatch;` style — no new import needed since we reference via `crate::ozma::OzmaPatch` inline, or add `use crate::ozma::OzmaPatch;` to the use block):
+
+Add to the `use` block at the top of `raw.rs`:
+```rust
+use crate::ozma::OzmaPatch;
+```
+
+Then use `ozma: Option<OzmaPatch>` (without `crate::` prefix).
+
+- [ ] **Step 6: Run tests to verify all pass**
+
+```bash
+cargo test -p ozmux_configs 2>&1 | tail -5
+```
+
+Expected output ends with: `test result: ok. N passed; 0 failed`
+
+- [ ] **Step 7: Lint**
+
+```bash
+cargo clippy -p ozmux_configs --fix --allow-dirty --allow-staged && cargo fmt
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/configs/src/ozma.rs crates/configs/src/lib.rs crates/configs/src/raw.rs
+git commit -m "feat(configs): add [ozma] config section with shell field"
+```
+
+---
+
+### Task 2: Scaffold `crates/ozma_mode` — `AppMode` + plugin stub
+
+**Files:**
+- Create: `crates/ozma_mode/Cargo.toml`
+- Create: `crates/ozma_mode/src/lib.rs`
+
+**Interfaces:**
+- Produces:
+  - `ozma_mode::AppMode` — `pub enum AppMode { Ozma, Ozmux }`, `Default = Ozma`
+  - `ozma_mode::OzmaModePlugin::new(config_shell: Option<String>) -> OzmaModePlugin`
+  - `ozma_mode::OzmaModeConfig` (internal resource, `pub(crate)`) — holds `shell: Option<String>`
+
+- [ ] **Step 1: Write failing test in a temporary inline location**
+
+We can't write the test file until the crate exists. Instead, create the skeleton first (Step 2), then add the test.
+
+- [ ] **Step 2: Create `crates/ozma_mode/Cargo.toml`**
+
+```toml
+[package]
+name = "ozma_mode"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+authors.workspace = true
+publish.workspace = true
+
+[dependencies]
+bevy              = { workspace = true }
+ozma_tty_engine   = { path = "../ozma_tty_engine" }
+ozma_tty_renderer = { path = "../ozma_tty_renderer" }
+ozmux_configs     = { path = "../configs" }
+tracing           = { workspace = true }
+anyhow            = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 3: Create `crates/ozma_mode/src/lib.rs`** with `AppMode`, `OzmaModeConfig`, and a stub `OzmaModePlugin`
+
+```rust
+//! Ozma single-terminal mode: owns `AppMode` State and the `OzmaModePlugin`.
+
+mod exit;
+mod layout;
+mod spawn;
+
+use bevy::prelude::*;
+
+/// Application mode. `Ozma` is the default (single PTY, no tmux).
+/// `Ozmux` activates the tmux multiplexer backend.
+///
+/// Owned here and re-exported so `crates/ozmux_mode` (future) can depend on
+/// this crate for the shared state type rather than duplicating it.
+#[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum AppMode {
+    /// Single PTY terminal, Alacritty VT emulation, no tmux.
+    #[default]
+    Ozma,
+    /// tmux backend, multiplexer layout.
+    Ozmux,
+}
+
+/// Internal resource storing the constructor-injected shell override.
+/// `None` means "fall back to `$SHELL` at spawn time".
+#[derive(Resource)]
+pub(crate) struct OzmaModeConfig {
+    pub(crate) shell: Option<String>,
+}
+
+/// Bevy plugin implementing Ozma mode: spawns a single PTY terminal on
+/// `OnEnter(AppMode::Ozma)`, resizes it to fill the window, and sends
+/// `AppExit` when the shell process exits.
+pub struct OzmaModePlugin {
+    config_shell: Option<String>,
+}
+
+impl OzmaModePlugin {
+    /// Constructs the plugin with the shell override from config.
+    ///
+    /// Pass `OzmuxConfigs.ozma.shell` here; the plugin resolves
+    /// `$SHELL` and `/bin/sh` fallbacks at spawn time.
+    pub fn new(config_shell: Option<String>) -> Self {
+        Self { config_shell }
+    }
+}
+
+impl Plugin for OzmaModePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_state::<AppMode>()
+            .insert_resource(OzmaModeConfig {
+                shell: self.config_shell.clone(),
+            })
+            .add_observer(exit::on_child_exit)
+            .add_systems(OnEnter(AppMode::Ozma), spawn::spawn_terminal)
+            .add_systems(
+                Update,
+                layout::resize_to_window
+                    .run_if(in_state(AppMode::Ozma))
+                    .run_if(
+                        resource_exists_and_changed::<layout::OzmaLastSize>
+                            .or(resource_exists_and_changed::<ozma_tty_renderer::TerminalCellMetricsResource>)
+                            .or(on_event::<bevy::window::WindowResized>),
+                    ),
+            )
+            .add_systems(OnExit(AppMode::Ozma), spawn::despawn_terminal);
+    }
+}
+```
+
+- [ ] **Step 4: Write failing test at the bottom of `lib.rs`** (inside `#[cfg(test)]`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_registers_state_and_defaults_to_ozma() {
+        let mut app = App::new();
+        app.add_plugins(OzmaModePlugin::new(None));
+        app.update();
+        assert_eq!(
+            *app.world().resource::<State<AppMode>>(),
+            State::new(AppMode::Ozma),
+        );
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails (because `exit`, `layout`, `spawn` modules are empty)**
+
+```bash
+cargo test -p ozma_mode 2>&1 | grep -E "error|FAILED"
+```
+
+Expected: compile errors for missing items in `exit`, `layout`, `spawn`.
+
+- [ ] **Step 6: Create stub files so the crate compiles**
+
+Create `crates/ozma_mode/src/exit.rs`:
+```rust
+//! Child-process exit observer: sends `AppExit` when the shell quits.
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalChildExit;
+
+/// Observer fired when the PTY child exits. Sends `AppExit::Success`.
+pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: EventWriter<AppExit>) {
+    exit.write(AppExit::Success);
+}
+```
+
+Create `crates/ozma_mode/src/layout.rs`:
+```rust
+//! Window-fill resize system for the Ozma terminal.
+use bevy::prelude::*;
+use crate::spawn::OzmaTerminal;
+use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+
+/// Tracks the last (cols, rows) sent to the terminal to guard against
+/// redundant resize calls.
+#[derive(Resource, Default)]
+pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
+
+/// Resizes the Ozma terminal to fill the primary window.
+pub(crate) fn resize_to_window(
+    mut _commands: Commands,
+    mut _last_size: ResMut<OzmaLastSize>,
+    mut _terminal_q: Query<
+        (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
+        With<OzmaTerminal>,
+    >,
+    _metrics: Res<TerminalCellMetricsResource>,
+    _window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    // TODO: implement in Task 5
+}
+```
+
+Create `crates/ozma_mode/src/spawn.rs`:
+```rust
+//! Terminal spawn and despawn for Ozma mode.
+use bevy::prelude::*;
+
+/// Marker component identifying the single Ozma terminal entity.
+#[derive(Component)]
+pub(crate) struct OzmaTerminal;
+
+/// Spawns the Ozma PTY terminal on mode entry.
+pub(crate) fn spawn_terminal(_commands: Commands) {
+    // TODO: implement in Task 3
+}
+
+/// Despawns the Ozma terminal on mode exit.
+pub(crate) fn despawn_terminal(
+    mut commands: Commands,
+    terminal_q: Query<Entity, With<OzmaTerminal>>,
+) {
+    for entity in terminal_q.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+```
+
+- [ ] **Step 7: Run the test to confirm it passes**
+
+```bash
+cargo test -p ozma_mode plugin_registers_state 2>&1 | tail -5
+```
+
+Expected: `test tests::plugin_registers_state_and_defaults_to_ozma ... ok`
+
+- [ ] **Step 8: Lint**
+
+```bash
+cargo clippy -p ozma_mode --fix --allow-dirty --allow-staged && cargo fmt
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ozma_mode/
+git commit -m "feat(ozma_mode): scaffold crate with AppMode State and plugin stub"
+```
+
+---
+
+### Task 3: Implement `spawn.rs` — shell resolution and terminal spawn
+
+**Files:**
+- Modify: `crates/ozma_mode/src/spawn.rs`
+
+**Interfaces:**
+- Consumes (from Task 2):
+  - `OzmaModeConfig { shell: Option<String> }` — `Res<OzmaModeConfig>` in system
+  - `OzmaTerminal` marker component — already defined
+- Consumes (from `ozma_tty_engine`):
+  - `TerminalBundle::spawn(SpawnOptions) -> anyhow::Result<TerminalBundle>`
+  - `SpawnOptions { cols: u16, rows: u16, shell: String, cwd: Option<PathBuf>, env: Vec<(String, String)>, osc_webview_gate: Arc<AtomicBool> }`
+- Consumes (from `ozma_tty_renderer`):
+  - `TerminalRenderBundle::new(Handle<TerminalUiMaterial>) -> TerminalRenderBundle`
+  - `TerminalCellMetricsResource { metrics: CellMetrics { advance_phys: f32, line_height_phys: f32 } }`
+  - `TerminalUiMaterial` — from `ozma_tty_renderer::material`
+- Produces:
+  - `resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String` — `pub(crate)` free function
+  - `spawn_terminal` system (replaces stub)
+  - `despawn_terminal` system (already implemented)
+
+- [ ] **Step 1: Write failing tests for `resolve_shell`**
+
+Add to `crates/ozma_mode/src/spawn.rs` (replace stub contents):
+
+```rust
+//! Terminal spawn and despawn for Ozma mode.
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalHandle;
+
+/// Marker component identifying the single Ozma terminal entity.
+#[derive(Component)]
+pub(crate) struct OzmaTerminal;
+
+/// Resolves the shell program to launch.
+///
+/// Priority: `config` → `env_shell` → `"/bin/sh"`.
+pub(crate) fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {
+    todo!()
+}
+
+pub(crate) fn spawn_terminal(_commands: Commands) {}
+
+pub(crate) fn despawn_terminal(
+    mut commands: Commands,
+    terminal_q: Query<Entity, With<OzmaTerminal>>,
+) {
+    for entity in terminal_q.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_shell_uses_config_first() {
+        assert_eq!(
+            resolve_shell(Some("/bin/fish"), Some("/bin/zsh")),
+            "/bin/fish"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_falls_back_to_env() {
+        assert_eq!(resolve_shell(None, Some("/bin/zsh")), "/bin/zsh");
+    }
+
+    #[test]
+    fn resolve_shell_falls_back_to_sh() {
+        assert_eq!(resolve_shell(None, None), "/bin/sh");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cargo test -p ozma_mode resolve_shell 2>&1 | grep -E "FAILED|panicked"
+```
+
+Expected: tests panic on `todo!()`.
+
+- [ ] **Step 3: Implement `resolve_shell`**
+
+Replace the `todo!()` body:
+
+```rust
+pub(crate) fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {
+    config
+        .or(env_shell)
+        .unwrap_or("/bin/sh")
+        .to_string()
+}
+```
+
+- [ ] **Step 4: Run resolve_shell tests — all must pass**
+
+```bash
+cargo test -p ozma_mode resolve_shell 2>&1 | tail -5
+```
+
+Expected: `3 passed; 0 failed`
+
+- [ ] **Step 5: Implement `spawn_terminal` system**
+
+Replace the full `crates/ozma_mode/src/spawn.rs` with:
+
+```rust
+//! Terminal spawn and despawn for Ozma mode.
+use crate::OzmaModeConfig;
+use bevy::prelude::*;
+use ozma_tty_engine::{SpawnOptions, TerminalBundle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::material::TerminalUiMaterial;
+use ozma_tty_renderer::prelude::TerminalRenderBundle;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+/// Marker component identifying the single Ozma terminal entity.
+#[derive(Component)]
+pub(crate) struct OzmaTerminal;
+
+/// Resolves the shell program to launch.
+///
+/// Priority: `config` → `env_shell` → `"/bin/sh"`.
+pub(crate) fn resolve_shell(config: Option<&str>, env_shell: Option<&str>) -> String {
+    config
+        .or(env_shell)
+        .unwrap_or("/bin/sh")
+        .to_string()
+}
+
+/// Spawns the Ozma terminal on `OnEnter(AppMode::Ozma)`.
+///
+/// Reads `OzmaModeConfig.shell` for the configured shell override;
+/// falls back to `$SHELL` then `/bin/sh`. Initial terminal dimensions
+/// are derived from the primary window and font metrics if available,
+/// otherwise default to 80×24.
+pub(crate) fn spawn_terminal(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<TerminalUiMaterial>>,
+    config: Res<OzmaModeConfig>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    let (cols, rows) = metrics
+        .as_ref()
+        .zip(window_q.single().ok())
+        .map(|(m, w)| {
+            let cell_w = m.metrics.advance_phys.floor().max(1.0);
+            let cell_h = m.metrics.line_height_phys.floor().max(1.0);
+            cells_for(
+                w.resolution.physical_width(),
+                w.resolution.physical_height(),
+                cell_w,
+                cell_h,
+            )
+        })
+        .unwrap_or((80, 24));
+
+    let shell = resolve_shell(
+        config.shell.as_deref(),
+        std::env::var("SHELL").ok().as_deref(),
+    );
+
+    let opts = SpawnOptions {
+        cols,
+        rows,
+        shell,
+        cwd: None,
+        env: Vec::new(),
+        osc_webview_gate: Arc::new(AtomicBool::new(false)),
+    };
+
+    match TerminalBundle::spawn(opts) {
+        Ok(bundle) => {
+            let material = materials.add(TerminalUiMaterial::default());
+            commands.spawn((
+                bundle,
+                TerminalRenderBundle::new(material),
+                OzmaTerminal,
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(0.0),
+                    top: Val::Px(0.0),
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    ..default()
+                },
+            ));
+        }
+        Err(e) => tracing::error!(?e, "failed to spawn ozma terminal"),
+    }
+}
+
+/// Despawns the Ozma terminal on `OnExit(AppMode::Ozma)`.
+pub(crate) fn despawn_terminal(
+    mut commands: Commands,
+    terminal_q: Query<Entity, With<OzmaTerminal>>,
+) {
+    for entity in terminal_q.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16, u16) {
+    let cols = ((w_px as f32 / cell_w).floor() as u16).max(1);
+    let rows = ((h_px as f32 / cell_h).floor() as u16).max(1);
+    (cols, rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_shell_uses_config_first() {
+        assert_eq!(
+            resolve_shell(Some("/bin/fish"), Some("/bin/zsh")),
+            "/bin/fish"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_falls_back_to_env() {
+        assert_eq!(resolve_shell(None, Some("/bin/zsh")), "/bin/zsh");
+    }
+
+    #[test]
+    fn resolve_shell_falls_back_to_sh() {
+        assert_eq!(resolve_shell(None, None), "/bin/sh");
+    }
+
+    #[test]
+    fn cells_for_divides_and_floors() {
+        assert_eq!(cells_for(800, 600, 8.0, 16.0), (100, 37));
+        assert_eq!(cells_for(0, 0, 8.0, 16.0), (1, 1));
+        assert_eq!(cells_for(807, 607, 8.0, 16.0), (100, 37));
+    }
+}
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cargo test -p ozma_mode 2>&1 | tail -8
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Lint**
+
+```bash
+cargo clippy -p ozma_mode --fix --allow-dirty --allow-staged && cargo fmt
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ozma_mode/src/spawn.rs
+git commit -m "feat(ozma_mode): implement shell resolution and terminal spawn"
+```
+
+---
+
+### Task 4: Implement `exit.rs` — child exit observer
+
+**Files:**
+- Modify: `crates/ozma_mode/src/exit.rs`
+
+**Interfaces:**
+- Consumes (from `ozma_tty_engine`): `TerminalChildExit` — `EntityEvent`, triggered via `commands.trigger_targets(ev, entity)`.
+- Produces: `on_child_exit` observer registered in `OzmaModePlugin::build`.
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `crates/ozma_mode/src/exit.rs`:
+
+```rust
+//! Child-process exit observer: sends `AppExit` when the shell quits.
+
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalChildExit;
+
+/// Observer fired when the PTY child process exits.
+///
+/// Sends `AppExit::Success` regardless of the exit code — the user
+/// closed their shell, so the application should quit.
+pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: EventWriter<AppExit>) {
+    exit.write(AppExit::Success);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn child_exit_sends_app_exit() {
+        #[derive(Resource, Default)]
+        struct GotExit(bool);
+
+        fn capture(mut reader: EventReader<AppExit>, mut flag: ResMut<GotExit>) {
+            if reader.read().next().is_some() {
+                flag.0 = true;
+            }
+        }
+
+        let mut app = App::new();
+        app.add_event::<AppExit>();
+        app.add_observer(on_child_exit);
+        app.init_resource::<GotExit>();
+        app.add_systems(Update, capture);
+
+        let entity = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .trigger_targets(TerminalChildExit { entity, code: Some(0) }, entity);
+        app.update();
+
+        assert!(
+            app.world().resource::<GotExit>().0,
+            "AppExit should have been sent on TerminalChildExit"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cargo test -p ozma_mode child_exit 2>&1 | grep -E "FAILED|error"
+```
+
+Expected: compile or test failure (stub has wrong signature or AppExit not registered).
+
+- [ ] **Step 3: Check if `AppExit` needs `add_event` or `add_message`**
+
+Run the test as written. If it fails with "resource not found" for `Events<AppExit>`, switch to:
+
+```rust
+app.add_message::<AppExit>();
+// and use MessageReader<AppExit> instead of EventReader<AppExit>
+```
+
+The correct variant depends on how Bevy 0.18 registers `AppExit`. If `EventWriter<AppExit>` causes a compile error in `on_child_exit`, switch to `MessageWriter<AppExit>` (imported from `bevy::ecs::message::MessageWriter`) and adjust the test's `capture` system similarly.
+
+Adjust `on_child_exit` accordingly:
+
+```rust
+// If MessageWriter is required:
+use bevy::ecs::message::MessageWriter;
+
+pub(crate) fn on_child_exit(_ev: On<TerminalChildExit>, mut exit: MessageWriter<AppExit>) {
+    exit.write(AppExit::Success);
+}
+```
+
+And test `capture`:
+```rust
+use bevy::ecs::message::MessageReader;
+fn capture(mut reader: MessageReader<AppExit>, mut flag: ResMut<GotExit>) {
+    if reader.read().next().is_some() { flag.0 = true; }
+}
+// and app.add_message::<AppExit>();
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+cargo test -p ozma_mode child_exit 2>&1 | tail -5
+```
+
+Expected: `test exit::tests::child_exit_sends_app_exit ... ok`
+
+- [ ] **Step 5: Lint**
+
+```bash
+cargo clippy -p ozma_mode --fix --allow-dirty --allow-staged && cargo fmt
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ozma_mode/src/exit.rs
+git commit -m "feat(ozma_mode): add child-exit observer"
+```
+
+---
+
+### Task 5: Implement `layout.rs` — resize terminal to window
+
+**Files:**
+- Modify: `crates/ozma_mode/src/layout.rs`
+
+**Interfaces:**
+- Consumes (from Task 3): `OzmaTerminal` marker component.
+- Consumes (from `ozma_tty_engine`):
+  - `TerminalHandle::resize(&mut self, pty: &mut PtyHandle, coalescer: &mut Coalescer, cols: u16, rows: u16) -> anyhow::Result<()>`
+  - `TerminalHandle::emit_pending(&mut self, commands: &mut Commands, entity: Entity)`
+- Consumes (from `ozma_tty_renderer`): `TerminalCellMetricsResource { metrics: CellMetrics { advance_phys: f32, line_height_phys: f32 } }`
+- Produces: `OzmaLastSize` resource, `resize_to_window` system (replaces stub).
+
+- [ ] **Step 1: Write a smoke test**
+
+Add to `crates/ozma_mode/src/layout.rs`:
+
+```rust
+//! Window-fill resize system for the Ozma terminal.
+use crate::spawn::OzmaTerminal;
+use bevy::prelude::*;
+use ozma_tty_engine::{Coalescer, PtyHandle, TerminalHandle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+
+/// Tracks the last (cols, rows) sent to the terminal to guard
+/// against redundant resize calls when the run condition fires.
+#[derive(Resource, Default)]
+pub(crate) struct OzmaLastSize(pub(crate) Option<(u16, u16)>);
+
+/// Resizes the Ozma terminal to fill the primary window.
+///
+/// Gated by `run_if` at registration — only runs on
+/// `TerminalCellMetricsResource` change or `WindowResized`.
+pub(crate) fn resize_to_window(
+    mut commands: Commands,
+    mut last_size: ResMut<OzmaLastSize>,
+    mut terminal_q: Query<
+        (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
+        With<OzmaTerminal>,
+    >,
+    metrics: Res<TerminalCellMetricsResource>,
+    window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok(window) = window_q.single() else {
+        return;
+    };
+    let Ok((entity, mut handle, mut pty, mut coalescer)) = terminal_q.single_mut() else {
+        return;
+    };
+
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cols = ((window.resolution.physical_width() as f32 / cell_w).floor() as u16).max(1);
+    let rows = ((window.resolution.physical_height() as f32 / cell_h).floor() as u16).max(1);
+
+    if last_size.0 == Some((cols, rows)) {
+        return;
+    }
+
+    match handle.resize(&mut pty, &mut coalescer, cols, rows) {
+        Ok(()) => {
+            last_size.0 = Some((cols, rows));
+            handle.emit_pending(&mut commands, entity);
+        }
+        Err(e) => tracing::warn!(?e, cols, rows, "failed to resize ozma terminal"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resize_to_window_does_not_panic_without_entities() {
+        let mut app = App::new();
+        app.init_resource::<OzmaLastSize>();
+        app.add_systems(Update, resize_to_window);
+        // No window, no terminal, no metrics — system should be a no-op.
+        app.update();
+    }
+}
+```
+
+- [ ] **Step 2: Also register `OzmaLastSize` in `OzmaModePlugin::build`**
+
+In `crates/ozma_mode/src/lib.rs`, add `init_resource::<layout::OzmaLastSize>()` to the `build` chain:
+
+```rust
+impl Plugin for OzmaModePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_state::<AppMode>()
+            .insert_resource(OzmaModeConfig {
+                shell: self.config_shell.clone(),
+            })
+            .init_resource::<layout::OzmaLastSize>()   // ← add this line
+            .add_observer(exit::on_child_exit)
+            .add_systems(OnEnter(AppMode::Ozma), spawn::spawn_terminal)
+            .add_systems(
+                Update,
+                layout::resize_to_window
+                    .run_if(in_state(AppMode::Ozma))
+                    .run_if(
+                        resource_exists_and_changed::<layout::OzmaLastSize>
+                            .or(resource_exists_and_changed::<ozma_tty_renderer::TerminalCellMetricsResource>)
+                            .or(on_event::<bevy::window::WindowResized>),
+                    ),
+            )
+            .add_systems(OnExit(AppMode::Ozma), spawn::despawn_terminal);
+    }
+}
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cargo test -p ozma_mode 2>&1 | tail -8
+```
+
+Expected: all tests pass. If the smoke test panics because `TerminalCellMetricsResource` is absent and `Res<>` panics on missing resource, wrap with `Option<Res<TerminalCellMetricsResource>>` and return early:
+
+```rust
+pub(crate) fn resize_to_window(
+    mut commands: Commands,
+    mut last_size: ResMut<OzmaLastSize>,
+    mut terminal_q: Query<
+        (Entity, &mut TerminalHandle, &mut PtyHandle, &mut Coalescer),
+        With<OzmaTerminal>,
+    >,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+    window_q: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Some(metrics) = metrics else { return; };
+    // ... rest unchanged
+```
+
+- [ ] **Step 4: Run the full workspace test suite**
+
+```bash
+cargo test 2>&1 | tail -10
+```
+
+Expected: all crates pass. Fix any issues before committing.
+
+- [ ] **Step 5: Lint**
+
+```bash
+make fix-lint
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ozma_mode/src/layout.rs crates/ozma_mode/src/lib.rs
+git commit -m "feat(ozma_mode): implement window-fill resize system"
+```
+
+---
+
+## Self-Review Checklist
+
+| Spec requirement | Covered by |
+|---|---|
+| `AppMode::Ozma` / `AppMode::Ozmux` enum, `Default = Ozma` | Task 2 `lib.rs` |
+| `AppMode` re-exported from `ozma_mode` crate | Task 2 `lib.rs` (`pub enum AppMode`) |
+| `[ozma] shell` config with `$SHELL` fallback | Task 1 `ozma.rs`, Task 3 `spawn.rs` |
+| `OzmaConfig` / `OzmaPatch` in `ozmux_configs` | Task 1 |
+| `RawConfigs.ozma` + `apply_to` arm | Task 1 `raw.rs` |
+| `OnEnter(AppMode::Ozma)` spawns `TerminalBundle` + `TerminalRenderBundle` | Task 3 `spawn.rs` |
+| `OzmaTerminal` marker component | Task 3 `spawn.rs` |
+| `TerminalChildExit` → `AppExit` via observer | Task 4 `exit.rs` |
+| `resize_to_window` gated by `run_if`, not in-body early return (except single/not-found guards) | Task 5 `layout.rs` |
+| `OzmaLastSize` resource guards redundant resizes | Task 5 |
+| `despawn_terminal` on `OnExit(AppMode::Ozma)` | Task 3 stub, live from Task 2 |
+| Shell resolution tests (config / env / fallback) | Task 3 |
+| `OzmaConfig` tests (default / patch / TOML parse) | Task 1 |
+| `child_exit_sends_app_exit` test | Task 4 |
+| `plugin_registers_state` test | Task 2 |
+| `main.rs` not modified | ✓ (no task touches `src/main.rs`) |

--- a/docs/superpowers/specs/2026-06-18-ozma-mode-design.md
+++ b/docs/superpowers/specs/2026-06-18-ozma-mode-design.md
@@ -1,0 +1,189 @@
+# ozma_mode Crate Design
+
+## Overview
+
+Introduce `crates/ozma_mode` — a new Bevy plugin crate that implements the Ozma mode: a
+single PTY terminal running directly through Alacritty's VT emulator, with no tmux
+dependency. This crate also owns the `AppMode` Bevy `States` enum shared across future mode
+crates (`ozmux_mode`).
+
+The immediate deliverable is the crate itself, ready to be plugged into `main.rs` in a
+later roadmap step (step 5/6). The binary (`src/main.rs`) is not modified in this task.
+
+## Background
+
+`docs/memo.md` defines two operating modes:
+
+- **Ozma mode** — single terminal, direct PTY, no tmux
+- **Ozmux mode** — tmux backend, multiplexer, current default
+
+Roadmap step 1 is to produce a complete `ozma_mode` crate. Steps 5 and 6 wire up the
+`AppMode` state and mode switching in the binary.
+
+## Crate Structure
+
+```
+crates/ozma_mode/
+  Cargo.toml
+  src/
+    lib.rs      — AppMode definition + re-export, OzmaModePlugin
+    spawn.rs    — OnEnter(AppMode::Ozma): spawn TerminalBundle with resolved shell
+    layout.rs   — Update: resize terminal to fill the primary window
+    exit.rs     — Update: TerminalChildExit → AppExit
+```
+
+No `mod.rs` files — Rust 2018+ module layout per `.claude/rules/rust.md`.
+
+### Dependencies (`Cargo.toml`)
+
+```toml
+[dependencies]
+bevy              = { workspace = true }
+ozma_tty_engine   = { path = "../ozma_tty_engine" }
+ozma_tty_renderer = { path = "../ozma_tty_renderer" }
+ozmux_configs     = { path = "../configs" }
+tracing           = { workspace = true }
+```
+
+## `AppMode` State
+
+Defined in `crates/ozma_mode/src/lib.rs` and re-exported as the crate's public API so that
+the future `crates/ozmux_mode` can depend on `ozma_mode` for the shared state type.
+
+```rust
+#[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum AppMode {
+    #[default]
+    Ozma,
+    Ozmux,
+}
+```
+
+`AppMode::Ozma` is the `Default`, so `app.init_state::<AppMode>()` in the binary starts in
+Ozma mode without any additional configuration.
+
+## `OzmaModePlugin` Systems
+
+| Schedule | Run condition | System | Responsibility |
+|---|---|---|---|
+| `OnEnter(AppMode::Ozma)` | — | `spawn_terminal` | Resolve shell, spawn `TerminalBundle` + `TerminalRenderBundle` |
+| `Update` | `in_state(AppMode::Ozma)` + `resource_exists_and_changed::<TerminalCellMetricsResource>.or(on_event::<WindowResized>)` | `resize_to_window` | Track primary window size, resize terminal |
+| observer | — | `on_child_exit` | `On<TerminalChildExit>`: send `AppExit` via `MessageWriter` |
+| `OnExit(AppMode::Ozma)` | — | `despawn_terminal` | Despawn terminal entity (future mode switch) |
+
+All `Update` systems use `.run_if(in_state(AppMode::Ozma))` at registration — no in-body
+early returns. `on_child_exit` is registered as `app.add_observer(on_child_exit)` since
+`TerminalChildExit` is an `EntityEvent` dispatched via `commands.trigger(...)`, not a
+Bevy message.
+
+### Shell Resolution (`spawn.rs`)
+
+Resolution order:
+
+1. `configs.ozma.shell` — value from `[ozma]` section of `config.toml`
+2. `std::env::var("SHELL")` — current user's shell
+3. `"/bin/sh"` — guaranteed fallback
+
+Environment variable lookup happens in `spawn.rs`, not inside `ozmux_configs`, so the
+`configs` crate remains free of environment variable dependencies.
+
+### Terminal Marker Component
+
+`spawn_terminal` inserts an `OzmaTerminal` marker component on the spawned entity so that
+`resize_to_window`, `handle_child_exit`, and `despawn_terminal` can query it unambiguously.
+
+```rust
+#[derive(Component)]
+struct OzmaTerminal;
+```
+
+### Layout (`layout.rs`)
+
+`resize_to_window` queries the `PrimaryWindow` for its physical size, reads cell metrics
+from `Res<TerminalCellMetricsResource>` (inserted at `Startup` by `TerminalFontPlugin`),
+computes `cols = floor(phys_w / advance_phys)` and `rows = floor(phys_h / line_height_phys)`
+— the same formula as `sync_client_size` in `src/tmux/render.rs:534-541` — and calls the
+resize API on the terminal. Cell counts are clamped to `1..=u16::MAX` before the call.
+Gated with `run_if(resource_exists_and_changed::<TerminalCellMetricsResource>.or(on_event::<WindowResized>))`
+so the system runs only on font or window size changes, not every frame.
+
+### Exit (`exit.rs`)
+
+`on_child_exit` is a Bevy observer (`fn on_child_exit(ev: On<TerminalChildExit>, mut exit: MessageWriter<AppExit>)`)
+registered via `app.add_observer(on_child_exit)`. On receipt it sends `AppExit::Success` via
+`MessageWriter<AppExit>`. No restart logic — app quits.
+
+## Config Extension
+
+A new `OzmaConfig` type is added to `crates/configs`:
+
+**`crates/configs/src/ozma.rs`** (new file, mirrors `tmux.rs` pattern):
+
+```rust
+pub struct OzmaConfig {
+    pub shell: Option<String>,
+}
+
+impl Default for OzmaConfig {
+    fn default() -> Self {
+        Self { shell: None }
+    }
+}
+```
+
+`OzmuxConfigs` gains a new field:
+
+```rust
+pub struct OzmuxConfigs {
+    // … existing fields …
+    pub ozma: OzmaConfig,
+}
+```
+
+Config TOML:
+
+```toml
+[ozma]
+shell = "/bin/zsh"   # optional; defaults to $SHELL → /bin/sh
+```
+
+`OzmaPatch` (deserialization struct) uses `#[serde(deny_unknown_fields)]` and an
+`Option<String>` for `shell`, matching the established pattern in `tmux.rs`.
+
+`crates/configs/src/raw.rs` also requires a new `pub(crate) ozma: Option<OzmaPatch>` field
+on `RawConfigs` and a corresponding `apply_to` branch in `OzmuxConfigs`. Without this,
+`[ozma]` in the user's config TOML would be rejected at parse time because `RawConfigs`
+uses `#[serde(deny_unknown_fields)]`.
+
+## Testing
+
+### `crates/ozma_mode`
+
+| Test | What it checks |
+|---|---|
+| `shell_resolution_uses_config` | When `OzmaConfig { shell: Some(...) }`, that value is used |
+| `shell_resolution_falls_back_to_env` | `OzmaConfig { shell: None }` + `$SHELL` set → env value used |
+| `shell_resolution_falls_back_to_sh` | `OzmaConfig { shell: None }` + `$SHELL` unset → `"/bin/sh"` |
+| `plugin_registers_state` | `App::new().add_plugins(OzmaModePlugin)` does not panic; `AppMode::Ozma` is the initial state |
+| `child_exit_sends_app_exit` | Writing `TerminalChildExit` message + `app.update()` triggers `AppExit` |
+
+PTY spawn and GPU rendering are excluded from unit tests. `spawn_terminal` and
+`despawn_terminal` are smoke-tested via `App::new()` without a real PTY.
+
+### `crates/configs`
+
+Following the pattern in `tmux.rs`:
+
+| Test | What it checks |
+|---|---|
+| `default_ozma_shell_is_none` | `OzmaConfig::default().shell == None` |
+| `patch_overrides_shell` | `OzmaPatch { shell: Some(...) }.apply_to(default)` sets the field |
+| `empty_patch_keeps_base` | `OzmaPatch::default().apply_to(default)` is a no-op |
+
+## Invariants
+
+- `OzmaTerminal` is inserted by `spawn_terminal` and queried exclusively by ozma-mode
+  systems; no other plugin may insert or remove it.
+- `despawn_terminal` runs on `OnExit(AppMode::Ozma)` and is the only place the
+  `OzmaTerminal` entity is despawned, ensuring a clean state before entering another mode.
+- Shell resolution never panics; the `/bin/sh` fallback is always reachable.

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -836,8 +836,8 @@ mod tests {
         // those, no snapshot/capture forms and the view freezes (the original
         // "scroll movement doesn't work" bug). The integration test below masked
         // this by starting a selection first.
-        use crate::clipboard::Clipboard;
         use super::super::render::RenderPlugin;
+        use crate::clipboard::Clipboard;
         use bevy::window::{PrimaryWindow, Window, WindowResolution};
         use ozma_tty_renderer::material::TerminalUiMaterial;
         use ozma_tty_renderer::prelude::TerminalGridPlugin;
@@ -1017,8 +1017,8 @@ mod tests {
     #[test]
     #[ignore = "requires a real tmux binary and a controlling PTY"]
     fn copy_mode_integration_drives_real_tmux() {
-        use crate::clipboard::Clipboard;
         use super::super::render::RenderPlugin;
+        use crate::clipboard::Clipboard;
         use bevy::window::{PrimaryWindow, Window, WindowResolution};
         use ozma_tty_renderer::material::TerminalUiMaterial;
         use ozma_tty_renderer::prelude::TerminalGridPlugin;

--- a/src/tmux/divider_handle.rs
+++ b/src/tmux/divider_handle.rs
@@ -154,8 +154,8 @@ fn divider_hover_feedback(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::render::{DividerPixelRect, PackedTmuxLayout};
+    use super::*;
     use bevy::math::Vec2;
     use std::collections::HashMap;
     use tmux_control_parser::{DividerAxis, PaneId};


### PR DESCRIPTION
## Problem

There is no crate that owns the `AppMode` state (`Ozma` / `Ozmux`) or the plugin that manages the single-PTY Ozma terminal mode. Without it, the binary cannot dispatch between Ozma (direct shell) and Ozmux (tmux backend) at startup.

## Solution

Adds the `crates/ozma_mode` crate and a supporting `[ozma]` config section:

**`crates/configs` (`ozmux_configs`)**
- New `crates/configs/src/ozma.rs`: `OzmaConfig { shell }` (resolved) and `OzmaPatch` (serde patch for TOML `[ozma]`), wired into `OzmuxConfigs` and `RawConfigs`.

**`crates/ozma_mode` (`ozma_mode`)**
- `lib.rs`: `AppMode` state (`Ozma` default / `Ozmux`), `OzmaModePlugin`, `OzmaModeConfig` resource.
- `spawn.rs`: `spawn_terminal` — reads config + `$SHELL`, sizes from window/metrics, spawns `TerminalBundle` + `TerminalRenderBundle` + `OzmaTerminal` marker with a full-window `Node`; `despawn_terminal` on mode exit. `cells_for` shared with `layout`.
- `layout.rs`: `OzmaLastSize` resource + `resize_to_window` system — gated by `run_if` on `OzmaLastSize`/`TerminalCellMetricsResource`/`WindowResized` changes; `reset_last_size` on `OnEnter` ensures first-frame resize fires even when metrics are stable.
- `exit.rs`: `on_child_exit` observer — sends `AppExit::Success` when the `OzmaTerminal`-marked entity's PTY child exits (filters out any other terminal's exit).

All four systems are covered by unit tests (7 passing). `SKIP`: wiring `OscWebviewGate` into `osc_webview_gate` on `SpawnOptions` — requires moving the resource to a shared crate or threading `Arc<AtomicBool>` through `OzmaModePlugin::new`; deferred to the binary-integration step.