### PR TITLE
feat(picker): mouse support for the tmux session picker

### DIFF
--- a/docs/superpowers/plans/2026-06-21-tmux-session-picker-mouse.md
+++ b/docs/superpowers/plans/2026-06-21-tmux-session-picker-mouse.md
@@ -1,0 +1,881 @@
+# Session Picker Mouse Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add click-to-open, hover-to-highlight, and wheel-scrolling (with a height-capped scroll area) to the keyboard-only tmux session picker.
+
+**Architecture:** All work is in `src/picker.rs`. Rows gain Bevy's `Button` (which carries `Interaction`) plus a `PickerRowLabel(usize)` index. One merged system (`handle_picker_row_interaction`) routes `Pressed`→open and `Hovered`→highlight, sharing an extracted `activate_row` helper with the keyboard `Enter` path. The list becomes a height-capped scroll container; a wheel system and a keep-selected-visible system drive its `ScrollPosition`. Two pure helpers (`wheel_delta_px`, `reveal_offset`) carry the unit-testable math.
+
+**Tech Stack:** Rust (edition 2024), Bevy 0.18.1 ECS + `bevy_ui` (`Button`/`Interaction`, `ScrollPosition`, `Overflow::scroll_y`, `ComputedNode`, `UiGlobalTransform`, `UiSystems`), `MouseWheel`/`MouseScrollUnit`.
+
+## Global Constraints
+
+- Bevy is pinned to **0.18.1**; edition **2024**; toolchain **1.95**. (Verbatim from `Cargo.lock`.)
+- All changes live in `src/picker.rs` (plus its `#[cfg(test)] mod tests`). No new modules; no changes outside this file.
+- `.claude/rules/rust.md` applies: no `mod.rs`; comments only `// TODO:`/`// NOTE:`/`// SAFETY:` (NOTE = critical caveat only); doc-comment every `pub` item; all `use` at the top in one contiguous block, no inline fully-qualified paths; **mutable params before immutable**; gate whole-system change checks with `run_if`, never in-body early return; let `DerefMut` drive change detection (guard writes with an equality check — no manual `set_changed`); `Plugin::build` is one method chain; `Query` params use descriptive nouns, never a `_q` suffix; private-items-last ordering within a block; minimize visibility (these are all module-internal items → no visibility modifier).
+- All in-code comments in English.
+- Reference facts (already verified against Bevy 0.18.1 source):
+  - `ScrollPosition(pub Vec2)` — values in **logical px**; access `scroll.0.y`. The layout system clamps only the *rendered* `ComputedNode.scroll_position`, **not** this component, so wheel/reveal code must clamp `scroll.0.y` itself.
+  - `ComputedNode::size() -> Vec2` and `ComputedNode::content_size() -> Vec2` are **physical px**; `ComputedNode.inverse_scale_factor: f32` converts physical→logical (`logical = physical * inverse_scale_factor`).
+  - `UiGlobalTransform` derefs to `Affine2`; `.translation` is the node center in **physical px**.
+  - `Button` requires (auto-inserts) `Node`, `FocusPolicy`, `Interaction`.
+
+## File Structure
+
+- **Modify:** `src/picker.rs` — the only production file. New items (all module-private):
+  - Component change: `PickerRowLabel` becomes a tuple struct `PickerRowLabel(usize)`.
+  - Helper fn: `activate_row(..)` (extracted from the `Enter` arm).
+  - Run condition: `picker_is_open`.
+  - Systems: `handle_picker_row_interaction`, `picker_row_hover_cursor`, `handle_picker_scroll`, `scroll_selected_into_view`.
+  - Pure helpers + const: `wheel_delta_px`, `reveal_offset`, `LINE_SCROLL_PX`.
+  - Layout edits in `spawn_picker_ui` (panel `max_height`, list `overflow`/`flex_grow`/`min_height`/`ScrollPosition`) and `sync_picker_ui` (rows spawn with `Button` + `PickerRowLabel(i)`).
+- **Modify (tests):** `src/picker.rs` `mod tests` — add unit tests for the pure helpers and an App test for hover.
+
+---
+
+### Task 1: Interactive rows + scroll-container layout
+
+Make rows carry `Button` + their index, and turn the list into a height-capped vertical scroll area. No new behavior yet (nothing reads the index or scrolls), so this is a self-contained structural change verified by build + a new spawn test.
+
+**Files:**
+- Modify: `src/picker.rs` (imports; `PickerRowLabel`; `spawn_picker_ui`; `sync_picker_ui`)
+- Test: `src/picker.rs` `mod tests`
+
+**Interfaces:**
+- Produces: `struct PickerRowLabel(usize)` — a module-private marker component carrying the row's linear position in `build_rows` order. Each picker row entity also carries `Button`. The `PickerList` node carries `ScrollPosition` and uses `Overflow::scroll_y()`.
+
+- [ ] **Step 1: Add the new imports**
+
+Add these three lines into the existing top-of-file `use` block (immediately after the existing `use bevy::prelude::*;` line — keep the block contiguous, no blank lines between imports):
+
+```rust
+use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
+use bevy::ui::{ComputedNode, ScrollPosition, UiGlobalTransform, UiSystems};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
+```
+
+(Some of these names are also in `bevy::prelude`; an explicit `use` of the same item alongside the glob is allowed and is required by the "no inline fully-qualified paths" rule. `MouseScrollUnit`, `MouseWheel`, `UiGlobalTransform`, `UiSystems`, and the `bevy::window::*` cursor types are *not* in the prelude, so they must be imported.)
+
+- [ ] **Step 2: Make `PickerRowLabel` carry the row index**
+
+Replace the unit marker:
+
+```rust
+#[derive(Component)]
+struct PickerRowLabel;
+```
+
+with a tuple struct holding the row's linear index:
+
+```rust
+#[derive(Component)]
+struct PickerRowLabel(usize);
+```
+
+- [ ] **Step 3: Add `max_height` to the panel and scroll config + `ScrollPosition` to the list**
+
+In `spawn_picker_ui`, the inner panel `Node` (the `.with_children` child with `min_width: Val::Px(360.0)`) gains a `max_height`. Change its `Node { .. }` to include:
+
+```rust
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Stretch,
+                        min_width: Val::Px(360.0),
+                        max_height: Val::Vh(65.0),
+                        padding: UiRect::axes(Val::Px(20.0), Val::Px(16.0)),
+                        row_gap: Val::Px(10.0),
+                        border: UiRect::all(Val::Px(1.0)),
+                        border_radius: BorderRadius::all(Val::Px(8.0)),
+                        ..default()
+                    },
+```
+
+Then change the `PickerList` node spawn so the list is a scroll viewport. Replace:
+
+```rust
+                    panel.spawn((
+                        Node {
+                            flex_direction: FlexDirection::Column,
+                            width: Val::Percent(100.0),
+                            row_gap: Val::Px(2.0),
+                            ..default()
+                        },
+                        PickerList,
+                    ));
+```
+
+with:
+
+```rust
+                    panel.spawn((
+                        Node {
+                            flex_direction: FlexDirection::Column,
+                            width: Val::Percent(100.0),
+                            row_gap: Val::Px(2.0),
+                            flex_grow: 1.0,
+                            min_height: Val::Px(0.0),
+                            overflow: Overflow::scroll_y(),
+                            ..default()
+                        },
+                        ScrollPosition::default(),
+                        PickerList,
+                    ));
+```
+
+(`min_height: 0` is the flexbox requirement that lets the list shrink below its content height inside the capped panel and actually scroll.)
+
+- [ ] **Step 4: Spawn rows with `Button` + their index**
+
+In `sync_picker_ui`, the despawn+respawn branch currently does `for (label, text_color, bar_color) in visuals`. Change it to enumerate and attach `Button` + `PickerRowLabel(i)`. Replace:
+
+```rust
+        commands.entity(list_entity).with_children(|parent| {
+            for (label, text_color, bar_color) in visuals {
+                parent.spawn((
+                    Node {
+                        width: Val::Percent(100.0),
+                        padding: UiRect::axes(Val::Px(8.0), Val::Px(2.0)),
+                        border_radius: BorderRadius::all(Val::Px(4.0)),
+                        ..default()
+                    },
+                    Text::new(label),
+                    TextColor(text_color),
+                    BackgroundColor(bar_color),
+                    TextFont {
+                        font_size: 14.0,
+                        ..default()
+                    },
+                    PickerRowLabel,
+                ));
+            }
+        });
+```
+
+with:
+
+```rust
+        commands.entity(list_entity).with_children(|parent| {
+            for (i, (label, text_color, bar_color)) in visuals.into_iter().enumerate() {
+                parent.spawn((
+                    Button,
+                    Node {
+                        width: Val::Percent(100.0),
+                        padding: UiRect::axes(Val::Px(8.0), Val::Px(2.0)),
+                        border_radius: BorderRadius::all(Val::Px(4.0)),
+                        ..default()
+                    },
+                    Text::new(label),
+                    TextColor(text_color),
+                    BackgroundColor(bar_color),
+                    TextFont {
+                        font_size: 14.0,
+                        ..default()
+                    },
+                    PickerRowLabel(i),
+                ));
+            }
+        });
+```
+
+The in-place reuse branch (the `if existing.len() == visuals.len()` arm) is unchanged: it queries `With<PickerRowLabel>` and updates text/color/bg only. Row positions are stable across reuse, so the stored index stays correct.
+
+- [ ] **Step 5: Write the failing spawn test**
+
+Add to `mod tests`:
+
+```rust
+    #[test]
+    fn rows_spawn_as_buttons_carrying_their_index() {
+        let mut app = App::new();
+        app.insert_resource(SessionPicker {
+            sessions: vec![fake_session(0, "alpha")],
+            windows: vec![],
+            selected: 0,
+            open: true,
+            last_open: true,
+        });
+        app.add_systems(Startup, spawn_picker_ui);
+        app.add_systems(Update, sync_picker_ui);
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<(&PickerRowLabel, Option<&Button>), With<PickerRowLabel>>();
+        let mut indices: Vec<usize> = Vec::new();
+        for (label, button) in q.iter(app.world()) {
+            assert!(button.is_some(), "every picker row must carry Button");
+            indices.push(label.0);
+        }
+        indices.sort_unstable();
+        // build_rows([alpha], []) == [Session(0), NewSession] -> indices 0,1
+        assert_eq!(indices, vec![0, 1]);
+    }
+```
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux-gui rows_spawn_as_buttons_carrying_their_index`
+Expected: FAIL — before Steps 2–4 are applied it would fail to compile (`PickerRowLabel(i)`) or assert; after applying Steps 2–4 it should pass. (If you wrote the test before the edits, it fails to compile against the unit `PickerRowLabel`.)
+
+- [ ] **Step 7: Run the full picker test module to verify everything passes**
+
+Run: `cargo test -p ozmux-gui picker` then `cargo build`
+Expected: PASS — `rows_spawn_as_buttons_carrying_their_index`, the existing `nav_reuses_row_entities_in_place`, `row_visuals_choose_tree_format`, etc. all green; the crate builds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "feat(picker): rows carry Button + index; list becomes a scroll container"
+```
+
+---
+
+### Task 2: Extract `activate_row` helper from the `Enter` arm
+
+Pure refactor: move the switch-vs-attach + mode-transition logic out of `handle_picker_input`'s `Enter` arm into a free fn so the upcoming click path can reuse it. No behavior change.
+
+**Files:**
+- Modify: `src/picker.rs` (`handle_picker_input` `Enter` arm; new `activate_row`)
+
+**Interfaces:**
+- Produces: `fn activate_row(connection: &mut TmuxConnection, state: &mut ConnectionState, next_mode: &mut NextState<AppMode>, configs: &OzmuxConfigsResource, control: Option<&ControlPlaneHandle>, picker: &SessionPicker, current_mode: &AppMode, row: PickerRow)` — applies one picker row: `apply_switch` while attached, else `apply_attach` and (if `should_enter_ozmux`) `next_mode.set(AppMode::Ozmux)`. Does **not** touch `picker.open` (the caller does).
+
+- [ ] **Step 1: Add the `activate_row` helper**
+
+Add this fn (place it directly above `apply_switch`, so private helpers stay grouped and below the systems that expose behavior):
+
+```rust
+// NOTE: mirrors the keyboard Enter arm exactly — used by both the Enter handler
+// and the mouse click handler so the two paths cannot diverge. Leaves
+// `picker.open` to the caller.
+fn activate_row(
+    connection: &mut TmuxConnection,
+    state: &mut ConnectionState,
+    next_mode: &mut NextState<AppMode>,
+    configs: &OzmuxConfigsResource,
+    control: Option<&ControlPlaneHandle>,
+    picker: &SessionPicker,
+    current_mode: &AppMode,
+    row: PickerRow,
+) {
+    if connection.client().is_some() {
+        apply_switch(connection, state, configs, control, picker, row);
+    } else {
+        let attached = apply_attach(connection, state, configs, control, picker, row);
+        if should_enter_ozmux(attached, current_mode) {
+            next_mode.set(AppMode::Ozmux);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite the `Enter` arm to call it**
+
+In `handle_picker_input`, replace the entire `KeyCode::Enter => { .. }` arm with:
+
+```rust
+            KeyCode::Enter => {
+                let row = rows
+                    .get(picker.selected)
+                    .copied()
+                    .unwrap_or(PickerRow::NewSession);
+                activate_row(
+                    &mut connection,
+                    &mut state,
+                    &mut next_mode,
+                    &configs,
+                    control.as_deref(),
+                    &picker,
+                    current_mode.get(),
+                    row,
+                );
+                picker.open = false;
+                break;
+            }
+```
+
+- [ ] **Step 3: Verify build + existing tests still pass**
+
+Run: `cargo test -p ozmux-gui picker`
+Expected: PASS — `esc_closes_the_picker`, `j_k_move_selection_like_arrows`, `should_enter_ozmux_only_when_attached_from_ozma`, etc. unchanged and green. (The `Enter`→attach path is still not unit-tested — it shells out to real tmux, exactly as before.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "refactor(picker): extract activate_row from the Enter arm"
+```
+
+---
+
+### Task 3: Merged click + hover system (`handle_picker_row_interaction`)
+
+One system handles both `Pressed`→open and `Hovered`→highlight (identical query → single system per rust.md). Hover-selection is gated on the user having moved the mouse since the picker opened, so opening under a stationary cursor keeps the keyboard's first-session selection.
+
+**Files:**
+- Modify: `src/picker.rs` (new `picker_is_open`, new `handle_picker_row_interaction`, plugin registration)
+- Test: `src/picker.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `activate_row(..)` (Task 2); `PickerRowLabel(usize)`, `build_rows`, `PickerRow` (existing).
+- Produces: `fn picker_is_open(picker: Res<SessionPicker>) -> bool`; `fn handle_picker_row_interaction(..)`.
+
+- [ ] **Step 1: Add the `picker_is_open` run condition**
+
+Add near the other free fns (below the systems, above the pure helpers):
+
+```rust
+fn picker_is_open(picker: Res<SessionPicker>) -> bool {
+    picker.open
+}
+```
+
+- [ ] **Step 2: Add the merged interaction system**
+
+Add this system (place it after `handle_picker_input`, before `apply_switch`):
+
+```rust
+// NOTE: `hover_armed` stays false until a CursorMoved arrives after the picker
+// opens, so opening under a stationary cursor does not hijack the keyboard's
+// first-session selection. Clicks (Pressed) are never gated by it.
+fn handle_picker_row_interaction(
+    mut picker: ResMut<SessionPicker>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut state: ResMut<ConnectionState>,
+    mut next_mode: ResMut<NextState<AppMode>>,
+    mut cursor_moved: MessageReader<CursorMoved>,
+    mut hover_armed: Local<bool>,
+    mut was_open: Local<bool>,
+    rows: Query<(&Interaction, &PickerRowLabel), Changed<Interaction>>,
+    configs: Res<OzmuxConfigsResource>,
+    current_mode: Res<State<AppMode>>,
+    control: Option<Res<ControlPlaneHandle>>,
+) {
+    let opened = picker.open && !*was_open;
+    *was_open = picker.open;
+    if opened {
+        *hover_armed = false;
+    }
+    if cursor_moved.read().count() > 0 {
+        *hover_armed = true;
+    }
+
+    for (interaction, label) in rows.iter() {
+        match interaction {
+            Interaction::Pressed => {
+                picker.selected = label.0;
+                let built = build_rows(&picker.sessions, &picker.windows);
+                let row = built
+                    .get(picker.selected)
+                    .copied()
+                    .unwrap_or(PickerRow::NewSession);
+                activate_row(
+                    &mut connection,
+                    &mut state,
+                    &mut next_mode,
+                    &configs,
+                    control.as_deref(),
+                    &picker,
+                    current_mode.get(),
+                    row,
+                );
+                picker.open = false;
+                break;
+            }
+            Interaction::Hovered => {
+                if *hover_armed {
+                    picker.selected = label.0;
+                }
+            }
+            Interaction::None => {}
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the system, gated on `picker_is_open`**
+
+In `OzmuxPickerPlugin::build`, extend the existing `app` method chain (do not start a new `app.` statement) by adding this `.add_systems(..)` call to the chain:
+
+```rust
+            .add_systems(
+                Update,
+                handle_picker_row_interaction.run_if(picker_is_open),
+            )
+```
+
+- [ ] **Step 4: Write the failing hover App test**
+
+Add to `mod tests`. It reuses the `picker_input_app` resource setup but registers the new system, drives a `CursorMoved` to arm hover, then sets a row's `Interaction` to `Hovered`:
+
+```rust
+    fn cursor_moved() -> CursorMoved {
+        CursorMoved {
+            window: Entity::PLACEHOLDER,
+            position: Vec2::ZERO,
+            delta: None,
+        }
+    }
+
+    #[test]
+    fn hover_moves_selection_only_after_the_mouse_moves() {
+        let mut app = App::new();
+        app.add_plugins(StatesPlugin);
+        app.insert_state(AppMode::Ozma);
+        app.add_message::<CursorMoved>();
+        app.insert_resource(SessionPicker {
+            sessions: vec![fake_session(0, "alpha"), fake_session(1, "beta")],
+            windows: vec![],
+            selected: 0,
+            open: true,
+            last_open: true,
+        });
+        app.init_resource::<ConnectionState>();
+        app.init_resource::<OzmuxConfigsResource>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.add_systems(Update, handle_picker_row_interaction);
+
+        // A hovered row exists but the mouse has not moved since open: no change.
+        let row = app.world_mut().spawn((Interaction::Hovered, PickerRowLabel(1))).id();
+        app.update();
+        assert_eq!(
+            app.world().resource::<SessionPicker>().selected,
+            0,
+            "stationary-cursor hover must not move selection"
+        );
+
+        // Arm by moving the mouse, then re-trigger the hover change.
+        app.world_mut().write_message(cursor_moved());
+        app.world_mut()
+            .entity_mut(row)
+            .insert(Interaction::None);
+        app.update();
+        app.world_mut()
+            .entity_mut(row)
+            .insert(Interaction::Hovered);
+        app.update();
+        assert_eq!(
+            app.world().resource::<SessionPicker>().selected,
+            1,
+            "after the mouse moves, hover moves selection"
+        );
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it fails, then passes**
+
+Run: `cargo test -p ozmux-gui hover_moves_selection_only_after_the_mouse_moves`
+Expected: before Step 2/3, FAIL to compile (no `handle_picker_row_interaction`); after, PASS.
+
+- [ ] **Step 6: Verify the whole picker module + build**
+
+Run: `cargo test -p ozmux-gui picker && cargo build`
+Expected: PASS / builds clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "feat(picker): click-to-open + hover-to-highlight via merged interaction system"
+```
+
+---
+
+### Task 4: Pointer cursor on row hover (`picker_row_hover_cursor`)
+
+While the picker is open, show a pointer cursor over rows so they read as clickable; revert to the default cursor when not over a row. Authoritative while open (the picker can appear at boot before any baseline cursor system runs).
+
+**Files:**
+- Modify: `src/picker.rs` (new `picker_row_hover_cursor`, plugin registration)
+
+**Interfaces:**
+- Consumes: `picker_is_open`, `PickerRowLabel` (existing).
+- Produces: `fn picker_row_hover_cursor(..)`.
+
+- [ ] **Step 1: Add the cursor system**
+
+Add after `handle_picker_row_interaction`:
+
+```rust
+fn picker_row_hover_cursor(
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    rows: Query<&Interaction, With<PickerRowLabel>>,
+) {
+    let hovering = rows
+        .iter()
+        .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
+    let Ok(mut icon) = cursor_icons.single_mut() else {
+        return;
+    };
+    let is_pointer = matches!(&*icon, CursorIcon::System(e) if *e == SystemCursorIcon::Pointer);
+    if hovering && !is_pointer {
+        *icon = CursorIcon::System(SystemCursorIcon::Pointer);
+    } else if !hovering && is_pointer {
+        *icon = CursorIcon::System(SystemCursorIcon::Default);
+    }
+}
+```
+
+(The `is_pointer` guard keeps the write conditional so `Changed<CursorIcon>` stays honest — no per-frame churn.)
+
+- [ ] **Step 2: Register it after `InputPhase::Hover`, gated on `picker_is_open`**
+
+Add to the `OzmuxPickerPlugin::build` chain:
+
+```rust
+            .add_systems(
+                Update,
+                picker_row_hover_cursor
+                    .after(crate::input::InputPhase::Hover)
+                    .run_if(picker_is_open),
+            )
+```
+
+- [ ] **Step 3: Verify build + tests**
+
+Run: `cargo build && cargo test -p ozmux-gui picker`
+Expected: builds clean; picker tests green. (Cursor behavior is verified manually in Task 7 — there is no headless cursor assertion.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "feat(picker): pointer cursor while hovering a row"
+```
+
+---
+
+### Task 5: Wheel scrolling (`wheel_delta_px` + `handle_picker_scroll`)
+
+Convert wheel events to a clamped `ScrollPosition` write on the list. The pure `wheel_delta_px` is TDD'd first; the system aggregates the frame's events and clamps the logical offset itself (layout does not clamp the component).
+
+**Files:**
+- Modify: `src/picker.rs` (new `LINE_SCROLL_PX`, `wheel_delta_px`, `handle_picker_scroll`, plugin registration)
+- Test: `src/picker.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `picker_is_open`, `PickerList` (existing).
+- Produces: `const LINE_SCROLL_PX: f32`; `fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32` (returns a **logical-px** delta; sign matches `ScrollPosition` — wheel-down yields a positive delta); `fn handle_picker_scroll(..)`.
+
+- [ ] **Step 1: Write the failing `wheel_delta_px` tests**
+
+Add to `mod tests`:
+
+```rust
+    #[test]
+    fn wheel_line_delta_is_inverted_and_scaled_by_row_stride() {
+        // Wheel up (y>0) scrolls content toward the top -> negative offset delta.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, 1.0), -LINE_SCROLL_PX);
+        // Wheel down (y<0) -> positive offset delta.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, -2.0), 2.0 * LINE_SCROLL_PX);
+    }
+
+    #[test]
+    fn wheel_pixel_delta_is_inverted_identity() {
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 5.0), -5.0);
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, -3.0), 3.0);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozmux-gui wheel_`
+Expected: FAIL to compile — `wheel_delta_px` / `LINE_SCROLL_PX` undefined.
+
+- [ ] **Step 3: Implement `wheel_delta_px` + the constant**
+
+Add near the other pure helpers (bottom of the file, above `mod tests`):
+
+```rust
+/// Logical pixels scrolled per wheel "line" notch. Roughly one row stride
+/// (row height ≈ 18px + 2px gap).
+const LINE_SCROLL_PX: f32 = 24.0;
+
+/// The logical-pixel `ScrollPosition` delta for one wheel event. The sign is
+/// inverted relative to the wheel `y` so that wheel-down (negative `y`) yields a
+/// positive delta — a larger `ScrollPosition.0.y` moves the content up, i.e. the
+/// viewport down. (Same structure as `tmux_inline_wheel_delta` but the opposite
+/// sign, because that path drives a terminal, not a scroll offset.)
+fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
+    match unit {
+        MouseScrollUnit::Line => -y * LINE_SCROLL_PX,
+        MouseScrollUnit::Pixel => -y,
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify the helper tests pass**
+
+Run: `cargo test -p ozmux-gui wheel_`
+Expected: PASS.
+
+- [ ] **Step 5: Add the wheel system**
+
+Add after `picker_row_hover_cursor`:
+
+```rust
+fn handle_picker_scroll(
+    mut list: Query<(&mut ScrollPosition, &ComputedNode), With<PickerList>>,
+    mut wheel: MessageReader<MouseWheel>,
+) {
+    let Ok((mut pos, node)) = list.single_mut() else {
+        wheel.clear();
+        return;
+    };
+    let mut delta = 0.0;
+    for ev in wheel.read() {
+        delta += wheel_delta_px(ev.unit, ev.y);
+    }
+    if delta == 0.0 {
+        return;
+    }
+    let inv = node.inverse_scale_factor;
+    let max = (node.content_size().y - node.size().y).max(0.0) * inv;
+    let next = (pos.0.y + delta).clamp(0.0, max);
+    if pos.0.y != next {
+        pos.0.y = next;
+    }
+}
+```
+
+- [ ] **Step 6: Register it, gated on `MouseWheel` + `picker_is_open`**
+
+Add to the `OzmuxPickerPlugin::build` chain:
+
+```rust
+            .add_systems(
+                Update,
+                handle_picker_scroll
+                    .run_if(on_message::<MouseWheel>)
+                    .run_if(picker_is_open),
+            )
+```
+
+- [ ] **Step 7: Verify build + tests**
+
+Run: `cargo build && cargo test -p ozmux-gui picker`
+Expected: builds clean; all picker tests (including the new wheel ones) green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "feat(picker): wheel-scroll the session list"
+```
+
+---
+
+### Task 6: Keep the selected row visible (`reveal_offset` + `scroll_selected_into_view`)
+
+Once the list scrolls, keyboard navigation must keep the selected row on screen. The pure `reveal_offset` is TDD'd first; the system measures the selected row's real laid-out rectangle (no uniform-height assumption), converts physical→logical, and writes a clamped `ScrollPosition`.
+
+**Files:**
+- Modify: `src/picker.rs` (new `reveal_offset`, `scroll_selected_into_view`, plugin registration + `sync_picker_ui` ordering)
+- Test: `src/picker.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `picker_is_open`, `PickerList`, `PickerRowLabel`, `SessionPicker` (existing).
+- Produces: `fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32, max: f32) -> f32` (all args logical px; content-relative `row_top`; returns the new offset clamped to `[0, max]`); `fn scroll_selected_into_view(..)`.
+
+- [ ] **Step 1: Write the failing `reveal_offset` tests**
+
+Add to `mod tests`:
+
+```rust
+    #[test]
+    fn reveal_leaves_a_fully_visible_row_unchanged() {
+        // row [40,60] inside viewport [30,130]: unchanged.
+        assert_eq!(reveal_offset(40.0, 20.0, 100.0, 30.0, 200.0), 30.0);
+    }
+
+    #[test]
+    fn reveal_scrolls_up_so_row_top_is_flush() {
+        // row top 10 is above current 50: offset becomes 10.
+        assert_eq!(reveal_offset(10.0, 20.0, 100.0, 50.0, 200.0), 10.0);
+    }
+
+    #[test]
+    fn reveal_scrolls_down_so_row_bottom_is_flush() {
+        // row [180,200], viewport height 100, current 0: 200 - 100 = 100.
+        assert_eq!(reveal_offset(180.0, 20.0, 100.0, 0.0, 200.0), 100.0);
+    }
+
+    #[test]
+    fn reveal_clamps_to_zero_and_to_max() {
+        assert_eq!(reveal_offset(-10.0, 20.0, 100.0, 5.0, 200.0), 0.0);
+        assert_eq!(reveal_offset(180.0, 20.0, 100.0, 0.0, 50.0), 50.0);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozmux-gui reveal_`
+Expected: FAIL to compile — `reveal_offset` undefined.
+
+- [ ] **Step 3: Implement `reveal_offset`**
+
+Add near the other pure helpers:
+
+```rust
+/// The new vertical scroll offset (logical px) that brings the row spanning
+/// `[row_top, row_top + row_h]` fully into a `viewport_h`-tall viewport currently
+/// scrolled to `current`. Scrolls up if the row is above the viewport, down if
+/// below, else unchanged; the result is clamped to `[0, max]`.
+fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32, max: f32) -> f32 {
+    let target = if row_top < current {
+        row_top
+    } else if row_top + row_h > current + viewport_h {
+        row_top + row_h - viewport_h
+    } else {
+        current
+    };
+    target.clamp(0.0, max.max(0.0))
+}
+```
+
+- [ ] **Step 4: Run to verify the helper tests pass**
+
+Run: `cargo test -p ozmux-gui reveal_`
+Expected: PASS.
+
+- [ ] **Step 5: Add the scroll-into-view system**
+
+Add after `handle_picker_scroll`:
+
+```rust
+// NOTE: writes ScrollPosition after UiSystems::Layout, so the correction lands on
+// the next frame's render. Reads physical-px geometry (ComputedNode size +
+// UiGlobalTransform center) and converts to logical via inverse_scale_factor,
+// because ScrollPosition is in logical px.
+fn scroll_selected_into_view(
+    mut list: Query<(&mut ScrollPosition, &ComputedNode, &UiGlobalTransform, &Children), With<PickerList>>,
+    rows: Query<(&ComputedNode, &UiGlobalTransform, &PickerRowLabel)>,
+    picker: Res<SessionPicker>,
+) {
+    let Ok((mut pos, list_node, list_tf, children)) = list.single_mut() else {
+        return;
+    };
+    let viewport_h_phys = list_node.size().y;
+    if viewport_h_phys <= 0.0 {
+        return;
+    }
+
+    let mut selected: Option<(f32, f32)> = None;
+    for &child in children.iter() {
+        let Ok((row_node, row_tf, label)) = rows.get(child) else {
+            continue;
+        };
+        if label.0 == picker.selected {
+            let h = row_node.size().y;
+            let top = row_tf.translation.y - h / 2.0;
+            selected = Some((top, h));
+            break;
+        }
+    }
+    let Some((row_top_global, row_h_phys)) = selected else {
+        return;
+    };
+    if row_h_phys <= 0.0 {
+        return;
+    }
+
+    let inv = list_node.inverse_scale_factor;
+    let list_top_global = list_tf.translation.y - viewport_h_phys / 2.0;
+    let current = pos.0.y;
+    let row_top = current + (row_top_global - list_top_global) * inv;
+    let row_h = row_h_phys * inv;
+    let viewport_h = viewport_h_phys * inv;
+    let max = (list_node.content_size().y - viewport_h_phys).max(0.0) * inv;
+
+    let next = reveal_offset(row_top, row_h, viewport_h, current, max);
+    if pos.0.y != next {
+        pos.0.y = next;
+    }
+}
+```
+
+- [ ] **Step 6: Register it after layout + add the `sync_picker_ui` ordering edge**
+
+In `OzmuxPickerPlugin::build`, change the existing `sync_picker_ui` registration so it runs before layout (so freshly-spawned rows have same-frame sizes). Replace:
+
+```rust
+            .add_systems(
+                PostUpdate,
+                sync_picker_ui.run_if(resource_exists_and_changed::<SessionPicker>),
+            );
+```
+
+with (note: this is the chain's terminal call today — keep the trailing `;` on the new last call):
+
+```rust
+            .add_systems(
+                PostUpdate,
+                sync_picker_ui
+                    .before(UiSystems::Layout)
+                    .run_if(resource_exists_and_changed::<SessionPicker>),
+            )
+            .add_systems(
+                PostUpdate,
+                scroll_selected_into_view
+                    .after(UiSystems::Layout)
+                    .run_if(picker_is_open)
+                    .run_if(resource_exists_and_changed::<SessionPicker>),
+            );
+```
+
+- [ ] **Step 7: Verify build + tests**
+
+Run: `cargo build && cargo test -p ozmux-gui picker`
+Expected: builds clean; all picker tests green (the existing `nav_reuses_row_entities_in_place` test registers `sync_picker_ui` in `Update` without UI plugins, so the `.before(UiSystems::Layout)` edge in the plugin does not affect it).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/picker.rs
+git commit -m "feat(picker): keep the selected row in view when scrolling"
+```
+
+---
+
+### Task 7: Final verification — lint, format, full test, manual smoke
+
+Confirm the whole change is clean and actually works in the running app.
+
+**Files:**
+- Modify: `src/picker.rs` (only if clippy/fmt request changes)
+
+- [ ] **Step 1: Lint + format**
+
+Run: `cargo clippy --workspace --fix --allow-dirty --allow-staged && cargo fmt`
+Expected: no remaining warnings in `src/picker.rs`; fmt leaves the file clean.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `cargo test`
+Expected: PASS (workspace-wide; in particular every `picker` test).
+
+- [ ] **Step 3: Manual smoke test**
+
+Run the app against a tmux server that has several sessions (enough rows to overflow ~65% of the window height):
+
+Run: `cargo run`
+Verify, in the picker:
+- Hovering a row moves the amber highlight to it; the cursor becomes a pointer over rows and reverts off them.
+- Opening the picker with the cursor already over the panel leaves the first session highlighted until you move the mouse.
+- Single-clicking a session / window / "New session" row opens it (attach/switch/create) exactly like pressing Enter would.
+- The mouse wheel scrolls the list; it stops cleanly at the top and bottom (no phantom over-scroll).
+- Arrowing past the bottom of the visible area scrolls the selected row back into view.
+
+- [ ] **Step 4: Commit any lint/fmt fixups**
+
+```bash
+git add -A
+git commit -m "chore(picker): clippy + fmt for mouse support" || echo "nothing to commit"
+```
+
+## Self-Review Notes
+
+- **Spec coverage:** click-to-open (Task 3), hover-to-highlight (Task 3), wheel-scroll (Task 5), height-capped scroll area (Task 1), keep-selected-visible (Task 6), shared `activate_row` Approach A (Task 2), pointer cursor (Task 4), the two Bevy-0.18.1 API corrections (`ScrollPosition.0.y` and `UiSystems::Layout` — used throughout Tasks 5/6), self-clamping (Tasks 5/6), measured-geometry reveal (Task 6), merged interaction system (Task 3), open-gate + `sync_picker_ui.before(UiSystems::Layout)` ordering (Task 6). Out-of-scope items (click-outside-dismiss, scrollbar thumb, double-click, digit-jump, footer text) are intentionally absent.
+- **Type consistency:** `PickerRowLabel(usize)` (Task 1) is read as `label.0` everywhere (Tasks 3, 6). `activate_row` signature in Task 2 matches its call sites in Tasks 2 and 3. `wheel_delta_px`/`reveal_offset` signatures in Tasks 5/6 match their tests and call sites. `picker_is_open` (Task 3) is reused in Tasks 4/5/6.
+- **Known residual risk:** the physical→logical conversion in `scroll_selected_into_view` (Task 6) is the one piece not covered by a pure unit test (the math helper `reveal_offset` is; the measurement/conversion is checked by the Task 7 manual smoke). On a non-HiDPI display `inverse_scale_factor == 1.0`, so the conversion is the identity; the smoke test should be run on the target display to confirm HiDPI behavior.

--- a/docs/superpowers/specs/2026-06-20-tmux-session-picker-mouse-design.md
+++ b/docs/superpowers/specs/2026-06-20-tmux-session-picker-mouse-design.md
@@ -101,33 +101,31 @@ The `Enter` arm of `handle_picker_input` is rewritten to:
 `picker.selected` → `rows.get(selected).copied().unwrap_or(PickerRow::NewSession)`
 → `activate_row(..)` → `picker.open = false`. Behavior is identical to today.
 
-### Click → open (`handle_picker_click`)
+### Row interaction (`handle_picker_row_interaction`)
 
-New system, gated on the picker being open. Queries
-`(&Interaction, &PickerRowLabel), Changed<Interaction>`. On a row whose
-interaction became `Pressed`:
+A single system handles both click and hover, gated on the picker being open.
+Click and hover share a byte-identical query
+(`(&Interaction, &PickerRowLabel), Changed<Interaction>`), so per
+`.claude/rules/rust.md` ("splitting into several systems that each re-query the
+same components is worse than the monolith") they are one system, not two. It
+holds the activation params (`NonSendMut<TmuxConnection>`,
+`ResMut<ConnectionState>`, `ResMut<NextState<AppMode>>`, plus
+configs/control/current_mode) — cheap borrows even on hover-only frames. For
+each row whose `Interaction` changed:
 
-1. set `picker.selected = label.0`;
-2. rebuild rows, take `rows.get(picker.selected).copied().unwrap_or(NewSession)`
-   (the same bounds-safe path as `Enter`);
-3. `activate_row(..)`;
-4. `picker.open = false`.
+- **`Pressed`** (click → open): set `picker.selected = label.0`; rebuild rows and
+  take `rows.get(picker.selected).copied().unwrap_or(NewSession)` (the same
+  bounds-safe path as `Enter`, so a row whose underlying session vanished between
+  refresh and click is handled identically — no panic); `activate_row(..)`;
+  `picker.open = false`.
+- **`Hovered`** (move highlight): set `picker.selected = label.0`.
 
-Because step 2 mirrors the keyboard path exactly, a row whose underlying session
-vanished between refresh and click is handled identically to `Enter` (no panic).
-
-### Hover → highlight (`handle_picker_hover`)
-
-New system, gated on the picker being open. Queries
-`(&Interaction, &PickerRowLabel), Changed<Interaction>`. On a row whose
-interaction became `Hovered`, set `picker.selected = label.0`.
-
-Using `Changed<Interaction>` means selection only moves when the cursor enters a
+Using `Changed<Interaction>` means hover only re-selects when the cursor enters a
 new row; a stationary cursor never overrides keyboard navigation. A `Local<bool>`
-tracking the closed→open edge suppresses hover-selection on the frames right
-after open, so the initial keyboard selection (first session) stands until the
-user actually moves the mouse. (This mirrors `confirm_prompt.rs`'s `armed`
-`Local` pattern.)
+tracking the closed→open edge suppresses the **hover** arm on the frames right
+after open (clicks are never suppressed), so the initial keyboard selection
+(first session) stands until the user actually moves the mouse. (This mirrors
+`confirm_prompt.rs`'s `armed` `Local` pattern.)
 
 ### Pointer cursor (`picker_row_hover_cursor`)
 
@@ -151,8 +149,11 @@ equality check so change detection stays honest.
 ### Wheel scroll (`handle_picker_scroll`)
 
 New system, `run_if(on_message::<MouseWheel>)` and gated on the picker being
-open. Reads `MouseWheel` and adds to the `PickerList`'s `ScrollPosition.offset_y`
-via a pure helper that mirrors `tmux_inline_wheel_delta`:
+open. Drains the frame's `MouseWheel` events, sums them into one delta (as
+`forward_wheel_to_tmux` does in `input.rs`), and writes the `PickerList`'s
+`ScrollPosition` once. `ScrollPosition` is a `ScrollPosition(pub Vec2)` newtype
+in Bevy 0.18.1, so the offset is `scroll.0.y` (there is no `offset_y` field).
+A pure helper converts each event's unit:
 
 ```rust
 fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
@@ -163,48 +164,62 @@ fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
 }
 ```
 
-(Sign chosen so wheel-down scrolls the content down, matching platform
-convention; `LINE_SCROLL_PX` is a small constant ≈ one row stride.) Bevy clamps
-`ScrollPosition` to the content range during layout, so over-scroll past either
-end is a no-op; an empty/short list (content ≤ viewport) cannot scroll.
+The `-y` matches `ScrollPosition`'s convention (a larger `.0.y` moves content
+up), so wheel-down scrolls the viewport down — the same *structure* as
+`tmux_inline_wheel_delta` but the opposite sign (the terminal wheel convention
+is inverted from a scroll-offset). `LINE_SCROLL_PX` is a small constant ≈ one
+row stride. The new offset must be clamped to `[0, max(content − viewport, 0)]`
+in our own code: Bevy's layout writes a clamped value to
+`ComputedNode.scroll_position` but does **not** write it back into the
+`ScrollPosition` component (PR #20093 preserves the component), so unclamped
+wheel writes would accumulate a phantom out-of-range offset the user has to
+scroll back through. An empty/short list (content ≤ viewport) therefore clamps
+to 0 and cannot scroll. Content and viewport heights come from the relevant
+`ComputedNode`s.
 
 ### Keep selection visible (`scroll_selected_into_view`)
 
 Once the list scrolls, keyboard navigation must keep the selected row in view —
-otherwise arrowing down moves the highlight off-screen. New system,
-`run_if(resource_exists_and_changed::<SessionPicker>)`, scheduled after the UI
-layout pass (`UiSystem::Layout`) so `ComputedNode` sizes are current for the
-frame.
+otherwise arrowing down moves the highlight off-screen. New system, gated on
+`picker_is_open` AND `resource_exists_and_changed::<SessionPicker>` (the
+`SessionPicker` also mutates on close, so the open gate avoids a useless
+layout-reading pass on the close frame), scheduled after the UI layout pass
+(`UiSystems::Layout`) so `ComputedNode` sizes are current for the frame.
 
-It reads the uniform row height from any row's `ComputedNode`, the viewport
-height from the `PickerList`'s `ComputedNode`, and computes the target offset via
-a pure helper:
+It reads the **selected row's actual** laid-out rectangle — its `ComputedNode`
+size and `UiGlobalTransform` position relative to the `PickerList`'s
+`ComputedNode`/transform — rather than assuming a uniform row height. (A long
+session name can wrap at the 360px min-width, so `selected * row_stride` would
+desync from reality and scroll to the wrong place, with no test to catch it.)
+The measured `(row_top, row_h, viewport_h, current)` feed a pure helper:
 
 ```rust
 /// New scroll offset so the row spanning [row_top, row_top+row_h] is fully
 /// visible in a viewport of height viewport_h currently scrolled to `current`.
-/// Scrolls up if the row is above the viewport, down if below, else unchanged.
+/// Scrolls up if the row is above the viewport, down if below, else unchanged;
+/// clamps to the content range.
 fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32) -> f32
 ```
 
-`row_top = selected * row_stride` (rows are uniform: same font, same padding,
-same `row_gap`, so `row_stride = row_h + gap`). The result is written to
-`ScrollPosition.offset_y` only when it differs from the current value (guarded
-write, honest change detection).
+The result is written to `ScrollPosition` (`scroll.0.y`) only when it differs
+from the current value (guarded write, honest change detection).
 
-NOTE (caveat to encode): this system depends on UI layout having run this frame;
-it must be ordered after `UiSystem::Layout`, and it no-ops on the frames before
-any row has a computed size. A one-frame latency in the rare
-open-with-huge-list case is acceptable.
+NOTE (caveat to encode): writing `ScrollPosition` after `UiSystems::Layout`
+affects the *next* frame's render, so every scroll-into-view correction lands
+one frame late — acceptable for keyboard nav. The system also no-ops until the
+selected row has a non-zero `ComputedNode` (e.g. the frame it is first spawned).
+If `sync_picker_ui` must hand newly-spawned rows same-frame computed sizes, order
+it `.before(UiSystems::Layout)`; the common in-place-reuse path keeps entities,
+so their `ComputedNode` stays valid regardless.
 
 ### Plugin registration
 
 `OzmuxPickerPlugin::build` adds the new systems via the existing chained-`app`
 idiom. A small `fn picker_is_open(picker: Res<SessionPicker>) -> bool` run
-condition gates the open-only systems (`handle_picker_click`,
-`handle_picker_hover`, `handle_picker_scroll`). `picker_row_hover_cursor` is
-registered after `InputPhase::Hover`; `scroll_selected_into_view` after
-`UiSystem::Layout`.
+condition gates the open-only systems (`handle_picker_row_interaction`,
+`handle_picker_scroll`, `scroll_selected_into_view`, and
+`picker_row_hover_cursor`). `picker_row_hover_cursor` is registered after
+`InputPhase::Hover`; `scroll_selected_into_view` after `UiSystems::Layout`.
 
 ## Testing
 
@@ -215,9 +230,9 @@ that never touch real tmux):
 - **`reveal_offset`** — row above the viewport scrolls up to it; row below
   scrolls down so its bottom is flush; row already within stays put; clamps at 0.
 - **Hover App test** — using the existing `picker_input_app`-style harness, mark
-  a row entity's `Interaction` as `Hovered` and run `handle_picker_hover`;
-  assert `picker.selected` updates to that row's index, and that the
-  post-open-suppression frame does not move it.
+  a row entity's `Interaction` as `Hovered` and run
+  `handle_picker_row_interaction`; assert `picker.selected` updates to that row's
+  index, and that the post-open-suppression frame does not move it.
 - Existing tests (`build_rows*`, `step_selection*`, `row_visuals*`,
   `nav_reuses_row_entities_in_place`, dispatch tests) stay green; the row-reuse
   test is extended to assert each reused row still carries `Button` +
@@ -231,8 +246,8 @@ mouse support — are fully covered by the pure-fn tests above.
 
 ## Error handling & edge cases
 
-- **Empty / short list** — `ScrollPosition` clamps to 0; wheel and
-  scroll-into-view are no-ops.
+- **Empty / short list** — content ≤ viewport, so our clamp pins
+  `ScrollPosition` (`scroll.0.y`) to 0; wheel and scroll-into-view are no-ops.
 - **Stale row index on click** — `rows.get(selected).unwrap_or(NewSession)`
   guards an index past the (possibly refreshed) row set, exactly as `Enter` does.
 - **Cursor over a row on open** — suppressed for the post-open frames so the
@@ -244,10 +259,10 @@ mouse support — are fully covered by the pure-fn tests above.
 
 - `src/picker.rs` — rows spawn with `Button` + `PickerRowLabel(usize)`; panel
   `max_height` + list `overflow`/`flex_grow`/`min_height`; `activate_row`
-  extracted; new systems `handle_picker_click`, `handle_picker_hover`,
-  `picker_row_hover_cursor`, `handle_picker_scroll`,
-  `scroll_selected_into_view`; `picker_is_open` run condition; new pure helpers
-  `wheel_delta_px`, `reveal_offset`; tests extended.
+  extracted; new systems `handle_picker_row_interaction` (click + hover),
+  `picker_row_hover_cursor`, `handle_picker_scroll`, `scroll_selected_into_view`;
+  `picker_is_open` run condition; new pure helpers `wheel_delta_px`,
+  `reveal_offset`; tests extended.
 
 No new modules; no changes outside `src/picker.rs`.
 
@@ -255,7 +270,8 @@ No new modules; no changes outside `src/picker.rs`.
 
 - Click-outside-the-panel to dismiss.
 - Double-click / click-to-highlight-then-Enter semantics.
-- A draggable scrollbar thumb (wheel + keyboard only).
+- A draggable scrollbar thumb (wheel + keyboard only; Bevy 0.18's native
+  `CoreScrollbar` widget could add one later if scope expands).
 - Digit-key quick-jump (still a separate later follow-up, per the chooser
   redesign spec).
 - Footer hint text changes (mouse is discoverable by hovering; the keyboard

--- a/docs/superpowers/specs/2026-06-20-tmux-session-picker-mouse-design.md
+++ b/docs/superpowers/specs/2026-06-20-tmux-session-picker-mouse-design.md
@@ -1,0 +1,262 @@
+# Session picker — mouse support
+
+Design spec — 2026-06-20
+Builds on: `docs/superpowers/specs/2026-06-15-session-chooser-redesign-design.md`
+(the choose-tree-style picker; this adds mouse interaction to it.)
+
+## Context
+
+The startup tmux session picker (`src/picker.rs`) is keyboard-only.
+`handle_picker_input` reads `KeyboardInput` and drives a `selected` index:
+`↑↓`/`jk` move it, `Enter` opens the selected row (attach / switch / new
+session), `Esc` cancels. Rows are plain `Text` nodes with no `Interaction`.
+The row list also has no height cap, so with many sessions/windows it overflows
+the window.
+
+The user wants the picker to be usable with the mouse. The repo already has a
+clean mouse idiom: window-bar entries are spawned as `Button` (which carries
+`Interaction`) and handled with `Changed<Interaction>` + a pointer
+`CursorIcon` (`src/tmux/window_bar.rs`, `src/tmux/window_bar_input.rs`). The
+wheel idiom is `MessageReader<MouseWheel>` with `MouseScrollUnit` Line/Pixel
+handling (`src/tmux/input.rs`). This work reuses both.
+
+This is an input + small-layout change to one screen. All changes are in
+`src/picker.rs`.
+
+## Settled decisions (from brainstorming)
+
+1. **Three mouse behaviors, no click-outside-dismiss.** In scope: click a row
+   to open it, hover a row to move the highlight, and wheel-scroll a long list.
+   Clicking the backdrop outside the panel does **not** dismiss the picker.
+2. **Single-click opens.** A single click on a row is the mouse equivalent of
+   pressing `Enter` on it — it attaches/switches/creates immediately. Hover
+   already provides the "preview" highlight, so no second click or
+   double-click is required.
+3. **Scroll area sized as a fraction of window height.** The panel is capped at
+   ~65% of the window height; the row list scrolls inside that cap. Adapts to
+   any window size. (Picked over a fixed visible-row count.)
+4. **Activation wiring: shared helper fn (Approach A).** The keyboard-`Enter`
+   path and the new click path both call one `activate_row(...)` helper rather
+   than going through an `EntityEvent` + observer or a `pending_open` flag.
+   Both call sites already hold the needed `&mut` params, so per
+   `.claude/rules/rust.md` ("prefer a helper fn unless the apply step needs
+   *isolated* `&mut`/NonSend access") a helper is the right altitude.
+5. **Hover is keyboard-first on open.** Hover re-selects only when the cursor
+   *enters a new row* (`Changed<Interaction>`), and hover-selection is
+   suppressed on the frames just after the picker opens, so opening always
+   highlights the first session rather than snapping to wherever the cursor sits.
+
+## Design
+
+All changes are in `src/picker.rs` (plus its `#[cfg(test)] mod tests`). The
+backdrop → panel → (title + `PickerList` + footer) structure and the in-place
+`sync_picker_ui` row update are preserved.
+
+### Rows become interactive
+
+Each row is spawned with the **`Button`** component (the `window_bar.rs` idiom —
+`Button` provides the `Interaction` the UI picking backend writes), and its
+linear row index is carried on the marker:
+
+```rust
+#[derive(Component)]
+struct PickerRowLabel(usize); // the row's position in build_rows order
+```
+
+`With<PickerRowLabel>` queries keep working unchanged. The index is set when a
+row is spawned (`PickerRowLabel(i)`); the in-place reuse branch of
+`sync_picker_ui` does not touch it (row positions are stable, so the stored
+index stays correct). Both the initial spawn and the despawn+respawn branch add
+`Button`; the reuse branch leaves the already-present `Button` in place.
+
+Picking is clipped to the scroll viewport, so rows scrolled out of view are not
+hovered or clickable — which is the desired behavior.
+
+### Activation helper (shared by keyboard + mouse)
+
+The logic currently inlined in the `Enter` arm of `handle_picker_input` is
+extracted to a helper that both the keyboard system and the new click system
+call:
+
+```rust
+fn activate_row(
+    connection: &mut TmuxConnection,
+    state: &mut ConnectionState,
+    next_mode: &mut NextState<AppMode>,
+    configs: &OzmuxConfigsResource,
+    control: Option<&ControlPlaneHandle>,
+    picker: &SessionPicker,
+    current_mode: &AppMode,
+    row: PickerRow,
+)
+```
+
+It performs the existing switch-vs-attach decision: if `connection.client()`
+is `Some`, call `apply_switch`; else call `apply_attach` and, when
+`should_enter_ozmux(attached, current_mode)`, set `next_mode` to
+`AppMode::Ozmux`. The caller sets `picker.open = false` afterward (as the
+`Enter` arm does today).
+
+The `Enter` arm of `handle_picker_input` is rewritten to:
+`picker.selected` → `rows.get(selected).copied().unwrap_or(PickerRow::NewSession)`
+→ `activate_row(..)` → `picker.open = false`. Behavior is identical to today.
+
+### Click → open (`handle_picker_click`)
+
+New system, gated on the picker being open. Queries
+`(&Interaction, &PickerRowLabel), Changed<Interaction>`. On a row whose
+interaction became `Pressed`:
+
+1. set `picker.selected = label.0`;
+2. rebuild rows, take `rows.get(picker.selected).copied().unwrap_or(NewSession)`
+   (the same bounds-safe path as `Enter`);
+3. `activate_row(..)`;
+4. `picker.open = false`.
+
+Because step 2 mirrors the keyboard path exactly, a row whose underlying session
+vanished between refresh and click is handled identically to `Enter` (no panic).
+
+### Hover → highlight (`handle_picker_hover`)
+
+New system, gated on the picker being open. Queries
+`(&Interaction, &PickerRowLabel), Changed<Interaction>`. On a row whose
+interaction became `Hovered`, set `picker.selected = label.0`.
+
+Using `Changed<Interaction>` means selection only moves when the cursor enters a
+new row; a stationary cursor never overrides keyboard navigation. A `Local<bool>`
+tracking the closed→open edge suppresses hover-selection on the frames right
+after open, so the initial keyboard selection (first session) stands until the
+user actually moves the mouse. (This mirrors `confirm_prompt.rs`'s `armed`
+`Local` pattern.)
+
+### Pointer cursor (`picker_row_hover_cursor`)
+
+New system, registered after `crate::input::InputPhase::Hover` (as
+`window_entry_hover_cursor` is). While the picker is open: if any row's
+`Interaction` is `Hovered`/`Pressed`, set the `PrimaryWindow` `CursorIcon` to
+`SystemCursorIcon::Pointer`; otherwise set it to the default. The picker is a
+modal backdrop, so this system is authoritative for the cursor while open rather
+than relying on the hyperlink baseline system to revert. Writes are guarded by an
+equality check so change detection stays honest.
+
+### Scroll layout
+
+- **Panel** gains `max_height: Val::Vh(65.0)`.
+- **`PickerList` node** gains `overflow: Overflow::scroll_y()`,
+  `flex_grow: 1.0`, and `min_height: Val::Px(0.0)`. The `min_height: 0` is the
+  flexbox requirement that lets the list shrink below its content height and
+  actually scroll; without it the list grows to fit all rows and the panel
+  blows past its cap. Title and footer stay pinned; only the row list scrolls.
+
+### Wheel scroll (`handle_picker_scroll`)
+
+New system, `run_if(on_message::<MouseWheel>)` and gated on the picker being
+open. Reads `MouseWheel` and adds to the `PickerList`'s `ScrollPosition.offset_y`
+via a pure helper that mirrors `tmux_inline_wheel_delta`:
+
+```rust
+fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
+    match unit {
+        MouseScrollUnit::Line => -y * LINE_SCROLL_PX, // one "line" ≈ a row's height
+        MouseScrollUnit::Pixel => -y,
+    }
+}
+```
+
+(Sign chosen so wheel-down scrolls the content down, matching platform
+convention; `LINE_SCROLL_PX` is a small constant ≈ one row stride.) Bevy clamps
+`ScrollPosition` to the content range during layout, so over-scroll past either
+end is a no-op; an empty/short list (content ≤ viewport) cannot scroll.
+
+### Keep selection visible (`scroll_selected_into_view`)
+
+Once the list scrolls, keyboard navigation must keep the selected row in view —
+otherwise arrowing down moves the highlight off-screen. New system,
+`run_if(resource_exists_and_changed::<SessionPicker>)`, scheduled after the UI
+layout pass (`UiSystem::Layout`) so `ComputedNode` sizes are current for the
+frame.
+
+It reads the uniform row height from any row's `ComputedNode`, the viewport
+height from the `PickerList`'s `ComputedNode`, and computes the target offset via
+a pure helper:
+
+```rust
+/// New scroll offset so the row spanning [row_top, row_top+row_h] is fully
+/// visible in a viewport of height viewport_h currently scrolled to `current`.
+/// Scrolls up if the row is above the viewport, down if below, else unchanged.
+fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32) -> f32
+```
+
+`row_top = selected * row_stride` (rows are uniform: same font, same padding,
+same `row_gap`, so `row_stride = row_h + gap`). The result is written to
+`ScrollPosition.offset_y` only when it differs from the current value (guarded
+write, honest change detection).
+
+NOTE (caveat to encode): this system depends on UI layout having run this frame;
+it must be ordered after `UiSystem::Layout`, and it no-ops on the frames before
+any row has a computed size. A one-frame latency in the rare
+open-with-huge-list case is acceptable.
+
+### Plugin registration
+
+`OzmuxPickerPlugin::build` adds the new systems via the existing chained-`app`
+idiom. A small `fn picker_is_open(picker: Res<SessionPicker>) -> bool` run
+condition gates the open-only systems (`handle_picker_click`,
+`handle_picker_hover`, `handle_picker_scroll`). `picker_row_hover_cursor` is
+registered after `InputPhase::Hover`; `scroll_selected_into_view` after
+`UiSystem::Layout`.
+
+## Testing
+
+Following the file's existing style (pure helpers unit-tested; light App systems
+that never touch real tmux):
+
+- **`wheel_delta_px`** — `Line` vs `Pixel`, sign, magnitude.
+- **`reveal_offset`** — row above the viewport scrolls up to it; row below
+  scrolls down so its bottom is flush; row already within stays put; clamps at 0.
+- **Hover App test** — using the existing `picker_input_app`-style harness, mark
+  a row entity's `Interaction` as `Hovered` and run `handle_picker_hover`;
+  assert `picker.selected` updates to that row's index, and that the
+  post-open-suppression frame does not move it.
+- Existing tests (`build_rows*`, `step_selection*`, `row_visuals*`,
+  `nav_reuses_row_entities_in_place`, dispatch tests) stay green; the row-reuse
+  test is extended to assert each reused row still carries `Button` +
+  `PickerRowLabel(index)`.
+
+Not unit-tested: the full click/`Enter` → attach round-trip, which shells out to
+real tmux. The file already avoids exercising that path in tests; `activate_row`
+is shared with the untested-by-design `Enter` arm, so click inherits the same
+coverage boundary. The decision/selection and scroll math — the parts unique to
+mouse support — are fully covered by the pure-fn tests above.
+
+## Error handling & edge cases
+
+- **Empty / short list** — `ScrollPosition` clamps to 0; wheel and
+  scroll-into-view are no-ops.
+- **Stale row index on click** — `rows.get(selected).unwrap_or(NewSession)`
+  guards an index past the (possibly refreshed) row set, exactly as `Enter` does.
+- **Cursor over a row on open** — suppressed for the post-open frames so the
+  keyboard's first-session selection stands.
+- **Layout not yet computed** — `scroll_selected_into_view` no-ops until rows
+  have a `ComputedNode` size.
+
+## Files touched
+
+- `src/picker.rs` — rows spawn with `Button` + `PickerRowLabel(usize)`; panel
+  `max_height` + list `overflow`/`flex_grow`/`min_height`; `activate_row`
+  extracted; new systems `handle_picker_click`, `handle_picker_hover`,
+  `picker_row_hover_cursor`, `handle_picker_scroll`,
+  `scroll_selected_into_view`; `picker_is_open` run condition; new pure helpers
+  `wheel_delta_px`, `reveal_offset`; tests extended.
+
+No new modules; no changes outside `src/picker.rs`.
+
+## Out of scope
+
+- Click-outside-the-panel to dismiss.
+- Double-click / click-to-highlight-then-Enter semantics.
+- A draggable scrollbar thumb (wheel + keyboard only).
+- Digit-key quick-jump (still a separate later follow-up, per the chooser
+  redesign spec).
+- Footer hint text changes (mouse is discoverable by hovering; the keyboard
+  hints stay as-is).

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -52,6 +52,10 @@ impl Plugin for OzmuxPickerPlugin {
             .add_systems(
                 PostUpdate,
                 sync_picker_ui.run_if(resource_exists_and_changed::<SessionPicker>),
+            )
+            .add_systems(
+                Update,
+                handle_picker_row_interaction.run_if(picker_is_open),
             );
     }
 }
@@ -394,6 +398,63 @@ fn sync_picker_ui(
     }
 }
 
+// NOTE: `hover_armed` stays false until a CursorMoved arrives after the picker
+// opens, so opening under a stationary cursor does not hijack the keyboard's
+// first-session selection. Clicks (Pressed) are never gated by it.
+fn handle_picker_row_interaction(
+    mut picker: ResMut<SessionPicker>,
+    mut connection: NonSendMut<TmuxConnection>,
+    mut state: ResMut<ConnectionState>,
+    mut next_mode: ResMut<NextState<AppMode>>,
+    mut cursor_moved: MessageReader<CursorMoved>,
+    mut hover_armed: Local<bool>,
+    mut was_open: Local<bool>,
+    rows: Query<(&Interaction, &PickerRowLabel), Changed<Interaction>>,
+    configs: Res<OzmuxConfigsResource>,
+    current_mode: Res<State<AppMode>>,
+    control: Option<Res<ControlPlaneHandle>>,
+) {
+    let opened = picker.open && !*was_open;
+    *was_open = picker.open;
+    if opened {
+        *hover_armed = false;
+    }
+    if cursor_moved.read().count() > 0 {
+        *hover_armed = true;
+    }
+
+    for (interaction, label) in rows.iter() {
+        match interaction {
+            Interaction::Pressed => {
+                picker.selected = label.0;
+                let built = build_rows(&picker.sessions, &picker.windows);
+                let row = built
+                    .get(picker.selected)
+                    .copied()
+                    .unwrap_or(PickerRow::NewSession);
+                activate_row(
+                    &mut connection,
+                    &mut state,
+                    &mut next_mode,
+                    &configs,
+                    control.as_deref(),
+                    &picker,
+                    current_mode.get(),
+                    row,
+                );
+                picker.open = false;
+                break;
+            }
+            Interaction::Hovered => {
+                if *hover_armed {
+                    picker.selected = label.0;
+                }
+            }
+            Interaction::None => {}
+        }
+    }
+}
+
 fn handle_picker_input(
     mut picker: ResMut<SessionPicker>,
     mut connection: NonSendMut<TmuxConnection>,
@@ -446,6 +507,10 @@ fn handle_picker_input(
             _ => {}
         }
     }
+}
+
+fn picker_is_open(picker: Res<SessionPicker>) -> bool {
+    picker.open
 }
 
 // NOTE: mirrors the keyboard Enter arm exactly — used by both the Enter handler
@@ -928,6 +993,58 @@ mod tests {
         assert_eq!(
             *app.world().resource::<State<AppMode>>().get(),
             AppMode::Ozmux
+        );
+    }
+
+    fn cursor_moved() -> CursorMoved {
+        CursorMoved {
+            window: Entity::PLACEHOLDER,
+            position: Vec2::ZERO,
+            delta: None,
+        }
+    }
+
+    #[test]
+    fn hover_moves_selection_only_after_the_mouse_moves() {
+        let mut app = App::new();
+        app.add_plugins(StatesPlugin);
+        app.insert_state(AppMode::Ozma);
+        app.add_message::<CursorMoved>();
+        app.insert_resource(SessionPicker {
+            sessions: vec![fake_session(0, "alpha"), fake_session(1, "beta")],
+            windows: vec![],
+            selected: 0,
+            open: true,
+            last_open: true,
+        });
+        app.init_resource::<ConnectionState>();
+        app.init_resource::<OzmuxConfigsResource>();
+        app.insert_non_send_resource(TmuxConnection::default());
+        app.add_systems(Update, handle_picker_row_interaction);
+
+        // A hovered row exists but the mouse has not moved since open: no change.
+        let row = app.world_mut().spawn((Interaction::Hovered, PickerRowLabel(1))).id();
+        app.update();
+        assert_eq!(
+            app.world().resource::<SessionPicker>().selected,
+            0,
+            "stationary-cursor hover must not move selection"
+        );
+
+        // Arm by moving the mouse, then re-trigger the hover change.
+        app.world_mut().write_message(cursor_moved());
+        app.world_mut()
+            .entity_mut(row)
+            .insert(Interaction::None);
+        app.update();
+        app.world_mut()
+            .entity_mut(row)
+            .insert(Interaction::Hovered);
+        app.update();
+        assert_eq!(
+            app.world().resource::<SessionPicker>().selected,
+            1,
+            "after the mouse moves, hover moves selection"
         );
     }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -430,32 +430,43 @@ fn handle_picker_input(
                     .get(picker.selected)
                     .copied()
                     .unwrap_or(PickerRow::NewSession);
-                if connection.client().is_some() {
-                    apply_switch(
-                        &mut connection,
-                        &mut state,
-                        &configs,
-                        control.as_deref(),
-                        &picker,
-                        row,
-                    );
-                } else {
-                    let attached = apply_attach(
-                        &mut connection,
-                        &mut state,
-                        &configs,
-                        control.as_deref(),
-                        &picker,
-                        row,
-                    );
-                    if should_enter_ozmux(attached, current_mode.get()) {
-                        next_mode.set(AppMode::Ozmux);
-                    }
-                }
+                activate_row(
+                    &mut connection,
+                    &mut state,
+                    &mut next_mode,
+                    &configs,
+                    control.as_deref(),
+                    &picker,
+                    current_mode.get(),
+                    row,
+                );
                 picker.open = false;
                 break;
             }
             _ => {}
+        }
+    }
+}
+
+// NOTE: mirrors the keyboard Enter arm exactly — used by both the Enter handler
+// and the mouse click handler so the two paths cannot diverge. Leaves
+// `picker.open` to the caller.
+fn activate_row(
+    connection: &mut TmuxConnection,
+    state: &mut ConnectionState,
+    next_mode: &mut NextState<AppMode>,
+    configs: &OzmuxConfigsResource,
+    control: Option<&ControlPlaneHandle>,
+    picker: &SessionPicker,
+    current_mode: &AppMode,
+    row: PickerRow,
+) {
+    if connection.client().is_some() {
+        apply_switch(connection, state, configs, control, picker, row);
+    } else {
+        let attached = apply_attach(connection, state, configs, control, picker, row);
+        if should_enter_ozmux(attached, current_mode) {
+            next_mode.set(AppMode::Ozmux);
         }
     }
 }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -3,6 +3,7 @@
 
 use crate::configs::OzmuxConfigsResource;
 use crate::control_plane::ControlPlaneHandle;
