### PR TITLE
feat(bundle): macOS .app bundling + CEF embedding + Homebrew cask CI

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,82 @@
+name: release-macos
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-14
+    env:
+      MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@1.95
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "release-macos"
+
+      - name: Provision CEF + release render process
+        run: make setup-cef-release
+
+      - name: Import signing certificate
+        if: env.MACOS_CERT_P12 != ''
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERT_P12 }}
+          p12-password: ${{ secrets.MACOS_CERT_PASSWORD }}
+
+      - name: Build, sign, (notarize), package
+        run: |
+          if [ -n "$MACOS_SIGN_IDENTITY" ]; then
+            python3 scripts/bundle_macos.py --notarize
+          else
+            python3 scripts/bundle_macos.py
+          fi
+
+      - name: Read artifact metadata
+        id: meta
+        run: |
+          VERSION="$(cargo metadata --format-version 1 --no-deps \
+            | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="ozmux-gui"))')"
+          ZIP="target/bundle/ozmux-${VERSION}-arm64.zip"
+          SHA="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open('${ZIP}','rb').read()).hexdigest())")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "zip=${ZIP}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.meta.outputs.zip }}
+
+      - name: Bump Homebrew cask
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SHA256: ${{ steps.meta.outputs.sha256 }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/not-elm/homebrew-ozmux.git" tap
+          mkdir -p tap/Casks
+          sed -e "s/__VERSION__/${VERSION}/g" -e "s/__SHA256__/${SHA256}/g" \
+            build/macos/homebrew/ozmux.rb.tmpl > tap/Casks/ozmux.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/ozmux.rb
+          git commit -m "ozmux ${VERSION}"
+          git push

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -53,6 +53,7 @@ jobs:
           VERSION="$(cargo metadata --format-version 1 --no-deps \
             | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="ozmux-gui"))')"
           ZIP="target/bundle/ozmux-${VERSION}-arm64.zip"
+          test -f "$ZIP" || { echo "Bundle not found: $ZIP"; exit 1; }
           SHA="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open('${ZIP}','rb').read()).hexdigest())")"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "zip=${ZIP}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -42,8 +42,13 @@ jobs:
       - name: Resolve version
         id: ver
         run: |
-          CARGO_VERSION="$(cargo metadata --format-version 1 --no-deps \
-            | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="ozmux-gui"))')"
+          CARGO_VERSION="$(cargo metadata --format-version 1 --no-deps | python3 -c '
+          import json, sys
+          pkgs = json.load(sys.stdin)["packages"]
+          v = next((p["version"] for p in pkgs if p["name"] == "ozmux-gui"), None)
+          if v is None:
+              sys.exit("package ozmux-gui not found in cargo metadata")
+          print(v)')"
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             TAG_VERSION="${GITHUB_REF_NAME#v}"
             if [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
@@ -60,7 +65,7 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          if [ -n "$MACOS_SIGN_IDENTITY" ]; then
+          if [ -n "$MACOS_CERT_P12" ] && [ -n "$MACOS_SIGN_IDENTITY" ]; then
             python3 scripts/bundle_macos.py --version "$VERSION" --notarize
           else
             python3 scripts/bundle_macos.py --version "$VERSION"
@@ -73,18 +78,20 @@ jobs:
         run: |
           ZIP="target/bundle/ozmux-${VERSION}-arm64.zip"
           test -f "$ZIP" || { echo "Bundle not found: $ZIP"; exit 1; }
-          SHA="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open('${ZIP}','rb').read()).hexdigest())")"
+          test -f "${ZIP}.sha256" || { echo "Missing sidecar: ${ZIP}.sha256"; exit 1; }
+          SHA="$(cut -d' ' -f1 "${ZIP}.sha256")"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "zip=${ZIP}" >> "$GITHUB_OUTPUT"
           echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Publish GitHub Release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.meta.outputs.zip }}
 
       - name: Bump Homebrew cask
-        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        if: github.ref_type == 'tag' && secrets.HOMEBREW_TAP_TOKEN != ''
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -39,19 +39,38 @@ jobs:
           p12-file-base64: ${{ secrets.MACOS_CERT_P12 }}
           p12-password: ${{ secrets.MACOS_CERT_PASSWORD }}
 
+      - name: Resolve version
+        id: ver
+        run: |
+          CARGO_VERSION="$(cargo metadata --format-version 1 --no-deps \
+            | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="ozmux-gui"))')"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG_VERSION="${GITHUB_REF_NAME#v}"
+            if [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
+              echo "Tag v${TAG_VERSION} does not match Cargo version ${CARGO_VERSION}; bump Cargo.toml or fix the tag." >&2
+              exit 1
+            fi
+            VERSION="${TAG_VERSION}"
+          else
+            VERSION="${CARGO_VERSION}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build, sign, (notarize), package
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           if [ -n "$MACOS_SIGN_IDENTITY" ]; then
-            python3 scripts/bundle_macos.py --notarize
+            python3 scripts/bundle_macos.py --version "$VERSION" --notarize
           else
-            python3 scripts/bundle_macos.py
+            python3 scripts/bundle_macos.py --version "$VERSION"
           fi
 
       - name: Read artifact metadata
         id: meta
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          VERSION="$(cargo metadata --format-version 1 --no-deps \
-            | python3 -c 'import json,sys; print(next(p["version"] for p in json.load(sys.stdin)["packages"] if p["name"]=="ozmux-gui"))')"
           ZIP="target/bundle/ozmux-${VERSION}-arm64.zip"
           test -f "$ZIP" || { echo "Bundle not found: $ZIP"; exit 1; }
           SHA="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open('${ZIP}','rb').read()).hexdigest())")"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ name = "ozmux-gui"
 path = "src/main.rs"
 
 [features]
