### PR TITLE
feat(ozma_terminal): multi-terminal keyboard input — KeyboardFocused routing + focus-aware IME

### DIFF
--- a/crates/ozma_terminal/src/input.rs
+++ b/crates/ozma_terminal/src/input.rs
@@ -1,7 +1,7 @@
 //! Default terminal keyboard dispatcher. Reads `KeyboardInput` and, per press,
 //! fires `PasteAction`, forwards a raw key as `TerminalKeyInput`, or skips it:
-//! host-reserved chords and unhandled meta/Cmd chords are dropped. Gated per
-//! entity by the `KeyboardDisabled` marker.
+//! host-reserved chords and unhandled meta/Cmd chords are dropped. Routed to the
+//! single `KeyboardFocused` entity and gated per entity by `KeyboardDisabled`.
 
 use crate::action::PasteAction;
 use crate::spawn::OzmaTerminal;

--- a/crates/ozma_terminal/src/input.rs
+++ b/crates/ozma_terminal/src/input.rs
@@ -98,7 +98,14 @@ fn dispatch_input(
     mut events: MessageReader<KeyboardInput>,
     bindings: Res<TerminalInputBindings>,
     keys: Res<ButtonInput<KeyCode>>,
-    terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)>,
+    terminal: Query<
+        Entity,
+        (
+            With<OzmaTerminal>,
+            With<KeyboardFocused>,
+            Without<KeyboardDisabled>,
+        ),
+    >,
 ) {
     // NOTE: keyboard routes to the single `KeyboardFocused` terminal. The host
     // owns focus policy and MUST keep exactly one OzmaTerminal both
@@ -183,6 +190,7 @@ mod tests {
     struct Captured {
         paste: u32,
         keys: Vec<TerminalKey>,
+        entities: Vec<Entity>,
     }
 
     fn test_app() -> App {
@@ -198,6 +206,7 @@ mod tests {
             })
             .add_observer(|ev: On<TerminalKeyInput>, mut c: ResMut<Captured>| {
                 c.keys.push(ev.key.clone());
+                c.entities.push(ev.entity);
             });
         app
     }
@@ -291,11 +300,12 @@ mod tests {
     fn routes_to_keyboard_focused_terminal() {
         let mut app = test_app();
         app.world_mut().spawn(OzmaTerminal);
-        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let focused = app.world_mut().spawn((OzmaTerminal, KeyboardFocused)).id();
         press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
         app.update();
         let c = app.world().resource::<Captured>();
         assert_eq!(c.keys, vec![TerminalKey::Text("a".into())]);
+        assert_eq!(c.entities, vec![focused]);
     }
 
     #[test]

--- a/crates/ozma_terminal/src/input.rs
+++ b/crates/ozma_terminal/src/input.rs
@@ -17,6 +17,14 @@ use ozma_tty_engine::{TerminalKey, TerminalKeyInput, TerminalModifiers};
 #[derive(Component)]
 pub struct KeyboardDisabled;
 
+/// When present on an `OzmaTerminal` entity, that terminal is the keyboard
+/// focus: the crate's keyboard dispatcher routes raw keys to it, and the host
+/// routes IME commits and anchors the OS candidate window to it. The host owns
+/// focus policy and maintains the "exactly one focused" invariant; a terminal
+/// with no `KeyboardFocused` receives no keyboard input.
+#[derive(Component)]
+pub struct KeyboardFocused;
+
 /// A keyboard chord, as a physical `KeyCode` plus the four modifier bits.
 /// Config-agnostic plain data the host supplies in `TerminalInputBindings`.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -90,11 +98,12 @@ fn dispatch_input(
     mut events: MessageReader<KeyboardInput>,
     bindings: Res<TerminalInputBindings>,
     keys: Res<ButtonInput<KeyCode>>,
-    terminal: Query<Entity, (With<OzmaTerminal>, Without<KeyboardDisabled>)>,
+    terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)>,
 ) {
-    // NOTE: keyboard keeps the single-terminal model — a future multi-terminal
-    // host MUST keep exactly one OzmaTerminal un-`KeyboardDisabled`, or this
-    // `.single()` returns Err and every keypress is silently dropped.
+    // NOTE: keyboard routes to the single `KeyboardFocused` terminal. The host
+    // owns focus policy and MUST keep exactly one OzmaTerminal both
+    // `KeyboardFocused` and not `KeyboardDisabled`, or this `.single()` returns
+    // Err and every keypress is silently dropped.
     let Ok(entity) = terminal.single() else {
         events.clear();
         return;
@@ -213,7 +222,7 @@ mod tests {
     #[test]
     fn plain_key_forwards_as_terminal_key() {
         let mut app = test_app();
-        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
         app.update();
         let c = app.world().resource::<Captured>();
@@ -224,7 +233,7 @@ mod tests {
     #[test]
     fn paste_chord_fires_paste_action() {
         let mut app = test_app();
-        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         hold_meta(&mut app);
         press(&mut app, KeyCode::KeyV, Key::Character("v".into()));
         app.update();
@@ -236,7 +245,7 @@ mod tests {
     #[test]
     fn reserved_chord_is_skipped() {
         let mut app = test_app();
-        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         app.world_mut()
             .resource_mut::<TerminalInputBindings>()
             .reserved = vec![ReservedChord {
@@ -257,7 +266,7 @@ mod tests {
     #[test]
     fn unhandled_meta_chord_is_dropped() {
         let mut app = test_app();
-        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         hold_meta(&mut app);
         press(&mut app, KeyCode::KeyJ, Key::Character("j".into()));
         app.update();
@@ -267,14 +276,45 @@ mod tests {
     }
 
     #[test]
-    fn keyboard_disabled_entity_fires_nothing() {
+    fn keyboard_disabled_overrides_focus() {
         let mut app = test_app();
-        app.world_mut().spawn((OzmaTerminal, KeyboardDisabled));
+        app.world_mut()
+            .spawn((OzmaTerminal, KeyboardFocused, KeyboardDisabled));
         press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
         app.update();
         let c = app.world().resource::<Captured>();
         assert!(c.keys.is_empty());
         assert_eq!(c.paste, 0);
+    }
+
+    #[test]
+    fn routes_to_keyboard_focused_terminal() {
+        let mut app = test_app();
+        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert_eq!(c.keys, vec![TerminalKey::Text("a".into())]);
+    }
+
+    #[test]
+    fn no_focused_terminal_drops_keys() {
+        let mut app = test_app();
+        app.world_mut().spawn(OzmaTerminal);
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(app.world().resource::<Captured>().keys.is_empty());
+    }
+
+    #[test]
+    fn two_focused_terminals_drop_keys() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(app.world().resource::<Captured>().keys.is_empty());
     }
 
     #[test]

--- a/crates/ozma_terminal/src/lib.rs
+++ b/crates/ozma_terminal/src/lib.rs
@@ -18,7 +18,9 @@ use crate::{exit::ExitPlugin, layout::LayoutPlugin};
 pub use action::PasteAction;
 use bevy::prelude::*;
 pub use clipboard::{Clipboard, build_paste_bytes};
-pub use input::{KeyboardDisabled, OzmaTerminalInputSet, ReservedChord, TerminalInputBindings};
+pub use input::{
+    KeyboardDisabled, KeyboardFocused, OzmaTerminalInputSet, ReservedChord, TerminalInputBindings,
+};
 pub use mouse::{FineModifier, MouseDisabled, OzmaMouseConfig, OzmaTerminalMouseSet};
 pub use spawn::{
     OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig, cells_for,

--- a/crates/ozma_terminal/src/spawn.rs
+++ b/crates/ozma_terminal/src/spawn.rs
@@ -11,8 +11,8 @@ use std::sync::atomic::AtomicBool;
 /// Marker component identifying an Ozma-mode terminal entity.
 ///
 /// One or more entities may carry this marker; mouse input routes to the
-/// topmost under the cursor, while keyboard input targets the single entity the
-/// host leaves un-`KeyboardDisabled`.
+/// topmost under the cursor, while keyboard input (raw keys and IME) targets the
+/// single entity the host marks `KeyboardFocused`.
 #[derive(Component)]
 pub struct OzmaTerminal;
 

--- a/docs/superpowers/plans/2026-06-20-ozma-terminal-multi-terminal-keyboard.md
+++ b/docs/superpowers/plans/2026-06-20-ozma-terminal-multi-terminal-keyboard.md
@@ -1,0 +1,480 @@
+# ozma_terminal Multi-Terminal Keyboard Input Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ozma_terminal`'s keyboard path route to a sticky `KeyboardFocused` terminal so it works with multiple live `OzmaTerminal` entities, mirroring the multi-terminal mouse effort (#164).
+
+**Architecture:** Add a positive `KeyboardFocused` marker component to the crate; `dispatch_input` routes to the single focused, non-disabled terminal via `.single()`. Focus (`KeyboardFocused`, sticky, host-owned) and modal gating (`KeyboardDisabled`, transient) stay orthogonal. The host inserts the marker on spawn and makes its two IME systems (`read_ime_events` commit routing, `ime_policy_system` enable + candidate-window anchoring) follow the focused terminal.
+
+**Tech Stack:** Rust 2024, Bevy 0.18 ECS, `cargo test`.
+
+## Global Constraints
+
+- Rust edition 2024, toolchain 1.95. No `mod.rs`.
+- Comments only `// TODO:` / `// NOTE:` / `// SAFETY:`, English only.
+- Every `pub` item has a `///` doc; module files have `//!`.
+- All `use` in one contiguous top-of-file block; no inline fully-qualified paths. Test-local `use` inside `#[cfg(test)] mod tests` is allowed.
+- Bevy: mutable `SystemParam`s before immutable; `Query` params are descriptive nouns (no `_q`); whole-system change gates via `run_if`, not in-body early return; `Plugin::build` is one method chain.
+- Visibility minimized; private items declared after `pub` ones; `#[expect(reason=…)]` over `#[allow]`.
+- Spec: `docs/superpowers/specs/2026-06-20-ozma-terminal-multi-terminal-keyboard-design.md`.
+
+---
+
+### Task 1: `KeyboardFocused` marker + `dispatch_input` routing (crate `ozma_terminal`)
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/input.rs` (marker, `dispatch_input` query + NOTE, tests)
+- Modify: `crates/ozma_terminal/src/lib.rs:21` (export)
+- Modify: `crates/ozma_terminal/src/spawn.rs:11-15` (doc)
+- Test: `crates/ozma_terminal/src/input.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub struct KeyboardFocused;` (in `ozma_terminal::input`, re-exported as `ozma_terminal::KeyboardFocused`). A unit marker component. `dispatch_input` routes raw keys to the entity matching `(With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)`, requiring exactly one such entity.
+
+- [ ] **Step 1: Add the `KeyboardFocused` marker**
+
+In `crates/ozma_terminal/src/input.rs`, immediately after the `KeyboardDisabled` definition (the `#[derive(Component)] pub struct KeyboardDisabled;` block ending at line 18), add:
+
+```rust
+/// When present on an `OzmaTerminal` entity, that terminal is the keyboard
+/// focus: the crate's keyboard dispatcher routes raw keys to it, and the host
+/// routes IME commits and anchors the OS candidate window to it. The host owns
+/// focus policy and maintains the "exactly one focused" invariant; a terminal
+/// with no `KeyboardFocused` receives no keyboard input.
+#[derive(Component)]
+pub struct KeyboardFocused;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `crates/ozma_terminal/src/input.rs`, inside `#[cfg(test)] mod tests`, add three tests (place them after `keyboard_disabled_entity_fires_nothing`):
+
+```rust
+    #[test]
+    fn routes_to_keyboard_focused_terminal() {
+        let mut app = test_app();
+        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert_eq!(c.keys, vec![TerminalKey::Text("a".into())]);
+    }
+
+    #[test]
+    fn no_focused_terminal_drops_keys() {
+        let mut app = test_app();
+        app.world_mut().spawn(OzmaTerminal);
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(app.world().resource::<Captured>().keys.is_empty());
+    }
+
+    #[test]
+    fn two_focused_terminals_drop_keys() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(app.world().resource::<Captured>().keys.is_empty());
+    }
+```
+
+- [ ] **Step 3: Run the new tests — verify they fail**
+
+Run: `cargo test -p ozma_terminal routes_to_keyboard_focused_terminal`
+Expected: FAIL. `dispatch_input` still calls `.single()` over `Without<KeyboardDisabled>`; with two `OzmaTerminal` entities present, `.single()` returns `Err`, every key is dropped, and the asserted `["a"]` is empty.
+
+- [ ] **Step 4: Update `dispatch_input` to route by focus**
+
+In `crates/ozma_terminal/src/input.rs`, change the `terminal` query parameter (currently line 93):
+
+```rust
+    terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)>,
+```
+
+Replace the existing `// NOTE:` block above the `let Ok(entity) = terminal.single()` line (currently lines 95-97) with:
+
+```rust
+    // NOTE: keyboard routes to the single `KeyboardFocused` terminal. The host
+    // owns focus policy and MUST keep exactly one OzmaTerminal both
+    // `KeyboardFocused` and not `KeyboardDisabled`, or this `.single()` returns
+    // Err and every keypress is silently dropped.
+```
+
+- [ ] **Step 5: Update existing tests to mark the spawned terminal focused**
+
+In `crates/ozma_terminal/src/input.rs` tests, the four single-terminal tests must spawn a focused terminal:
+
+- `plain_key_forwards_as_terminal_key`: change `app.world_mut().spawn(OzmaTerminal);` to `app.world_mut().spawn((OzmaTerminal, KeyboardFocused));`
+- `paste_chord_fires_paste_action`: same change.
+- `reserved_chord_is_skipped`: same change.
+- `unhandled_meta_chord_is_dropped`: same change.
+
+Then convert `keyboard_disabled_entity_fires_nothing` to prove disabled overrides focus — rename it and add the focus marker:
+
+```rust
+    #[test]
+    fn keyboard_disabled_overrides_focus() {
+        let mut app = test_app();
+        app.world_mut()
+            .spawn((OzmaTerminal, KeyboardFocused, KeyboardDisabled));
+        press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert!(c.keys.is_empty());
+        assert_eq!(c.paste, 0);
+    }
+```
+
+- [ ] **Step 6: Run the full crate test suite — verify green**
+
+Run: `cargo test -p ozma_terminal`
+Expected: PASS (all tests, including the three new ones and the renamed disabled-overrides-focus test).
+
+- [ ] **Step 7: Export the marker and fix the `OzmaTerminal` doc**
+
+In `crates/ozma_terminal/src/lib.rs`, replace the `input` re-export (line 21):
+
+```rust
+pub use input::{
+    KeyboardDisabled, KeyboardFocused, OzmaTerminalInputSet, ReservedChord, TerminalInputBindings,
+};
+```
+
+In `crates/ozma_terminal/src/spawn.rs`, update the `OzmaTerminal` doc body (lines 13-15) to:
+
+```rust
+/// One or more entities may carry this marker; mouse input routes to the
+/// topmost under the cursor, while keyboard input (raw keys and IME) targets the
+/// single entity the host marks `KeyboardFocused`.
+```
+
+- [ ] **Step 8: Confirm the crate builds clean and commit**
+
+Run: `cargo test -p ozma_terminal && cargo clippy -p ozma_terminal`
+Expected: PASS, no warnings.
+
+```bash
+git add crates/ozma_terminal/src/input.rs crates/ozma_terminal/src/lib.rs crates/ozma_terminal/src/spawn.rs
+git commit -m "feat(ozma_terminal): route keyboard to KeyboardFocused terminal"
+```
+
+---
+
+### Task 2: Host inserts `KeyboardFocused` on the spawned terminal
+
+**Files:**
+- Modify: `src/ozma.rs:4` (import), `src/ozma.rs:33-50` (`spawn_terminal`)
+
+**Interfaces:**
+- Consumes: `ozma_terminal::KeyboardFocused` (Task 1).
+- Produces: the host's single `OzmaTerminal` always carries `KeyboardFocused`, so `dispatch_input.single()` finds exactly one focused terminal. No code in later tasks depends on new symbols here.
+
+- [ ] **Step 1: Import `KeyboardFocused`**
+
+In `src/ozma.rs`, extend the import (line 4):
+
+```rust
+use ozma_terminal::{
+    KeyboardFocused, OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig,
+};
+```
+
+- [ ] **Step 2: Spawn the terminal focused**
+
+In `src/ozma.rs`, in `spawn_terminal`, change the spawn call so the bundle is tupled with the marker. Replace:
+
+```rust
+        Ok(bundle) => {
+            commands.spawn(bundle);
+        }
+```
+
+with:
+
+```rust
+        Ok(bundle) => {
+            commands.spawn((bundle, KeyboardFocused));
+        }
+```
+
+- [ ] **Step 3: Update the `OzmaModePlugin` / `spawn_terminal` doc**
+
+In `src/ozma.rs`, update the `OzmaModePlugin` doc line that reads "Spawns one `OzmaTerminal` entity on `OnEnter(AppMode::Ozma)`" (line 19) to note focus:
+
+```rust
+/// Spawns one `OzmaTerminal` entity (marked `KeyboardFocused`, the keyboard
+/// target) on `OnEnter(AppMode::Ozma)` and despawns it on `OnExit(AppMode::Ozma)`.
+```
+
+(Keep the remaining doc sentences about plugin ordering unchanged.)
+
+- [ ] **Step 4: Build the binary — verify it compiles**
+
+Run: `cargo build -p ozmux-gui`
+Expected: PASS, no warnings. (There is no unit test for `spawn_terminal`; it spawns a real PTY. The crate-level routing tests from Task 1 prove the dispatch behavior; this task only wires the host to satisfy the focus invariant.)
+
+- [ ] **Step 5: Manual verification**
+
+Run: `cargo run`
+Expected: the terminal accepts keyboard input (type `echo hi` + Enter; the shell echoes and runs it). This confirms the host's spawned terminal is `KeyboardFocused` and `dispatch_input` routes to it. If keys do nothing, the marker is not being inserted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ozma.rs
+git commit -m "feat: mark the host Ozma terminal KeyboardFocused on spawn"
+```
+
+---
+
+### Task 3: Host IME follows `KeyboardFocused` (`src/input/ime.rs`)
+
+**Files:**
+- Modify: `src/input/ime.rs:25` (import), `:171` (`ime_policy_system` param), `:224-234` (Ozma surface resolution), `:306` (`read_ime_events` param), `:352-365` (Ozma commit arm)
+- Test: `src/input/ime.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `ozma_terminal::KeyboardFocused` (Task 1).
+- Produces: in `AppMode::Ozma`, IME commit text routes to the `KeyboardFocused` terminal (`TerminalKeyInput { entity: <focused>, key: Text(..), .. }`), and `ime_policy_system` enables IME + anchors `ime_position` at that terminal's cursor.
+
+- [ ] **Step 1: Write the failing IME tests**
+
+In `src/input/ime.rs`, inside `#[cfg(test)] mod tests`, add a test-local import as the first line after `use super::*;` (line ~403):
+
+```rust
+    use ozma_terminal::KeyboardFocused;
+```
+
+Then add these two tests at the end of the `tests` module (before its closing `}`):
+
+```rust
+    #[test]
+    fn ime_commit_routes_to_focused_ozma_terminal() {
+        use bevy::prelude::On;
+
+        #[derive(Resource, Default)]
+        struct Hits(Vec<Entity>);
+
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin))
+            .add_systems(Update, read_ime_events);
+        app.init_resource::<ImeState>();
+        app.init_resource::<FocusedWebview>();
+        app.init_resource::<Hits>();
+        app.init_state::<AppMode>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.add_message::<Ime>();
+        app.add_observer(|ev: On<TerminalKeyInput>, mut hits: ResMut<Hits>| {
+            hits.0.push(ev.entity);
+        });
+
+        app.world_mut().spawn(OzmaTerminal);
+        let focused = app.world_mut().spawn((OzmaTerminal, KeyboardFocused)).id();
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .write(Ime::Commit {
+                window: Entity::PLACEHOLDER,
+                value: "あ".into(),
+            });
+        app.update();
+
+        assert_eq!(app.world().resource::<Hits>().0, vec![focused]);
+    }
+
+    #[test]
+    fn ime_enabled_and_anchored_for_focused_ozma_terminal() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin));
+        app.init_resource::<FocusedWebview>();
+        app.init_state::<AppMode>();
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+
+        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((
+            OzmaTerminal,
+            KeyboardFocused,
+            ComputedNode::default(),
+            UiGlobalTransform::default(),
+            TerminalGrid {
+                cursor: Some(Cursor::default()),
+                ..default()
+            },
+        ));
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ime_enabled: false,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+
+        app.world_mut().run_system_once(ime_policy_system).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>();
+        let window = q.single(app.world()).expect("primary window");
+        assert!(
+            window.ime_enabled,
+            "IME must enable for the focused Ozma terminal even with another terminal present"
+        );
+        assert_eq!(
+            window.ime_position,
+            Vec2::new(0.0, 16.0),
+            "candidate window anchors one row below the focused terminal's cursor"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the new tests — verify they fail**
+
+Run: `cargo test -p ozmux-gui ime_commit_routes_to_focused_ozma_terminal ime_enabled_and_anchored_for_focused_ozma_terminal`
+Expected: FAIL.
+- `ime_commit_routes_to_focused_ozma_terminal`: with two `OzmaTerminal` entities the Ozma arm's `ozma_terminal.single()` returns `Err`, so no `TerminalKeyInput` fires and `Hits` is empty.
+- `ime_enabled_and_anchored_for_focused_ozma_terminal`: with two terminals the old `ozma_terminal.single().is_ok()` is `false` so IME stays disabled, and the old Ozma arm never anchors `ime_position` (stays `Vec2::ZERO`).
+
+- [ ] **Step 3: Make `read_ime_events` route to the focused terminal**
+
+In `src/input/ime.rs`, change the import (line 25):
+
+```rust
+use ozma_terminal::{KeyboardFocused, OzmaTerminal};
+```
+
+Change the `read_ime_events` `ozma_terminal` parameter (line 306):
+
+```rust
+    ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
+```
+
+In the `AppMode::Ozma` arm of `read_ime_events` (lines 352-365), add a `// NOTE:` directly above the `let Ok(entity) = ozma_terminal.single() else { continue; };` line:
+
+```rust
+                AppMode::Ozma => {
+                    // NOTE: bevy_cef delivers the commit to the webview independently; suppress here to prevent duplicate input.
+                    if focused_webview.0.is_some() {
+                        continue;
+                    }
+                    // NOTE: route the commit to the focused terminal but do NOT
+                    // also filter on `KeyboardDisabled` — IME composition itself
+                    // sets `KeyboardDisabled` (suppressing raw keys via
+                    // `dispatch_input`), yet the commit must still land here.
+                    let Ok(entity) = ozma_terminal.single() else {
+                        continue;
+                    };
+                    commands.trigger(TerminalKeyInput {
+                        entity,
+                        key: TerminalKey::Text(commit_text),
+                        modifiers: TerminalModifiers::default(),
+                    });
+                }
+```
+
+- [ ] **Step 4: Make `ime_policy_system` use the focused terminal as the Ozma surface**
+
+In `src/input/ime.rs`, change the `ime_policy_system` `ozma_terminal` parameter (line 171):
+
+```rust
+    ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
+```
+
+Replace the no-surface early-return block (currently lines 224-234):
+
+```rust
+    let Some(entity) = active_surface else {
+        if *current_mode.get() == AppMode::Ozma {
+            let desired = ozma_terminal.single().is_ok();
+            if window.ime_enabled != desired {
+                window.ime_enabled = desired;
+            }
+        } else if window.ime_enabled {
+            window.ime_enabled = false;
+        }
+        return;
+    };
+```
+
+with:
+
+```rust
+    let surface = match active_surface {
+        Some(entity) => Some(entity),
+        // NOTE: Ozma mode has no tmux ActivePane; the keyboard-focused terminal
+        // is the IME surface, so the shared path below anchors `ime_position` at
+        // its cursor (the tmux path's same px math).
+        None if *current_mode.get() == AppMode::Ozma => ozma_terminal.single().ok(),
+        None => None,
+    };
+    let Some(entity) = surface else {
+        if window.ime_enabled {
+            window.ime_enabled = false;
+        }
+        return;
+    };
+```
+
+(The existing copy-mode / `desired` / anchoring code below this block is unchanged and now runs for the focused Ozma terminal: `copy_modes.get(entity)` is `Err` for it, so `desired` is `true`, and `anchors.get(entity)` succeeds because `OzmaTerminal` carries `ComputedNode` / `UiGlobalTransform` / `TerminalGrid`.)
+
+- [ ] **Step 5: Remove the now-redundant test-local import**
+
+In `src/input/ime.rs` tests module, delete the `use ozma_terminal::KeyboardFocused;` line added in Step 1 — `use super::*;` now re-exports `KeyboardFocused` because the top-of-file import (Step 3) brings it into the module. (The new tests reference `OzmaTerminal` via `super::*` and `KeyboardFocused` via `super::*`; no test-local `ozma_terminal` import remains.)
+
+- [ ] **Step 6: Run the IME tests — verify green**
+
+Run: `cargo test -p ozmux-gui ime`
+Expected: PASS — the two new tests plus all existing IME tests (`commit_consumes_state_with_active_pane`, `ime_enabled_for_active_tmux_pane`, etc.) stay green.
+
+- [ ] **Step 7: Build clean and commit**
+
+Run: `cargo build -p ozmux-gui && cargo clippy -p ozmux-gui`
+Expected: PASS, no warnings.
+
+```bash
+git add src/input/ime.rs
+git commit -m "feat: route Ozma IME commit and anchoring to the focused terminal"
+```
+
+---
+
+### Task 4: Workspace verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full workspace test + lint**
+
+Run: `cargo test && cargo clippy --workspace`
+Expected: PASS, no warnings across the workspace.
+
+- [ ] **Step 2: Manual end-to-end check (raw keys + IME)**
+
+Run: `cargo run`
+Expected:
+- Typing reaches the shell (raw-key path).
+- IME composition (switch to a Japanese IME, type, confirm) commits to the terminal and the candidate window appears at the cursor (IME path).
+
+No commit for this task (verification only). If any step fails, return to the owning task.
+
+---
+
+## Notes for the implementer
+
+- **Package names:** the crate is `ozma_terminal`; the host binary package is `ozmux-gui`. Use `-p ozma_terminal` / `-p ozmux-gui` to scope `cargo test`.
+- **Why `.single()` is kept** in `dispatch_input` and both IME systems: the host maintains the "exactly one `KeyboardFocused`" invariant. Two focused terminals is a host bug and degrades to "keys dropped" (the `two_focused_terminals_drop_keys` test pins this contract), the same failure shape as before this change.
+- **Out of scope (do not implement):** focus *policy* (what moves `KeyboardFocused` between terminals — click-to-focus, cycle keybind), multi-terminal layout/spawning, and multi-terminal exit policy. The host still spawns one terminal; this change is forward-looking capability.

--- a/docs/superpowers/specs/2026-06-20-ozma-terminal-multi-terminal-keyboard-design.md
+++ b/docs/superpowers/specs/2026-06-20-ozma-terminal-multi-terminal-keyboard-design.md
@@ -1,0 +1,262 @@
+# ozma_terminal Multi-Terminal Keyboard Input — Design
+
+**Date:** 2026-06-20
+**Status:** Design (pre-plan)
+**Crate:** `ozma_terminal` (+ host `src/ozma.rs`, `src/input/ime.rs`)
+
+## Goal
+
+Make the self-contained `ozma_terminal` crate's **keyboard** handling correct
+when more than one `OzmaTerminal` entity is live at once, mirroring what the
+multi-terminal **mouse** effort (#164,
+`2026-06-20-ozma-terminal-multi-terminal-mouse-design.md`) did for mouse.
+
+Because keyboard has no cursor, routing is by **sticky focus** rather than
+hit-testing: exactly one terminal carries a `KeyboardFocused` marker and
+receives all keyboard input — raw keys (`dispatch_input`) and IME (commit
+routing + candidate-window anchoring) — until the host moves the marker.
+
+## Scope
+
+**In scope:**
+
+- `dispatch_input` (`crates/ozma_terminal/src/input.rs`): route to the
+  `KeyboardFocused` terminal instead of `terminal.single()` over
+  `Without<KeyboardDisabled>`.
+- New `KeyboardFocused` marker component in the crate, exported from `lib.rs`.
+- Host IME (`src/input/ime.rs`): `read_ime_events` commit routing **and**
+  `ime_policy_system` enable/anchor — both follow `KeyboardFocused`.
+- Host: insert `KeyboardFocused` on the spawned terminal (`src/ozma.rs`).
+  `maintain_input_gates` (`src/ozma_input.rs`) keeps its responsibility (toggle
+  the modal `KeyboardDisabled` / `MouseDisabled` markers on all terminals).
+
+**Out of scope (flagged dependencies, not changed here):**
+
+- **Focus *policy*.** What actually *moves* focus between terminals
+  (click-to-focus, a cycle keybind, layout/z-order) is a separate effort. The
+  crate stays mechanism-only ("host-driven marker only"), and the host still
+  spawns exactly one terminal — so the marker never moves yet. This change is
+  forward-looking capability, exactly as the mouse PR shipped topmost routing
+  before any multi-terminal host existed.
+- **Layout / multi-terminal spawning.** `LayoutPlugin::resize_to_window`
+  (`layout.rs`) and `src/ozma.rs spawn_terminal` remain single-terminal. A real
+  multi-terminal host owns per-terminal sizing/positioning and PTY resize.
+- **Exit.** `exit.rs` multi-terminal exit policy is unaddressed (as in the mouse
+  effort).
+- **Single-window assumptions retained.** One window, many terminals.
+
+## Background — why it breaks today
+
+The keyboard path assumes exactly one interactive terminal:
+
+- `dispatch_input` (`input.rs:88`) calls `terminal.single()` over
+  `Query<Entity, (With<OzmaTerminal>, Without<KeyboardDisabled>)>`. The moment a
+  second un-disabled `OzmaTerminal` exists, `.single()` returns `Err` and **all**
+  keyboard input is dropped (`events.clear()`).
+- The host IME path has the same shape in two places, both in `src/input/ime.rs`:
+  - `read_ime_events` (`:357`, Ozma arm) routes the IME commit text via
+    `ozma_terminal.single()` → `TerminalKeyInput`. With 2+ terminals the commit
+    is dropped.
+  - `ime_policy_system` (`:226`, Ozma arm) toggles `ime_enabled =
+    ozma_terminal.single().is_ok()`; with 2+ terminals `.single()` → `Err` →
+    `is_ok()` is false → IME is silently disabled entirely. (This arm also never
+    anchors `ime_position` in Ozma mode today — it returns right after the toggle
+    — so Ozma-mode candidate-window anchoring is a pre-existing gap.)
+
+### Precedent: the multi-terminal mouse effort
+
+#164 made the crate's **mouse** path multi-terminal capable: topmost-under-cursor
+routing, a per-entity `MouseDisabled` marker, and entity-locked gestures. It
+explicitly punted keyboard:
+
+> **Keyboard routing.** `dispatch_input` keeps `terminal.single()` over
+> `Without<KeyboardDisabled>`. With multiple terminals the host is responsible
+> for keeping exactly one terminal un-`KeyboardDisabled` (the keyboard-focused
+> one). A true multi-terminal keyboard-focus mechanism is a separate effort.
+
+This design is that separate effort. It replaces the fragile "keep exactly one
+un-`KeyboardDisabled`" contract with an explicit positive `KeyboardFocused`
+marker, so modal gating (`KeyboardDisabled`) and focus (`KeyboardFocused`) are
+independent concerns.
+
+## Design decisions (from brainstorming)
+
+1. **Routing model:** sticky focus — exactly one `KeyboardFocused` terminal
+   receives keyboard input. (Mouse routes by cursor; keyboard has no cursor.)
+2. **Focus is host-driven, marker only:** the crate exposes the `KeyboardFocused`
+   marker and routes to it; it makes **no** focus decisions. The host owns all
+   focus policy. Purest mirror of the mouse PR's "crate = mechanism, host =
+   policy" split.
+3. **Representation:** a `KeyboardFocused` marker **component**, consistent with
+   the crate's existing per-entity marker gating (`KeyboardDisabled`,
+   `MouseDisabled`). The "exactly one focused" invariant is the host's
+   responsibility; two markers → `.single()` `Err` → keys dropped (same failure
+   shape as today).
+4. **IME follows focus:** both host IME systems target `KeyboardFocused`, so raw
+   keys, IME commits, and the candidate-window anchor all follow one focus.
+5. **Marker ownership:** the **host** inserts `KeyboardFocused` (spawn
+   `(bundle, KeyboardFocused)`); the crate's `OzmaTerminalBundle` does **not**
+   default to focused (see Alternatives).
+
+## Architecture
+
+The pure keyboard logic — `current_terminal_modifiers`, `chord_matches`,
+`bevy_key_to_terminal_key` — is **unchanged**. Only the routing query, one new
+marker, and the host integration change. The gather → decide → apply seam is
+intact: `dispatch_input` still gathers events and `commands.trigger`s
+`PasteAction` / `TerminalKeyInput` at `ev.entity`; the apply observers
+(`on_terminal_key_input`, `on_paste`) target `ev.entity` and need no change.
+
+### 1. `KeyboardFocused` marker
+
+New marker beside `KeyboardDisabled` in `input.rs`, re-exported from `lib.rs`:
+
+```rust
+/// When present on an `OzmaTerminal` entity, that terminal is the keyboard
+/// focus: the crate's keyboard dispatcher routes raw keys to it (and the host
+/// routes IME commits / anchors the candidate window to it). The host
+/// maintains the "exactly one focused" invariant; a terminal with no
+/// `KeyboardFocused` receives no keyboard input.
+#[derive(Component)]
+pub struct KeyboardFocused;
+```
+
+- `KeyboardFocused` lives in `input.rs` (alongside `KeyboardDisabled`), exported
+  from `lib.rs` so the gating + focus API is colocated at the export site.
+- It is distinct from the modal `KeyboardDisabled` (see §2). The crate makes no
+  focus decisions; the host is the sole writer.
+
+### 2. `dispatch_input` routing
+
+The query gains the positive focus filter:
+
+```rust
+terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)>,
+```
+
+- Still `.single()`; still `events.clear()` + `return` on `Err`. The body is
+  otherwise unchanged.
+- The existing `// NOTE:` at the `.single()` site is rewritten: the host MUST
+  keep exactly one terminal `KeyboardFocused`-and-not-`KeyboardDisabled`, or
+  `.single()` returns `Err` and every keypress is silently dropped.
+
+### 3. `KeyboardFocused` vs `KeyboardDisabled` — orthogonal
+
+| Marker | Meaning | Lifetime | Writer |
+| --- | --- | --- | --- |
+| `KeyboardFocused` | "this terminal is the keyboard target" | sticky (set on spawn; moved by future focus policy) | host (focus policy) |
+| `KeyboardDisabled` | modal suppression (picker / IME-composing / webview-focused / window-unfocused) | transient | host (`maintain_input_gates`) |
+
+- During a modal, `maintain_input_gates` marks **all** terminals
+  `KeyboardDisabled` (unchanged). The focused terminal is then *also*
+  `KeyboardDisabled` → the dispatch set is empty → keys drop. Outside a modal,
+  the focused terminal is the sole un-disabled focused one → routes.
+- This reproduces today's single-terminal behavior exactly, with **no new global
+  resource**. The host does **not** remove `KeyboardFocused` during modals —
+  only `KeyboardDisabled` toggles.
+
+### 4. IME follows focus (host, `src/input/ime.rs`)
+
+Both Ozma-arm `.single()` sites retarget to the `KeyboardFocused` terminal.
+
+- **`read_ime_events`** (Ozma arm): replace `ozma_terminal.single()` with a
+  focus query `Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>`.
+  **Critical (`// NOTE:`):** this path does **not** gate on `KeyboardDisabled`.
+  IME composition itself is one of the modal triggers that sets
+  `KeyboardDisabled` (suppressing raw keys via `dispatch_input`), but the IME
+  *commit* must still land on the focused terminal. Gating the commit on
+  `KeyboardDisabled` would drop every committed composition.
+- **`ime_policy_system`** (Ozma arm): today, with no tmux `ActivePane`, it only
+  sets `ime_enabled = ozma_terminal.single().is_ok()` and returns without
+  anchoring. Change it to treat the `KeyboardFocused` terminal as the surface:
+  - `ime_enabled` ← a `KeyboardFocused` terminal exists;
+  - anchor `ime_position` at that terminal's cursor by reusing the **existing**
+    tmux anchoring math — `anchors.get(focused)` over
+    `(&ComputedNode, &UiGlobalTransform, &TerminalGrid)`, which `OzmaTerminal`
+    already carries (the mouse hit-test reads the same components). This fixes
+    the multi-terminal break **and** closes the pre-existing Ozma-mode
+    no-anchor gap, so the candidate window appears at the focused terminal's
+    cursor (one row below, per the existing macOS anchoring `// NOTE:`).
+  - Copy-mode handling stays as in the tmux path where applicable; the Ozma
+    terminal has no tmux `CopyModeState`, so the `desired = !in_copy_mode` guard
+    naturally resolves to "enabled" for it.
+
+### 5. Host integration & marker ownership (`src/ozma.rs`, `src/ozma_input.rs`)
+
+- `maintain_input_gates` (`src/ozma_input.rs`) is **unchanged** in
+  responsibility: it toggles `KeyboardDisabled` / `MouseDisabled` on every
+  terminal from the global `disable` bool. It does **not** touch
+  `KeyboardFocused`.
+- `spawn_terminal` (`src/ozma.rs`) spawns `(bundle, KeyboardFocused)` so the one
+  host terminal is the keyboard target for its lifetime. A future multi-terminal
+  host moves the marker via its focus policy.
+
+## Alternatives considered
+
+- **Resource `KeyboardFocus(Option<Entity>)`** instead of a marker component.
+  Single source of truth (structurally impossible to have "two focused"), and
+  `dispatch_input` would read + validate the entity. **Rejected:** it introduces
+  a different vocabulary than the crate's existing per-entity markers
+  (`KeyboardDisabled`, `MouseDisabled`); the marker keeps the gating + focus API
+  uniform and the failure mode (`.single()` `Err`) identical to today.
+- **Crate's `OzmaTerminalBundle` defaults to `KeyboardFocused`** (friendlier
+  spawn-and-go). **Rejected:** spawning two terminals → both focused →
+  `.single()` `Err`; the host would then have to remove the marker from
+  all-but-one. That contradicts "host-driven marker only" and adds a
+  multi-terminal footgun. The host inserts the marker explicitly instead.
+- **Reuse `KeyboardDisabled` alone** (host keeps exactly one un-disabled, the
+  original mouse-PR note's contract). **Rejected:** it conflates the transient
+  modal gate with sticky focus — a modal would have to remember and restore
+  which terminal was focused. The positive `KeyboardFocused` marker separates the
+  two concerns cleanly.
+
+## Change surface
+
+**Crate `ozma_terminal`:**
+
+| File | Change |
+| --- | --- |
+| `input.rs:14-18` | add `pub struct KeyboardFocused;` + doc, beside `KeyboardDisabled` |
+| `input.rs:88-101` | `dispatch_input` query adds `With<KeyboardFocused>`; rewrite the `.single()` `// NOTE:` |
+| `input.rs` tests | spawn `(OzmaTerminal, KeyboardFocused)`; add multi-terminal / focused-but-disabled / no-focus cases (see Testing) |
+| `lib.rs:21` | export `KeyboardFocused` |
+| `spawn.rs` | `OzmaTerminal` doc: note keyboard focus is host-driven via `KeyboardFocused` (mirror the mouse-doc multi-terminal premise fix) |
+
+**Host:**
+
+| File | Change |
+| --- | --- |
+| `src/ozma.rs` (`spawn_terminal`) | spawn `(bundle, KeyboardFocused)`; import `KeyboardFocused` |
+| `src/input/ime.rs` (`read_ime_events`, Ozma arm) | query `KeyboardFocused` terminal; `// NOTE:` it must not gate on `KeyboardDisabled` |
+| `src/input/ime.rs` (`ime_policy_system`, Ozma arm) | enable + anchor `ime_position` at the `KeyboardFocused` terminal's cursor (reuse tmux math) |
+
+## Testing
+
+- **Routing — focus required:** existing `dispatch_input` tests spawn
+  `(OzmaTerminal, KeyboardFocused)` (now required to receive keys); plain-key,
+  paste-chord, reserved-chord, meta-chord cases stay green.
+- **Multi-terminal dispatch:** two live terminals, one `KeyboardFocused` → only
+  the focused one receives keys (proves the old `.single()`-drops-everything
+  failure is gone).
+- **Gating wins over focus:** a `KeyboardFocused`-but-`KeyboardDisabled`
+  terminal drops keys (modal still suppresses).
+- **No focus:** zero `KeyboardFocused` terminals → keys dropped (`.single()`
+  `Err` path).
+- **Pure logic untouched:** `bevy_key_to_terminal_key` / `chord_matches` /
+  `current_terminal_modifiers` tests stay green.
+- **Host IME:** the commit-routing change is a query-filter swap; existing IME
+  behavior holds once spawns carry `KeyboardFocused`. Add a focused-routing
+  assertion where the `NonSend TmuxConnection` deps allow (the Ozma arm path
+  triggers `TerminalKeyInput`, which is observable as in the existing crate
+  tests).
+
+## Constraints (repo coding rules)
+
+- Rust 2024 / toolchain 1.95. No `mod.rs`. Comments only `// TODO:` / `// NOTE:`
+  / `// SAFETY:`, English. Every `pub` item `///`-documented; module files `//!`.
+- Imports in one top block, no inline fully-qualified paths.
+- Bevy: mutable `SystemParam`s before immutable; whole-system change gates via
+  `run_if` not in-body early return; `Plugin::build` one method chain; `Query`
+  params descriptive nouns (no `_q`).
+- Visibility minimized; private items last in a block; `#[expect(reason=…)]` over
+  `#[allow]`.

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -22,7 +22,7 @@ use bevy::prelude::{Entity, State};
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{Ime, PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
-use ozma_terminal::OzmaTerminal;
+use ozma_terminal::{KeyboardFocused, OzmaTerminal};
 use ozma_tty_engine::{TerminalHandle, TerminalKey, TerminalKeyInput, TerminalModifiers};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::prelude::{TerminalGrid, TerminalOverlays};
@@ -168,7 +168,7 @@ pub(crate) fn ime_policy_system(
     inline_slots: Query<&InlineWebview>,
     overlays: Query<&TerminalOverlays>,
     current_mode: Res<State<AppMode>>,
-    ozma_terminal: Query<(), With<OzmaTerminal>>,
+    ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
 ) {
     let Ok(mut window) = primary_window.single_mut() else {
         return;
@@ -221,13 +221,16 @@ pub(crate) fn ime_policy_system(
         return;
     }
 
-    let Some(entity) = active_surface else {
-        if *current_mode.get() == AppMode::Ozma {
-            let desired = ozma_terminal.single().is_ok();
-            if window.ime_enabled != desired {
-                window.ime_enabled = desired;
-            }
-        } else if window.ime_enabled {
+    let surface = match active_surface {
+        Some(entity) => Some(entity),
+        // NOTE: Ozma mode has no tmux ActivePane; the keyboard-focused terminal
+        // is the IME surface, so the shared path below anchors `ime_position` at
+        // its cursor (the tmux path's same px math).
+        None if *current_mode.get() == AppMode::Ozma => ozma_terminal.single().ok(),
+        None => None,
+    };
+    let Some(entity) = surface else {
+        if window.ime_enabled {
             window.ime_enabled = false;
         }
         return;
@@ -303,7 +306,7 @@ pub(crate) fn read_ime_events(
     focused_webview: Res<FocusedWebview>,
     inline_parents: Query<&ChildOf, With<InlineWebview>>,
     current_mode: Res<State<AppMode>>,
-    ozma_terminal: Query<Entity, With<OzmaTerminal>>,
+    ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
     copy_modes: Query<(), With<CopyModeState>>,
 ) {
     let active = active_pane.map(|single| *single);
@@ -354,6 +357,10 @@ pub(crate) fn read_ime_events(
                     if focused_webview.0.is_some() {
                         continue;
                     }
+                    // NOTE: route the commit to the focused terminal but do NOT
+                    // also filter on `KeyboardDisabled` — IME composition itself
+                    // sets `KeyboardDisabled` (suppressing raw keys via
+                    // `dispatch_input`), yet the commit must still land here.
                     let Ok(entity) = ozma_terminal.single() else {
                         continue;
                     };
@@ -911,6 +918,97 @@ mod tests {
         assert!(
             !app.world().resource::<ImeState>().is_composing(),
             "commit should clear the composition even when dropped",
+        );
+    }
+
+    #[test]
+    fn ime_commit_routes_to_focused_ozma_terminal() {
+        use bevy::prelude::On;
+
+        #[derive(Resource, Default)]
+        struct Hits(Vec<Entity>);
+
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin))
+            .add_systems(Update, read_ime_events);
+        app.init_resource::<ImeState>();
+        app.init_resource::<FocusedWebview>();
+        app.init_resource::<Hits>();
+        app.init_state::<AppMode>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.add_message::<Ime>();
+        app.add_observer(|ev: On<TerminalKeyInput>, mut hits: ResMut<Hits>| {
+            hits.0.push(ev.entity);
+        });
+
+        app.world_mut().spawn(OzmaTerminal);
+        let focused = app.world_mut().spawn((OzmaTerminal, KeyboardFocused)).id();
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .write(Ime::Commit {
+                window: Entity::PLACEHOLDER,
+                value: "あ".into(),
+            });
+        app.update();
+
+        assert_eq!(app.world().resource::<Hits>().0, vec![focused]);
+    }
+
+    #[test]
+    fn ime_enabled_and_anchored_for_focused_ozma_terminal() {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin));
+        app.init_resource::<FocusedWebview>();
+        app.init_state::<AppMode>();
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
+
+        app.world_mut().spawn(OzmaTerminal);
+        app.world_mut().spawn((
+            OzmaTerminal,
+            KeyboardFocused,
+            ComputedNode::default(),
+            UiGlobalTransform::default(),
+            TerminalGrid {
+                cursor: Some(Cursor::default()),
+                ..default()
+            },
+        ));
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ime_enabled: false,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+
+        app.world_mut().run_system_once(ime_policy_system).unwrap();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Window, With<PrimaryWindow>>();
+        let window = q.single(app.world()).expect("primary window");
+        assert!(
+            window.ime_enabled,
+            "IME must enable for the focused Ozma terminal even with another terminal present"
+        );
+        assert_eq!(
+            window.ime_position,
+            Vec2::new(0.0, 16.0),
+            "candidate window anchors one row below the focused terminal's cursor"
         );
     }
 }

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -146,12 +146,13 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 /// `PrimaryWindow.ime_enabled` and `.ime_position`.
 ///
 /// `ime_enabled` is `true` iff a CEF webview owns focus (it drives its own
-/// IME through bevy_cef's `Ime` → CEF bridge), OR a tmux pane is active and
-/// that pane does NOT have `CopyModeState`, OR — in `AppMode::Ozma` with no
-/// active pane — a `KeyboardFocused` terminal exists (its cursor is the anchor).
+/// IME through bevy_cef's `Ime` → CEF bridge), OR a surface exists that does
+/// NOT have `CopyModeState`. The surface is the active tmux pane, or — in
+/// `AppMode::Ozma` with no active pane — the `KeyboardFocused` terminal; both
+/// flow through the same copy-mode gate below.
 ///
 /// `ime_position` is the logical-pixel anchor for the OS candidate
-/// window — computed from the active pane's `UiGlobalTransform`
+/// window — computed from the surface's `UiGlobalTransform`
 /// translation + `TerminalGrid.cursor` × cell pitch, then divided by
 /// the window scale factor. When the focused webview is an INLINE child of
 /// the active pane, the anchor instead comes from that child's overlay
@@ -224,9 +225,7 @@ pub(crate) fn ime_policy_system(
 
     let surface = match active_surface {
         Some(entity) => Some(entity),
-        // NOTE: Ozma mode has no tmux ActivePane; the keyboard-focused terminal
-        // is the IME surface, so the shared path below anchors `ime_position` at
-        // its cursor (the tmux path's same px math).
+        // NOTE: Ozma mode has no tmux ActivePane; fall back to the focused terminal.
         None if *current_mode.get() == AppMode::Ozma => ozma_terminal.single().ok(),
         None => None,
     };
@@ -272,7 +271,7 @@ pub(crate) fn ime_policy_system(
     let Ok((node, ui_xform, grid)) = anchors.get(entity) else {
         return;
     };
-    let scale = window.resolution.scale_factor();
+    let scale = window.resolution.scale_factor().max(f32::EPSILON);
     let cell_w_phys = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
     let cursor_cell = grid.cursor.clone().unwrap_or_default();

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -147,7 +147,8 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 ///
 /// `ime_enabled` is `true` iff a CEF webview owns focus (it drives its own
 /// IME through bevy_cef's `Ime` → CEF bridge), OR a tmux pane is active and
-/// that pane does NOT have `CopyModeState`.
+/// that pane does NOT have `CopyModeState`, OR — in `AppMode::Ozma` with no
+/// active pane — a `KeyboardFocused` terminal exists (its cursor is the anchor).
 ///
 /// `ime_position` is the logical-pixel anchor for the OS candidate
 /// window — computed from the active pane's `UiGlobalTransform`

--- a/src/ozma.rs
+++ b/src/ozma.rs
@@ -1,7 +1,9 @@
 //! AppMode state enum and the Ozma single-terminal lifecycle plugin.
 
 use bevy::prelude::*;
-use ozma_terminal::{OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig};
+use ozma_terminal::{
+    KeyboardFocused, OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig,
+};
 
 /// Application mode. `Ozma` is the default (single PTY, no tmux).
 /// `Ozmux` activates the tmux multiplexer backend.
@@ -16,8 +18,8 @@ pub(crate) enum AppMode {
 
 /// Bevy plugin that registers the `AppMode::Ozma` spawn/despawn lifecycle.
 ///
-/// Spawns one `OzmaTerminal` entity on `OnEnter(AppMode::Ozma)` and
-/// despawns it on `OnExit(AppMode::Ozma)`. Requires `AppMode` to be
+/// Spawns one `OzmaTerminal` entity (marked `KeyboardFocused`, the keyboard
+/// target) on `OnEnter(AppMode::Ozma)` and despawns it on `OnExit(AppMode::Ozma)`. Requires `AppMode` to be
 /// inserted via `App::insert_state` before this plugin runs, and
 /// `OzmaTerminalPlugin` must be added first (it inserts `OzmaTerminalConfig`
 /// that `spawn_terminal` reads).
@@ -40,7 +42,7 @@ fn spawn_terminal(
         ..default()
     }) {
         Ok(bundle) => {
-            commands.spawn(bundle);
+            commands.spawn((bundle, KeyboardFocused));
         }
         Err(e) => {
             tracing::error!(?e, "failed to spawn ozma terminal");

--- a/src/ozma.rs
+++ b/src/ozma.rs
@@ -19,10 +19,10 @@ pub(crate) enum AppMode {
 /// Bevy plugin that registers the `AppMode::Ozma` spawn/despawn lifecycle.
 ///
 /// Spawns one `OzmaTerminal` entity (marked `KeyboardFocused`, the keyboard
-/// target) on `OnEnter(AppMode::Ozma)` and despawns it on `OnExit(AppMode::Ozma)`. Requires `AppMode` to be
-/// inserted via `App::insert_state` before this plugin runs, and
-/// `OzmaTerminalPlugin` must be added first (it inserts `OzmaTerminalConfig`
-/// that `spawn_terminal` reads).
+/// target) on `OnEnter(AppMode::Ozma)` and despawns it on
+/// `OnExit(AppMode::Ozma)`. Requires `AppMode` to be inserted via
+/// `App::insert_state` before this plugin runs, and `OzmaTerminalPlugin` must
+/// be added first (it inserts `OzmaTerminalConfig` that `spawn_terminal` reads).
 pub(crate) struct OzmaModePlugin;
 
 impl Plugin for OzmaModePlugin {


### PR DESCRIPTION
## Problem

`ozma_terminal`'s **keyboard** path assumed exactly one live terminal. `dispatch_input` and the host IME systems (`read_ime_events`, `ime_policy_system`) all resolved their target with `.single()` over `OzmaTerminal`, so the moment a second terminal exists every keypress and IME commit is dropped. The earlier multi-terminal **mouse** work (#164) made mouse routing multi-terminal aware but explicitly deferred keyboard — "a true multi-terminal keyboard-focus mechanism is a separate effort." This PR is that effort.

## Solution

Keyboard has no cursor, so routing is by **sticky focus** rather than hit-testing: a new `KeyboardFocused` marker component marks the one terminal that receives keyboard input.

- **`ozma_terminal` crate** — add `KeyboardFocused`; `dispatch_input` routes to `(With<OzmaTerminal>, With<KeyboardFocused>, Without<KeyboardDisabled>)`. `KeyboardFocused` (sticky focus) and `KeyboardDisabled` (transient modal gate) are kept orthogonal, so single-terminal behavior is unchanged with no new global resource.
- **Host (`src/ozma.rs`)** — spawns its single terminal carrying `KeyboardFocused`, satisfying the "exactly one focused" invariant the `.single()` contract depends on (two-focused or zero-focused → keys dropped is the intended, documented degradation).
- **Host IME (`src/input/ime.rs`)** — `read_ime_events` commit routing and `ime_policy_system` enable + candidate-window anchoring now follow the focused terminal, so raw keys and IME stay coherent. The IME commit path deliberately does **not** also gate on `KeyboardDisabled` (IME composition itself sets that marker, yet the commit must still land). This also closes a pre-existing gap where Ozma-mode IME was never anchored.

Affected areas: `crates/ozma_terminal` (`input.rs`, `lib.rs`, `spawn.rs`), host (`src/ozma.rs`, `src/input/ime.rs`), plus the design + plan docs under `docs/superpowers/`.

**Out of scope (forward-looking, mirrors how #164 shipped routing before any multi-terminal host):** focus *policy* (what moves the marker — click-to-focus, a cycle keybind) and multi-terminal layout/spawning. The host still spawns one terminal.

### Tests

`ozma_terminal` 62/62, host IME 38/38 (incl. a new focused-routing test), `cargo clippy` + `cargo fmt --check` clean on the touched crates. Note: an unrelated, pre-existing `ozmux_tmux` test (`connection_reset_clears_everything`) fails identically on the base commit and is untouched by this branch.

### Known follow-up

While a modal (e.g. the session picker) owns the keyboard, IME composition still anchors at / commits to the background terminal — a **pre-existing** modal/IME interaction this work makes slightly more visible (it now also anchors the candidate window). A correct fix needs the IME systems to distinguish "disabled due to composition" from "disabled due to a modal," which is a separate change; tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
