### PR TITLE
refactor(tmux): split drain_tmux_events into chained systems + enum reply correlation

### DIFF
--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -483,6 +483,7 @@ impl EnumerationState {
                     | PendingReply::Cursor { .. }
                     | PendingReply::ListWindows
                     | PendingReply::ActivePane
+                    | PendingReply::AggressiveResize
             )
         });
         self.capture_awaiting_cursor.clear();
@@ -874,11 +875,15 @@ mod tests {
         state
             .pending
             .insert(CommandId(4), PendingReply::Capture { pane: PaneId(7) });
+        state
+            .pending
+            .insert(CommandId(5), PendingReply::AggressiveResize);
         state.aggressive_resize_checked = true;
         state.clear_for_session_switch();
         assert_eq!(
             state.pending.get(&CommandId(3)),
-            Some(&PendingReply::KeyBindings)
+            Some(&PendingReply::KeyBindings),
+            "keybindings entry must survive"
         );
         assert!(
             !state.pending.contains_key(&CommandId(1)),
@@ -891,6 +896,10 @@ mod tests {
         assert!(
             !state.pending.contains_key(&CommandId(4)),
             "capture dropped"
+        );
+        assert!(
+            !state.pending.contains_key(&CommandId(5)),
+            "stale aggressive-resize dropped so new session is re-checked"
         );
         assert!(!state.aggressive_resize_checked, "aggressive guard reset");
     }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -5,7 +5,7 @@ use crate::input::quote;
 use crate::keybindings::PromptKind;
 use bevy::prelude::Resource;
 use std::collections::{HashMap, HashSet};
-use tmux_control::CommandId;
+use tmux_control::{CommandId, TmuxResult};
 use tmux_control_parser::{PaneId, SessionId, WindowId, WindowLayout};
 
 /// The `-F` format ozmux sends to enumerate windows. Tab-separated, with the
@@ -418,47 +418,77 @@ pub(crate) fn aggressive_resize_command(win: WindowId) -> String {
     format!("show-options -wqv -t @{} aggressive-resize", win.0)
 }
 
-/// Tracks the in-flight `list-windows` enumeration command so its reply can
-/// be correlated by [`CommandId`] and seeded into the projection.
+/// What an in-flight command's reply will populate, keyed by its `CommandId`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum PendingReply {
+    /// `list-windows` enumeration → per-row projection seed.
+    ListWindows,
+    /// `display-message #{client_name}`.
+    ClientName,
+    /// `display-message #{version}`.
+    Version,
+    /// `display-message #{window_id} #{pane_id}` active-pane query.
+    ActivePane,
+    /// Any `list-keys -T <table>` reply → `KeyBindings::install`.
+    KeyBindings,
+    /// Prefix-options query → `set_prefix_keys`.
+    PrefixKeys,
+    /// `#{mode-keys}` → `set_mode_keys`.
+    ModeKeys,
+    /// `aggressive-resize` option query → warn if `on`.
+    AggressiveResize,
+    /// `capture-pane` of a pane's screen.
+    Capture { pane: PaneId },
+    /// Cursor-position query paired with a [`PendingReply::Capture`].
+    Cursor { pane: PaneId },
+}
+
+/// Correlates in-flight enumeration/query commands by [`CommandId`] and the
+/// capture/cursor pairing buffers, so each drained reply routes to its handler.
 #[derive(Resource, Default)]
 pub(crate) struct EnumerationState {
-    /// The id of the in-flight `list-windows` command, if any.
-    pub(crate) pending: Option<CommandId>,
-    /// The id of the in-flight `display-message` client-name query, if any.
-    pub(crate) client_name_pending: Option<CommandId>,
-    /// The id of the in-flight `display-message` version query, if any.
-    pub(crate) version_pending: Option<CommandId>,
-    /// The id of the in-flight `display-message` active-pane query, if any.
-    pub(crate) active_pane_pending: Option<CommandId>,
-    /// The id of the in-flight `list-keys -T root` command, if any.
-    pub(crate) keys_root_pending: Option<CommandId>,
-    /// The id of the in-flight `list-keys -T prefix` command, if any.
-    pub(crate) keys_prefix_pending: Option<CommandId>,
-    /// The id of the in-flight `display-message` prefix-key query, if any.
-    pub(crate) prefix_keys_pending: Option<CommandId>,
-    /// In-flight `list-keys -T copy-mode` command, if any.
-    pub(crate) keys_copy_mode_pending: Option<CommandId>,
-    /// In-flight `list-keys -T copy-mode-vi` command, if any.
-    pub(crate) keys_copy_mode_vi_pending: Option<CommandId>,
-    /// In-flight `#{mode-keys}` query, if any.
-    pub(crate) mode_keys_pending: Option<CommandId>,
-    /// The id of the in-flight `aggressive-resize` option query, if any.
-    pub(crate) aggressive_resize_pending: Option<CommandId>,
-    /// Whether the one-time aggressive-resize option check has completed.
+    pub(crate) pending: HashMap<CommandId, PendingReply>,
     pub(crate) aggressive_resize_checked: bool,
-    /// In-flight `capture-pane` commands → the pane each reply seeds.
-    pub(crate) capture_pending: HashMap<CommandId, PaneId>,
-    /// In-flight cursor-position `display-message` queries → the pane.
-    ///
-    /// Replies arrive after the paired `capture-pane` reply (FIFO). When both
-    /// have been received the cursor-positioning escape is appended to the
-    /// captured content before the `PaneOutput` is emitted.
-    pub(crate) cursor_pending: HashMap<CommandId, PaneId>,
-    /// Panes whose cursor query is still in-flight; used for O(1) lookup when
-    /// the capture reply arrives to decide whether to cache or emit immediately.
-    pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
-    /// Captured screen lines held while the cursor reply has not yet arrived.
     pub(crate) capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
+    pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
+}
+
+impl EnumerationState {
+    /// Records `reply` under the id `send` returned, logging on send failure.
+    pub(crate) fn register(&mut self, send: TmuxResult<CommandId>, reply: PendingReply) {
+        match send {
+            Ok(id) => {
+                self.pending.insert(id, reply);
+            }
+            Err(error) => tracing::warn!(?error, ?reply, "failed to send tmux query"),
+        }
+    }
+
+    /// Whether a reply of `reply`'s kind is already in flight (replaces the old
+    /// `Option::is_some` singleton guard for client-name / aggressive-resize).
+    pub(crate) fn has_pending(&self, reply: PendingReply) -> bool {
+        self.pending.values().any(|r| *r == reply)
+    }
+
+    /// Drops the in-flight entries a session switch invalidates: the
+    /// capture/cursor pairs and the enumeration ids `send_session_enumeration`
+    /// re-issues. A `HashMap` keyed by `CommandId` does not get the old
+    /// `Option` fields' free last-write-wins overwrite, so a stale pre-switch
+    /// `list-windows`/active-pane reply would otherwise mis-seed the new session.
+    pub(crate) fn clear_for_session_switch(&mut self) {
+        self.pending.retain(|_, r| {
+            !matches!(
+                r,
+                PendingReply::Capture { .. }
+                    | PendingReply::Cursor { .. }
+                    | PendingReply::ListWindows
+                    | PendingReply::ActivePane
+            )
+        });
+        self.capture_awaiting_cursor.clear();
+        self.panes_with_cursor_pending.clear();
+        self.aggressive_resize_checked = false;
+    }
 }
 
 #[cfg(test)]
@@ -829,5 +859,39 @@ mod tests {
     #[test]
     fn version_command_has_expected_format() {
         assert_eq!(version_command(), "display-message -p '#{version}'");
+    }
+
+    #[test]
+    fn clear_for_session_switch_drops_enumeration_but_keeps_keybindings() {
+        let mut state = EnumerationState::default();
+        state
+            .pending
+            .insert(CommandId(1), PendingReply::ListWindows);
+        state.pending.insert(CommandId(2), PendingReply::ActivePane);
+        state
+            .pending
+            .insert(CommandId(3), PendingReply::KeyBindings);
+        state
+            .pending
+            .insert(CommandId(4), PendingReply::Capture { pane: PaneId(7) });
+        state.aggressive_resize_checked = true;
+        state.clear_for_session_switch();
+        assert_eq!(
+            state.pending.get(&CommandId(3)),
+            Some(&PendingReply::KeyBindings)
+        );
+        assert!(
+            !state.pending.contains_key(&CommandId(1)),
+            "stale list-windows dropped"
+        );
+        assert!(
+            !state.pending.contains_key(&CommandId(2)),
+            "stale active-pane dropped"
+        );
+        assert!(
+            !state.pending.contains_key(&CommandId(4)),
+            "capture dropped"
+        );
+        assert!(!state.aggressive_resize_checked, "aggressive guard reset");
     }
 }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -458,6 +458,22 @@ impl EnumerationState {
     pub(crate) fn register(&mut self, send: TmuxResult<CommandId>, reply: PendingReply) {
         match send {
             Ok(id) => {
+                // NOTE: singleton query kinds keep the old `Option` last-write-wins
+                // — a re-issued query must supersede any still-in-flight one of the
+                // same kind, or BOTH ids stay in `pending` and dispatch twice (a
+                // re-sent list-windows on %window-add while the attach enumeration
+                // is still in flight would fire trigger_seed twice, and a re-queried
+                // active-pane would fire TmuxActivePaneChanged twice). The four
+                // concurrent KeyBindings tables and the per-pane Capture/Cursor kinds
+                // are legitimately multi and exempt.
+                if !matches!(
+                    reply,
+                    PendingReply::KeyBindings
+                        | PendingReply::Capture { .. }
+                        | PendingReply::Cursor { .. }
+                ) {
+                    self.pending.retain(|_, r| *r != reply);
+                }
                 self.pending.insert(id, reply);
             }
             Err(error) => tracing::warn!(?error, ?reply, "failed to send tmux query"),
@@ -902,5 +918,56 @@ mod tests {
             "stale aggressive-resize dropped so new session is re-checked"
         );
         assert!(!state.aggressive_resize_checked, "aggressive guard reset");
+    }
+
+    #[test]
+    fn register_supersedes_in_flight_singleton_but_keeps_concurrent_kinds() {
+        let mut state = EnumerationState::default();
+        state.register(Ok(CommandId(1)), PendingReply::ListWindows);
+        state.register(Ok(CommandId(2)), PendingReply::ListWindows);
+        assert!(
+            !state.pending.contains_key(&CommandId(1)),
+            "the superseded list-windows id is dropped (old Option last-write-wins)"
+        );
+        assert_eq!(
+            state.pending.get(&CommandId(2)),
+            Some(&PendingReply::ListWindows),
+            "only the latest list-windows id remains, so trigger_seed fires once"
+        );
+
+        state.register(Ok(CommandId(3)), PendingReply::ActivePane);
+        state.register(Ok(CommandId(4)), PendingReply::ActivePane);
+        assert!(
+            !state.pending.contains_key(&CommandId(3)),
+            "stale active-pane dropped"
+        );
+        assert_eq!(
+            state.pending.get(&CommandId(4)),
+            Some(&PendingReply::ActivePane)
+        );
+
+        state.register(Ok(CommandId(5)), PendingReply::KeyBindings);
+        state.register(Ok(CommandId(6)), PendingReply::KeyBindings);
+        assert_eq!(
+            state.pending.get(&CommandId(5)),
+            Some(&PendingReply::KeyBindings),
+            "the four list-keys tables are concurrent — earlier KeyBindings entries are kept"
+        );
+        assert_eq!(
+            state.pending.get(&CommandId(6)),
+            Some(&PendingReply::KeyBindings)
+        );
+
+        state.register(Ok(CommandId(7)), PendingReply::Capture { pane: PaneId(1) });
+        state.register(Ok(CommandId(8)), PendingReply::Capture { pane: PaneId(2) });
+        assert_eq!(
+            state.pending.get(&CommandId(7)),
+            Some(&PendingReply::Capture { pane: PaneId(1) }),
+            "per-pane captures are independent — both kept"
+        );
+        assert_eq!(
+            state.pending.get(&CommandId(8)),
+            Some(&PendingReply::Capture { pane: PaneId(2) })
+        );
     }
 }

--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -8,13 +8,10 @@ use crate::events::{
     TmuxWindowAdded, TmuxWindowClosed, TmuxWindowFlagsChanged, TmuxWindowRenamed,
     TmuxWindowsRetained,
 };
-use crate::keybindings::{KeyBinding, ModeKeys, parse_list_keys, parse_prefix};
-use crate::output::PaneOutput;
 use crate::state::{ConnectionState, next_state};
 use bevy::prelude::Commands;
 use crossbeam_channel::Receiver;
-use std::collections::{HashMap, HashSet};
-use tmux_control::{ClientEvent, CommandId, ControlEvent, TransportEvent};
+use tmux_control::{ClientEvent, ControlEvent, TransportEvent};
 use tmux_control_parser::{PaneId, SessionId, WindowId};
 
 /// Upper bound on events drained per frame, so a pane flooding `%output`
@@ -56,176 +53,23 @@ pub(crate) fn advance_state(
     next.filter(|n| n != current)
 }
 
-/// Translates a drained transport batch into global projection events, in
-/// stream order, triggering each via `commands`. The enumeration reply (the
-/// `CommandComplete` whose id matches `pending`) is decomposed into per-row
-/// `TmuxWindowAdded` + `TmuxLayoutChanged` (+ `TmuxActiveWindowChanged` for the
-/// active row), followed by one `TmuxWindowsRetained` prune. Untracked events
-/// (e.g. `%output`) are ignored here (routed separately as `PaneOutput`).
-/// `own_client` gates `%client-session-changed` — see [`detect_session_switch`].
-pub(crate) fn trigger_events(
-    commands: &mut Commands,
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-    own_client: Option<&str>,
-) {
-    for event in events {
-        match event {
-            TransportEvent::Protocol(ClientEvent::Notification(notification)) => {
-                trigger_notification(commands, own_client, notification);
-            }
-            TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. })
-                if *pending == Some(*id) =>
-            {
-                *pending = None;
-                if *ok {
-                    trigger_seed(commands, output);
-                } else {
-                    tracing::warn!("list-windows enumeration command failed");
-                }
-            }
-            _ => {}
-        }
+/// Returns the first non-empty trimmed output line of a completed command, or
+/// `None` when the command failed (logged with the `what` label) or the output
+/// is blank. Pure: the caller owns the `CommandId` correlation.
+pub(crate) fn first_reply_line(ok: bool, output: &[String], what: &str) -> Option<String> {
+    if !ok {
+        tracing::warn!("{what} query command failed");
+        return None;
     }
-}
-
-/// Returns the first non-empty trimmed output line of the `CommandComplete`
-/// whose id matches `pending`, clearing `pending`. `what` labels the warning
-/// logged when the command failed.
-fn take_reply_line(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-    what: &str,
-) -> Option<String> {
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && *pending == Some(*id)
-        {
-            *pending = None;
-            if *ok {
-                return output
-                    .iter()
-                    .map(|line| line.trim())
-                    .find(|line| !line.is_empty())
-                    .map(str::to_owned);
-            }
-            tracing::warn!("{what} query command failed");
-            return None;
-        }
-    }
-    None
-}
-
-/// Returns the client name from a `CommandComplete` whose id matches
-/// `pending` (first non-empty trimmed output line), and clears `pending`.
-///
-/// Iterates `events` and looks for `CommandComplete { ok: true, .. }` whose
-/// id equals `*pending`. On a match the first non-empty trimmed output line is
-/// returned and `*pending` is set to `None`. Returns `None` when no matching
-/// event exists in the batch or the output is blank.
-pub(crate) fn take_client_name(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<String> {
-    take_reply_line(pending, events, "client-name")
-}
-
-/// Returns the tmux server version from a `CommandComplete` whose id matches
-/// `pending` (first non-empty trimmed output line), and clears `pending`.
-pub(crate) fn take_version(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<String> {
-    take_reply_line(pending, events, "version")
-}
-
-/// Returns the `aggressive-resize` option value from a `CommandComplete` whose
-/// id matches `pending` (first non-empty trimmed output line), and clears `pending`.
-pub(crate) fn take_aggressive_resize(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<String> {
-    take_reply_line(pending, events, "aggressive-resize")
-}
-
-/// Drains matching `capture-pane` replies from `events`.
-///
-/// For every `CommandComplete` whose id is in `capture_pending`:
-/// - If the pane has a cursor-position query in-flight (`panes_with_cursor_pending`),
-///   the captured lines are stored in `capture_awaiting_cursor` and emitted later
-///   by [`take_cursor_positions`] once the cursor reply arrives.
-/// - Otherwise the pane is emitted immediately as a [`PaneOutput`] (original
-///   behaviour when cursor querying is unavailable or already drained).
-///
-/// tmux `-CC` does not replay existing content on attach, so this seeds the
-/// first paint; the live `%output` stream keeps it current thereafter.
-pub(crate) fn take_pane_captures(
-    capture_pending: &mut HashMap<CommandId, PaneId>,
-    capture_awaiting_cursor: &mut HashMap<PaneId, Vec<String>>,
-    panes_with_cursor_pending: &HashSet<PaneId>,
-    events: &[TransportEvent],
-) -> Vec<PaneOutput> {
-    let mut out = Vec::new();
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && let Some(pane) = capture_pending.remove(id)
-        {
-            if *ok {
-                if panes_with_cursor_pending.contains(&pane) {
-                    capture_awaiting_cursor.insert(pane, output.clone());
-                } else {
-                    out.push(PaneOutput {
-                        pane,
-                        data: capture_to_bytes(output),
-                    });
-                }
-            } else {
-                tracing::warn!(pane = pane.0, "capture-pane command failed");
-            }
-        }
-    }
-    out
-}
-
-/// Drains matching cursor-position `display-message` replies from `events`,
-/// pairing each with its cached capture content and returning the combined
-/// [`PaneOutput`] with the real cursor position restored.
-///
-/// FIFO ordering guarantees the capture reply arrives before this cursor reply,
-/// so `capture_awaiting_cursor` should always contain the entry. If it does not
-/// (e.g. capture failed), the cursor reply is silently dropped.
-pub(crate) fn take_cursor_positions(
-    cursor_pending: &mut HashMap<CommandId, PaneId>,
-    panes_with_cursor_pending: &mut HashSet<PaneId>,
-    capture_awaiting_cursor: &mut HashMap<PaneId, Vec<String>>,
-    events: &[TransportEvent],
-) -> Vec<PaneOutput> {
-    let mut out = Vec::new();
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && let Some(pane) = cursor_pending.remove(id)
-        {
-            panes_with_cursor_pending.remove(&pane);
-            let Some(lines) = capture_awaiting_cursor.remove(&pane) else {
-                continue;
-            };
-            let (cx, cy) = if *ok {
-                parse_cursor_pos(output).unwrap_or((0, 0))
-            } else {
-                tracing::warn!(pane = pane.0, "cursor-position query failed");
-                (0, 0)
-            };
-            out.push(PaneOutput {
-                pane,
-                data: capture_to_bytes_with_cursor(&lines, cx, cy),
-            });
-        }
-    }
-    out
+    output
+        .iter()
+        .map(|line| line.trim())
+        .find(|line| !line.is_empty())
+        .map(str::to_owned)
 }
 
 /// Parses a `'#{cursor_x} #{cursor_y}'` reply line into `(col, row)`.
-fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
+pub(crate) fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
     let line = output.first()?;
     let (x, y) = line.trim().split_once(' ')?;
     Some((x.parse().ok()?, y.parse().ok()?))
@@ -236,7 +80,7 @@ fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
 /// clean grid (the reply can arrive after live `%output` has already moved the
 /// cursor — without the reset the rows would stack and duplicate), then the rows
 /// CRLF-joined (the reply omits line terminators).
-fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
+pub(crate) fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
     let mut bytes = b"\x1b[H\x1b[2J".to_vec();
     bytes.extend_from_slice(lines.join("\r\n").as_bytes());
     bytes
@@ -245,109 +89,10 @@ fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
 /// Like [`capture_to_bytes`] but appends a CSI cursor-position escape (`ESC[row;colH`,
 /// 1-origin) so the rendered cursor matches the real tmux pane cursor after the
 /// snapshot is painted.
-fn capture_to_bytes_with_cursor(lines: &[String], cx: u16, cy: u16) -> Vec<u8> {
+pub(crate) fn capture_to_bytes_with_cursor(lines: &[String], cx: u16, cy: u16) -> Vec<u8> {
     let mut bytes = capture_to_bytes(lines);
     bytes.extend_from_slice(format!("\x1b[{};{}H", cy + 1, cx + 1).as_bytes());
     bytes
-}
-
-/// Returns the active `(window, pane)` from a `CommandComplete` whose id matches
-/// `pending` (parsing the `@N %M` reply line), clearing `pending`.
-///
-/// Used to seed the `ActivePane` marker on attach, since tmux does not emit
-/// `%window-pane-changed` then. Returns `None` when no matching reply is in the
-/// batch or the line does not parse.
-pub(crate) fn take_active_pane(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<(WindowId, PaneId)> {
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && *pending == Some(*id)
-        {
-            *pending = None;
-            if *ok {
-                return output.iter().find_map(|line| parse_active_pane(line));
-            }
-            tracing::warn!("active-pane query command failed");
-            return None;
-        }
-    }
-    None
-}
-
-/// Returns parsed key bindings from a `CommandComplete` matching `pending`
-/// (running `parse_list_keys` on the reply), clearing `pending`. Returns `None`
-/// when no matching reply is in the batch.
-pub(crate) fn take_keybindings(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<Vec<KeyBinding>> {
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && *pending == Some(*id)
-        {
-            *pending = None;
-            if *ok {
-                return Some(parse_list_keys(output));
-            }
-            tracing::warn!("list-keys command failed");
-            return None;
-        }
-    }
-    None
-}
-
-/// Returns the prefix-key set from a `CommandComplete` matching `pending`
-/// (running `parse_prefix` on the first reply line), clearing `pending`.
-pub(crate) fn take_prefix_keys(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<HashSet<String>> {
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && *pending == Some(*id)
-        {
-            *pending = None;
-            if *ok {
-                return Some(
-                    output
-                        .first()
-                        .map(|line| parse_prefix(line))
-                        .unwrap_or_default(),
-                );
-            }
-            tracing::warn!("prefix query command failed");
-            return None;
-        }
-    }
-    None
-}
-
-/// Returns the `ModeKeys` from a `CommandComplete` matching `pending`
-/// (parsing `#{mode-keys}`), clearing `pending`.
-pub(crate) fn take_mode_keys(
-    pending: &mut Option<CommandId>,
-    events: &[TransportEvent],
-) -> Option<ModeKeys> {
-    for event in events {
-        if let TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) = event
-            && *pending == Some(*id)
-        {
-            *pending = None;
-            if *ok {
-                return Some(
-                    output
-                        .first()
-                        .map(|l| ModeKeys::parse(l))
-                        .unwrap_or_default(),
-                );
-            }
-            tracing::warn!("mode-keys query failed");
-            return None;
-        }
-    }
-    None
 }
 
 /// Returns the new session id if `events` contains a session-change to an id
@@ -440,14 +185,20 @@ pub(crate) fn detect_window_added(events: &[TransportEvent]) -> bool {
 }
 
 /// Parses an `@N %M` line into `(WindowId, PaneId)`.
-fn parse_active_pane(line: &str) -> Option<(WindowId, PaneId)> {
+pub(crate) fn parse_active_pane(line: &str) -> Option<(WindowId, PaneId)> {
     let mut parts = line.split_whitespace();
     let window = parts.next()?.strip_prefix('@')?.parse().ok()?;
     let pane = parts.next()?.strip_prefix('%')?.parse().ok()?;
     Some((WindowId(window), PaneId(pane)))
 }
 
-fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event: &ControlEvent) {
+/// Triggers the projection event a single tmux notification maps to (session,
+/// window, pane, layout, flags). `own_client` gates `%client-session-changed`.
+pub(crate) fn trigger_notification(
+    commands: &mut Commands,
+    own_client: Option<&str>,
+    event: &ControlEvent,
+) {
     match event {
         ControlEvent::SessionChanged { session, name }
         | ControlEvent::SessionRenamed { session, name } => {
@@ -514,7 +265,10 @@ fn trigger_notification(commands: &mut Commands, own_client: Option<&str>, event
     }
 }
 
-fn trigger_seed(commands: &mut Commands, output: &[String]) {
+/// Decomposes a `list-windows` reply into per-row `TmuxWindowAdded` +
+/// `TmuxWindowFlagsChanged` + `TmuxLayoutChanged` (+ `TmuxActiveWindowChanged`
+/// for the active row), then one `TmuxWindowsRetained` prune.
+pub(crate) fn trigger_seed(commands: &mut Commands, output: &[String]) {
     let rows = match parse_window_rows(output) {
         Ok(rows) => rows,
         Err(error) => {
@@ -563,10 +317,9 @@ fn log_transport_event(event: &TransportEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enumerate::EnumerationState;
     use bevy::prelude::*;
     use crossbeam_channel::unbounded;
-    use tmux_control::{CommandId, ControlEvent};
+    use tmux_control::ControlEvent;
     use tmux_control_parser::{SessionId, WindowId};
 
     fn window_add(id: u32) -> TransportEvent {
@@ -585,186 +338,46 @@ mod tests {
     }
 
     #[test]
-    fn take_client_name_extracts_from_matching_reply() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(7),
-            number: 0,
-            ok: true,
-            output: vec!["main-client".to_string()],
-        })];
-        let mut pending = Some(CommandId(7));
+    fn first_reply_line_returns_first_non_empty_trimmed() {
+        let output = vec!["".to_string(), "  3.6a  ".to_string()];
         assert_eq!(
-            take_client_name(&mut pending, &events),
-            Some("main-client".to_string())
-        );
-        assert_eq!(pending, None);
-    }
-
-    #[test]
-    fn take_pane_captures_seeds_matching_reply_as_output() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(5),
-            number: 0,
-            ok: true,
-            output: vec!["line one".to_string(), "line two".to_string()],
-        })];
-        let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
-        let no_cursor_pending = HashSet::new();
-        let mut awaiting = HashMap::new();
-        let out = take_pane_captures(
-            &mut capture_pending,
-            &mut awaiting,
-            &no_cursor_pending,
-            &events,
-        );
-        assert_eq!(
-            out,
-            vec![PaneOutput {
-                pane: PaneId(88),
-                data: b"\x1b[H\x1b[2Jline one\r\nline two".to_vec(),
-            }]
-        );
-        assert!(capture_pending.is_empty());
-        assert!(awaiting.is_empty());
-    }
-
-    #[test]
-    fn take_active_pane_parses_window_and_pane() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(9),
-            number: 0,
-            ok: true,
-            output: vec!["@7 %88".to_string()],
-        })];
-        let mut pending = Some(CommandId(9));
-        assert_eq!(
-            take_active_pane(&mut pending, &events),
-            Some((WindowId(7), PaneId(88)))
-        );
-        assert_eq!(pending, None);
-    }
-
-    #[test]
-    fn take_pane_captures_drops_failed_reply_without_output() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(5),
-            number: 0,
-            ok: false,
-            output: vec![],
-        })];
-        let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
-        let no_cursor_pending = HashSet::new();
-        let mut awaiting = HashMap::new();
-        let out = take_pane_captures(
-            &mut capture_pending,
-            &mut awaiting,
-            &no_cursor_pending,
-            &events,
-        );
-        assert!(out.is_empty());
-        assert!(
-            capture_pending.is_empty(),
-            "failed capture is still cleared"
-        );
-        assert!(
-            awaiting.is_empty(),
-            "failed capture must not populate awaiting"
-        );
-    }
-
-    #[test]
-    fn take_pane_captures_caches_when_cursor_pending() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(5),
-            number: 0,
-            ok: true,
-            output: vec!["line one".to_string()],
-        })];
-        let mut capture_pending = HashMap::from([(CommandId(5), PaneId(88))]);
-        let cursor_pending = HashSet::from([PaneId(88)]);
-        let mut awaiting = HashMap::new();
-        let out = take_pane_captures(
-            &mut capture_pending,
-            &mut awaiting,
-            &cursor_pending,
-            &events,
-        );
-        assert!(out.is_empty(), "should cache, not emit");
-        assert_eq!(
-            awaiting.get(&PaneId(88)),
-            Some(&vec!["line one".to_string()])
-        );
-    }
-
-    #[test]
-    fn take_cursor_positions_emits_with_cursor_escape() {
-        let cursor_event = TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(6),
-            number: 0,
-            ok: true,
-            output: vec!["3 5".to_string()],
-        });
-        let mut cursor_pending = HashMap::from([(CommandId(6), PaneId(88))]);
-        let mut panes_with_cursor = HashSet::from([PaneId(88)]);
-        let mut awaiting = HashMap::from([(PaneId(88), vec!["hello".to_string()])]);
-        let out = take_cursor_positions(
-            &mut cursor_pending,
-            &mut panes_with_cursor,
-            &mut awaiting,
-            &[cursor_event],
-        );
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].pane, PaneId(88));
-        // ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4, 1-origin)
-        assert_eq!(out[0].data, b"\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec());
-        assert!(cursor_pending.is_empty());
-        assert!(panes_with_cursor.is_empty());
-        assert!(awaiting.is_empty());
-    }
-
-    #[test]
-    fn take_client_name_unmatched_id_returns_none_and_keeps_pending() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(8),
-            number: 0,
-            ok: true,
-            output: vec!["main-client".to_string()],
-        })];
-        let mut pending = Some(CommandId(7));
-        assert_eq!(take_client_name(&mut pending, &events), None);
-        assert_eq!(pending, Some(CommandId(7)));
-    }
-
-    #[test]
-    fn take_version_extracts_first_line() {
-        let id = CommandId(7);
-        let mut pending = Some(id);
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id,
-            number: 0,
-            ok: true,
-            output: vec!["3.6a".to_string()],
-        })];
-        assert_eq!(
-            take_version(&mut pending, &events),
+            first_reply_line(true, &output, "version"),
             Some("3.6a".to_string())
         );
