### PR TITLE
fix(cef): per-process root_cache_path so multiple ozmux instances run concurrently

### DIFF
--- a/docs/superpowers/plans/2026-06-20-cef-per-process-profile.md
+++ b/docs/superpowers/plans/2026-06-20-cef-per-process-profile.md
@@ -1,0 +1,381 @@
+# Per-Process CEF Profile Directory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each ozmux process a unique per-PID CEF `root_cache_path` so multiple instances run concurrently without Chromium's per-profile singleton-lock error.
+
+**Architecture:** A new `src/cef_profile.rs` module owns a `CefProfileDir` RAII guard — a per-PID directory `$TMPDIR/ozmux-cef/<pid>/` created at startup (after sweeping dead-owner dirs), passed to bevy_cef's `CefPlugin.root_cache_path`, and removed on drop. The startup sweep (not `Drop`) is the primary cleanup, since macOS teardown may not unwind. It mirrors the existing `RuntimeRoot` idiom in `crates/webview_host/src/host.rs`.
+
+**Tech Stack:** Rust (edition 2024), Bevy 0.18, `bevy_cef` (git `passthrough`, CEF 145), `libc` (already a dependency) for PID-liveness, `std::fs` / `std::env::temp_dir`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-cef-per-process-profile-design.md`
+
+## Global Constraints
+
+- Edition 2024, toolchain pinned `1.95` (`rust-toolchain.toml`).
+- No `mod.rs`; module files are `foo.rs` (`.claude/rules/rust.md`).
+- All `use` at file top in one contiguous block; no inline fully-qualified paths in signatures/bodies.
+- Comments: only `// TODO:` / `// NOTE:` / `// SAFETY:`. `// NOTE:` is for critical caveats only.
+- Doc comments: `//!` on the module file; `///` on every externally-`pub` item (not required for `pub(crate)`).
+- Visibility: start private; widen only for real callers. Items used only across modules in this binary crate are `pub(crate)`, not `pub`.
+- Item ordering: `pub` / `pub(crate)` items before private (no-modifier) items.
+- Parameter ordering: mutable params before immutable (n/a here — all params are immutable by-value).
+- `unsafe { ... }` requires a `// SAFETY:` comment.
+- Lint/format gate before commit: `cargo clippy --workspace --all-targets` clean and `cargo fmt`.
+- Target platform is macOS; `libc::kill` covers all unix, with a `#[cfg(not(unix))]` fallback.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/cef_profile.rs` (**new**) | `CefProfileDir` RAII guard: per-PID profile dir, startup sweep of dead-owner dirs, `Drop` cleanup, PID-liveness. Pure `std::fs` + `libc::kill`; unit-tested without GUI/CEF. |
+| `src/webview_render.rs` (**modify**) | `cef_plugin()` gains a `root_cache_path: PathBuf` parameter and sets `CefPlugin.root_cache_path: Some(..)`. |
+| `src/main.rs` (**modify**) | Declare `mod cef_profile;`; in `main()`, `CefProfileDir::acquire()` before building the app, pass its path into `cef_plugin(..)`, hold the guard for the app's lifetime. |
+
+This is one cohesive change (a new leaf module plus two wiring edits). It is a single task: the module is dead code without the wiring, so a reviewer gates them together. Steps follow TDD; the final committed state is warning-clean.
+
+---
+
+### Task 1: Per-process CEF profile directory
+
+**Files:**
+- Create: `src/cef_profile.rs`
+- Test: `src/cef_profile.rs` (inline `#[cfg(test)] mod tests`)
+- Modify: `src/main.rs` (mod declaration + `main()` wiring)
+- Modify: `src/webview_render.rs` (`cef_plugin` signature + body)
+
+**Interfaces:**
+- Produces:
+  - `pub(crate) struct CefProfileDir` with `pub(crate) fn acquire() -> std::io::Result<CefProfileDir>` and `pub(crate) fn path(&self) -> &std::path::Path`.
+  - Private internals (same module + tests only): `fn resolve_in(parent: &Path, pid: u32) -> std::io::Result<CefProfileDir>`, `fn sweep_in(base: &Path, is_alive: impl Fn(u32) -> bool, self_pid: u32)`, `fn pid_alive(pid: u32) -> bool`.
+  - `cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: PathBuf) -> CefPlugin` (changed signature).
+- Consumes: bevy_cef `CefPlugin { root_cache_path: Option<String>, .. }` (`/Users/taiga/workspace/bevy_cef/wt/passthrough/src/lib.rs:48-58`); `RuntimeRoot` idiom for reference (`crates/webview_host/src/host.rs`).
+
+---
+
+- [ ] **Step 1: Write the failing tests + module skeleton**
+
+Create `src/cef_profile.rs` with the module doc, the public surface as stubs (so the test module compiles and the asserts fail), and the four hermetic unit tests:
+
+```rust
+//! Per-process CEF profile directory: a unique `root_cache_path` per ozmux
+//! instance so concurrent instances never collide on Chromium's per-profile
+//! singleton lock.
+
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// A per-process CEF profile directory (`$TMPDIR/ozmux-cef/<pid>/`), removed on drop.
+///
+/// Chromium's `ProcessSingleton` permits only one live process per profile
+/// directory, so a shared profile makes a second ozmux instance fail. Keying the
+/// directory by PID guarantees concurrent instances never collide, since live
+/// PIDs are unique.
+pub(crate) struct CefProfileDir {
+    path: PathBuf,
+}
+
+impl CefProfileDir {
+    /// Sweeps stale per-PID profile directories (dead owners) under the shared
+    /// base, then creates and claims this process's own profile directory.
+    pub(crate) fn acquire() -> std::io::Result<Self> {
+        todo!()
+    }
+
+    /// The absolute path to pass to CEF as `root_cache_path`.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn resolve_in(_parent: &Path, _pid: u32) -> std::io::Result<Self> {
+        todo!()
+    }
+}
+
+impl Drop for CefProfileDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn sweep_in(_base: &Path, _is_alive: impl Fn(u32) -> bool, _self_pid: u32) {
+    todo!()
+}
+
+#[cfg(unix)]
+fn pid_alive(_pid: u32) -> bool {
+    todo!()
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_in_creates_0700_dir_and_drops() {
+        let parent = tempfile::tempdir().unwrap();
+        let path = {
+            let profile = CefProfileDir::resolve_in(parent.path(), 4242).unwrap();
+            assert!(profile.path().is_absolute());
+            assert_eq!(profile.path(), parent.path().join("4242"));
+            #[cfg(unix)]
+            {
+                let mode = std::fs::metadata(profile.path())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+                assert_eq!(mode, 0o700);
+            }
+            profile.path().to_path_buf()
+        };
+        assert!(!path.exists(), "Drop must remove the profile dir");
+    }
+
+    #[test]
+    fn resolve_in_replaces_stale_same_pid_dir() {
+        let parent = tempfile::tempdir().unwrap();
+        let stale = parent.path().join("4243");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("SingletonLock"), b"stale").unwrap();
+
+        let profile = CefProfileDir::resolve_in(parent.path(), 4243).unwrap();
+
+        assert_eq!(profile.path(), stale);
+        assert!(profile.path().exists());
+        assert!(
+            !profile.path().join("SingletonLock").exists(),
+            "a fresh profile dir must not inherit the stale lock marker"
+        );
+        assert!(
+            std::fs::read_dir(profile.path()).unwrap().next().is_none(),
+            "the re-created profile dir must be empty"
+        );
+    }
+
+    #[test]
+    fn sweep_in_removes_dead_keeps_alive_and_self() {
+        let base = tempfile::tempdir().unwrap();
+        for pid in ["100", "200", "300"] {
+            std::fs::create_dir_all(base.path().join(pid)).unwrap();
+        }
+        let is_alive = |pid: u32| pid == 100;
+
+        sweep_in(base.path(), is_alive, 300);
+
+        assert!(base.path().join("100").exists(), "alive owner kept");
+        assert!(!base.path().join("200").exists(), "dead owner swept");
+        assert!(base.path().join("300").exists(), "self never swept");
+    }
+
+    #[test]
+    fn sweep_in_ignores_non_numeric_entries() {
+        let base = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(base.path().join("not-a-pid")).unwrap();
+        std::fs::write(base.path().join("README"), b"x").unwrap();
+        std::fs::create_dir_all(base.path().join("200")).unwrap();
+        let is_alive = |_pid: u32| false;
+
+        sweep_in(base.path(), is_alive, 999);
+
+        assert!(base.path().join("not-a-pid").exists(), "non-numeric dir untouched");
+        assert!(base.path().join("README").exists(), "stray file untouched");
+        assert!(!base.path().join("200").exists(), "numeric dead owner swept");
+    }
+}
+```
+
+Then declare the module in `src/main.rs`. Add `mod cef_profile;` to the module-declaration block (alphabetical, between `mod bootstrap;` and `mod configs;`):
+
+```rust
+mod bootstrap;
+mod cef_profile;
+mod configs;
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --bin ozmux-gui cef_profile -- --nocapture`
+Expected: the three tests that exercise `resolve_in` / `sweep_in` FAIL via `todo!()` panic (`not yet implemented`). (`resolve_in_creates_0700_dir_and_drops`, `resolve_in_replaces_stale_same_pid_dir`, `sweep_in_removes_dead_keeps_alive_and_self`, `sweep_in_ignores_non_numeric_entries` all panic.)
+
+- [ ] **Step 3: Implement `resolve_in`, `sweep_in`, `acquire`, `pid_alive`**
+
+Replace the three `todo!()` bodies (`acquire`, `resolve_in`, `sweep_in`, and the unix `pid_alive`) with the real implementations:
+
+```rust
+    pub(crate) fn acquire() -> std::io::Result<Self> {
+        let base = std::env::temp_dir().join("ozmux-cef");
+        std::fs::create_dir_all(&base)?;
+        #[cfg(unix)]
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700))?;
+        let pid = std::process::id();
+        sweep_in(&base, pid_alive, pid);
+        Self::resolve_in(&base, pid)
+    }
+```
+
+```rust
+    fn resolve_in(parent: &Path, pid: u32) -> std::io::Result<Self> {
+        let path = parent.join(pid.to_string());
+        // NOTE: no concurrent process can share our PID, so a pre-existing dir
+        // here is a stale leftover from a dead same-PID process; removing it
+        // keeps the profile freshly ephemeral. It must never inherit cross-run
+        // state — a reused stale SingletonLock would otherwise mislead Chromium.
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path)?;
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
+        Ok(Self { path })
+    }
+```
+
+```rust
+fn sweep_in(base: &Path, is_alive: impl Fn(u32) -> bool, self_pid: u32) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid != self_pid && !is_alive(pid) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+```
+
+```rust
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: `kill` with signal 0 sends no signal; it performs only the
+    // existence/permission check and has no preconditions on `pid`.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // NOTE: ESRCH means no such process (dead); any other errno (e.g. EPERM —
+    // the process exists but is owned by another user) means alive.
+    // Misclassifying a live PID as dead would let the sweep delete a running
+    // instance's profile directory.
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test --bin ozmux-gui cef_profile`
+Expected: `test result: ok. 4 passed; 0 failed`.
+
+- [ ] **Step 5: Wire `cef_plugin` and `main()`**
+
+In `src/webview_render.rs`, add the import (top `use` block) and change `cef_plugin`:
+
+```rust
+use std::path::PathBuf;
+```
+
+```rust
+/// Builds the `CefPlugin` with the `ozma-dyn://` (dynamic, Tier 1) scheme bound
+/// to its shared `DynAssetRegistry`, using `root_cache_path` as this process's
+/// unique CEF profile directory (one Chromium singleton lock per instance).
+pub fn cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: PathBuf) -> CefPlugin {
+    CefPlugin {
+        custom_schemes: vec![custom_dyn_scheme(dyn_registry)],
+        command_line_config: cef_command_line_config(),
+        root_cache_path: Some(root_cache_path.to_string_lossy().into_owned()),
+        ..Default::default()
+    }
+}
+```
+
+In `src/main.rs`, add the import to the `use` block:
+
+```rust
+use crate::cef_profile::CefProfileDir;
+```
+
+In `main()`, acquire the profile right after `let dyn_registry = DynAssetRegistry::default();` and bind it so it lives for the whole app run:
+
+```rust
+    let dyn_registry = DynAssetRegistry::default();
+    let cef_profile =
+        CefProfileDir::acquire().expect("create per-process CEF profile directory");
+```
+
+Then pass the path into `cef_plugin` (replace the existing `cef_plugin(dyn_registry.clone()),` line inside the first `.add_plugins((..))` tuple):
+
+```rust
+            cef_plugin(dyn_registry.clone(), cef_profile.path().to_path_buf()),
+```
+
+The `cef_profile` binding stays in scope until `main()` returns (after `.run()`), so its `Drop` is the best-effort secondary cleanup; the startup sweep is primary.
+
+- [ ] **Step 6: Build, lint, and re-test (final state must be warning-clean)**
+
+Run: `cargo build --bin ozmux-gui`
+Expected: compiles with no warnings (no `dead_code` for `CefProfileDir` / `acquire` / `path`, now that `main()` uses them).
+
+Run: `cargo clippy --workspace --all-targets`
+Expected: no warnings.
+
+Run: `cargo fmt`
+Then: `cargo test --bin ozmux-gui cef_profile`
+Expected: `test result: ok. 4 passed; 0 failed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cef_profile.rs src/main.rs src/webview_render.rs
+git commit -m "$(cat <<'EOF'
+fix(cef): per-process root_cache_path so multiple instances run concurrently
+
+Each ozmux process now gets a unique CEF profile dir ($TMPDIR/ozmux-cef/<pid>),
+keyed by PID, so concurrent instances never collide on Chromium's per-profile
+singleton lock. A startup sweep removes dead-owner dirs (primary cleanup, since
+macOS teardown may not unwind); Drop is best-effort secondary cleanup.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 8: Manual verification (cannot be automated — needs GUI + CEF)**
+
+This step does not commit; it confirms the runtime fix. Requires `make setup-cef` to have been run.
+
+1. Build and launch two instances:
+   - Terminal A: `cargo run` — confirm the embedded webview renders.
+   - Terminal B (while A is running): `cargo run` — confirm it ALSO launches and renders, with **no** CEF singleton/profile error.
+2. While both run: `ls $TMPDIR/ozmux-cef/` shows one `<pid>` directory per live instance.
+3. Quit both. Launch a third instance, then quit it; confirm `ls $TMPDIR/ozmux-cef/` does not accumulate dead-owner dirs (the startup sweep reclaimed them).
+4. Confirm ozmux no longer writes a fresh lock into `~/Library/Application Support/CEF/User Data` (its `SingletonLock` is no longer (re)created by ozmux launches).
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Per-PID unique `root_cache_path` → Step 5 (`cef_plugin` sets `Some(path)`), Step 3/5 (`acquire` builds `$TMPDIR/ozmux-cef/<pid>`). ✓
+- Startup sweep of dead-owner dirs (primary cleanup) → Step 3 `sweep_in` + `acquire`; tested Step 1/4. ✓
+- `Drop` secondary cleanup → Step 1 `impl Drop`; tested by `resolve_in_creates_0700_dir_and_drops`. ✓
+- Same-PID stale-dir removal (fresh ephemeral invariant) → Step 3 `resolve_in` `remove_dir_all`; tested by `resolve_in_replaces_stale_same_pid_dir`. ✓
+- Base dir `0700` + per-PID dir `0700` → Step 3 `acquire` / `resolve_in`; tested by `resolve_in_creates_0700_dir_and_drops`. ✓
+- `libc::kill(pid, 0)` liveness (ESRCH=dead, EPERM/0=alive) + non-unix fallback → Step 3 `pid_alive` + Step 1 `#[cfg(not(unix))]`. ✓
+- Incognito/in-memory comes free (bevy_cef leaves `cache_path` empty) → no code needed; documented in spec. ✓
+- Hold guard for app lifetime → Step 5 `cef_profile` binding in `main()`. ✓
+- Manual two-instance verification → Step 8. ✓
+
+**2. Placeholder scan:** No `TBD`/`TODO`/"handle errors" placeholders; every code step shows complete code. The `todo!()` bodies in Step 1 are intentional TDD red-state stubs, fully replaced in Step 3. ✓
+
+**3. Type consistency:** `CefProfileDir`, `acquire() -> io::Result<Self>`, `path(&self) -> &Path`, `resolve_in(&Path, u32) -> io::Result<Self>`, `sweep_in(&Path, impl Fn(u32)->bool, u32)`, `pid_alive(u32) -> bool`, and `cef_plugin(DynAssetRegistry, PathBuf) -> CefPlugin` are used identically across Steps 1, 3, and 5. ✓