+use crate::input::InputPhase;
 use crate::ozma::AppMode;
 use crate::theme;
 use bevy::ecs::hierarchy::Children;
@@ -13,7 +14,7 @@ use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, ScrollPosition, UiGlobalTransform, UiSystems};
-use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, WindowResized};
 use ozmux_configs::StartupMode;
 use ozmux_tmux::{
     AttachTarget, ConnectionState, TmuxConnection, attach_or_create, select_attach_target,
@@ -34,10 +35,7 @@ impl Plugin for OzmuxPickerPlugin {
                 OnEnter(AppMode::Ozmux),
                 dispatch_startup_mode.run_if(not(resource_exists::<StartupDispatched>)),
             )
-            .add_systems(
-                Update,
-                handle_picker_input.after(crate::input::InputPhase::FocusedKey),
-            )
+            .add_systems(Update, handle_picker_input.after(InputPhase::FocusedKey))
             .add_systems(Update, refresh_picker_on_open)
             .add_systems(
                 Update,
@@ -60,15 +58,18 @@ impl Plugin for OzmuxPickerPlugin {
                 scroll_selected_into_view
                     .after(UiSystems::Layout)
                     .run_if(picker_is_open)
-                    .run_if(resource_exists_and_changed::<SessionPicker>),
+                    .run_if(
+                        resource_exists_and_changed::<SessionPicker>
+                            .or(on_message::<WindowResized>),
+                    ),
             )
-            .add_systems(Update, handle_picker_row_interaction.run_if(picker_is_open))
-            .add_systems(
-                Update,
-                picker_row_hover_cursor
-                    .after(crate::input::InputPhase::Hover)
-                    .run_if(picker_is_open),
-            )
+            // NOTE: handle_picker_row_interaction and picker_row_hover_cursor are
+            // deliberately NOT gated by run_if(picker_is_open): both must observe
+            // the picker's closed state to reset per-open state (re-disarm hover,
+            // and revert the pointer cursor on the click that closes the picker);
+            // gated off while closed, that reset never runs.
+            .add_systems(Update, handle_picker_row_interaction)
+            .add_systems(Update, picker_row_hover_cursor.after(InputPhase::Hover))
             .add_systems(
                 Update,
                 handle_picker_scroll
@@ -416,9 +417,12 @@ fn sync_picker_ui(
     }
 }
 
-// NOTE: `hover_armed` stays false until a CursorMoved arrives after the picker
-// opens, so opening under a stationary cursor does not hijack the keyboard's
-// first-session selection. Clicks (Pressed) are never gated by it.
+// NOTE: this system is ungated (no run_if(picker_is_open)) on purpose. The
+// `was_open` open-edge detector must observe the closed→open transition to
+// re-disarm hover; gated off while the picker is closed it would freeze at
+// `true` and never re-disarm on reopen, letting a stationary cursor hijack the
+// keyboard's selection. `hover_armed` stays false until a CursorMoved arrives
+// after each open; clicks (Pressed) are never gated by it.
 fn handle_picker_row_interaction(
     mut picker: ResMut<SessionPicker>,
     mut connection: NonSendMut<TmuxConnection>,
@@ -436,6 +440,10 @@ fn handle_picker_row_interaction(
     *was_open = picker.open;
     if opened {
         *hover_armed = false;
+    }
+    if !picker.open {
+        cursor_moved.clear();
+        return;
     }
     if cursor_moved.read().count() > 0 {
         *hover_armed = true;
@@ -464,7 +472,7 @@ fn handle_picker_row_interaction(
                 break;
             }
             Interaction::Hovered => {
-                if *hover_armed {
+                if *hover_armed && picker.selected != label.0 {
                     picker.selected = label.0;
                 }
             }
@@ -473,21 +481,31 @@ fn handle_picker_row_interaction(
     }
 }
 
+// NOTE: ungated, and reverts only the pointer cursor THIS system set
+// (`we_set_pointer`). The picker can close (via a click on a row) while a row is
+// still hovered; a gated system would stop before reverting and leave a stuck
+// hand cursor over the terminal. Reverting only our own pointer avoids fighting
+// other cursor owners (e.g. the hyperlink hover cursor) once the picker closes.
 fn picker_row_hover_cursor(
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    mut we_set_pointer: Local<bool>,
+    picker: Res<SessionPicker>,
     rows: Query<&Interaction, With<PickerRowLabel>>,
 ) {
-    let hovering = rows
-        .iter()
-        .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
+    let hovering = picker.open
+        && rows
+            .iter()
+            .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
     let Ok(mut icon) = cursor_icons.single_mut() else {
         return;
     };
     let is_pointer = matches!(&*icon, CursorIcon::System(e) if *e == SystemCursorIcon::Pointer);
     if hovering && !is_pointer {
         *icon = CursorIcon::System(SystemCursorIcon::Pointer);
-    } else if !hovering && is_pointer {
+        *we_set_pointer = true;
+    } else if !hovering && *we_set_pointer && is_pointer {
         *icon = CursorIcon::System(SystemCursorIcon::Default);
+        *we_set_pointer = false;
     }
 }
 
@@ -499,16 +517,15 @@ fn handle_picker_scroll(
         wheel.clear();
         return;
     };
+    let inv = node.inverse_scale_factor;
     let mut delta = 0.0;
     for ev in wheel.read() {
-        delta += wheel_delta_px(ev.unit, ev.y);
+        delta += wheel_delta_px(ev.unit, ev.y, inv);
     }
     if delta == 0.0 {
         return;
     }
-    let inv = node.inverse_scale_factor;
-    let max = (node.content_size().y - node.size().y).max(0.0) * inv;
-    let next = (pos.0.y + delta).clamp(0.0, max);
+    let next = (pos.0.y + delta).clamp(0.0, max_scroll_logical(node));
     if pos.0.y != next {
         pos.0.y = next;
     }
@@ -564,7 +581,7 @@ fn scroll_selected_into_view(
     let row_top = current + (row_top_global - list_top_global) * inv;
     let row_h = row_h_phys * inv;
     let viewport_h = viewport_h_phys * inv;
-    let max = (list_node.content_size().y - viewport_h_phys).max(0.0) * inv;
+    let max = max_scroll_logical(list_node);
 
     let next = reveal_offset(row_top, row_h, viewport_h, current, max);
     if pos.0.y != next {
@@ -630,9 +647,8 @@ fn picker_is_open(picker: Res<SessionPicker>) -> bool {
     picker.open
 }
 
-// NOTE: mirrors the keyboard Enter arm exactly — used by both the Enter handler
-// and the mouse click handler so the two paths cannot diverge. Leaves
-// `picker.open` to the caller.
+// NOTE: leaves `picker.open` to the caller — every call site must set it false
+// after activating, or the picker stays open over the now-attached session.
 fn activate_row(
     connection: &mut TmuxConnection,
     state: &mut ConnectionState,
@@ -888,24 +904,32 @@ const LINE_SCROLL_PX: f32 = 24.0;
 /// The logical-pixel `ScrollPosition` delta for one wheel event. The sign is
 /// inverted relative to the wheel `y` so that wheel-down (negative `y`) yields a
 /// positive delta — a larger `ScrollPosition.0.y` moves the content up, i.e. the
-/// viewport down. (Same structure as `tmux_inline_wheel_delta` but the opposite
-/// sign, because that path drives a terminal, not a scroll offset.)
-fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
+/// viewport down. `Pixel` deltas arrive in physical pixels and are scaled to
+/// logical px by `inverse_scale_factor`; `Line` notches are already a logical
+/// constant.
+fn wheel_delta_px(unit: MouseScrollUnit, y: f32, inverse_scale_factor: f32) -> f32 {
     match unit {
         MouseScrollUnit::Line => -y * LINE_SCROLL_PX,
-        MouseScrollUnit::Pixel => -y,
+        MouseScrollUnit::Pixel => -y * inverse_scale_factor,
     }
+}
+
+/// The maximum vertical scroll offset (logical px) of a scroll-container node:
+/// the content height that overflows the viewport, converted physical→logical.
+fn max_scroll_logical(node: &ComputedNode) -> f32 {
+    (node.content_size().y - node.size().y).max(0.0) * node.inverse_scale_factor
 }
 
 /// The new vertical scroll offset (logical px) that brings the row spanning
 /// `[row_top, row_top + row_h]` fully into a `viewport_h`-tall viewport currently
 /// scrolled to `current`. Scrolls up if the row is above the viewport, down if
-/// below, else unchanged; the result is clamped to `[0, max]`.
+/// below, else unchanged; a row taller than the viewport shows its top rather
+/// than its bottom. The result is clamped to `[0, max]`.
 fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32, max: f32) -> f32 {
     let target = if row_top < current {
         row_top
     } else if row_top + row_h > current + viewport_h {
-        row_top + row_h - viewport_h
+        (row_top + row_h - viewport_h).min(row_top)
     } else {
         current
     };
@@ -1193,6 +1217,27 @@ mod tests {
             1,
             "after the mouse moves, hover moves selection"
         );
+
+        // Close the picker, then reopen with the cursor still parked on the row.
+        // The reopen must re-disarm hover so the stationary cursor cannot hijack
+        // the keyboard's selection (regression: the open-edge Local froze when the
+        // system was gated by run_if(picker_is_open) and never ran while closed).
+        app.world_mut().resource_mut::<SessionPicker>().open = false;
+        app.update();
+        {
+            let mut picker = app.world_mut().resource_mut::<SessionPicker>();
+            picker.selected = 0;
+            picker.open = true;
+        }
+        app.world_mut().entity_mut(row).insert(Interaction::None);
+        app.update();
+        app.world_mut().entity_mut(row).insert(Interaction::Hovered);
+        app.update();
+        assert_eq!(
+            app.world().resource::<SessionPicker>().selected,
+            0,
+            "reopening with a stationary cursor must re-disarm hover (no hijack)"
+        );
     }
 
     #[test]
@@ -1224,19 +1269,26 @@ mod tests {
 
     #[test]
     fn wheel_line_delta_is_inverted_and_scaled_by_row_stride() {
+        // Line notches ignore the scale factor (LINE_SCROLL_PX is already logical).
         // Wheel up (y>0) scrolls content toward the top -> negative offset delta.
-        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, 1.0), -LINE_SCROLL_PX);
-        // Wheel down (y<0) -> positive offset delta.
         assert_eq!(
-            wheel_delta_px(MouseScrollUnit::Line, -2.0),
+            wheel_delta_px(MouseScrollUnit::Line, 1.0, 1.0),
+            -LINE_SCROLL_PX
+        );
+        // Wheel down (y<0) -> positive offset delta; scale factor is ignored.
+        assert_eq!(
+            wheel_delta_px(MouseScrollUnit::Line, -2.0, 2.0),
             2.0 * LINE_SCROLL_PX
         );
     }
 
     #[test]
-    fn wheel_pixel_delta_is_inverted_identity() {
-        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 5.0), -5.0);
-        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, -3.0), 3.0);
+    fn wheel_pixel_delta_is_inverted_and_scaled_to_logical() {
+        // At 1x the pixel delta is just inverted.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 5.0, 1.0), -5.0);
+        // On a 2x display (inverse_scale_factor 0.5) a 10-physical-px delta is
+        // 5 logical px.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 10.0, 0.5), -5.0);
     }
 
     #[test]
@@ -1261,6 +1313,13 @@ mod tests {
     fn reveal_clamps_to_zero_and_to_max() {
         assert_eq!(reveal_offset(-10.0, 20.0, 100.0, 5.0, 200.0), 0.0);
         assert_eq!(reveal_offset(180.0, 20.0, 100.0, 0.0, 50.0), 50.0);
+    }
+
+    #[test]
+    fn reveal_shows_top_of_a_row_taller_than_the_viewport() {
+        // A row taller than the viewport shows its top, not its bottom: when the
+        // row is below, clamp to row_top (120) rather than row_bottom - viewport.
+        assert_eq!(reveal_offset(120.0, 200.0, 100.0, 0.0, 500.0), 120.0);
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -62,6 +62,12 @@ impl Plugin for OzmuxPickerPlugin {
                 picker_row_hover_cursor
                     .after(crate::input::InputPhase::Hover)
                     .run_if(picker_is_open),
+            )
+            .add_systems(
+                Update,
+                handle_picker_scroll
+                    .run_if(on_message::<MouseWheel>)
+                    .run_if(picker_is_open),
             );
     }
 }
@@ -479,6 +485,29 @@ fn picker_row_hover_cursor(
     }
 }
 
+fn handle_picker_scroll(
+    mut list: Query<(&mut ScrollPosition, &ComputedNode), With<PickerList>>,
+    mut wheel: MessageReader<MouseWheel>,
+) {
+    let Ok((mut pos, node)) = list.single_mut() else {
+        wheel.clear();
+        return;
+    };
+    let mut delta = 0.0;
+    for ev in wheel.read() {
+        delta += wheel_delta_px(ev.unit, ev.y);
+    }
+    if delta == 0.0 {
+        return;
+    }
+    let inv = node.inverse_scale_factor;
+    let max = (node.content_size().y - node.size().y).max(0.0) * inv;
+    let next = (pos.0.y + delta).clamp(0.0, max);
+    if pos.0.y != next {
+        pos.0.y = next;
+    }
+}
+
 fn handle_picker_input(
     mut picker: ResMut<SessionPicker>,
     mut connection: NonSendMut<TmuxConnection>,
@@ -785,6 +814,22 @@ fn step_selection(selected: usize, entry_count: usize, up: bool) -> usize {
         selected + 1
     } else {
         selected
+    }
+}
+
+/// Logical pixels scrolled per wheel "line" notch. Roughly one row stride
+/// (row height ≈ 18px + 2px gap).
+const LINE_SCROLL_PX: f32 = 24.0;
+
+/// The logical-pixel `ScrollPosition` delta for one wheel event. The sign is
+/// inverted relative to the wheel `y` so that wheel-down (negative `y`) yields a
+/// positive delta — a larger `ScrollPosition.0.y` moves the content up, i.e. the
+/// viewport down. (Same structure as `tmux_inline_wheel_delta` but the opposite
+/// sign, because that path drives a terminal, not a scroll offset.)
+fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
+    match unit {
+        MouseScrollUnit::Line => -y * LINE_SCROLL_PX,
+        MouseScrollUnit::Pixel => -y,
     }
 }
 
@@ -1097,6 +1142,20 @@ mod tests {
         indices.sort_unstable();
         // build_rows([alpha], []) == [Session(0), NewSession] -> indices 0,1
         assert_eq!(indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn wheel_line_delta_is_inverted_and_scaled_by_row_stride() {
+        // Wheel up (y>0) scrolls content toward the top -> negative offset delta.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, 1.0), -LINE_SCROLL_PX);
+        // Wheel down (y<0) -> positive offset delta.
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, -2.0), 2.0 * LINE_SCROLL_PX);
+    }
+
+    #[test]
+    fn wheel_pixel_delta_is_inverted_identity() {
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 5.0), -5.0);
+        assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, -3.0), 3.0);
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -62,10 +62,7 @@ impl Plugin for OzmuxPickerPlugin {
                     .run_if(picker_is_open)
                     .run_if(resource_exists_and_changed::<SessionPicker>),
             )