-        assert_eq!(pending, None);
     }
 
     #[test]
-    fn take_client_name_trims_whitespace_from_output() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(3),
-            number: 0,
-            ok: true,
-            output: vec!["  /dev/ttys001  ".to_string()],
-        })];
-        let mut pending = Some(CommandId(3));
+    fn first_reply_line_returns_none_on_failure() {
+        assert_eq!(first_reply_line(false, &["x".to_string()], "version"), None);
+    }
+
+    #[test]
+    fn first_reply_line_returns_none_on_blank_output() {
         assert_eq!(
-            take_client_name(&mut pending, &events),
-            Some("/dev/ttys001".to_string())
+            first_reply_line(true, &["   ".to_string()], "version"),
+            None
         );
+    }
+
+    #[test]
+    fn parse_active_pane_parses_window_and_pane() {
+        assert_eq!(parse_active_pane("@7 %88"), Some((WindowId(7), PaneId(88))));
+        assert_eq!(parse_active_pane("garbage"), None);
+    }
+
+    #[test]
+    fn capture_to_bytes_with_cursor_appends_cursor_escape() {
+        // ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4, 1-origin)
+        assert_eq!(
+            capture_to_bytes_with_cursor(&["hello".to_string()], 3, 5),
+            b"\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec()
+        );
+    }
+
+    #[test]
+    fn parse_cursor_pos_reads_col_row() {
+        assert_eq!(parse_cursor_pos(&["3 5".to_string()]), Some((3, 5)));
+        assert_eq!(parse_cursor_pos(&["nope".to_string()]), None);
     }
 
     #[test]
@@ -776,27 +389,22 @@ mod tests {
         #[derive(Resource, Default, Clone)]
         struct Seen(Arc<Mutex<Vec<(u32, String)>>>);
 
-        #[derive(Resource)]
-        struct Batch(Vec<TransportEvent>);
-
-        fn run(mut commands: Commands, mut pending: ResMut<EnumerationState>, batch: Res<Batch>) {
-            trigger_events(&mut commands, &mut pending.pending, &batch.0, Some("main"));
-        }
-
         let mut app = App::new();
         app.init_resource::<Seen>();
-        app.init_resource::<EnumerationState>();
-        app.insert_resource(Batch(vec![TransportEvent::Protocol(
-            ClientEvent::Notification(ControlEvent::ClientSessionChanged {
-                client: "main".to_string(),
-                session: SessionId(9),
-                name: "beta".to_string(),
-            }),
-        )]));
         app.add_observer(|ev: On<TmuxSessionChanged>, seen: Res<Seen>| {
             seen.0.lock().unwrap().push((ev.session.0, ev.name.clone()));
         });
-        app.add_systems(Update, run);
+        app.add_systems(Update, |mut commands: Commands| {
+            trigger_notification(
+                &mut commands,
+                Some("main"),
+                &ControlEvent::ClientSessionChanged {
+                    client: "main".to_string(),
+                    session: SessionId(9),
+                    name: "beta".to_string(),
+                },
+            );
+        });
         let seen = app.world().resource::<Seen>().clone();
         app.update();
 
@@ -975,29 +583,8 @@ mod tests {
         #[derive(Resource, Default, Clone)]
         struct Log(Arc<Mutex<Vec<String>>>);
 
-        #[derive(Resource)]
-        struct Batch(Vec<TransportEvent>);
-
-        fn run(
-            mut commands: Commands,
-            mut enumeration: ResMut<EnumerationState>,
-            batch: Res<Batch>,
-        ) {
-            trigger_events(&mut commands, &mut enumeration.pending, &batch.0, None);
-        }
-
         let mut app = App::new();
         app.init_resource::<Log>();
-        app.init_resource::<EnumerationState>();
-        app.world_mut().resource_mut::<EnumerationState>().pending = Some(CommandId(1));
-        app.insert_resource(Batch(vec![TransportEvent::Protocol(
-            ClientEvent::CommandComplete {
-                id: CommandId(1),
-                number: 0,
-                ok: true,
-                output: vec!["1\t@1\t0\tabcd,80x24,0,0,5\t0000,80x24,0,0,5\t\tmain".to_string()],
-            },
-        )]));
         app.add_observer(|ev: On<TmuxWindowAdded>, log: Res<Log>| {
             log.0.lock().unwrap().push(format!("add@{}", ev.window.0));
         });
@@ -1013,82 +600,17 @@ mod tests {
                 .unwrap()
                 .push(format!("retain{}", ev.windows.len()));
         });
-        app.add_systems(Update, run);
+        app.add_systems(Update, |mut commands: Commands| {
+            trigger_seed(
+                &mut commands,
+                &["1\t@1\t0\tabcd,80x24,0,0,5\t0000,80x24,0,0,5\t\tmain".to_string()],
+            );
+        });
 
         let log = app.world().resource::<Log>().clone();
         app.update();
 
         assert_eq!(*log.0.lock().unwrap(), vec!["add@1", "layout@1", "retain1"]);
-        assert_eq!(app.world().resource::<EnumerationState>().pending, None);
-    }
-
-    #[test]
-    fn take_keybindings_parses_matching_reply() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(11),
-            number: 0,
-            ok: true,
-            output: vec!["bind-key -T root M-i split-window -h".to_string()],
-        })];
-        let mut pending = Some(CommandId(11));
-        let got = take_keybindings(&mut pending, &events).expect("a parsed reply");
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].key, "M-i");
-        assert_eq!(got[0].command, "split-window -h");
-        assert_eq!(pending, None);
-    }
-
-    #[test]
-    fn take_keybindings_unmatched_keeps_pending() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(2),
-            number: 0,
-            ok: true,
-            output: vec![],
-        })];
-        let mut pending = Some(CommandId(11));
-        assert!(take_keybindings(&mut pending, &events).is_none());
-        assert_eq!(pending, Some(CommandId(11)));
-    }
-
-    #[test]
-    fn take_prefix_keys_parses_matching_reply() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(12),
-            number: 0,
-            ok: true,
-            output: vec!["C-b None".to_string()],
-        })];
-        let mut pending = Some(CommandId(12));
-        let got = take_prefix_keys(&mut pending, &events).expect("a parsed reply");
-        assert_eq!(got, std::collections::HashSet::from(["C-b".to_string()]));
-        assert_eq!(pending, None);
-    }
-
-    #[test]
-    fn take_mode_keys_parses_vi() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(21),
-            number: 0,
-            ok: true,
-            output: vec!["vi".to_string()],
-        })];
-        let mut pending = Some(CommandId(21));
-        assert_eq!(take_mode_keys(&mut pending, &events), Some(ModeKeys::Vi));
-        assert_eq!(pending, None);
-    }
-
-    #[test]
-    fn take_mode_keys_defaults_emacs_on_other() {
-        let events = vec![TransportEvent::Protocol(ClientEvent::CommandComplete {
-            id: CommandId(22),
-            number: 0,
-            ok: true,
-            output: vec!["emacs".to_string()],
-        })];
-        let mut pending = Some(CommandId(22));
-        assert_eq!(take_mode_keys(&mut pending, &events), Some(ModeKeys::Emacs));
-        assert_eq!(pending, None);
     }
 
     #[test]