--- a/docs/superpowers/specs/2026-06-20-cef-per-process-profile-design.md
+++ b/docs/superpowers/specs/2026-06-20-cef-per-process-profile-design.md
@@ -1,0 +1,248 @@
+# Per-Process CEF Profile Directory — Design
+
+**Date:** 2026-06-20
+**Status:** Draft (pending spec review)
+**Topic:** Fix the CEF error that occurs when multiple ozmux instances run concurrently.
+
+## Problem
+
+Launching a second ozmux instance while a first is already running produces a
+CEF error and the second instance's embedded webview fails to start.
+
+### Root cause (confirmed)
+
+ozmux never sets a per-instance CEF `root_cache_path`, so every instance shares
+one Chromium profile directory, and Chromium permits only one live process per
+profile directory.
+
+The chain:
+
+1. `src/webview_render.rs` — `cef_plugin()` builds
+   `CefPlugin { custom_schemes, command_line_config, ..Default::default() }`.
+   The `..Default::default()` leaves **`root_cache_path: None`**.
+2. That flows through bevy_cef's `MessageLoopPlugin` → `cef_initialize`, which
+   does `root_cache_path.unwrap_or_default()` → CEF `Settings.root_cache_path = ""`
+   (empty). `cache_path` is also empty (bevy_cef never sets it).
+3. With **both** `cache_path` and `root_cache_path` empty, CEF on macOS falls
+   back to the fixed platform default profile directory:
+   `~/Library/Application Support/CEF/User Data`.
+4. Confirmed live on this machine: that directory exists and holds Chromium's
+   process-singleton lock:
+
+   ```
+   SingletonLock   -> <host>-<pid>
+   SingletonCookie -> <number>
+   SingletonSocket -> /var/folders/.../SingletonSocket
+   ```
+
+5. Chromium's `ProcessSingleton` permits exactly one process per profile dir.
+   A second ozmux points at the **same** `User Data` dir, cannot acquire the
+   lock held by instance #1, and the CEF init / browser creation fails.
+
+### Secondary findings (context, not in scope to fix here)
+
+- bevy_cef's doc comment on `CefPlugin::root_cache_path` claims empty defaults to
+  "the executable's directory"; the real CEF behavior (proven by the live lock
+  dir above) is the platform default user-data dir. The doc is inaccurate.
+  Fixing it is an optional upstream follow-up in the separate bevy_cef repo.
+- The repo previously isolated this in the old out-of-process browser host
+  (git `3c30383`, "per-activity profile isolation"); the current in-process
+  bevy_cef path dropped explicit cache scoping.
+- `RuntimeRoot` (the per-PID control-socket dir in `crates/webview_host`) is
+  already isolated per process, but it is unrelated to the CEF cache and does
+  not help here.
+
+## Goal & non-goals
+
+**Goal:** Multiple ozmux instances run concurrently, each with its own CEF
+profile, with no singleton-lock conflict.
+
+**Chosen model:** Ephemeral per-process profile. Each instance gets a unique,
+absolute `root_cache_path` keyed by PID. Two concurrent instances always have
+distinct PIDs, so they can never collide on the lock. No cross-run persistence
+is expected (the Tier-1 inline webviews are app-driven and ephemeral).
+
+**Non-goals (YAGNI):**
+
+- No persistent cache across runs; no cross-run instance identity.
+- No config knob for the profile location.
+- Not fixing bevy_cef's inaccurate doc comment in this change.
+- Windows is not a target (ozmux ships macOS-only per `CLAUDE.md` / `Makefile`).
+
+## Design
+
+A new `src/cef_profile.rs` module owns one concern: compute, create, and clean
+up a unique per-process CEF profile directory. It mirrors the existing
+`RuntimeRoot` (`crates/webview_host/src/host.rs`) idiom: a per-PID directory
+under the system temp dir, `0700`, removed on `Drop`, with a testable
+`resolve_in(parent, pid)` core.
+
+### Data flow
+
+```
+main()
+  └─ CefProfileDir::acquire()
+        ├─ sweep dead-owner dirs under $TMPDIR/ozmux-cef/
+        └─ create $TMPDIR/ozmux-cef/<pid>/   (0700)
+  └─ cef_plugin(dyn_registry, profile.path())   // passes Some(path) as root_cache_path
+        └─ CEF: unique profile → unique SingletonLock → no cross-instance conflict
+  └─ guard `cef_profile` held in main() for the app's lifetime
+        └─ Drop = best-effort secondary cleanup
+```
+
+Because bevy_cef leaves `cache_path` empty, CEF runs the profile in **incognito
+(in-memory) mode**: page caches are in-memory and no profile-specific data is
+persisted. Installation-specific data (the `SingletonLock` / `SingletonCookie`
+/ `SingletonSocket` skeleton) is still written under `root_cache_path` — which
+is exactly what we want, since the per-PID lock is the whole point. No change to
+bevy_cef is required; we only populate the `root_cache_path` it already exposes.
+Note bevy_cef's `cef_initialize` already `create_dir_all`s a non-empty
+`root_cache_path`, so ozmux's own directory creation (below) is partly redundant
+— but still required, because the sweep and the `0700` chmod must happen *before*
+CEF initializes, and CEF never chmods.
+
+### The `CefProfileDir` type
+
+```rust
+//! Per-process CEF profile directory: a unique root_cache_path per ozmux
+//! instance so concurrent instances never collide on Chromium's per-profile
+//! singleton lock.
+
+/// A per-process CEF profile directory (`<base>/ozmux-cef/<pid>/`), removed on drop.
+pub struct CefProfileDir {
+    path: PathBuf,
+}
+
+impl CefProfileDir {
+    /// Sweeps stale per-PID profile dirs (dead owners) under the shared base,
+    /// then creates and claims this process's own profile dir.
+    pub fn acquire() -> std::io::Result<Self> {
+        // base = std::env::temp_dir().join("ozmux-cef")
+        // create base (chmod 0700, parity with RuntimeRoot's intermediate dir);
+        // sweep_in(base, pid_alive, std::process::id()); resolve_in(base, pid)
+    }
+
+    /// The absolute path to pass as CEF `root_cache_path`.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    // --- testable internals ---
+
+    fn resolve_in(parent: &Path, pid: u32) -> std::io::Result<Self> {
+        // root = parent/<pid>
+        // remove_dir_all(root) first — no concurrent process can share our PID,
+        //   so any pre-existing root is a stale leftover from a dead same-PID
+        //   process; removing it guarantees a fresh, truly-ephemeral profile.
+        // create_dir_all(root); chmod 0700 (parity with RuntimeRoot)
+    }
+
+    fn sweep_in(base: &Path, is_alive: impl Fn(u32) -> bool, self_pid: u32) {
+        // for each dir entry whose name parses as u32 `n`:
+        //   if n != self_pid && !is_alive(n) { let _ = remove_dir_all(entry); }
+        // ignore non-numeric entries and all errors (best-effort)
+    }
+}
+
+impl Drop for CefProfileDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // libc::kill(pid as i32, 0): 0 or EPERM => alive; ESRCH => dead
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    // conservative: never sweep on non-unix; rely on Drop only
+    true
+}
+```
+
+`resolve_in` and `sweep_in` take injected parameters (a parent path; a liveness
+predicate) so they are unit-testable with no GUI, no CEF, and no real PIDs —
+exactly the `RuntimeRoot::resolve_in` testability shape already in the repo.
+
+The root crate already depends on `libc` (`Cargo.toml`), so `pid_alive` adds no
+new dependency.
+
+### Wiring
+
+- `cef_plugin` gains a parameter:
+  `pub fn cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: PathBuf) -> CefPlugin`.
+  It sets `root_cache_path: Some(root_cache_path.to_string_lossy().into_owned())`
+  instead of relying on `..Default::default()`'s `None`.
+- `main()` resolves the profile before building the app and holds the guard for
+  the app's lifetime:
+
+  ```rust
+  let cef_profile = CefProfileDir::acquire().expect("create CEF profile dir");
+  // ...
+  cef_plugin(dyn_registry.clone(), cef_profile.path().to_path_buf())
+  // ...
+  // `cef_profile` stays bound in main() across `.run()`.
+  ```
+
+### Cleanup semantics (robustness core)
+
+- **Primary = startup sweep.** `Drop` is **not** guaranteed to run on every exit
+  path: the macOS winit/CEF teardown may tear the process down without unwinding
+  `main()`'s stack, and bevy_cef's helper-process path calls `std::process::exit`
+  (which skips destructors). Rather than depend on resolving exactly which quit
+  paths unwind, the design makes the sweep — not `Drop` — the primary cleanup.
+  The sweep removes any `ozmux-cef/<pid>` whose owner is dead, reclaiming dirs
+  left by `kill -9`, hard exits, or any non-unwinding teardown.
+- **Secondary = `Drop`** on clean teardown.
+- The sweep **never** deletes the current PID's dir or a live PID's dir.
+- PID reuse — **other** PIDs: if a dead instance's PID now belongs to a live
+  unrelated process, the sweep skips that stale dir (treats it as alive). This is
+  a tiny, bounded leak that self-heals when that PID later dies, and is harmless
+  because no live ozmux uses that stale dir. (Even if such a stale dir were
+  reused, its `SingletonLock` points at a dead PID, which Chromium breaks
+  automatically.)
+- PID reuse — **our own** PID: a leftover `ozmux-cef/<our-pid>` can exist at
+  startup if a previous process with the same PID died without cleanup. Since no
+  *concurrent* process can share our PID, that dir is necessarily stale, so
+  `resolve_in` deletes it before recreating — preserving the "fresh, ephemeral
+  profile per run" invariant (no inherited cross-run state).
+
+### Error handling
+
+- `acquire()` returns `io::Result`; `main()` `.expect()`s it with a clear
+  message. If the temp dir is not writable, CEF could not run anyway, so failing
+  fast is consistent with bevy_cef's own `cef_initialize` assertion.
+- `sweep_in` is best-effort: all errors (unreadable entries, races with another
+  instance sweeping the same base) are ignored.
+
+## Testing
+
+### Unit tests (pure fs, no GUI/CEF) — in `src/cef_profile.rs`
+
+- `resolve_in` creates `<parent>/<pid>`, `path()` is absolute, mode is `0700`;
+  `Drop` removes the directory.
+- `resolve_in` on a `<parent>/<pid>` that already exists (with a stale marker
+  file inside) replaces it with a fresh empty directory — proves the same-PID
+  stale-dir guarantee.
+- `sweep_in` with an injected liveness predicate over pids `{alive, dead, self}`
+  removes only the dead one and keeps the alive one and `self`.
+- `sweep_in` ignores non-numeric directory entries and stray files (does not
+  panic, does not delete them).
+
+### Manual verification (cannot be automated — needs GUI + CEF)
+
+- Launch two ozmux instances → both render webviews, no CEF error.
+- Confirm `$TMPDIR/ozmux-cef/<pid>` directories appear per instance and stale
+  ones are swept on a later launch.
+- Confirm ozmux no longer writes a fresh lock into
+  `~/Library/Application Support/CEF/User Data`.
+
+## Files touched
+
+- **New:** `src/cef_profile.rs` (`CefProfileDir`, `pid_alive`, tests).
+- **Modified:** `src/main.rs` — declare `mod cef_profile;`, resolve the guard,
+  pass the path into `cef_plugin`.
+- **Modified:** `src/webview_render.rs` — `cef_plugin` takes a `PathBuf` and sets
+  `root_cache_path: Some(..)`.

