### PR TITLE
feat(webview): allow TUI widgets to overlay inline webviews

### DIFF
--- a/apps/ozbrowser/src/ui.rs
+++ b/apps/ozbrowser/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Clear, Paragraph};
+use ratatui::widgets::{Block, Paragraph};
 use ratatui_ozma::{FramePlacements, WebviewWidget};
 
 /// Draws the whole frame: status/address bar (1 row) + webview, with help modal overlay.
@@ -26,16 +26,15 @@ pub(crate) fn draw(
         _ => draw_status_bar(frame, chunks[0], app),
     }
 
-    if app.mode() != Mode::Help {
-        frame.render_stateful_widget(
-            WebviewWidget::new(handle_id).focused(app.mode() == Mode::Insert),
-            chunks[1],
-            placements,
-        );
-        return;
-    }
+    frame.render_stateful_widget(
+        WebviewWidget::new(handle_id).focused(app.mode() == Mode::Insert),
+        chunks[1],
+        placements,
+    );
 
-    draw_help_modal(frame);
+    if app.mode() == Mode::Help {
+        draw_help_modal(frame);
+    }
 }
 
 fn draw_status_bar(frame: &mut Frame<'_>, area: Rect, app: &App) {
@@ -62,7 +61,6 @@ fn draw_address_bar(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
 fn draw_help_modal(frame: &mut Frame<'_>) {
     let area = centered_rect(62, 85, frame.area());
-    frame.render_widget(Clear, area);
     let lines = vec![
         Line::from("  Normal Mode Shortcuts"),
         Line::from(""),

--- a/crates/ozma_tty_engine/src/palette.rs
+++ b/crates/ozma_tty_engine/src/palette.rs
@@ -6,10 +6,11 @@
 //!   16..=231 — 6×6×6 RGB cube, channel ramp `[0, 95, 135, 175, 215, 255]`
 //!   232..=255 — 24 grayscale ramp from value 8 to 238 in steps of 10
 //!
-//! Default fg / bg (`AColor::Named(Foreground | Background)`) map to
-//! sentinel colors (`Color::WHITE` / `Color::BLACK`) until the theme
-//! story lands in `src/`. See spec § Risks > "Color::Default semantic
-//! is lost in the schema".
+//! `AColor::Named(Foreground)` maps to `Color::WHITE` as a sentinel.
+//! `AColor::Named(Background)` maps to `Color::NONE` (transparent) so that
+//! cells with the terminal default background let the pane background
+//! (`bg_padding_color`) and any inline webview overlays show through.
+//! Cells with an explicit ANSI color are fully opaque and occlude overlays.
 
 use alacritty_terminal::vte::ansi::{Color as AColor, NamedColor};
 use bevy::prelude::Color;
@@ -49,9 +50,11 @@ pub(crate) fn acolor_to_bevy(c: AColor) -> Color {
 /// Convert a `NamedColor` (whose discriminants jump past 255 starting
 /// at `Foreground = 256`) into a `bevy::Color`.
 ///
-/// `Foreground` / `Background` / `Cursor` / `BrightForeground` /
-/// `DimForeground` fall back to white/black sentinels until the
-/// theme story lands. `Dim*` base colors map to the regular palette
+/// `Foreground` / `Cursor` / `BrightForeground` / `DimForeground` fall
+/// back to `Color::WHITE`. `Background` maps to `Color::NONE` (transparent)
+/// so that default-background cells let webview overlays and the pane
+/// background show through; cells with explicit ANSI colors are opaque
+/// and occlude overlays. `Dim*` base colors map to the regular palette
 /// index (faint is approximated by the base intensity rather than
 /// the bright variant); without this, every `\e[2;Nm`-styled cell
 /// would render as solid white because the Dim* discriminants exceed
@@ -59,7 +62,7 @@ pub(crate) fn acolor_to_bevy(c: AColor) -> Color {
 fn named_color_to_bevy(named: NamedColor) -> Color {
     match named {
         NamedColor::Foreground => Color::WHITE,
-        NamedColor::Background => Color::BLACK,
+        NamedColor::Background => Color::NONE,
         NamedColor::Cursor => Color::WHITE,
         NamedColor::BrightForeground => Color::WHITE,
         NamedColor::DimForeground => Color::WHITE,
@@ -166,10 +169,10 @@ mod tests {
     }
 
     #[test]
-    fn named_background_is_black_sentinel() {
+    fn named_background_is_transparent() {
         assert_eq!(
             acolor_to_bevy(AColor::Named(NamedColor::Background)),
-            Color::BLACK
+            Color::NONE
         );
     }
 

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -110,6 +110,9 @@ const GLYPH_NONE: u32 = 0xFFFFFFFFu;
 // and inline-webview overlays keep their full color. Runs in LINEAR space —
 // `inactive_tint.rgb` is uploaded pre-linearized by the host.
 fn tint_bg(c: vec4<f32>) -> vec4<f32> {
+    // NOTE: alpha=0 means transparent (terminal default bg sentinel); preserve
+    // the zero vector so blend_premultiplied_over does not add phantom RGB.
+    if c.a == 0.0 { return c; }
     return vec4<f32>(mix(c.rgb, params.inactive_tint.rgb, params.inactive_tint.a), c.a);
 }
 
@@ -149,13 +152,20 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 // Top-level pipeline stages
 // ============================================================================
 
-// Pipeline for a fragment that lies inside the grid: background → inline
-// overlays → primary glyph → left-neighbor overdraw → text decorations →
-// cursor → selection.
+// Pipeline for a fragment that lies inside the grid: pane background →
+// inline overlays → cell background → primary glyph → left-neighbor
+// overdraw → text decorations → cursor → selection.
+//
+// The pane background (fallback) is the base layer. Inline webview overlays
+// composite over it next. The cell's own background then composites OVER the
+// overlay result: a transparent cell background (the terminal default) lets
+// the webview show through, while an opaque cell background (set by a TUI
+// widget) occludes the webview and appears in front of it. Glyphs render
+// last, on top of everything.
 fn paint_grid_cell(hit: CellHit, fallback: vec4<f32>) -> vec4<f32> {
     let colors = resolve_cell_colors(hit.cell);
-    var color = tint_bg(colors.bg);
-    color = paint_inline_overlays(hit, color);
+    var color = paint_inline_overlays(hit, fallback);
+    color = blend_premultiplied_over(color, tint_bg(colors.bg));
     color = paint_primary_glyph(hit, colors.fg, color);
     color = paint_left_overdraw(hit, color);
     return paint_cell_overlays(hit, colors.fg, color);
@@ -195,7 +205,7 @@ fn paint_right_strip(p_px: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
         p_px.y - f32(row) * params.cell_size_px.y,
     );
     let colors = resolve_cell_colors(strip_cell);
-    var color = tint_bg(colors.bg);
+    var color = blend_premultiplied_over(fallback, tint_bg(colors.bg));
     // NOTE: paint_cell_glyph (NOT paint_primary_glyph). strip_local.x is
     // in [cell_pitch.x, cell_pitch.x + max_overflow_phys) — already in
     // the right-half coordinate space of any STYLE_WIDE_RIGHT_HALF wide
@@ -397,11 +407,13 @@ fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
 }
 
 // Inline-overlay compositing (spec §6.2): samples each ACTIVE overlay slot
-// whose cell-rect contains this fragment and composites it OVER the cell
-// background. Source is premultiplied alpha (CEF convention, spec §6.3);
-// the sRGB texture view linearizes on read, so values mix in linear space
-// with no manual conversion. Glyphs paint AFTER overlays, so terminal text
-// sits on top of an inline webview.
+// whose cell-rect contains this fragment and composites it OVER the pane
+// background (`base`, which is `fallback` from `paint_grid_cell`). Source
+// is premultiplied alpha (CEF convention, spec §6.3); the sRGB texture view
+// linearizes on read, so values mix in linear space with no manual
+// conversion. The cell's own background composites OVER this result in
+// `paint_grid_cell`, so an opaque widget background occludes the webview.
+// Glyphs paint last, so terminal text sits on top of an inline webview.
 //
 // uv derives from the UNCLIPPED rect (rect.x may be negative when the rect
 // is partially scrolled above the viewport), so partial visibility never
@@ -526,6 +538,13 @@ fn resolve_cell_colors(cell: Cell) -> CellColors {
         let tmp = fg;
         fg = bg;
         bg = tmp;
+        // NOTE: The terminal default bg maps to transparent (alpha=0) so that
+        // cells without an explicit background let webview overlays show through.
+        // When reverse-video promotes that transparent sentinel to the glyph
+        // foreground color, materialise it as opaque black so text stays visible.
+        if fg.a == 0.0 {
+            fg = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
     }
     if dim {
         fg = vec4<f32>(fg.rgb * 0.66, fg.a);
@@ -584,7 +603,11 @@ fn sample_glyph_coverage(glyph: Glyph, local_px: vec2<f32>) -> f32 {
 }
 
 fn blend_glyph(base: vec4<f32>, fg: vec4<f32>, coverage: f32) -> vec4<f32> {
-    return mix(base, vec4<f32>(fg.rgb, max(fg.a, coverage)), coverage);
+    // NOTE: multiply the blend factor by fg.a so that a transparent fg
+    // (STYLE_HIDDEN with transparent default bg) produces no ink at all.
+    // For opaque fg (fg.a == 1.0) this is a no-op; coverage drives blending
+    // as before.
+    return mix(base, vec4<f32>(fg.rgb, max(fg.a, coverage)), coverage * fg.a);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

`WebviewWidget` always rendered in the foreground, making it impossible to overlay other TUI widgets on top of an inline webview in the same frame. The GPU shader composited the webview over cell backgrounds, and `WebviewWidget` called `Clear` before any other widget could paint — so even correctly-ordered Ratatui draws were hidden.

## Solution

### GPU compositing order (shader)

Changed `paint_grid_cell` from:
```
cell_bg → webview overlay → glyphs
```
to:
```
pane_bg (fallback) → webview overlay → cell_bg (OVER) → glyphs
```

A cell whose background is **transparent** (the terminal default) lets the webview show through. A cell with an **explicit opaque background** (any ANSI color, or `ratatui::Style::bg(Color::Black)`) composites in front and occludes the webview. Widgets rendered after `WebviewWidget` in the same frame appear on top.

**Affected:** `crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl`

### Terminal default background → transparent

`NamedColor::Background` now maps to `Color::NONE` (α = 0) instead of `Color::BLACK`. Default-background cells carry α = 0 in the packed GPU field; the OVER blend with α = 0 src is a no-op, so the webview or pane background shows through those cells. Explicit ANSI bg colors remain fully opaque.

**Affected:** `crates/ozma_tty_engine/src/palette.rs`

### Three shader correctness fixes for the α = 0 sentinel

Introduced by making the default background transparent; caught and fixed in the same PR:

| Fix | Location | Problem | Fix |
|-----|----------|---------|-----|
| `tint_bg` guard | `tint_bg()` | α=0 input produced nonzero RGB that `blend_premultiplied_over` added additively to webview content in inactive panes (colour cast) | Early-return `c` when `c.a == 0.0` |
| `STYLE_REVERSE` | `resolve_cell_colors()` | Reverse-video swap promoted transparent default-bg to glyph fg colour → `blend_glyph` rendered it as α=0 ink (wrong alpha at antialiased edges) | Materialise transparent fg as opaque black `(0,0,0,1)` after the swap |
| `STYLE_HIDDEN` + `blend_glyph` | `blend_glyph()` | Hidden text with transparent bg set fg = NONE, but `max(fg.a=0, coverage)` drove the blend → black marks painted over the webview | Multiply blend factor by `fg.a`; transparent fg → no ink |

### ozbrowser Help modal overlay

Always render `WebviewWidget` (so the webview stays composited), then draw the Help modal *after* it. The modal's `bg(Color::Black)` cells (opaque) occlude the webview correctly via the new compositing order. Removed the now-redundant `Clear` call inside `draw_help_modal` — `WebviewWidget` already clears the area and `Paragraph+Block` with a solid background fills it completely.

**Affected:** `apps/ozbrowser/src/ui.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)