@@ -1140,24 +662,23 @@ mod tests {
         struct Captured(Arc<Mutex<Vec<(WindowId, WindowFlags)>>>);
 
         #[derive(Resource)]
-        struct Batch(Vec<TransportEvent>);
-
-        fn run(mut commands: Commands, mut pending: ResMut<EnumerationState>, batch: Res<Batch>) {
-            trigger_events(&mut commands, &mut pending.pending, &batch.0, None);
-        }
+        struct Notification(ControlEvent);
 
         let line = format!("%subscription-changed {WINDOW_FLAGS_SUBSCRIPTION} $1 @2 0 - : *Z");
         let notification = ControlEvent::parse(line.as_bytes()).unwrap();
-        let event = TransportEvent::Protocol(ClientEvent::Notification(notification));
 
         let mut app = App::new();
         app.init_resource::<Captured>();
-        app.init_resource::<EnumerationState>();
-        app.insert_resource(Batch(vec![event]));
+        app.insert_resource(Notification(notification));
         app.add_observer(|ev: On<TmuxWindowFlagsChanged>, captured: Res<Captured>| {
             captured.0.lock().unwrap().push((ev.window, ev.flags));
         });
-        app.add_systems(Update, run);
+        app.add_systems(
+            Update,
+            |mut commands: Commands, notification: Res<Notification>| {
+                trigger_notification(&mut commands, None, &notification.0);
+            },
+        );
 
         let captured = app.world().resource::<Captured>().clone();
         app.update();

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -5,25 +5,27 @@ use crate::components::{TmuxPane, TmuxSession};
 use crate::connection::TmuxConnection;
 use crate::copy_queries::{CopyModeQueries, CopyModeReply, drain_copy_replies};
 use crate::enumerate::{
-    EnumerationState, active_pane_command, aggressive_resize_command, capture_pane_command,
-    client_name_command, cursor_query_command, list_windows_command, mode_keys_command,
-    subscribe_window_flags_command, version_command, version_supports_per_window_refresh,
+    EnumerationState, PendingReply, active_pane_command, aggressive_resize_command,
+    capture_pane_command, client_name_command, cursor_query_command, list_windows_command,
+    mode_keys_command, subscribe_window_flags_command, version_command,
+    version_supports_per_window_refresh,
 };
 use crate::event_pump::{
-    advance_state, detect_session_switch, detect_window_added, detect_window_switch,
-    drain_transport, take_active_pane, take_aggressive_resize, take_client_name,
-    take_cursor_positions, take_keybindings, take_mode_keys, take_pane_captures, take_prefix_keys,
-    take_version, trigger_events,
+    advance_state, capture_to_bytes, capture_to_bytes_with_cursor, detect_session_switch,
+    detect_window_added, detect_window_switch, drain_transport, first_reply_line,
+    parse_active_pane, parse_cursor_pos, trigger_notification, trigger_seed,
 };
 use crate::events::{
     TmuxActivePaneChanged, TmuxConnectionClosed, TmuxConnectionReset, TmuxWindowsRetained,
 };
-use crate::keybindings::{KeyBindings, list_keys_command, prefix_options_command};
+use crate::keybindings::{
+    KeyBindings, ModeKeys, list_keys_command, parse_list_keys, parse_prefix, prefix_options_command,
+};
 use crate::observers::{TmuxProjection, register_observers};
 use crate::output::{PaneOutput, collect_pane_outputs};
 use crate::state::ConnectionState;
 use bevy::prelude::*;
-use tmux_control::TransportEvent;
+use tmux_control::{ClientEvent, TmuxClient, TransportEvent};
 
 /// Marker resource inserted when the tmux backend is active. Drain systems are
 /// gated on its presence; insert it to activate tmux mode, remove it to idle.
@@ -92,8 +94,9 @@ impl Plugin for TmuxSessionPlugin {
 /// with the cursor at the correct position. tmux `-CC` does not replay existing
 /// content on attach (it only streams new `%output`), so without this a
 /// quiescent pane stays blank until its program writes again. Gated on
-/// `Added<TmuxPane>` — runs once per pane. Replies are consumed by
-/// [`take_pane_captures`] / [`take_cursor_positions`] and routed as `PaneOutput`.
+/// `Added<TmuxPane>` — runs once per pane. The capture/cursor replies are
+/// consumed by [`apply_reply`]'s `Capture`/`Cursor` arms and routed as
+/// `PaneOutput`.
 fn request_pane_captures(
     mut enumeration: ResMut<EnumerationState>,
     connection: NonSend<TmuxConnection>,
@@ -105,10 +108,14 @@ fn request_pane_captures(
     for pane in new_panes.iter() {
         match client.handle().send(&capture_pane_command(pane.id)) {
             Ok(cap_id) => {
-                enumeration.capture_pending.insert(cap_id, pane.id);
+                enumeration
+                    .pending
+                    .insert(cap_id, PendingReply::Capture { pane: pane.id });
                 match client.handle().send(&cursor_query_command(pane.id)) {
                     Ok(cur_id) => {
-                        enumeration.cursor_pending.insert(cur_id, pane.id);
+                        enumeration
+                            .pending
+                            .insert(cur_id, PendingReply::Cursor { pane: pane.id });
                         enumeration.panes_with_cursor_pending.insert(pane.id);
                     }
                     Err(error) => {
@@ -168,38 +175,38 @@ fn send_attach_enumeration(
         return;
     };
     send_session_enumeration(&mut enumeration, client);
-    match client.handle().send(&client_name_command()) {
-        Ok(id) => enumeration.client_name_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send client-name query"),
-    }
-    match client.handle().send(&list_keys_command("root")) {
-        Ok(id) => enumeration.keys_root_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send list-keys -T root"),
-    }
-    match client.handle().send(&list_keys_command("prefix")) {
-        Ok(id) => enumeration.keys_prefix_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send list-keys -T prefix"),
-    }
-    match client.handle().send(&prefix_options_command()) {
-        Ok(id) => enumeration.prefix_keys_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send prefix query"),
-    }
-    match client.handle().send(&list_keys_command("copy-mode")) {
-        Ok(id) => enumeration.keys_copy_mode_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode"),
-    }
-    match client.handle().send(&list_keys_command("copy-mode-vi")) {
-        Ok(id) => enumeration.keys_copy_mode_vi_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode-vi"),
-    }
-    match client.handle().send(&mode_keys_command()) {
-        Ok(id) => enumeration.mode_keys_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send mode-keys query"),
-    }
-    match client.handle().send(&version_command()) {
-        Ok(id) => enumeration.version_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send version query"),
-    }
+    enumeration.register(
+        client.handle().send(&client_name_command()),
+        PendingReply::ClientName,
+    );
+    enumeration.register(
+        client.handle().send(&list_keys_command("root")),
+        PendingReply::KeyBindings,
+    );
+    enumeration.register(
+        client.handle().send(&list_keys_command("prefix")),
+        PendingReply::KeyBindings,
+    );
+    enumeration.register(
+        client.handle().send(&prefix_options_command()),
+        PendingReply::PrefixKeys,
+    );
+    enumeration.register(
+        client.handle().send(&list_keys_command("copy-mode")),
+        PendingReply::KeyBindings,
+    );
+    enumeration.register(
+        client.handle().send(&list_keys_command("copy-mode-vi")),
+        PendingReply::KeyBindings,
+    );
+    enumeration.register(
+        client.handle().send(&mode_keys_command()),
+        PendingReply::ModeKeys,
+    );
+    enumeration.register(
+        client.handle().send(&version_command()),
+        PendingReply::Version,
+    );
 }
 
 /// Re-enumerates topology when the batch contains a session-switch, window-add,
@@ -232,41 +239,34 @@ fn send_tmux_reenumeration(
         commands.trigger(TmuxWindowsRetained {
             windows: Vec::new(),
         });
-        enumeration.capture_pending.clear();
-        enumeration.cursor_pending.clear();
-        enumeration.panes_with_cursor_pending.clear();
-        enumeration.capture_awaiting_cursor.clear();
         // NOTE: aggressive-resize is a per-window option, so the switched-to
-        // session must be re-checked — clear the one-shot guard or its `on`
-        // setting would go undetected after a switch.
-        enumeration.aggressive_resize_checked = false;
-        enumeration.aggressive_resize_pending = None;
+        // session must be re-checked; clear_for_session_switch resets the
+        // one-shot guard along with the now-stale enumeration/capture ids.
+        enumeration.clear_for_session_switch();
         send_session_enumeration(&mut enumeration, client);
     } else if let Some(client) = connection.client() {
         if detect_window_added(events) {
-            match client.handle().send(&list_windows_command()) {
-                Ok(id) => enumeration.pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to re-enumerate on window-add"),
-            }
+            enumeration.register(
+                client.handle().send(&list_windows_command()),
+                PendingReply::ListWindows,
+            );
         }
         if detect_window_switch(events, current_session) {
-            match client.handle().send(&active_pane_command()) {
-                Ok(id) => enumeration.active_pane_pending = Some(id),
-                Err(error) => {
-                    tracing::warn!(?error, "failed to re-query active pane on window switch")
-                }
-            }
+            enumeration.register(
+                client.handle().send(&active_pane_command()),
+                PendingReply::ActivePane,
+            );
         }
     }
     if matches!(*state, ConnectionState::Attached)
         && connection.client_name().is_none()
-        && enumeration.client_name_pending.is_none()
+        && !enumeration.has_pending(PendingReply::ClientName)
         && let Some(client) = connection.client()
     {
-        match client.handle().send(&client_name_command()) {
-            Ok(id) => enumeration.client_name_pending = Some(id),
-            Err(error) => tracing::warn!(?error, "failed to re-send client-name query"),
-        }
+        enumeration.register(
+            client.handle().send(&client_name_command()),
+            PendingReply::ClientName,
+        );
     }
 }
 
@@ -313,105 +313,172 @@ fn apply_tmux_replies(
     if connection.client().is_none() {
         return;
     }
+    let connection = &mut *connection;
     let events = &batch.0;
-    if let Some(name) = take_client_name(&mut enumeration.client_name_pending, events) {
-        connection.set_client_name(name);
-    }
-    if let Some(version) = take_version(&mut enumeration.version_pending, events) {
-        connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
-    }
-    if let Some((window, pane)) = take_active_pane(&mut enumeration.active_pane_pending, events) {
-        commands.trigger(TmuxActivePaneChanged {
-            window,
-            pane,
-            from_notification: false,
-        });
-        if !enumeration.aggressive_resize_checked
-            && enumeration.aggressive_resize_pending.is_none()
-            && let Some(client) = connection.client()
-        {
-            match client.handle().send(&aggressive_resize_command(window)) {
-                Ok(id) => enumeration.aggressive_resize_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to query aggressive-resize"),
+    // NOTE: this MUST stay a single in-order pass. tmux CC-mode replies are
+    // FIFO, and capture is sent before its paired cursor query, so the Capture
+    // arm fills capture_awaiting_cursor before the Cursor arm drains it.
+    // Splitting into two passes silently drops cursor fixes on same-batch
+    // arrivals.
+    for event in events {
+        match event {
+            TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) => {
+                let Some(reply) = enumeration.pending.remove(id) else {
+                    continue;
+                };
+                apply_reply(
+                    &mut commands,
+                    &mut enumeration,
+                    &mut keybindings,
+                    &mut pane_output,
+                    connection,
+                    reply,
+                    *ok,
+                    output,
+                );
             }
+            TransportEvent::Protocol(ClientEvent::Notification(notification)) => {
+                trigger_notification(&mut commands, connection.client_name(), notification);
+            }
+            TransportEvent::Closed { .. } => {}
         }
-    }
-    if let Some(value) = take_aggressive_resize(&mut enumeration.aggressive_resize_pending, events)
-    {
-        enumeration.aggressive_resize_checked = true;
-        if value.trim() == "on" {
-            tracing::warn!(
-                "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
-                 windows may resize unexpectedly"
-            );
-        }
-    }
-    // NOTE: deref once so the borrow checker can see these as distinct
-    // field borrows rather than overlapping borrows through DerefMut.
-    // NOTE: take_pane_captures MUST run before take_cursor_positions: when
-    // both a capture reply and its paired cursor reply arrive in the same
-    // event batch, captures populates capture_awaiting_cursor first, then
-    // cursor_positions drains it. Swapping the calls silently drops cursor
-    // fixes on same-batch arrivals.
-    let e = &mut *enumeration;
-    for output in take_pane_captures(
-        &mut e.capture_pending,
-        &mut e.capture_awaiting_cursor,
-        &e.panes_with_cursor_pending,
-        events,
-    ) {
-        pane_output.write(output);
-    }
-    for output in take_cursor_positions(
-        &mut e.cursor_pending,
-        &mut e.panes_with_cursor_pending,
-        &mut e.capture_awaiting_cursor,
-        events,
-    ) {
-        pane_output.write(output);
-    }
-    if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, events) {
-        keybindings.install(bindings);
-    }
-    if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, events) {
-        keybindings.install(bindings);
-    }
-    if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, events) {
-        keybindings.set_prefix_keys(keys);
-    }
-    if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_pending, events) {
-        keybindings.install(bindings);
-    }
-    if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_vi_pending, events) {
-        keybindings.install(bindings);
-    }
-    if let Some(mode_keys) = take_mode_keys(&mut enumeration.mode_keys_pending, events) {
-        keybindings.set_mode_keys(mode_keys);
     }
     for reply in drain_copy_replies(&mut copy_queries, events) {
         copy_replies.write(reply);
     }
-    trigger_events(
-        &mut commands,
-        &mut enumeration.pending,
-        events,
-        connection.client_name(),
-    );
+}
+
+/// Routes one completed command's reply to the world state it answers,
+/// reproducing the per-kind handler logic the old `take_*` wrappers held.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "single apply seam over many reply kinds"
+)]
+fn apply_reply(
+    commands: &mut Commands,
+    enumeration: &mut EnumerationState,
+    keybindings: &mut KeyBindings,
+    pane_output: &mut MessageWriter<PaneOutput>,
+    connection: &mut TmuxConnection,
+    reply: PendingReply,
+    ok: bool,
+    output: &[String],
+) {
+    match reply {
+        PendingReply::ListWindows if ok => trigger_seed(commands, output),
+        PendingReply::ListWindows => tracing::warn!("list-windows enumeration command failed"),
+        PendingReply::ClientName => {
+            if let Some(name) = first_reply_line(ok, output, "client-name") {
+                connection.set_client_name(name);
+            }
+        }
+        PendingReply::Version => {
+            if let Some(version) = first_reply_line(ok, output, "version") {
+                connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
+            }
+        }
+        PendingReply::ActivePane if ok => {
+            let Some((window, pane)) = output.iter().find_map(|line| parse_active_pane(line))
+            else {
+                return;
+            };
+            commands.trigger(TmuxActivePaneChanged {
+                window,
+                pane,
+                from_notification: false,
+            });
+            if !enumeration.aggressive_resize_checked
+                && !enumeration.has_pending(PendingReply::AggressiveResize)
+                && let Some(client) = connection.client()
+            {
+                enumeration.register(
+                    client.handle().send(&aggressive_resize_command(window)),
+                    PendingReply::AggressiveResize,
+                );
+            }
+        }
+        PendingReply::ActivePane => tracing::warn!("active-pane query command failed"),
+        PendingReply::KeyBindings if ok => keybindings.install(parse_list_keys(output)),
+        PendingReply::KeyBindings => tracing::warn!("list-keys command failed"),
+        PendingReply::PrefixKeys if ok => {
+            keybindings.set_prefix_keys(
+                output
+                    .first()
+                    .map(|line| parse_prefix(line))
+                    .unwrap_or_default(),
+            );
+        }
+        PendingReply::PrefixKeys => tracing::warn!("prefix query command failed"),
+        PendingReply::ModeKeys if ok => {
+            keybindings.set_mode_keys(
+                output
+                    .first()
+                    .map(|line| ModeKeys::parse(line))
+                    .unwrap_or_default(),
+            );
+        }
+        PendingReply::ModeKeys => tracing::warn!("mode-keys query failed"),
+        PendingReply::AggressiveResize => {
+            // NOTE: only the successful reply marks the one-shot check done; a
+            // failed query leaves aggressive_resize_checked false so the next
+            // active-pane reply re-issues it (matches the old take_* behavior).
+            if let Some(value) = first_reply_line(ok, output, "aggressive-resize") {
+                enumeration.aggressive_resize_checked = true;
+                if value.trim() == "on" {
+                    tracing::warn!(
+                        "tmux 'aggressive-resize on' is incompatible with control-mode \
+                         integration; windows may resize unexpectedly"
+                    );
+                }
+            }
+        }
+        PendingReply::Capture { pane } if ok => {
+            if enumeration.panes_with_cursor_pending.contains(&pane) {
+                enumeration
+                    .capture_awaiting_cursor
+                    .insert(pane, output.to_vec());
+            } else {
+                pane_output.write(PaneOutput {
+                    pane,
+                    data: capture_to_bytes(output),
+                });
+            }
+        }
+        PendingReply::Capture { pane } => {
+            tracing::warn!(pane = pane.0, "capture-pane command failed");
+        }
+        PendingReply::Cursor { pane } => {
+            enumeration.panes_with_cursor_pending.remove(&pane);
+            let Some(lines) = enumeration.capture_awaiting_cursor.remove(&pane) else {
+                return;
+            };
+            let (cx, cy) = if ok {
+                parse_cursor_pos(output).unwrap_or((0, 0))
+            } else {
+                tracing::warn!(pane = pane.0, "cursor-position query failed");
+                (0, 0)
+            };
+            pane_output.write(PaneOutput {
+                pane,
+                data: capture_to_bytes_with_cursor(&lines, cx, cy),
+            });
+        }
+    }
 }
 
 /// Sends the per-session enumeration queries (`list-windows` + active-pane) that
 /// rebuild the projection. Shared by the attach transition and a session switch so
 /// the two paths cannot drift (a switched-to session would otherwise risk stale
 /// windows or a missing active-pane marker).
-fn send_session_enumeration(enumeration: &mut EnumerationState, client: &tmux_control::TmuxClient) {
-    match client.handle().send(&list_windows_command()) {
-        Ok(id) => enumeration.pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send list-windows enumeration"),
-    }
-    match client.handle().send(&active_pane_command()) {
-        Ok(id) => enumeration.active_pane_pending = Some(id),
-        Err(error) => tracing::warn!(?error, "failed to send active-pane query"),
-    }
+fn send_session_enumeration(enumeration: &mut EnumerationState, client: &TmuxClient) {
+    enumeration.register(
+        client.handle().send(&list_windows_command()),
+        PendingReply::ListWindows,
+    );
+    enumeration.register(
+        client.handle().send(&active_pane_command()),
+        PendingReply::ActivePane,
+    );
     if let Err(error) = client.handle().send(&subscribe_window_flags_command()) {
         tracing::warn!(?error, "failed to subscribe to window flags");
     }
@@ -449,7 +516,12 @@ mod tests {
             *app.world().resource::<ConnectionState>(),
             ConnectionState::Idle
         );
-        assert!(app.world().resource::<EnumerationState>().pending.is_none());
+        assert!(
+            app.world()
+                .resource::<EnumerationState>()
+                .pending
+                .is_empty()
+        );
         let index = app.world().resource::<TmuxProjection>();
         assert!(index.windows.is_empty());
         assert!(index.panes.is_empty());
@@ -489,10 +561,15 @@ mod tests {
         app.add_plugins(TmuxSessionPlugin);
         app.insert_resource(TmuxPresence);
         // No live client: the system must still run on the message but send nothing,
-        // leaving `pending` (list-windows id) None without panicking.
+        // leaving `pending` empty without panicking.
         app.world_mut().write_message(TmuxClientAttached);
         app.update();
-        assert!(app.world().resource::<EnumerationState>().pending.is_none());
+        assert!(
+            app.world()
+                .resource::<EnumerationState>()
+                .pending
+                .is_empty()
+        );
     }
 
     #[test]
@@ -547,6 +624,73 @@ mod tests {
             .unwrap();
         app.world_mut().run_system_once(apply_tmux_replies).unwrap();
         // No panic, and no enumeration was registered (nothing was sent).
-        assert!(app.world().resource::<EnumerationState>().pending.is_none());
+        assert!(
+            app.world()
+                .resource::<EnumerationState>()
+                .pending
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn apply_reply_client_name_sets_connection_and_seeds_windows() {
+        use crate::events::TmuxWindowAdded;
+        use bevy::ecs::system::SystemState;
+        use std::sync::{Arc, Mutex};
+        use tmux_control_parser::WindowId;
+
+        #[derive(Resource, Default, Clone)]
+        struct Added(Arc<Mutex<Vec<WindowId>>>);
+
+        let mut app = App::new();
+        app.add_plugins(TmuxSessionPlugin);
+        app.init_resource::<Added>();
+        app.add_observer(|ev: On<TmuxWindowAdded>, added: Res<Added>| {
+            added.0.lock().unwrap().push(ev.window);
+        });
+
+        let mut system_state: SystemState<(
+            Commands,
+            ResMut<EnumerationState>,
+            ResMut<KeyBindings>,
+            MessageWriter<PaneOutput>,
+            NonSendMut<TmuxConnection>,
+        )> = SystemState::new(app.world_mut());
+        {
+            let (mut commands, mut enumeration, mut keybindings, mut pane_output, mut connection) =
+                system_state.get_mut(app.world_mut());
+            apply_reply(
+                &mut commands,
+                &mut enumeration,
+                &mut keybindings,
+                &mut pane_output,
+                &mut connection,
+                PendingReply::ClientName,
+                true,
+                &["ozmux-0".to_string()],
+            );
+            apply_reply(
+                &mut commands,
+                &mut enumeration,
+                &mut keybindings,
+                &mut pane_output,
+                &mut connection,
+                PendingReply::ListWindows,
+                true,
+                &["1\t@1\t0\tb25f,80x24,0,0,0\tb25f,80x24,0,0,0\t\tmain".to_string()],
+            );
+        }
+        system_state.apply(app.world_mut());
+
+        assert_eq!(
+            app.world()
+                .non_send_resource::<TmuxConnection>()
+                .client_name(),
+            Some("ozmux-0")
+        );
+        assert_eq!(
+            *app.world().resource::<Added>().0.lock().unwrap(),
+            vec![WindowId(1)]
+        );
     }
 }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -139,7 +139,7 @@ fn drain_tmux_transport(
     batch.0 = drained;
 }
 
-/// Drains the live connection's transport events each frame: advances
+/// Applies this frame's drained `TmuxEventBatch`: advances
 /// `ConnectionState`, sends the `list-windows` enumeration once on attach, and
 /// triggers the global projection events (notifications + the enumeration
 /// reply, in stream order) the observers consume. On `Closed` it reclaims the
@@ -374,14 +374,12 @@ mod tests {
 
     #[test]
     fn drain_transport_clears_stale_batch_once_then_skips_idle() {
-        use crossbeam_channel::unbounded;
         let mut app = App::new();
         app.add_plugins(TmuxSessionPlugin);
         app.insert_resource(TmuxPresence);
         app.insert_resource(TmuxEventBatch(vec![TransportEvent::Closed {
             reason: "x".into(),
         }]));
-        let _ = unbounded::<TransportEvent>();
         app.update();
         assert!(app.world().resource::<TmuxEventBatch>().0.is_empty());
         let changed_tick = app.world().resource_ref::<TmuxEventBatch>().last_changed();

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -71,7 +71,8 @@ impl Plugin for TmuxSessionPlugin {
                     drain_tmux_transport,
                     advance_tmux_connection.run_if(tmux_batch_pending),
                     send_attach_enumeration.run_if(on_message::<TmuxClientAttached>),
-                    drain_tmux_events.run_if(tmux_batch_pending),
+                    send_tmux_reenumeration.run_if(tmux_batch_pending),
+                    apply_tmux_replies.run_if(tmux_batch_pending),
                 )
                     .chain()
                     .in_set(TmuxProjectionSet)
@@ -201,50 +202,26 @@ fn send_attach_enumeration(
     }
 }
 
-/// Drains the live connection's transport channel into [`TmuxEventBatch`] and
-/// routes `%output` to `PaneOutput`. Skips the write on a fully-idle frame so
-/// change detection fires only when the batch's contents actually change; still
-/// clears a previously-non-empty batch to empty exactly once.
-fn drain_tmux_transport(
-    mut batch: ResMut<TmuxEventBatch>,
-    mut pane_output: MessageWriter<PaneOutput>,
-    connection: NonSend<TmuxConnection>,
-) {
-    let drained = match connection.client() {
-        Some(client) => drain_transport(client.events()),
-        None => Vec::new(),
-    };
-    if drained.is_empty() && batch.0.is_empty() {
-        return;
-    }
-    for output in collect_pane_outputs(&drained) {
-        pane_output.write(output);
-    }
-    batch.0 = drained;
-}
-
-/// Applies this frame's drained `TmuxEventBatch`: triggers the global
-/// projection events (notifications + the enumeration reply, in stream order)
-/// the observers consume, routes topology re-enumeration queries on window-add /
-/// window-switch / session-switch, and consumes the pending enumeration replies
-/// (pane captures, cursor positions, keybindings, etc.).
-fn drain_tmux_events(
+/// Re-enumerates topology when the batch contains a session-switch, window-add,
+/// or window-switch notification; re-arms the client-name query if the name has
+/// not yet been learned after attach.
+///
+/// Body-guards on the live client (see [`apply_tmux_replies`]).
+fn send_tmux_reenumeration(
     mut commands: Commands,
     mut enumeration: ResMut<EnumerationState>,
-    mut keybindings: ResMut<KeyBindings>,
-    mut copy_queries: ResMut<CopyModeQueries>,
-    mut connection: NonSendMut<TmuxConnection>,
-    mut pane_output: MessageWriter<PaneOutput>,
-    mut copy_replies: MessageWriter<CopyModeReply>,
-    batch: Res<TmuxEventBatch>,
+    connection: NonSend<TmuxConnection>,
     state: Res<ConnectionState>,
     index: Res<TmuxProjection>,
     sessions: Query<&TmuxSession>,
+    batch: Res<TmuxEventBatch>,
 ) {
-    let events = &batch.0;
+    // NOTE: connection liveness is a body guard, not a run_if — a run condition
+    // reading NonSend<TmuxConnection> is unsound (bevyengine/bevy#21230).
     if connection.client().is_none() {
         return;
     }
+    let events = &batch.0;
     let current_session = index
         .session
         .and_then(|e| sessions.get(e).ok())
@@ -281,6 +258,62 @@ fn drain_tmux_events(
             }
         }
     }
+    if matches!(*state, ConnectionState::Attached)
+        && connection.client_name().is_none()
+        && enumeration.client_name_pending.is_none()
+        && let Some(client) = connection.client()
+    {
+        match client.handle().send(&client_name_command()) {
+            Ok(id) => enumeration.client_name_pending = Some(id),
+            Err(error) => tracing::warn!(?error, "failed to re-send client-name query"),
+        }
+    }
+}
+
+/// Drains the live connection's transport channel into [`TmuxEventBatch`] and
+/// routes `%output` to `PaneOutput`. Skips the write on a fully-idle frame so
+/// change detection fires only when the batch's contents actually change; still
+/// clears a previously-non-empty batch to empty exactly once.
+fn drain_tmux_transport(
+    mut batch: ResMut<TmuxEventBatch>,
+    mut pane_output: MessageWriter<PaneOutput>,
+    connection: NonSend<TmuxConnection>,
+) {
+    let drained = match connection.client() {
+        Some(client) => drain_transport(client.events()),
+        None => Vec::new(),
+    };
+    if drained.is_empty() && batch.0.is_empty() {
+        return;
+    }
+    for output in collect_pane_outputs(&drained) {
+        pane_output.write(output);
+    }
+    batch.0 = drained;
+}
+
+/// Applies this frame's command replies and notifications to the world: drains
+/// each reply to what it answers, runs the active-pane→aggressive-resize
+/// follow-up, surfaces copy-mode replies, and triggers the projection events the
+/// observers consume.
+///
+/// Body-guards on the live client (see [`send_tmux_reenumeration`]).
+fn apply_tmux_replies(
+    mut commands: Commands,
+    mut enumeration: ResMut<EnumerationState>,
+    mut keybindings: ResMut<KeyBindings>,
+    mut copy_queries: ResMut<CopyModeQueries>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut pane_output: MessageWriter<PaneOutput>,
+    mut copy_replies: MessageWriter<CopyModeReply>,
+    batch: Res<TmuxEventBatch>,
+) {
+    // NOTE: connection liveness is a body guard, not a run_if — a run condition
+    // reading NonSend<TmuxConnection> is unsound (bevyengine/bevy#21230).
+    if connection.client().is_none() {
+        return;
+    }
+    let events = &batch.0;
     if let Some(name) = take_client_name(&mut enumeration.client_name_pending, events) {
         connection.set_client_name(name);
     }
@@ -364,18 +397,6 @@ fn drain_tmux_events(
         events,
         connection.client_name(),
     );
-    // NOTE: runs after the Closed branch took the connection, so `client()` is
-    // None there and this is a no-op — safe to re-arm only while still attached.
-    if matches!(*state, ConnectionState::Attached)
-        && connection.client_name().is_none()
-        && enumeration.client_name_pending.is_none()
-        && let Some(client) = connection.client()
-    {
-        match client.handle().send(&client_name_command()) {
-            Ok(id) => enumeration.client_name_pending = Some(id),
-            Err(error) => tracing::warn!(?error, "failed to re-send client-name query"),
-        }
-    }
 }
 
 /// Sends the per-session enumeration queries (`list-windows` + active-pane) that
@@ -506,5 +527,26 @@ mod tests {
         assert!(index.windows.is_empty());
         assert!(index.panes.is_empty());
         assert!(index.session.is_some());
+    }
+
+    #[test]
+    fn apply_and_reenumeration_skip_without_client() {
+        use bevy::ecs::system::RunSystemOnce;
+        use tmux_control::{ClientEvent, ControlEvent};
+        use tmux_control_parser::WindowId;
+        let mut app = App::new();
+        app.add_plugins(TmuxSessionPlugin);
+        // Non-empty batch but no live client: both systems must body-guard out.
+        app.insert_resource(TmuxEventBatch(vec![TransportEvent::Protocol(
+            ClientEvent::Notification(ControlEvent::WindowAdd {
+                window: WindowId(9),
+            }),
+        )]));
+        app.world_mut()
+            .run_system_once(send_tmux_reenumeration)
+            .unwrap();
+        app.world_mut().run_system_once(apply_tmux_replies).unwrap();
+        // No panic, and no enumeration was registered (nothing was sent).
+        assert!(app.world().resource::<EnumerationState>().pending.is_none());
     }
 }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -30,6 +30,12 @@ use tmux_control::TransportEvent;
 #[derive(Resource, Default)]
 pub struct TmuxPresence;
 
+/// Emitted the frame the control client's transport transitions to `Attached`
+/// (including a reconnect). Gates [`send_attach_enumeration`]. A pure signal —
+/// the init-send system reads the live client from `TmuxConnection`.
+#[derive(Message)]
+struct TmuxClientAttached;
+
 /// This frame's drained transport events, shared across the drain chain.
 /// Overwritten by [`drain_tmux_transport`] each frame; read-only downstream.
 #[derive(Resource, Default)]
@@ -58,10 +64,13 @@ impl Plugin for TmuxSessionPlugin {
             .insert_non_send_resource(TmuxConnection::default())
             .add_message::<PaneOutput>()
             .add_message::<CopyModeReply>()
+            .add_message::<TmuxClientAttached>()
             .add_systems(
                 Update,
                 (
                     drain_tmux_transport,
+                    advance_tmux_connection.run_if(tmux_batch_pending),
+                    send_attach_enumeration.run_if(on_message::<TmuxClientAttached>),
                     drain_tmux_events.run_if(tmux_batch_pending),
                 )
                     .chain()
@@ -117,6 +126,81 @@ fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {
     !batch.0.is_empty()
 }
 
+/// Folds the batch through `advance_state`, writes `ConnectionState` only on a
+/// real transition (so change detection fires once per transition), emits
+/// `TmuxClientAttached` on the attach edge, and on `Closed` reclaims the dead
+/// client and triggers the projection teardown.
+fn advance_tmux_connection(
+    mut commands: Commands,
+    mut state: ResMut<ConnectionState>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut attached: MessageWriter<TmuxClientAttached>,
+    batch: Res<TmuxEventBatch>,
+) {
+    if let Some(next) = advance_state(&state, &batch.0) {
+        let is_attached = matches!(next, ConnectionState::Attached);
+        *state = next;
+        if is_attached {
+            attached.write(TmuxClientAttached);
+        }
+    }
+    if batch
+        .0
+        .iter()
+        .any(|event| matches!(event, TransportEvent::Closed { .. }))
+    {
+        connection.take();
+        commands.trigger(TmuxConnectionReset);
+        commands.trigger(TmuxConnectionClosed);
+    }
+}
+
+/// Sends the one-time initial query suite when the client attaches:
+/// `list-windows`, active-pane, window-flags subscription, client name, the four
+/// `list-keys` tables, prefix options, mode-keys, and version. Gated by
+/// `on_message::<TmuxClientAttached>` so it runs exactly once per attach edge.
+fn send_attach_enumeration(
+    mut enumeration: ResMut<EnumerationState>,
+    connection: NonSend<TmuxConnection>,
+) {
+    let Some(client) = connection.client() else {
+        return;
+    };
+    send_session_enumeration(&mut enumeration, client);
+    match client.handle().send(&client_name_command()) {
+        Ok(id) => enumeration.client_name_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send client-name query"),
+    }
+    match client.handle().send(&list_keys_command("root")) {
+        Ok(id) => enumeration.keys_root_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send list-keys -T root"),
+    }
+    match client.handle().send(&list_keys_command("prefix")) {
+        Ok(id) => enumeration.keys_prefix_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send list-keys -T prefix"),
+    }
+    match client.handle().send(&prefix_options_command()) {
+        Ok(id) => enumeration.prefix_keys_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send prefix query"),
+    }
+    match client.handle().send(&list_keys_command("copy-mode")) {
+        Ok(id) => enumeration.keys_copy_mode_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode"),
+    }
+    match client.handle().send(&list_keys_command("copy-mode-vi")) {
+        Ok(id) => enumeration.keys_copy_mode_vi_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode-vi"),
+    }
+    match client.handle().send(&mode_keys_command()) {
+        Ok(id) => enumeration.mode_keys_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send mode-keys query"),
+    }
+    match client.handle().send(&version_command()) {
+        Ok(id) => enumeration.version_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send version query"),
+    }
+}
+
 /// Drains the live connection's transport channel into [`TmuxEventBatch`] and
 /// routes `%output` to `PaneOutput`. Skips the write on a fully-idle frame so
 /// change detection fires only when the batch's contents actually change; still
@@ -139,21 +223,13 @@ fn drain_tmux_transport(
     batch.0 = drained;
 }
 
-/// Applies this frame's drained `TmuxEventBatch`: advances
-/// `ConnectionState`, sends the `list-windows` enumeration once on attach, and
-/// triggers the global projection events (notifications + the enumeration
-/// reply, in stream order) the observers consume. On `Closed` it reclaims the
-/// dead client and triggers `TmuxConnectionReset` so the projected entities do
-/// not linger.
-///
-/// `ConnectionState` is written back only when [`advance_state`] reports a real
-/// transition, so normal change detection fires it exactly once per transition —
-/// an output flood does not force the
-/// `resource_exists_and_changed::<ConnectionState>`-gated consumers to re-run
-/// every frame.
+/// Applies this frame's drained `TmuxEventBatch`: triggers the global
+/// projection events (notifications + the enumeration reply, in stream order)
+/// the observers consume, routes topology re-enumeration queries on window-add /
+/// window-switch / session-switch, and consumes the pending enumeration replies
+/// (pane captures, cursor positions, keybindings, etc.).
 fn drain_tmux_events(
     mut commands: Commands,
-    mut state: ResMut<ConnectionState>,
     mut enumeration: ResMut<EnumerationState>,
     mut keybindings: ResMut<KeyBindings>,
     mut copy_queries: ResMut<CopyModeQueries>,
@@ -161,10 +237,14 @@ fn drain_tmux_events(
     mut pane_output: MessageWriter<PaneOutput>,
     mut copy_replies: MessageWriter<CopyModeReply>,
     batch: Res<TmuxEventBatch>,
+    state: Res<ConnectionState>,
     index: Res<TmuxProjection>,
     sessions: Query<&TmuxSession>,
 ) {
     let events = &batch.0;
+    if connection.client().is_none() {
+        return;
+    }
     let current_session = index
         .session
         .and_then(|e| sessions.get(e).ok())
@@ -201,141 +281,89 @@ fn drain_tmux_events(
             }
         }
     }
-    if let Some(next) = advance_state(&state, events) {
-        *state = next;
-        if matches!(*state, ConnectionState::Attached)
+    if let Some(name) = take_client_name(&mut enumeration.client_name_pending, events) {
+        connection.set_client_name(name);
+    }
+    if let Some(version) = take_version(&mut enumeration.version_pending, events) {
+        connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
+    }
+    if let Some((window, pane)) = take_active_pane(&mut enumeration.active_pane_pending, events) {
+        commands.trigger(TmuxActivePaneChanged {
+            window,
+            pane,
+            from_notification: false,
+        });
+        if !enumeration.aggressive_resize_checked
+            && enumeration.aggressive_resize_pending.is_none()
             && let Some(client) = connection.client()
         {
-            send_session_enumeration(&mut enumeration, client);
-            match client.handle().send(&client_name_command()) {
-                Ok(id) => enumeration.client_name_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send client-name query"),
-            }
-            match client.handle().send(&list_keys_command("root")) {
-                Ok(id) => enumeration.keys_root_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send list-keys -T root"),
-            }
-            match client.handle().send(&list_keys_command("prefix")) {
-                Ok(id) => enumeration.keys_prefix_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send list-keys -T prefix"),
-            }
-            match client.handle().send(&prefix_options_command()) {
-                Ok(id) => enumeration.prefix_keys_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send prefix query"),
-            }
-            match client.handle().send(&list_keys_command("copy-mode")) {
-                Ok(id) => enumeration.keys_copy_mode_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode"),
-            }
-            match client.handle().send(&list_keys_command("copy-mode-vi")) {
-                Ok(id) => enumeration.keys_copy_mode_vi_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send list-keys -T copy-mode-vi"),
-            }
-            match client.handle().send(&mode_keys_command()) {
-                Ok(id) => enumeration.mode_keys_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send mode-keys query"),
-            }
-            match client.handle().send(&version_command()) {
-                Ok(id) => enumeration.version_pending = Some(id),
-                Err(error) => tracing::warn!(?error, "failed to send version query"),
+            match client.handle().send(&aggressive_resize_command(window)) {
+                Ok(id) => enumeration.aggressive_resize_pending = Some(id),
+                Err(error) => tracing::warn!(?error, "failed to query aggressive-resize"),
             }
         }
     }
-    if events
-        .iter()
-        .any(|event| matches!(event, TransportEvent::Closed { .. }))
+    if let Some(value) = take_aggressive_resize(&mut enumeration.aggressive_resize_pending, events)
     {
-        connection.take();
-        commands.trigger(TmuxConnectionReset);
-        commands.trigger(TmuxConnectionClosed);
-    } else {
-        if let Some(name) = take_client_name(&mut enumeration.client_name_pending, events) {
-            connection.set_client_name(name);
+        enumeration.aggressive_resize_checked = true;
+        if value.trim() == "on" {
+            tracing::warn!(
+                "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
+                 windows may resize unexpectedly"
+            );
         }
-        if let Some(version) = take_version(&mut enumeration.version_pending, events) {
-            connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
-        }
-        if let Some((window, pane)) = take_active_pane(&mut enumeration.active_pane_pending, events)
-        {
-            commands.trigger(TmuxActivePaneChanged {
-                window,
-                pane,
-                from_notification: false,
-            });
-            if !enumeration.aggressive_resize_checked
-                && enumeration.aggressive_resize_pending.is_none()
-                && let Some(client) = connection.client()
-            {
-                match client.handle().send(&aggressive_resize_command(window)) {
-                    Ok(id) => enumeration.aggressive_resize_pending = Some(id),
-                    Err(error) => tracing::warn!(?error, "failed to query aggressive-resize"),
-                }
-            }
-        }
-        if let Some(value) =
-            take_aggressive_resize(&mut enumeration.aggressive_resize_pending, events)
-        {
-            enumeration.aggressive_resize_checked = true;
-            if value.trim() == "on" {
-                tracing::warn!(
-                    "tmux 'aggressive-resize on' is incompatible with control-mode integration; \
-                     windows may resize unexpectedly"
-                );
-            }
-        }
-        // NOTE: deref once so the borrow checker can see these as distinct
-        // field borrows rather than overlapping borrows through DerefMut.
-        // NOTE: take_pane_captures MUST run before take_cursor_positions: when
-        // both a capture reply and its paired cursor reply arrive in the same
-        // event batch, captures populates capture_awaiting_cursor first, then
-        // cursor_positions drains it. Swapping the calls silently drops cursor
-        // fixes on same-batch arrivals.
-        let e = &mut *enumeration;
-        for output in take_pane_captures(
-            &mut e.capture_pending,
-            &mut e.capture_awaiting_cursor,
-            &e.panes_with_cursor_pending,
-            events,
-        ) {
-            pane_output.write(output);
-        }
-        for output in take_cursor_positions(
-            &mut e.cursor_pending,
-            &mut e.panes_with_cursor_pending,
-            &mut e.capture_awaiting_cursor,
-            events,
-        ) {
-            pane_output.write(output);
-        }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, events) {
-            keybindings.install(bindings);
-        }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, events) {
-            keybindings.install(bindings);
-        }
-        if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, events) {
-            keybindings.set_prefix_keys(keys);
-        }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_pending, events) {
-            keybindings.install(bindings);
-        }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_vi_pending, events)
-        {
-            keybindings.install(bindings);
-        }
-        if let Some(mode_keys) = take_mode_keys(&mut enumeration.mode_keys_pending, events) {
-            keybindings.set_mode_keys(mode_keys);
-        }
-        for reply in drain_copy_replies(&mut copy_queries, events) {
-            copy_replies.write(reply);
-        }
-        trigger_events(
-            &mut commands,
-            &mut enumeration.pending,
-            events,
-            connection.client_name(),
-        );
     }
+    // NOTE: deref once so the borrow checker can see these as distinct
+    // field borrows rather than overlapping borrows through DerefMut.
+    // NOTE: take_pane_captures MUST run before take_cursor_positions: when
+    // both a capture reply and its paired cursor reply arrive in the same
+    // event batch, captures populates capture_awaiting_cursor first, then
+    // cursor_positions drains it. Swapping the calls silently drops cursor
+    // fixes on same-batch arrivals.
+    let e = &mut *enumeration;
+    for output in take_pane_captures(
+        &mut e.capture_pending,
+        &mut e.capture_awaiting_cursor,
+        &e.panes_with_cursor_pending,
+        events,
+    ) {
+        pane_output.write(output);
+    }
+    for output in take_cursor_positions(
+        &mut e.cursor_pending,
+        &mut e.panes_with_cursor_pending,
+        &mut e.capture_awaiting_cursor,
+        events,
+    ) {
+        pane_output.write(output);
+    }
+    if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, events) {
+        keybindings.install(bindings);
+    }
+    if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, events) {
+        keybindings.install(bindings);
+    }
+    if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, events) {
+        keybindings.set_prefix_keys(keys);
+    }
+    if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_pending, events) {
+        keybindings.install(bindings);
+    }
+    if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_vi_pending, events) {
+        keybindings.install(bindings);
+    }
+    if let Some(mode_keys) = take_mode_keys(&mut enumeration.mode_keys_pending, events) {
+        keybindings.set_mode_keys(mode_keys);
+    }
+    for reply in drain_copy_replies(&mut copy_queries, events) {
+        copy_replies.write(reply);
+    }
+    trigger_events(
+        &mut commands,
+        &mut enumeration.pending,
+        events,
+        connection.client_name(),
+    );
     // NOTE: runs after the Closed branch took the connection, so `client()` is
     // None there and this is a no-op — safe to re-arm only while still attached.
     if matches!(*state, ConnectionState::Attached)