-# Dev-only diagnostics. Forwards to `bevy_cef/debug`, which loads CEF from
-# `~/.local/share/cef` and uses the debug render process. Distribution builds
-# MUST omit this so CEF loads from the bundled `Contents/Frameworks`. Enable
-# for development with `cargo run --features debug`.
+# Default-on for development: `cargo run` / `make run` load CEF from
+# ~/.local/share/cef via bevy_cef's debug loader. Distribution builds MUST
+# drop this — the bundler builds with `--no-default-features` so the release
+# binary loads CEF from the app's bundled Contents/Frameworks instead.
+default = ["debug"]
 debug = ["bevy_cef/debug"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ name = "ozmux-gui"
 path = "src/main.rs"
 
 [features]
-# Dev-only diagnostics. Enables the CEF `remote-debugging-port` (a local
-# Chromium DevTools/CDP endpoint on 127.0.0.1:9222) for inspecting the
-# embedded webview. Off by default so the endpoint is not exposed in normal
-# builds; enable with `cargo run --features debug`.
-debug = []
+# Dev-only diagnostics. Forwards to `bevy_cef/debug`, which loads CEF from
+# `~/.local/share/cef` and uses the debug render process. Distribution builds
+# MUST omit this so CEF loads from the bundled `Contents/Frameworks`. Enable
+# for development with `cargo run --features debug`.
+debug = ["bevy_cef/debug"]
 
 [dependencies]
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "passthrough", features = ["debug"] }
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "passthrough" }
 bevy_cef_core = { workspace = true }
 ozma_terminal = { path = "crates/ozma_terminal" }
 ozma_tty_renderer = { path = "crates/ozma_tty_renderer" }
@@ -92,3 +92,9 @@ bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "passthr
 [workspace.lints.clippy]
 too_many_arguments = "allow"
 type_complexity = "allow"
+
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+strip = true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build clean help fix-lint setup-cef ozmd ozmd-web
+.PHONY: run build clean help fix-lint setup-cef ozmd ozmd-web setup-cef-release bundle-macos release-macos
 
 OZMUX_EXTENSION_ROOT := $(CURDIR)/extensions
 CARGO_BIN_DIR := $(if $(CARGO_HOME),$(CARGO_HOME)/bin,$(HOME)/.cargo/bin)
@@ -14,6 +14,9 @@ help:
 	@echo "  run            - Run the ozmux-gui Bevy app (cargo run)"
 	@echo "  build          - Build the workspace (cargo build)"
 	@echo "  setup-cef      - Install the CEF framework + debug render process for ozmux-gui (macOS, one-time)"
+	@echo "  setup-cef-release - Install arm64 CEF + release render process (for bundling)"
+	@echo "  bundle-macos   - Build and package the ozmux .app (pass BUNDLE_ARGS=...)"
+	@echo "  release-macos  - setup-cef-release then bundle with notarization"
 	@echo "  fix-lint       - clippy --fix + rustfmt + biome lint:fix"
 	@echo "  clean          - cargo clean (remove the workspace target dir)"
 	@echo "  ozmd           - Build the web bundle then the ozmd binary"
@@ -44,3 +47,18 @@ ozmd-web:
 
 ozmd: ozmd-web
 	cargo build -p ozmd
+
+BEVY_CEF_RENDER_PROCESS := bevy_cef_render_process
+BEVY_CEF_GIT := https://github.com/not-elm/bevy_cef
+BEVY_CEF_BRANCH := passthrough
+
+setup-cef-release:
+	cargo install export-cef-dir@$(CEF_VERSION) --force
+	export-cef-dir --force "$(HOME)/.local/share/cef"
+	cargo install --git $(BEVY_CEF_GIT) --branch $(BEVY_CEF_BRANCH) $(BEVY_CEF_RENDER_PROCESS)
+
+bundle-macos:
+	python3 scripts/bundle_macos.py $(BUNDLE_ARGS)
+
+release-macos: setup-cef-release
+	python3 scripts/bundle_macos.py --notarize $(BUNDLE_ARGS)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ A terminal multiplexer built as a single
 GPU rendering, layout, input, and in-process CEF webview rendering all run in
 one ECS world.
 
+## Installation
+
+macOS (Apple Silicon) via Homebrew Cask:
+
+```bash
+brew install --cask not-elm/ozmux/ozmux
+```
+
+This taps `not-elm/homebrew-ozmux`, installs `ozmux.app` into `/Applications`,
+and pulls in `tmux` as a dependency. Upgrade later with:
+
+```bash
+brew upgrade --cask ozmux
+```
+
 ## Prerequisites
 
 - Rust 1.95 (pinned by `rust-toolchain.toml`)

--- a/build/macos/Entitlements.plist
+++ b/build/macos/Entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/build/macos/Info.plist
+++ b/build/macos/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>ozmux</string>
+    <key>CFBundleExecutable</key>
+    <string>ozmux-gui</string>
+    <key>CFBundleIdentifier</key>
+    <string>not.elm.ozmux</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon.icns</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>ozmux</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>0.0.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/build/macos/Info.plist
+++ b/build/macos/Info.plist
@@ -10,8 +10,6 @@
     <string>ozmux-gui</string>
     <key>CFBundleIdentifier</key>
     <string>not.elm.ozmux</string>
-    <key>CFBundleIconFile</key>
-    <string>AppIcon.icns</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>

--- a/build/macos/homebrew/ozmux.rb.tmpl
+++ b/build/macos/homebrew/ozmux.rb.tmpl
@@ -1,0 +1,20 @@
+cask "ozmux" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/not-elm/ozmux/releases/download/v#{version}/ozmux-#{version}-arm64.zip"
+  name "ozmux"
+  desc "Terminal multiplexer as a native GUI app"
+  homepage "https://github.com/not-elm/ozmux"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+  depends_on formula: "tmux"
+
+  app "ozmux.app"
+
+  caveats do
+    "If macOS blocks the app (un-notarized build), clear quarantine:\n" \
+    "  xattr -dr com.apple.quarantine \"#{appdir}/ozmux.app\""
+  end
+end

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -42,6 +42,35 @@ def helper_bundle_id(base: str, suffix: str) -> str:
     return f"{base}.helper.{raw}"
 
 
+def merge_cef_keys(plist: dict) -> dict:
+    env = plist.get("LSEnvironment")
+    if env is None:
+        env = {}
+    elif not isinstance(env, dict):
+        raise ValueError("LSEnvironment exists but is not a dictionary")
+    env["MallocNanoZone"] = "0"
+    plist["LSEnvironment"] = env
+
+    existing = plist.get("LSMinimumSystemVersion")
+    if existing is None or version_less_than(str(existing), MIN_MACOS):
+        plist["LSMinimumSystemVersion"] = MIN_MACOS
+
+    plist.setdefault("NSSupportsAutomaticGraphicsSwitching", True)
+    return plist
+
+
+def build_helper_plist(name: str, bundle_id: str) -> dict:
+    return {
+        "CFBundleExecutable": name,
+        "CFBundleName": name,
+        "CFBundleIdentifier": bundle_id,
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundlePackageType": "APPL",
+        "LSEnvironment": {"MallocNanoZone": "0"},
+        "LSUIElement": True,
+    }
+
+
 @dataclass
 class BundleConfig:
     version: str

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -187,6 +187,91 @@ def verify_prerequisites(cfg: BundleConfig) -> None:
         )
 
 