--- a/src/cef_profile.rs
+++ b/src/cef_profile.rs
@@ -74,6 +74,13 @@ fn sweep_in(base: &Path, is_alive: impl Fn(u32) -> bool, self_pid: u32) {
 
 #[cfg(unix)]
 fn pid_alive(pid: u32) -> bool {
+    // NOTE: kill(0, …) and kill(<negative>, …) target a process GROUP, not one
+    // PID; a directory named 0 or above pid_t's positive range would otherwise
+    // misclassify liveness and risk sweeping the wrong directory. Real PIDs are
+    // 1..=i32::MAX — treat anything outside that as alive so it is never swept.
+    if pid == 0 || pid > i32::MAX as u32 {
+        return true;
+    }
     // SAFETY: `kill` with signal 0 sends no signal; it performs only the
     // existence/permission check and has no preconditions on `pid`.
     let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };

--- a/src/cef_profile.rs
+++ b/src/cef_profile.rs
@@ -1,0 +1,176 @@
+//! Per-process CEF profile directory: a unique `root_cache_path` per ozmux
+//! instance so concurrent instances never collide on Chromium's per-profile
+//! singleton lock.
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// A per-process CEF profile directory (`$TMPDIR/ozmux-cef/<pid>/`), removed on drop.
+///
+/// Chromium's `ProcessSingleton` permits only one live process per profile
+/// directory, so a shared profile makes a second ozmux instance fail. Keying the
+/// directory by PID guarantees concurrent instances never collide, since live
+/// PIDs are unique.
+pub(crate) struct CefProfileDir {
+    path: PathBuf,
+}
+
+impl CefProfileDir {
+    /// Sweeps stale per-PID profile directories (dead owners) under the shared
+    /// base, then creates and claims this process's own profile directory.
+    pub(crate) fn acquire() -> std::io::Result<Self> {
+        let base = std::env::temp_dir().join("ozmux-cef");
+        std::fs::create_dir_all(&base)?;
+        #[cfg(unix)]
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700))?;
+        let pid = std::process::id();
+        sweep_in(&base, pid_alive, pid);
+        Self::resolve_in(&base, pid)
+    }
+
+    /// The absolute path to pass to CEF as `root_cache_path`.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn resolve_in(parent: &Path, pid: u32) -> std::io::Result<Self> {
+        let path = parent.join(pid.to_string());
+        // NOTE: no concurrent process can share our PID, so a pre-existing dir
+        // here is a stale leftover from a dead same-PID process; removing it
+        // keeps the profile freshly ephemeral. It must never inherit cross-run
+        // state — a reused stale SingletonLock would otherwise mislead Chromium.
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path)?;
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for CefProfileDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn sweep_in(base: &Path, is_alive: impl Fn(u32) -> bool, self_pid: u32) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid != self_pid && !is_alive(pid) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: `kill` with signal 0 sends no signal; it performs only the
+    // existence/permission check and has no preconditions on `pid`.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // NOTE: ESRCH means no such process (dead); any other errno (e.g. EPERM —
+    // the process exists but is owned by another user) means alive.
+    // Misclassifying a live PID as dead would let the sweep delete a running
+    // instance's profile directory.
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_in_creates_0700_dir_and_drops() {
+        let parent = tempfile::tempdir().unwrap();
+        let path = {
+            let profile = CefProfileDir::resolve_in(parent.path(), 4242).unwrap();
+            assert!(profile.path().is_absolute());
+            assert_eq!(profile.path(), parent.path().join("4242"));
+            #[cfg(unix)]
+            {
+                let mode = std::fs::metadata(profile.path())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+                assert_eq!(mode, 0o700);
+            }
+            profile.path().to_path_buf()
+        };
+        assert!(!path.exists(), "Drop must remove the profile dir");
+    }
+
+    #[test]
+    fn resolve_in_replaces_stale_same_pid_dir() {
+        let parent = tempfile::tempdir().unwrap();
+        let stale = parent.path().join("4243");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("SingletonLock"), b"stale").unwrap();
+
+        let profile = CefProfileDir::resolve_in(parent.path(), 4243).unwrap();
+
+        assert_eq!(profile.path(), stale);
+        assert!(profile.path().exists());
+        assert!(
+            !profile.path().join("SingletonLock").exists(),
+            "a fresh profile dir must not inherit the stale lock marker"
+        );
+        assert!(
+            std::fs::read_dir(profile.path()).unwrap().next().is_none(),
+            "the re-created profile dir must be empty"
+        );
+    }
+
+    #[test]
+    fn sweep_in_removes_dead_keeps_alive_and_self() {
+        let base = tempfile::tempdir().unwrap();
+        for pid in ["100", "200", "300"] {
+            std::fs::create_dir_all(base.path().join(pid)).unwrap();
+        }
+        let is_alive = |pid: u32| pid == 100;
+
+        sweep_in(base.path(), is_alive, 300);
+
+        assert!(base.path().join("100").exists(), "alive owner kept");
+        assert!(!base.path().join("200").exists(), "dead owner swept");
+        assert!(base.path().join("300").exists(), "self never swept");
+    }
+
+    #[test]
+    fn sweep_in_ignores_non_numeric_entries() {
+        let base = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(base.path().join("not-a-pid")).unwrap();
+        std::fs::write(base.path().join("README"), b"x").unwrap();
+        std::fs::create_dir_all(base.path().join("200")).unwrap();
+        let is_alive = |_pid: u32| false;
+
+        sweep_in(base.path(), is_alive, 999);
+
+        assert!(
+            base.path().join("not-a-pid").exists(),
+            "non-numeric dir untouched"
+        );
+        assert!(base.path().join("README").exists(), "stray file untouched");
+        assert!(
+            !base.path().join("200").exists(),
+            "numeric dead owner swept"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! ozmux Bevy GUI entry point.
 
 mod bootstrap;
+mod cef_profile;
 mod configs;
 mod control_plane;
 mod font;
@@ -16,6 +17,7 @@ mod tmux;
 mod ui;
 mod webview_render;
 
+use crate::cef_profile::CefProfileDir;
 use crate::control_plane::OzmuxControlPlanePlugin;
 use crate::inline_webview::OzmuxInlineWebviewPlugin;
 use crate::input::hyperlink::HyperlinkInputPlugin;
@@ -54,6 +56,7 @@ fn main() {
         StartupMode::Ozma | StartupMode::Ozmux | StartupMode::AutoAttach => AppMode::Ozmux,
     };
     let dyn_registry = DynAssetRegistry::default();
+    let cef_profile = CefProfileDir::acquire().expect("create per-process CEF profile directory");
     App::new()
         .add_plugins((
             DefaultPlugins.set(WindowPlugin {
@@ -64,7 +67,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            cef_plugin(dyn_registry.clone()),
+            cef_plugin(dyn_registry.clone(), cef_profile.path().to_path_buf()),
         ))
         .insert_state(initial_mode)
         .add_plugins((

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            cef_plugin(dyn_registry.clone(), cef_profile.path().to_path_buf()),
+            cef_plugin(dyn_registry.clone(), cef_profile.path()),
         ))
         .insert_state(initial_mode)
         .add_plugins((

--- a/src/webview_render.rs
+++ b/src/webview_render.rs
@@ -13,6 +13,7 @@ use ozmux_tmux::{ActivePane, TmuxPane};
 use ozmux_webview_host::DynAssetRegistry;
 use ozmux_webview_host::dyn_scheme::custom_dyn_scheme;
 use serde_json::Value;
+use std::path::PathBuf;
 
 pub(crate) mod preload;
 
@@ -32,11 +33,13 @@ struct OzmuxFrame(serde_json::Value);
 const OZMA_CALL_KIND: &str = "ozma.call";
 
 /// Builds the `CefPlugin` with the `ozma-dyn://` (dynamic, Tier 1) scheme bound
-/// to its shared `DynAssetRegistry`.
-pub fn cef_plugin(dyn_registry: DynAssetRegistry) -> CefPlugin {
+/// to its shared `DynAssetRegistry`, using `root_cache_path` as this process's
+/// unique CEF profile directory (one Chromium singleton lock per instance).
+pub(crate) fn cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: PathBuf) -> CefPlugin {
     CefPlugin {
         custom_schemes: vec![custom_dyn_scheme(dyn_registry)],
         command_line_config: cef_command_line_config(),
+        root_cache_path: Some(root_cache_path.to_string_lossy().into_owned()),
         ..Default::default()
     }
 }

--- a/src/webview_render.rs
+++ b/src/webview_render.rs
@@ -13,7 +13,7 @@ use ozmux_tmux::{ActivePane, TmuxPane};
 use ozmux_webview_host::DynAssetRegistry;
 use ozmux_webview_host::dyn_scheme::custom_dyn_scheme;
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::Path;
 
 pub(crate) mod preload;
 
@@ -35,7 +35,7 @@ const OZMA_CALL_KIND: &str = "ozma.call";
 /// Builds the `CefPlugin` with the `ozma-dyn://` (dynamic, Tier 1) scheme bound
 /// to its shared `DynAssetRegistry`, using `root_cache_path` as this process's
 /// unique CEF profile directory (one Chromium singleton lock per instance).
-pub(crate) fn cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: PathBuf) -> CefPlugin {
+pub(crate) fn cef_plugin(dyn_registry: DynAssetRegistry, root_cache_path: &Path) -> CefPlugin {
     CefPlugin {
         custom_schemes: vec![custom_dyn_scheme(dyn_registry)],
         command_line_config: cef_command_line_config(),


### PR DESCRIPTION
## Problem

Launching a second ozmux instance while one is running produced a CEF error and the second instance's embedded webview failed to start.

## Root cause

ozmux never set a per-instance CEF `root_cache_path`, so every instance shared one Chromium profile directory — and Chromium's `ProcessSingleton` permits only one live process per profile dir.

- `cef_plugin()` built `CefPlugin { ..Default::default() }`, leaving `root_cache_path: None`.
- bevy_cef forwarded that to CEF as `Settings.root_cache_path = ""`; with `cache_path` also empty, CEF on macOS falls back to the fixed default profile `~/Library/Application Support/CEF/User Data`.
- That dir holds Chromium's `SingletonLock`/`SingletonCookie`/`SingletonSocket`; the second instance can't acquire the lock and fails.

## Fix

Each process now gets a unique per-PID CEF profile directory `$TMPDIR/ozmux-cef/<pid>/`, passed to bevy_cef's `CefPlugin.root_cache_path`. Two concurrent instances always have distinct PIDs, so they never collide on the singleton lock. Since bevy_cef leaves `cache_path` empty, the profile runs incognito/in-memory — only the lock skeleton is written.

New `src/cef_profile.rs` adds a `CefProfileDir` RAII guard mirroring the existing `RuntimeRoot` idiom:
- **Startup sweep** removes dead-owner dirs (`libc::kill(pid, 0)` liveness; `ESRCH` = dead). This is the **primary** cleanup, because macOS teardown may not unwind `main()` (so `Drop` is best-effort secondary).
- `resolve_in` removes a pre-existing same-PID dir before recreating, so a relaunch with a reused PID gets a fresh, ephemeral profile (no inherited stale `SingletonLock`).

## Testing

- 4 hermetic unit tests (`resolve_in` ×2, `sweep_in` ×2); full `ozmux-gui` suite: 352 passed, 0 failed. `cargo clippy --workspace --all-targets` clean.
- **Pending manual verification (cannot be automated):** launch two `cargo run` instances concurrently → both render webviews with no CEF singleton error; confirm `$TMPDIR/ozmux-cef/<pid>` dirs appear per instance and stale ones are swept on a later launch.

## Process

Spec + plan committed under `docs/superpowers/`; reviewed via `forte:spec-review` (Codex + Claude), implemented subagent-driven (task review + opus whole-branch review), and a final `code-review max --fix` pass (hardened `pid_alive` against process-group `kill` semantics; `cef_plugin` now takes `&Path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)