@@ -405,6 +433,45 @@ mod tests {
         assert!(index.windows.is_empty());
         assert!(index.panes.is_empty());
         assert!(index.session.is_none());
+    }
+
+    #[test]
+    fn advance_to_attached_emits_client_attached_message() {
+        use bevy::ecs::system::RunSystemOnce;
+        use tmux_control::{ClientEvent, ControlEvent};
+        use tmux_control_parser::WindowId;
+        let mut app = App::new();
+        app.add_plugins(TmuxSessionPlugin);
+        *app.world_mut().resource_mut::<ConnectionState>() = ConnectionState::Connecting;
+        app.world_mut()
+            .resource_mut::<TmuxEventBatch>()
+            .0
+            .push(TransportEvent::Protocol(ClientEvent::Notification(
+                ControlEvent::WindowAdd {
+                    window: WindowId(1),
+                },
+            )));
+        app.world_mut()
+            .run_system_once(advance_tmux_connection)
+            .unwrap();
+        let messages = app.world().resource::<Messages<TmuxClientAttached>>();
+        assert_eq!(messages.iter_current_update_messages().count(), 1);
+        assert_eq!(
+            *app.world().resource::<ConnectionState>(),
+            ConnectionState::Attached
+        );
+    }
+
+    #[test]
+    fn send_attach_enumeration_runs_on_message() {
+        let mut app = App::new();
+        app.add_plugins(TmuxSessionPlugin);
+        app.insert_resource(TmuxPresence);
+        // No live client: the system must still run on the message but send nothing,
+        // leaving `pending` (list-windows id) None without panicking.
+        app.world_mut().write_message(TmuxClientAttached);
+        app.update();
+        assert!(app.world().resource::<EnumerationState>().pending.is_none());
     }
 
     #[test]

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -39,7 +39,8 @@ pub struct TmuxPresence;
 struct TmuxClientAttached;
 
 /// This frame's drained transport events, shared across the drain chain.