+def run(argv: list[str]) -> None:
+    print(f"==> {' '.join(argv)}")
+    subprocess.run(argv, check=True)
+
+
+def lipo_archs(path: Path) -> set[str]:
+    out = subprocess.run(lipo_archs_argv(path), capture_output=True, text=True, check=True).stdout
+    return parse_lipo_archs(out)
+
+
+def assemble_app(cfg: BundleConfig) -> None:
+    app = cfg.app_path
+    if app.exists():
+        shutil.rmtree(app)
+    contents = app / "Contents"
+    (contents / "MacOS").mkdir(parents=True)
+    (contents / "Resources").mkdir(parents=True)
+    (contents / "Frameworks").mkdir(parents=True)
+
+    template = REPO_ROOT / "build" / "macos" / "Info.plist"
+    with open(template, "rb") as f:
+        plist = plistlib.load(f)
+    plist["CFBundleShortVersionString"] = cfg.version
+    plist["CFBundleVersion"] = cfg.version
+    with open(contents / "Info.plist", "wb") as f:
+        plistlib.dump(plist, f)
+
+    dest_bin = contents / "MacOS" / cfg.bin_name
+    shutil.copy2(cfg.bin_source, dest_bin)
+    dest_bin.chmod(0o755)
+
+    assets = REPO_ROOT / "assets"
+    if assets.is_dir():
+        shutil.copytree(assets, contents / "Resources" / "assets")
+
+    icns = REPO_ROOT / "build" / "macos" / "AppIcon.icns"
+    if icns.is_file():
+        shutil.copy2(icns, contents / "Resources" / "AppIcon.icns")
+
+    print(f"Assembled {app}")
+
+
+def embed_cef(cfg: BundleConfig) -> None:
+    contents = cfg.app_path / "Contents"
+    plist_path = contents / "Info.plist"
+    with open(plist_path, "rb") as f:
+        plist = plistlib.load(f)
+    merge_cef_keys(plist)
+    with open(plist_path, "wb") as f:
+        plistlib.dump(plist, f)
+
+    main_bin = contents / "MacOS" / cfg.bin_name
+    cef_bin = cfg.cef_framework / "Chromium Embedded Framework"
+    common = lipo_archs(main_bin) & lipo_archs(cfg.helper_bin) & lipo_archs(cef_bin)
+    if not common:
+        raise SystemExit(
+            "architecture mismatch: no common arch among main/helper/CEF binaries"
+        )
+    print(f"Architecture check passed (common: {', '.join(sorted(common))})")
+
+    frameworks = contents / "Frameworks"
+    old_cef = frameworks / "Chromium Embedded Framework.framework"
+    if old_cef.exists():
+        shutil.rmtree(old_cef)
+    for suffix in HELPER_SUFFIXES:
+        helper_app = frameworks / f"{cfg.bin_name} Helper{suffix}.app"
+        if helper_app.exists():
+            shutil.rmtree(helper_app)
+
+    run(["cp", "-R", str(cfg.cef_framework), str(frameworks)])
+
+    for suffix in HELPER_SUFFIXES:
+        helper_name = f"{cfg.bin_name} Helper{suffix}"
+        helper_app = frameworks / f"{helper_name}.app"
+        macos = helper_app / "Contents" / "MacOS"
+        macos.mkdir(parents=True)
+        dest = macos / helper_name
+        shutil.copy2(cfg.helper_bin, dest)
+        dest.chmod(0o755)
+        hp = build_helper_plist(helper_name, helper_bundle_id(cfg.bundle_id_base, suffix))
+        with open(helper_app / "Contents" / "Info.plist", "wb") as f:
+            plistlib.dump(hp, f)
+        print(f"  Created {helper_name}.app")
+
+
 @dataclass
 class BundleConfig:
     version: str

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -350,10 +350,6 @@ def main(argv: list[str] | None = None) -> None:
     print(f"artifact={cfg.zip_path}")
 
 
-if __name__ == "__main__":
-    main()
-
-
 @dataclass
 class BundleConfig:
     version: str
@@ -377,3 +373,7 @@ class BundleConfig:
     @property
     def zip_path(self) -> Path:
         return self.out_dir / zip_name(self.app_name, self.version, self.arch)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -71,6 +71,59 @@ def build_helper_plist(name: str, bundle_id: str) -> dict:
     }
 
 