-            .add_systems(
-                Update,
-                handle_picker_row_interaction.run_if(picker_is_open),
-            )
+            .add_systems(Update, handle_picker_row_interaction.run_if(picker_is_open))
             .add_systems(
                 Update,
                 picker_row_hover_cursor
@@ -522,7 +519,15 @@ fn handle_picker_scroll(
 // UiGlobalTransform center) and converts to logical via inverse_scale_factor,
 // because ScrollPosition is in logical px.
 fn scroll_selected_into_view(
-    mut list: Query<(&mut ScrollPosition, &ComputedNode, &UiGlobalTransform, &Children), With<PickerList>>,
+    mut list: Query<
+        (
+            &mut ScrollPosition,
+            &ComputedNode,
+            &UiGlobalTransform,
+            &Children,
+        ),
+        With<PickerList>,
+    >,
     rows: Query<(&ComputedNode, &UiGlobalTransform, &PickerRowLabel)>,
     picker: Res<SessionPicker>,
 ) {
@@ -1166,7 +1171,10 @@ mod tests {
         app.add_systems(Update, handle_picker_row_interaction);
 
         // A hovered row exists but the mouse has not moved since open: no change.
-        let row = app.world_mut().spawn((Interaction::Hovered, PickerRowLabel(1))).id();
+        let row = app
+            .world_mut()
+            .spawn((Interaction::Hovered, PickerRowLabel(1)))
+            .id();
         app.update();
         assert_eq!(
             app.world().resource::<SessionPicker>().selected,
@@ -1176,13 +1184,9 @@ mod tests {
 
         // Arm by moving the mouse, then re-trigger the hover change.
         app.world_mut().write_message(cursor_moved());
-        app.world_mut()
-            .entity_mut(row)
-            .insert(Interaction::None);
+        app.world_mut().entity_mut(row).insert(Interaction::None);
         app.update();
-        app.world_mut()
-            .entity_mut(row)
-            .insert(Interaction::Hovered);
+        app.world_mut().entity_mut(row).insert(Interaction::Hovered);
         app.update();
         assert_eq!(
             app.world().resource::<SessionPicker>().selected,
@@ -1223,7 +1227,10 @@ mod tests {
         // Wheel up (y>0) scrolls content toward the top -> negative offset delta.
         assert_eq!(wheel_delta_px(MouseScrollUnit::Line, 1.0), -LINE_SCROLL_PX);
         // Wheel down (y<0) -> positive offset delta.
-        assert_eq!(wheel_delta_px(MouseScrollUnit::Line, -2.0), 2.0 * LINE_SCROLL_PX);
+        assert_eq!(
+            wheel_delta_px(MouseScrollUnit::Line, -2.0),
+            2.0 * LINE_SCROLL_PX
+        );
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -56,6 +56,12 @@ impl Plugin for OzmuxPickerPlugin {
             .add_systems(
                 Update,
                 handle_picker_row_interaction.run_if(picker_is_open),
+            )
+            .add_systems(
+                Update,
+                picker_row_hover_cursor
+                    .after(crate::input::InputPhase::Hover)
+                    .run_if(picker_is_open),
             );
     }
 }
@@ -452,6 +458,24 @@ fn handle_picker_row_interaction(
             }
             Interaction::None => {}
         }
+    }
+}
+
+fn picker_row_hover_cursor(
+    mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
+    rows: Query<&Interaction, With<PickerRowLabel>>,
+) {
+    let hovering = rows
+        .iter()
+        .any(|i| matches!(i, Interaction::Hovered | Interaction::Pressed));
+    let Ok(mut icon) = cursor_icons.single_mut() else {
+        return;
+    };
+    let is_pointer = matches!(&*icon, CursorIcon::System(e) if *e == SystemCursorIcon::Pointer);
+    if hovering && !is_pointer {
+        *icon = CursorIcon::System(SystemCursorIcon::Pointer);
+    } else if !hovering && is_pointer {
+        *icon = CursorIcon::System(SystemCursorIcon::Default);
     }
 }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -51,7 +51,16 @@ impl Plugin for OzmuxPickerPlugin {
             )
             .add_systems(
                 PostUpdate,
-                sync_picker_ui.run_if(resource_exists_and_changed::<SessionPicker>),
+                sync_picker_ui
+                    .before(UiSystems::Layout)
+                    .run_if(resource_exists_and_changed::<SessionPicker>),
+            )
+            .add_systems(
+                PostUpdate,
+                scroll_selected_into_view
+                    .after(UiSystems::Layout)
+                    .run_if(picker_is_open)
+                    .run_if(resource_exists_and_changed::<SessionPicker>),
             )
             .add_systems(
                 Update,
@@ -508,6 +517,56 @@ fn handle_picker_scroll(
     }
 }
 
+// NOTE: writes ScrollPosition after UiSystems::Layout, so the correction lands on
+// the next frame's render. Reads physical-px geometry (ComputedNode size +
+// UiGlobalTransform center) and converts to logical via inverse_scale_factor,
+// because ScrollPosition is in logical px.
+fn scroll_selected_into_view(
+    mut list: Query<(&mut ScrollPosition, &ComputedNode, &UiGlobalTransform, &Children), With<PickerList>>,
+    rows: Query<(&ComputedNode, &UiGlobalTransform, &PickerRowLabel)>,
+    picker: Res<SessionPicker>,
+) {
+    let Ok((mut pos, list_node, list_tf, children)) = list.single_mut() else {
+        return;
+    };
+    let viewport_h_phys = list_node.size().y;
+    if viewport_h_phys <= 0.0 {
+        return;
+    }
+
+    let mut selected: Option<(f32, f32)> = None;
+    for child in children.iter() {
+        let Ok((row_node, row_tf, label)) = rows.get(child) else {
+            continue;
+        };
+        if label.0 == picker.selected {
+            let h = row_node.size().y;
+            let top = row_tf.translation.y - h / 2.0;
+            selected = Some((top, h));
+            break;
+        }
+    }
+    let Some((row_top_global, row_h_phys)) = selected else {
+        return;
+    };
+    if row_h_phys <= 0.0 {
+        return;
+    }
+
+    let inv = list_node.inverse_scale_factor;
+    let list_top_global = list_tf.translation.y - viewport_h_phys / 2.0;
+    let current = pos.0.y;
+    let row_top = current + (row_top_global - list_top_global) * inv;
+    let row_h = row_h_phys * inv;
+    let viewport_h = viewport_h_phys * inv;
+    let max = (list_node.content_size().y - viewport_h_phys).max(0.0) * inv;
+
+    let next = reveal_offset(row_top, row_h, viewport_h, current, max);
+    if pos.0.y != next {
+        pos.0.y = next;
+    }
+}
+
 fn handle_picker_input(
     mut picker: ResMut<SessionPicker>,
     mut connection: NonSendMut<TmuxConnection>,
@@ -833,6 +892,21 @@ fn wheel_delta_px(unit: MouseScrollUnit, y: f32) -> f32 {
     }
 }
 
+/// The new vertical scroll offset (logical px) that brings the row spanning
+/// `[row_top, row_top + row_h]` fully into a `viewport_h`-tall viewport currently
+/// scrolled to `current`. Scrolls up if the row is above the viewport, down if
+/// below, else unchanged; the result is clamped to `[0, max]`.
+fn reveal_offset(row_top: f32, row_h: f32, viewport_h: f32, current: f32, max: f32) -> f32 {
+    let target = if row_top < current {
+        row_top
+    } else if row_top + row_h > current + viewport_h {
+        row_top + row_h - viewport_h
+    } else {
+        current
+    };
+    target.clamp(0.0, max.max(0.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1156,6 +1230,30 @@ mod tests {
     fn wheel_pixel_delta_is_inverted_identity() {
         assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, 5.0), -5.0);
         assert_eq!(wheel_delta_px(MouseScrollUnit::Pixel, -3.0), 3.0);
+    }
+
+    #[test]
+    fn reveal_leaves_a_fully_visible_row_unchanged() {
+        // row [40,60] inside viewport [30,130]: unchanged.
+        assert_eq!(reveal_offset(40.0, 20.0, 100.0, 30.0, 200.0), 30.0);
+    }
+
+    #[test]
+    fn reveal_scrolls_up_so_row_top_is_flush() {
+        // row top 10 is above current 50: offset becomes 10.
+        assert_eq!(reveal_offset(10.0, 20.0, 100.0, 50.0, 200.0), 10.0);
+    }
+
+    #[test]
+    fn reveal_scrolls_down_so_row_bottom_is_flush() {
+        // row [180,200], viewport height 100, current 0: 200 - 100 = 100.
+        assert_eq!(reveal_offset(180.0, 20.0, 100.0, 0.0, 200.0), 100.0);
+    }
+
+    #[test]
+    fn reveal_clamps_to_zero_and_to_max() {
+        assert_eq!(reveal_offset(-10.0, 20.0, 100.0, 5.0, 200.0), 0.0);
+        assert_eq!(reveal_offset(180.0, 20.0, 100.0, 0.0, 50.0), 50.0);
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -10,7 +10,10 @@ use bevy::ecs::message::MessageReader;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists_and_changed};
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;
+use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
+use bevy::ui::{ComputedNode, ScrollPosition, UiGlobalTransform, UiSystems};
+use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon};
 use ozmux_configs::StartupMode;
 use ozmux_tmux::{
     AttachTarget, ConnectionState, TmuxConnection, attach_or_create, select_attach_target,
@@ -84,7 +87,7 @@ struct PickerBackdrop;
 struct PickerList;
 
 #[derive(Component)]
-struct PickerRowLabel;
+struct PickerRowLabel(usize);
 
 fn build_rows(sessions: &[SessionInfo], windows: &[WindowEntry]) -> Vec<PickerRow> {
     let mut rows = Vec::new();
@@ -227,6 +230,7 @@ fn spawn_picker_ui(mut commands: Commands) {
                         flex_direction: FlexDirection::Column,
                         align_items: AlignItems::Stretch,
                         min_width: Val::Px(360.0),
+                        max_height: Val::Vh(65.0),
                         padding: UiRect::axes(Val::Px(20.0), Val::Px(16.0)),
                         row_gap: Val::Px(10.0),
                         border: UiRect::all(Val::Px(1.0)),
@@ -250,8 +254,12 @@ fn spawn_picker_ui(mut commands: Commands) {
                             flex_direction: FlexDirection::Column,
                             width: Val::Percent(100.0),
                             row_gap: Val::Px(2.0),
+                            flex_grow: 1.0,
+                            min_height: Val::Px(0.0),
+                            overflow: Overflow::scroll_y(),
                             ..default()
                         },
+                        ScrollPosition::default(),
                         PickerList,
                     ));
                     panel.spawn((
@@ -363,8 +371,9 @@ fn sync_picker_ui(
     } else {
         commands.entity(list_entity).despawn_related::<Children>();
         commands.entity(list_entity).with_children(|parent| {
-            for (label, text_color, bar_color) in visuals {
+            for (i, (label, text_color, bar_color)) in visuals.into_iter().enumerate() {
                 parent.spawn((
+                    Button,
                     Node {
                         width: Val::Percent(100.0),
                         padding: UiRect::axes(Val::Px(8.0), Val::Px(2.0)),
@@ -378,7 +387,7 @@ fn sync_picker_ui(
                         font_size: 14.0,
                         ..default()
                     },
-                    PickerRowLabel,
+                    PickerRowLabel(i),
                 ));
             }
         });
@@ -909,6 +918,33 @@ mod tests {
             *app.world().resource::<State<AppMode>>().get(),
             AppMode::Ozmux
         );
+    }
+
+    #[test]
+    fn rows_spawn_as_buttons_carrying_their_index() {
+        let mut app = App::new();
+        app.insert_resource(SessionPicker {
+            sessions: vec![fake_session(0, "alpha")],
+            windows: vec![],
+            selected: 0,
+            open: true,
+            last_open: true,
+        });
+        app.add_systems(Startup, spawn_picker_ui);
+        app.add_systems(Update, sync_picker_ui);
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<(&PickerRowLabel, Option<&Button>), With<PickerRowLabel>>();
+        let mut indices: Vec<usize> = Vec::new();
+        for (label, button) in q.iter(app.world()) {
+            assert!(button.is_some(), "every picker row must carry Button");
+            indices.push(label.0);
+        }
+        indices.sort_unstable();
+        // build_rows([alpha], []) == [Session(0), NewSession] -> indices 0,1
+        assert_eq!(indices, vec![0, 1]);
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -35,46 +35,45 @@ impl Plugin for OzmuxPickerPlugin {
                 OnEnter(AppMode::Ozmux),
                 dispatch_startup_mode.run_if(not(resource_exists::<StartupDispatched>)),
             )
-            .add_systems(Update, handle_picker_input.after(InputPhase::FocusedKey))
-            .add_systems(Update, refresh_picker_on_open)
             .add_systems(
                 Update,
-                refresh_session_ozmux_sock
-                    .run_if(resource_exists_and_changed::<ConnectionState>)
-                    .in_set(crate::tmux::OzmuxActiveSet),
+                (
+                    handle_picker_input.after(InputPhase::FocusedKey),
+                    refresh_picker_on_open,
+                    refresh_session_ozmux_sock
+                        .run_if(resource_exists_and_changed::<ConnectionState>)
+                        .in_set(crate::tmux::OzmuxActiveSet),
+                    // NOTE: handle_picker_row_interaction and picker_row_hover_cursor
+                    // are deliberately NOT gated by run_if(picker_is_open): both must
+                    // observe the picker's closed state to reset per-open state
+                    // (re-disarm hover, and revert the pointer cursor on the click
+                    // that closes the picker); gated off while closed, that reset
+                    // never runs.
+                    handle_picker_row_interaction,
+                    picker_row_hover_cursor.after(InputPhase::Hover),
+                    handle_picker_scroll
+                        .run_if(on_message::<MouseWheel>)
+                        .run_if(picker_is_open),
+                ),
+            )
+            .add_systems(
+                PostUpdate,
+                (
+                    sync_picker_ui
+                        .before(UiSystems::Layout)
+                        .run_if(resource_exists_and_changed::<SessionPicker>),
+                    scroll_selected_into_view
+                        .after(UiSystems::Layout)
+                        .run_if(picker_is_open)
+                        .run_if(
+                            resource_exists_and_changed::<SessionPicker>
+                                .or(on_message::<WindowResized>),
+                        ),
+                ),
             )
             .add_systems(
                 Last,
                 cleanup_session_ozmux_sock.run_if(on_message::<AppExit>),
-            )
-            .add_systems(
-                PostUpdate,
-                sync_picker_ui
-                    .before(UiSystems::Layout)
-                    .run_if(resource_exists_and_changed::<SessionPicker>),
-            )
-            .add_systems(
-                PostUpdate,
-                scroll_selected_into_view
-                    .after(UiSystems::Layout)
-                    .run_if(picker_is_open)
-                    .run_if(
-                        resource_exists_and_changed::<SessionPicker>
-                            .or(on_message::<WindowResized>),
-                    ),
-            )
-            // NOTE: handle_picker_row_interaction and picker_row_hover_cursor are
-            // deliberately NOT gated by run_if(picker_is_open): both must observe
-            // the picker's closed state to reset per-open state (re-disarm hover,
-            // and revert the pointer cursor on the click that closes the picker);
-            // gated off while closed, that reset never runs.
-            .add_systems(Update, handle_picker_row_interaction)
-            .add_systems(Update, picker_row_hover_cursor.after(InputPhase::Hover))
-            .add_systems(
-                Update,
-                handle_picker_scroll
-                    .run_if(on_message::<MouseWheel>)
-                    .run_if(picker_is_open),
             );
     }
 }


### PR DESCRIPTION
## Problem

The startup tmux session picker is keyboard-only: sessions and windows can only be navigated with `↑↓`/`jk` and opened with `Enter`. The mouse does nothing, and the row list has no height cap, so it overflows the window once there are more sessions/windows than fit on screen.

## Solution

Adds full mouse support to the session picker. All production changes are in `src/picker.rs` (UI/engine); the design spec and implementation plan live under `docs/superpowers/`.

- **Click a row → open it** (attach / switch / new session) — the mouse equivalent of `Enter`. The keyboard `Enter` arm was extracted into a shared `activate_row` helper so the two paths can't diverge.
- **Hover a row → moves the selection highlight**, and a pointer cursor marks rows as clickable. Hover only takes over *after the mouse moves* following an open, so opening with the cursor already parked over a row keeps the keyboard's default selection.
- **Wheel-scroll for long lists**: the list becomes a height-capped (~65vh) `Overflow::scroll_y()` container; the wheel scrolls it (self-clamped, HiDPI-aware), and keyboard navigation auto-scrolls the selected row back into view (and re-centers on window resize).

Click and hover share one `Changed<Interaction>` system; the scroll math is factored into unit-tested pure helpers (`wheel_delta_px`, `reveal_offset`, `max_scroll_logical`) with the physical→logical (`inverse_scale_factor`) conversion isolated. No changes outside `src/picker.rs`.

### Process & verification

Built via brainstorming → spec-review (Codex + Claude, two breaking Bevy-0.18.1 API errors caught) → writing-plans → subagent-driven implementation (7 tasks, per-task + whole-branch review) → `/code-review max` (multi-agent verified). The deeper review caught two correctness bugs the earlier reviews missed — both from `run_if(picker_is_open)` freezing system `Local` state while the picker was closed (a hover-arming hijack on reopen, and a stuck pointer cursor after a click-close) — now fixed and regression-tested.

`cargo build`, `clippy`, `fmt` clean; **366/366 tests pass**.

<details><summary>Screenshots</summary>

Pending the manual GUI smoke test (requires a live display + a tmux server with enough sessions to overflow the list) — not yet run in this environment.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