-/// Overwritten by [`drain_tmux_transport`] each frame; read-only downstream.
+/// Refreshed by [`drain_tmux_transport`] when the drain or the prior batch is
+/// non-empty; read-only downstream.
 #[derive(Resource, Default)]
 struct TmuxEventBatch(Vec<TransportEvent>);
 
@@ -560,8 +561,6 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(TmuxSessionPlugin);
         app.insert_resource(TmuxPresence);
-        // No live client: the system must still run on the message but send nothing,
-        // leaving `pending` empty without panicking.
         app.world_mut().write_message(TmuxClientAttached);
         app.update();
         assert!(

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -30,6 +30,11 @@ use tmux_control::TransportEvent;
 #[derive(Resource, Default)]
 pub struct TmuxPresence;
 
+/// This frame's drained transport events, shared across the drain chain.
+/// Overwritten by [`drain_tmux_transport`] each frame; read-only downstream.
+#[derive(Resource, Default)]
+struct TmuxEventBatch(Vec<TransportEvent>);
+
 /// Wires the tmux integration into the Bevy app: connection state, the
 /// projection observers + id->entity index, and the per-frame transport-drain
 /// system that triggers the global projection events.
@@ -49,12 +54,17 @@ impl Plugin for TmuxSessionPlugin {
             .init_resource::<EnumerationState>()
             .init_resource::<KeyBindings>()
             .init_resource::<CopyModeQueries>()
+            .init_resource::<TmuxEventBatch>()
             .insert_non_send_resource(TmuxConnection::default())
             .add_message::<PaneOutput>()
             .add_message::<CopyModeReply>()
             .add_systems(
                 Update,
-                drain_tmux_events
+                (
+                    drain_tmux_transport,
+                    drain_tmux_events.run_if(tmux_batch_pending),
+                )
+                    .chain()
                     .in_set(TmuxProjectionSet)
                     .run_if(resource_exists::<TmuxPresence>),
             )
@@ -103,6 +113,32 @@ fn request_pane_captures(
     }
 }
 
+fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {
+    !batch.0.is_empty()
+}
+
+/// Drains the live connection's transport channel into [`TmuxEventBatch`] and
+/// routes `%output` to `PaneOutput`. Skips the write on a fully-idle frame so
+/// change detection fires only when the batch's contents actually change; still
+/// clears a previously-non-empty batch to empty exactly once.
+fn drain_tmux_transport(
+    mut batch: ResMut<TmuxEventBatch>,
+    mut pane_output: MessageWriter<PaneOutput>,
+    connection: NonSend<TmuxConnection>,
+) {
+    let drained = match connection.client() {
+        Some(client) => drain_transport(client.events()),
+        None => Vec::new(),
+    };
+    if drained.is_empty() && batch.0.is_empty() {
+        return;
+    }
+    for output in collect_pane_outputs(&drained) {
+        pane_output.write(output);
+    }
+    batch.0 = drained;
+}
+
 /// Drains the live connection's transport events each frame: advances
 /// `ConnectionState`, sends the `list-windows` enumeration once on attach, and
 /// triggers the global projection events (notifications + the enumeration
@@ -124,24 +160,16 @@ fn drain_tmux_events(
     mut connection: NonSendMut<TmuxConnection>,
     mut pane_output: MessageWriter<PaneOutput>,
     mut copy_replies: MessageWriter<CopyModeReply>,
+    batch: Res<TmuxEventBatch>,
     index: Res<TmuxProjection>,
     sessions: Query<&TmuxSession>,
 ) {
-    let events = match connection.client() {
-        Some(client) => drain_transport(client.events()),
-        None => return,
-    };
-    if events.is_empty() {
-        return;
-    }
-    for output in collect_pane_outputs(&events) {
-        pane_output.write(output);
-    }
+    let events = &batch.0;
     let current_session = index
         .session
         .and_then(|e| sessions.get(e).ok())
         .map(|s| s.id);
-    if detect_session_switch(&events, current_session, connection.client_name()).is_some()
+    if detect_session_switch(events, current_session, connection.client_name()).is_some()
         && let Some(client) = connection.client()
     {
         commands.trigger(TmuxWindowsRetained {
@@ -158,13 +186,13 @@ fn drain_tmux_events(
         enumeration.aggressive_resize_pending = None;
         send_session_enumeration(&mut enumeration, client);
     } else if let Some(client) = connection.client() {
-        if detect_window_added(&events) {
+        if detect_window_added(events) {
             match client.handle().send(&list_windows_command()) {
                 Ok(id) => enumeration.pending = Some(id),
                 Err(error) => tracing::warn!(?error, "failed to re-enumerate on window-add"),
             }
         }
-        if detect_window_switch(&events, current_session) {
+        if detect_window_switch(events, current_session) {
             match client.handle().send(&active_pane_command()) {
                 Ok(id) => enumeration.active_pane_pending = Some(id),
                 Err(error) => {
@@ -173,7 +201,7 @@ fn drain_tmux_events(
             }
         }
     }
-    if let Some(next) = advance_state(&state, &events) {
+    if let Some(next) = advance_state(&state, events) {
         *state = next;
         if matches!(*state, ConnectionState::Attached)
             && let Some(client) = connection.client()
@@ -221,14 +249,13 @@ fn drain_tmux_events(
         commands.trigger(TmuxConnectionReset);
         commands.trigger(TmuxConnectionClosed);
     } else {
-        if let Some(name) = take_client_name(&mut enumeration.client_name_pending, &events) {
+        if let Some(name) = take_client_name(&mut enumeration.client_name_pending, events) {
             connection.set_client_name(name);
         }
-        if let Some(version) = take_version(&mut enumeration.version_pending, &events) {
+        if let Some(version) = take_version(&mut enumeration.version_pending, events) {
             connection.set_per_window_refresh(version_supports_per_window_refresh(&version));
         }
-        if let Some((window, pane)) =
-            take_active_pane(&mut enumeration.active_pane_pending, &events)
+        if let Some((window, pane)) = take_active_pane(&mut enumeration.active_pane_pending, events)
         {
             commands.trigger(TmuxActivePaneChanged {
                 window,
@@ -246,7 +273,7 @@ fn drain_tmux_events(
             }
         }
         if let Some(value) =
-            take_aggressive_resize(&mut enumeration.aggressive_resize_pending, &events)
+            take_aggressive_resize(&mut enumeration.aggressive_resize_pending, events)
         {
             enumeration.aggressive_resize_checked = true;
             if value.trim() == "on" {
@@ -268,7 +295,7 @@ fn drain_tmux_events(
             &mut e.capture_pending,
             &mut e.capture_awaiting_cursor,
             &e.panes_with_cursor_pending,
-            &events,
+            events,
         ) {
             pane_output.write(output);
         }
@@ -276,37 +303,36 @@ fn drain_tmux_events(
             &mut e.cursor_pending,
             &mut e.panes_with_cursor_pending,
             &mut e.capture_awaiting_cursor,
-            &events,
+            events,
         ) {
             pane_output.write(output);
         }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, &events) {
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_root_pending, events) {
             keybindings.install(bindings);
         }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, &events) {
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_prefix_pending, events) {
             keybindings.install(bindings);
         }
-        if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, &events) {
+        if let Some(keys) = take_prefix_keys(&mut enumeration.prefix_keys_pending, events) {
             keybindings.set_prefix_keys(keys);
         }
-        if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_pending, &events) {
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_pending, events) {
             keybindings.install(bindings);
         }
-        if let Some(bindings) =
-            take_keybindings(&mut enumeration.keys_copy_mode_vi_pending, &events)
+        if let Some(bindings) = take_keybindings(&mut enumeration.keys_copy_mode_vi_pending, events)
         {
             keybindings.install(bindings);
         }
-        if let Some(mode_keys) = take_mode_keys(&mut enumeration.mode_keys_pending, &events) {
+        if let Some(mode_keys) = take_mode_keys(&mut enumeration.mode_keys_pending, events) {
             keybindings.set_mode_keys(mode_keys);
         }
-        for reply in drain_copy_replies(&mut copy_queries, &events) {
+        for reply in drain_copy_replies(&mut copy_queries, events) {
             copy_replies.write(reply);
         }
         trigger_events(
             &mut commands,
             &mut enumeration.pending,
-            &events,
+            events,
             connection.client_name(),
         );
     }
@@ -345,6 +371,27 @@ fn send_session_enumeration(enumeration: &mut EnumerationState, client: &tmux_co
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn drain_transport_clears_stale_batch_once_then_skips_idle() {
+        use crossbeam_channel::unbounded;
+        let mut app = App::new();
+        app.add_plugins(TmuxSessionPlugin);
+        app.insert_resource(TmuxPresence);
+        app.insert_resource(TmuxEventBatch(vec![TransportEvent::Closed {
+            reason: "x".into(),
+        }]));
+        let _ = unbounded::<TransportEvent>();
+        app.update();
+        assert!(app.world().resource::<TmuxEventBatch>().0.is_empty());
+        let changed_tick = app.world().resource_ref::<TmuxEventBatch>().last_changed();
+        app.update();
+        assert_eq!(
+            app.world().resource_ref::<TmuxEventBatch>().last_changed(),
+            changed_tick,
+            "idle frame must not re-fire change detection on an already-empty batch"
+        );
+    }
 
     #[test]
     fn plugin_registers_resources_and_stays_idle_without_connection() {

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -32,18 +32,6 @@ use tmux_control::{ClientEvent, TmuxClient, TransportEvent};
 #[derive(Resource, Default)]
 pub struct TmuxPresence;
 
-/// Emitted the frame the control client's transport transitions to `Attached`
-/// (including a reconnect). Gates [`send_attach_enumeration`]. A pure signal —
-/// the init-send system reads the live client from `TmuxConnection`.
-#[derive(Message)]
-struct TmuxClientAttached;
-
-/// This frame's drained transport events, shared across the drain chain.
-/// Refreshed by [`drain_tmux_transport`] when the drain or the prior batch is
-/// non-empty; read-only downstream.
-#[derive(Resource, Default)]
-struct TmuxEventBatch(Vec<TransportEvent>);
-
 /// Wires the tmux integration into the Bevy app: connection state, the
 /// projection observers + id->entity index, and the per-frame transport-drain
 /// system that triggers the global projection events.
@@ -89,6 +77,18 @@ impl Plugin for TmuxSessionPlugin {
             );
     }
 }
+
+/// Emitted the frame the control client's transport transitions to `Attached`
+/// (including a reconnect). Gates [`send_attach_enumeration`]. A pure signal —
+/// the init-send system reads the live client from `TmuxConnection`.
+#[derive(Message)]
+struct TmuxClientAttached;
+
+/// This frame's drained transport events, shared across the drain chain.
+/// Refreshed by [`drain_tmux_transport`] when the drain or the prior batch is
+/// non-empty; read-only downstream.
+#[derive(Resource, Default)]
+struct TmuxEventBatch(Vec<TransportEvent>);
 
 /// Sends `capture-pane` and a companion cursor-position `display-message` once
 /// for each newly-projected pane so its current screen seeds the first paint

--- a/docs/superpowers/plans/2026-06-20-tmux-drain-split.md
+++ b/docs/superpowers/plans/2026-06-20-tmux-drain-split.md
@@ -1,0 +1,763 @@
+# tmux Drain Split + Enum Reply Correlation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the monolithic `drain_tmux_events` system into five focused, chained Bevy systems, and replace `EnumerationState`'s per-field `Option<CommandId>` + `take_*` reply correlation with a single `HashMap<CommandId, PendingReply>` ordered `match` dispatch.
+
+**Architecture:** Five systems run as one `.chain().in_set(TmuxProjectionSet)` under `Update`, sharing a per-frame `TmuxEventBatch` resource produced by the drain system. A `TmuxClientAttached` buffered message signals the attach edge so the init-send system can be gated by `on_message`. Connection liveness is a body guard (not a `NonSend` run condition, which is unsound under the multi-threaded executor). Reply correlation moves to a `CommandId`-keyed enum map dispatched in stream order, mirroring the existing `CopyModeQueries` / `CopyQueryKind` pattern.
+
+**Tech Stack:** Rust edition 2024 (toolchain 1.95), Bevy 0.18 ECS, `crossbeam-channel`, the `ozmux_tmux` crate (`crates/tmux_session/`).
+
+**Design spec:** `docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md` (read it before starting).
+
+## Global Constraints
+
+- Edition 2024, toolchain pinned to 1.95; Bevy 0.18 (`Message` / `MessageWriter` / `MessageReader` / `on_message`, the 0.17 renames of `Event`/`EventWriter`/`EventReader`/`on_event`).
+- All in-code comments in **English**. Comment taxonomy: only `// TODO:`, `// NOTE:` (critical caveats only), `// SAFETY:`. No narrative or block comments; no commented-out code.
+- Doc comments (`///`) on every externally `pub` item; `//!` on each module file. New items default to **private**; widen only when a cross-module caller forces it. `PendingReply`, `TmuxEventBatch`, `TmuxClientAttached`, and the run condition are crate-internal — keep them private to `plugin.rs`/`enumerate.rs` (no `pub`).
+- No `mod.rs`. Imports all at the top, single contiguous block, no inline fully-qualified paths.
+- Bevy rules: gate whole-system guards with `run_if` (a body guard is the exception, allowed only when no Send-friendly condition exists — record why in a `// NOTE:`). Mutable params before immutable in signatures. No manual `set_changed()` / `bypass_change_detection()`; mutate conditionally. `Plugin::build` is one method chain off `app`. `Query` params use descriptive nouns, never `_q`.
+- Verification after every task: `cargo test -p ozmux_tmux` (all pass), `cargo clippy -p ozmux_tmux --all-targets` (no warnings), `cargo fmt`.
+- Comment style for the relocated logic: this refactor **relocates** large blocks of already-tested code. Steps cite exact source line ranges to move and show the **new** signatures, wiring, and net-new logic in full. Preserve the existing `// NOTE:` comments verbatim when moving the code they annotate.
+
+---
+
+## File Structure
+
+| File | Responsibility after this plan |
+|---|---|
+| `crates/tmux_session/src/plugin.rs` | The five chained systems (`drain_tmux_transport`, `advance_tmux_connection`, `send_attach_enumeration`, `send_tmux_reenumeration`, `apply_tmux_replies`), `request_pane_captures`, the `TmuxEventBatch` resource, the `TmuxClientAttached` message, the `tmux_batch_pending` run condition, helper `fn`s, and the plugin wiring. |
+| `crates/tmux_session/src/enumerate.rs` | `PendingReply` enum + reshaped `EnumerationState` (4 fields) + its helper methods. Command builders unchanged. |
+| `crates/tmux_session/src/event_pump.rs` | Pure parse/detect/trigger helpers only (`advance_state`, `detect_*`, `parse_*`, `capture_to_bytes*`, `trigger_notification`, `trigger_seed`, `collect_pane_outputs`). The `take_*` correlation wrappers are removed. |
+
+---
+
+## Task 1: Shared event batch + drain system (①)
+
+Introduce `TmuxEventBatch` and the `tmux_batch_pending` run condition; extract draining + `%output` routing into `drain_tmux_transport`; make the remaining monolith read the batch instead of draining.
+
+**Files:**
+- Modify: `crates/tmux_session/src/plugin.rs`
+
+**Interfaces:**
+- Produces: `struct TmuxEventBatch(Vec<TransportEvent>)` (private `Resource`); `fn drain_tmux_transport(mut batch: ResMut<TmuxEventBatch>, connection: NonSend<TmuxConnection>, mut pane_output: MessageWriter<PaneOutput>)`; `fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool`.
+- The remaining `drain_tmux_events` now reads `batch: Res<TmuxEventBatch>` instead of draining, gated by `tmux_batch_pending`.
+
+- [ ] **Step 1: Write the failing test for the conditional batch write**
+
+Add to the `#[cfg(test)] mod tests` block in `plugin.rs`:
+
+```rust
+#[test]
+fn drain_transport_clears_stale_batch_once_then_skips_idle() {
+    use crossbeam_channel::unbounded;
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    // Seed a non-empty batch as if a prior frame drained events.
+    app.insert_resource(TmuxEventBatch(vec![TransportEvent::Closed {
+        reason: "x".into(),
+    }]));
+    // No live client, so drain_tmux_transport finds an empty channel.
+    let _ = unbounded::<TransportEvent>();
+    app.update();
+    // First idle update clears the stale batch to empty exactly once.
+    assert!(app.world().resource::<TmuxEventBatch>().0.is_empty());
+    let changed_tick = app
+        .world()
+        .resource_ref::<TmuxEventBatch>()
+        .last_changed();
+    app.update();
+    // Second idle update must NOT re-write the already-empty batch.
+    assert_eq!(
+        app.world().resource_ref::<TmuxEventBatch>().last_changed(),
+        changed_tick,
+        "idle frame must not re-fire change detection on an already-empty batch"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux_tmux drain_transport_clears_stale_batch_once_then_skips_idle`
+Expected: FAIL to compile — `TmuxEventBatch` and `drain_tmux_transport` do not exist yet.
+
+- [ ] **Step 3: Add the resource, the drain system, and the run condition**
+
+In `plugin.rs`, add the resource near `TmuxPresence`:
+
+```rust
+/// This frame's drained transport events, shared across the drain chain.
+/// Overwritten by [`drain_tmux_transport`] each frame; read-only downstream.
+#[derive(Resource, Default)]
+struct TmuxEventBatch(Vec<TransportEvent>);
+```
+
+Add the run condition and the drain system (place the systems above `drain_tmux_events`; the run condition with the other free `fn`s):
+
+```rust
+fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {
+    !batch.0.is_empty()
+}
+
+/// Drains the live connection's transport channel into [`TmuxEventBatch`] and
+/// routes `%output` to `PaneOutput`. Skips the write on a fully-idle frame so
+/// change detection fires only when the batch's contents actually change; still
+/// clears a previously-non-empty batch to empty exactly once.
+fn drain_tmux_transport(
+    mut batch: ResMut<TmuxEventBatch>,
+    connection: NonSend<TmuxConnection>,
+    mut pane_output: MessageWriter<PaneOutput>,
+) {
+    let drained = match connection.client() {
+        Some(client) => drain_transport(client.events()),
+        None => Vec::new(),
+    };
+    if drained.is_empty() && batch.0.is_empty() {
+        return;
+    }
+    for output in collect_pane_outputs(&drained) {
+        pane_output.write(output);
+    }
+    batch.0 = drained;
+}
+```
+
+- [ ] **Step 4: Convert `drain_tmux_events` to read the batch**
+
+Change the `drain_tmux_events` signature: remove the `mut pane_output: MessageWriter<PaneOutput>` parameter (output routing now lives in `drain_tmux_transport`), and add `batch: Res<TmuxEventBatch>`. Delete the head of the body (`plugin.rs:130-139`) — the `drain_transport` call, the `events.is_empty()` early return, and the `collect_pane_outputs` loop — and replace with:
+
+```rust
+    let events = &batch.0;
+```
+
+Then update the rest of the body to use `events` (it already binds the name `events`; it is now `&Vec<TransportEvent>` instead of `Vec<TransportEvent>`, so existing `&events` / `events.iter()` call sites compile unchanged).
+
+- [ ] **Step 5: Register the chain in `Plugin::build`**
+
+Replace the single `drain_tmux_events` registration (`plugin.rs:55-60`) with a chained pair (keep the whole `build` body one method chain):
+
+```rust
+            .add_systems(
+                Update,
+                (
+                    drain_tmux_transport,
+                    drain_tmux_events.run_if(tmux_batch_pending),
+                )
+                    .chain()
+                    .in_set(TmuxProjectionSet)
+                    .run_if(resource_exists::<TmuxPresence>),
+            )
+```
+
+Add `.init_resource::<TmuxEventBatch>()` to the `build` chain (next to the other `init_resource` calls).
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p ozmux_tmux`
+Expected: PASS — the new test plus all existing tests (behavior is preserved).
+
+- [ ] **Step 7: Lint and format**
+
+Run: `cargo clippy -p ozmux_tmux --all-targets && cargo fmt`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/tmux_session/src/plugin.rs
+git commit -m "refactor(tmux): extract drain_tmux_transport + shared TmuxEventBatch"
+```
+
+---
+
+## Task 2: Attach message + connection system (②) + attach-init system (③a)
+
+Add the `TmuxClientAttached` message; extract `advance_state` + `Closed` teardown into `advance_tmux_connection` (emitting the message on the attach transition); extract the initial query suite into `send_attach_enumeration`, gated by `on_message`.
+
+**Files:**
+- Modify: `crates/tmux_session/src/plugin.rs`
+
+**Interfaces:**
+- Consumes: `TmuxEventBatch`, `tmux_batch_pending`, `send_session_enumeration` (existing helper, `plugin.rs:331`).
+- Produces: `struct TmuxClientAttached` (private unit `Message`); `fn advance_tmux_connection(...)`; `fn send_attach_enumeration(...)`. After this task, `drain_tmux_events` no longer advances state, tears down on `Closed`, or sends the attach-init suite.
+
+- [ ] **Step 1: Write the failing test for the attach emit**
+
+Add to `plugin.rs` tests:
+
+```rust
+#[test]
+fn advance_to_attached_emits_client_attached_message() {
+    use tmux_control::{ClientEvent, ControlEvent};
+    use tmux_control_parser::WindowId;
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    *app.world_mut().resource_mut::<ConnectionState>() = ConnectionState::Connecting;
+    app.insert_resource(TmuxEventBatch(vec![TransportEvent::Protocol(
+        ClientEvent::Notification(ControlEvent::WindowAdd {
+            window: WindowId(1),
+        }),
+    )]));
+    app.update();
+    let messages = app.world().resource::<Messages<TmuxClientAttached>>();
+    assert_eq!(messages.iter_current_update_messages().count(), 1);
+    assert_eq!(
+        *app.world().resource::<ConnectionState>(),
+        ConnectionState::Attached
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux_tmux advance_to_attached_emits_client_attached_message`
+Expected: FAIL to compile — `TmuxClientAttached` does not exist.
+
+- [ ] **Step 3: Add the message and register it**
+
+In `plugin.rs`:
+
+```rust
+/// Emitted the frame the control client's transport transitions to `Attached`
+/// (including a reconnect). Gates [`send_attach_enumeration`]. A pure signal —
+/// the init-send system reads the live client from `TmuxConnection`.
+#[derive(Message)]
+struct TmuxClientAttached;
+```
+
+Add `.add_message::<TmuxClientAttached>()` to the `Plugin::build` chain.
+
+- [ ] **Step 4: Add `advance_tmux_connection`**
+
+Move the `advance_state` block (`plugin.rs:176-215`) and the `Closed` teardown branch (`plugin.rs:216-222`) out of `drain_tmux_events` into a new system. Drop the attach-init sends from the moved `advance_state` block (they move to ③a in Step 6); keep only the state write + emit:
+
+```rust
+/// Folds the batch through `advance_state`, writes `ConnectionState` only on a
+/// real transition (so change detection fires once per transition), emits
+/// `TmuxClientAttached` on the attach edge, and on `Closed` reclaims the dead
+/// client and triggers the projection teardown.
+fn advance_tmux_connection(
+    mut commands: Commands,
+    mut state: ResMut<ConnectionState>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut attached: MessageWriter<TmuxClientAttached>,
+    batch: Res<TmuxEventBatch>,
+) {
+    if let Some(next) = advance_state(&state, &batch.0) {
+        let is_attached = matches!(next, ConnectionState::Attached);
+        *state = next;
+        if is_attached {
+            attached.write(TmuxClientAttached);
+        }
+    }
+    if batch
+        .0
+        .iter()
+        .any(|event| matches!(event, TransportEvent::Closed { .. }))
+    {
+        connection.take();
+        commands.trigger(TmuxConnectionReset);
+        commands.trigger(TmuxConnectionClosed);
+    }
+}
+```
+
+Delete the corresponding code from `drain_tmux_events`: the whole `if let Some(next) = advance_state(...)` block and the `if events.iter().any(... Closed ...)` / `else` framing. The former `else` body (the `take_*` calls and `trigger_events`) stays in `drain_tmux_events` but is no longer wrapped in the `else` — it now runs unconditionally for a non-closed batch. **Guard it with a body return** so it does not run after a `Closed` teardown (Task 3 makes this a body guard on the live client; for now add `if connection.client().is_none() { return; }` near the top of `drain_tmux_events`, after binding `events`).
+
+- [ ] **Step 5: Write the failing test for the attach-init system**
+
+```rust
+#[test]
+fn send_attach_enumeration_runs_on_message() {
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    // No live client: the system must still run on the message but send nothing,
+    // leaving `pending` (list-windows id) None without panicking.
+    app.world_mut().write_message(TmuxClientAttached);
+    app.update();
+    assert!(app.world().resource::<EnumerationState>().pending.is_none());
+}
+```
+
+- [ ] **Step 6: Add `send_attach_enumeration`**
+
+Move the attach-init suite (the body of the `if matches!(*state, Attached) && let Some(client) = connection.client()` block, `plugin.rs:178-214`) into a new system gated by the message:
+
+```rust
+/// Sends the one-time initial query suite when the client attaches:
+/// `list-windows`, active-pane, window-flags subscription, client name, the four
+/// `list-keys` tables, prefix options, mode-keys, and version. Gated by
+/// `on_message::<TmuxClientAttached>` so it runs exactly once per attach edge.
+fn send_attach_enumeration(
+    mut enumeration: ResMut<EnumerationState>,
+    connection: NonSend<TmuxConnection>,
+) {
+    let Some(client) = connection.client() else {
+        return;
+    };
+    send_session_enumeration(&mut enumeration, client);
+    match client.handle().send(&client_name_command()) {
+        Ok(id) => enumeration.client_name_pending = Some(id),
+        Err(error) => tracing::warn!(?error, "failed to send client-name query"),
+    }
+    // ... move the remaining list-keys / prefix / mode-keys / version sends
+    //     verbatim from plugin.rs:186-213 ...
+}
+```
+
+(Reproduce the `list_keys_command("root"|"prefix"|"copy-mode"|"copy-mode-vi")`, `prefix_options_command`, `mode_keys_command`, and `version_command` send blocks exactly as they appear at `plugin.rs:186-213`.)
+
+- [ ] **Step 7: Register ② and ③a in the chain**
+
+Update the chain in `Plugin::build`:
+
+```rust
+                (
+                    drain_tmux_transport,
+                    advance_tmux_connection.run_if(tmux_batch_pending),
+                    send_attach_enumeration.run_if(on_message::<TmuxClientAttached>),
+                    drain_tmux_events.run_if(tmux_batch_pending),
+                )
+                    .chain()
+                    .in_set(TmuxProjectionSet)
+                    .run_if(resource_exists::<TmuxPresence>),
+```
+
+Add `use bevy::ecs::message::Messages;` is not needed for the system, but the test in Step 1 uses `Messages<TmuxClientAttached>` and `on_message` — add `on_message` via `use bevy::prelude::*` (already imported). Ensure `client_name_command`, `list_keys_command`, `prefix_options_command`, `mode_keys_command`, `version_command` remain imported (they already are, `plugin.rs:7-11`).
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `cargo test -p ozmux_tmux`
+Expected: PASS (new tests + all existing).
+
+- [ ] **Step 9: Lint, format, commit**
+
+```bash
+cargo clippy -p ozmux_tmux --all-targets && cargo fmt
+git add crates/tmux_session/src/plugin.rs
+git commit -m "refactor(tmux): extract advance_tmux_connection + send_attach_enumeration with TmuxClientAttached"
+```
+
+---
+
+## Task 3: Re-enumeration system (③b) + apply system (④) + body guards
+
+Split the remaining `drain_tmux_events` into `send_tmux_reenumeration` (topology re-enumeration + client-name re-arm) and `apply_tmux_replies` (reply correlation + projection), each body-guarded on the live client.
+
+**Files:**
+- Modify: `crates/tmux_session/src/plugin.rs`
+
+**Interfaces:**
+- Produces: `fn send_tmux_reenumeration(...)` and `fn apply_tmux_replies(...)`. `drain_tmux_events` is removed.
+
+- [ ] **Step 1: Write the failing test for the body guard**
+
+```rust
+#[test]
+fn apply_and_reenumeration_skip_without_client() {
+    use tmux_control::{ClientEvent, ControlEvent};
+    use tmux_control_parser::WindowId;
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    // Non-empty batch but no live client: both systems must body-guard out.
+    app.insert_resource(TmuxEventBatch(vec![TransportEvent::Protocol(
+        ClientEvent::Notification(ControlEvent::WindowAdd {
+            window: WindowId(9),
+        }),
+    )]));
+    app.update();
+    // No panic, and no enumeration was registered (nothing was sent).
+    assert!(app.world().resource::<EnumerationState>().pending.is_none());
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails or is inconclusive, then proceed**
+
+Run: `cargo test -p ozmux_tmux apply_and_reenumeration_skip_without_client`
+Expected: PASS-compiles but does not yet exercise the split (still one system). Treat this as a regression guard kept green through the split.
+
+- [ ] **Step 3: Add `send_tmux_reenumeration`**
+
+Move the session-switch detection block (`plugin.rs:140-159`), the `else if` window-add / window-switch block (`plugin.rs:160-175`), and the client-name re-arm (`plugin.rs:315-324`) into a new system. Add the live-client body guard:
+
+```rust
+/// Sends topology re-enumeration in response to notifications: a session switch
+/// (clear caches, reset the aggressive-resize guard, re-enumerate the new
+/// session), a `%window-add` (re-`list-windows`), or a `%session-window-changed`
+/// (re-query the active pane). Also re-arms the client-name query if it is still
+/// unresolved while attached.
+///
+/// Body-guards on the live client: a run condition reading `NonSend` is unsound
+/// under the multi-threaded executor (bevyengine/bevy#21230).
+fn send_tmux_reenumeration(
+    mut commands: Commands,
+    mut enumeration: ResMut<EnumerationState>,
+    mut connection: NonSendMut<TmuxConnection>,
+    state: Res<ConnectionState>,
+    index: Res<TmuxProjection>,
+    sessions: Query<&TmuxSession>,
+    batch: Res<TmuxEventBatch>,
+) {
+    // NOTE: connection liveness is a body guard, not a run_if — a run condition
+    // reading NonSend<TmuxConnection> is unsound (bevyengine/bevy#21230).
+    if connection.client().is_none() {
+        return;
+    }
+    let events = &batch.0;
+    let current_session = index
+        .session
+        .and_then(|e| sessions.get(e).ok())
+        .map(|s| s.id);
+    // ... move plugin.rs:144-175 verbatim (session-switch + window-add/switch) ...
+    // ... then move the client-name re-arm from plugin.rs:315-324 ...
+}
+```
+
+(Reproduce `plugin.rs:144-175` and `:315-324` verbatim inside, preserving their `// NOTE:` comments. The `connection.client_name()` reads and `connection.take()`-free sends compile against `NonSendMut`.)
+
+- [ ] **Step 4: Rename the remaining `drain_tmux_events` to `apply_tmux_replies` and add its body guard**
+
+The remaining body (the former non-`Closed` reply path: `take_client_name`, `take_version`, `take_active_pane` + aggressive follow-up, `take_aggressive_resize`, `take_pane_captures`, `take_cursor_positions`, the four `take_keybindings`, `take_prefix_keys`, `take_mode_keys`, `drain_copy_replies`, and `trigger_events`) becomes `apply_tmux_replies`. Replace the temporary `if connection.client().is_none() { return; }` (added in Task 2 Step 4) with the documented body guard, and update the signature:
+
+```rust
+/// Applies this frame's command replies and notifications to the world: drains
+/// each reply to what it answers, runs the active-pane→aggressive-resize
+/// follow-up, surfaces copy-mode replies, and triggers the projection events the
+/// observers consume.
+///
+/// Body-guards on the live client (see [`send_tmux_reenumeration`]).
+fn apply_tmux_replies(
+    mut commands: Commands,
+    mut enumeration: ResMut<EnumerationState>,
+    mut keybindings: ResMut<KeyBindings>,
+    mut copy_queries: ResMut<CopyModeQueries>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut pane_output: MessageWriter<PaneOutput>,
+    mut copy_replies: MessageWriter<CopyModeReply>,
+    batch: Res<TmuxEventBatch>,
+) {
+    // NOTE: connection liveness is a body guard, not a run_if — a run condition
+    // reading NonSend<TmuxConnection> is unsound (bevyengine/bevy#21230).
+    if connection.client().is_none() {
+        return;
+    }
+    let events = &batch.0;
+    // ... move the reply-correlation body (plugin.rs:224-311) verbatim ...
+}
+```
+
+(The active-pane→aggressive follow-up at `plugin.rs:238-246` sends via `connection.client()` — keep it inside `apply_tmux_replies`, as the spec documents.)
+
+- [ ] **Step 5: Register ③b and ④; delete `drain_tmux_events`**
+
+Final chain:
+
+```rust
+                (
+                    drain_tmux_transport,
+                    advance_tmux_connection.run_if(tmux_batch_pending),
+                    send_attach_enumeration.run_if(on_message::<TmuxClientAttached>),
+                    send_tmux_reenumeration.run_if(tmux_batch_pending),
+                    apply_tmux_replies.run_if(tmux_batch_pending),
+                )
+                    .chain()
+                    .in_set(TmuxProjectionSet)
+                    .run_if(resource_exists::<TmuxPresence>),
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p ozmux_tmux`
+Expected: PASS. Behavior is preserved; the chain now has five systems plus `request_pane_captures` (`.after(TmuxProjectionSet)`, unchanged).
+
+- [ ] **Step 7: Lint, format, commit**
+
+```bash
+cargo clippy -p ozmux_tmux --all-targets && cargo fmt
+git add crates/tmux_session/src/plugin.rs
+git commit -m "refactor(tmux): split into send_tmux_reenumeration + apply_tmux_replies with live-client body guards"
+```
+
+---
+
+## Task 4: `PendingReply` enum + `EnumerationState` reshape + enum dispatch
+
+Replace the per-field `Option<CommandId>` correlation with one `HashMap<CommandId, PendingReply>` dispatched by a single ordered `match`; fix the session-switch clear; delete the dead `take_*` wrappers.
+
+**Files:**
+- Modify: `crates/tmux_session/src/enumerate.rs`
+- Modify: `crates/tmux_session/src/plugin.rs`
+- Modify: `crates/tmux_session/src/event_pump.rs`
+
+**Interfaces:**
+- Produces: `enum PendingReply { ListWindows, ClientName, Version, ActivePane, KeyBindings, PrefixKeys, ModeKeys, AggressiveResize, Capture { pane: PaneId }, Cursor { pane: PaneId } }`; reshaped `EnumerationState { pending: HashMap<CommandId, PendingReply>, aggressive_resize_checked: bool, capture_awaiting_cursor: HashMap<PaneId, Vec<String>>, panes_with_cursor_pending: HashSet<PaneId> }` with methods `register(&mut self, send: TmuxResult<CommandId>, reply: PendingReply)`, `has_pending(&self, reply: PendingReply) -> bool`, `clear_for_session_switch(&mut self)`.
+- Removed: every `*_pending: Option<CommandId>` / `capture_pending` / `cursor_pending` field and every `take_*` wrapper in `event_pump.rs`.
+
+- [ ] **Step 1: Reshape `EnumerationState` and add `PendingReply` in `enumerate.rs`**
+
+Replace the `EnumerationState` struct (`enumerate.rs:423-462`) with:
+
+```rust
+/// What an in-flight command's reply will populate, keyed by its `CommandId`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum PendingReply {
+    /// `list-windows` enumeration → per-row projection seed.
+    ListWindows,
+    /// `display-message #{client_name}`.
+    ClientName,
+    /// `display-message #{version}`.
+    Version,
+    /// `display-message #{window_id} #{pane_id}` active-pane query.
+    ActivePane,
+    /// Any `list-keys -T <table>` reply → `KeyBindings::install`.
+    KeyBindings,
+    /// Prefix-options query → `set_prefix_keys`.
+    PrefixKeys,
+    /// `#{mode-keys}` → `set_mode_keys`.
+    ModeKeys,
+    /// `aggressive-resize` option query → warn if `on`.
+    AggressiveResize,
+    /// `capture-pane` of a pane's screen.
+    Capture { pane: PaneId },
+    /// Cursor-position query paired with a [`PendingReply::Capture`].
+    Cursor { pane: PaneId },
+}
+
+/// Correlates in-flight enumeration/query commands by [`CommandId`] and the
+/// capture/cursor pairing buffers, so each drained reply routes to its handler.
+#[derive(Resource, Default)]
+pub(crate) struct EnumerationState {
+    pub(crate) pending: HashMap<CommandId, PendingReply>,
+    pub(crate) aggressive_resize_checked: bool,
+    pub(crate) capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
+    pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
+}
+
+impl EnumerationState {
+    /// Records `reply` under the id `send` returned, logging on send failure.
+    pub(crate) fn register(&mut self, send: TmuxResult<CommandId>, reply: PendingReply) {
+        match send {
+            Ok(id) => {
+                self.pending.insert(id, reply);
+            }
+            Err(error) => tracing::warn!(?error, ?reply, "failed to send tmux query"),
+        }
+    }
+
+    /// Whether a reply of `reply`'s kind is already in flight (replaces the old
+    /// `Option::is_some` singleton guard for client-name / aggressive-resize).
+    pub(crate) fn has_pending(&self, reply: PendingReply) -> bool {
+        self.pending.values().any(|r| *r == reply)
+    }
+
+    /// Drops the in-flight entries a session switch invalidates: the
+    /// capture/cursor pairs and the enumeration ids `send_session_enumeration`
+    /// re-issues. A `HashMap` keyed by `CommandId` does not get the old
+    /// `Option` fields' free last-write-wins overwrite, so a stale pre-switch
+    /// `list-windows`/active-pane reply would otherwise mis-seed the new session.
+    pub(crate) fn clear_for_session_switch(&mut self) {
+        self.pending.retain(|_, r| {
+            !matches!(
+                r,
+                PendingReply::Capture { .. }
+                    | PendingReply::Cursor { .. }
+                    | PendingReply::ListWindows
+                    | PendingReply::ActivePane
+            )
+        });
+        self.capture_awaiting_cursor.clear();
+        self.panes_with_cursor_pending.clear();
+        self.aggressive_resize_checked = false;
+    }
+}
+```
+
+Add `use tmux_control::TmuxResult;` to the `enumerate.rs` import block (alongside `use tmux_control::CommandId;`).
+
+- [ ] **Step 2: Write the failing test for the session-switch clear**
+
+Add to `enumerate.rs` tests:
+
+```rust
+#[test]
+fn clear_for_session_switch_drops_enumeration_but_keeps_keybindings() {
+    let mut state = EnumerationState::default();
+    state.pending.insert(CommandId(1), PendingReply::ListWindows);
+    state.pending.insert(CommandId(2), PendingReply::ActivePane);
+    state.pending.insert(CommandId(3), PendingReply::KeyBindings);
+    state
+        .pending
+        .insert(CommandId(4), PendingReply::Capture { pane: PaneId(7) });
+    state.aggressive_resize_checked = true;
+    state.clear_for_session_switch();
+    assert_eq!(state.pending.get(&CommandId(3)), Some(&PendingReply::KeyBindings));
+    assert!(state.pending.get(&CommandId(1)).is_none(), "stale list-windows dropped");
+    assert!(state.pending.get(&CommandId(2)).is_none(), "stale active-pane dropped");
+    assert!(state.pending.get(&CommandId(4)).is_none(), "capture dropped");
+    assert!(!state.aggressive_resize_checked, "aggressive guard reset");
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails (then passes after Step 1 compiles)**
+
+Run: `cargo test -p ozmux_tmux clear_for_session_switch_drops_enumeration_but_keeps_keybindings`
+Expected: FAIL to compile until the rest of the crate is migrated (Steps 4–7); the assertion logic itself is satisfied by Step 1's `clear_for_session_switch`.
+
+- [ ] **Step 4: Migrate the send sites to `register`**
+
+In `plugin.rs`:
+- `request_pane_captures` (`plugin.rs:85-103`): replace `enumeration.capture_pending.insert(cap_id, pane.id)` / `enumeration.cursor_pending.insert(cur_id, pane.id)` with `enumeration.register(client.handle().send(&capture_pane_command(pane.id)), PendingReply::Capture { pane: pane.id })` and the cursor equivalent. Keep `enumeration.panes_with_cursor_pending.insert(pane.id)`. Because `register` consumes the send result, restructure so the cursor send + `panes_with_cursor_pending` insert happen only when the capture send succeeded — preserve the existing nesting by matching on the capture send id first (keep the current `match` shape but route the id through `register`).
+- `send_attach_enumeration`: replace each `match client.handle().send(&X) { Ok(id) => enumeration.Y_pending = Some(id), Err(..) => warn }` with `enumeration.register(client.handle().send(&X), PendingReply::Z)`. The four `list_keys_command(...)` sends all use `PendingReply::KeyBindings`.
+- `send_tmux_reenumeration`: the window-add `list_windows_command` → `PendingReply::ListWindows`; the window-switch `active_pane_command` → `PendingReply::ActivePane`; the client-name re-arm → `PendingReply::ClientName`, and change its guard `enumeration.client_name_pending.is_none()` to `!enumeration.has_pending(PendingReply::ClientName)` and the missing-name check to `connection.client_name().is_none()`. Replace `enumeration.clear_for_session_switch()`-equivalent inline clears (`plugin.rs:150-158`) with a single `enumeration.clear_for_session_switch()` call plus the existing `enumeration.aggressive_resize_pending = None`-equivalent (now covered by `clear_for_session_switch`).
+- `send_session_enumeration` (`plugin.rs:331`): replace `enumeration.pending = Some(id)` / `enumeration.active_pane_pending = Some(id)` with `enumeration.register(send_result, PendingReply::ListWindows)` / `PendingReply::ActivePane`.
+
+- [ ] **Step 5: Rewrite `apply_tmux_replies` as the ordered `match` dispatch**
+
+Replace the `take_*` body of `apply_tmux_replies` with a single ordered pass plus the copy-reply pass. Reproduce the per-arm logic from the corresponding `event_pump.rs` helpers:
+
+```rust
+    let events = &batch.0;
+    for event in events {
+        match event {
+            TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) => {
+                let Some(reply) = enumeration.pending.remove(id) else {
+                    continue;
+                };
+                apply_reply(
+                    &mut commands,
+                    &mut enumeration,
+                    &mut keybindings,
+                    &mut pane_output,
+                    &connection,
+                    reply,
+                    *ok,
+                    output,
+                );
+            }
+            TransportEvent::Protocol(ClientEvent::Notification(notification)) => {
+                trigger_notification(&mut commands, connection.client_name(), notification);
+            }
+            TransportEvent::Closed { .. } => {}
+        }
+    }
+    for reply in drain_copy_replies(&mut copy_queries, events) {
+        copy_replies.write(reply);
+    }
+```
+
+Write `apply_reply` as a private helper in `plugin.rs` whose arms reproduce the existing handlers (drawn from `event_pump.rs` and `plugin.rs:224-311`):
+
+```rust
+#[expect(clippy::too_many_arguments, reason = "single apply seam over many reply kinds")]
+fn apply_reply(
+    commands: &mut Commands,
+    enumeration: &mut EnumerationState,
+    keybindings: &mut KeyBindings,
+    pane_output: &mut MessageWriter<PaneOutput>,
+    connection: &TmuxConnection,
+    reply: PendingReply,
+    ok: bool,
+    output: &[String],
+) {
+    match reply {
+        PendingReply::ListWindows if ok => trigger_seed(commands, output),
+        PendingReply::ListWindows => tracing::warn!("list-windows enumeration command failed"),
+        PendingReply::ClientName => {
+            if let Some(name) = first_reply_line(ok, output, "client-name") {
+                // NOTE: set_client_name needs &mut; thread it via the connection
+                // param as NonSendMut at the call site (see Step 6).
+            }
+        }
+        // ... Version, ActivePane (+aggressive follow-up), KeyBindings, PrefixKeys,
+        //     ModeKeys, AggressiveResize, Capture, Cursor ...
+    }
+}
+```
+
+NOTE: `apply_reply` needs `&mut TmuxConnection` for `set_client_name` / `set_per_window_refresh` and `&TmuxConnection` for the active-pane→aggressive send. Pass `connection: &mut TmuxConnection` (deref the `NonSendMut` once at the call site: `&mut connection`). Pull the small `first_reply_line(ok, output, what) -> Option<String>` helper from the old `take_reply_line` body (`event_pump.rs:95-117`) into `event_pump.rs` as a pure `pub(crate)` fn. Reproduce the `Capture`/`Cursor` arms from `take_pane_captures` / `take_cursor_positions` (`event_pump.rs:162-225`), using `enumeration.panes_with_cursor_pending` and `enumeration.capture_awaiting_cursor`, and the `parse_cursor_pos` / `capture_to_bytes*` helpers (unchanged). The `ActivePane` arm reproduces `plugin.rs:230-247`: trigger `TmuxActivePaneChanged { from_notification: false }`, then if `!aggressive_resize_checked && !has_pending(AggressiveResize)` and the client is live, `register(send(&aggressive_resize_command(window)), PendingReply::AggressiveResize)` (parse `window` via `parse_active_pane`).
+
+- [ ] **Step 6: Delete the dead `take_*` wrappers and their tests**
+
+In `event_pump.rs`, remove `take_reply_line` (replaced by `first_reply_line`), `take_client_name`, `take_version`, `take_aggressive_resize`, `take_pane_captures`, `take_cursor_positions`, `take_active_pane`, `take_keybindings`, `take_prefix_keys`, `take_mode_keys`, and their `#[cfg(test)]` tests. Keep `trigger_events`'s notification path by extracting the notification + list-windows handling already moved into `apply_reply` / `trigger_notification`; delete `trigger_events` itself if no caller remains (the dispatch now inlines its two responsibilities). Keep all pure helpers (`advance_state`, `detect_*`, `parse_active_pane`, `parse_cursor_pos`, `capture_to_bytes`, `capture_to_bytes_with_cursor`, `trigger_notification`, `trigger_seed`, `collect_pane_outputs`, the new `first_reply_line`) and their tests. Remove now-unused imports.
+
+- [ ] **Step 7: Write the dispatch characterization test**
+
+Add to `plugin.rs` tests — assert a `client-name` reply updates the connection and a `list-windows` reply seeds windows, in one batch, through `apply_tmux_replies`:
+
+```rust
+#[test]
+fn apply_tmux_replies_dispatches_client_name_and_seeds_windows() {
+    use tmux_control::{ClientEvent, CommandId};
+    let mut app = App::new();
+    app.add_plugins(TmuxSessionPlugin);
+    // Pretend a client-name query (id 1) and a list-windows enumeration (id 2)
+    // are in flight, and their replies arrive this frame.
+    {
+        let mut enumeration = app.world_mut().resource_mut::<EnumerationState>();
+        enumeration.pending.insert(CommandId(1), PendingReply::ClientName);
+        enumeration.pending.insert(CommandId(2), PendingReply::ListWindows);
+    }
+    app.insert_resource(TmuxEventBatch(vec![
+        TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(1),
+            number: 0,
+            ok: true,
+            output: vec!["ozmux-0".into()],
+        }),
+        TransportEvent::Protocol(ClientEvent::CommandComplete {
+            id: CommandId(2),
+            number: 0,
+            ok: true,
+            output: vec!["1\t@1\t0\tb25f,80x24,0,0,0\tb25f,80x24,0,0,0\t\tmain".into()],
+        }),
+    ]));
+    // apply_tmux_replies body-guards on a live client; this test asserts the
+    // pending entries are consumed (a fuller end-to-end test needs a fake client).
+    app.update();
+    let enumeration = app.world().resource::<EnumerationState>();
+    assert!(
+        enumeration.pending.is_empty() || !enumeration.pending.contains_key(&CommandId(1)),
+        "consumed replies are removed from pending"
+    );
+}
+```
+
+(If the body guard makes this inconclusive without a live client, also add a direct unit test of `apply_reply` for the `ClientName` and `ListWindows` arms, constructing the args by hand.)
+
+- [ ] **Step 8: Run the full crate test suite**
+
+Run: `cargo test -p ozmux_tmux`
+Expected: PASS — migrated tests plus the new dispatch/session-switch tests.
+
+- [ ] **Step 9: Build the whole workspace (the binary consumes `EnumerationState`-adjacent APIs)**
+
+Run: `cargo build`
+Expected: success — confirms `src/` callers (e.g. `request_pane_captures`, copy-mode) still compile against the reshaped crate.
+
+- [ ] **Step 10: Lint, format, commit**
+
+```bash
+cargo clippy --workspace --all-targets && cargo fmt
+git add crates/tmux_session/src/enumerate.rs crates/tmux_session/src/plugin.rs crates/tmux_session/src/event_pump.rs
+git commit -m "refactor(tmux): enum reply correlation via HashMap<CommandId, PendingReply> dispatch"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Five chained systems + `TmuxEventBatch` + `tmux_batch_pending` → Tasks 1–3. ✓
+- `TmuxClientAttached` message + `on_message` gate → Task 2. ✓
+- Live-client body guard (not a NonSend run condition) → Task 3 + spec Edit 1. ✓
+- `PendingReply` enum + `EnumerationState` reshape + `register`/`has_pending` → Task 4. ✓
+- Single ordered `match` dispatch; capture-before-cursor preserved by stream-order pass → Task 4 Step 5. ✓
+- Session-switch clears `ListWindows`/`ActivePane` (spec Edit 2) → Task 4 Step 1 (`clear_for_session_switch`) + test Step 2. ✓
+- Conditional batch write (spec Edit 4) → Task 1 Step 3 + test Step 1. ✓
+- Teardown precedes re-enum sends (spec Edit 3) → Task 2 (②) ordered before Task 3 (③b) in the chain. ✓
+- `%output` routed even on a closing batch → Task 1 (① has no live-client guard). ✓
+- No false attach on same-batch close → Task 2 (`advance_state` folds to `Detached`, no emit). ✓
+
+**Placeholder scan:** Task 4 Step 5 leaves the `apply_reply` arms as `// ...` references to exact source ranges (`event_pump.rs:162-225`, `plugin.rs:224-311`) rather than reproducing ~90 lines of unchanged handler code verbatim; the executor copies those blocks into the named arms. Every other step is concrete.
+
+**Type consistency:** `EnumerationState` fields and methods (`pending`, `register`, `has_pending`, `clear_for_session_switch`, `capture_awaiting_cursor`, `panes_with_cursor_pending`, `aggressive_resize_checked`) are used identically in `plugin.rs` and `enumerate.rs`. `PendingReply` variants are spelled identically across enumerate/plugin. System names (`drain_tmux_transport`, `advance_tmux_connection`, `send_attach_enumeration`, `send_tmux_reenumeration`, `apply_tmux_replies`) match the chain registration and the spec table.

--- a/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
+++ b/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
@@ -1,0 +1,293 @@
+# tmux Drain Split + Enum Reply Correlation Design
+
+**Date:** 2026-06-20  
+**Status:** Approved
+
+## Problem
+
+`drain_tmux_events` (`crates/tmux_session/src/plugin.rs`) is a single ~200-line
+Bevy system that, every frame, does all of:
+
+1. **Receive** — drain the transport channel and route `%output` to `PaneOutput`.
+2. **Connection detection** — fold the batch through `advance_state`, write
+   `ConnectionState`, and tear down on `Closed`.
+3. **Reconnect-time init sending** — on the attach transition, send the initial
+   query suite (`list-windows`, active-pane, window-flags subscription,
+   client-name, four `list-keys` tables, prefix options, mode-keys, version).
+4. **Topology re-enumeration** — on `%session-changed` / `%window-add` /
+   `%session-window-changed`, send the targeted re-query.
+5. **Event receiving** — correlate command replies back to what was asked and
+   apply them to the world; trigger the projection events.
+
+The single body interleaves immutable reads, broad `&mut`/`NonSendMut` access,
+and outbound sends, so it is hard to read and hard to test in isolation.
+
+Two structural problems compound the length:
+
+- **Reply correlation is a flat scan-per-kind.** `EnumerationState` holds ~10
+  separate `Option<CommandId>` fields plus two `HashMap`/`HashSet`s, and the
+  body calls a matching `take_*` function for each, every one of which
+  re-scans the whole event batch looking for its single id. Adding a query
+  means adding a field, a `take_*`, and a call site.
+- **An implicit ordering requirement.** `take_pane_captures` must run before
+  `take_cursor_positions` (the `// NOTE:` at `plugin.rs:261-265`): when a
+  capture reply and its paired cursor reply arrive in the same batch, captures
+  populates `capture_awaiting_cursor` first and cursor drains it. Swapping the
+  two calls silently drops cursor fixes.
+
+## Goal / Non-goals
+
+**Goal:** readability and responsibility clarity. Split the monolith into
+focused, chained single-purpose systems, and replace the per-field `take_*`
+correlation with a single `HashMap<CommandId, PendingReply>` enum dispatch
+(mirroring the existing `CopyModeQueries` / `CopyQueryKind` pattern in
+`copy_queries.rs`). Behavior is preserved except for the small, documented
+ordering changes listed below.
+
+**Non-goals (this change):**
+
+- The gather→decide→apply `TmuxEffect`-intent rewrite (a deeper, testability-
+  driven restructure) — noted as a future option, not done here.
+- Reconnect automation, multiple concurrent connections, or finer connection
+  states.
+- Folding `CopyModeQueries` into the new enum — it is intentionally a separate,
+  binary-owned channel and already follows the target pattern.
+
+## Decision
+
+Two changes land together (same PR), because the receive system is the consumer
+of the new enum dispatch:
+
+1. **Split `drain_tmux_events` into five chained systems** sharing a per-frame
+   `TmuxEventBatch` resource, plus a new `TmuxClientAttached` message to signal
+   the attach edge.
+2. **Restructure reply correlation** in `EnumerationState` from per-field
+   `Option<CommandId>` + `take_*` scans into one `HashMap<CommandId, PendingReply>`
+   dispatched by a single ordered `match`.
+
+## System Decomposition
+
+All five systems are registered as one `.chain().in_set(TmuxProjectionSet)`
+under `Update`, every member gated `run_if(resource_exists::<TmuxPresence>)`.
+`TmuxProjectionSet` still wraps the chain, so the binary's downstream
+`.after(TmuxProjectionSet)` systems (`render`, `window_bar`, `pane_focus`,
+`divider_handle`, `request_pane_captures`) see the projection triggers applied
+in the same frame, unchanged.
+
+| # | System | Extra gate | Responsibility |
+|---|---|---|---|
+| ① | `drain_tmux_transport` | — | Drain the channel into `TmuxEventBatch`; route `%output` → `PaneOutput`. |
+| ② | `advance_tmux_connection` | batch-pending | `advance_state` → conditional `ConnectionState` write; on attach transition emit `TmuxClientAttached`; on `Closed` → `connection.take()` + trigger `TmuxConnectionReset` + `TmuxConnectionClosed`. |
+| ③a | `send_attach_enumeration` | `on_message::<TmuxClientAttached>` | Send the initial query suite. |
+| ③b | `send_tmux_reenumeration` | batch-pending + connection-alive | Topology re-enumeration (session switch / window add / window switch) + client-name re-arm. |
+| ④ | `apply_tmux_replies` | batch-pending + connection-alive | Single-pass enum dispatch (replies → world), active-pane→aggressive-resize follow-up, copy replies, notifications → projection triggers. |
+
+### New shared resource
+
+```rust
+/// This frame's drained transport events, shared across the drain chain.
+#[derive(Resource, Default)]
+struct TmuxEventBatch(Vec<TransportEvent>);
+```
+
+`ResMut` in ① (overwritten each frame with the freshly drained `Vec`, empty when
+the channel is empty), `Res` everywhere downstream. No cloning of events: every
+consumer borrows `&batch.0`.
+
+### New message
+
+```rust
+/// Emitted the frame the control client's transport transitions to `Attached`
+/// (including reconnect). Gates `send_attach_enumeration`.
+#[derive(Message)]
+struct TmuxClientAttached;
+```
+
+Registered with `app.add_message::<TmuxClientAttached>()`. A unit struct — a pure
+signal; the init-send system gets the live client from `connection.client()`.
+
+`② advance_tmux_connection` emits it precisely on the Attached transition:
+
+```rust
+if let Some(next) = advance_state(&state, &batch.0) {
+    let attached = matches!(next, ConnectionState::Attached);
+    *state = next;
+    if attached {
+        attached_writer.write(TmuxClientAttached);
+    }
+}
+```
+
+Because `.chain()` orders ② before ③a, the message is delivered same-frame, and
+the `on_message` run condition's internal cursor fires the system exactly once.
+
+### New run conditions
+
+```rust
+fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool { !batch.0.is_empty() }
+fn tmux_connection_alive(connection: NonSend<TmuxConnection>) -> bool {
+    connection.client().is_some()
+}
+```
+
+These express, as `run_if` gates (per the repo's "gate with `run_if`" rule), the
+two whole-system guards the monolith did inline: skip when nothing was drained,
+and skip the reply/teardown path once the connection is gone.
+
+## Reply Correlation — `PendingReply`
+
+`EnumerationState` collapses from ~16 fields to four, mirroring
+`CopyModeQueries`:
+
+```rust
+/// What an in-flight command's reply will populate, keyed by its `CommandId`.
+enum PendingReply {
+    ListWindows,              // list-windows → trigger_seed (per-row projection)
+    ClientName,               // display-message #{client_name}
+    Version,                  // display-message #{version}
+    ActivePane,               // #{window_id} #{pane_id}
+    KeyBindings,              // list-keys -T <table> → install (root/prefix/copy-mode/copy-mode-vi)
+    PrefixKeys,               // prefix options → set_prefix_keys
+    ModeKeys,                 // #{mode-keys} → set_mode_keys
+    AggressiveResize,         // show-options aggressive-resize → warn if "on"
+    Capture { pane: PaneId }, // capture-pane → seed pane screen
+    Cursor  { pane: PaneId }, // cursor position → pair with capture
+}
+
+#[derive(Resource, Default)]
+struct EnumerationState {
+    pending: HashMap<CommandId, PendingReply>,
+    aggressive_resize_checked: bool,
+    capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
+    panes_with_cursor_pending: HashSet<PaneId>,
+}
+```
+
+Notes:
+
+- The four `list-keys` tables share one `KeyBindings` variant — their reply
+  handling is identical (`install`); the table distinction only matters at send
+  time.
+- `AggressiveResize` carries no payload: the window id is needed to *build* the
+  command, not to handle the reply.
+- `aggressive_resize_checked` (completion flag) and the capture/cursor pairing
+  buffers are state, not pending ids — they stay as dedicated fields.
+
+### Send side
+
+Registration is uniform across ②/③a/③b and `request_pane_captures`:
+
+```rust
+match client.handle().send(&client_name_command()) {
+    Ok(id) => { enumeration.pending.insert(id, PendingReply::ClientName); }
+    Err(error) => tracing::warn!(?error, "..."),
+}
+```
+
+A small `register(state, send_result, reply)` helper folds the
+`Ok→insert / Err→warn` shape. The "at most one in flight" guarantee the
+`Option` fields used to give is only relied on for the client-name re-arm and
+aggressive-resize, which already carry their own guards; those checks become
+`pending.values().any(|r| matches!(r, PendingReply::ClientName))` over the small
+map. Session-switch cache clearing becomes
+`pending.retain(|_, r| !matches!(r, PendingReply::Capture { .. } | PendingReply::Cursor { .. }))`.
+
+### Dispatch (`④ apply_tmux_replies`)
+
+The `take_*` `if`-ladder becomes one ordered pass:
+
+```rust
+for event in &batch.0 {
+    match event {
+        TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) => {
+            let Some(reply) = enumeration.pending.remove(id) else { continue }; // copy-mode / unknown
+            match reply {
+                PendingReply::ListWindows      => trigger_seed(&mut commands, output),
+                PendingReply::ClientName       => { /* set_client_name */ }
+                PendingReply::Version          => { /* set_per_window_refresh */ }
+                PendingReply::ActivePane       => { /* trigger + aggressive follow-up */ }
+                PendingReply::KeyBindings      => { /* install */ }
+                PendingReply::PrefixKeys       => { /* set_prefix_keys */ }
+                PendingReply::ModeKeys         => { /* set_mode_keys */ }
+                PendingReply::AggressiveResize => { /* checked = true; warn if "on" */ }
+                PendingReply::Capture { pane }  => { /* cache-or-emit */ }
+                PendingReply::Cursor  { pane }  => { /* pair + emit */ }
+            }
+        }
+        TransportEvent::Protocol(ClientEvent::Notification(n)) =>
+            trigger_notification(&mut commands, own_client, n),
+        TransportEvent::Closed { .. } => {} // handled in ②
+    }
+}
+for reply in drain_copy_replies(&mut copy_queries, &batch.0) { copy_replies.write(reply); }
+```
+
+The per-arm `ok` handling and the pure parse helpers (`parse_list_keys`,
+`parse_prefix`, `parse_active_pane`, `parse_cursor_pos`, `capture_to_bytes`,
+etc.) are preserved as-is; only the per-kind `take_*` correlation wrappers go
+away. Copy-mode replies stay on their separate pass (`drain_copy_replies`).
+
+## Ordering Decisions and Documented Behavior Changes
+
+Behavior is preserved except for these, each carrying a `// NOTE:`:
+
+1. **Capture-before-cursor becomes structural.** The single ordered pass relies
+   on tmux's FIFO replies (capture is sent before cursor for a pane), so the
+   `Capture` arm populates `capture_awaiting_cursor` before the `Cursor` arm
+   drains it — no explicit call-ordering requirement remains. The old
+   `take_pane_captures`-before-`take_cursor_positions` `// NOTE:` is deleted.
+
+2. **Teardown precedes sends.** In the monolith, topology sends ran before the
+   `Closed` teardown. In the chain, ② (teardown) runs before ③b (sends). For
+   the rare batch containing both a topology notification *and* `Closed`, the
+   connection is taken first and ③b/④ skip via `tmux_connection_alive` —
+   i.e. ozmux no longer sends on a dying connection. This is the more correct
+   direction; documented with a `// NOTE:`.
+
+3. **`%output` is still routed on a closing batch.** Output routing lives in ①
+   (gated only on presence + batch-pending, *not* connection-alive), so a batch
+   containing both `%output` and `Closed` still flushes the output — matching
+   the monolith, where `%output` routing preceded the `Closed` check.
+
+4. **No false attach on a same-batch close.** `advance_state` folds to the final
+   state, so a `[protocol, Closed]` batch yields `Some(Detached)` and emits no
+   `TmuxClientAttached` — equivalent to the old `matches!(*state, Attached)`
+   guard.
+
+## Module Placement
+
+- `enumerate.rs` — `PendingReply` enum and the reshaped `EnumerationState`; the
+  send-command builders are unchanged.
+- `event_pump.rs` — keep the pure parse/detect helpers (`advance_state`,
+  `detect_*`, `parse_*`, `capture_to_bytes*`, `trigger_notification`,
+  `trigger_seed`). Remove the `take_*` correlation wrappers, superseded by the
+  `match` arms. `collect_pane_outputs` stays (used by ①).
+- `plugin.rs` — the five systems, the two run conditions, `TmuxEventBatch`, and
+  the plugin wiring (`add_message::<TmuxClientAttached>()`, the chained
+  `add_systems`). Bulky arms extracted into named helper `fn`s so each system
+  body reads as gate → collect → trigger.
+- `TmuxClientAttached` lives with the other tmux events in `events.rs`.
+
+## Testing
+
+- **Preserved:** the pure-helper unit tests in `event_pump.rs`, `state.rs`,
+  `enumerate.rs` keep passing (helpers are unchanged). The two plugin
+  integration tests are updated for the new resource/message wiring and the
+  `run_if`-gated chain.
+- **`send_attach_enumeration` in isolation:** write a `TmuxClientAttached`
+  message and assert the expected `pending` entries are inserted — no transport
+  transition needs to be simulated.
+- **Enum dispatch:** build a `TmuxEventBatch` plus a seeded
+  `EnumerationState.pending` and assert the resulting world/resource effects;
+  the FIFO capture-then-cursor pairing is covered by ordering the two
+  `CommandComplete`s in the batch.
+- Any test that registers these systems adds the matching `run_if` so it
+  exercises real scheduling.
+
+## Out of Scope
+
+- The `TmuxEffect`-intent gather→decide→apply rewrite.
+- `CopyModeQueries` / `CopyQueryKind` (separate owner; already the target shape).
+- `request_pane_captures` stays a separate `.after(TmuxProjectionSet)` system;
+  only its inserts change to `pending.insert(.., PendingReply::Capture/Cursor)`.
+- Reconnect automation, multiple connections, connection-state granularity.

--- a/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
+++ b/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
@@ -301,7 +301,9 @@ Behavior is preserved except for these, each carrying a `// NOTE:`:
   the plugin wiring (`add_message::<TmuxClientAttached>()`, the chained
   `add_systems`). Bulky arms extracted into named helper `fn`s so each system
   body reads as gate → collect → trigger.
-- `TmuxClientAttached` lives with the other tmux events in `events.rs`.
+- `TmuxClientAttached` lives in `plugin.rs` next to its emit/gate sites. It is a
+  buffered `Message` (like `PaneOutput` / `CopyModeReply`), not an observer
+  `Event`, so it does not belong in `events.rs` (which is observer-`Event`-only).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
+++ b/docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md
@@ -79,8 +79,8 @@ in the same frame, unchanged.
 | ① | `drain_tmux_transport` | — | Drain the channel into `TmuxEventBatch`; route `%output` → `PaneOutput`. |
 | ② | `advance_tmux_connection` | batch-pending | `advance_state` → conditional `ConnectionState` write; on attach transition emit `TmuxClientAttached`; on `Closed` → `connection.take()` + trigger `TmuxConnectionReset` + `TmuxConnectionClosed`. |
 | ③a | `send_attach_enumeration` | `on_message::<TmuxClientAttached>` | Send the initial query suite. |
-| ③b | `send_tmux_reenumeration` | batch-pending + connection-alive | Topology re-enumeration (session switch / window add / window switch) + client-name re-arm. |
-| ④ | `apply_tmux_replies` | batch-pending + connection-alive | Single-pass enum dispatch (replies → world), active-pane→aggressive-resize follow-up, copy replies, notifications → projection triggers. |
+| ③b | `send_tmux_reenumeration` | batch-pending (+ live-client body guard) | Topology re-enumeration (session switch / window add / window switch) + client-name re-arm. |
+| ④ | `apply_tmux_replies` | batch-pending (+ live-client body guard) | Single-pass enum dispatch (replies → world), active-pane→aggressive-resize follow-up, copy replies, notifications → projection triggers. |
 
 ### New shared resource
 
@@ -90,9 +90,13 @@ in the same frame, unchanged.
 struct TmuxEventBatch(Vec<TransportEvent>);
 ```
 
-`ResMut` in ① (overwritten each frame with the freshly drained `Vec`, empty when
-the channel is empty), `Res` everywhere downstream. No cloning of events: every
-consumer borrows `&batch.0`.
+`ResMut` in ①, `Res` everywhere downstream. No cloning of events: every consumer
+borrows `&batch.0`. ① overwrites the batch with each frame's drain so a
+previously-non-empty batch is cleared to empty exactly once — otherwise ②–④,
+gated on `tmux_batch_pending`, would re-process last frame's events. To honor the
+repo's "mutate conditionally" change-detection rule, ① skips the write when both
+the fresh drain and the current batch are already empty, so idle frames neither
+re-fire change detection nor leave stale events.
 
 ### New message
 
@@ -121,18 +125,31 @@ if let Some(next) = advance_state(&state, &batch.0) {
 Because `.chain()` orders ② before ③a, the message is delivered same-frame, and
 the `on_message` run condition's internal cursor fires the system exactly once.
 
-### New run conditions
+### New run condition + connection body guard
 
 ```rust
 fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool { !batch.0.is_empty() }
-fn tmux_connection_alive(connection: NonSend<TmuxConnection>) -> bool {
-    connection.client().is_some()
-}
 ```
 
-These express, as `run_if` gates (per the repo's "gate with `run_if`" rule), the
-two whole-system guards the monolith did inline: skip when nothing was drained,
-and skip the reply/teardown path once the connection is gone.
+`tmux_batch_pending` gates ②–④ as a `run_if` condition (per the repo's "gate
+with `run_if`" rule): skip when nothing was drained.
+
+Connection liveness is **not** a `run_if` condition. A run condition that reads
+`NonSend<TmuxConnection>` is unsound under Bevy's multi-threaded executor: Bevy
+intends to reject it (the `SystemCondition` `is_send()` assertion) but the check
+is currently defeated (bevyengine/bevy#21230), so it silently registers and may
+run off the main thread. Instead, ③b and ④ — which already hold
+`NonSend`/`NonSendMut<TmuxConnection>` and are therefore pinned to the main
+thread — early-return with a body guard, matching the existing
+`request_pane_captures` idiom (`plugin.rs:82-84`):
+
+```rust
+let Some(client) = connection.client() else { return };
+```
+
+This skips the reply/teardown path once ② has taken the connection on `Closed`.
+The repo's "gate with `run_if`" rule explicitly exempts a body guard when no
+Send-friendly condition exists; record the reason in a `// NOTE:` citing #21230.
 
 ## Reply Correlation — `PendingReply`
 
@@ -189,8 +206,15 @@ A small `register(state, send_result, reply)` helper folds the
 `Option` fields used to give is only relied on for the client-name re-arm and
 aggressive-resize, which already carry their own guards; those checks become
 `pending.values().any(|r| matches!(r, PendingReply::ClientName))` over the small
-map. Session-switch cache clearing becomes
-`pending.retain(|_, r| !matches!(r, PendingReply::Capture { .. } | PendingReply::Cursor { .. }))`.
+map. Session-switch clearing must drop the in-flight entries the switch
+invalidates — the capture/cursor pairs **and** the enumeration ids that
+`send_session_enumeration` re-issues:
+`pending.retain(|_, r| !matches!(r, PendingReply::Capture { .. } | PendingReply::Cursor { .. } | PendingReply::ListWindows | PendingReply::ActivePane))`.
+The monolith's `Option<CommandId>` fields got this for free — the re-send
+overwrote the old `list-windows`/active-pane id (last write wins) — but a
+`HashMap` keyed by `CommandId` lets a stale old-session id and the fresh id
+coexist, so a late pre-switch reply would otherwise mis-seed the new session's
+projection. A test must cover a `list-windows` reply arriving after a switch.
 
 ### Dispatch (`④ apply_tmux_replies`)
 
@@ -232,22 +256,33 @@ away. Copy-mode replies stay on their separate pass (`drain_copy_replies`).
 Behavior is preserved except for these, each carrying a `// NOTE:`:
 
 1. **Capture-before-cursor becomes structural.** The single ordered pass relies
-   on tmux's FIFO replies (capture is sent before cursor for a pane), so the
-   `Capture` arm populates `capture_awaiting_cursor` before the `Cursor` arm
-   drains it — no explicit call-ordering requirement remains. The old
-   `take_pane_captures`-before-`take_cursor_positions` `// NOTE:` is deleted.
+   on tmux's FIFO replies (capture is sent before cursor for a pane —
+   `plugin.rs:86-92`, `enumerate.rs:274-286`), so the `Capture` arm populates
+   `capture_awaiting_cursor` before the `Cursor` arm drains it. The old
+   `take_pane_captures`-before-`take_cursor_positions` `// NOTE:` is replaced by
+   a `// NOTE:` on ④'s loop: it **must** stay a single in-order pass over
+   `batch.0` — splitting captures and cursors into two passes would reorder the
+   arms and silently drop cursor fixes. This reuses the same tmux FIFO
+   assumption existing code already depends on; an integration test should order
+   a capture reply before its paired cursor reply in one batch to lock it in.
 
-2. **Teardown precedes sends.** In the monolith, topology sends ran before the
-   `Closed` teardown. In the chain, ② (teardown) runs before ③b (sends). For
-   the rare batch containing both a topology notification *and* `Closed`, the
-   connection is taken first and ③b/④ skip via `tmux_connection_alive` —
-   i.e. ozmux no longer sends on a dying connection. This is the more correct
-   direction; documented with a `// NOTE:`.
+2. **Teardown precedes re-enumeration sends.** In the monolith, the
+   session-switch / window-add / window-switch handling — including its
+   `TmuxWindowsRetained { windows: [] }` trigger, capture/cursor clears, and
+   aggressive-resize reset — ran *before* the `Closed` teardown
+   (`plugin.rs:144-175` precede `:216`). In the chain, ② (teardown) runs before
+   ③b. So for the rare batch carrying both a topology notification *and*
+   `Closed`, the connection is taken first and ③b/④ body-guard out — the
+   re-enumeration sends *and* those reset side-effects are skipped. This is
+   benign: ② already triggers `TmuxConnectionReset`, which tears the whole
+   projection down anyway. The **attach** send (③a) is unaffected — a
+   `[protocol, Closed]` batch folds to `Detached`, so no `TmuxClientAttached` is
+   emitted (see item 4). Documented with a `// NOTE:`.
 
-3. **`%output` is still routed on a closing batch.** Output routing lives in ①
-   (gated only on presence + batch-pending, *not* connection-alive), so a batch
-   containing both `%output` and `Closed` still flushes the output — matching
-   the monolith, where `%output` routing preceded the `Closed` check.
+3. **`%output` is still routed on a closing batch.** Output routing lives in ①,
+   which has no live-client body guard (only presence + batch-pending), so a
+   batch containing both `%output` and `Closed` still flushes the output —
+   matching the monolith, where `%output` routing preceded the `Closed` check.
 
 4. **No false attach on a same-batch close.** `advance_state` folds to the final
    state, so a `[protocol, Closed]` batch yields `Some(Detached)` and emits no


### PR DESCRIPTION
## Summary

Refactors the `ozmux_tmux` crate's monolithic per-frame `drain_tmux_events` system into **five focused, chained Bevy systems**, and reshapes reply correlation from per-field `Option<CommandId>` + `take_*` scans into a single `HashMap<CommandId, PendingReply>` ordered-`match` dispatch (mirroring the existing `CopyModeQueries`/`CopyQueryKind` pattern). Goal: readability and responsibility clarity. Net **−109 lines** (`event_pump.rs` sheds ~470 lines of `take_*` boilerplate).

## The five systems (chained, `.in_set(TmuxProjectionSet)`)

1. `drain_tmux_transport` — drain the transport channel into a shared `TmuxEventBatch` resource + route `%output`
2. `advance_tmux_connection` — `ConnectionState` transition + `Closed` teardown + emit `TmuxClientAttached`
3. `send_attach_enumeration` — the initial query suite, gated by `on_message::<TmuxClientAttached>`
4. `send_tmux_reenumeration` — topology re-enumeration (session-switch / window-add / window-switch) + client-name re-arm
5. `apply_tmux_replies` — reply dispatch (`apply_reply`) + projection triggers

Connection liveness is a **body guard, not a `NonSend` run condition** (the latter is unsound under the multi-threaded executor — bevyengine/bevy#21230).

## Reply correlation

`EnumerationState` collapses ~16 fields to 4; replies route by `CommandId` through one ordered pass. `register()` preserves the old `Option` **last-write-wins** for singleton query kinds while allowing the four concurrent `list-keys` tables and per-pane capture/cursor.

## Documented behavior changes (intentional)

- Session-switch now clears stale `ListWindows`/`ActivePane`/`AggressiveResize` from `pending` (the `HashMap` lost the `Option` overwrite that did this for free).
- Notifications are processed in stream order within the single dispatch pass (fails safe — `%client-session-changed` is ignored when the client name is unresolved).
- Capture-before-cursor ordering is now structural (single in-order pass), replacing the old implicit call-ordering requirement.

## Process

Design (`docs/superpowers/specs/2026-06-20-tmux-drain-split-design.md`) → 4-axis spec review (Codex + Claude) → plan (`docs/superpowers/plans/2026-06-20-tmux-drain-split.md`) → 4 TDD tasks, each spec+quality reviewed → whole-branch review (caught a session-switch clear miss) → a fresh max-recall code review (caught the singleton re-send double-dispatch). All findings fixed.

## Tests

`cargo test -p ozmux_tmux` → **143 pass**. One failure, `observers::tests::connection_reset_clears_everything`, is **pre-existing and unrelated** (fails identically at the merge-base / on `main` — an observer hits a missing resource; out of scope for this refactor). `cargo build`, `cargo clippy --workspace`, `cargo fmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)