+def cargo_build_argv(triple: str, profile: str) -> list[str]:
+    return ["cargo", "build", "--profile", profile, "--target", triple, "--locked"]
+
+
+def lipo_archs_argv(path: Path) -> list[str]:
+    return ["lipo", "-archs", str(path)]
+
+
+def parse_lipo_archs(output: str) -> set[str]:
+    return set(output.split())
+
+
+def codesign_argv(identity: str, path: Path, *, hardened: bool, entitlements: Path | None) -> list[str]:
+    argv = ["codesign", "--force", "--sign", identity]
+    if hardened:
+        argv += ["--options", "runtime"]
+    if entitlements is not None:
+        argv += ["--entitlements", str(entitlements)]
+    argv.append(str(path))
+    return argv
+
+
+def codesign_verify_argv(path: Path) -> list[str]:
+    return ["codesign", "--verify", "--deep", "--strict", str(path)]
+
+
+def xattr_strip_argv(path: Path) -> list[str]:
+    return ["xattr", "-cr", str(path)]
+
+
+def ditto_zip_argv(app: Path, dest: Path) -> list[str]:
+    return ["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", str(app), str(dest)]
+
+
+def notarytool_submit_argv(zip_path: Path, apple_id: str, team_id: str, password: str) -> list[str]:
+    return [
+        "xcrun", "notarytool", "submit", str(zip_path),
+        "--apple-id", apple_id, "--team-id", team_id, "--password", password, "--wait",
+    ]
+
+
+def stapler_argv(app: Path) -> list[str]:
+    return ["xcrun", "stapler", "staple", str(app)]
+
+
+def compute_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 @dataclass
 class BundleConfig:
     version: str

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -124,6 +124,69 @@ def compute_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def cargo_version(bin_name: str) -> str:
+    out = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, check=True,
+    ).stdout
+    meta = json.loads(out)
+    for pkg in meta["packages"]:
+        if pkg["name"] == bin_name:
+            return pkg["version"]
+    raise SystemExit(f"package {bin_name} not found in cargo metadata")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Bundle ozmux into a CEF-embedded macOS .app")
+    p.add_argument("--version")
+    p.add_argument("--bin")
+    p.add_argument("--skip-build", action="store_true")
+    p.add_argument("--no-sign", action="store_true")
+    p.add_argument("--sign-identity")
+    p.add_argument("--notarize", action="store_true")
+    p.add_argument("--cef-framework",
+                   default="~/.local/share/cef/Chromium Embedded Framework.framework")
+    p.add_argument("--helper-bin", default="~/.cargo/bin/bevy_cef_render_process")
+    p.add_argument("--out-dir", default=str(REPO_ROOT / "target" / "bundle"))
+    return p
+
+
+def resolve_config(args: argparse.Namespace) -> BundleConfig:
+    version = args.version or cargo_version(BIN_NAME)
+    bin_source = (
+        Path(args.bin) if args.bin
+        else REPO_ROOT / "target" / TARGET_TRIPLE / CARGO_PROFILE / BIN_NAME
+    )
+    sign_identity = args.sign_identity or os.environ.get("MACOS_SIGN_IDENTITY") or "-"
+    notarize = args.notarize
+    if notarize and sign_identity == "-":
+        print("==> WARNING: --notarize requires a Developer ID identity; disabling notarization")
+        notarize = False
+    return BundleConfig(
+        version=version, app_name=APP_NAME, bin_name=BIN_NAME, bundle_id_base=BUNDLE_ID_BASE,
+        arch=ARCH, target_triple=TARGET_TRIPLE, bin_source=bin_source,
+        cef_framework=Path(args.cef_framework).expanduser(),
+        helper_bin=Path(args.helper_bin).expanduser(),
+        out_dir=Path(args.out_dir), sign_identity=sign_identity,
+        no_sign=args.no_sign, notarize=notarize,
+    )
+
+
+def verify_prerequisites(cfg: BundleConfig) -> None:
+    if not cfg.bin_source.is_file():
+        raise SystemExit(f"binary not found: {cfg.bin_source} (build first or pass --bin)")
+    if not cfg.cef_framework.is_dir():
+        raise SystemExit(
+            f"CEF framework not found: {cfg.cef_framework} (run `make setup-cef-release`)"
+        )
+    if not cfg.helper_bin.is_file():
+        raise SystemExit(
+            f"render-process helper not found: {cfg.helper_bin}\n"
+            "Install it: cargo install --git https://github.com/not-elm/bevy_cef "
+            "--branch passthrough bevy_cef_render_process"
+        )
+
+
 @dataclass
 class BundleConfig:
     version: str

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Bundle ozmux into a CEF-embedded macOS .app and package it for Homebrew."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+APP_NAME = "ozmux"
+BIN_NAME = "ozmux-gui"
+BUNDLE_ID_BASE = "not.elm.ozmux"
+ARCH = "arm64"
+TARGET_TRIPLE = "aarch64-apple-darwin"
+CARGO_PROFILE = "dist"
+HELPER_SUFFIXES = ("", " (GPU)", " (Renderer)", " (Plugin)")
+MIN_MACOS = "11.0"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def zip_name(app_name: str, version: str, arch: str) -> str:
+    return f"{app_name}-{version}-{arch}.zip"
+
+
+def version_less_than(a: str, b: str) -> bool:
+    parse = lambda s: [int(p) for p in s.split(".") if p.isdigit()]
+    return parse(a) < parse(b)
+
+
+def helper_bundle_id(base: str, suffix: str) -> str:
+    if not suffix:
+        return f"{base}.helper"
+    raw = suffix.lower().replace(" ", "").replace("(", "").replace(")", "")
+    return f"{base}.helper.{raw}"
+
+
+@dataclass
+class BundleConfig:
+    version: str
+    app_name: str
+    bin_name: str
+    bundle_id_base: str
+    arch: str
+    target_triple: str
+    bin_source: Path
+    cef_framework: Path
+    helper_bin: Path
+    out_dir: Path
+    sign_identity: str
+    no_sign: bool
+    notarize: bool
+
+    @property
+    def app_path(self) -> Path:
+        return self.out_dir / f"{self.app_name}.app"
+
+    @property
+    def zip_path(self) -> Path:
+        return self.out_dir / zip_name(self.app_name, self.version, self.arch)

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -272,6 +272,88 @@ def embed_cef(cfg: BundleConfig) -> None:
         print(f"  Created {helper_name}.app")
 
 
+def strip_xattrs(cfg: BundleConfig) -> None:
+    run(xattr_strip_argv(cfg.app_path))
+
+
+def codesign_bundle(cfg: BundleConfig) -> None:
+    hardened = cfg.sign_identity != "-"
+    entitlements = (REPO_ROOT / "build" / "macos" / "Entitlements.plist") if hardened else None
+    cef_fw = cfg.app_path / "Contents" / "Frameworks" / "Chromium Embedded Framework.framework"
+
+    libs = cef_fw / "Libraries"
+    if libs.is_dir():
+        for dylib in sorted(libs.glob("*.dylib")):
+            run(codesign_argv(cfg.sign_identity, dylib, hardened=hardened, entitlements=entitlements))
+    run(codesign_argv(cfg.sign_identity, cef_fw / "Chromium Embedded Framework",
+                      hardened=hardened, entitlements=entitlements))
+    run(codesign_argv(cfg.sign_identity, cef_fw, hardened=hardened, entitlements=entitlements))
+
+    frameworks = cfg.app_path / "Contents" / "Frameworks"
+    for suffix in HELPER_SUFFIXES:
+        helper_app = frameworks / f"{cfg.bin_name} Helper{suffix}.app"
+        run(codesign_argv(cfg.sign_identity, helper_app, hardened=hardened, entitlements=entitlements))
+
+    run(codesign_argv(cfg.sign_identity, cfg.app_path, hardened=hardened, entitlements=entitlements))
+    run(codesign_verify_argv(cfg.app_path))
+
+
+def notarize(cfg: BundleConfig) -> None:
+    apple_id = os.environ.get("APPLE_ID")
+    team_id = os.environ.get("APPLE_TEAM_ID")
+    password = os.environ.get("APPLE_APP_PASSWORD")
+    if not (apple_id and team_id and password):
+        print("==> notarization credentials absent; skipping notarize")
+        return
+    tmp_zip = cfg.out_dir / "notarize-upload.zip"
+    if tmp_zip.exists():
+        tmp_zip.unlink()
+    run(ditto_zip_argv(cfg.app_path, tmp_zip))
+    run(notarytool_submit_argv(tmp_zip, apple_id, team_id, password))
+    run(stapler_argv(cfg.app_path))
+    tmp_zip.unlink(missing_ok=True)
+
+
+def package(cfg: BundleConfig) -> str:
+    dest = cfg.zip_path
+    if dest.exists():
+        dest.unlink()
+    run(ditto_zip_argv(cfg.app_path, dest))
+    digest = compute_sha256(dest)
+    (dest.parent / (dest.name + ".sha256")).write_text(f"{digest}  {dest.name}\n")
+    return digest
+
+
+def cargo_build(cfg: BundleConfig) -> None:
+    run(cargo_build_argv(cfg.target_triple, CARGO_PROFILE))
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_arg_parser().parse_args(argv)
+    cfg = resolve_config(args)
+    cfg.out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_build:
+        cargo_build(cfg)
+    verify_prerequisites(cfg)
+    assemble_app(cfg)
+    embed_cef(cfg)
+    strip_xattrs(cfg)
+    if not cfg.no_sign:
+        codesign_bundle(cfg)
+    if cfg.notarize:
+        notarize(cfg)
+    digest = package(cfg)
+
+    print(f"version={cfg.version}")
+    print(f"sha256={digest}")
+    print(f"artifact={cfg.zip_path}")
+
+
+if __name__ == "__main__":
+    main()
+
+
 @dataclass
 class BundleConfig:
     version: str

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -72,7 +72,8 @@ def build_helper_plist(name: str, bundle_id: str) -> dict:
 
 
 def cargo_build_argv(triple: str, profile: str) -> list[str]:
-    return ["cargo", "build", "--profile", profile, "--target", triple, "--locked"]
+    return ["cargo", "build", "--profile", profile, "--target", triple,
+            "--locked", "--no-default-features"]
 
 
 def lipo_archs_argv(path: Path) -> list[str]:
@@ -162,6 +163,9 @@ def resolve_config(args: argparse.Namespace) -> BundleConfig:
     if notarize and sign_identity == "-":
         print("==> WARNING: --notarize requires a Developer ID identity; disabling notarization")
         notarize = False
+    if notarize and args.no_sign:
+        print("==> WARNING: --no-sign skips signing; disabling notarization")
+        notarize = False
     return BundleConfig(
         version=version, app_name=APP_NAME, bin_name=BIN_NAME, bundle_id_base=BUNDLE_ID_BASE,
         arch=ARCH, target_triple=TARGET_TRIPLE, bin_source=bin_source,
@@ -187,8 +191,9 @@ def verify_prerequisites(cfg: BundleConfig) -> None:
         )
 
 
-def run(argv: list[str]) -> None:
-    print(f"==> {' '.join(argv)}")
+def run(argv: list[str], redact: tuple[str, ...] = ()) -> None:
+    shown = " ".join("***" if arg in redact else arg for arg in argv)
+    print(f"==> {shown}")
     subprocess.run(argv, check=True)
 
 
@@ -211,6 +216,10 @@ def assemble_app(cfg: BundleConfig) -> None:
         plist = plistlib.load(f)
     plist["CFBundleShortVersionString"] = cfg.version
     plist["CFBundleVersion"] = cfg.version
+    icns = REPO_ROOT / "build" / "macos" / "AppIcon.icns"
+    has_icns = icns.is_file()
+    if has_icns:
+        plist["CFBundleIconFile"] = "AppIcon.icns"
     with open(contents / "Info.plist", "wb") as f:
         plistlib.dump(plist, f)
 
@@ -218,12 +227,7 @@ def assemble_app(cfg: BundleConfig) -> None:
     shutil.copy2(cfg.bin_source, dest_bin)
     dest_bin.chmod(0o755)
 
-    assets = REPO_ROOT / "assets"
-    if assets.is_dir():
-        shutil.copytree(assets, contents / "Resources" / "assets")
-
-    icns = REPO_ROOT / "build" / "macos" / "AppIcon.icns"
-    if icns.is_file():
+    if has_icns:
         shutil.copy2(icns, contents / "Resources" / "AppIcon.icns")
 
     print(f"Assembled {app}")
@@ -302,14 +306,20 @@ def notarize(cfg: BundleConfig) -> None:
     apple_id = os.environ.get("APPLE_ID")
     team_id = os.environ.get("APPLE_TEAM_ID")
     password = os.environ.get("APPLE_APP_PASSWORD")
-    if not (apple_id and team_id and password):
-        print("==> notarization credentials absent; skipping notarize")
-        return
+    missing = [name for name, value in (
+        ("APPLE_ID", apple_id),
+        ("APPLE_TEAM_ID", team_id),
+        ("APPLE_APP_PASSWORD", password),
+    ) if not value]
+    if missing:
+        raise SystemExit(
+            "--notarize requires these environment variables: " + ", ".join(missing)
+        )
     tmp_zip = cfg.out_dir / "notarize-upload.zip"
     if tmp_zip.exists():
         tmp_zip.unlink()
     run(ditto_zip_argv(cfg.app_path, tmp_zip))
-    run(notarytool_submit_argv(tmp_zip, apple_id, team_id, password))
+    run(notarytool_submit_argv(tmp_zip, apple_id, team_id, password), redact=(password,))
     run(stapler_argv(cfg.app_path))
     tmp_zip.unlink(missing_ok=True)
 

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -84,7 +84,8 @@ class CommandBuilders(unittest.TestCase):
     def test_cargo_build_argv(self):
         self.assertEqual(
             bm.cargo_build_argv("aarch64-apple-darwin", "dist"),
-            ["cargo", "build", "--profile", "dist", "--target", "aarch64-apple-darwin", "--locked"],
+            ["cargo", "build", "--profile", "dist", "--target", "aarch64-apple-darwin", "--locked",
+             "--no-default-features"],
         )
 
     def test_parse_lipo_archs(self):
@@ -274,6 +275,28 @@ class EndToEnd(unittest.TestCase):
                 ["codesign", "--verify", "--deep", "--strict", str(out / "ozmux.app")],
                 check=True,
             )
