### PR TITLE
feat(ozma_terminal): mouse input — app reporting, selection + copy, wheel scrollback, Cmd-click links

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -411,6 +411,62 @@ Exception: a call that must be preceded by local logic (e.g., a conditional
 for the calls after the branch. Keep each such sub-chain as long as possible;
 do not split further than the branch requires.
 
+## System composition — keep systems focused; split by responsibility
+
+A Bevy system that, in one body, **gathers** input, **decides** what to do, and
+**applies** the result is doing three jobs at once: it grows long, mixes
+immutable reads with broad `&mut` access, and traps the decision logic behind
+ECS params (and resources with no public constructor), making it untestable.
+Split such systems along the gather → decide → apply seam.
+
+- **Pure decision helpers** take plain data and return *effect values* (an enum
+  / `Vec` of intents), touching no world state — unit-testable without an `App`.
+  Example: `decide_button` / `decide_wheel` (`crates/ozma_terminal/src/mouse.rs`)
+  return `Vec<MouseEffect>`.
+- **Apply via an `EntityEvent` + observer** (the repo idiom). The gather system
+  queries the target **immutably**, computes effects, and `commands.trigger(...)`s
+  them; the observer holds the `&mut` access and writes the world. See
+  `dispatch_input` → `TerminalKeyInput` → `on_terminal_key_input`
+  (`crates/ozma_tty_engine/src/plugin.rs`) and `PasteAction` / `on_paste`
+  (`crates/ozma_terminal/src/action.rs`).
+- **Extract bulky inline blocks** into named helper `fn`s so the body reads as
+  gate → collect → trigger. Gate preconditions with `run_if` (see "System
+  optimization — gate with `run_if`").
+
+Required:
+
+| Instead of (one system does everything) | Use |
+| --- | --- |
+| Read input, decide, and write the world inline in one system | A pure decide helper returning effect values + an `EntityEvent`/observer that applies them |
+| Decision logic interleaved with `&mut` world access | Decision over borrowed data returning intents; mutation isolated to the apply observer |
+| A 40-plus-line inline block in a system body | A named helper `fn` the system calls |
+
+Forbidden:
+
+| Pattern | Why |
+| --- | --- |
+| `.pipe()` to chain a gather system into an apply system | Not this repo's idiom — it sequences with `EntityEvent` + observer and `.chain()` / system-sets, and uses `.pipe()` nowhere |
+| A long system whose only structure is sequential gather/decide/apply phases that could each be a helper or observer | Defeats single-responsibility; hides the apply surface |
+
+Rationale: a gather system that ends in `commands.trigger(Effects { .. })` makes
+its effect on the world legible at the signature, and the observer is the one
+place to look for mutation. The pure decider is testable without a PTY / GPU /
+`App`, and an immutable gather query plus a `&mut` apply observer never contend
+for the same data (separate systems; the observer runs at command flush).
+
+Exceptions:
+
+- A genuinely **single-purpose** system (only gathers, only decides, or only
+  applies) is already focused — leave it.
+- **Do not over-fragment.** Splitting into several systems that each re-query
+  the same components (duplicate access / scheduling cost) is worse than the
+  monolith when a private helper `fn` would do. Prefer a helper `fn` unless the
+  apply step needs isolated `&mut` / NonSend access (the observer case) or
+  independent scheduling.
+- Some apply steps cannot be made pure (NonSend resources, async round-trip
+  state). Move what you can to the observer; keep the irreducible reads in the
+  gather system and record why in a `// NOTE:`.
+
 ## Escape hatches
 
 When a rule is physically impossible to follow (e.g., trybuild fixtures, generated code, FFI conventions), justify the exception with a one-line `// NOTE:` and apply a local lint allowance:
@@ -448,6 +504,7 @@ Not tool-enforced — review-time check required. The following rules cannot cur
 - Change detection — no manual `set_changed()` / `bypass_change_detection()`-then-`set_changed()` notification; mutate conditionally so normal `DerefMut` drives change detection (see "Change detection — let mutation drive it, don't force it manually")
 - Imports — no inline fully-qualified paths in signatures, bodies, or type parameters; add a `use` at the top instead (see "Imports — import, don't inline")
 - Naming — `Query` parameters must not use a `_q` suffix; use a descriptive singular or plural noun (see "Naming — Query parameters")
+- System composition — long systems that interleave gather/decide/apply must be split: pure decision helpers returning effect values, apply via an `EntityEvent`+observer (or a focused apply system), bulky inline blocks extracted to helpers (see "System composition — keep systems focused; split by responsibility")
 
 If you add a tool or script that detects any of these, move the corresponding entry into the tool-enforced list above.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,6 +4887,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "bevy",
+ "open",
  "ozma_tty_engine",
  "ozma_tty_renderer",
  "tracing",

--- a/apps/ozbrowser/src/main.rs
+++ b/apps/ozbrowser/src/main.rs
@@ -113,42 +113,100 @@ fn event_loop(
 // SDK has no unregister/Drop path yet. Fix this when the SDK exposes one.
 fn register_view(ozma: &Ozma, url: &str, url_tx: Sender<String>) -> anyhow::Result<WebviewHandle> {
     let pass = [
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Esc },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('j') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Down },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('k') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Up },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char(' ') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::PageDown },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::PageUp },
-        KeyChord { mods: KeyModifiers::CONTROL, code: KeyCode::Char('d') },
-        KeyChord { mods: KeyModifiers::CONTROL, code: KeyCode::Char('u') },
-        KeyChord { mods: KeyModifiers::CONTROL, code: KeyCode::Char('f') },
-        KeyChord { mods: KeyModifiers::CONTROL, code: KeyCode::Char('b') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('g') },
-        KeyChord { mods: KeyModifiers::SHIFT,   code: KeyCode::Char('g') },
-        KeyChord { mods: KeyModifiers::SHIFT,   code: KeyCode::Char('h') },
-        KeyChord { mods: KeyModifiers::SHIFT,   code: KeyCode::Char('l') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('o') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('r') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('i') },
-        KeyChord { mods: KeyModifiers::NONE,    code: KeyCode::Char('q') },
-        KeyChord { mods: KeyModifiers::CONTROL, code: KeyCode::Char('c') },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Esc,
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('j'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Down,
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('k'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Up,
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char(' '),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::PageDown,
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::PageUp,
+        },
+        KeyChord {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char('d'),
+        },
+        KeyChord {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char('u'),
+        },
+        KeyChord {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char('f'),
+        },
+        KeyChord {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char('b'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('g'),
+        },
+        KeyChord {
+            mods: KeyModifiers::SHIFT,
+            code: KeyCode::Char('g'),
+        },
+        KeyChord {
+            mods: KeyModifiers::SHIFT,
+            code: KeyCode::Char('h'),
+        },
+        KeyChord {
+            mods: KeyModifiers::SHIFT,
+            code: KeyCode::Char('l'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('o'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('r'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('i'),
+        },
+        KeyChord {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::Char('q'),
+        },
+        KeyChord {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char('c'),
+        },
     ];
-    let view = ozma.register(
-        Webview::url(url)
-            .interactive(true)
-            .passthrough(pass)
-            .on(
-                "urlChanged",
-                move |args: serde_json::Value| -> Result<(), RpcError> {
-                    if let Some(u) = args["url"].as_str() {
-                        let _ = url_tx.send(u.to_owned());
-                    }
-                    Ok(())
-                },
-            ),
-    )?;
+    let view = ozma.register(Webview::url(url).interactive(true).passthrough(pass).on(
+        "urlChanged",
+        move |args: serde_json::Value| -> Result<(), RpcError> {
+            if let Some(u) = args["url"].as_str() {
+                let _ = url_tx.send(u.to_owned());
+            }
+            Ok(())
+        },
+    ))?;
     Ok(view)
 }
 

--- a/crates/ozma_terminal/Cargo.toml
+++ b/crates/ozma_terminal/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 anyhow            = { workspace = true }
 arboard           = { version = "3", features = ["wayland-data-control"] }
 bevy              = { workspace = true }
+open              = { workspace = true }
 ozma_tty_engine   = { path = "../ozma_tty_engine" }
 ozma_tty_renderer = { path = "../ozma_tty_renderer" }
 tracing           = { workspace = true }

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -64,7 +64,12 @@ pub(crate) fn hyperlink_hover_cursor(
 ) {
     let modifier_held = link_modifier_held(&{
         let m = current_terminal_modifiers(&keys);
-        ProtocolModifiers { shift: m.shift, ctrl: m.ctrl, alt: m.alt, meta: m.meta }
+        ProtocolModifiers {
+            shift: m.shift,
+            ctrl: m.ctrl,
+            alt: m.alt,
+            meta: m.meta,
+        }
     });
     hover.entity = None;
     hover.hyperlink_id = None;
@@ -100,9 +105,15 @@ fn resolve_hover(
     };
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
-    let Some((cell, _side)) =
-        cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
-    else {
+    let Some((cell, _side)) = cell_at_cursor(
+        node,
+        transform,
+        cursor_phys,
+        cell_w,
+        cell_h,
+        grid.cols,
+        grid.rows,
+    ) else {
         return SystemCursorIcon::Default;
     };
     let id = grid
@@ -134,6 +145,9 @@ mod tests {
         assert_eq!(cursor_decision(true, true, true), SystemCursorIcon::Pointer);
         assert_eq!(cursor_decision(true, false, true), SystemCursorIcon::Text);
         assert_eq!(cursor_decision(false, true, true), SystemCursorIcon::Text);
-        assert_eq!(cursor_decision(false, false, false), SystemCursorIcon::Default);
+        assert_eq!(
+            cursor_decision(false, false, false),
+            SystemCursorIcon::Default
+        );
     }
 }

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -4,11 +4,12 @@
 //! `CursorIcon`.
 
 use crate::input::InputDisabled;
-use crate::mouse::{cell_at_cursor, protocol_mods};
+use crate::mouse::{OzmaTerminalMouseSet, cell_at_cursor, protocol_mods};
 use crate::spawn::OzmaTerminal;
+use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
-use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
+use bevy::window::{CursorIcon, CursorMoved, PrimaryWindow, SystemCursorIcon, Window};
 use ozma_tty_engine::ProtocolModifiers;
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid, is_allowed};
@@ -35,20 +36,27 @@ pub(crate) fn try_open_uri(uri: &str) {
     }
 }
 
-/// The cursor icon over the grid: pointer over a link with the modifier held,
-/// otherwise the I-beam. Off-grid cases return `Default` in `resolve_hover`
-/// before this is reached.
-fn cursor_decision(has_link: bool, modifier_held: bool) -> SystemCursorIcon {
-    if has_link && modifier_held {
-        SystemCursorIcon::Pointer
-    } else {
-        SystemCursorIcon::Text
+/// Registers the terminal's hyperlink hover-cursor feedback.
+///
+/// Adds `hyperlink_hover_cursor` to `OzmaTerminalMouseSet`, gated to run only
+/// when the pointer moves or a key is pressed. The click-open path lives in the
+/// mouse dispatcher, not here.
+pub(crate) struct HyperlinkPlugin;
+
+impl Plugin for HyperlinkPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_message::<CursorMoved>().add_systems(
+            Update,
+            hyperlink_hover_cursor
+                .in_set(OzmaTerminalMouseSet)
+                .run_if(on_message::<KeyboardInput>.or(on_message::<CursorMoved>)),
+        );
     }
 }
 
 /// Updates `HyperlinkHoverState` and the window cursor as the pointer moves over
 /// the terminal grid. Gated to the single enabled `OzmaTerminal`.
-pub(crate) fn hyperlink_hover_cursor(
+fn hyperlink_hover_cursor(
     mut hover: ResMut<HyperlinkHoverState>,
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
     terminal: Query<
@@ -70,6 +78,17 @@ pub(crate) fn hyperlink_hover_cursor(
         if *icon != desired {
             *icon = desired;
         }
+    }
+}
+
+/// The cursor icon over the grid: pointer over a link with the modifier held,
+/// otherwise the I-beam. Off-grid cases return `Default` in `resolve_hover`
+/// before this is reached.
+fn cursor_decision(has_link: bool, modifier_held: bool) -> SystemCursorIcon {
+    if has_link && modifier_held {
+        SystemCursorIcon::Pointer
+    } else {
+        SystemCursorIcon::Text
     }
 }
 

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -1,0 +1,140 @@
+//! Cmd/Ctrl-click hyperlink activation and hover-cursor feedback for the Ozma
+//! terminal. The click-open path is invoked from the mouse dispatcher; the hover
+//! system updates `HyperlinkHoverState` (renderer underline) and the window
+//! `CursorIcon`.
+
+use crate::input::{InputDisabled, current_terminal_modifiers};
+use crate::mouse::cell_at_cursor;
+use crate::spawn::OzmaTerminal;
+use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
+use ozma_tty_engine::ProtocolModifiers;
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid, is_allowed};
+
+/// Returns `true` when the platform link-activation modifier is held: Cmd on
+/// macOS, Ctrl elsewhere.
+pub(crate) fn link_modifier_held(mods: &ProtocolModifiers) -> bool {
+    if cfg!(target_os = "macos") {
+        mods.meta
+    } else {
+        mods.ctrl
+    }
+}
+
+/// Validates `uri` against the shared allowlist and opens it via the OS default
+/// handler. Disallowed URIs are dropped with a debug log.
+#[expect(dead_code, reason = "called by apply_effect (Task 6)")]
+pub(crate) fn try_open_uri(uri: &str) {
+    if !is_allowed(uri) {
+        debug!("hyperlink: dropping disallowed uri {}", uri);
+        return;
+    }
+    if let Err(e) = open::that_detached(uri) {
+        warn!("hyperlink: failed to open {}: {}", uri, e);
+    }
+}
+
+/// The cursor icon for a hover state: pointer over a link with the modifier
+/// held, I-beam over the grid, arrow elsewhere.
+pub(crate) fn cursor_decision(
+    has_link: bool,
+    modifier_held: bool,
+    over_grid: bool,
+) -> SystemCursorIcon {
+    match (over_grid, has_link, modifier_held) {
+        (true, true, true) => SystemCursorIcon::Pointer,
+        (true, _, _) => SystemCursorIcon::Text,
+        _ => SystemCursorIcon::Default,
+    }
+}
+
+/// Updates `HyperlinkHoverState` and the window cursor as the pointer moves over
+/// the terminal grid. Gated to the single enabled `OzmaTerminal`.
+pub(crate) fn hyperlink_hover_cursor(
+    mut hover: ResMut<HyperlinkHoverState>,
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    terminal: Query<
+        (Entity, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let modifier_held = link_modifier_held(&{
+        let m = current_terminal_modifiers(&keys);
+        ProtocolModifiers { shift: m.shift, ctrl: m.ctrl, alt: m.alt, meta: m.meta }
+    });
+    hover.entity = None;
+    hover.hyperlink_id = None;
+    hover.modifier_held = modifier_held;
+
+    let decision = resolve_hover(&mut hover, &terminal, &metrics, &windows, modifier_held);
+    if let Ok(mut icon) = cursor_icons.single_mut() {
+        let desired = CursorIcon::System(decision);
+        if *icon != desired {
+            *icon = desired;
+        }
+    }
+}
+
+fn resolve_hover(
+    hover: &mut HyperlinkHoverState,
+    terminal: &Query<
+        (Entity, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    metrics: &Res<TerminalCellMetricsResource>,
+    windows: &Query<&Window, With<PrimaryWindow>>,
+    modifier_held: bool,
+) -> SystemCursorIcon {
+    let Ok(window) = windows.single() else {
+        return SystemCursorIcon::Default;
+    };
+    let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
+        return SystemCursorIcon::Default;
+    };
+    let Ok((entity, node, transform, grid)) = terminal.single() else {
+        return SystemCursorIcon::Default;
+    };
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let Some((cell, _side)) =
+        cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
+    else {
+        return SystemCursorIcon::Default;
+    };
+    let id = grid
+        .hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16)
+        .map(|(id, _uri)| id);
+    hover.entity = Some(entity);
+    hover.hyperlink_id = id;
+    cursor_decision(id.is_some(), modifier_held, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_modifier_matches_platform() {
+        let mut m = ProtocolModifiers::default();
+        assert!(!link_modifier_held(&m));
+        if cfg!(target_os = "macos") {
+            m.meta = true;
+        } else {
+            m.ctrl = true;
+        }
+        assert!(link_modifier_held(&m));
+    }
+
+    #[test]
+    fn cursor_decision_pointer_only_on_link_with_modifier() {
+        assert_eq!(cursor_decision(true, true, true), SystemCursorIcon::Pointer);
+        assert_eq!(cursor_decision(true, false, true), SystemCursorIcon::Text);
+        assert_eq!(cursor_decision(false, true, true), SystemCursorIcon::Text);
+        assert_eq!(cursor_decision(false, false, false), SystemCursorIcon::Default);
+    }
+}

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -25,7 +25,6 @@ pub(crate) fn link_modifier_held(mods: &ProtocolModifiers) -> bool {
 
 /// Validates `uri` against the shared allowlist and opens it via the OS default
 /// handler. Disallowed URIs are dropped with a debug log.
-#[expect(dead_code, reason = "called by apply_effect (Task 6)")]
 pub(crate) fn try_open_uri(uri: &str) {
     if !is_allowed(uri) {
         debug!("hyperlink: dropping disallowed uri {}", uri);

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -3,8 +3,8 @@
 //! system updates `HyperlinkHoverState` (renderer underline) and the window
 //! `CursorIcon`.
 
-use crate::input::{InputDisabled, current_terminal_modifiers};
-use crate::mouse::cell_at_cursor;
+use crate::input::InputDisabled;
+use crate::mouse::{cell_at_cursor, protocol_mods};
 use crate::spawn::OzmaTerminal;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
@@ -35,17 +35,14 @@ pub(crate) fn try_open_uri(uri: &str) {
     }
 }
 
-/// The cursor icon for a hover state: pointer over a link with the modifier
-/// held, I-beam over the grid, arrow elsewhere.
-pub(crate) fn cursor_decision(
-    has_link: bool,
-    modifier_held: bool,
-    over_grid: bool,
-) -> SystemCursorIcon {
-    match (over_grid, has_link, modifier_held) {
-        (true, true, true) => SystemCursorIcon::Pointer,
-        (true, _, _) => SystemCursorIcon::Text,
-        _ => SystemCursorIcon::Default,
+/// The cursor icon over the grid: pointer over a link with the modifier held,
+/// otherwise the I-beam. Off-grid cases return `Default` in `resolve_hover`
+/// before this is reached.
+fn cursor_decision(has_link: bool, modifier_held: bool) -> SystemCursorIcon {
+    if has_link && modifier_held {
+        SystemCursorIcon::Pointer
+    } else {
+        SystemCursorIcon::Text
     }
 }
 
@@ -62,15 +59,7 @@ pub(crate) fn hyperlink_hover_cursor(
     keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let modifier_held = link_modifier_held(&{
-        let m = current_terminal_modifiers(&keys);
-        ProtocolModifiers {
-            shift: m.shift,
-            ctrl: m.ctrl,
-            alt: m.alt,
-            meta: m.meta,
-        }
-    });
+    let modifier_held = link_modifier_held(&protocol_mods(&keys));
     hover.entity = None;
     hover.hyperlink_id = None;
     hover.modifier_held = modifier_held;
@@ -121,7 +110,7 @@ fn resolve_hover(
         .map(|(id, _uri)| id);
     hover.entity = Some(entity);
     hover.hyperlink_id = id;
-    cursor_decision(id.is_some(), modifier_held, true)
+    cursor_decision(id.is_some(), modifier_held)
 }
 
 #[cfg(test)]
@@ -142,12 +131,8 @@ mod tests {
 
     #[test]
     fn cursor_decision_pointer_only_on_link_with_modifier() {
-        assert_eq!(cursor_decision(true, true, true), SystemCursorIcon::Pointer);
-        assert_eq!(cursor_decision(true, false, true), SystemCursorIcon::Text);
-        assert_eq!(cursor_decision(false, true, true), SystemCursorIcon::Text);
-        assert_eq!(
-            cursor_decision(false, false, false),
-            SystemCursorIcon::Default
-        );
+        assert_eq!(cursor_decision(true, true), SystemCursorIcon::Pointer);
+        assert_eq!(cursor_decision(false, true), SystemCursorIcon::Text);
+        assert_eq!(cursor_decision(true, false), SystemCursorIcon::Text);
     }
 }

--- a/crates/ozma_terminal/src/hyperlink.rs
+++ b/crates/ozma_terminal/src/hyperlink.rs
@@ -86,7 +86,7 @@ fn resolve_hover(
         (Entity, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
         (With<OzmaTerminal>, Without<InputDisabled>),
     >,
-    metrics: &Res<TerminalCellMetricsResource>,
+    metrics: &TerminalCellMetricsResource,
     windows: &Query<&Window, With<PrimaryWindow>>,
     modifier_held: bool,
 ) -> SystemCursorIcon {

--- a/crates/ozma_terminal/src/input.rs
+++ b/crates/ozma_terminal/src/input.rs
@@ -125,7 +125,7 @@ fn dispatch_input(
     }
 }
 
-fn current_terminal_modifiers(keys: &ButtonInput<KeyCode>) -> TerminalModifiers {
+pub(crate) fn current_terminal_modifiers(keys: &ButtonInput<KeyCode>) -> TerminalModifiers {
     TerminalModifiers {
         ctrl: keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight),
         shift: keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight),

--- a/crates/ozma_terminal/src/lib.rs
+++ b/crates/ozma_terminal/src/lib.rs
@@ -3,6 +3,7 @@
 mod action;
 mod clipboard;
 mod exit;
+mod hyperlink;
 mod input;
 mod layout;
 mod mouse;

--- a/crates/ozma_terminal/src/lib.rs
+++ b/crates/ozma_terminal/src/lib.rs
@@ -5,16 +5,19 @@ mod clipboard;
 mod exit;
 mod input;
 mod layout;
+mod mouse;
 mod spawn;
 
 use crate::action::OzmaActionPlugin;
 use crate::input::OzmaInputPlugin;
+use crate::mouse::OzmaMousePlugin;
 use crate::spawn::on_add_inject_render;
 use crate::{exit::ExitPlugin, layout::LayoutPlugin};
 pub use action::PasteAction;
 use bevy::prelude::*;
 pub use clipboard::{Clipboard, build_paste_bytes};
 pub use input::{InputDisabled, OzmaTerminalInputSet, ReservedChord, TerminalInputBindings};
+pub use mouse::{FineModifier, OzmaMouseConfig, OzmaTerminalMouseSet};
 pub use spawn::{
     OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig, cells_for,
     resolve_shell,
@@ -35,7 +38,7 @@ impl Plugin for OzmaTerminalPlugin {
         app.insert_resource(OzmaTerminalConfig {
             shell: self.config_shell.clone(),
         })
-        .add_plugins((ExitPlugin, LayoutPlugin, OzmaActionPlugin, OzmaInputPlugin))
+        .add_plugins((ExitPlugin, LayoutPlugin, OzmaActionPlugin, OzmaInputPlugin, OzmaMousePlugin))
         .add_observer(on_add_inject_render);
     }
 }

--- a/crates/ozma_terminal/src/lib.rs
+++ b/crates/ozma_terminal/src/lib.rs
@@ -39,7 +39,13 @@ impl Plugin for OzmaTerminalPlugin {
         app.insert_resource(OzmaTerminalConfig {
             shell: self.config_shell.clone(),
         })
-        .add_plugins((ExitPlugin, LayoutPlugin, OzmaActionPlugin, OzmaInputPlugin, OzmaMousePlugin))
+        .add_plugins((
+            ExitPlugin,
+            LayoutPlugin,
+            OzmaActionPlugin,
+            OzmaInputPlugin,
+            OzmaMousePlugin,
+        ))
         .add_observer(on_add_inject_render);
     }
 }

--- a/crates/ozma_terminal/src/lib.rs
+++ b/crates/ozma_terminal/src/lib.rs
@@ -10,6 +10,7 @@ mod mouse;
 mod spawn;
 
 use crate::action::OzmaActionPlugin;
+use crate::hyperlink::HyperlinkPlugin;
 use crate::input::OzmaInputPlugin;
 use crate::mouse::OzmaMousePlugin;
 use crate::spawn::on_add_inject_render;
@@ -45,6 +46,7 @@ impl Plugin for OzmaTerminalPlugin {
             OzmaActionPlugin,
             OzmaInputPlugin,
             OzmaMousePlugin,
+            HyperlinkPlugin,
         ))
         .add_observer(on_add_inject_render);
     }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -4,19 +4,24 @@
 //! `ButtonAction` / `WheelAction` routers, applying the result to the
 //! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
 
+use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;
-use bevy::input::mouse::{MouseButtonInput, MouseScrollUnit, MouseWheel};
+use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
+use bevy::time::{Real, Time};
 use bevy::ui::{ComputedNode, UiGlobalTransform};
-use bevy::window::CursorMoved;
+use bevy::window::{CursorMoved, PrimaryWindow};
 use ozma_tty_engine::{
-    ButtonAction, ButtonConfig, ButtonEvent, ButtonEventKind, CellCoord, Column, Line,
-    MouseButtonKind, Point, ProtocolModifiers, SelectionType, Side, TermMode, WheelAction,
-    WheelConfig, WheelModifiers,
+    ButtonAction, ButtonConfig, ButtonEvent, ButtonEventKind, CellCoord, Coalescer, Column, Line,
+    MouseButtonKind, Point, ProtocolModifiers, PtyHandle, SelectionType, Side, TermMode,
+    TerminalHandle, TerminalModifiers, WheelAction, WheelConfig, WheelModifiers,
 };
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::schema::TerminalGrid;
 use std::time::Duration;
 
-use crate::hyperlink::hyperlink_hover_cursor;
+use crate::clipboard::Clipboard;
+use crate::hyperlink::{hyperlink_hover_cursor, link_modifier_held, try_open_uri};
 use crate::input::current_terminal_modifiers;
 
 /// Which modifier activates "fine" (1 line per notch) wheel scrolling.
@@ -88,7 +93,6 @@ pub(crate) enum DragPhase {
 /// last cell a drag reached (dedup + lazy materialization).
 pub(crate) struct DragGesture {
     /// Which mouse button is being held.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read by drag dispatch systems (Task 6)"))]
     pub(crate) button: MouseButtonKind,
     /// The cell where the gesture originated.
     pub(crate) origin: CellCoord,
@@ -106,7 +110,6 @@ pub(crate) struct DragGesture {
 #[derive(Resource, Default)]
 pub(crate) struct OzmaMouseGesture {
     /// Consecutive-click counter for multi-click detection.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read by button dispatch systems (Task 6)"))]
     pub(crate) click: ClickTracker,
     /// In-progress button gesture, or `None` when idle.
     pub(crate) drag: Option<DragGesture>,
@@ -121,7 +124,6 @@ pub(crate) struct ClickTracker {
 impl ClickTracker {
     /// Registers a press at `now` / logical `pos`, returning the click count
     /// (1..=3). `cfg` is `(timeout, drift_px)`.
-    #[cfg_attr(not(test), expect(dead_code, reason = "called by button dispatch systems (Task 3)"))]
     pub(crate) fn register(&mut self, now: Duration, pos: Vec2, cfg: (Duration, f32)) -> u8 {
         let (timeout, drift) = cfg;
         let count = match self.last {
@@ -180,7 +182,6 @@ pub(crate) fn to_viewport_point(cell: CellCoord) -> Point {
 }
 
 /// Builds `ProtocolModifiers` from the held keys.
-#[cfg_attr(not(test), expect(dead_code, reason = "called by button and wheel dispatch systems (Task 6)"))]
 pub(crate) fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
     let m = current_terminal_modifiers(keys);
     ProtocolModifiers {
@@ -216,7 +217,6 @@ pub(crate) enum MouseEffect {
 /// click state) and returns the effects to apply. A Cmd/Ctrl-click on a linked
 /// cell opens the URL and consumes the event; otherwise the engine's
 /// `ButtonAction::route` decides forward-to-app vs local selection.
-#[cfg_attr(not(test), expect(dead_code, reason = "called by dispatch systems (Task 6)"))]
 pub(crate) fn decide_button(
     gesture: &mut OzmaMouseGesture,
     modes: TermMode,
@@ -286,7 +286,6 @@ pub(crate) struct WheelAccumulator {
 
 /// Cells of scroll for one wheel event: `Line` units count directly, `Pixel`
 /// units divide by the cell height. Positive = wheel-up (toward older lines).
-#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
 pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f32 {
     match unit {
         MouseScrollUnit::Line => y,
@@ -297,7 +296,6 @@ pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f
 /// Adds `delta_cells` to the accumulator and returns whole notches to emit
 /// (positive = up/older), carrying the remainder. Resets the residual on a
 /// sign flip, then processes the new delta at full magnitude.
-#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
 pub(crate) fn accumulate_notches(
     acc: &mut WheelAccumulator,
     delta_cells: f32,
@@ -317,7 +315,6 @@ pub(crate) fn accumulate_notches(
 
 /// Pure wheel decision. `notches` is in the engine convention (negative =
 /// up/older); callers negate the Bevy-derived up-positive value before calling.
-#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
 pub(crate) fn decide_wheel(
     modes: TermMode,
     notches: i32,
@@ -329,6 +326,180 @@ pub(crate) fn decide_wheel(
         WheelAction::Noop => Vec::new(),
         WheelAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
         WheelAction::ScrollViewport(lines) => vec![MouseEffect::Scroll(lines)],
+    }
+}
+
+/// The crate's mouse-button dispatcher. Resolves the cursor cell, tracks clicks
+/// and drag state, drives `decide_button`, and applies the effects. Skips the
+/// `OzmaTerminal` while it carries `InputDisabled`.
+pub(crate) fn dispatch_mouse_buttons(
+    mut gesture: ResMut<OzmaMouseGesture>,
+    mut buttons: MessageReader<MouseButtonInput>,
+    mut terminal: Query<
+        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<crate::spawn::OzmaTerminal>, Without<crate::input::InputDisabled>),
+    >,
+    mut clipboard: ResMut<Clipboard>,
+    cfg: Res<OzmaMouseConfig>,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    time: Res<Time<Real>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    };
+    let Ok(window) = windows.single() else {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    };
+    if !window.focused {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    }
+    let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
+        buttons.clear();
+        return;
+    };
+    let scale = window.scale_factor();
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let modes = handle.current_modes();
+    let mods = protocol_mods(&keys);
+    let modifier_held = link_modifier_held(&mods);
+
+    for ev in buttons.read() {
+        let Some(button) = map_button(ev.button) else { continue };
+        let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows) else { continue };
+        let kind = match ev.state {
+            ButtonState::Pressed => ButtonEventKind::Press,
+            ButtonState::Released => ButtonEventKind::Release,
+        };
+        let click_count = if kind == ButtonEventKind::Press {
+            gesture.click.register(time.elapsed(), cursor_phys / scale, (cfg.double_click_timeout, cfg.click_drift_px))
+        } else {
+            1
+        };
+        let link_at_cell = (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
+            .then(|| grid.hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16).map(|(_id, uri)| uri.as_str().to_string()))
+            .flatten();
+        let evt = ButtonEvent { kind, button, cell, side, click_count };
+        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, link_at_cell, &cfg.buttons);
+        for effect in effects {
+            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+        }
+    }
+
+    if gesture.drag.is_some()
+        && let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
+        && gesture.drag.as_ref().is_some_and(|d| d.last_cell != cell)
+    {
+        let button = gesture.drag.as_ref().map(|d| d.button).unwrap_or(MouseButtonKind::Left);
+        let evt = ButtonEvent { kind: ButtonEventKind::Drag, button, cell, side, click_count: 1 };
+        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, None, &cfg.buttons);
+        for effect in effects {
+            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+        }
+    }
+}
+
+/// The crate's wheel dispatcher: accumulates notches, drives `decide_wheel`,
+/// applies the result.
+pub(crate) fn dispatch_mouse_wheel(
+    mut gesture_acc: ResMut<WheelAccumulator>,
+    mut wheel: MessageReader<MouseWheel>,
+    mut terminal: Query<
+        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<crate::spawn::OzmaTerminal>, Without<crate::input::InputDisabled>),
+    >,
+    mut clipboard: ResMut<Clipboard>,
+    cfg: Res<OzmaMouseConfig>,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+        wheel.clear();
+        return;
+    };
+    let Ok(window) = windows.single() else { wheel.clear(); return };
+    if !window.focused { wheel.clear(); return }
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+
+    let mut delta_cells = 0.0f32;
+    for ev in wheel.read() {
+        delta_cells += wheel_delta_cells(ev.unit, ev.y, cell_h);
+    }
+    let raw = accumulate_notches(&mut gesture_acc, delta_cells, cfg.cells_per_notch);
+    if raw == 0 {
+        return;
+    }
+    // NOTE: Bevy +y (up/older) → engine convention (negative = up/older).
+    let notches = -raw;
+    let cell = window
+        .cursor_position()
+        .map(|c| c * window.scale_factor())
+        .and_then(|p| cell_at_cursor(node, transform, p, cell_w, cell_h, grid.cols, grid.rows))
+        .map(|(cell, _)| cell)
+        .unwrap_or(CellCoord { col: 1, row: 1 });
+    let m = current_terminal_modifiers(&keys);
+    let mods = WheelModifiers {
+        shift: m.shift,
+        ctrl: m.ctrl,
+        alt: m.alt,
+        fine: fine_held(cfg.fine_modifier, &m),
+    };
+    for effect in decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel) {
+        apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+    }
+}
+
+fn fine_held(modifier: FineModifier, m: &TerminalModifiers) -> bool {
+    match modifier {
+        FineModifier::Shift => m.shift,
+        FineModifier::Ctrl => m.ctrl,
+        FineModifier::Alt => m.alt,
+        FineModifier::None => true,
+    }
+}
+
+fn map_button(b: MouseButton) -> Option<MouseButtonKind> {
+    match b {
+        MouseButton::Left => Some(MouseButtonKind::Left),
+        MouseButton::Middle => Some(MouseButtonKind::Middle),
+        MouseButton::Right => Some(MouseButtonKind::Right),
+        _ => None,
+    }
+}
+
+fn apply_effect(
+    handle: &mut TerminalHandle,
+    pty: &mut PtyHandle,
+    coalescer: &mut Coalescer,
+    clipboard: &mut Clipboard,
+    effect: MouseEffect,
+) {
+    match effect {
+        MouseEffect::Write(b) => {
+            if let Err(e) = handle.write(pty, &b) {
+                tracing::warn!(?e, "ozma mouse pty write failed");
+            }
+        }
+        MouseEffect::SelStart { point, side, ty } => handle.selection_start_at(coalescer, point, side, ty),
+        MouseEffect::SelUpdate { point, side } => handle.selection_update_to(coalescer, point, side),
+        MouseEffect::SelClear => handle.selection_clear(coalescer),
+        MouseEffect::Copy => {
+            if let Some(text) = handle.selection_to_string() {
+                clipboard.write(text);
+            }
+        }
+        MouseEffect::Scroll(lines) => handle.scroll(coalescer, lines),
+        MouseEffect::OpenUri(uri) => try_open_uri(&uri),
     }
 }
 
@@ -375,6 +546,12 @@ impl Plugin for OzmaMousePlugin {
                 hyperlink_hover_cursor
                     .in_set(OzmaTerminalMouseSet)
                     .run_if(on_message::<KeyboardInput>.or(on_message::<CursorMoved>)),
+            )
+            .add_systems(
+                Update,
+                (dispatch_mouse_buttons, dispatch_mouse_wheel)
+                    .in_set(OzmaTerminalMouseSet)
+                    .run_if(on_message::<MouseButtonInput>.or(on_message::<CursorMoved>).or(on_message::<MouseWheel>)),
             );
     }
 }
@@ -382,7 +559,42 @@ impl Plugin for OzmaMousePlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::input::mouse::{MouseButton, MouseButtonInput};
     use ozma_tty_engine::{ButtonEvent, ButtonEventKind, MouseButtonKind};
+
+    use crate::input::InputDisabled;
+    use crate::spawn::OzmaTerminal;
+
+    #[test]
+    fn input_disabled_terminal_drains_without_arming_a_gesture() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<MouseButtonInput>()
+            .init_resource::<OzmaMouseConfig>()
+            .init_resource::<OzmaMouseGesture>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<Clipboard>()
+            .insert_resource(test_metrics())
+            .add_systems(Update, dispatch_mouse_buttons);
+        app.world_mut().spawn((OzmaTerminal, InputDisabled));
+        app.world_mut().spawn((Window { focused: true, ..default() }, PrimaryWindow));
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseButtonInput>>()
+            .write(MouseButtonInput { button: MouseButton::Left, state: ButtonState::Pressed, window: Entity::PLACEHOLDER });
+        app.update();
+        assert!(app.world().resource::<OzmaMouseGesture>().drag.is_none());
+    }
+
+    fn test_metrics() -> TerminalCellMetricsResource {
+        use ozma_tty_renderer::CellMetrics;
+        TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0, line_height_phys: 16.0, ascent_phys: 12.0, descent_phys: 4.0,
+                underline_position_phys: -2.0, underline_thickness_phys: 1.0, max_overflow_phys: 0.0,
+            },
+            phys_font_size: 16,
+        }
+    }
 
     fn ev(kind: ButtonEventKind, col: u32, row: u32, count: u8) -> ButtonEvent {
         ButtonEvent {

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -73,7 +73,7 @@ pub struct OzmaTerminalMouseSet;
 
 /// Phase of an in-progress left-drag: `Armed` after a single-click press (no
 /// selection started yet), `Started` once the pointer crossed into another cell.
-#[allow(dead_code)]
+#[cfg_attr(not(test), expect(dead_code, reason = "constructed by decide_button (Task 3)"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DragPhase {
     /// The button is held but the pointer has not left the origin cell.
@@ -84,7 +84,7 @@ pub(crate) enum DragPhase {
 
 /// An in-progress button gesture: the held button, the selection anchor, and the
 /// last cell a drag reached (dedup + lazy materialization).
-#[allow(dead_code)]
+#[cfg_attr(not(test), expect(dead_code, reason = "fields read by decide_button and drag dispatch systems (Task 3)"))]
 pub(crate) struct DragGesture {
     /// Which mouse button is being held.
     pub(crate) button: MouseButtonKind,
@@ -104,24 +104,23 @@ pub(crate) struct DragGesture {
 #[derive(Resource, Default)]
 pub(crate) struct OzmaMouseGesture {
     /// Consecutive-click counter for multi-click detection.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code, reason = "read by button dispatch systems (Task 6)"))]
     pub(crate) click: ClickTracker,
     /// In-progress button gesture, or `None` when idle.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code, reason = "read by button dispatch systems (Task 6)"))]
     pub(crate) drag: Option<DragGesture>,
 }
 
 /// Consecutive-click counter using a timeout + positional-drift gate.
 #[derive(Default)]
 pub(crate) struct ClickTracker {
-    #[allow(dead_code)]
     last: Option<(Duration, Vec2, u8)>,
 }
 
 impl ClickTracker {
     /// Registers a press at `now` / logical `pos`, returning the click count
     /// (1..=3). `cfg` is `(timeout, drift_px)`.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code, reason = "called by button dispatch systems (Task 3)"))]
     pub(crate) fn register(&mut self, now: Duration, pos: Vec2, cfg: (Duration, f32)) -> u8 {
         let (timeout, drift) = cfg;
         let count = match self.last {
@@ -137,7 +136,6 @@ impl ClickTracker {
 
 /// 1-indexed `(CellCoord, Side)` of the cell at pane-local physical `local`,
 /// clamped to `1..=cols` × `1..=rows`. `Side` is `Left` in the left half.
-#[allow(dead_code)]
 pub(crate) fn cell_at_local(
     local: Vec2,
     cell_w: f32,
@@ -159,7 +157,7 @@ pub(crate) fn cell_at_local(
 
 /// Resolves the window-space physical cursor to a cell on the terminal node, or
 /// `None` when the cursor is outside the node.
-#[allow(dead_code)]
+#[cfg_attr(not(test), expect(dead_code, reason = "called by cursor hit-test systems (Task 6)"))]
 pub(crate) fn cell_at_cursor(
     node: &ComputedNode,
     transform: &UiGlobalTransform,
@@ -177,13 +175,13 @@ pub(crate) fn cell_at_cursor(
 
 /// Converts a 1-indexed protocol `CellCoord` into the engine's viewport-relative
 /// selection `Point` (row 0 = top of viewport; the engine translates for scroll).
-#[allow(dead_code)]
+#[cfg_attr(not(test), expect(dead_code, reason = "called by selection dispatch systems (Task 6)"))]
 pub(crate) fn to_viewport_point(cell: CellCoord) -> Point {
     Point::new(Line(cell.row as i32 - 1), Column(cell.col as usize - 1))
 }
 
 /// Builds `ProtocolModifiers` from the held keys.
-#[allow(dead_code)]
+#[cfg_attr(not(test), expect(dead_code, reason = "called by button and wheel dispatch systems (Task 6)"))]
 pub(crate) fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
     let m = current_terminal_modifiers(keys);
     ProtocolModifiers {

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -9,8 +9,8 @@ use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::CursorMoved;
 use ozma_tty_engine::{
-    ButtonConfig, CellCoord, Column, Line, MouseButtonKind, Point, ProtocolModifiers,
-    SelectionType, Side, WheelConfig,
+    ButtonAction, ButtonConfig, ButtonEvent, ButtonEventKind, CellCoord, Column, Line,
+    MouseButtonKind, Point, ProtocolModifiers, SelectionType, Side, TermMode, WheelConfig,
 };
 use std::time::Duration;
 
@@ -73,7 +73,6 @@ pub struct OzmaTerminalMouseSet;
 
 /// Phase of an in-progress left-drag: `Armed` after a single-click press (no
 /// selection started yet), `Started` once the pointer crossed into another cell.
-#[cfg_attr(not(test), expect(dead_code, reason = "constructed by decide_button (Task 3)"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DragPhase {
     /// The button is held but the pointer has not left the origin cell.
@@ -84,9 +83,9 @@ pub(crate) enum DragPhase {
 
 /// An in-progress button gesture: the held button, the selection anchor, and the
 /// last cell a drag reached (dedup + lazy materialization).
-#[cfg_attr(not(test), expect(dead_code, reason = "fields read by decide_button and drag dispatch systems (Task 3)"))]
 pub(crate) struct DragGesture {
     /// Which mouse button is being held.
+    #[cfg_attr(not(test), expect(dead_code, reason = "read by drag dispatch systems (Task 6)"))]
     pub(crate) button: MouseButtonKind,
     /// The cell where the gesture originated.
     pub(crate) origin: CellCoord,
@@ -107,7 +106,6 @@ pub(crate) struct OzmaMouseGesture {
     #[cfg_attr(not(test), expect(dead_code, reason = "read by button dispatch systems (Task 6)"))]
     pub(crate) click: ClickTracker,
     /// In-progress button gesture, or `None` when idle.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read by button dispatch systems (Task 6)"))]
     pub(crate) drag: Option<DragGesture>,
 }
 
@@ -175,7 +173,6 @@ pub(crate) fn cell_at_cursor(
 
 /// Converts a 1-indexed protocol `CellCoord` into the engine's viewport-relative
 /// selection `Point` (row 0 = top of viewport; the engine translates for scroll).
-#[cfg_attr(not(test), expect(dead_code, reason = "called by selection dispatch systems (Task 6)"))]
 pub(crate) fn to_viewport_point(cell: CellCoord) -> Point {
     Point::new(Line(cell.row as i32 - 1), Column(cell.col as usize - 1))
 }
@@ -189,6 +186,121 @@ pub(crate) fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
         ctrl: m.ctrl,
         alt: m.alt,
         meta: m.meta,
+    }
+}
+
+/// A resolved intent the apply step writes to the handle / clipboard. Kept
+/// separate from application so the decision logic is unit-testable without a
+/// `TerminalHandle` (which has no public constructor).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MouseEffect {
+    /// Write these bytes to the PTY.
+    Write(Vec<u8>),
+    /// Start a new local selection at `point`.
+    SelStart { point: Point, side: Side, ty: SelectionType },
+    /// Extend the current selection's moving end to `point`.
+    SelUpdate { point: Point, side: Side },
+    /// Clear any active local selection.
+    SelClear,
+    /// Copy the current selection to the clipboard.
+    Copy,
+    /// Scroll the viewport by `i32` lines (negative = up).
+    #[expect(dead_code, reason = "emitted by wheel dispatch systems (Task 6)")]
+    Scroll(i32),
+    /// Open the given URI in the host browser / handler.
+    OpenUri(String),
+}
+
+/// Pure per-event decision for a mouse button. Mutates `gesture` (drag phase /
+/// click state) and returns the effects to apply. A Cmd/Ctrl-click on a linked
+/// cell opens the URL and consumes the event; otherwise the engine's
+/// `ButtonAction::route` decides forward-to-app vs local selection.
+#[cfg_attr(not(test), expect(dead_code, reason = "called by dispatch systems (Task 6)"))]
+pub(crate) fn decide_button(
+    gesture: &mut OzmaMouseGesture,
+    modes: TermMode,
+    evt: ButtonEvent,
+    mods: ProtocolModifiers,
+    modifier_held: bool,
+    link_at_cell: Option<String>,
+    cfg: &ButtonConfig,
+) -> Vec<MouseEffect> {
+    if evt.kind == ButtonEventKind::Press
+        && evt.button == MouseButtonKind::Left
+        && modifier_held
+        && let Some(uri) = link_at_cell
+    {
+        return vec![MouseEffect::OpenUri(uri)];
+    }
+
+    let mut effects = match ButtonAction::route(modes, evt, mods, cfg) {
+        ButtonAction::Noop => Vec::new(),
+        ButtonAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
+        ButtonAction::ClearAndWriteToPty(b) => vec![MouseEffect::SelClear, MouseEffect::Write(b)],
+        ButtonAction::ArmDrag { ty, cell, side } => {
+            gesture.drag = Some(DragGesture {
+                button: evt.button,
+                origin: cell,
+                side,
+                ty,
+                phase: DragPhase::Armed,
+                last_cell: cell,
+            });
+            vec![MouseEffect::SelClear]
+        }
+        ButtonAction::StartLocalSelection { ty, cell, side } => {
+            gesture.drag = Some(DragGesture {
+                button: evt.button,
+                origin: cell,
+                side,
+                ty,
+                phase: DragPhase::Started,
+                last_cell: cell,
+            });
+            vec![MouseEffect::SelStart { point: to_viewport_point(cell), side, ty }]
+        }
+        ButtonAction::UpdateLocalSelection { cell, side } => update_selection(gesture, cell, side),
+        ButtonAction::ClearLocalSelection => {
+            gesture.drag = None;
+            vec![MouseEffect::SelClear]
+        }
+    };
+
+    if evt.kind == ButtonEventKind::Release && evt.button == MouseButtonKind::Left {
+        if effects.is_empty()
+            && matches!(&gesture.drag, Some(d) if d.phase == DragPhase::Started)
+        {
+            effects.push(MouseEffect::Copy);
+        }
+        gesture.drag = None;
+    }
+    effects
+}
+
+/// Lazily materializes an armed selection on the first cell change, then extends.
+fn update_selection(gesture: &mut OzmaMouseGesture, cell: CellCoord, side: Side) -> Vec<MouseEffect> {
+    let Some(drag) = gesture.drag.as_mut() else {
+        return Vec::new();
+    };
+    match drag.phase {
+        DragPhase::Armed => {
+            if cell == drag.origin {
+                return Vec::new();
+            }
+            let origin = drag.origin;
+            let ty = drag.ty;
+            let origin_side = drag.side;
+            drag.phase = DragPhase::Started;
+            drag.last_cell = cell;
+            vec![
+                MouseEffect::SelStart { point: to_viewport_point(origin), side: origin_side, ty },
+                MouseEffect::SelUpdate { point: to_viewport_point(cell), side },
+            ]
+        }
+        DragPhase::Started => {
+            drag.last_cell = cell;
+            vec![MouseEffect::SelUpdate { point: to_viewport_point(cell), side }]
+        }
     }
 }
 
@@ -208,6 +320,97 @@ impl Plugin for OzmaMousePlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ozma_tty_engine::{ButtonEvent, ButtonEventKind, MouseButtonKind};
+
+    fn ev(kind: ButtonEventKind, col: u32, row: u32, count: u8) -> ButtonEvent {
+        ButtonEvent {
+            kind,
+            button: MouseButtonKind::Left,
+            cell: CellCoord { col, row },
+            side: Side::Left,
+            click_count: count,
+        }
+    }
+
+    #[test]
+    fn local_single_press_arms_drag_and_clears() {
+        let mut g = OzmaMouseGesture::default();
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+        assert_eq!(fx, vec![MouseEffect::SelClear]);
+        assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+    }
+
+    #[test]
+    fn local_drag_materializes_then_extends() {
+        let mut g = OzmaMouseGesture::default();
+        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        assert_eq!(fx, vec![
+            MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Simple },
+            MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 7, row: 5 }), side: Side::Left },
+        ]);
+        let fx2 = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 9, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        assert_eq!(fx2, vec![MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 9, row: 5 }), side: Side::Left }]);
+    }
+
+    #[test]
+    fn release_after_drag_copies() {
+        let mut g = OzmaMouseGesture::default();
+        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        assert_eq!(fx, vec![MouseEffect::Copy]);
+        assert!(g.drag.is_none());
+    }
+
+    #[test]
+    fn release_after_bare_click_does_not_copy() {
+        let mut g = OzmaMouseGesture::default();
+        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        assert_eq!(fx, vec![]);
+        assert!(g.drag.is_none());
+    }
+
+    #[test]
+    fn double_click_starts_word_selection() {
+        let mut g = OzmaMouseGesture::default();
+        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 2), ProtocolModifiers::default(), false, None, &cfg);
+        assert_eq!(fx, vec![MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Semantic }]);
+    }
+
+    #[test]
+    fn app_capture_press_forwards_sgr_bytes() {
+        let mut g = OzmaMouseGesture::default();
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+        assert_eq!(fx, vec![MouseEffect::SelClear, MouseEffect::Write(b"\x1b[<0;5;5M".to_vec())]);
+    }
+
+    #[test]
+    fn shift_bypass_selects_even_when_captured() {
+        let mut g = OzmaMouseGesture::default();
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let mods = ProtocolModifiers { shift: true, ..Default::default() };
+        let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), mods, false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+        assert_eq!(fx, vec![MouseEffect::SelClear]);
+        assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+    }
+
+    #[test]
+    fn cmd_click_on_link_opens_and_consumes() {
+        let mut g = OzmaMouseGesture::default();
+        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers { meta: true, ..Default::default() }, true, Some("https://example.com".into()),
+            &ButtonConfig { max_protocol_events_per_frame: 8 });
+        assert_eq!(fx, vec![MouseEffect::OpenUri("https://example.com".into())]);
+        assert!(g.drag.is_none(), "a link-open press must not arm a drag");
+    }
 
     #[test]
     fn default_config_sets_button_cap_explicitly() {

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -201,7 +201,11 @@ pub(crate) enum MouseEffect {
     /// Write these bytes to the PTY.
     Write(Vec<u8>),
     /// Start a new local selection at `point`.
-    SelStart { point: Point, side: Side, ty: SelectionType },
+    SelStart {
+        point: Point,
+        side: Side,
+        ty: SelectionType,
+    },
     /// Extend the current selection's moving end to `point`.
     SelUpdate { point: Point, side: Side },
     /// Clear any active local selection.
@@ -259,7 +263,11 @@ pub(crate) fn decide_button(
                 phase: DragPhase::Started,
                 last_cell: cell,
             });
-            vec![MouseEffect::SelStart { point: to_viewport_point(cell), side, ty }]
+            vec![MouseEffect::SelStart {
+                point: to_viewport_point(cell),
+                side,
+                ty,
+            }]
         }
         ButtonAction::UpdateLocalSelection { cell, side } => update_selection(gesture, cell, side),
         ButtonAction::ClearLocalSelection => {
@@ -269,9 +277,7 @@ pub(crate) fn decide_button(
     };
 
     if evt.kind == ButtonEventKind::Release && evt.button == MouseButtonKind::Left {
-        if effects.is_empty()
-            && matches!(&gesture.drag, Some(d) if d.phase == DragPhase::Started)
-        {
+        if effects.is_empty() && matches!(&gesture.drag, Some(d) if d.phase == DragPhase::Started) {
             effects.push(MouseEffect::Copy);
         }
         gesture.drag = None;
@@ -337,7 +343,14 @@ pub(crate) fn dispatch_mouse_buttons(
     mut gesture: ResMut<OzmaMouseGesture>,
     mut buttons: MessageReader<MouseButtonInput>,
     mut terminal: Query<
-        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (
+            &mut TerminalHandle,
+            &mut PtyHandle,
+            &mut Coalescer,
+            &ComputedNode,
+            &UiGlobalTransform,
+            &TerminalGrid,
+        ),
         (With<OzmaTerminal>, Without<InputDisabled>),
     >,
     mut clipboard: ResMut<Clipboard>,
@@ -347,7 +360,8 @@ pub(crate) fn dispatch_mouse_buttons(
     time: Res<Time<Real>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut()
+    else {
         buttons.clear();
         gesture.drag = None;
         return;
@@ -374,36 +388,108 @@ pub(crate) fn dispatch_mouse_buttons(
     let modifier_held = link_modifier_held(&mods);
 
     for ev in buttons.read() {
-        let Some(button) = map_button(ev.button) else { continue };
-        let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows) else { continue };
+        let Some(button) = map_button(ev.button) else {
+            continue;
+        };
+        let Some((cell, side)) = cell_at_cursor(
+            node,
+            transform,
+            cursor_phys,
+            cell_w,
+            cell_h,
+            grid.cols,
+            grid.rows,
+        ) else {
+            continue;
+        };
         let kind = match ev.state {
             ButtonState::Pressed => ButtonEventKind::Press,
             ButtonState::Released => ButtonEventKind::Release,
         };
         let click_count = if kind == ButtonEventKind::Press {
-            gesture.click.register(time.elapsed(), cursor_phys / scale, (cfg.double_click_timeout, cfg.click_drift_px))
+            gesture.click.register(
+                time.elapsed(),
+                cursor_phys / scale,
+                (cfg.double_click_timeout, cfg.click_drift_px),
+            )
         } else {
             1
         };
-        let link_at_cell = (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
-            .then(|| grid.hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16).map(|(_id, uri)| uri.as_str().to_string()))
-            .flatten();
-        let evt = ButtonEvent { kind, button, cell, side, click_count };
-        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, link_at_cell, &cfg.buttons);
+        let link_at_cell =
+            (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
+                .then(|| {
+                    grid.hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16)
+                        .map(|(_id, uri)| uri.as_str().to_string())
+                })
+                .flatten();
+        let evt = ButtonEvent {
+            kind,
+            button,
+            cell,
+            side,
+            click_count,
+        };
+        let effects = decide_button(
+            &mut gesture,
+            modes,
+            evt,
+            mods,
+            modifier_held,
+            link_at_cell,
+            &cfg.buttons,
+        );
         for effect in effects {
-            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+            apply_effect(
+                &mut handle,
+                &mut pty,
+                &mut coalescer,
+                &mut clipboard,
+                effect,
+            );
         }
     }
 
     if gesture.drag.is_some()
-        && let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
+        && let Some((cell, side)) = cell_at_cursor(
+            node,
+            transform,
+            cursor_phys,
+            cell_w,
+            cell_h,
+            grid.cols,
+            grid.rows,
+        )
         && gesture.drag.as_ref().is_some_and(|d| d.last_cell != cell)
     {
-        let button = gesture.drag.as_ref().map(|d| d.button).unwrap_or(MouseButtonKind::Left);
-        let evt = ButtonEvent { kind: ButtonEventKind::Drag, button, cell, side, click_count: 1 };
-        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, None, &cfg.buttons);
+        let button = gesture
+            .drag
+            .as_ref()
+            .map(|d| d.button)
+            .unwrap_or(MouseButtonKind::Left);
+        let evt = ButtonEvent {
+            kind: ButtonEventKind::Drag,
+            button,
+            cell,
+            side,
+            click_count: 1,
+        };
+        let effects = decide_button(
+            &mut gesture,
+            modes,
+            evt,
+            mods,
+            modifier_held,
+            None,
+            &cfg.buttons,
+        );
         for effect in effects {
-            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+            apply_effect(
+                &mut handle,
+                &mut pty,
+                &mut coalescer,
+                &mut clipboard,
+                effect,
+            );
         }
     }
 }
@@ -414,7 +500,14 @@ pub(crate) fn dispatch_mouse_wheel(
     mut gesture_acc: ResMut<WheelAccumulator>,
     mut wheel: MessageReader<MouseWheel>,
     mut terminal: Query<
-        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (
+            &mut TerminalHandle,
+            &mut PtyHandle,
+            &mut Coalescer,
+            &ComputedNode,
+            &UiGlobalTransform,
+            &TerminalGrid,
+        ),
         (With<OzmaTerminal>, Without<InputDisabled>),
     >,
     mut clipboard: ResMut<Clipboard>,
@@ -423,12 +516,19 @@ pub(crate) fn dispatch_mouse_wheel(
     keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut()
+    else {
         wheel.clear();
         return;
     };
-    let Ok(window) = windows.single() else { wheel.clear(); return };
-    if !window.focused { wheel.clear(); return }
+    let Ok(window) = windows.single() else {
+        wheel.clear();
+        return;
+    };
+    if !window.focused {
+        wheel.clear();
+        return;
+    }
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
 
@@ -456,7 +556,13 @@ pub(crate) fn dispatch_mouse_wheel(
         fine: fine_held(cfg.fine_modifier, &m),
     };
     for effect in decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel) {
-        apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+        apply_effect(
+            &mut handle,
+            &mut pty,
+            &mut coalescer,
+            &mut clipboard,
+            effect,
+        );
     }
 }
 
@@ -491,8 +597,12 @@ fn apply_effect(
                 tracing::warn!(?e, "ozma mouse pty write failed");
             }
         }
-        MouseEffect::SelStart { point, side, ty } => handle.selection_start_at(coalescer, point, side, ty),
-        MouseEffect::SelUpdate { point, side } => handle.selection_update_to(coalescer, point, side),
+        MouseEffect::SelStart { point, side, ty } => {
+            handle.selection_start_at(coalescer, point, side, ty)
+        }
+        MouseEffect::SelUpdate { point, side } => {
+            handle.selection_update_to(coalescer, point, side)
+        }
         MouseEffect::SelClear => handle.selection_clear(coalescer),
         MouseEffect::Copy => {
             if let Some(text) = handle.selection_to_string() {
@@ -505,7 +615,11 @@ fn apply_effect(
 }
 
 /// Lazily materializes an armed selection on the first cell change, then extends.
-fn update_selection(gesture: &mut OzmaMouseGesture, cell: CellCoord, side: Side) -> Vec<MouseEffect> {
+fn update_selection(
+    gesture: &mut OzmaMouseGesture,
+    cell: CellCoord,
+    side: Side,
+) -> Vec<MouseEffect> {
     let Some(drag) = gesture.drag.as_mut() else {
         return Vec::new();
     };
@@ -520,13 +634,23 @@ fn update_selection(gesture: &mut OzmaMouseGesture, cell: CellCoord, side: Side)
             drag.phase = DragPhase::Started;
             drag.last_cell = cell;
             vec![
-                MouseEffect::SelStart { point: to_viewport_point(origin), side: origin_side, ty },
-                MouseEffect::SelUpdate { point: to_viewport_point(cell), side },
+                MouseEffect::SelStart {
+                    point: to_viewport_point(origin),
+                    side: origin_side,
+                    ty,
+                },
+                MouseEffect::SelUpdate {
+                    point: to_viewport_point(cell),
+                    side,
+                },
             ]
         }
         DragPhase::Started => {
             drag.last_cell = cell;
-            vec![MouseEffect::SelUpdate { point: to_viewport_point(cell), side }]
+            vec![MouseEffect::SelUpdate {
+                point: to_viewport_point(cell),
+                side,
+            }]
         }
     }
 }
@@ -552,7 +676,11 @@ impl Plugin for OzmaMousePlugin {
                 Update,
                 (dispatch_mouse_buttons, dispatch_mouse_wheel)
                     .in_set(OzmaTerminalMouseSet)
-                    .run_if(on_message::<MouseButtonInput>.or(on_message::<CursorMoved>).or(on_message::<MouseWheel>)),
+                    .run_if(
+                        on_message::<MouseButtonInput>
+                            .or(on_message::<CursorMoved>)
+                            .or(on_message::<MouseWheel>),
+                    ),
             );
     }
 }
@@ -575,10 +703,20 @@ mod tests {
             .insert_resource(test_metrics())
             .add_systems(Update, dispatch_mouse_buttons);
         app.world_mut().spawn((OzmaTerminal, InputDisabled));
-        app.world_mut().spawn((Window { focused: true, ..default() }, PrimaryWindow));
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
         app.world_mut()
             .resource_mut::<bevy::ecs::message::Messages<MouseButtonInput>>()
-            .write(MouseButtonInput { button: MouseButton::Left, state: ButtonState::Pressed, window: Entity::PLACEHOLDER });
+            .write(MouseButtonInput {
+                button: MouseButton::Left,
+                state: ButtonState::Pressed,
+                window: Entity::PLACEHOLDER,
+            });
         app.update();
         assert!(app.world().resource::<OzmaMouseGesture>().drag.is_none());
     }
@@ -587,8 +725,13 @@ mod tests {
         use ozma_tty_renderer::CellMetrics;
         TerminalCellMetricsResource {
             metrics: CellMetrics {
-                advance_phys: 8.0, line_height_phys: 16.0, ascent_phys: 12.0, descent_phys: 4.0,
-                underline_position_phys: -2.0, underline_thickness_phys: 1.0, max_overflow_phys: 0.0,
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
             },
             phys_font_size: 16,
         }
@@ -607,33 +750,116 @@ mod tests {
     #[test]
     fn local_single_press_arms_drag_and_clears() {
         let mut g = OzmaMouseGesture::default();
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
-            ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+        );
         assert_eq!(fx, vec![MouseEffect::SelClear]);
-        assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+        assert!(matches!(
+            g.drag,
+            Some(DragGesture {
+                phase: DragPhase::Armed,
+                ..
+            })
+        ));
     }
 
     #[test]
     fn local_drag_materializes_then_extends() {
         let mut g = OzmaMouseGesture::default();
-        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
-        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        assert_eq!(fx, vec![
-            MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Simple },
-            MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 7, row: 5 }), side: Side::Left },
-        ]);
-        let fx2 = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 9, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        assert_eq!(fx2, vec![MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 9, row: 5 }), side: Side::Left }]);
+        let cfg = ButtonConfig {
+            max_protocol_events_per_frame: 8,
+        };
+        decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Drag, 7, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        assert_eq!(
+            fx,
+            vec![
+                MouseEffect::SelStart {
+                    point: to_viewport_point(CellCoord { col: 5, row: 5 }),
+                    side: Side::Left,
+                    ty: SelectionType::Simple
+                },
+                MouseEffect::SelUpdate {
+                    point: to_viewport_point(CellCoord { col: 7, row: 5 }),
+                    side: Side::Left
+                },
+            ]
+        );
+        let fx2 = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Drag, 9, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        assert_eq!(
+            fx2,
+            vec![MouseEffect::SelUpdate {
+                point: to_viewport_point(CellCoord { col: 9, row: 5 }),
+                side: Side::Left
+            }]
+        );
     }
 
     #[test]
     fn release_after_drag_copies() {
         let mut g = OzmaMouseGesture::default();
-        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
-        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        let cfg = ButtonConfig {
+            max_protocol_events_per_frame: 8,
+        };
+        decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Drag, 7, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Release, 7, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
         assert_eq!(fx, vec![MouseEffect::Copy]);
         assert!(g.drag.is_none());
     }
@@ -641,9 +867,27 @@ mod tests {
     #[test]
     fn release_after_bare_click_does_not_copy() {
         let mut g = OzmaMouseGesture::default();
-        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
-        decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+        let cfg = ButtonConfig {
+            max_protocol_events_per_frame: 8,
+        };
+        decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Release, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
         assert_eq!(fx, vec![]);
         assert!(g.drag.is_none());
     }
@@ -651,35 +895,98 @@ mod tests {
     #[test]
     fn double_click_starts_word_selection() {
         let mut g = OzmaMouseGesture::default();
-        let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 2), ProtocolModifiers::default(), false, None, &cfg);
-        assert_eq!(fx, vec![MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Semantic }]);
+        let cfg = ButtonConfig {
+            max_protocol_events_per_frame: 8,
+        };
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 2),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        assert_eq!(
+            fx,
+            vec![MouseEffect::SelStart {
+                point: to_viewport_point(CellCoord { col: 5, row: 5 }),
+                side: Side::Left,
+                ty: SelectionType::Semantic
+            }]
+        );
     }
 
     #[test]
     fn app_capture_press_forwards_sgr_bytes() {
         let mut g = OzmaMouseGesture::default();
         let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
-        let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
-        assert_eq!(fx, vec![MouseEffect::SelClear, MouseEffect::Write(b"\x1b[<0;5;5M".to_vec())]);
+        let fx = decide_button(
+            &mut g,
+            modes,
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+        );
+        assert_eq!(
+            fx,
+            vec![
+                MouseEffect::SelClear,
+                MouseEffect::Write(b"\x1b[<0;5;5M".to_vec())
+            ]
+        );
     }
 
     #[test]
     fn shift_bypass_selects_even_when_captured() {
         let mut g = OzmaMouseGesture::default();
         let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
-        let mods = ProtocolModifiers { shift: true, ..Default::default() };
-        let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), mods, false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+        let mods = ProtocolModifiers {
+            shift: true,
+            ..Default::default()
+        };
+        let fx = decide_button(
+            &mut g,
+            modes,
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            mods,
+            false,
+            None,
+            &ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+        );
         assert_eq!(fx, vec![MouseEffect::SelClear]);
-        assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+        assert!(matches!(
+            g.drag,
+            Some(DragGesture {
+                phase: DragPhase::Armed,
+                ..
+            })
+        ));
     }
 
     #[test]
     fn cmd_click_on_link_opens_and_consumes() {
         let mut g = OzmaMouseGesture::default();
-        let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
-            ProtocolModifiers { meta: true, ..Default::default() }, true, Some("https://example.com".into()),
-            &ButtonConfig { max_protocol_events_per_frame: 8 });
+        let fx = decide_button(
+            &mut g,
+            TermMode::empty(),
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers {
+                meta: true,
+                ..Default::default()
+            },
+            true,
+            Some("https://example.com".into()),
+            &ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+        );
         assert_eq!(fx, vec![MouseEffect::OpenUri("https://example.com".into())]);
         assert!(g.drag.is_none(), "a link-open press must not arm a drag");
     }
@@ -687,10 +994,16 @@ mod tests {
     #[test]
     fn default_config_sets_button_cap_explicitly() {
         let cfg = OzmaMouseConfig::default();
-        assert_eq!(cfg.buttons.max_protocol_events_per_frame, 8, "must NOT be ButtonConfig::default()'s 0");
+        assert_eq!(
+            cfg.buttons.max_protocol_events_per_frame, 8,
+            "must NOT be ButtonConfig::default()'s 0"
+        );
         assert_eq!(cfg.wheel.max_protocol_events_per_frame, 8);
         assert_eq!(cfg.cells_per_notch, 0.5);
-        assert_eq!(cfg.double_click_timeout, std::time::Duration::from_millis(400));
+        assert_eq!(
+            cfg.double_click_timeout,
+            std::time::Duration::from_millis(400)
+        );
         assert_eq!(cfg.click_drift_px, 8.0);
         assert_eq!(cfg.fine_modifier, FineModifier::Alt);
     }
@@ -718,10 +1031,38 @@ mod tests {
     fn click_tracker_counts_within_timeout_and_drift() {
         let mut t = ClickTracker::default();
         let cfg = (std::time::Duration::from_millis(400), 8.0f32);
-        assert_eq!(t.register(std::time::Duration::from_millis(0), Vec2::new(10.0, 10.0), cfg), 1);
-        assert_eq!(t.register(std::time::Duration::from_millis(200), Vec2::new(11.0, 11.0), cfg), 2);
-        assert_eq!(t.register(std::time::Duration::from_millis(350), Vec2::new(12.0, 10.0), cfg), 3);
-        assert_eq!(t.register(std::time::Duration::from_millis(900), Vec2::new(12.0, 10.0), cfg), 1);
+        assert_eq!(
+            t.register(
+                std::time::Duration::from_millis(0),
+                Vec2::new(10.0, 10.0),
+                cfg
+            ),
+            1
+        );
+        assert_eq!(
+            t.register(
+                std::time::Duration::from_millis(200),
+                Vec2::new(11.0, 11.0),
+                cfg
+            ),
+            2
+        );
+        assert_eq!(
+            t.register(
+                std::time::Duration::from_millis(350),
+                Vec2::new(12.0, 10.0),
+                cfg
+            ),
+            3
+        );
+        assert_eq!(
+            t.register(
+                std::time::Duration::from_millis(900),
+                Vec2::new(12.0, 10.0),
+                cfg
+            ),
+            1
+        );
     }
 
     #[test]
@@ -804,14 +1145,26 @@ mod tests {
     #[test]
     fn scrollback_up_returns_positive_viewport_scroll() {
         // Bevy +y (wheel up) → caller negates → engine notches negative → into history.
-        let fx = decide_wheel(TermMode::empty(), -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+        let fx = decide_wheel(
+            TermMode::empty(),
+            -1,
+            CellCoord { col: 1, row: 1 },
+            WheelModifiers::default(),
+            &WheelConfig::default(),
+        );
         assert_eq!(fx, vec![MouseEffect::Scroll(3)]);
     }
 
     #[test]
     fn app_capture_wheel_forwards_bytes() {
         let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
-        let fx = decide_wheel(modes, -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+        let fx = decide_wheel(
+            modes,
+            -1,
+            CellCoord { col: 1, row: 1 },
+            WheelModifiers::default(),
+            &WheelConfig::default(),
+        );
         assert!(matches!(fx.as_slice(), [MouseEffect::Write(b)] if !b.is_empty()));
     }
 }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -22,7 +22,8 @@ use std::time::Duration;
 
 use crate::clipboard::Clipboard;
 use crate::hyperlink::{hyperlink_hover_cursor, link_modifier_held, try_open_uri};
-use crate::input::current_terminal_modifiers;
+use crate::input::{InputDisabled, current_terminal_modifiers};
+use crate::spawn::OzmaTerminal;
 
 /// Which modifier activates "fine" (1 line per notch) wheel scrolling.
 /// Crate-local mirror of the host config enum (the crate must not depend on
@@ -337,7 +338,7 @@ pub(crate) fn dispatch_mouse_buttons(
     mut buttons: MessageReader<MouseButtonInput>,
     mut terminal: Query<
         (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
-        (With<crate::spawn::OzmaTerminal>, Without<crate::input::InputDisabled>),
+        (With<OzmaTerminal>, Without<InputDisabled>),
     >,
     mut clipboard: ResMut<Clipboard>,
     cfg: Res<OzmaMouseConfig>,
@@ -414,7 +415,7 @@ pub(crate) fn dispatch_mouse_wheel(
     mut wheel: MessageReader<MouseWheel>,
     mut terminal: Query<
         (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
-        (With<crate::spawn::OzmaTerminal>, Without<crate::input::InputDisabled>),
+        (With<OzmaTerminal>, Without<InputDisabled>),
     >,
     mut clipboard: ResMut<Clipboard>,
     cfg: Res<OzmaMouseConfig>,
@@ -561,9 +562,6 @@ mod tests {
     use super::*;
     use bevy::input::mouse::{MouseButton, MouseButtonInput};
     use ozma_tty_engine::{ButtonEvent, ButtonEventKind, MouseButtonKind};
-
-    use crate::input::InputDisabled;
-    use crate::spawn::OzmaTerminal;
 
     #[test]
     fn input_disabled_terminal_drains_without_arming_a_gesture() {

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -4,6 +4,7 @@
 //! `ButtonAction` / `WheelAction` routers, applying the result to the
 //! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
 
+use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::{MouseButtonInput, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
@@ -15,6 +16,7 @@ use ozma_tty_engine::{
 };
 use std::time::Duration;
 
+use crate::hyperlink::hyperlink_hover_cursor;
 use crate::input::current_terminal_modifiers;
 
 /// Which modifier activates "fine" (1 line per notch) wheel scrolling.
@@ -156,7 +158,6 @@ pub(crate) fn cell_at_local(
 
 /// Resolves the window-space physical cursor to a cell on the terminal node, or
 /// `None` when the cursor is outside the node.
-#[cfg_attr(not(test), expect(dead_code, reason = "called by cursor hit-test systems (Task 6)"))]
 pub(crate) fn cell_at_cursor(
     node: &ComputedNode,
     transform: &UiGlobalTransform,
@@ -365,9 +366,16 @@ impl Plugin for OzmaMousePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<OzmaMouseConfig>()
             .init_resource::<OzmaMouseGesture>()
+            .init_resource::<WheelAccumulator>()
             .add_message::<MouseButtonInput>()
             .add_message::<MouseWheel>()
-            .add_message::<CursorMoved>();
+            .add_message::<CursorMoved>()
+            .add_systems(
+                Update,
+                hyperlink_hover_cursor
+                    .in_set(OzmaTerminalMouseSet)
+                    .run_if(on_message::<KeyboardInput>.or(on_message::<CursorMoved>)),
+            );
     }
 }
 

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -5,7 +5,6 @@
 //! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
 
 use bevy::input::ButtonState;
-use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::time::{Real, Time};
@@ -21,7 +20,7 @@ use ozma_tty_renderer::schema::TerminalGrid;
 use std::time::Duration;
 
 use crate::clipboard::Clipboard;
-use crate::hyperlink::{hyperlink_hover_cursor, link_modifier_held, try_open_uri};
+use crate::hyperlink::{link_modifier_held, try_open_uri};
 use crate::input::{InputDisabled, current_terminal_modifiers};
 use crate::spawn::OzmaTerminal;
 
@@ -773,12 +772,6 @@ impl Plugin for OzmaMousePlugin {
             .add_message::<MouseWheel>()
             .add_message::<CursorMoved>()
             .add_observer(on_terminal_mouse_effects)
-            .add_systems(
-                Update,
-                hyperlink_hover_cursor
-                    .in_set(OzmaTerminalMouseSet)
-                    .run_if(on_message::<KeyboardInput>.or(on_message::<CursorMoved>)),
-            )
             .add_systems(
                 Update,
                 (dispatch_mouse_buttons, dispatch_mouse_wheel)

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -90,11 +90,9 @@ pub(crate) enum DragPhase {
     Started,
 }
 
-/// An in-progress button gesture: the held button, the selection anchor, and the
-/// last cell a drag reached (dedup + lazy materialization).
+/// An in-progress local-selection gesture: the selection anchor, the granularity,
+/// and the drag phase (drives lazy materialization of the selection).
 pub(crate) struct DragGesture {
-    /// Which mouse button is being held.
-    pub(crate) button: MouseButtonKind,
     /// The cell where the gesture originated.
     pub(crate) origin: CellCoord,
     /// The half of the origin cell where the gesture started.
@@ -103,7 +101,14 @@ pub(crate) struct DragGesture {
     pub(crate) ty: SelectionType,
     /// Current phase of the drag.
     pub(crate) phase: DragPhase,
-    /// The last cell the drag endpoint was updated to (for dedup).
+}
+
+/// A held mouse button and the last cell a drag was synthesized for. Tracked
+/// for BOTH local selection and app-forward drags — the forward path never sets
+/// `drag`, so drag-motion synthesis must not depend on it.
+#[derive(Clone, Copy)]
+pub(crate) struct HeldPointer {
+    pub(crate) button: MouseButtonKind,
     pub(crate) last_cell: CellCoord,
 }
 
@@ -112,8 +117,10 @@ pub(crate) struct DragGesture {
 pub(crate) struct OzmaMouseGesture {
     /// Consecutive-click counter for multi-click detection.
     pub(crate) click: ClickTracker,
-    /// In-progress button gesture, or `None` when idle.
+    /// In-progress local-selection gesture, or `None` when idle.
     pub(crate) drag: Option<DragGesture>,
+    /// Held button + last drag cell, for both local and app-forward drags.
+    pub(crate) held: Option<HeldPointer>,
 }
 
 /// Consecutive-click counter using a timeout + positional-drift gate.
@@ -245,23 +252,19 @@ pub(crate) fn decide_button(
         ButtonAction::ClearAndWriteToPty(b) => vec![MouseEffect::SelClear, MouseEffect::Write(b)],
         ButtonAction::ArmDrag { ty, cell, side } => {
             gesture.drag = Some(DragGesture {
-                button: evt.button,
                 origin: cell,
                 side,
                 ty,
                 phase: DragPhase::Armed,
-                last_cell: cell,
             });
             vec![MouseEffect::SelClear]
         }
         ButtonAction::StartLocalSelection { ty, cell, side } => {
             gesture.drag = Some(DragGesture {
-                button: evt.button,
                 origin: cell,
                 side,
                 ty,
                 phase: DragPhase::Started,
-                last_cell: cell,
             });
             vec![MouseEffect::SelStart {
                 point: to_viewport_point(cell),
@@ -364,16 +367,19 @@ pub(crate) fn dispatch_mouse_buttons(
     else {
         buttons.clear();
         gesture.drag = None;
+        gesture.held = None;
         return;
     };
     let Ok(window) = windows.single() else {
         buttons.clear();
         gesture.drag = None;
+        gesture.held = None;
         return;
     };
     if !window.focused {
         buttons.clear();
         gesture.drag = None;
+        gesture.held = None;
         return;
     }
     let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
@@ -438,6 +444,7 @@ pub(crate) fn dispatch_mouse_buttons(
             link_at_cell,
             &cfg.buttons,
         );
+        let opened = matches!(effects.as_slice(), [MouseEffect::OpenUri(_)]);
         for effect in effects {
             apply_effect(
                 &mut handle,
@@ -447,9 +454,19 @@ pub(crate) fn dispatch_mouse_buttons(
                 effect,
             );
         }
+        match kind {
+            ButtonEventKind::Press if !opened => {
+                gesture.held = Some(HeldPointer {
+                    button,
+                    last_cell: cell,
+                });
+            }
+            ButtonEventKind::Release => gesture.held = None,
+            _ => {}
+        }
     }
 
-    if gesture.drag.is_some()
+    if let Some(held) = gesture.held
         && let Some((cell, side)) = cell_at_cursor(
             node,
             transform,
@@ -459,13 +476,9 @@ pub(crate) fn dispatch_mouse_buttons(
             grid.cols,
             grid.rows,
         )
-        && gesture.drag.as_ref().is_some_and(|d| d.last_cell != cell)
+        && held.last_cell != cell
     {
-        let button = gesture
-            .drag
-            .as_ref()
-            .map(|d| d.button)
-            .unwrap_or(MouseButtonKind::Left);
+        let button = held.button;
         let evt = ButtonEvent {
             kind: ButtonEventKind::Drag,
             button,
@@ -490,6 +503,9 @@ pub(crate) fn dispatch_mouse_buttons(
                 &mut clipboard,
                 effect,
             );
+        }
+        if let Some(h) = gesture.held.as_mut() {
+            h.last_cell = cell;
         }
     }
 }
@@ -632,7 +648,6 @@ fn update_selection(
             let ty = drag.ty;
             let origin_side = drag.side;
             drag.phase = DragPhase::Started;
-            drag.last_cell = cell;
             vec![
                 MouseEffect::SelStart {
                     point: to_viewport_point(origin),
@@ -646,7 +661,6 @@ fn update_selection(
             ]
         }
         DragPhase::Started => {
-            drag.last_cell = cell;
             vec![MouseEffect::SelUpdate {
                 point: to_viewport_point(cell),
                 side,
@@ -942,6 +956,37 @@ mod tests {
     }
 
     #[test]
+    fn app_capture_drag_forwards_motion_bytes() {
+        let mut g = OzmaMouseGesture::default();
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let cfg = ButtonConfig {
+            max_protocol_events_per_frame: 8,
+        };
+        decide_button(
+            &mut g,
+            modes,
+            ev(ButtonEventKind::Press, 5, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        let fx = decide_button(
+            &mut g,
+            modes,
+            ev(ButtonEventKind::Drag, 6, 5, 1),
+            ProtocolModifiers::default(),
+            false,
+            None,
+            &cfg,
+        );
+        assert!(
+            matches!(fx.as_slice(), [MouseEffect::Write(b)] if b.starts_with(b"\x1b[<32;")),
+            "a drag under app capture must forward a motion report (SGR cb motion bit 32), got {fx:?}"
+        );
+    }
+
+    #[test]
     fn shift_bypass_selects_even_when_captured() {
         let mut g = OzmaMouseGesture::default();
         let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
@@ -1096,27 +1141,21 @@ mod tests {
     #[test]
     fn drag_gesture_phase_transitions() {
         let armed = DragGesture {
-            button: MouseButtonKind::Left,
             origin: CellCoord { col: 1, row: 1 },
             side: Side::Left,
             ty: SelectionType::Simple,
             phase: DragPhase::Armed,
-            last_cell: CellCoord { col: 1, row: 1 },
         };
         assert_eq!(armed.phase, DragPhase::Armed);
-        assert_eq!(armed.button, MouseButtonKind::Left);
         assert_eq!((armed.origin.col, armed.origin.row), (1, 1));
         assert_eq!(armed.side, Side::Left);
         assert_eq!(armed.ty, SelectionType::Simple);
-        assert_eq!((armed.last_cell.col, armed.last_cell.row), (1, 1));
 
         let started = DragGesture {
             phase: DragPhase::Started,
-            last_cell: CellCoord { col: 3, row: 2 },
             ..armed
         };
         assert_eq!(started.phase, DragPhase::Started);
-        assert_eq!((started.last_cell.col, started.last_cell.row), (3, 2));
     }
 
     #[test]

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -1,0 +1,316 @@
+//! Default mouse handler for the Ozma terminal: app reporting, local text
+//! selection + copy, wheel scrollback, and Cmd-click hyperlink open. Reads Bevy
+//! mouse input, hit-tests the cursor to a cell, and drives the engine's pure
+//! `ButtonAction` / `WheelAction` routers, applying the result to the
+//! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
+
+use bevy::input::mouse::{MouseButtonInput, MouseWheel};
+use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::CursorMoved;
+use ozma_tty_engine::{
+    ButtonConfig, CellCoord, Column, Line, MouseButtonKind, Point, ProtocolModifiers,
+    SelectionType, Side, WheelConfig,
+};
+use std::time::Duration;
+
+use crate::input::current_terminal_modifiers;
+
+/// Which modifier activates "fine" (1 line per notch) wheel scrolling.
+/// Crate-local mirror of the host config enum (the crate must not depend on
+/// `ozmux_configs`). Default `Alt`: on macOS Shift+wheel becomes horizontal
+/// scroll at the OS level, so Shift never reaches the app as vertical `y`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum FineModifier {
+    /// Shift key activates fine scrolling.
+    Shift,
+    /// Control key activates fine scrolling.
+    Ctrl,
+    /// Alt/Option key activates fine scrolling.
+    #[default]
+    Alt,
+    /// Fine scrolling is disabled (always coarse).
+    None,
+}
+
+/// Host-supplied mouse policy. `Default` is a working spawn-and-go config; the
+/// host overrides it from `ozmux_configs`.
+#[derive(Resource)]
+pub struct OzmaMouseConfig {
+    /// Button-report burst cap. MUST be non-zero or forwarded clicks are dropped.
+    pub buttons: ButtonConfig,
+    /// Wheel routing config (lines-per-notch, fine lines, burst cap).
+    pub wheel: WheelConfig,
+    /// Cells of wheel travel per emitted notch (smooth-scroll accumulation).
+    pub cells_per_notch: f32,
+    /// Max gap between clicks counted as a double / triple click.
+    pub double_click_timeout: Duration,
+    /// Max cursor drift (logical px) between clicks of one chord.
+    pub click_drift_px: f32,
+    /// Which modifier activates fine scrolling.
+    pub fine_modifier: FineModifier,
+}
+
+impl Default for OzmaMouseConfig {
+    fn default() -> Self {
+        Self {
+            buttons: ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+            wheel: WheelConfig::default(),
+            cells_per_notch: 0.5,
+            double_click_timeout: Duration::from_millis(400),
+            click_drift_px: 8.0,
+            fine_modifier: FineModifier::Alt,
+        }
+    }
+}
+
+/// System set for the crate's three mouse systems. Hosts maintaining
+/// `InputDisabled` should schedule their maintainer `.before(OzmaTerminalMouseSet)`.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OzmaTerminalMouseSet;
+
+/// Phase of an in-progress left-drag: `Armed` after a single-click press (no
+/// selection started yet), `Started` once the pointer crossed into another cell.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DragPhase {
+    /// The button is held but the pointer has not left the origin cell.
+    Armed,
+    /// The pointer has crossed a cell boundary and selection is active.
+    Started,
+}
+
+/// An in-progress button gesture: the held button, the selection anchor, and the
+/// last cell a drag reached (dedup + lazy materialization).
+#[allow(dead_code)]
+pub(crate) struct DragGesture {
+    /// Which mouse button is being held.
+    pub(crate) button: MouseButtonKind,
+    /// The cell where the gesture originated.
+    pub(crate) origin: CellCoord,
+    /// The half of the origin cell where the gesture started.
+    pub(crate) side: Side,
+    /// The selection granularity (word, line, etc.).
+    pub(crate) ty: SelectionType,
+    /// Current phase of the drag.
+    pub(crate) phase: DragPhase,
+    /// The last cell the drag endpoint was updated to (for dedup).
+    pub(crate) last_cell: CellCoord,
+}
+
+/// Tracks the current mouse gesture and consecutive-click count.
+#[derive(Resource, Default)]
+pub(crate) struct OzmaMouseGesture {
+    /// Consecutive-click counter for multi-click detection.
+    #[allow(dead_code)]
+    pub(crate) click: ClickTracker,
+    /// In-progress button gesture, or `None` when idle.
+    #[allow(dead_code)]
+    pub(crate) drag: Option<DragGesture>,
+}
+
+/// Consecutive-click counter using a timeout + positional-drift gate.
+#[derive(Default)]
+pub(crate) struct ClickTracker {
+    #[allow(dead_code)]
+    last: Option<(Duration, Vec2, u8)>,
+}
+
+impl ClickTracker {
+    /// Registers a press at `now` / logical `pos`, returning the click count
+    /// (1..=3). `cfg` is `(timeout, drift_px)`.
+    #[allow(dead_code)]
+    pub(crate) fn register(&mut self, now: Duration, pos: Vec2, cfg: (Duration, f32)) -> u8 {
+        let (timeout, drift) = cfg;
+        let count = match self.last {
+            Some((t, p, c)) if now.saturating_sub(t) <= timeout && p.distance(pos) <= drift => {
+                (c + 1).min(3)
+            }
+            _ => 1,
+        };
+        self.last = Some((now, pos, count));
+        count
+    }
+}
+
+/// 1-indexed `(CellCoord, Side)` of the cell at pane-local physical `local`,
+/// clamped to `1..=cols` × `1..=rows`. `Side` is `Left` in the left half.
+#[allow(dead_code)]
+pub(crate) fn cell_at_local(
+    local: Vec2,
+    cell_w: f32,
+    cell_h: f32,
+    cols: u16,
+    rows: u16,
+) -> (CellCoord, Side) {
+    let col_f = (local.x / cell_w).max(0.0);
+    let row_f = (local.y / cell_h).max(0.0);
+    let col = (col_f.floor() as u32 + 1).min(cols as u32).max(1);
+    let row = (row_f.floor() as u32 + 1).min(rows as u32).max(1);
+    let side = if col_f - col_f.floor() < 0.5 {
+        Side::Left
+    } else {
+        Side::Right
+    };
+    (CellCoord { col, row }, side)
+}
+
+/// Resolves the window-space physical cursor to a cell on the terminal node, or
+/// `None` when the cursor is outside the node.
+#[allow(dead_code)]
+pub(crate) fn cell_at_cursor(
+    node: &ComputedNode,
+    transform: &UiGlobalTransform,
+    cursor_phys: Vec2,
+    cell_w: f32,
+    cell_h: f32,
+    cols: u16,
+    rows: u16,
+) -> Option<(CellCoord, Side)> {
+    let local = node
+        .normalize_point(*transform, cursor_phys)
+        .map(|n| (n + Vec2::splat(0.5)) * node.size)?;
+    Some(cell_at_local(local, cell_w, cell_h, cols, rows))
+}
+
+/// Converts a 1-indexed protocol `CellCoord` into the engine's viewport-relative
+/// selection `Point` (row 0 = top of viewport; the engine translates for scroll).
+#[allow(dead_code)]
+pub(crate) fn to_viewport_point(cell: CellCoord) -> Point {
+    Point::new(Line(cell.row as i32 - 1), Column(cell.col as usize - 1))
+}
+
+/// Builds `ProtocolModifiers` from the held keys.
+#[allow(dead_code)]
+pub(crate) fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
+    let m = current_terminal_modifiers(keys);
+    ProtocolModifiers {
+        shift: m.shift,
+        ctrl: m.ctrl,
+        alt: m.alt,
+        meta: m.meta,
+    }
+}
+
+/// Registers the crate's mouse systems and resources.
+pub(crate) struct OzmaMousePlugin;
+
+impl Plugin for OzmaMousePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<OzmaMouseConfig>()
+            .init_resource::<OzmaMouseGesture>()
+            .add_message::<MouseButtonInput>()
+            .add_message::<MouseWheel>()
+            .add_message::<CursorMoved>();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_sets_button_cap_explicitly() {
+        let cfg = OzmaMouseConfig::default();
+        assert_eq!(cfg.buttons.max_protocol_events_per_frame, 8, "must NOT be ButtonConfig::default()'s 0");
+        assert_eq!(cfg.wheel.max_protocol_events_per_frame, 8);
+        assert_eq!(cfg.cells_per_notch, 0.5);
+        assert_eq!(cfg.double_click_timeout, std::time::Duration::from_millis(400));
+        assert_eq!(cfg.click_drift_px, 8.0);
+        assert_eq!(cfg.fine_modifier, FineModifier::Alt);
+    }
+
+    #[test]
+    fn cell_at_local_is_one_indexed_and_clamped() {
+        let (cell, side) = cell_at_local(Vec2::new(0.0, 0.0), 10.0, 20.0, 80, 24);
+        assert_eq!((cell.col, cell.row), (1, 1));
+        assert_eq!(side, Side::Left);
+        let (cell, _) = cell_at_local(Vec2::new(10_000.0, 10_000.0), 10.0, 20.0, 80, 24);
+        assert_eq!((cell.col, cell.row), (80, 24));
+        let (cell, side) = cell_at_local(Vec2::new(17.0, 5.0), 10.0, 20.0, 80, 24);
+        assert_eq!(cell.col, 2);
+        assert_eq!(side, Side::Right);
+    }
+
+    #[test]
+    fn to_viewport_point_zero_indexes_the_one_indexed_cell() {
+        let p = to_viewport_point(CellCoord { col: 5, row: 3 });
+        assert_eq!(p.line.0, 2);
+        assert_eq!(p.column.0, 4);
+    }
+
+    #[test]
+    fn click_tracker_counts_within_timeout_and_drift() {
+        let mut t = ClickTracker::default();
+        let cfg = (std::time::Duration::from_millis(400), 8.0f32);
+        assert_eq!(t.register(std::time::Duration::from_millis(0), Vec2::new(10.0, 10.0), cfg), 1);
+        assert_eq!(t.register(std::time::Duration::from_millis(200), Vec2::new(11.0, 11.0), cfg), 2);
+        assert_eq!(t.register(std::time::Duration::from_millis(350), Vec2::new(12.0, 10.0), cfg), 3);
+        assert_eq!(t.register(std::time::Duration::from_millis(900), Vec2::new(12.0, 10.0), cfg), 1);
+    }
+
+    #[test]
+    fn protocol_mods_sets_ctrl_and_shift() {
+        let mut keys = ButtonInput::<KeyCode>::default();
+        keys.press(KeyCode::ControlLeft);
+        keys.press(KeyCode::ShiftLeft);
+        let mods = protocol_mods(&keys);
+        assert!(mods.ctrl);
+        assert!(mods.shift);
+        assert!(!mods.alt);
+        assert!(!mods.meta);
+    }
+
+    #[test]
+    fn cell_at_cursor_resolves_known_point() {
+        let node = ComputedNode {
+            size: Vec2::new(800.0, 600.0),
+            ..ComputedNode::DEFAULT
+        };
+        let transform = UiGlobalTransform::from_xy(400.0, 300.0);
+        // node center is (400, 300), so physical (0, 0) is top-left, (800, 600) is bottom-right
+        // at cell pitch 10x20 with 80 cols, 30 rows:
+        // physical (15, 25) → local (15, 25) → col 2 (10-19), row 2 (20-39)
+        let result = cell_at_cursor(&node, &transform, Vec2::new(15.0, 25.0), 10.0, 20.0, 80, 30);
+        let (cell, _) = result.expect("point inside node must resolve");
+        assert_eq!(cell.col, 2);
+        assert_eq!(cell.row, 2);
+    }
+
+    #[test]
+    fn drag_gesture_phase_transitions() {
+        let armed = DragGesture {
+            button: MouseButtonKind::Left,
+            origin: CellCoord { col: 1, row: 1 },
+            side: Side::Left,
+            ty: SelectionType::Simple,
+            phase: DragPhase::Armed,
+            last_cell: CellCoord { col: 1, row: 1 },
+        };
+        assert_eq!(armed.phase, DragPhase::Armed);
+        assert_eq!(armed.button, MouseButtonKind::Left);
+        assert_eq!((armed.origin.col, armed.origin.row), (1, 1));
+        assert_eq!(armed.side, Side::Left);
+        assert_eq!(armed.ty, SelectionType::Simple);
+        assert_eq!((armed.last_cell.col, armed.last_cell.row), (1, 1));
+
+        let started = DragGesture {
+            phase: DragPhase::Started,
+            last_cell: CellCoord { col: 3, row: 2 },
+            ..armed
+        };
+        assert_eq!(started.phase, DragPhase::Started);
+        assert_eq!((started.last_cell.col, started.last_cell.row), (3, 2));
+    }
+
+    #[test]
+    fn mouse_gesture_resource_default_is_idle() {
+        let g = OzmaMouseGesture::default();
+        assert!(g.drag.is_none());
+        let mut t = g.click;
+        let cfg = (Duration::from_millis(400), 8.0f32);
+        assert_eq!(t.register(Duration::from_millis(0), Vec2::ZERO, cfg), 1);
+    }
+}

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -38,7 +38,7 @@ pub enum FineModifier {
     /// Alt/Option key activates fine scrolling.
     #[default]
     Alt,
-    /// Fine scrolling is disabled (always coarse).
+    /// No modifier required; fine scrolling is always active.
     None,
 }
 
@@ -311,7 +311,10 @@ pub(crate) fn accumulate_notches(
     delta_cells: f32,
     cells_per_notch: f32,
 ) -> i32 {
-    if acc.residual_cells != 0.0 && acc.residual_cells.signum() != delta_cells.signum() {
+    if acc.residual_cells != 0.0
+        && delta_cells != 0.0
+        && acc.residual_cells.signum() != delta_cells.signum()
+    {
         acc.residual_cells = 0.0;
     }
     let threshold = cells_per_notch.max(f32::EPSILON);
@@ -382,11 +385,13 @@ pub(crate) fn dispatch_mouse_buttons(
         gesture.held = None;
         return;
     }
-    let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
+    let scale = window.scale_factor();
+    let Some(cursor_phys) = window.cursor_position().map(|c| c * scale) else {
         buttons.clear();
+        gesture.drag = None;
+        gesture.held = None;
         return;
     };
-    let scale = window.scale_factor();
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
     let modes = handle.current_modes();
@@ -397,6 +402,16 @@ pub(crate) fn dispatch_mouse_buttons(
         let Some(button) = map_button(ev.button) else {
             continue;
         };
+        let kind = match ev.state {
+            ButtonState::Pressed => ButtonEventKind::Press,
+            ButtonState::Released => ButtonEventKind::Release,
+        };
+        // NOTE: a release with the cursor off the terminal node must still be
+        // processed (via the last tracked cell) — otherwise `held`/`drag` stick
+        // and later cursor motion replays stale selection / forward reports.
+        let release_fallback = (kind == ButtonEventKind::Release)
+            .then(|| gesture.held.map(|h| (h.last_cell, Side::Left)))
+            .flatten();
         let Some((cell, side)) = cell_at_cursor(
             node,
             transform,
@@ -405,12 +420,9 @@ pub(crate) fn dispatch_mouse_buttons(
             cell_h,
             grid.cols,
             grid.rows,
-        ) else {
+        )
+        .or(release_fallback) else {
             continue;
-        };
-        let kind = match ev.state {
-            ButtonState::Pressed => ButtonEventKind::Press,
-            ButtonState::Released => ButtonEventKind::Release,
         };
         let click_count = if kind == ButtonEventKind::Press {
             gesture.click.register(
@@ -1179,6 +1191,16 @@ mod tests {
         assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
         assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
         assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -2);
+    }
+
+    #[test]
+    fn accumulator_zero_delta_does_not_reset_residual() {
+        // A zero / negative-zero delta has no direction and must NOT trip the
+        // sign-flip reset (signum(-0.0) == -1.0 would otherwise drop the carry).
+        let mut acc = WheelAccumulator::default();
+        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc, -0.0, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
     }
 
     #[test]

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -294,24 +294,19 @@ pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f
 }
 
 /// Adds `delta_cells` to the accumulator and returns whole notches to emit
-/// (positive = up/older), carrying the remainder. Resets on a sign flip and
-/// caps the contributing delta to one notch to avoid a burst in the new direction.
+/// (positive = up/older), carrying the remainder. Resets the residual on a
+/// sign flip, then processes the new delta at full magnitude.
 #[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
 pub(crate) fn accumulate_notches(
     acc: &mut WheelAccumulator,
     delta_cells: f32,
     cells_per_notch: f32,
 ) -> i32 {
-    let threshold = cells_per_notch.max(f32::EPSILON);
-    let effective_delta = if acc.residual_cells != 0.0
-        && acc.residual_cells.signum() != delta_cells.signum()
-    {
+    if acc.residual_cells != 0.0 && acc.residual_cells.signum() != delta_cells.signum() {
         acc.residual_cells = 0.0;
-        delta_cells.signum() * delta_cells.abs().min(threshold)
-    } else {
-        delta_cells
-    };
-    acc.residual_cells += effective_delta;
+    }
+    let threshold = cells_per_notch.max(f32::EPSILON);
+    acc.residual_cells += delta_cells;
     let notches = (acc.residual_cells / threshold).trunc() as i32;
     if notches != 0 {
         acc.residual_cells -= notches as f32 * threshold;
@@ -585,7 +580,7 @@ mod tests {
         let mut acc = WheelAccumulator::default();
         assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
         assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
-        assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -1);
+        assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -2);
     }
 
     #[test]

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -4,13 +4,14 @@
 //! `ButtonAction` / `WheelAction` routers, applying the result to the
 //! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
 
-use bevy::input::mouse::{MouseButtonInput, MouseWheel};
+use bevy::input::mouse::{MouseButtonInput, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::CursorMoved;
 use ozma_tty_engine::{
     ButtonAction, ButtonConfig, ButtonEvent, ButtonEventKind, CellCoord, Column, Line,
-    MouseButtonKind, Point, ProtocolModifiers, SelectionType, Side, TermMode, WheelConfig,
+    MouseButtonKind, Point, ProtocolModifiers, SelectionType, Side, TermMode, WheelAction,
+    WheelConfig, WheelModifiers,
 };
 use std::time::Duration;
 
@@ -205,7 +206,6 @@ pub(crate) enum MouseEffect {
     /// Copy the current selection to the clipboard.
     Copy,
     /// Scroll the viewport by `i32` lines (negative = up).
-    #[expect(dead_code, reason = "emitted by wheel dispatch systems (Task 6)")]
     Scroll(i32),
     /// Open the given URI in the host browser / handler.
     OpenUri(String),
@@ -275,6 +275,65 @@ pub(crate) fn decide_button(
         gesture.drag = None;
     }
     effects
+}
+
+/// Carries the sub-notch wheel remainder across frames.
+#[derive(Resource, Default)]
+pub(crate) struct WheelAccumulator {
+    residual_cells: f32,
+}
+
+/// Cells of scroll for one wheel event: `Line` units count directly, `Pixel`
+/// units divide by the cell height. Positive = wheel-up (toward older lines).
+#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
+pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f32 {
+    match unit {
+        MouseScrollUnit::Line => y,
+        MouseScrollUnit::Pixel => y / cell_h.max(1.0),
+    }
+}
+
+/// Adds `delta_cells` to the accumulator and returns whole notches to emit
+/// (positive = up/older), carrying the remainder. Resets on a sign flip and
+/// caps the contributing delta to one notch to avoid a burst in the new direction.
+#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
+pub(crate) fn accumulate_notches(
+    acc: &mut WheelAccumulator,
+    delta_cells: f32,
+    cells_per_notch: f32,
+) -> i32 {
+    let threshold = cells_per_notch.max(f32::EPSILON);
+    let effective_delta = if acc.residual_cells != 0.0
+        && acc.residual_cells.signum() != delta_cells.signum()
+    {
+        acc.residual_cells = 0.0;
+        delta_cells.signum() * delta_cells.abs().min(threshold)
+    } else {
+        delta_cells
+    };
+    acc.residual_cells += effective_delta;
+    let notches = (acc.residual_cells / threshold).trunc() as i32;
+    if notches != 0 {
+        acc.residual_cells -= notches as f32 * threshold;
+    }
+    notches
+}
+
+/// Pure wheel decision. `notches` is in the engine convention (negative =
+/// up/older); callers negate the Bevy-derived up-positive value before calling.
+#[cfg_attr(not(test), expect(dead_code, reason = "called by wheel dispatch system (Task 6)"))]
+pub(crate) fn decide_wheel(
+    modes: TermMode,
+    notches: i32,
+    cell: CellCoord,
+    mods: WheelModifiers,
+    cfg: &WheelConfig,
+) -> Vec<MouseEffect> {
+    match WheelAction::route(modes, notches, cell, mods, cfg) {
+        WheelAction::Noop => Vec::new(),
+        WheelAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
+        WheelAction::ScrollViewport(lines) => vec![MouseEffect::Scroll(lines)],
+    }
 }
 
 /// Lazily materializes an armed selection on the first cell change, then extends.
@@ -513,5 +572,33 @@ mod tests {
         let mut t = g.click;
         let cfg = (Duration::from_millis(400), 8.0f32);
         assert_eq!(t.register(Duration::from_millis(0), Vec2::ZERO, cfg), 1);
+    }
+
+    #[test]
+    fn line_delta_is_direct_pixel_divides_by_cell_height() {
+        assert_eq!(wheel_delta_cells(MouseScrollUnit::Line, 2.0, 16.0), 2.0);
+        assert_eq!(wheel_delta_cells(MouseScrollUnit::Pixel, 32.0, 16.0), 2.0);
+    }
+
+    #[test]
+    fn accumulator_emits_on_threshold_and_carries_remainder() {
+        let mut acc = WheelAccumulator::default();
+        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
+        assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -1);
+    }
+
+    #[test]
+    fn scrollback_up_returns_positive_viewport_scroll() {
+        // Bevy +y (wheel up) → caller negates → engine notches negative → into history.
+        let fx = decide_wheel(TermMode::empty(), -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+        assert_eq!(fx, vec![MouseEffect::Scroll(3)]);
+    }
+
+    #[test]
+    fn app_capture_wheel_forwards_bytes() {
+        let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        let fx = decide_wheel(modes, -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+        assert!(matches!(fx.as_slice(), [MouseEffect::Write(b)] if !b.is_empty()));
     }
 }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -225,6 +225,18 @@ pub(crate) enum MouseEffect {
     OpenUri(String),
 }
 
+/// Carries a gather system's decided mouse effects to the apply observer, so the
+/// dispatch systems stay read-only on the terminal and all mutation lives in one
+/// place (`on_terminal_mouse_effects`), mirroring `PasteAction` / `on_paste`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct TerminalMouseEffects {
+    /// The terminal entity to apply the effects to.
+    #[event_target]
+    pub(crate) entity: Entity,
+    /// The decided effects, applied in order.
+    pub(crate) effects: Vec<MouseEffect>,
+}
+
 /// Pure per-event decision for a mouse button. Mutates `gesture` (drag phase /
 /// click state) and returns the effects to apply. A Cmd/Ctrl-click on a linked
 /// cell opens the URL and consumes the event; otherwise the engine's
@@ -346,28 +358,26 @@ pub(crate) fn decide_wheel(
 /// and drag state, drives `decide_button`, and applies the effects. Skips the
 /// `OzmaTerminal` while it carries `InputDisabled`.
 pub(crate) fn dispatch_mouse_buttons(
+    mut commands: Commands,
     mut gesture: ResMut<OzmaMouseGesture>,
     mut buttons: MessageReader<MouseButtonInput>,
-    mut terminal: Query<
+    terminal: Query<
         (
-            &mut TerminalHandle,
-            &mut PtyHandle,
-            &mut Coalescer,
+            Entity,
+            &TerminalHandle,
             &ComputedNode,
             &UiGlobalTransform,
             &TerminalGrid,
         ),
         (With<OzmaTerminal>, Without<InputDisabled>),
     >,
-    mut clipboard: ResMut<Clipboard>,
     cfg: Res<OzmaMouseConfig>,
     metrics: Res<TerminalCellMetricsResource>,
     keys: Res<ButtonInput<KeyCode>>,
     time: Res<Time<Real>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut()
-    else {
+    let Ok((entity, handle, node, transform, grid)) = terminal.single() else {
         buttons.clear();
         gesture.drag = None;
         gesture.held = None;
@@ -392,85 +402,47 @@ pub(crate) fn dispatch_mouse_buttons(
         gesture.held = None;
         return;
     };
-    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
-    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let ctx = CellContext {
+        node,
+        transform,
+        grid,
+        cell_w: metrics.metrics.advance_phys.floor().max(1.0),
+        cell_h: metrics.metrics.line_height_phys.floor().max(1.0),
+    };
     let modes = handle.current_modes();
     let mods = protocol_mods(&keys);
     let modifier_held = link_modifier_held(&mods);
 
+    let mut effects: Vec<MouseEffect> = Vec::new();
     for ev in buttons.read() {
-        let Some(button) = map_button(ev.button) else {
-            continue;
-        };
-        let kind = match ev.state {
-            ButtonState::Pressed => ButtonEventKind::Press,
-            ButtonState::Released => ButtonEventKind::Release,
-        };
-        // NOTE: a release with the cursor off the terminal node must still be
-        // processed (via the last tracked cell) — otherwise `held`/`drag` stick
-        // and later cursor motion replays stale selection / forward reports.
-        let release_fallback = (kind == ButtonEventKind::Release)
-            .then(|| gesture.held.map(|h| (h.last_cell, Side::Left)))
-            .flatten();
-        let Some((cell, side)) = cell_at_cursor(
-            node,
-            transform,
+        let Some((evt, link)) = resolve_button_event(
+            &mut gesture,
+            &ctx,
+            ev,
             cursor_phys,
-            cell_w,
-            cell_h,
-            grid.cols,
-            grid.rows,
-        )
-        .or(release_fallback) else {
+            scale,
+            modifier_held,
+            time.elapsed(),
+            &cfg,
+        ) else {
             continue;
         };
-        let click_count = if kind == ButtonEventKind::Press {
-            gesture.click.register(
-                time.elapsed(),
-                cursor_phys / scale,
-                (cfg.double_click_timeout, cfg.click_drift_px),
-            )
-        } else {
-            1
-        };
-        let link_at_cell =
-            (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
-                .then(|| {
-                    grid.hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16)
-                        .map(|(_id, uri)| uri.as_str().to_string())
-                })
-                .flatten();
-        let evt = ButtonEvent {
-            kind,
-            button,
-            cell,
-            side,
-            click_count,
-        };
-        let effects = decide_button(
+        let decided = decide_button(
             &mut gesture,
             modes,
             evt,
             mods,
             modifier_held,
-            link_at_cell,
+            link,
             &cfg.buttons,
         );
-        let opened = matches!(effects.as_slice(), [MouseEffect::OpenUri(_)]);
-        for effect in effects {
-            apply_effect(
-                &mut handle,
-                &mut pty,
-                &mut coalescer,
-                &mut clipboard,
-                effect,
-            );
-        }
-        match kind {
+        let opened = matches!(decided.as_slice(), [MouseEffect::OpenUri(_)]);
+        effects.extend(decided);
+        match evt.kind {
             ButtonEventKind::Press if !opened => {
                 gesture.held = Some(HeldPointer {
-                    button,
-                    last_cell: cell,
+                    button: evt.button,
+                    last_cell: evt.cell,
                 });
             }
             ButtonEventKind::Release => gesture.held = None,
@@ -478,74 +450,48 @@ pub(crate) fn dispatch_mouse_buttons(
         }
     }
 
-    if let Some(held) = gesture.held
-        && let Some((cell, side)) = cell_at_cursor(
-            node,
-            transform,
-            cursor_phys,
-            cell_w,
-            cell_h,
-            grid.cols,
-            grid.rows,
-        )
-        && held.last_cell != cell
-    {
-        let button = held.button;
-        let evt = ButtonEvent {
-            kind: ButtonEventKind::Drag,
-            button,
-            cell,
-            side,
-            click_count: 1,
-        };
-        let effects = decide_button(
-            &mut gesture,
-            modes,
-            evt,
-            mods,
-            modifier_held,
-            None,
-            &cfg.buttons,
-        );
-        for effect in effects {
-            apply_effect(
-                &mut handle,
-                &mut pty,
-                &mut coalescer,
-                &mut clipboard,
-                effect,
-            );
-        }
+    if let Some((drag_effects, new_cell)) = synthesize_drag(
+        &mut gesture,
+        &ctx,
+        cursor_phys,
+        modes,
+        mods,
+        modifier_held,
+        &cfg.buttons,
+    ) {
+        effects.extend(drag_effects);
         if let Some(h) = gesture.held.as_mut() {
-            h.last_cell = cell;
+            h.last_cell = new_cell;
         }
+    }
+
+    if !effects.is_empty() {
+        commands.trigger(TerminalMouseEffects { entity, effects });
     }
 }
 
-/// The crate's wheel dispatcher: accumulates notches, drives `decide_wheel`,
-/// applies the result.
+/// The crate's wheel dispatcher: accumulates notches, drives `decide_wheel`, and
+/// triggers `TerminalMouseEffects` for the apply observer.
 pub(crate) fn dispatch_mouse_wheel(
+    mut commands: Commands,
     mut gesture_acc: ResMut<WheelAccumulator>,
     mut wheel: MessageReader<MouseWheel>,
-    mut terminal: Query<
+    terminal: Query<
         (
-            &mut TerminalHandle,
-            &mut PtyHandle,
-            &mut Coalescer,
+            Entity,
+            &TerminalHandle,
             &ComputedNode,
             &UiGlobalTransform,
             &TerminalGrid,
         ),
         (With<OzmaTerminal>, Without<InputDisabled>),
     >,
-    mut clipboard: ResMut<Clipboard>,
     cfg: Res<OzmaMouseConfig>,
     metrics: Res<TerminalCellMetricsResource>,
     keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
-    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut()
-    else {
+    let Ok((entity, handle, node, transform, grid)) = terminal.single() else {
         wheel.clear();
         return;
     };
@@ -557,13 +503,18 @@ pub(crate) fn dispatch_mouse_wheel(
         wheel.clear();
         return;
     }
-    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
-    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let ctx = CellContext {
+        node,
+        transform,
+        grid,
+        cell_w: metrics.metrics.advance_phys.floor().max(1.0),
+        cell_h: metrics.metrics.line_height_phys.floor().max(1.0),
+    };
 
-    let mut delta_cells = 0.0f32;
-    for ev in wheel.read() {
-        delta_cells += wheel_delta_cells(ev.unit, ev.y, cell_h);
-    }
+    let delta_cells: f32 = wheel
+        .read()
+        .map(|ev| wheel_delta_cells(ev.unit, ev.y, ctx.cell_h))
+        .sum();
     let raw = accumulate_notches(&mut gesture_acc, delta_cells, cfg.cells_per_notch);
     if raw == 0 {
         return;
@@ -573,24 +524,131 @@ pub(crate) fn dispatch_mouse_wheel(
     let cell = window
         .cursor_position()
         .map(|c| c * window.scale_factor())
-        .and_then(|p| cell_at_cursor(node, transform, p, cell_w, cell_h, grid.cols, grid.rows))
+        .and_then(|p| ctx.hit(p))
         .map(|(cell, _)| cell)
         .unwrap_or(CellCoord { col: 1, row: 1 });
-    let m = current_terminal_modifiers(&keys);
-    let mods = WheelModifiers {
+    let mods = build_wheel_modifiers(&keys, &cfg);
+    let effects = decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel);
+    if !effects.is_empty() {
+        commands.trigger(TerminalMouseEffects { entity, effects });
+    }
+}
+
+/// Read-only hit-test context for one gather run: the terminal node geometry,
+/// cell pitch, and grid dimensions — so helpers resolve a cursor to a cell
+/// without re-threading seven arguments.
+struct CellContext<'a> {
+    node: &'a ComputedNode,
+    transform: &'a UiGlobalTransform,
+    grid: &'a TerminalGrid,
+    cell_w: f32,
+    cell_h: f32,
+}
+
+impl CellContext<'_> {
+    fn hit(&self, cursor_phys: Vec2) -> Option<(CellCoord, Side)> {
+        cell_at_cursor(
+            self.node,
+            self.transform,
+            cursor_phys,
+            self.cell_w,
+            self.cell_h,
+            self.grid.cols,
+            self.grid.rows,
+        )
+    }
+}
+
+/// Resolves one `MouseButtonInput` to a `ButtonEvent` + optional link URI, or
+/// `None` when it maps to no terminal button or no cell. Encapsulates button
+/// mapping, the off-node release fallback, click-count registration, and the
+/// modifier-gated hyperlink lookup.
+fn resolve_button_event(
+    gesture: &mut OzmaMouseGesture,
+    ctx: &CellContext,
+    ev: &MouseButtonInput,
+    cursor_phys: Vec2,
+    scale: f32,
+    modifier_held: bool,
+    now: Duration,
+    cfg: &OzmaMouseConfig,
+) -> Option<(ButtonEvent, Option<String>)> {
+    let button = map_button(ev.button)?;
+    let kind = match ev.state {
+        ButtonState::Pressed => ButtonEventKind::Press,
+        ButtonState::Released => ButtonEventKind::Release,
+    };
+    // NOTE: a release with the cursor off the terminal node must still be
+    // processed (via the last tracked cell) — otherwise `held`/`drag` stick and
+    // later cursor motion replays stale selection / forward reports.
+    let release_fallback = (kind == ButtonEventKind::Release)
+        .then(|| gesture.held.map(|h| (h.last_cell, Side::Left)))
+        .flatten();
+    let (cell, side) = ctx.hit(cursor_phys).or(release_fallback)?;
+    let click_count = if kind == ButtonEventKind::Press {
+        gesture.click.register(
+            now,
+            cursor_phys / scale,
+            (cfg.double_click_timeout, cfg.click_drift_px),
+        )
+    } else {
+        1
+    };
+    let link = (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
+        .then(|| {
+            ctx.grid
+                .hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16)
+                .map(|(_id, uri)| uri.as_str().to_string())
+        })
+        .flatten();
+    Some((
+        ButtonEvent {
+            kind,
+            button,
+            cell,
+            side,
+            click_count,
+        },
+        link,
+    ))
+}
+
+/// Synthesizes a drag-motion effect set when a held pointer crosses into a new
+/// cell. Returns the decided effects and the new last-cell to record, or `None`
+/// when no button is held, the pointer is off-node, or it has not moved.
+fn synthesize_drag(
+    gesture: &mut OzmaMouseGesture,
+    ctx: &CellContext,
+    cursor_phys: Vec2,
+    modes: TermMode,
+    mods: ProtocolModifiers,
+    modifier_held: bool,
+    cfg: &ButtonConfig,
+) -> Option<(Vec<MouseEffect>, CellCoord)> {
+    let held = gesture.held?;
+    let (cell, side) = ctx.hit(cursor_phys)?;
+    if held.last_cell == cell {
+        return None;
+    }
+    let evt = ButtonEvent {
+        kind: ButtonEventKind::Drag,
+        button: held.button,
+        cell,
+        side,
+        click_count: 1,
+    };
+    let effects = decide_button(gesture, modes, evt, mods, modifier_held, None, cfg);
+    Some((effects, cell))
+}
+
+/// Builds `WheelModifiers` from the held keys + the fine-scroll config.
+fn build_wheel_modifiers(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> WheelModifiers {
+    let m = current_terminal_modifiers(keys);
+    WheelModifiers {
         shift: m.shift,
         ctrl: m.ctrl,
         alt: m.alt,
         fine: fine_held(cfg.fine_modifier, &m),
-    };
-    for effect in decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel) {
-        apply_effect(
-            &mut handle,
-            &mut pty,
-            &mut coalescer,
-            &mut clipboard,
-            effect,
-        );
     }
 }
 
@@ -612,24 +670,46 @@ fn map_button(b: MouseButton) -> Option<MouseButtonKind> {
     }
 }
 
+/// Applies a gather system's decided mouse effects to the target terminal — the
+/// sole apply path for both mouse dispatch systems. Runs at command flush (same
+/// frame as the trigger), mirroring `on_paste` / `on_terminal_key_input`.
+fn on_terminal_mouse_effects(
+    ev: On<TerminalMouseEffects>,
+    mut clipboard: ResMut<Clipboard>,
+    mut terminals: Query<(&mut TerminalHandle, &mut PtyHandle, &mut Coalescer), With<OzmaTerminal>>,
+) {
+    let Ok((mut handle, mut pty, mut coalescer)) = terminals.get_mut(ev.entity) else {
+        return;
+    };
+    for effect in &ev.effects {
+        apply_effect(
+            &mut handle,
+            &mut pty,
+            &mut coalescer,
+            &mut clipboard,
+            effect,
+        );
+    }
+}
+
 fn apply_effect(
     handle: &mut TerminalHandle,
     pty: &mut PtyHandle,
     coalescer: &mut Coalescer,
     clipboard: &mut Clipboard,
-    effect: MouseEffect,
+    effect: &MouseEffect,
 ) {
     match effect {
         MouseEffect::Write(b) => {
-            if let Err(e) = handle.write(pty, &b) {
+            if let Err(e) = handle.write(pty, b) {
                 tracing::warn!(?e, "ozma mouse pty write failed");
             }
         }
         MouseEffect::SelStart { point, side, ty } => {
-            handle.selection_start_at(coalescer, point, side, ty)
+            handle.selection_start_at(coalescer, *point, *side, *ty)
         }
         MouseEffect::SelUpdate { point, side } => {
-            handle.selection_update_to(coalescer, point, side)
+            handle.selection_update_to(coalescer, *point, *side)
         }
         MouseEffect::SelClear => handle.selection_clear(coalescer),
         MouseEffect::Copy => {
@@ -637,8 +717,8 @@ fn apply_effect(
                 clipboard.write(text);
             }
         }
-        MouseEffect::Scroll(lines) => handle.scroll(coalescer, lines),
-        MouseEffect::OpenUri(uri) => try_open_uri(&uri),
+        MouseEffect::Scroll(lines) => handle.scroll(coalescer, *lines),
+        MouseEffect::OpenUri(uri) => try_open_uri(uri),
     }
 }
 
@@ -692,6 +772,7 @@ impl Plugin for OzmaMousePlugin {
             .add_message::<MouseButtonInput>()
             .add_message::<MouseWheel>()
             .add_message::<CursorMoved>()
+            .add_observer(on_terminal_mouse_effects)
             .add_systems(
                 Update,
                 hyperlink_hover_cursor
@@ -745,6 +826,22 @@ mod tests {
             });
         app.update();
         assert!(app.world().resource::<OzmaMouseGesture>().drag.is_none());
+    }
+
+    #[test]
+    fn mouse_effects_on_entity_without_terminal_does_not_panic() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<Clipboard>()
+            .add_observer(on_terminal_mouse_effects);
+        let entity = app.world_mut().spawn_empty().id();
+        app.world_mut().trigger(TerminalMouseEffects {
+            entity,
+            effects: vec![MouseEffect::Scroll(3)],
+        });
+        app.update();
+        // Reaching here proves the observer handles the missing-terminal path
+        // without panicking; effect correctness is covered by the decide_* tests.
     }
 
     fn test_metrics() -> TerminalCellMetricsResource {

--- a/crates/ozma_tty_renderer/src/schema/hyperlink.rs
+++ b/crates/ozma_tty_renderer/src/schema/hyperlink.rs
@@ -41,3 +41,50 @@ impl HyperlinkUri {
         &self.0
     }
 }
+
+const ALLOWED_SCHEMES: &[&str] = &["http", "https", "mailto", "ftp"];
+
+/// Returns `true` when `uri` carries a scheme on the v1 allowlist
+/// (`http`, `https`, `mailto`, `ftp`), case-insensitive.
+pub fn is_allowed(uri: &str) -> bool {
+    scheme_of(uri)
+        .map(|s| s.to_ascii_lowercase())
+        .is_some_and(|s| ALLOWED_SCHEMES.contains(&s.as_str()))
+}
+
+/// Parses an RFC 3986 scheme: first byte ALPHA, continuation
+/// ALPHA / DIGIT / `+` / `-` / `.`. Returns `None` for malformed input.
+fn scheme_of(uri: &str) -> Option<&str> {
+    let (scheme, _) = uri.split_once(':')?;
+    let mut bytes = scheme.bytes();
+    let first = bytes.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if !bytes.all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.') {
+        return None;
+    }
+    Some(scheme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_allowed_accepts_canonical_schemes_case_insensitive() {
+        assert!(is_allowed("http://example.com"));
+        assert!(is_allowed("HTTPS://example.com"));
+        assert!(is_allowed("Mailto:foo@example"));
+        assert!(is_allowed("ftp://example.com"));
+    }
+
+    #[test]
+    fn is_allowed_rejects_dangerous_or_unknown_schemes() {
+        assert!(!is_allowed("javascript:alert(1)"));
+        assert!(!is_allowed("file:///etc/passwd"));
+        assert!(!is_allowed("data:text/html,<script>"));
+        assert!(!is_allowed(""));
+        assert!(!is_allowed("no-colon-here"));
+    }
+}

--- a/crates/ozma_tty_renderer/src/schema/hyperlink.rs
+++ b/crates/ozma_tty_renderer/src/schema/hyperlink.rs
@@ -84,6 +84,8 @@ mod tests {
         assert!(!is_allowed("javascript:alert(1)"));
         assert!(!is_allowed("file:///etc/passwd"));
         assert!(!is_allowed("data:text/html,<script>"));
+        assert!(!is_allowed("vscode://"));
+        assert!(!is_allowed("vscode://example.com"));
         assert!(!is_allowed(""));
         assert!(!is_allowed("no-colon-here"));
     }

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -25,7 +25,6 @@ pub use components::{
 };
 pub use connect::attach_or_create;
 pub use connection::TmuxConnection;
-pub use events::{TmuxConnectionClosed, TmuxConnectionReset};
 pub use copy_queries::{CopyModeQueries, CopyModeReply, CopyQueryKind};
 pub use enumerate::{
     CopyState, LIST_WINDOWS_FORMAT, WindowRow, absolute_to_visible_row, copy_mode_capture_command,
@@ -35,6 +34,7 @@ pub use enumerate::{
     set_environment_command, set_environment_in_session_command, show_buffer_command,
     switch_client_command, version_command, window_refresh_client_command,
 };
+pub use events::{TmuxConnectionClosed, TmuxConnectionReset};
 pub use input::{KeyMods, bevy_key_to_tmux_name, send_bytes_command, send_pane_keys_command};
 pub use keybindings::{
     CopyAction, Forwarded, KeyBindings, PromptKind, copy_mode_dispatch, plan_forward,

--- a/docs/superpowers/plans/2026-06-19-ozma-terminal-mouse-input.md
+++ b/docs/superpowers/plans/2026-06-19-ozma-terminal-mouse-input.md
@@ -1,0 +1,1394 @@
+# ozma_terminal Mouse Input Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the self-contained `ozma_terminal` crate working mouse support — app reporting (SGR/X10), text selection + copy, wheel scrollback, and Cmd-click hyperlinks — by adding Bevy glue over the engine's existing pure routers.
+
+**Architecture:** The engine (`ozma_tty_engine`) already owns the per-event decisions (`ButtonAction::route`, `WheelAction::route`, SGR/X10 encoder). The crate adds Bevy systems that read input, hit-test the cursor to a cell, track click-count + drag state, and translate router output into a small private `MouseEffect` list that a thin apply step writes to the `TerminalHandle` / `Clipboard`. The decision logic is pure (no `TerminalHandle`, which has no public constructor) so it is unit-testable without a PTY; protocol-byte correctness is already covered by engine tests.
+
+**Tech Stack:** Rust 2024, Bevy 0.18, `alacritty_terminal` (via the engine), `arboard` (clipboard, existing), `open` (URL launch, new dep).
+
+**Spec:** `docs/superpowers/specs/2026-06-19-ozma-terminal-mouse-input-design.md`
+
+## Global Constraints
+
+- Rust edition 2024, toolchain 1.95. Every `pub` item gets a `///` doc comment; every module file gets a `//!` header.
+- No `mod.rs` (use `foo.rs` + `foo/bar.rs`). Comments restricted to `// TODO:` / `// NOTE:` / `// SAFETY:`; all comments in English.
+- Imports: single contiguous `use` block at the top; no inline fully-qualified paths in signatures/bodies.
+- Bevy systems: mutable `SystemParam`s declared before immutable ones; gate whole-system change checks with `run_if`, not in-body early returns; `Plugin::build` is one method chain.
+- `Query` params use descriptive nouns, never a `_q` suffix.
+- The `ozma_terminal` crate MUST NOT depend on `ozmux_configs`, `ozmux_tmux`, or `bevy_cef`. (`FineModifier` is therefore a crate-local enum, not the `ozmux_configs` one.)
+- Selection copies to the system clipboard **on Left release** (matching the repo's tmux VT path).
+- `ButtonConfig` derives `Default` with `max_protocol_events_per_frame = 0`, which makes `route()` drop every forwarded button event — `OzmaMouseConfig::default` MUST set the buttons cap to `8` explicitly.
+- Wheel sign: Bevy `MouseWheel.y > 0` is wheel-up; `WheelAction::route` treats **negative notches as up/older**, so the accumulator output is negated before calling `route`.
+- Cell coordinates: hit-test produces **1-indexed** `CellCoord` (what SGR/X10 want); `to_viewport_point` subtracts 1 for the engine's viewport-relative selection `Point`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/ozma_tty_renderer/src/schema/hyperlink.rs` (modify) | Add the shared URL-scheme allowlist (`is_allowed` pub, `scheme_of` private). |
+| `src/input/hyperlink.rs` (modify) | Delete its `is_allowed`/`scheme_of`; delegate to `schema::is_allowed`. |
+| `crates/ozma_terminal/Cargo.toml` (modify) | Add `open = { workspace = true }`. |
+| `crates/ozma_terminal/src/mouse.rs` (create) | `OzmaMousePlugin`, `OzmaMouseConfig`, `FineModifier`, `OzmaTerminalMouseSet`, `OzmaMouseGesture`, `ClickTracker`, hit-test + `to_viewport_point` helpers, `MouseEffect`, `decide_button`, `decide_wheel`, the two dispatch systems, `apply_effect`. |
+| `crates/ozma_terminal/src/hyperlink.rs` (create) | `link_modifier_held`, `try_open_uri`, `hyperlink_hover_cursor` system, `cursor_decision`. |
+| `crates/ozma_terminal/src/lib.rs` (modify) | `mod mouse; mod hyperlink;`; add `OzmaMousePlugin`; re-export `OzmaMouseConfig`, `FineModifier`, `OzmaTerminalMouseSet`. |
+| `crates/ozma_terminal/src/input.rs` (modify) | Promote `current_terminal_modifiers` to `pub(crate)` (reused by mouse/hyperlink). |
+| `src/input/shortcuts.rs` (modify) | Add `populate_mouse_config` Startup system mapping `OzmuxConfigsResource.mouse` → `OzmaMouseConfig`. |
+| `src/input.rs` (modify) | Register `populate_mouse_config`. |
+| `src/ozma_input.rs` (modify) | `maintain_input_disabled` also runs `.before(OzmaTerminalMouseSet)`. |
+
+> Start with a flat `mouse.rs`. Split into `mouse/buttons.rs` + `mouse/wheel.rs` only if it grows past ~350 lines.
+
+---
+
+## Task 1: Relocate the URL-scheme allowlist into the renderer schema
+
+**Files:**
+- Modify: `crates/ozma_tty_renderer/src/schema/hyperlink.rs`
+- Modify: `src/input/hyperlink.rs:79-102` (delete copies), `:48-56` (delegate)
+
+**Interfaces:**
+- Produces: `ozma_tty_renderer::schema::is_allowed(uri: &str) -> bool` (the `http`/`https`/`mailto`/`ftp` allowlist, case-insensitive, rejecting `javascript:`/`file:`/`data:`).
+
+- [ ] **Step 1: Add the failing test in the schema crate**
+
+Append to `crates/ozma_tty_renderer/src/schema/hyperlink.rs`'s `#[cfg(test)] mod tests` (create the module if absent):
+
+```rust
+#[test]
+fn is_allowed_accepts_canonical_schemes_case_insensitive() {
+    assert!(is_allowed("http://example.com"));
+    assert!(is_allowed("HTTPS://example.com"));
+    assert!(is_allowed("Mailto:foo@example"));
+    assert!(is_allowed("ftp://example.com"));
+}
+
+#[test]
+fn is_allowed_rejects_dangerous_or_unknown_schemes() {
+    assert!(!is_allowed("javascript:alert(1)"));
+    assert!(!is_allowed("file:///etc/passwd"));
+    assert!(!is_allowed("data:text/html,<script>"));
+    assert!(!is_allowed(""));
+    assert!(!is_allowed("no-colon-here"));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p ozma_tty_renderer is_allowed`
+Expected: FAIL — `cannot find function is_allowed`.
+
+- [ ] **Step 3: Implement the allowlist in the schema crate**
+
+Add to `crates/ozma_tty_renderer/src/schema/hyperlink.rs` (above the test module):
+
+```rust
+const ALLOWED_SCHEMES: &[&str] = &["http", "https", "mailto", "ftp"];
+
+/// Returns `true` when `uri` carries a scheme on the v1 allowlist
+/// (`http`, `https`, `mailto`, `ftp`), case-insensitive.
+pub fn is_allowed(uri: &str) -> bool {
+    scheme_of(uri)
+        .map(|s| s.to_ascii_lowercase())
+        .is_some_and(|s| ALLOWED_SCHEMES.contains(&s.as_str()))
+}
+
+/// Parses an RFC 3986 scheme: first byte ALPHA, continuation
+/// ALPHA / DIGIT / `+` / `-` / `.`. Returns `None` for malformed input.
+fn scheme_of(uri: &str) -> Option<&str> {
+    let (scheme, _) = uri.split_once(':')?;
+    let mut bytes = scheme.bytes();
+    let first = bytes.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if !bytes.all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.') {
+        return None;
+    }
+    Some(scheme)
+}
+```
+
+If `schema/hyperlink.rs` has no `//!` header, it already declares a module (it's re-exported via `pub use hyperlink::*` in `schema.rs`), so a header exists; otherwise add `//! OSC 8 hyperlink schema types and the URL-scheme allowlist.`
+
+- [ ] **Step 4: Run the schema tests**
+
+Run: `cargo test -p ozma_tty_renderer is_allowed`
+Expected: PASS.
+
+- [ ] **Step 5: Delete the copies in `src/input/hyperlink.rs` and delegate**
+
+In `src/input/hyperlink.rs`: delete `const ALLOWED_SCHEMES`, `fn scheme_of`, and `fn is_allowed` (lines ~79-102) and their `scheme_of`/`is_allowed` tests. Change `try_open_uri` to call the schema version:
+
+```rust
+if !ozma_tty_renderer::schema::is_allowed(uri) {
+    debug!("hyperlink: dropping disallowed uri {}", uri);
+    return;
+}
+```
+
+Add `use ozma_tty_renderer::schema::is_allowed;` to the top `use` block and write `is_allowed(uri)` (not the inline path). Keep the `should_open_at` function in `src/input/hyperlink.rs` unchanged (it stays per-host).
+
+- [ ] **Step 6: Build + test the workspace**
+
+Run: `cargo test -p ozma_tty_renderer && cargo build && cargo test -p ozmux-gui hyperlink`
+Expected: PASS; no references to a removed `is_allowed` in `src/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ozma_tty_renderer/src/schema/hyperlink.rs src/input/hyperlink.rs
+git commit -m "refactor(renderer): share URL-scheme allowlist via schema; src delegates
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Crate foundation — config, types, helpers, plugin skeleton
+
+**Files:**
+- Modify: `crates/ozma_terminal/Cargo.toml`
+- Create: `crates/ozma_terminal/src/mouse.rs`
+- Modify: `crates/ozma_terminal/src/lib.rs`
+
+**Interfaces:**
+- Produces: `OzmaMouseConfig` (Resource), `FineModifier` (enum), `OzmaTerminalMouseSet` (SystemSet), `OzmaMousePlugin` (Plugin), `OzmaMouseGesture`/`DragGesture`/`DragPhase`, `ClickTracker`, `cell_at_local(local: Vec2, cell_w: f32, cell_h: f32, cols: u16, rows: u16) -> (CellCoord, Side)`, `cell_at_cursor(...) -> Option<(CellCoord, Side)>`, `to_viewport_point(cell: CellCoord) -> Point`, `protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers`.
+
+- [ ] **Step 1: Add the `open` dependency**
+
+In `crates/ozma_terminal/Cargo.toml` `[dependencies]`, add (alphabetical order is not enforced here; place near the others):
+
+```toml
+open = { workspace = true }
+```
+
+- [ ] **Step 2: Write the failing foundation tests**
+
+Create `crates/ozma_terminal/src/mouse.rs` with only the `use` block + a `#[cfg(test)] mod tests` containing:
+
+```rust
+#[test]
+fn default_config_sets_button_cap_explicitly() {
+    let cfg = OzmaMouseConfig::default();
+    assert_eq!(cfg.buttons.max_protocol_events_per_frame, 8, "must NOT be ButtonConfig::default()'s 0");
+    assert_eq!(cfg.wheel.max_protocol_events_per_frame, 8);
+    assert_eq!(cfg.cells_per_notch, 0.5);
+    assert_eq!(cfg.double_click_timeout, std::time::Duration::from_millis(400));
+    assert_eq!(cfg.click_drift_px, 8.0);
+    assert_eq!(cfg.fine_modifier, FineModifier::Alt);
+}
+
+#[test]
+fn cell_at_local_is_one_indexed_and_clamped() {
+    let (cell, side) = cell_at_local(Vec2::new(0.0, 0.0), 10.0, 20.0, 80, 24);
+    assert_eq!((cell.col, cell.row), (1, 1));
+    assert_eq!(side, Side::Left);
+    let (cell, _) = cell_at_local(Vec2::new(10_000.0, 10_000.0), 10.0, 20.0, 80, 24);
+    assert_eq!((cell.col, cell.row), (80, 24));
+    let (cell, side) = cell_at_local(Vec2::new(17.0, 5.0), 10.0, 20.0, 80, 24);
+    assert_eq!(cell.col, 2);
+    assert_eq!(side, Side::Right);
+}
+
+#[test]
+fn to_viewport_point_zero_indexes_the_one_indexed_cell() {
+    let p = to_viewport_point(CellCoord { col: 5, row: 3 });
+    assert_eq!(p.line.0, 2);
+    assert_eq!(p.column.0, 4);
+}
+
+#[test]
+fn click_tracker_counts_within_timeout_and_drift() {
+    let mut t = ClickTracker::default();
+    let cfg = (std::time::Duration::from_millis(400), 8.0f32);
+    assert_eq!(t.register(std::time::Duration::from_millis(0), Vec2::new(10.0, 10.0), cfg), 1);
+    assert_eq!(t.register(std::time::Duration::from_millis(200), Vec2::new(11.0, 11.0), cfg), 2);
+    assert_eq!(t.register(std::time::Duration::from_millis(350), Vec2::new(12.0, 10.0), cfg), 3);
+    assert_eq!(t.register(std::time::Duration::from_millis(900), Vec2::new(12.0, 10.0), cfg), 1);
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: FAIL — types/functions not found.
+
+- [ ] **Step 4: Implement the foundation**
+
+Write the rest of `crates/ozma_terminal/src/mouse.rs`:
+
+```rust
+//! Default mouse handler for the Ozma terminal: app reporting, local text
+//! selection + copy, wheel scrollback, and Cmd-click hyperlink open. Reads Bevy
+//! mouse input, hit-tests the cursor to a cell, and drives the engine's pure
+//! `ButtonAction` / `WheelAction` routers, applying the result to the
+//! `TerminalHandle` / `Clipboard`. Gated per entity by `InputDisabled`.
+
+use crate::clipboard::Clipboard;
+use crate::hyperlink::{link_modifier_held, try_open_uri};
+use crate::input::{InputDisabled, current_terminal_modifiers};
+use crate::spawn::OzmaTerminal;
+use bevy::input::ButtonState;
+use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseScrollUnit, MouseWheel};
+use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::PrimaryWindow;
+use ozma_tty_engine::{
+    ButtonAction, ButtonConfig, ButtonEvent, ButtonEventKind, CellCoord, Coalescer, Column, Line,
+    MouseButtonKind, Point, ProtocolModifiers, PtyHandle, SelectionType, Side, TermMode,
+    TerminalHandle, WheelAction, WheelConfig, WheelModifiers,
+};
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::schema::TerminalGrid;
+use std::time::Duration;
+
+/// Which modifier activates "fine" (1 line per notch) wheel scrolling.
+/// Crate-local mirror of the host config enum (the crate must not depend on
+/// `ozmux_configs`). Default `Alt`: on macOS Shift+wheel becomes horizontal
+/// scroll at the OS level, so Shift never reaches the app as vertical `y`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum FineModifier {
+    Shift,
+    Ctrl,
+    #[default]
+    Alt,
+    None,
+}
+
+/// Host-supplied mouse policy. `Default` is a working spawn-and-go config; the
+/// host overrides it from `ozmux_configs`.
+#[derive(Resource)]
+pub struct OzmaMouseConfig {
+    /// Button-report burst cap. MUST be non-zero or forwarded clicks are dropped.
+    pub buttons: ButtonConfig,
+    /// Wheel routing config (lines-per-notch, fine lines, burst cap).
+    pub wheel: WheelConfig,
+    /// Cells of wheel travel per emitted notch (smooth-scroll accumulation).
+    pub cells_per_notch: f32,
+    /// Max gap between clicks counted as a double / triple click.
+    pub double_click_timeout: Duration,
+    /// Max cursor drift (logical px) between clicks of one chord.
+    pub click_drift_px: f32,
+    /// Which modifier activates fine scrolling.
+    pub fine_modifier: FineModifier,
+}
+
+impl Default for OzmaMouseConfig {
+    fn default() -> Self {
+        Self {
+            buttons: ButtonConfig {
+                max_protocol_events_per_frame: 8,
+            },
+            wheel: WheelConfig::default(),
+            cells_per_notch: 0.5,
+            double_click_timeout: Duration::from_millis(400),
+            click_drift_px: 8.0,
+            fine_modifier: FineModifier::Alt,
+        }
+    }
+}
+
+/// System set for the crate's three mouse systems. Hosts maintaining
+/// `InputDisabled` should schedule their maintainer `.before(OzmaTerminalMouseSet)`.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OzmaTerminalMouseSet;
+
+/// Phase of an in-progress left-drag: `Armed` after a single-click press (no
+/// selection started yet), `Started` once the pointer crossed into another cell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DragPhase {
+    Armed,
+    Started,
+}
+
+/// An in-progress button gesture: the held button, the selection anchor, and the
+/// last cell a drag reached (dedup + lazy materialization).
+pub(crate) struct DragGesture {
+    pub(crate) button: MouseButtonKind,
+    pub(crate) origin: CellCoord,
+    pub(crate) side: Side,
+    pub(crate) ty: SelectionType,
+    pub(crate) phase: DragPhase,
+    pub(crate) last_cell: CellCoord,
+}
+
+/// Tracks the current mouse gesture and consecutive-click count.
+#[derive(Resource, Default)]
+pub(crate) struct OzmaMouseGesture {
+    pub(crate) click: ClickTracker,
+    pub(crate) drag: Option<DragGesture>,
+}
+
+/// Consecutive-click counter using a timeout + positional-drift gate.
+#[derive(Default)]
+pub(crate) struct ClickTracker {
+    last: Option<(Duration, Vec2, u8)>,
+}
+
+impl ClickTracker {
+    /// Registers a press at `now` / logical `pos`, returning the click count
+    /// (1..=3). `cfg` is `(timeout, drift_px)`.
+    pub(crate) fn register(&mut self, now: Duration, pos: Vec2, cfg: (Duration, f32)) -> u8 {
+        let (timeout, drift) = cfg;
+        let count = match self.last {
+            Some((t, p, c)) if now.saturating_sub(t) <= timeout && p.distance(pos) <= drift => {
+                (c + 1).min(3)
+            }
+            _ => 1,
+        };
+        self.last = Some((now, pos, count));
+        count
+    }
+}
+
+/// 1-indexed `(CellCoord, Side)` of the cell at pane-local physical `local`,
+/// clamped to `1..=cols` × `1..=rows`. `Side` is `Left` in the left half.
+pub(crate) fn cell_at_local(
+    local: Vec2,
+    cell_w: f32,
+    cell_h: f32,
+    cols: u16,
+    rows: u16,
+) -> (CellCoord, Side) {
+    let col_f = (local.x / cell_w).max(0.0);
+    let row_f = (local.y / cell_h).max(0.0);
+    let col = (col_f.floor() as u32 + 1).min(cols as u32).max(1);
+    let row = (row_f.floor() as u32 + 1).min(rows as u32).max(1);
+    let side = if col_f - col_f.floor() < 0.5 {
+        Side::Left
+    } else {
+        Side::Right
+    };
+    (CellCoord { col, row }, side)
+}
+
+/// Resolves the window-space physical cursor to a cell on the terminal node, or
+/// `None` when the cursor is outside the node.
+pub(crate) fn cell_at_cursor(
+    node: &ComputedNode,
+    transform: &UiGlobalTransform,
+    cursor_phys: Vec2,
+    cell_w: f32,
+    cell_h: f32,
+    cols: u16,
+    rows: u16,
+) -> Option<(CellCoord, Side)> {
+    let local = node
+        .normalize_point(*transform, cursor_phys)
+        .map(|n| (n + Vec2::splat(0.5)) * node.size)?;
+    Some(cell_at_local(local, cell_w, cell_h, cols, rows))
+}
+
+/// Converts a 1-indexed protocol `CellCoord` into the engine's viewport-relative
+/// selection `Point` (row 0 = top of viewport; the engine translates for scroll).
+pub(crate) fn to_viewport_point(cell: CellCoord) -> Point {
+    Point::new(Line(cell.row as i32 - 1), Column(cell.col as usize - 1))
+}
+
+/// Builds `ProtocolModifiers` from the held keys.
+pub(crate) fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
+    let m = current_terminal_modifiers(keys);
+    ProtocolModifiers {
+        shift: m.shift,
+        ctrl: m.ctrl,
+        alt: m.alt,
+        meta: m.meta,
+    }
+}
+
+/// Registers the crate's mouse systems and resources.
+pub(crate) struct OzmaMousePlugin;
+
+impl Plugin for OzmaMousePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<OzmaMouseConfig>()
+            .init_resource::<OzmaMouseGesture>()
+            .add_message::<MouseButtonInput>()
+            .add_message::<MouseWheel>()
+            .add_message::<CursorMoved>();
+    }
+}
+```
+
+> The `add_message::<...>()` calls are REQUIRED: later tasks register systems gated on `run_if(on_message::<MouseButtonInput>)` / `MouseWheel` / `CursorMoved`, and under `MinimalPlugins` (the crate's lib test path) those `Messages<T>` resources do not otherwise exist, so the run conditions would panic. This mirrors `OzmaInputPlugin`'s `add_message::<KeyboardInput>()`. They use the `MouseButtonInput` / `MouseWheel` / `CursorMoved` imports, so add `use bevy::input::mouse::{MouseButtonInput, MouseWheel};` and `use bevy::window::CursorMoved;` to the `use` block in this task (the other input imports are added in Tasks 5–6 as their code lands — keep this task's `use` block to names actually referenced here so the build stays warning-free).
+
+Note `OzmaMouseConfig` cannot derive `Default` via `#[derive]` because `Duration` is fine but the explicit cap matters — the hand-written `impl Default` above is required. Leave the unused-import warnings for items consumed in later tasks by prefixing the `use` of not-yet-used names is not allowed; instead, only import what Step 4's code references and add the rest in Tasks 3–6. (Practically: trim the `use` block to the names actually used here — `ButtonConfig`, `WheelConfig`, `CellCoord`, `Column`, `Line`, `Point`, `Side`, `ProtocolModifiers`, `KeyCode`, `ButtonInput`, `Vec2`, `Duration`, `ComputedNode`, `UiGlobalTransform`, the plugin/`App`/`Resource`/`SystemSet` prelude items, and `current_terminal_modifiers` — and grow it per task.)
+
+- [ ] **Step 5: Wire the module into the crate**
+
+In `crates/ozma_terminal/src/lib.rs`: add `mod mouse;` (and `mod hyperlink;` will be added in Task 6 — add it now as an empty module to keep `mouse.rs`'s `use crate::hyperlink::...` resolvable, OR defer the `use crate::hyperlink` line until Task 6). Simplest: in this task, comment out (omit) the `use crate::hyperlink::{...}` import and the `Clipboard` import until they're used in Tasks 5–6. Add to `lib.rs`:
+
+```rust
+mod mouse;
+```
+
+and in the re-export list:
+
+```rust
+pub use mouse::{FineModifier, OzmaMouseConfig, OzmaTerminalMouseSet};
+```
+
+and add `OzmaMousePlugin` to the `OzmaTerminalPlugin::build` plugin tuple:
+
+```rust
+.add_plugins((ExitPlugin, LayoutPlugin, OzmaActionPlugin, OzmaInputPlugin, OzmaMousePlugin))
+```
+
+(add `use crate::mouse::OzmaMousePlugin;` to the `use` block).
+
+- [ ] **Step 6: Run the foundation tests**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ozma_terminal/Cargo.toml crates/ozma_terminal/src/mouse.rs crates/ozma_terminal/src/lib.rs
+git commit -m "feat(ozma_terminal): mouse config, gesture state, hit-test helpers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `MouseEffect` + `decide_button` (pure)
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/mouse.rs`
+
+**Interfaces:**
+- Consumes: `OzmaMouseGesture`, `cell_at_local`/`to_viewport_point`, `OzmaMouseConfig`, engine `ButtonAction::route`.
+- Produces: `enum MouseEffect`; `fn decide_button(gesture: &mut OzmaMouseGesture, modes: TermMode, evt: ButtonEvent, mods: ProtocolModifiers, modifier_held: bool, link_at_cell: Option<String>, cfg: &ButtonConfig) -> Vec<MouseEffect>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mouse.rs` `mod tests`:
+
+```rust
+use ozma_tty_engine::{ButtonEvent, ButtonEventKind, MouseButtonKind};
+
+fn ev(kind: ButtonEventKind, col: u32, row: u32, count: u8) -> ButtonEvent {
+    ButtonEvent {
+        kind,
+        button: MouseButtonKind::Left,
+        cell: CellCoord { col, row },
+        side: Side::Left,
+        click_count: count,
+    }
+}
+
+#[test]
+fn local_single_press_arms_drag_and_clears() {
+    let mut g = OzmaMouseGesture::default();
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
+        ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+    assert_eq!(fx, vec![MouseEffect::SelClear]);
+    assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+}
+
+#[test]
+fn local_drag_materializes_then_extends() {
+    let mut g = OzmaMouseGesture::default();
+    let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+    decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    assert_eq!(fx, vec![
+        MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Simple },
+        MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 7, row: 5 }), side: Side::Left },
+    ]);
+    let fx2 = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 9, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    assert_eq!(fx2, vec![MouseEffect::SelUpdate { point: to_viewport_point(CellCoord { col: 9, row: 5 }), side: Side::Left }]);
+}
+
+#[test]
+fn release_after_drag_copies() {
+    let mut g = OzmaMouseGesture::default();
+    let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+    decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Drag, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 7, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    assert_eq!(fx, vec![MouseEffect::Copy]);
+    assert!(g.drag.is_none());
+}
+
+#[test]
+fn release_after_bare_click_does_not_copy() {
+    let mut g = OzmaMouseGesture::default();
+    let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+    decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Release, 5, 5, 1), ProtocolModifiers::default(), false, None, &cfg);
+    assert_eq!(fx, vec![]);
+    assert!(g.drag.is_none());
+}
+
+#[test]
+fn double_click_starts_word_selection() {
+    let mut g = OzmaMouseGesture::default();
+    let cfg = ButtonConfig { max_protocol_events_per_frame: 8 };
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 2), ProtocolModifiers::default(), false, None, &cfg);
+    assert_eq!(fx, vec![MouseEffect::SelStart { point: to_viewport_point(CellCoord { col: 5, row: 5 }), side: Side::Left, ty: SelectionType::Semantic }]);
+}
+
+#[test]
+fn app_capture_press_forwards_sgr_bytes() {
+    let mut g = OzmaMouseGesture::default();
+    let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+    let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), ProtocolModifiers::default(), false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+    assert_eq!(fx, vec![MouseEffect::SelClear, MouseEffect::Write(b"\x1b[<0;5;5M".to_vec())]);
+}
+
+#[test]
+fn shift_bypass_selects_even_when_captured() {
+    let mut g = OzmaMouseGesture::default();
+    let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+    let mods = ProtocolModifiers { shift: true, ..Default::default() };
+    let fx = decide_button(&mut g, modes, ev(ButtonEventKind::Press, 5, 5, 1), mods, false, None, &ButtonConfig { max_protocol_events_per_frame: 8 });
+    assert_eq!(fx, vec![MouseEffect::SelClear]);
+    assert!(matches!(g.drag, Some(DragGesture { phase: DragPhase::Armed, .. })));
+}
+
+#[test]
+fn cmd_click_on_link_opens_and_consumes() {
+    let mut g = OzmaMouseGesture::default();
+    let fx = decide_button(&mut g, TermMode::empty(), ev(ButtonEventKind::Press, 5, 5, 1),
+        ProtocolModifiers { meta: true, ..Default::default() }, true, Some("https://example.com".into()),
+        &ButtonConfig { max_protocol_events_per_frame: 8 });
+    assert_eq!(fx, vec![MouseEffect::OpenUri("https://example.com".into())]);
+    assert!(g.drag.is_none(), "a link-open press must not arm a drag");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: FAIL — `MouseEffect` / `decide_button` not found.
+
+- [ ] **Step 3: Implement `MouseEffect` + `decide_button`**
+
+Add to `mouse.rs` (and extend the `use` block with `ButtonAction`, `ButtonEvent`, `ButtonEventKind`, `MouseButtonKind`, `SelectionType`):
+
+```rust
+/// A resolved intent the apply step writes to the handle / clipboard. Kept
+/// separate from application so the decision logic is unit-testable without a
+/// `TerminalHandle` (which has no public constructor).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MouseEffect {
+    Write(Vec<u8>),
+    SelStart { point: Point, side: Side, ty: SelectionType },
+    SelUpdate { point: Point, side: Side },
+    SelClear,
+    Copy,
+    Scroll(i32),
+    OpenUri(String),
+}
+
+/// Pure per-event decision for a mouse button. Mutates `gesture` (drag phase /
+/// click state) and returns the effects to apply. A Cmd/Ctrl-click on a linked
+/// cell opens the URL and consumes the event; otherwise the engine's
+/// `ButtonAction::route` decides forward-to-app vs local selection.
+pub(crate) fn decide_button(
+    gesture: &mut OzmaMouseGesture,
+    modes: TermMode,
+    evt: ButtonEvent,
+    mods: ProtocolModifiers,
+    modifier_held: bool,
+    link_at_cell: Option<String>,
+    cfg: &ButtonConfig,
+) -> Vec<MouseEffect> {
+    if evt.kind == ButtonEventKind::Press
+        && evt.button == MouseButtonKind::Left
+        && modifier_held
+        && let Some(uri) = link_at_cell
+    {
+        return vec![MouseEffect::OpenUri(uri)];
+    }
+
+    let mut effects = match ButtonAction::route(modes, evt, mods, cfg) {
+        ButtonAction::Noop => Vec::new(),
+        ButtonAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
+        ButtonAction::ClearAndWriteToPty(b) => vec![MouseEffect::SelClear, MouseEffect::Write(b)],
+        ButtonAction::ArmDrag { ty, cell, side } => {
+            gesture.drag = Some(DragGesture {
+                button: evt.button,
+                origin: cell,
+                side,
+                ty,
+                phase: DragPhase::Armed,
+                last_cell: cell,
+            });
+            vec![MouseEffect::SelClear]
+        }
+        ButtonAction::StartLocalSelection { ty, cell, side } => {
+            gesture.drag = Some(DragGesture {
+                button: evt.button,
+                origin: cell,
+                side,
+                ty,
+                phase: DragPhase::Started,
+                last_cell: cell,
+            });
+            vec![MouseEffect::SelStart { point: to_viewport_point(cell), side, ty }]
+        }
+        ButtonAction::UpdateLocalSelection { cell, side } => update_selection(gesture, cell, side),
+        ButtonAction::ClearLocalSelection => {
+            gesture.drag = None;
+            vec![MouseEffect::SelClear]
+        }
+    };
+
+    if evt.kind == ButtonEventKind::Release && evt.button == MouseButtonKind::Left {
+        if effects.is_empty()
+            && matches!(&gesture.drag, Some(d) if d.phase == DragPhase::Started)
+        {
+            effects.push(MouseEffect::Copy);
+        }
+        gesture.drag = None;
+    }
+    effects
+}
+
+/// Lazily materializes an armed selection on the first cell change, then extends.
+fn update_selection(gesture: &mut OzmaMouseGesture, cell: CellCoord, side: Side) -> Vec<MouseEffect> {
+    let Some(drag) = gesture.drag.as_mut() else {
+        return Vec::new();
+    };
+    match drag.phase {
+        DragPhase::Armed => {
+            if cell == drag.origin {
+                return Vec::new();
+            }
+            let origin = drag.origin;
+            let ty = drag.ty;
+            let origin_side = drag.side;
+            drag.phase = DragPhase::Started;
+            drag.last_cell = cell;
+            vec![
+                MouseEffect::SelStart { point: to_viewport_point(origin), side: origin_side, ty },
+                MouseEffect::SelUpdate { point: to_viewport_point(cell), side },
+            ]
+        }
+        DragPhase::Started => {
+            drag.last_cell = cell;
+            vec![MouseEffect::SelUpdate { point: to_viewport_point(cell), side }]
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: PASS (all decide_button tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(ozma_terminal): pure decide_button + MouseEffect
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wheel accumulation + `decide_wheel` (pure)
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/mouse.rs`
+
+**Interfaces:**
+- Consumes: engine `WheelAction::route`, `WheelConfig`, `WheelModifiers`, `CellCoord`.
+- Produces: `WheelAccumulator` (Resource); `fn accumulate_notches(acc: &mut WheelAccumulator, delta_cells: f32, cells_per_notch: f32) -> i32`; `fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f32`; `fn decide_wheel(modes: TermMode, notches: i32, cell: CellCoord, mods: WheelModifiers, cfg: &WheelConfig) -> Vec<MouseEffect>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `mouse.rs` `mod tests`:
+
+```rust
+use ozma_tty_engine::{WheelConfig, WheelModifiers};
+
+#[test]
+fn line_delta_is_direct_pixel_divides_by_cell_height() {
+    assert_eq!(wheel_delta_cells(MouseScrollUnit::Line, 2.0, 16.0), 2.0);
+    assert_eq!(wheel_delta_cells(MouseScrollUnit::Pixel, 32.0, 16.0), 2.0);
+}
+
+#[test]
+fn accumulator_emits_on_threshold_and_carries_remainder() {
+    let mut acc = WheelAccumulator::default();
+    assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
+    assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
+    assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -1);
+}
+
+#[test]
+fn scrollback_up_returns_positive_viewport_scroll() {
+    // Bevy +y (wheel up) → caller negates → engine notches negative → into history.
+    let fx = decide_wheel(TermMode::empty(), -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+    assert_eq!(fx, vec![MouseEffect::Scroll(3)]);
+}
+
+#[test]
+fn app_capture_wheel_forwards_bytes() {
+    let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+    let fx = decide_wheel(modes, -1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &WheelConfig::default());
+    assert!(matches!(fx.as_slice(), [MouseEffect::Write(b)] if !b.is_empty()));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: FAIL — wheel items not found.
+
+- [ ] **Step 3: Implement the wheel decision**
+
+Add to `mouse.rs` (extend `use` with `WheelAction`, `WheelModifiers`, `MouseScrollUnit`):
+
+```rust
+/// Carries the sub-notch wheel remainder across frames.
+#[derive(Resource, Default)]
+pub(crate) struct WheelAccumulator {
+    residual_cells: f32,
+}
+
+/// Cells of scroll for one wheel event: `Line` units count directly, `Pixel`
+/// units divide by the cell height. Positive = wheel-up (toward older lines).
+pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f32 {
+    match unit {
+        MouseScrollUnit::Line => y,
+        MouseScrollUnit::Pixel => y / cell_h.max(1.0),
+    }
+}
+
+/// Adds `delta_cells` to the accumulator and returns whole notches to emit
+/// (positive = up/older), carrying the remainder. Resets on a sign flip.
+pub(crate) fn accumulate_notches(
+    acc: &mut WheelAccumulator,
+    delta_cells: f32,
+    cells_per_notch: f32,
+) -> i32 {
+    if acc.residual_cells != 0.0 && acc.residual_cells.signum() != delta_cells.signum() {
+        acc.residual_cells = 0.0;
+    }
+    let threshold = cells_per_notch.max(f32::EPSILON);
+    acc.residual_cells += delta_cells;
+    let notches = (acc.residual_cells / threshold).trunc() as i32;
+    if notches != 0 {
+        acc.residual_cells -= notches as f32 * threshold;
+    }
+    notches
+}
+
+/// Pure wheel decision. `notches` is in the engine convention (negative =
+/// up/older); callers negate the Bevy-derived up-positive value before calling.
+pub(crate) fn decide_wheel(
+    modes: TermMode,
+    notches: i32,
+    cell: CellCoord,
+    mods: WheelModifiers,
+    cfg: &WheelConfig,
+) -> Vec<MouseEffect> {
+    match WheelAction::route(modes, notches, cell, mods, cfg) {
+        WheelAction::Noop => Vec::new(),
+        WheelAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
+        WheelAction::ScrollViewport(lines) => vec![MouseEffect::Scroll(lines)],
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p ozma_terminal --lib mouse::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(ozma_terminal): pure decide_wheel + pixel-notch accumulation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Hyperlink module — open + hover cursor
+
+**Files:**
+- Create: `crates/ozma_terminal/src/hyperlink.rs`
+- Modify: `crates/ozma_terminal/src/lib.rs` (`mod hyperlink;`), `crates/ozma_terminal/src/mouse.rs` (uncomment the `use crate::hyperlink::{...}`)
+
+**Interfaces:**
+- Consumes: `current_terminal_modifiers`, `ozma_tty_renderer::schema::{is_allowed, HyperlinkHoverState, TerminalGrid}`, `TerminalCellMetricsResource`.
+- Produces: `fn link_modifier_held(mods: &ProtocolModifiers) -> bool`; `fn try_open_uri(uri: &str)`; `fn cursor_decision(has_link: bool, modifier_held: bool, over_grid: bool) -> SystemCursorIcon`; `hyperlink_hover_cursor` system; `HyperlinkInputPlugin` (or fold registration into `OzmaMousePlugin`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/ozma_terminal/src/hyperlink.rs` with the `use` block + `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn link_modifier_matches_platform() {
+    let mut m = ProtocolModifiers::default();
+    assert!(!link_modifier_held(&m));
+    if cfg!(target_os = "macos") {
+        m.meta = true;
+    } else {
+        m.ctrl = true;
+    }
+    assert!(link_modifier_held(&m));
+}
+
+#[test]
+fn cursor_decision_pointer_only_on_link_with_modifier() {
+    assert_eq!(cursor_decision(true, true, true), SystemCursorIcon::Pointer);
+    assert_eq!(cursor_decision(true, false, true), SystemCursorIcon::Text);
+    assert_eq!(cursor_decision(false, true, true), SystemCursorIcon::Text);
+    assert_eq!(cursor_decision(false, false, false), SystemCursorIcon::Default);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozma_terminal --lib hyperlink::`
+Expected: FAIL — module/functions not found.
+
+- [ ] **Step 3: Implement `hyperlink.rs`**
+
+```rust
+//! Cmd/Ctrl-click hyperlink activation and hover-cursor feedback for the Ozma
+//! terminal. The click-open path is invoked from the mouse dispatcher; the hover
+//! system updates `HyperlinkHoverState` (renderer underline) and the window
+//! `CursorIcon`.
+
+use crate::input::{InputDisabled, current_terminal_modifiers};
+use crate::mouse::{OzmaTerminalMouseSet, cell_at_cursor};
+use crate::spawn::OzmaTerminal;
+use bevy::input::keyboard::KeyboardInput;
+use bevy::prelude::*;
+use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
+use ozma_tty_engine::ProtocolModifiers;
+use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid, is_allowed};
+
+/// Returns `true` when the platform link-activation modifier is held: Cmd on
+/// macOS, Ctrl elsewhere.
+pub(crate) fn link_modifier_held(mods: &ProtocolModifiers) -> bool {
+    if cfg!(target_os = "macos") {
+        mods.meta
+    } else {
+        mods.ctrl
+    }
+}
+
+/// Validates `uri` against the shared allowlist and opens it via the OS default
+/// handler. Disallowed URIs are dropped with a debug log.
+pub(crate) fn try_open_uri(uri: &str) {
+    if !is_allowed(uri) {
+        debug!("hyperlink: dropping disallowed uri {}", uri);
+        return;
+    }
+    if let Err(e) = open::that_detached(uri) {
+        warn!("hyperlink: failed to open {}: {}", uri, e);
+    }
+}
+
+/// The cursor icon for a hover state: pointer over a link with the modifier
+/// held, I-beam over the grid, arrow elsewhere.
+pub(crate) fn cursor_decision(
+    has_link: bool,
+    modifier_held: bool,
+    over_grid: bool,
+) -> SystemCursorIcon {
+    match (over_grid, has_link, modifier_held) {
+        (true, true, true) => SystemCursorIcon::Pointer,
+        (true, _, _) => SystemCursorIcon::Text,
+        _ => SystemCursorIcon::Default,
+    }
+}
+
+/// Updates `HyperlinkHoverState` and the window cursor as the pointer moves over
+/// the terminal grid. Gated to the single enabled `OzmaTerminal`.
+fn hyperlink_hover_cursor(
+    mut hover: ResMut<HyperlinkHoverState>,
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    terminal: Query<
+        (Entity, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let modifier_held = link_modifier_held(&{
+        let m = current_terminal_modifiers(&keys);
+        ProtocolModifiers { shift: m.shift, ctrl: m.ctrl, alt: m.alt, meta: m.meta }
+    });
+    hover.entity = None;
+    hover.hyperlink_id = None;
+    hover.modifier_held = modifier_held;
+
+    let decision = resolve_hover(&mut hover, &terminal, &metrics, &windows, modifier_held);
+    if let Ok(mut icon) = cursor_icons.single_mut() {
+        let desired = CursorIcon::System(decision);
+        if *icon != desired {
+            *icon = desired;
+        }
+    }
+}
+
+fn resolve_hover(
+    hover: &mut HyperlinkHoverState,
+    terminal: &Query<
+        (Entity, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    metrics: &TerminalCellMetricsResource,
+    windows: &Query<&Window, With<PrimaryWindow>>,
+    modifier_held: bool,
+) -> SystemCursorIcon {
+    let Ok(window) = windows.single() else {
+        return SystemCursorIcon::Default;
+    };
+    let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
+        return SystemCursorIcon::Default;
+    };
+    let Ok((entity, node, transform, grid)) = terminal.single() else {
+        return SystemCursorIcon::Default;
+    };
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let Some((cell, _side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
+    else {
+        return SystemCursorIcon::Default;
+    };
+    let id = grid
+        .hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16)
+        .map(|(id, _uri)| id);
+    hover.entity = Some(entity);
+    hover.hyperlink_id = id;
+    cursor_decision(id.is_some(), modifier_held, true)
+}
+```
+
+Register the hover system in `OzmaMousePlugin::build` (Task 2) by extending its chain:
+
+```rust
+app.init_resource::<OzmaMouseConfig>()
+    .init_resource::<OzmaMouseGesture>()
+    .init_resource::<crate::mouse::WheelAccumulator>()
+    .add_systems(
+        Update,
+        crate::hyperlink::hyperlink_hover_cursor
+            .in_set(OzmaTerminalMouseSet)
+            .run_if(on_message::<KeyboardInput>.or(on_message::<CursorMoved>)),
+    );
+```
+
+(`hyperlink_hover_cursor` must be `pub(crate)` for the plugin to name it; adjust `fn` → `pub(crate) fn`. Add `mod hyperlink;` to `lib.rs`. Add the imports `use bevy::input::keyboard::KeyboardInput;`, `use bevy::window::CursorMoved;` to `mouse.rs` for the run conditions. `HyperlinkHoverState` is a renderer resource — confirm it is registered by the renderer plugin; if not present in a headless test, the system is simply not exercised.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p ozma_terminal --lib hyperlink:: && cargo build -p ozma_terminal`
+Expected: PASS + compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ozma_terminal/src/hyperlink.rs crates/ozma_terminal/src/lib.rs crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(ozma_terminal): hyperlink open + hover cursor
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Dispatch systems + apply, with gating test
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/mouse.rs`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–5; engine `TerminalHandle`/`PtyHandle`/`Coalescer`, `Clipboard`, `TerminalGrid`, `TerminalCellMetricsResource`.
+- Produces: `dispatch_mouse_buttons`, `dispatch_mouse_wheel` systems (registered in `OzmaMousePlugin`), `apply_effect`.
+
+- [ ] **Step 1: Write the failing gating test**
+
+Add to `mouse.rs` `mod tests`:
+
+```rust
+use crate::spawn::OzmaTerminal;
+use crate::input::InputDisabled;
+use bevy::input::mouse::{MouseButton, MouseButtonInput};
+
+#[test]
+fn input_disabled_terminal_drains_without_arming_a_gesture() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_message::<MouseButtonInput>()
+        .init_resource::<OzmaMouseConfig>()
+        .init_resource::<OzmaMouseGesture>()
+        .init_resource::<ButtonInput<KeyCode>>()
+        .init_resource::<Clipboard>()
+        .insert_resource(test_metrics())
+        .add_systems(Update, dispatch_mouse_buttons);
+    app.world_mut().spawn((OzmaTerminal, InputDisabled));
+    app.world_mut().spawn((Window { focused: true, ..default() }, PrimaryWindow));
+    app.world_mut()
+        .resource_mut::<bevy::ecs::message::Messages<MouseButtonInput>>()
+        .write(MouseButtonInput { button: MouseButton::Left, state: ButtonState::Pressed, window: Entity::PLACEHOLDER });
+    app.update();
+    assert!(app.world().resource::<OzmaMouseGesture>().drag.is_none());
+}
+
+fn test_metrics() -> TerminalCellMetricsResource {
+    use ozma_tty_renderer::CellMetrics;
+    TerminalCellMetricsResource {
+        metrics: CellMetrics {
+            advance_phys: 8.0, line_height_phys: 16.0, ascent_phys: 12.0, descent_phys: 4.0,
+            underline_position_phys: -2.0, underline_thickness_phys: 1.0, max_overflow_phys: 0.0,
+        },
+        phys_font_size: 16,
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozma_terminal --lib mouse::input_disabled`
+Expected: FAIL — `dispatch_mouse_buttons` not found.
+
+- [ ] **Step 3: Implement the systems + apply**
+
+Add to `mouse.rs` (extend `use` with `Clipboard`, `try_open_uri`, `link_modifier_held`, `MouseButton`, `MouseButtonInput`, `TerminalHandle`, `PtyHandle`, `Coalescer`, `TerminalGrid`, `Time`, `Real`, `ButtonState`):
+
+```rust
+/// The crate's mouse-button dispatcher. Resolves the cursor cell, tracks clicks
+/// and drag state, drives `decide_button`, and applies the effects. Skips the
+/// `OzmaTerminal` while it carries `InputDisabled`.
+pub(crate) fn dispatch_mouse_buttons(
+    mut gesture: ResMut<OzmaMouseGesture>,
+    mut buttons: MessageReader<MouseButtonInput>,
+    mut terminal: Query<
+        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    mut clipboard: ResMut<Clipboard>,
+    cfg: Res<OzmaMouseConfig>,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    time: Res<Time<Real>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    };
+    let Ok(window) = windows.single() else {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    };
+    if !window.focused {
+        buttons.clear();
+        gesture.drag = None;
+        return;
+    }
+    let Some(cursor_phys) = window.cursor_position().map(|c| c * window.scale_factor()) else {
+        buttons.clear();
+        return;
+    };
+    let scale = window.scale_factor();
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let modes = handle.current_modes();
+    let mods = protocol_mods(&keys);
+    let modifier_held = link_modifier_held(&mods);
+
+    for ev in buttons.read() {
+        let Some(button) = map_button(ev.button) else { continue };
+        let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows) else { continue };
+        let kind = match ev.state {
+            ButtonState::Pressed => ButtonEventKind::Press,
+            ButtonState::Released => ButtonEventKind::Release,
+        };
+        let click_count = if kind == ButtonEventKind::Press {
+            gesture.click.register(time.elapsed(), cursor_phys / scale, (cfg.double_click_timeout, cfg.click_drift_px))
+        } else {
+            1
+        };
+        let link_at_cell = (kind == ButtonEventKind::Press && button == MouseButtonKind::Left && modifier_held)
+            .then(|| grid.hyperlink_at((cell.row - 1) as u16, (cell.col - 1) as u16).map(|(_id, uri)| uri.as_str().to_string()))
+            .flatten();
+        let evt = ButtonEvent { kind, button, cell, side, click_count };
+        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, link_at_cell, &cfg.buttons);
+        for effect in effects {
+            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+        }
+    }
+
+    if gesture.drag.is_some()
+        && let Some((cell, side)) = cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, grid.cols, grid.rows)
+        && gesture.drag.as_ref().is_some_and(|d| d.last_cell != cell)
+    {
+        let button = gesture.drag.as_ref().map(|d| d.button).unwrap_or(MouseButtonKind::Left);
+        let evt = ButtonEvent { kind: ButtonEventKind::Drag, button, cell, side, click_count: 1 };
+        let effects = decide_button(&mut gesture, modes, evt, mods, modifier_held, None, &cfg.buttons);
+        for effect in effects {
+            apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+        }
+    }
+}
+
+/// The crate's wheel dispatcher: accumulates notches, drives `decide_wheel`,
+/// applies the result.
+pub(crate) fn dispatch_mouse_wheel(
+    mut gesture_acc: ResMut<WheelAccumulator>,
+    mut wheel: MessageReader<MouseWheel>,
+    mut terminal: Query<
+        (&mut TerminalHandle, &mut PtyHandle, &mut Coalescer, &ComputedNode, &UiGlobalTransform, &TerminalGrid),
+        (With<OzmaTerminal>, Without<InputDisabled>),
+    >,
+    mut clipboard: ResMut<Clipboard>,
+    cfg: Res<OzmaMouseConfig>,
+    metrics: Res<TerminalCellMetricsResource>,
+    keys: Res<ButtonInput<KeyCode>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let Ok((mut handle, mut pty, mut coalescer, node, transform, grid)) = terminal.single_mut() else {
+        wheel.clear();
+        return;
+    };
+    let Ok(window) = windows.single() else { wheel.clear(); return };
+    if !window.focused { wheel.clear(); return }
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+
+    let mut delta_cells = 0.0f32;
+    for ev in wheel.read() {
+        delta_cells += wheel_delta_cells(ev.unit, ev.y, cell_h);
+    }
+    let raw = accumulate_notches(&mut gesture_acc, delta_cells, cfg.cells_per_notch);
+    if raw == 0 {
+        return;
+    }
+    // Bevy +y (up/older) → engine convention (negative = up/older).
+    let notches = -raw;
+    let cell = window
+        .cursor_position()
+        .map(|c| c * window.scale_factor())
+        .and_then(|p| cell_at_cursor(node, transform, p, cell_w, cell_h, grid.cols, grid.rows))
+        .map(|(cell, _)| cell)
+        .unwrap_or(CellCoord { col: 1, row: 1 });
+    let m = current_terminal_modifiers(&keys);
+    let mods = WheelModifiers {
+        shift: m.shift,
+        ctrl: m.ctrl,
+        alt: m.alt,
+        fine: fine_held(cfg.fine_modifier, &m),
+    };
+    for effect in decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel) {
+        apply_effect(&mut handle, &mut pty, &mut coalescer, &mut clipboard, effect);
+    }
+}
+
+fn fine_held(modifier: FineModifier, m: &ozma_tty_engine::TerminalModifiers) -> bool {
+    match modifier {
+        FineModifier::Shift => m.shift,
+        FineModifier::Ctrl => m.ctrl,
+        FineModifier::Alt => m.alt,
+        FineModifier::None => true,
+    }
+}
+
+fn map_button(b: MouseButton) -> Option<MouseButtonKind> {
+    match b {
+        MouseButton::Left => Some(MouseButtonKind::Left),
+        MouseButton::Middle => Some(MouseButtonKind::Middle),
+        MouseButton::Right => Some(MouseButtonKind::Right),
+        _ => None,
+    }
+}
+
+fn apply_effect(
+    handle: &mut TerminalHandle,
+    pty: &mut PtyHandle,
+    coalescer: &mut Coalescer,
+    clipboard: &mut Clipboard,
+    effect: MouseEffect,
+) {
+    match effect {
+        MouseEffect::Write(b) => {
+            if let Err(e) = handle.write(pty, &b) {
+                tracing::warn!(?e, "ozma mouse pty write failed");
+            }
+        }
+        MouseEffect::SelStart { point, side, ty } => handle.selection_start_at(coalescer, point, side, ty),
+        MouseEffect::SelUpdate { point, side } => handle.selection_update_to(coalescer, point, side),
+        MouseEffect::SelClear => handle.selection_clear(coalescer),
+        MouseEffect::Copy => {
+            if let Some(text) = handle.selection_to_string() {
+                clipboard.write(text);
+            }
+        }
+        MouseEffect::Scroll(lines) => handle.scroll(coalescer, lines),
+        MouseEffect::OpenUri(uri) => try_open_uri(&uri),
+    }
+}
+```
+
+Add `use ozma_tty_engine::TerminalModifiers;` to the `use` block (or write `current_terminal_modifiers`'s return type via its existing re-export). Register both systems in `OzmaMousePlugin::build`:
+
+```rust
+.add_systems(
+    Update,
+    (dispatch_mouse_buttons, dispatch_mouse_wheel)
+        .in_set(OzmaTerminalMouseSet)
+        .run_if(on_message::<MouseButtonInput>.or(on_message::<CursorMoved>).or(on_message::<MouseWheel>)),
+)
+```
+
+(Add `app.add_message::<MouseButtonInput>().add_message::<MouseWheel>();` if not already present from `DefaultPlugins` — in the headless test we add them manually.)
+
+- [ ] **Step 4: Run the gating test + full crate tests**
+
+Run: `cargo test -p ozma_terminal`
+Expected: PASS (gating test + all pure tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `cargo clippy -p ozma_terminal --all-targets`
+Expected: no warnings.
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(ozma_terminal): mouse-button + wheel dispatch systems
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Host wiring + manual verification
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/input.rs` (promote `current_terminal_modifiers` to `pub(crate)`)
+- Modify: `src/input/shortcuts.rs` (add `populate_mouse_config`)
+- Modify: `src/input.rs` (register it)
+- Modify: `src/ozma_input.rs` (`.before(OzmaTerminalMouseSet)`)
+
+**Interfaces:**
+- Consumes: `ozma_terminal::{OzmaMouseConfig, FineModifier, OzmaTerminalMouseSet}`, `OzmuxConfigsResource.mouse`.
+
+- [ ] **Step 1: Promote `current_terminal_modifiers`**
+
+In `crates/ozma_terminal/src/input.rs:128`, change `fn current_terminal_modifiers` to `pub(crate) fn current_terminal_modifiers`.
+
+Run: `cargo build -p ozma_terminal`
+Expected: compiles (it is now used by `mouse.rs`/`hyperlink.rs`).
+
+- [ ] **Step 2: Write the failing config-mapping test**
+
+In `src/input/shortcuts.rs` `#[cfg(test)] mod tests`, add (after adding the function in Step 3 you will re-run):
+
+```rust
+#[test]
+fn mouse_config_maps_from_ozmux_config() {
+    use ozmux_configs::mouse::{FineModifier as CfgFine, MouseConfig};
+    let mut mc = MouseConfig::default();
+    mc.fine_modifier = CfgFine::Ctrl;
+    mc.max_protocol_events_per_frame = 5;
+    mc.cells_per_notch = 1.0;
+    let out = ozma_mouse_config(&mc);
+    assert_eq!(out.buttons.max_protocol_events_per_frame, 5);
+    assert_eq!(out.wheel.max_protocol_events_per_frame, 5);
+    assert_eq!(out.wheel.lines_per_notch, mc.lines_per_notch);
+    assert_eq!(out.cells_per_notch, 1.0);
+    assert_eq!(out.fine_modifier, ozma_terminal::FineModifier::Ctrl);
+    assert_eq!(out.double_click_timeout, std::time::Duration::from_millis(mc.double_click_timeout_ms as u64));
+    assert_eq!(out.click_drift_px, mc.click_drift_px);
+}
+```
+
+- [ ] **Step 3: Implement the mapping + Startup system**
+
+Add to `src/input/shortcuts.rs` (add `use ozma_terminal::{OzmaMouseConfig, FineModifier};` and `use ozmux_configs::mouse::{FineModifier as CfgFineModifier, MouseConfig};` to the top `use` block; `use ozma_tty_engine::{ButtonConfig, WheelConfig};` too):
+
+```rust
+/// Maps the resolved `[mouse]` config block to the terminal crate's
+/// `OzmaMouseConfig`.
+fn ozma_mouse_config(mc: &MouseConfig) -> OzmaMouseConfig {
+    OzmaMouseConfig {
+        buttons: ButtonConfig { max_protocol_events_per_frame: mc.max_protocol_events_per_frame },
+        wheel: WheelConfig {
+            lines_per_notch: mc.lines_per_notch,
+            fine_lines: mc.fine_lines,
+            max_protocol_events_per_frame: mc.max_protocol_events_per_frame,
+        },
+        cells_per_notch: mc.cells_per_notch,
+        double_click_timeout: std::time::Duration::from_millis(mc.double_click_timeout_ms as u64),
+        click_drift_px: mc.click_drift_px,
+        fine_modifier: match mc.fine_modifier {
+            CfgFineModifier::Shift => FineModifier::Shift,
+            CfgFineModifier::Ctrl => FineModifier::Ctrl,
+            CfgFineModifier::Alt => FineModifier::Alt,
+            CfgFineModifier::None => FineModifier::None,
+        },
+    }
+}
+
+/// `Startup` system: inserts `OzmaMouseConfig` from the resolved `[mouse]` block.
+pub(crate) fn populate_mouse_config(mut commands: Commands, configs: Res<OzmuxConfigsResource>) {
+    commands.insert_resource(ozma_mouse_config(&configs.mouse));
+}
+```
+
+- [ ] **Step 4: Register the Startup system**
+
+In `src/input.rs`, add `shortcuts::populate_mouse_config` to the same `Startup` tuple that holds `shortcuts::build_resolved_shortcuts` / `shortcuts::populate_input_bindings` (around `src/input.rs:37-38`).
+
+- [ ] **Step 5: Gate the mouse set in the host**
+
+In `src/ozma_input.rs`: add `OzmaTerminalMouseSet` to the import from `ozma_terminal`, and extend the `maintain_input_disabled` registration:
+
+```rust
+maintain_input_disabled
+    .before(OzmaTerminalInputSet)
+    .before(OzmaTerminalMouseSet)
+    .run_if(in_state(AppMode::Ozma)),
+```
+
+- [ ] **Step 6: Build, test, lint**
+
+Run: `cargo test -p ozma_terminal && cargo test -p ozmux-gui mouse_config && cargo build && cargo clippy --workspace --all-targets && cargo fmt --check`
+Expected: PASS / no warnings.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `cargo run`
+Verify in Ozma mode (no tmux): (1) run `vim`, click to move the cursor and drag to select — vim reacts (app reporting); (2) at the shell, drag across text → it highlights; release → paste into another app confirms the clipboard got it; (3) `seq 200` then wheel up → the viewport scrolls into scrollback, wheel down returns to the tail; (4) print an OSC-8 hyperlink (`printf '\e]8;;https://example.com\e\\link\e]8;;\e\\\n'`), hover with Cmd held → cursor becomes a pointer; Cmd-click → browser opens.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ozma_terminal/src/input.rs src/input/shortcuts.rs src/input.rs src/ozma_input.rs
+git commit -m "feat(ozma): wire host mouse config + InputDisabled gating for the terminal
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** app reporting (T3 forward path + T6 apply), selection + copy (T3 + T6 copy-on-release), wheel scrollback + alt-screen (T4 + T6), Cmd-click + hover (T5 + T3 OpenUri), config (T2 + T7), gating (T6 + T7), allowlist sharing (T1). Non-goals (autoscroll, inline-webview, middle-click paste, multi-button, Cmd+C) are not implemented, as intended.
+- **Type consistency:** `MouseEffect`, `decide_button`/`decide_wheel`, `cell_at_local`/`cell_at_cursor`/`to_viewport_point`, `OzmaMouseConfig`, `FineModifier`, `OzmaTerminalMouseSet`, `OzmaMouseGesture`/`DragGesture`/`DragPhase`, `ClickTracker`, `WheelAccumulator` are defined in Task 2–4 and consumed by the same names in Tasks 5–7. `ButtonConfig`/`WheelConfig`/`WheelModifiers`/`ProtocolModifiers`/`CellCoord`/`Point`/`Side`/`SelectionType`/`TermMode` are engine re-exports.
+- **Known soft spot:** the systems (`dispatch_mouse_buttons`/`dispatch_mouse_wheel`) are covered only by the headless gating test + the pure decision tests; full end-to-end behavior is covered by the Task 7 manual smoke test (a `TerminalHandle` has no public constructor for a unit test).

--- a/docs/superpowers/specs/2026-06-19-ozma-terminal-mouse-input-design.md
+++ b/docs/superpowers/specs/2026-06-19-ozma-terminal-mouse-input-design.md
@@ -1,0 +1,390 @@
+# ozma_terminal: Mouse Input
+
+**Date:** 2026-06-19
+**Status:** Draft
+
+## Overview
+
+Give the self-contained `crates/ozma_terminal` working mouse support, so a
+consumer that spawns one `OzmaTerminalBundle` gets a terminal where the mouse
+behaves like any modern terminal — with **no mouse wiring of its own**. Four
+behaviors, all driven by routers that **already exist and are unit-tested** in
+`ozma_tty_engine`:
+
+- **App mouse reporting** — forward clicks / drags / wheel to TUI apps that
+  enable mouse mode (vim, htop, less, an inner tmux) as SGR / X10 reports.
+- **Text selection + copy** — click-drag, double / triple-click word / line,
+  Alt+drag block, Shift to force-select even under app capture; copy-on-release
+  to the system clipboard.
+- **Wheel scrollback** — wheel scrolls the viewport when no app has capture;
+  alt-screen apps get arrow-key translation instead.
+- **Cmd-click hyperlinks** — Cmd/Ctrl-click an OSC-8 link to open it, plus a
+  hover cursor (pointer over a link with the modifier held, I-beam over the
+  grid).
+
+This mirrors the keyboard work in
+[`2026-06-19-ozma-terminal-input-action-design.md`](2026-06-19-ozma-terminal-input-action-design.md):
+the crate owns the default mouse dispatcher; the host only maintains
+`InputDisabled` and supplies config.
+
+## Motivation
+
+The standalone `ozma_terminal` (Ozma mode, `AppMode::Ozma`) has **zero** mouse
+support today — only the keyboard `input.rs` dispatcher. Clicking, dragging,
+selecting, and scrolling the wheel all do nothing. Apps that request mouse mode
+receive no events.
+
+### Key insight: the engine already owns the mouse decisions
+
+`ozma_tty_engine` contains a complete, pure, Bevy- and PTY-agnostic mouse
+stack with **no consumers** — orphaned when the old multiplexer's Bevy glue
+was deleted during the tmux migration (commit `8c9a4d9`, "delete old
+mouse/input modules"), while the routers survived because they are
+Bevy-agnostic:
+
+- `buttons.rs` — `ButtonAction::route(modes, evt, mods, cfg)`: the per-event
+  decision. Chooses **forward to app** (SGR/X10 encode → PTY bytes) vs **local
+  selection**, including the Shift-bypass and Alt-block rules.
+- `wheel.rs` — `WheelAction::route(modes, notches, cell, mods, cfg)`: chooses
+  **app wheel report** vs **alt-screen arrow translation** vs **host
+  scrollback**.
+- `mouse_encode.rs` — the shared SGR / X10 encoder (`encode_protocol_event`).
+
+These return abstract actions (`WriteToPty(bytes)`, `StartLocalSelection{…}`,
+`ScrollViewport(lines)`, …). `TerminalHandle` already exposes everything to
+apply them: `current_modes()`, `write()`, `scroll()`, `selection_start_at()` /
+`selection_update_to()` / `selection_clear()` / `selection_to_string()`. The
+hyperlink predicate `grid.hyperlink_at()` and `HyperlinkHoverState` live in
+`ozma_tty_renderer`.
+
+So this is **Bevy glue only**: read input, hit-test the cursor to a cell, track
+click count + drag state, call the router, apply the result. The protocol bytes
+and routing logic are not re-implemented.
+
+## Goals
+
+- A consumer that spawns `OzmaTerminalBundle` gets all four behaviors with no
+  mouse-specific wiring.
+- The crate stays self-contained: it consumes only `ozma_tty_engine`,
+  `ozma_tty_renderer`, `bevy`, `arboard`, and (new) `open`. No dependency on
+  `ozmux_configs`, `ozmux_tmux`, or `bevy_cef`.
+- Mouse is gated by the existing `InputDisabled` marker, identically to the
+  keyboard dispatcher — the host's `src/ozma_input.rs` already maintains it.
+- The security-sensitive URL-scheme allowlist has **one** source of truth
+  shared by the standalone crate and the tmux path (no drift).
+
+## Non-Goals (v1)
+
+- **Drag-autoscroll into scrollback** (dragging a selection past the window
+  edge to extend into off-screen lines). Deferred; the engine routers do not
+  include it and it needs a timer-driven tick.
+- **Inline-webview mouse routing** — the crate has no webview dependency.
+- **Middle-click primary-selection paste** — `ButtonAction::route` intentionally
+  `Noop`s middle/right on the local path.
+- **Simultaneous multi-button gestures** — track one primary button at a time.
+- **`Cmd+C` keyboard copy of a selection** — copy-on-release covers the mouse
+  flow; keyboard copy is a separate concern.
+- **Any change to the tmux mouse path** (`src/tmux/mouse.rs`).
+
+## Architecture
+
+### Crate module map (`crates/ozma_terminal/src`)
+
+| File | Role |
+| --- | --- |
+| `mouse.rs` (new) | `OzmaMousePlugin`, `OzmaMouseConfig`, `OzmaTerminalMouseSet`, `OzmaMouseGesture`, the cursor→cell hit-test + `to_viewport_point` helpers, and the button + wheel dispatch systems (`ClickTracker` + `DragGesture` state machine, pixel→notch accumulation, `ButtonAction` / `WheelAction` application). Split into `mouse/buttons.rs` + `mouse/wheel.rs` only past ~350 lines (see note). |
+| `hyperlink.rs` (new) | Hover-cursor system (updates `HyperlinkHoverState` + `CursorIcon`) and `try_open_uri` (allowlist check + `open::that_detached`). |
+| `lib.rs` (extended) | `mod mouse; mod hyperlink;`; `OzmaTerminalPlugin` adds `OzmaMousePlugin`; re-export `OzmaMouseConfig`, `OzmaTerminalMouseSet`. |
+
+Start with a flat `mouse.rs` — it matches the keyboard sibling `input.rs` (the
+crate's current largest file at 360 lines), and the Ozma glue is materially
+smaller than the tmux path (no panes / dividers / webview routing). Split into
+`mouse/buttons.rs` + `mouse/wheel.rs` (mirroring the engine's own division) only
+if the file grows past ~350 lines.
+
+### Shared crate change (`ozma_tty_renderer`)
+
+Move **only the URL-scheme allowlist** out of `src/input/hyperlink.rs` (which
+keeps its tmux-coupled hover system and its own `try_open_uri`) into the
+renderer `schema` module, where `TerminalGrid` already lives and which is a
+dependency of **both** hosts:
+
+- `schema::scheme_of(uri) -> Option<&str>` (private)
+- `schema::is_allowed(uri) -> bool` — the `http` / `https` / `mailto` / `ftp`
+  allowlist that rejects `javascript:` / `file:` / `data:`
+
+`should_open_at` is **not** relocated: it takes `ozma_tty_engine::MouseButtonKind`
+and `ButtonEventKind`, so moving it into `ozma_tty_renderer` would add a new
+`renderer → engine` crate dependency that does not exist today
+(`crates/ozma_tty_renderer/Cargo.toml` has no `ozma_tty_engine`). Instead each
+host keeps its own trivial `Press + Left + modifier` gate and calls
+`grid.hyperlink_at(row, col)` directly. The security-sensitive part — the
+allowlist — is the single source of truth that must not drift, and that is what
+moves. `src/input/hyperlink.rs` deletes its `scheme_of` / `is_allowed` copies
+and delegates; its `try_open_uri` calls `schema::is_allowed`.
+
+### Three input systems, cleanly partitioned
+
+| System | Set / gating | Reads | Effect |
+| --- | --- | --- | --- |
+| `dispatch_mouse_buttons` | `OzmaTerminalMouseSet`, `run_if(on_message::<MouseButtonInput>.or(on_message::<CursorMoved>))`, skips `InputDisabled` | `MouseButtonInput`, window cursor | `ButtonAction::route` → PTY write / local selection / clipboard |
+| `dispatch_mouse_wheel` | `OzmaTerminalMouseSet`, `run_if(on_message::<MouseWheel>)`, skips `InputDisabled` | `MouseWheel`, window cursor | `WheelAction::route` → PTY write / viewport scroll |
+| `hyperlink_hover_cursor` | `OzmaTerminalMouseSet`, `run_if(on_message::<CursorMoved>.or(on_message::<KeyboardInput>))`, skips `InputDisabled` | window cursor, keys, `TerminalGrid` | updates `HyperlinkHoverState` + window `CursorIcon` |
+
+## Component Specification
+
+### `crates/ozma_terminal/src/mouse.rs`
+
+`OzmaMousePlugin` registers the three systems in `OzmaTerminalMouseSet`,
+`init_resource`s `OzmaMouseConfig`, `OzmaMouseGesture`, and the wheel
+accumulator, and `add_message`s the Bevy input messages it gates on.
+
+```rust
+#[derive(Resource)]
+pub struct OzmaMouseConfig {
+    pub buttons: ButtonConfig,        // engine: max_protocol_events_per_frame
+    pub wheel: WheelConfig,           // engine: lines_per_notch, fine_lines, max_…
+    pub double_click_timeout: Duration,
+    pub click_drift_px: f32,
+    pub drag_threshold_px: f32,
+    pub fine_modifier: FineModifier,  // crate-local enum (NOT ozmux_configs); selects WheelModifiers.fine
+}
+```
+
+`Default`: 400 ms / 8 px drift / 4 px drag threshold, `WheelConfig::default()`
+(3 lines-per-notch, fine = 1, cap 8). **Caveat:** `ButtonConfig` derives
+`Default` with `max_protocol_events_per_frame = 0`, and a zero cap makes
+`route()` drop every forwarded button event (`buttons.rs:117`). So
+`OzmaMouseConfig::default` must set `buttons: ButtonConfig {
+max_protocol_events_per_frame: 8 }` **explicitly** — not `ButtonConfig::default()` —
+or app mouse reporting silently never fires.
+
+Shared helpers (pure, unit-tested):
+
+- `cell_at_cursor(node, transform, cursor_phys, cell_w, cell_h, cols, rows) -> (col0, row0, Side)`
+  — 0-indexed cell + half-cell side, clamped to the grid. Same math as
+  `src/tmux/pane_hit::cell_at_local`. `cols` / `rows` come from the live
+  `TerminalGrid` (window-fill sized, `layout.rs`), not assumed.
+- `to_protocol_cell(col0, row0) -> CellCoord` — `+1` to each (SGR/X10 is
+  1-indexed).
+- `to_viewport_point(cell: CellCoord) -> Point` — `Point { line: Line(row-1),
+  column: Column(col-1) }`; the engine's `selection_start_at` translates this
+  viewport-relative row through `viewport_row_to_line`, so scroll during a drag
+  is handled engine-side.
+- **Thresholds are logical px; the cursor is physical.** `drag_threshold_px` /
+  `click_drift_px` are logical config units — multiply by `window.scale_factor()`
+  before comparing against physical cursor distances (as `src/tmux/mouse.rs:366`
+  does).
+
+### Button dispatch (in `mouse.rs`, or `mouse/buttons.rs` if split)
+
+State:
+
+```rust
+#[derive(Resource, Default)]
+struct OzmaMouseGesture { click: ClickTracker, drag: Option<DragGesture> }
+
+struct DragGesture {
+    button: MouseButtonKind,
+    origin: CellCoord,      // 1-indexed; selection anchor
+    side: Side,
+    ty: SelectionType,
+    phase: DragPhase,       // Armed | Started
+    last_cell: CellCoord,   // dedup + drag synthesis
+}
+enum DragPhase { Armed, Started }
+```
+
+The dispatch system queries `(&mut TerminalHandle, &mut PtyHandle, &mut
+Coalescer)` on the single `OzmaTerminal` — all three are already components on
+the entity (`layout.rs` queries the same trio) — and the `selection_*` /
+`scroll` calls take `&mut Coalescer` to arm the renderer emit.
+
+`ClickTracker` is the timeout+drift→count(1/2/3) tracker already proven in
+`src/tmux/mouse.rs:177` (ported verbatim, not shared — ~19 lines with three
+existing unit tests; the tmux copy stays put).
+
+Per-frame `dispatch_mouse_buttons`:
+
+1. Bail (clearing `MouseButtonInput`, resetting `gesture.drag`, keeping any
+   committed selection) when: no single `OzmaTerminal` without `InputDisabled`,
+   no window, window unfocused, or no cursor position.
+2. Resolve cursor→cell (0-indexed for selection, 1-indexed `CellCoord` for the
+   protocol). `modes = handle.current_modes()`; `mods` from `ButtonInput<KeyCode>`.
+3. Per `MouseButtonInput`:
+   - **Left Press with `link_modifier_held` + a link under the cursor**
+     (`grid.hyperlink_at(row0, col0)` returns `Some(uri)`): `try_open_uri(uri)`,
+     consume (no select / forward). Link check precedes selection, matching the
+     tmux arbiter.
+   - Else build `ButtonEvent { kind, button, cell: protocol_cell, side,
+     click_count }` (count from `ClickTracker` on press) and call
+     `ButtonAction::route(modes, evt, mods, &cfg.buttons)`; apply (table below).
+4. After events: if `gesture.drag` is held and the resolved cell differs from
+   `last_cell`, synthesize a `Drag` event, route it, apply, update `last_cell`.
+
+`apply_button_action`:
+
+| `ButtonAction` | Effect |
+| --- | --- |
+| `WriteToPty(b)` | `handle.write(&mut pty, &b)` |
+| `ClearAndWriteToPty(b)` | `selection_clear(&mut coalescer)`; `handle.write(&mut pty, &b)` |
+| `ArmDrag{cell,side,ty}` | `gesture.drag = DragGesture{phase: Armed, …}`; `selection_clear(&mut coalescer)` |
+| `StartLocalSelection{cell,side,ty}` | `selection_start_at(&mut coalescer, to_viewport_point(cell), side, ty)`; `phase = Started` |
+| `UpdateLocalSelection{cell,side}` | if `Armed` and `cell != origin`: `selection_start_at(&mut coalescer, origin)` then mark `Started`; `selection_update_to(&mut coalescer, to_viewport_point(cell), side)` (these arm the emit — no separate flush) |
+| `ClearLocalSelection` | `selection_clear(&mut coalescer)` |
+| `Noop` | — |
+
+**Copy-on-release:** on Left Release with a live selection (`Started`, or a
+double/triple-click word/line), `if let Some(text) = handle.selection_to_string()
+{ clipboard.write(text); }` (the method returns `Option<String>`), then
+`gesture.drag = None`. App-forward path never sets a selection.
+
+### Wheel dispatch (in `mouse.rs`, or `mouse/wheel.rs` if split)
+
+`WheelAccumulator` resource holds the fractional Pixel-unit remainder so pixel
+deltas accrue into whole notches (Line-unit `y` maps directly). Per-frame
+`dispatch_mouse_wheel`:
+
+1. Same gating as buttons (single enabled terminal, focused window).
+2. Sum `MouseWheel` events into integer `notches` (sign-significant; negative =
+   up/older), keeping the remainder. `Line`-unit `y` maps directly; `Pixel`-unit
+   `y` divides by `cell_h` to match the tmux convention (`src/tmux/input.rs:747`)
+   so trackpad scroll speed is consistent across modes.
+3. Resolve cursor cell (1-indexed) and `WheelModifiers { shift, ctrl, alt, fine }`
+   (`fine` resolved from `cfg.fine_modifier`).
+4. `WheelAction::route(modes, notches, cell, mods, &cfg.wheel)`:
+
+| `WheelAction` | Effect |
+| --- | --- |
+| `ScrollViewport(lines)` | `handle.scroll(&mut coalescer, lines)` |
+| `WriteToPty(b)` | `handle.write(&mut pty, &b)` |
+| `Noop` | — |
+
+### `crates/ozma_terminal/src/hyperlink.rs`
+
+- `link_modifier_held(mods) -> bool` — Cmd (meta) on macOS, Ctrl elsewhere.
+  Reuses the crate's `current_terminal_modifiers` (promoted to `pub(crate)`).
+- `try_open_uri(uri)` — `schema::is_allowed` then `open::that_detached`; drop
+  disallowed with a debug log, warn on opener error.
+- `hyperlink_hover_cursor` system — single full-screen grid, no tmux/CEF. Reads
+  window cursor + keys + `TerminalGrid`, updates `HyperlinkHoverState`
+  (`entity`, `hyperlink_id`, `modifier_held`) so the renderer's hover-underline
+  works in Ozma mode, and sets `PrimaryWindow` `CursorIcon`: `Pointer` over a
+  link with the modifier held, `Text` over the grid, else `Default`. The
+  idempotent-write pattern (only mutate `CursorIcon` on change) is preserved.
+
+### Binary changes (`src/`)
+
+- `src/main.rs` — unchanged; `OzmaTerminalPlugin` already added pulls in
+  `OzmaMousePlugin`. Mouse works at defaults with no further wiring.
+- `src/ozma_input.rs` — add `.before(OzmaTerminalMouseSet)` to the existing
+  `InputDisabled` maintainer so mouse is gated identically to keyboard.
+- `src/input/shortcuts.rs` (or sibling) — a `Startup` system inserts
+  `OzmaMouseConfig` derived from `ozmux_configs` `[mouse]`, mirroring the
+  existing `TerminalInputBindings` derivation.
+- `src/input/hyperlink.rs` — delete `scheme_of` / `is_allowed` / `should_open_at`;
+  delegate to `schema::`.
+
+## Data Flow
+
+```
+winit → Bevy MouseButtonInput / MouseWheel / CursorMoved
+  → OzmaTerminalMouseSet (skips when InputDisabled / unfocused)
+    → hit-test cursor → cell (ComputedNode + UiGlobalTransform + CellMetrics)
+    → buttons: ClickTracker + DragGesture → ButtonEvent
+         → ButtonAction::route(handle.current_modes(), …)
+              → WriteToPty        → handle.write(pty)            [app gets SGR/X10]
+              → Start/Update/Clear → handle.selection_*           [local highlight]
+              → (release)          → clipboard.write(sel_to_string) [copy-on-release]
+    → wheel: accumulate notches → WheelAction::route(…)
+              → ScrollViewport → handle.scroll(coalescer)         [scrollback]
+              → WriteToPty     → handle.write(pty)                [app wheel / alt-screen]
+    → hyperlink: Cmd/Ctrl + link → try_open_uri; hover → CursorIcon + HoverState
+```
+
+### Behavior table
+
+| Input | `MOUSE_MODE` off (or Shift held) | `MOUSE_MODE` on, no Shift |
+| --- | --- | --- |
+| Left click | clear selection | forward press report |
+| Left drag | local selection, copy on release | forward motion reports |
+| Double / triple click | word / line select + copy | forward (router decides) |
+| Alt+drag | block selection | block selection (local, Alt is local) |
+| Wheel (primary screen) | scroll viewport | forward wheel report |
+| Wheel (alt-screen) | arrow translation | forward wheel report |
+| Cmd/Ctrl+click on link | open URL | open URL (link check precedes routing) |
+
+> The two wheel rows actually gate on `MOUSE_REPORT_CLICK | MOUSE_DRAG |
+> MOUSE_MOTION` (the set `WheelAction::route` checks), not the aggregate
+> `MOUSE_MODE` the button rows use; the column headers are a simplification.
+
+## Error Handling
+
+- No window / no cursor position / no enabled terminal → drain events, reset
+  in-progress `DragGesture`, keep committed selection.
+- Window unfocused or `InputDisabled` present → same drain + reset.
+- `handle.write` error → `tracing::warn!` (as the key path does).
+- Protocol burst is capped inside `route()` (`max_protocol_events_per_frame`).
+- Disallowed / malformed link scheme → dropped with a debug log.
+
+## Testing
+
+Protocol-byte correctness and routing decisions are **already** covered by the
+engine's `buttons.rs` / `wheel.rs` / `mouse_encode.rs` tests, so glue tests
+focus on what is new:
+
+- **Pure helpers** (the bulk): `cell_at_cursor` / `to_viewport_point` /
+  `to_protocol_cell`, `ClickTracker`, the `DragGesture` Armed→Started
+  materialization, wheel pixel→notch accumulation, and the relocated
+  `schema::is_allowed` / `scheme_of`.
+- **System-level** (headless app, following the crate's `input.rs` /
+  `clipboard.rs` test style): `InputDisabled` and unfocused gating drop
+  everything; a left drag materializes a selection and copy-on-release writes
+  `Clipboard`; double / triple-click selects word / line; Shift-bypass selects
+  locally even when `MOUSE_MODE` is set; wheel with no app capture scrolls the
+  viewport.
+
+## Migration Steps
+
+1. Relocate the scheme allowlist (`scheme_of` / `is_allowed`) into
+   `ozma_tty_renderer::schema`; update `src/input/hyperlink.rs` to delegate. (No
+   behavior change; the allowlist tests move with them. `should_open_at` stays
+   per-host.)
+2. Add `open = { workspace = true }` to `crates/ozma_terminal/Cargo.toml` (the
+   workspace already pins `open = "5"`; use the `workspace = true` form like the
+   root crate).
+3. Add `crates/ozma_terminal/src/mouse.rs` + `mouse/buttons.rs` + `mouse/wheel.rs`
+   (config, set, gesture, hit-test, systems, apply).
+4. Add `crates/ozma_terminal/src/hyperlink.rs` (hover + open).
+5. Wire `OzmaMousePlugin` into `OzmaTerminalPlugin`; re-export config + set.
+6. Host: `.before(OzmaTerminalMouseSet)` in `src/ozma_input.rs`; insert
+   `OzmaMouseConfig` from `ozmux_configs`.
+7. `cargo test`, `cargo clippy --workspace`, `cargo fmt`; manual smoke (vim
+   mouse, drag-select + paste, wheel scrollback, Cmd-click a link).
+
+## Decisions & Rationale
+
+- **Glue in the crate, not `src/`** — matches the self-contained direction of
+  the keyboard work; the crate can drive a mouse on its own.
+- **Flat `mouse.rs` first** — matches the keyboard sibling `input.rs`; split into
+  `mouse/buttons.rs` + `mouse/wheel.rs` only if it grows past ~350 lines.
+- **Allowlist (only) in renderer `schema`** — single source of truth for
+  security-sensitive scheme filtering, shared by both hosts. `should_open_at` is
+  *not* moved: it depends on `ozma_tty_engine` mouse enums and would create a
+  `renderer → engine` dependency; each host keeps the trivial click-gate and
+  calls `grid.hyperlink_at` directly.
+- **Copy-on-release to system clipboard** — matches the repo's tmux VT
+  selection convention and macOS norms.
+- **Poll the window cursor (not `CursorMoved` deltas) for drag** — matches the
+  tmux arbiter; simpler than reconstructing position from motion events.
+
+## Open Questions
+
+- Should `ClickTracker` (and `cell_at_*`) be extracted to a shared location for
+  both the tmux path and the crate, or is the small duplication acceptable?
+  (Current plan: duplicate; the tmux path is otherwise structurally different.)
+- ~~Default `fine_modifier`~~ **Resolved:** `FineModifier` is a **crate-local**
+  enum (mirroring `ozmux_configs::mouse::FineModifier` but without the
+  dependency, per the self-contained goal); the host maps its config value
+  across the boundary. Default `Shift` (the engine's wheel tests treat
+  Shift-as-fine, `wheel.rs:457`).

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -161,8 +161,6 @@ impl WebviewHandle {
     pub(crate) fn new_shared(id: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
         Self { id, writer }
     }
-
-
 }
 
 #[cfg(test)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -36,6 +36,7 @@ impl Plugin for OzmuxShortcutPlugin {
                 (
                     shortcuts::build_resolved_shortcuts,
                     shortcuts::populate_input_bindings,
+                    shortcuts::populate_mouse_config,
                 )
                     .chain(),
             )

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -14,7 +14,7 @@ use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, Window};
 use bevy_cef::prelude::WebviewSource;
 use ozma_tty_renderer::TerminalCellMetricsResource;
-use ozma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid};
+use ozma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid, is_allowed};
 use ozmux_configs::shortcuts::Modifiers;
 use ozmux_tmux::TmuxPane;
 
@@ -74,31 +74,6 @@ pub(crate) fn should_open_at(
         return None;
     }
     grid.hyperlink_at(row, col).map(|(_id, uri)| uri.clone())
-}
-
-const ALLOWED_SCHEMES: &[&str] = &["http", "https", "mailto", "ftp"];
-
-/// Parses an RFC 3986 scheme: first byte ALPHA, continuation
-/// ALPHA / DIGIT / `+` / `-` / `.`. Returns `None` for malformed input.
-fn scheme_of(uri: &str) -> Option<&str> {
-    let (scheme, _) = uri.split_once(':')?;
-    let mut bytes = scheme.bytes();
-    let first = bytes.next()?;
-    if !first.is_ascii_alphabetic() {
-        return None;
-    }
-    if !bytes.all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.') {
-        return None;
-    }
-    Some(scheme)
-}
-
-/// Returns `true` when `uri` carries a scheme on the v1 allowlist
-/// (`http`, `https`, `mailto`, `ftp`), case-insensitive.
-fn is_allowed(uri: &str) -> bool {
-    scheme_of(uri)
-        .map(|s| s.to_ascii_lowercase())
-        .is_some_and(|s| ALLOWED_SCHEMES.contains(&s.as_str()))
 }
 
 fn hyperlink_hover_and_cursor(
@@ -256,48 +231,6 @@ mod tests {
     use bevy::prelude::Color;
     use ozma_tty_engine::{ButtonEventKind, MouseButtonKind};
     use ozma_tty_renderer::schema::{Cell, HyperlinkId, HyperlinkUri};
-
-    #[test]
-    fn scheme_of_rejects_leading_digit() {
-        assert_eq!(scheme_of("1abc:foo"), None);
-    }
-
-    #[test]
-    fn scheme_of_rejects_empty_scheme() {
-        assert_eq!(scheme_of(":foo"), None);
-        assert_eq!(scheme_of("no-colon"), None);
-    }
-
-    #[test]
-    fn scheme_of_rejects_disallowed_punctuation() {
-        assert_eq!(scheme_of("my_scheme:foo"), None);
-    }
-
-    #[test]
-    fn scheme_of_accepts_canonical_schemes() {
-        assert_eq!(scheme_of("http:foo"), Some("http"));
-        assert_eq!(scheme_of("https:foo"), Some("https"));
-        assert_eq!(scheme_of("git+ssh:foo"), Some("git+ssh"));
-        assert_eq!(scheme_of("a-b.c:foo"), Some("a-b.c"));
-    }
-
-    #[test]
-    fn is_allowed_accepts_canonical_schemes_case_insensitive() {
-        assert!(is_allowed("http://example.com"));
-        assert!(is_allowed("HTTPS://example.com"));
-        assert!(is_allowed("Mailto:foo@example"));
-        assert!(is_allowed("ftp://example.com"));
-    }
-
-    #[test]
-    fn is_allowed_rejects_dangerous_or_unknown_schemes() {
-        assert!(!is_allowed("javascript:alert(1)"));
-        assert!(!is_allowed("file:///etc/passwd"));
-        assert!(!is_allowed("data:text/html,<script>"));
-        assert!(!is_allowed("vscode://"));
-        assert!(!is_allowed(""));
-        assert!(!is_allowed("no-colon-here"));
-    }
 
     fn make_grid_with_link(
         row: usize,

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -1,7 +1,8 @@
-//! OSC 8 hyperlink hover detection, cursor-icon control, scheme
-//! allowlist, and Cmd+click activation. The plugin registered here
-//! also re-exports the pure predicates the mouse-buttons system calls
-//! during interception.
+//! OSC 8 hyperlink hover detection, cursor-icon control, and Cmd+click
+//! activation. Scheme validation is delegated to
+//! `ozma_tty_renderer::schema::is_allowed` (this module does not own the
+//! allowlist). The plugin registered here also re-exports the pure
+//! predicates the mouse-buttons system calls during interception.
 
 use crate::input::{InputPhase, current_modifiers};
 use crate::tmux::pane_hit::{cell_at_local, tmux_pane_at_phys};

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -5,7 +5,9 @@
 
 use crate::configs::OzmuxConfigsResource;
 use bevy::prelude::*;
-use ozma_terminal::{ReservedChord, TerminalInputBindings};
+use ozma_terminal::{FineModifier, OzmaMouseConfig, ReservedChord, TerminalInputBindings};
+use ozma_tty_engine::{ButtonConfig, WheelConfig};
+use ozmux_configs::mouse::{FineModifier as CfgFineModifier, MouseConfig};
 use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
 
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
@@ -119,6 +121,35 @@ pub(crate) fn build_resolved_shortcuts(
 /// `build_resolved_shortcuts`.
 pub(crate) fn populate_input_bindings(mut commands: Commands, resolved: Res<ResolvedShortcuts>) {
     commands.insert_resource(resolved.input_bindings());
+}
+
+/// Maps the resolved `[mouse]` config block to the terminal crate's
+/// `OzmaMouseConfig`.
+fn ozma_mouse_config(mc: &MouseConfig) -> OzmaMouseConfig {
+    OzmaMouseConfig {
+        buttons: ButtonConfig {
+            max_protocol_events_per_frame: mc.max_protocol_events_per_frame,
+        },
+        wheel: WheelConfig {
+            lines_per_notch: mc.lines_per_notch,
+            fine_lines: mc.fine_lines,
+            max_protocol_events_per_frame: mc.max_protocol_events_per_frame,
+        },
+        cells_per_notch: mc.cells_per_notch,
+        double_click_timeout: std::time::Duration::from_millis(mc.double_click_timeout_ms as u64),
+        click_drift_px: mc.click_drift_px,
+        fine_modifier: match mc.fine_modifier {
+            CfgFineModifier::Shift => FineModifier::Shift,
+            CfgFineModifier::Ctrl => FineModifier::Ctrl,
+            CfgFineModifier::Alt => FineModifier::Alt,
+            CfgFineModifier::None => FineModifier::None,
+        },
+    }
+}
+
+/// `Startup` system: inserts `OzmaMouseConfig` from the resolved `[mouse]` block.
+pub(crate) fn populate_mouse_config(mut commands: Commands, configs: Res<OzmuxConfigsResource>) {
+    commands.insert_resource(ozma_mouse_config(&configs.mouse));
 }
 
 /// Maps a config logical `Key` to the physical `KeyCode` ozmux matches on.
@@ -278,6 +309,28 @@ mod tests {
         let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
         assert!(r.is_release_inline_focus(KeyCode::Escape, mods(true, true, false, false)));
         assert!(!r.is_release_inline_focus(KeyCode::KeyV, mods(false, false, false, true)));
+    }
+
+    #[test]
+    fn mouse_config_maps_from_ozmux_config() {
+        use ozmux_configs::mouse::{FineModifier as CfgFine, MouseConfig};
+        let mc = MouseConfig {
+            fine_modifier: CfgFine::Ctrl,
+            max_protocol_events_per_frame: 5,
+            cells_per_notch: 1.0,
+            ..MouseConfig::default()
+        };
+        let out = ozma_mouse_config(&mc);
+        assert_eq!(out.buttons.max_protocol_events_per_frame, 5);
+        assert_eq!(out.wheel.max_protocol_events_per_frame, 5);
+        assert_eq!(out.wheel.lines_per_notch, mc.lines_per_notch);
+        assert_eq!(out.cells_per_notch, 1.0);
+        assert_eq!(out.fine_modifier, ozma_terminal::FineModifier::Ctrl);
+        assert_eq!(
+            out.double_click_timeout,
+            std::time::Duration::from_millis(mc.double_click_timeout_ms as u64)
+        );
+        assert_eq!(out.click_drift_px, mc.click_drift_px);
     }
 
     #[test]

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -9,6 +9,7 @@ use ozma_terminal::{FineModifier, OzmaMouseConfig, ReservedChord, TerminalInputB
 use ozma_tty_engine::{ButtonConfig, WheelConfig};
 use ozmux_configs::mouse::{FineModifier as CfgFineModifier, MouseConfig};
 use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
+use std::time::Duration;
 
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
 /// the exact modifier set required, and the action to run.
@@ -136,7 +137,7 @@ fn ozma_mouse_config(mc: &MouseConfig) -> OzmaMouseConfig {
             max_protocol_events_per_frame: mc.max_protocol_events_per_frame,
         },
         cells_per_notch: mc.cells_per_notch,
-        double_click_timeout: std::time::Duration::from_millis(mc.double_click_timeout_ms as u64),
+        double_click_timeout: Duration::from_millis(mc.double_click_timeout_ms as u64),
         click_drift_px: mc.click_drift_px,
         fine_modifier: match mc.fine_modifier {
             CfgFineModifier::Shift => FineModifier::Shift,

--- a/src/ozma_input.rs
+++ b/src/ozma_input.rs
@@ -14,7 +14,7 @@ use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
-use ozma_terminal::{InputDisabled, OzmaTerminal, OzmaTerminalInputSet};
+use ozma_terminal::{InputDisabled, OzmaTerminal, OzmaTerminalInputSet, OzmaTerminalMouseSet};
 use ozmux_configs::shortcuts::ShortcutAction;
 
 /// Registers the host-side input systems for `AppMode::Ozma`.
@@ -26,6 +26,7 @@ impl Plugin for OzmaHostInputPlugin {
             Update,
             maintain_input_disabled
                 .before(OzmaTerminalInputSet)
+                .before(OzmaTerminalMouseSet)
                 .run_if(in_state(AppMode::Ozma)),
         )
         .add_systems(


### PR DESCRIPTION
## Problem

Ozma mode — the standalone single-terminal `ozma_terminal` crate (`AppMode::Ozma`) — had **no mouse support at all**. Clicking, dragging, text selection, and the scroll wheel did nothing, and TUI apps that enable mouse mode (vim `set mouse=a`, htop, less, an inner tmux) received no events. Only keyboard input was wired.

The engine (`ozma_tty_engine`) already shipped a complete, unit-tested **but entirely unused** mouse stack — `ButtonAction::route`, `WheelAction::route`, and the SGR/X10 encoder — orphaned when the old multiplexer's Bevy glue was removed during the tmux migration. The decision logic existed; nothing drove it.

## Solution

Add the Bevy glue in `ozma_terminal` that drives the engine's existing routers, plus minimal host wiring. The crate stays self-contained (mirrors the keyboard `input.rs` path) and is gated by the existing `InputDisabled` marker, so the host's `src/ozma_input.rs` already governs when it runs.

**Behaviors** (the four the engine routers already decide between):
- **App mouse reporting** — clicks, **drags**, and wheel forwarded to mouse-capturing apps as SGR/X10 reports.
- **Text selection + copy-on-release** — click-drag, double/triple-click word/line, Alt+drag block, Shift to force-select even under app capture; copies to the system clipboard.
- **Wheel scrollback** — scrolls the viewport when no app has capture; alt-screen apps get arrow-key translation.
- **Cmd/Ctrl-click hyperlinks** — opens OSC-8 links, with a hover cursor (pointer over a link with the modifier held, I-beam over the grid).

**Architecture:** pure `decide_button` / `decide_wheel` functions return a private `MouseEffect` list (PTY-free, so unit-testable without a `TerminalHandle`, which has no public constructor); a thin `apply_effect` writes the effects to the `TerminalHandle` / `Clipboard`. Two dispatch systems + one hover system. Protocol-byte correctness stays in the engine's existing tests.

**Affected parts:**
- **`crates/ozma_terminal`** (engine consumer) — new `mouse.rs` + `hyperlink.rs`; `OzmaMousePlugin`, `OzmaMouseConfig`, `OzmaTerminalMouseSet` (added by `OzmaTerminalPlugin`).
- **`crates/ozma_tty_renderer`** (engine/schema) — the security-sensitive URL-scheme allowlist (`is_allowed`/`scheme_of`) moved into `schema` so the binary and the crate share one source of truth; `src/input/hyperlink.rs` now delegates.
- **`src/`** (binary/host) — maps `ozmux_configs` `[mouse]` → `OzmaMouseConfig`; `maintain_input_disabled` now also gates `OzmaTerminalMouseSet`.
- **`docs/`** — design spec + implementation plan.

**Scope:** Ozma mode only. The Ozmux/tmux-mode mouse path (`src/tmux/`) is a separate, pre-existing implementation (pane focus, dividers, copy-mode IPC, native VT selection, inline-webview routing) and is **intentionally left unchanged** — it does not use the engine routers.

**Testing:** `ozma_terminal` 55 + `ozma_tty_renderer` 40 unit tests pass; `cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean. A max-effort code-review pass caught and fixed a drag-motion forwarding bug and an off-node-release state leak.

⚠️ The **interactive GUI smoke is pending manual verification** — the CEF-backed GUI can't run headlessly, so please sanity-check vim-`set mouse=a` dragging, drag-select + paste, wheel scrollback, and Cmd-click on a link before merge.

<sub>Note: a workspace `cargo fmt` incidentally reflowed `apps/ozbrowser/src/main.rs` (hand-aligned literals → rustfmt form) and reordered imports in `crates/tmux_session` / `sdk/ratatui-ozma` — formatting only, no logic.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
