### PR TITLE
refactor(configs): drop async loading API, rename load_blocking to load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,7 +4983,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "toml",
  "tracing",
 ]
@@ -6426,18 +6425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ publish = false
 # part of bevy's default set via 2d/3d/ui → default_platform → default_font,
 # but listing it explicitly here protects against future "default-features = false".
 bevy = { version = "0.18", features = ["default_font"] }
-tokio = { version = "1.52" }
 anyhow = { version = "1" }
 thiserror = { version = "2" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ozmux_configs/Cargo.toml
+++ b/crates/ozmux_configs/Cargo.toml
@@ -10,7 +10,6 @@ publish.workspace = true
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
 toml = { workspace = true }
 dirs = { workspace = true }
 tracing = { workspace = true }
@@ -25,4 +24,3 @@ required-features = ["test_support"]
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }

--- a/crates/ozmux_configs/src/lib.rs
+++ b/crates/ozmux_configs/src/lib.rs
@@ -59,44 +59,13 @@ impl OzmuxConfigs {
     /// Returns `Default::default()` when the resolved path does not exist.
     /// Any other I/O failure, TOML parse error, or validation failure is
     /// surfaced as `OzmuxConfigsError`.
-    pub async fn load() -> OzmuxConfigsResult<Self> {
-        Self::load_with_env(&path::SystemEnv).await
+    pub fn load() -> OzmuxConfigsResult<Self> {
+        Self::load_with_env(&path::SystemEnv)
     }
 
-    /// Synchronous variant of [`Self::load`] that reads via `std::fs`.
-    /// Useful for callers that cannot easily host a tokio runtime
-    /// (e.g. Bevy `Plugin::build`).
-    pub fn load_blocking() -> OzmuxConfigsResult<Self> {
-        Self::load_blocking_with_env(&path::SystemEnv)
-    }
-
-    async fn load_with_env(env: &dyn path::Env) -> OzmuxConfigsResult<Self> {
+    fn load_with_env(env: &dyn path::Env) -> OzmuxConfigsResult<Self> {
         let configured_path = path::resolve_config_path(env)?;
         tracing::info!(path = %configured_path.display(), "resolving ozmux config path");
-
-        let text = match tokio::fs::read_to_string(&configured_path).await {
-            Ok(t) => t,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                tracing::info!(
-                    path = %configured_path.display(),
-                    "ozmux config not found; using defaults"
-                );
-                return Ok(Self::default());
-            }
-            Err(source) => {
-                return Err(OzmuxConfigsError::Io {
-                    path: configured_path,
-                    source,
-                });
-            }
-        };
-
-        Self::parse_and_validate(&text, &configured_path)
-    }
-
-    fn load_blocking_with_env(env: &dyn path::Env) -> OzmuxConfigsResult<Self> {
-        let configured_path = path::resolve_config_path(env)?;
-        tracing::info!(path = %configured_path.display(), "resolving ozmux config path (sync)");
 
         let text = match std::fs::read_to_string(&configured_path) {
             Ok(t) => t,
@@ -141,7 +110,7 @@ pub mod test_support {
 
     /// Loads [`OzmuxConfigs`] against a caller-controlled environment instead
     /// of the process-wide one.
-    pub async fn load_with_overrides(
+    pub fn load_with_overrides(
         ozmux_config: Option<PathBuf>,
         xdg_config_home: Option<PathBuf>,
         home_dir: Option<PathBuf>,
@@ -168,38 +137,7 @@ pub mod test_support {
             xdg: xdg_config_home.map(|p| p.to_string_lossy().into_owned()),
             home: home_dir,
         };
-        OzmuxConfigs::load_with_env(&env).await
-    }
-
-    /// Synchronous variant of [`load_with_overrides`].
-    pub fn load_blocking_with_overrides(
-        ozmux_config: Option<PathBuf>,
-        xdg_config_home: Option<PathBuf>,
-        home_dir: Option<PathBuf>,
-    ) -> OzmuxConfigsResult<OzmuxConfigs> {
-        struct FixedEnv {
-            ozmux: Option<String>,
-            xdg: Option<String>,
-            home: Option<PathBuf>,
-        }
-        impl path::Env for FixedEnv {
-            fn var(&self, key: &str) -> Option<String> {
-                match key {
-                    path::ENV_OZMUX_CONFIG => self.ozmux.clone(),
-                    path::ENV_XDG_CONFIG_HOME => self.xdg.clone(),
-                    _ => None,
-                }
-            }
-            fn home_dir(&self) -> Option<PathBuf> {
-                self.home.clone()
-            }
-        }
-        let env = FixedEnv {
-            ozmux: ozmux_config.map(|p| p.to_string_lossy().into_owned()),
-            xdg: xdg_config_home.map(|p| p.to_string_lossy().into_owned()),
-            home: home_dir,
-        };
-        OzmuxConfigs::load_blocking_with_env(&env)
+        OzmuxConfigs::load_with_env(&env)
     }
 }
 

--- a/crates/ozmux_configs/tests/load.rs
+++ b/crates/ozmux_configs/tests/load.rs
@@ -9,12 +9,10 @@ fn fixture(name: &str) -> PathBuf {
         .join(name)
 }
 
-#[tokio::test]
-async fn missing_file_yields_defaults() {
+#[test]
+fn missing_file_yields_defaults() {
     let nonexistent = fixture("does_not_exist.toml");
-    let configs = load_with_overrides(Some(nonexistent), None, None)
-        .await
-        .unwrap();
+    let configs = load_with_overrides(Some(nonexistent), None, None).unwrap();
     let defaults = OzmuxConfigs::default();
     assert_eq!(
         configs.shortcuts.bindings.iter().count(),
@@ -22,11 +20,9 @@ async fn missing_file_yields_defaults() {
     );
 }
 
-#[tokio::test]
-async fn empty_file_yields_defaults() {
-    let configs = load_with_overrides(Some(fixture("empty.toml")), None, None)
-        .await
-        .unwrap();
+#[test]
+fn empty_file_yields_defaults() {
+    let configs = load_with_overrides(Some(fixture("empty.toml")), None, None).unwrap();
     let defaults = OzmuxConfigs::default();
     assert_eq!(
         configs.shortcuts.bindings.iter().count(),
@@ -38,11 +34,9 @@ async fn empty_file_yields_defaults() {
     );
 }
 
-#[tokio::test]
-async fn bindings_section_overrides_one_binding_keeps_others() {
-    let configs = load_with_overrides(Some(fixture("bindings_replace.toml")), None, None)
-        .await
-        .unwrap();
+#[test]
+fn bindings_section_overrides_one_binding_keeps_others() {
+    let configs = load_with_overrides(Some(fixture("bindings_replace.toml")), None, None).unwrap();
     let close = configs
         .shortcuts
         .bindings
@@ -58,11 +52,9 @@ async fn bindings_section_overrides_one_binding_keeps_others() {
     );
 }
 
-#[tokio::test]
-async fn theme_patch_preserves_other_fields() {
-    let configs = load_with_overrides(Some(fixture("theme_accent.toml")), None, None)
-        .await
-        .unwrap();
+#[test]
+fn theme_patch_preserves_other_fields() {
+    let configs = load_with_overrides(Some(fixture("theme_accent.toml")), None, None).unwrap();
     assert_eq!(configs.theme.accent, "#deadbe");
     let defaults = OzmuxConfigs::default();
     assert_eq!(configs.theme.background, defaults.theme.background);
@@ -71,11 +63,9 @@ async fn theme_patch_preserves_other_fields() {
     assert_eq!(configs.theme.destructive, defaults.theme.destructive);
 }
 
-#[tokio::test]
-async fn duplicate_chord_rejected() {
-    let err = load_with_overrides(Some(fixture("duplicate_binding.toml")), None, None)
-        .await
-        .unwrap_err();
+#[test]
+fn duplicate_chord_rejected() {
+    let err = load_with_overrides(Some(fixture("duplicate_binding.toml")), None, None).unwrap_err();
     match err {
         OzmuxConfigsError::DuplicateChords(dupes) => {
             assert!(!dupes.is_empty(), "must report at least one duplicate");
@@ -84,11 +74,9 @@ async fn duplicate_chord_rejected() {
     }
 }
 
-#[tokio::test]
-async fn modifier_binding_accepted() {
-    let configs = load_with_overrides(Some(fixture("modifier_binding.toml")), None, None)
-        .await
-        .unwrap();
+#[test]
+fn modifier_binding_accepted() {
+    let configs = load_with_overrides(Some(fixture("modifier_binding.toml")), None, None).unwrap();
     let close = configs
         .shortcuts
         .bindings
@@ -98,46 +86,18 @@ async fn modifier_binding_accepted() {
     assert!(close.modifiers.shift, "the fixture's binding carries Shift");
 }
 
-#[tokio::test]
-async fn syntax_error_surfaces_parse_toml() {
-    let err = load_with_overrides(Some(fixture("syntax_error.toml")), None, None)
-        .await
-        .unwrap_err();
-    match err {
-        OzmuxConfigsError::ParseToml { path, .. } => {
-            assert!(path.ends_with("syntax_error.toml"));
-        }
-        other => panic!("expected ParseToml, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn unknown_action_surfaces_parse_toml() {
-    let err = load_with_overrides(Some(fixture("unknown_action.toml")), None, None)
-        .await
-        .unwrap_err();
-    assert!(matches!(err, OzmuxConfigsError::ParseToml { .. }));
-}
-
 #[test]
-fn load_blocking_missing_file_yields_defaults() {
-    use ozmux_configs::test_support::load_blocking_with_overrides;
-    let nonexistent = fixture("does_not_exist.toml");
-    let configs = load_blocking_with_overrides(Some(nonexistent), None, None).unwrap();
-    let defaults = OzmuxConfigs::default();
-    assert_eq!(
-        configs.shortcuts.bindings.iter().count(),
-        defaults.shortcuts.bindings.iter().count()
-    );
-}
-
-#[test]
-fn load_blocking_syntax_error_returns_parse_toml_with_path() {
-    use ozmux_configs::test_support::load_blocking_with_overrides;
+fn syntax_error_surfaces_parse_toml() {
     let path = fixture("syntax_error.toml");
-    let err = load_blocking_with_overrides(Some(path.clone()), None, None).unwrap_err();
+    let err = load_with_overrides(Some(path.clone()), None, None).unwrap_err();
     match err {
         OzmuxConfigsError::ParseToml { path: p, .. } => assert_eq!(p, path),
         other => panic!("expected ParseToml, got {other:?}"),
     }
+}
+
+#[test]
+fn unknown_action_surfaces_parse_toml() {
+    let err = load_with_overrides(Some(fixture("unknown_action.toml")), None, None).unwrap_err();
+    assert!(matches!(err, OzmuxConfigsError::ParseToml { .. }));
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -11,13 +11,12 @@ use ozmux_configs::OzmuxConfigs;
 pub(crate) struct OzmuxConfigsResource(pub(crate) OzmuxConfigs);
 
 /// Bevy Plugin that loads ozmux config from disk at `Plugin::build` and
-/// inserts it as [`OzmuxConfigsResource`]. Synchronous; uses `std::fs`,
-/// no tokio runtime is created here.
+/// inserts it as [`OzmuxConfigsResource`]. Synchronous; uses `std::fs`.
 pub(crate) struct OzmuxConfigsPlugin;
 
 impl Plugin for OzmuxConfigsPlugin {
     fn build(&self, app: &mut App) {
-        let configs = OzmuxConfigs::load_blocking().unwrap_or_else(|err| match &err {
+        let configs = OzmuxConfigs::load().unwrap_or_else(|err| match &err {
             // File-not-found: empty user config means use defaults. `OzmuxConfigsError::Io` is
             // { path, source }; drill into source.kind() to inspect ErrorKind.
             ozmux_configs::OzmuxConfigsError::Io { source, .. }
@@ -55,7 +54,7 @@ impl Plugin for OzmuxConfigsPlugin {
 /// Crate-internal mutex guarding `OZMUX_CONFIG` env-var mutations across
 /// tests. Any test (in any module) that mutates the process env BEFORE
 /// constructing `OzmuxConfigsPlugin` (or anything else that calls
-/// `OzmuxConfigs::load_blocking`) MUST acquire this guard for the duration
+/// `OzmuxConfigs::load`) MUST acquire this guard for the duration
 /// of the construction.
 #[cfg(test)]
 pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -158,7 +157,7 @@ mod tests {
             std::env::set_var("OZMUX_CONFIG", &tmp);
         }
 
-        let err = OzmuxConfigs::load_blocking().expect_err("must error on unknown field");
+        let err = OzmuxConfigs::load().expect_err("must error on unknown field");
         // The outer error must wrap an inner cause via Error::source().
         let source = std::error::Error::source(&err);
         // ParseToml carries a toml::de::Error as #[source]; assert that path

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ use ui::{
 };
 
 fn main() {
-    let pre_configs = ozmux_configs::OzmuxConfigs::load_blocking().unwrap_or_default();
+    let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
     // NOTE: Always start in AppMode::Ozmux so Startup deferred commands
     // (e.g. init_atlas_image inserting AtlasImage) are flushed before any
     // OnEnter(AppMode::Ozma) fires. on_enter_ozmux_picker handles


### PR DESCRIPTION
## Context

`ozmux_configs` exposed two parallel loading paths: an async one (`load` / `load_with_env`, backed by `tokio::fs`) and a synchronous one (`load_blocking` / `load_blocking_with_env`, backed by `std::fs`). Every real caller already used the blocking path — `src/main.rs` and `OzmuxConfigsPlugin` (`src/configs.rs`) both load config once at Bevy `Plugin::build`, where no tokio runtime exists.

The async API existed only to back the crate's own `#[tokio::test]` tests, making `tokio` a dependency of `ozmux_configs` purely for an unused API — and `ozmux_configs` was the **only** workspace member pulling tokio in. This is the cleanup captured by the branch name.

## Changes

- **`crates/ozmux_configs/src/lib.rs`** — delete the async `load()` and private `load_with_env()`; rename the blocking pair to `load()` / `load_with_env()` (now `std::fs`-based). In `test_support`, delete the async `load_with_overrides` and rename the blocking helper to `load_with_overrides`. Doc comments merged onto the surviving items.
- **`crates/ozmux_configs/tests/load.rs`** — convert the 8 `#[tokio::test]` tests to plain `#[test]`; drop the 2 now-redundant `load_blocking_*` tests, folding the stricter path-equality assertion into `syntax_error_surfaces_parse_toml`.
- **`crates/ozmux_configs/Cargo.toml`** — remove tokio from `[dependencies]` and `[dev-dependencies]`.
- **Root `Cargo.toml`** — remove the now-unused `tokio` entry from `[workspace.dependencies]` (`Cargo.lock` drops `tokio-macros` accordingly).
- **`src/main.rs` / `src/configs.rs`** — update 3 call sites to `load()` and refresh 2 stale doc references.

## Verification

- `cargo test -p ozmux_configs --features test_support` — 122 unit + 8 integration tests pass.
- `cargo build` — full workspace compiles.
- `cargo test -p ozmux-gui ... configs::` — 4 `OzmuxConfigsPlugin` tests pass.
- `cargo clippy -p ozmux_configs --all-targets` and `cargo fmt --check` — clean.
- `cargo tree -p ozmux_configs` shows no tokio. (The lone remaining `tokio` in the full tree is a transitive dep of a third-party crate, not via any workspace crate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)