+
+
+class NotarizeGuards(unittest.TestCase):
+    def _parse(self, argv):
+        return bm.build_arg_parser().parse_args(argv)
+
+    def test_no_sign_disables_notarize(self):
+        cfg = bm.resolve_config(self._parse([
+            "--version", "0.1.0", "--no-sign", "--notarize",
+            "--sign-identity", "Developer ID Application: X",
+        ]))
+        self.assertFalse(cfg.notarize)
+
+    def test_notarize_raises_without_credentials(self):
+        cfg = bm.resolve_config(self._parse([
+            "--version", "0.1.0", "--notarize",
+            "--sign-identity", "Developer ID Application: X",
+        ]))
+        for var in ("APPLE_ID", "APPLE_TEAM_ID", "APPLE_APP_PASSWORD"):
+            os.environ.pop(var, None)
+        with self.assertRaises(SystemExit):
+            bm.notarize(cfg)
 
 
 if __name__ == "__main__":

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -194,7 +194,6 @@ class AssembleAndEmbed(unittest.TestCase):
         return fw
 
     def _cfg(self, d: Path) -> "bm.BundleConfig":
-        import shutil as _sh
         self._macho(d / "ozmux-gui")
         self._macho(d / "helper")
         fw = self._fake_cef(d)

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -77,5 +77,68 @@ class PlistLogic(unittest.TestCase):
         self.assertTrue(p["LSUIElement"])
 
 
+class CommandBuilders(unittest.TestCase):
+    def test_cargo_build_argv(self):
+        self.assertEqual(
+            bm.cargo_build_argv("aarch64-apple-darwin", "dist"),
+            ["cargo", "build", "--profile", "dist", "--target", "aarch64-apple-darwin", "--locked"],
+        )
+
+    def test_parse_lipo_archs(self):
+        self.assertEqual(bm.parse_lipo_archs("x86_64 arm64\n"), {"x86_64", "arm64"})
+
+    def test_codesign_argv_adhoc(self):
+        argv = bm.codesign_argv("-", Path("/tmp/a.app"), hardened=False, entitlements=None)
+        self.assertEqual(argv, ["codesign", "--force", "--sign", "-", "/tmp/a.app"])
+
+    def test_codesign_argv_hardened(self):
+        argv = bm.codesign_argv(
+            "Developer ID Application: X", Path("/tmp/a.app"),
+            hardened=True, entitlements=Path("/tmp/e.plist"),
+        )
+        self.assertEqual(argv, [
+            "codesign", "--force", "--sign", "Developer ID Application: X",
+            "--options", "runtime", "--entitlements", "/tmp/e.plist", "/tmp/a.app",
+        ])
+
+    def test_codesign_verify_argv(self):
+        self.assertEqual(
+            bm.codesign_verify_argv(Path("/tmp/a.app")),
+            ["codesign", "--verify", "--deep", "--strict", "/tmp/a.app"],
+        )
+
+    def test_ditto_zip_argv(self):
+        self.assertEqual(
+            bm.ditto_zip_argv(Path("/tmp/a.app"), Path("/tmp/a.zip")),
+            ["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", "/tmp/a.app", "/tmp/a.zip"],
+        )
+
+    def test_xattr_strip_argv(self):
+        self.assertEqual(bm.xattr_strip_argv(Path("/tmp/a.app")), ["xattr", "-cr", "/tmp/a.app"])
+
+    def test_notarytool_submit_argv(self):
+        self.assertEqual(
+            bm.notarytool_submit_argv(Path("/tmp/a.zip"), "me@x.com", "TEAM", "pw"),
+            ["xcrun", "notarytool", "submit", "/tmp/a.zip", "--apple-id", "me@x.com",
+             "--team-id", "TEAM", "--password", "pw", "--wait"],
+        )
+
+    def test_stapler_argv(self):
+        self.assertEqual(bm.stapler_argv(Path("/tmp/a.app")), ["xcrun", "stapler", "staple", "/tmp/a.app"])
+
+    def test_compute_sha256(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"hello")
+            name = f.name
+        try:
+            self.assertEqual(
+                bm.compute_sha256(Path(name)),
+                "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            )
+        finally:
+            os.unlink(name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -39,5 +39,43 @@ class PureHelpers(unittest.TestCase):
         self.assertEqual(cfg.zip_path, Path("/tmp/out/ozmux-1.2.3-arm64.zip"))
 
 
+class PlistLogic(unittest.TestCase):
+    def test_merge_cef_keys_into_empty(self):
+        out = bm.merge_cef_keys({})
+        self.assertEqual(out["LSEnvironment"]["MallocNanoZone"], "0")
+        self.assertEqual(out["LSMinimumSystemVersion"], "11.0")
+        self.assertTrue(out["NSSupportsAutomaticGraphicsSwitching"])
+
+    def test_merge_cef_keys_preserves_existing_env(self):
+        out = bm.merge_cef_keys({"LSEnvironment": {"FOO": "bar"}})
+        self.assertEqual(out["LSEnvironment"]["FOO"], "bar")
+        self.assertEqual(out["LSEnvironment"]["MallocNanoZone"], "0")
+
+    def test_merge_cef_keys_keeps_higher_min_version(self):
+        out = bm.merge_cef_keys({"LSMinimumSystemVersion": "12.0"})
+        self.assertEqual(out["LSMinimumSystemVersion"], "12.0")
+
+    def test_merge_cef_keys_bumps_lower_min_version(self):
+        out = bm.merge_cef_keys({"LSMinimumSystemVersion": "10.15"})
+        self.assertEqual(out["LSMinimumSystemVersion"], "11.0")
+
+    def test_merge_cef_keys_keeps_existing_graphics_switch(self):
+        out = bm.merge_cef_keys({"NSSupportsAutomaticGraphicsSwitching": False})
+        self.assertFalse(out["NSSupportsAutomaticGraphicsSwitching"])
+
+    def test_merge_cef_keys_rejects_bad_env(self):
+        with self.assertRaises(ValueError):
+            bm.merge_cef_keys({"LSEnvironment": "not-a-dict"})
+
+    def test_build_helper_plist(self):
+        p = bm.build_helper_plist("ozmux-gui Helper (GPU)", "not.elm.ozmux.helper.gpu")
+        self.assertEqual(p["CFBundleExecutable"], "ozmux-gui Helper (GPU)")
+        self.assertEqual(p["CFBundleName"], "ozmux-gui Helper (GPU)")
+        self.assertEqual(p["CFBundleIdentifier"], "not.elm.ozmux.helper.gpu")
+        self.assertEqual(p["CFBundlePackageType"], "APPL")
+        self.assertEqual(p["LSEnvironment"]["MallocNanoZone"], "0")
+        self.assertTrue(p["LSUIElement"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -128,7 +130,6 @@ class CommandBuilders(unittest.TestCase):
         self.assertEqual(bm.stapler_argv(Path("/tmp/a.app")), ["xcrun", "stapler", "staple", "/tmp/a.app"])
 
     def test_compute_sha256(self):
-        import tempfile
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"hello")
             name = f.name
@@ -167,7 +168,6 @@ class ConfigResolution(unittest.TestCase):
         self.assertFalse(cfg.notarize)
 
     def test_verify_prerequisites_missing_binary(self):
-        import tempfile
         with tempfile.TemporaryDirectory() as d:
             cfg = bm.resolve_config(self._parse([
                 "--version", "0.1.0", "--bin", str(Path(d) / "missing"),
@@ -205,7 +205,6 @@ class AssembleAndEmbed(unittest.TestCase):
         )
 
     def setUp(self):
-        import tempfile
         self._tmp = tempfile.TemporaryDirectory()
         self.d = Path(self._tmp.name)
         self.cfg = self._cfg(self.d)
@@ -252,7 +251,6 @@ class EndToEnd(unittest.TestCase):
         return fw
 
     def test_main_adhoc_end_to_end(self):
-        import tempfile
         with tempfile.TemporaryDirectory() as d:
             d = Path(d)
             self._macho(d / "ozmux-gui")
@@ -272,7 +270,6 @@ class EndToEnd(unittest.TestCase):
             self.assertTrue(sha_file.is_file())
             self.assertEqual(bm.compute_sha256(zip_path), sha_file.read_text().split()[0])
             # ad-hoc signature must verify
-            import subprocess
             subprocess.run(
                 ["codesign", "--verify", "--deep", "--strict", str(out / "ozmux.app")],
                 check=True,

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import bundle_macos as bm
+
+
+class PureHelpers(unittest.TestCase):
+    def test_zip_name(self):
+        self.assertEqual(bm.zip_name("ozmux", "0.1.0", "arm64"), "ozmux-0.1.0-arm64.zip")
+
+    def test_version_less_than(self):
+        self.assertTrue(bm.version_less_than("10.15", "11.0"))
+        self.assertFalse(bm.version_less_than("11.0", "11.0"))
+        self.assertFalse(bm.version_less_than("12.3", "11.0"))
+
+    def test_helper_bundle_id_base(self):
+        self.assertEqual(bm.helper_bundle_id("not.elm.ozmux", ""), "not.elm.ozmux.helper")
+
+    def test_helper_bundle_id_variants(self):
+        self.assertEqual(bm.helper_bundle_id("not.elm.ozmux", " (GPU)"), "not.elm.ozmux.helper.gpu")
+        self.assertEqual(bm.helper_bundle_id("not.elm.ozmux", " (Renderer)"), "not.elm.ozmux.helper.renderer")
+        self.assertEqual(bm.helper_bundle_id("not.elm.ozmux", " (Plugin)"), "not.elm.ozmux.helper.plugin")
+
+    def test_config_paths(self):
+        cfg = bm.BundleConfig(
+            version="1.2.3", app_name="ozmux", bin_name="ozmux-gui",
+            bundle_id_base="not.elm.ozmux", arch="arm64", target_triple="aarch64-apple-darwin",
+            bin_source=Path("/tmp/ozmux-gui"), cef_framework=Path("/tmp/cef"),
+            helper_bin=Path("/tmp/helper"), out_dir=Path("/tmp/out"),
+            sign_identity="-", no_sign=False, notarize=False,
+        )
+        self.assertEqual(cfg.app_path, Path("/tmp/out/ozmux.app"))
+        self.assertEqual(cfg.zip_path, Path("/tmp/out/ozmux-1.2.3-arm64.zip"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -237,5 +237,47 @@ class AssembleAndEmbed(unittest.TestCase):
             self.assertTrue(hp["LSUIElement"])
 
 
+@unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
+class EndToEnd(unittest.TestCase):
+    def _macho(self, dest: Path) -> None:
+        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
+        shutil.copy("/usr/bin/true", dest)
+        dest.chmod(0o755)
+
+    def _fake_cef(self, root: Path) -> Path:
+        fw = root / "Chromium Embedded Framework.framework"
+        (fw / "Libraries").mkdir(parents=True)
+        self._macho(fw / "Chromium Embedded Framework")
+        self._macho(fw / "Libraries" / "libEGL.dylib")
+        return fw
+
+    def test_main_adhoc_end_to_end(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            self._macho(d / "ozmux-gui")
+            self._macho(d / "helper")
+            fw = self._fake_cef(d)
+            out = d / "out"
+            bm.main([
+                "--skip-build", "--version", "9.9.9",
+                "--bin", str(d / "ozmux-gui"),
+                "--cef-framework", str(fw),
+                "--helper-bin", str(d / "helper"),
+                "--out-dir", str(out),
+            ])
+            zip_path = out / "ozmux-9.9.9-arm64.zip"
+            self.assertTrue(zip_path.is_file())
+            sha_file = out / "ozmux-9.9.9-arm64.zip.sha256"
+            self.assertTrue(sha_file.is_file())
+            self.assertEqual(bm.compute_sha256(zip_path), sha_file.read_text().split()[0])
+            # ad-hoc signature must verify
+            import subprocess
+            subprocess.run(
+                ["codesign", "--verify", "--deep", "--strict", str(out / "ozmux.app")],
+                check=True,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 import unittest
 from pathlib import Path
@@ -174,6 +175,67 @@ class ConfigResolution(unittest.TestCase):
             ]))
             with self.assertRaises(SystemExit):
                 bm.verify_prerequisites(cfg)
+
+
+@unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
+class AssembleAndEmbed(unittest.TestCase):
+    def _macho(self, dest: Path) -> None:
+        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
+        shutil.copy("/usr/bin/true", dest)
+        dest.chmod(0o755)
+
+    def _fake_cef(self, root: Path) -> Path:
+        fw = root / "Chromium Embedded Framework.framework"
+        (fw / "Libraries").mkdir(parents=True)
+        self._macho(fw / "Chromium Embedded Framework")
+        self._macho(fw / "Libraries" / "libEGL.dylib")
+        (fw / "Resources").mkdir()
+        (fw / "Resources" / "icudtl.dat").write_bytes(b"fake")
+        return fw
+
+    def _cfg(self, d: Path) -> "bm.BundleConfig":
+        import shutil as _sh
+        self._macho(d / "ozmux-gui")
+        self._macho(d / "helper")
+        fw = self._fake_cef(d)
+        return bm.BundleConfig(
+            version="9.9.9", app_name="ozmux", bin_name="ozmux-gui",
+            bundle_id_base="not.elm.ozmux", arch="arm64", target_triple="aarch64-apple-darwin",
+            bin_source=d / "ozmux-gui", cef_framework=fw, helper_bin=d / "helper",
+            out_dir=d / "out", sign_identity="-", no_sign=True, notarize=False,
+        )
+
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self.cfg = self._cfg(self.d)
+        self.cfg.out_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_assemble_then_embed(self):
+        import plistlib
+        bm.assemble_app(self.cfg)
+        bm.embed_cef(self.cfg)
+        contents = self.cfg.app_path / "Contents"
+        self.assertTrue((contents / "MacOS" / "ozmux-gui").is_file())
+        with open(contents / "Info.plist", "rb") as f:
+            plist = plistlib.load(f)
+        self.assertEqual(plist["CFBundleShortVersionString"], "9.9.9")
+        self.assertEqual(plist["LSEnvironment"]["MallocNanoZone"], "0")
+        self.assertTrue(plist["NSSupportsAutomaticGraphicsSwitching"])
+        fw = contents / "Frameworks" / "Chromium Embedded Framework.framework"
+        self.assertTrue((fw / "Chromium Embedded Framework").is_file())
+        for suffix, idsfx in [("", "helper"), (" (GPU)", "helper.gpu"),
+                              (" (Renderer)", "helper.renderer"), (" (Plugin)", "helper.plugin")]:
+            helper = contents / "Frameworks" / f"ozmux-gui Helper{suffix}.app"
+            self.assertTrue((helper / "Contents" / "MacOS" / f"ozmux-gui Helper{suffix}").is_file())
+            with open(helper / "Contents" / "Info.plist", "rb") as f:
+                hp = plistlib.load(f)
+            self.assertEqual(hp["CFBundleIdentifier"], f"not.elm.ozmux.{idsfx}")
+            self.assertTrue(hp["LSUIElement"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -140,5 +140,41 @@ class CommandBuilders(unittest.TestCase):
             os.unlink(name)
 
 
+class ConfigResolution(unittest.TestCase):
+    def _parse(self, argv):
+        return bm.build_arg_parser().parse_args(argv)
+
+    def test_resolve_defaults_with_explicit_version(self):
+        cfg = bm.resolve_config(self._parse(["--version", "0.1.0", "--skip-build"]))
+        self.assertEqual(cfg.version, "0.1.0")
+        self.assertEqual(cfg.bin_name, "ozmux-gui")
+        self.assertEqual(cfg.sign_identity, "-")
+        self.assertFalse(cfg.notarize)
+        self.assertEqual(cfg.bin_source.name, "ozmux-gui")
+        self.assertIn("aarch64-apple-darwin", str(cfg.bin_source))
+
+    def test_resolve_sign_identity_from_env(self):
+        os.environ["MACOS_SIGN_IDENTITY"] = "Developer ID Application: Y"
+        try:
+            cfg = bm.resolve_config(self._parse(["--version", "0.1.0"]))
+            self.assertEqual(cfg.sign_identity, "Developer ID Application: Y")
+        finally:
+            del os.environ["MACOS_SIGN_IDENTITY"]
+
+    def test_notarize_downgraded_when_adhoc(self):
+        cfg = bm.resolve_config(self._parse(["--version", "0.1.0", "--notarize"]))
+        self.assertFalse(cfg.notarize)
+
+    def test_verify_prerequisites_missing_binary(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            cfg = bm.resolve_config(self._parse([
+                "--version", "0.1.0", "--bin", str(Path(d) / "missing"),
+                "--cef-framework", d, "--helper-bin", str(Path(d) / "missing-helper"),
+            ]))
+            with self.assertRaises(SystemExit):
+                bm.verify_prerequisites(cfg)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a macOS app-bundling + Homebrew distribution pipeline for `ozmux-gui`:

- **`scripts/bundle_macos.py`** — a stdlib-only (Python 3.9+) CLI that builds the `ozmux-gui` binary, assembles a CEF-embedded `.app` (4 helper apps, merged `Info.plist`, `lipo` arch check), codesigns inside-out (ad-hoc by default; Developer ID + notarization when configured), and packages a `.zip` + `sha256`. It is a Python port/superset of `bevy_cef`'s Rust `bevy_cef_bundle_app`.
- **`scripts/test_bundle_macos.py`** — 30 stdlib `unittest` tests: pure-logic units + macOS-gated integration (assemble+embed, and a full ad-hoc end-to-end with a real `codesign --verify`).
- **`build/macos/`** — `Info.plist` template, hardened-runtime `Entitlements.plist`, and `homebrew/ozmux.rb.tmpl` (cask template).
- **`Cargo.toml`** — `[profile.dist]`, and `debug` is now a default feature forwarding to `bevy_cef/debug` (dev `cargo run` loads CEF from `~/.local/share/cef`); the bundler builds dist with `--no-default-features` so the **release** binary loads CEF from the app's `Contents/Frameworks` (the load-bearing precondition).
- **`Makefile`** — `setup-cef-release`, `bundle-macos`, `release-macos`.
- **`.github/workflows/release-macos.yml`** — tag-triggered build/sign/(notarize)/release + cross-repo cask bump to `not-elm/homebrew-ozmux`.

Scope: **arm64-only** for the first release (universal is a documented follow-up). Signing/notarization are **optional & configurable** — CI degrades to ad-hoc when secrets are absent.

## Manual follow-ups (out of this PR)
- Create the tap repo `not-elm/homebrew-ozmux` and add CI secrets (`HOMEBREW_TAP_TOKEN`, optional Apple signing/notarization).
- Pin `bevy_cef` to a revision (currently `branch = "passthrough"`) so the embedded render-process helper always matches the linked `bevy_cef`.
- Smoke-test the bundled `.app` on a clean machine.

## Testing
- `python3 scripts/test_bundle_macos.py` → 30/30 pass (macOS arm64), including a real `codesign --verify --deep --strict` on the produced bundle.
- `cargo check --no-default-features` (the distribution CEF-load path) compiles clean.
- Subagent-driven implementation with per-task review + a final whole-branch review + a workflow-backed `max` code review (15 findings → 10 fixed, 5 deferred/justified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wHiHsCtfc8nbfhaT47cKB
