### PR TITLE
refactor(ratatui-ozma): rename Webview::passthrough → forward_keys

### DIFF
--- a/apps/ozbrowser/src/main.rs
+++ b/apps/ozbrowser/src/main.rs
@@ -112,7 +112,7 @@ fn event_loop(
 // unregistered — the old handle is dropped but the server-side entry persists because the
 // SDK has no unregister/Drop path yet. Fix this when the SDK exposes one.
 fn register_view(ozma: &Ozma, url: &str, url_tx: Sender<String>) -> anyhow::Result<WebviewHandle> {
-    let pass = [
+    let forward = [
         KeyChord {
             mods: KeyModifiers::NONE,
             code: KeyCode::Esc,
@@ -198,15 +198,20 @@ fn register_view(ozma: &Ozma, url: &str, url_tx: Sender<String>) -> anyhow::Resu
             code: KeyCode::Char('c'),
         },
     ];
-    let view = ozma.register(Webview::url(url).interactive(true).passthrough(pass).on(
-        "urlChanged",
-        move |args: serde_json::Value| -> Result<(), RpcError> {
-            if let Some(u) = args["url"].as_str() {
-                let _ = url_tx.send(u.to_owned());
-            }
-            Ok(())
-        },
-    ))?;
+    let view = ozma.register(
+        Webview::url(url)
+            .interactive(true)
+            .forward_keys(forward)
+            .on(
+                "urlChanged",
+                move |args: serde_json::Value| -> Result<(), RpcError> {
+                    if let Some(u) = args["url"].as_str() {
+                        let _ = url_tx.send(u.to_owned());
+                    }
+                    Ok(())
+                },
+            ),
+    )?;
     Ok(view)
 }
 

--- a/sdk/ratatui-ozma/examples/focus_grid.rs
+++ b/sdk/ratatui-ozma/examples/focus_grid.rs
@@ -4,7 +4,7 @@
 //!
 //! A 2x2 grid — two native panels (NW, SE) and two webviews (NE, SW). The app
 //! OWNS focus in a `focused` string and moves it spatially with `Alt+h/j/k/l`.
-//! The webview cells declare those chords as PASSTHROUGH, so the host forwards
+//! The webview cells declare those chords as FORWARD-KEYS, so the host forwards
 //! them to the PTY (reaching plain `event::read`) and suppresses them from the
 //! page even while a webview is focused — that is how focus can leave a focused
 //! webview. `WebviewWidget::focused` reports focus to the SDK; the `OzmaBackend`
@@ -63,9 +63,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     ];
     let ne =
-        ozma.register(Webview::inline(webview_html("NE webview", "#8be9fd")).passthrough(nav))?;
+        ozma.register(Webview::inline(webview_html("NE webview", "#8be9fd")).forward_keys(nav))?;
     let sw =
-        ozma.register(Webview::inline(webview_html("SW webview", "#bd93f9")).passthrough(nav))?;
+        ozma.register(Webview::inline(webview_html("SW webview", "#bd93f9")).forward_keys(nav))?;
 
     enable_raw_mode()?;
     if let Err(e) = execute!(stdout(), EnterAlternateScreen) {

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -3,7 +3,7 @@
 //! Renders a webview and a native status line. The app OWNS focus in a simple
 //! `web_focused` bool: `Alt+l` focuses the webview, `Alt+h` returns focus to the
 //! app, and `q` quits while the app is focused. `Alt+h`/`Alt+l` are declared as
-//! passthrough chords, so the host forwards them to the PTY (reaching plain
+//! forward-key chords, so the host forwards them to the PTY (reaching plain
 //! `event::read`) and suppresses them from the page even while the webview is
 //! focused. `WebviewWidget::focused` tells the SDK the current focus; the
 //! `OzmaBackend` wrapping the terminal emits the control-plane focus op on change.
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let view = ozma.register(
         Webview::inline(html)
-            .passthrough([
+            .forward_keys([
                 KeyChord {
                     mods: KeyModifiers::ALT,
                     code: KeyCode::Char('h'),

--- a/sdk/ratatui-ozma/src/keychord.rs
+++ b/sdk/ratatui-ozma/src/keychord.rs
@@ -1,4 +1,4 @@
-//! A keyboard chord declared as passthrough for a webview (crossterm-typed).
+//! A keyboard chord declared as a forward-key for a webview (crossterm-typed).
 
 use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 use serde::Serialize;

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -55,7 +55,7 @@ pub(crate) enum RegisterKind {
         interactive: bool,
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        passthrough: Vec<KeyChord>,
+        forward_keys: Vec<KeyChord>,
     },
     /// A directory of assets served at `ozma-dyn://<handle>/`.
     Dir {
@@ -67,7 +67,7 @@ pub(crate) enum RegisterKind {
         interactive: bool,
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        passthrough: Vec<KeyChord>,
+        forward_keys: Vec<KeyChord>,
     },
     /// Load a remote `http(s)` URL as the top-level document.
     Url {
@@ -79,7 +79,7 @@ pub(crate) enum RegisterKind {
         bridge: bool,
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        passthrough: Vec<KeyChord>,
+        forward_keys: Vec<KeyChord>,
     },
 }
 
@@ -151,7 +151,7 @@ mod tests {
         let v = serde_json::to_value(ClientMsg::Register(RegisterKind::Inline {
             html: "<h1>hi</h1>".into(),
             interactive: true,
-            passthrough: Vec::new(),
+            forward_keys: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["op"], "register");
@@ -244,7 +244,7 @@ mod tests {
             url: "https://example.com".into(),
             interactive: true,
             bridge: false,
-            passthrough: Vec::new(),
+            forward_keys: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["op"], "register");
@@ -253,8 +253,8 @@ mod tests {
         assert_eq!(v["interactive"], true);
         assert_eq!(v["bridge"], false);
         assert!(
-            v.get("passthrough").is_none(),
-            "empty passthrough must be skipped"
+            v.get("forward_keys").is_none(),
+            "empty forward_keys must be skipped"
         );
     }
 
@@ -264,7 +264,7 @@ mod tests {
             url: "https://app.example.com".into(),
             interactive: true,
             bridge: true,
-            passthrough: Vec::new(),
+            forward_keys: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["kind"], "url");

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -28,7 +28,7 @@ impl Webview {
             kind: RegisterKind::Inline {
                 html: html.into(),
                 interactive: true,
-                passthrough: Vec::new(),
+                forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -45,7 +45,7 @@ impl Webview {
                 url: url.into(),
                 interactive: true,
                 bridge: false,
-                passthrough: Vec::new(),
+                forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -58,7 +58,7 @@ impl Webview {
                 root: root.as_ref().display().to_string(),
                 entry: entry.into(),
                 interactive: true,
-                passthrough: Vec::new(),
+                forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -85,11 +85,11 @@ impl Webview {
 
     /// Declares chords the page lets through to the app while focused (the host
     /// forwards them to the PTY so the app reads them via `crossterm::event::read`).
-    pub fn passthrough(mut self, keys: impl IntoIterator<Item = KeyChord>) -> Self {
+    pub fn forward_keys(mut self, keys: impl IntoIterator<Item = KeyChord>) -> Self {
         match &mut self.kind {
-            RegisterKind::Inline { passthrough, .. }
-            | RegisterKind::Dir { passthrough, .. }
-            | RegisterKind::Url { passthrough, .. } => passthrough.extend(keys),
+            RegisterKind::Inline { forward_keys, .. }
+            | RegisterKind::Dir { forward_keys, .. }
+            | RegisterKind::Url { forward_keys, .. } => forward_keys.extend(keys),
         }
         self
     }
@@ -214,25 +214,25 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_rides_register_wire() {
+    fn forward_keys_rides_register_wire() {
         use ratatui::crossterm::event::{KeyCode, KeyModifiers};
-        let wv = Webview::inline("x").passthrough([KeyChord {
+        let wv = Webview::inline("x").forward_keys([KeyChord {
             mods: KeyModifiers::ALT,
             code: KeyCode::Char('h'),
         }]);
         let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
         assert_eq!(v["op"], "register");
-        assert_eq!(v["passthrough"][0]["key"], "h");
-        assert_eq!(v["passthrough"][0]["mods"][0], "alt");
+        assert_eq!(v["forward_keys"][0]["key"], "h");
+        assert_eq!(v["forward_keys"][0]["mods"][0], "alt");
     }
 
     #[test]
-    fn empty_passthrough_is_omitted_from_wire() {
+    fn empty_forward_keys_is_omitted_from_wire() {
         let wv = Webview::inline("x");
         let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
         assert!(
-            v.get("passthrough").is_none(),
-            "empty passthrough must be skipped"
+            v.get("forward_keys").is_none(),
+            "empty forward_keys must be skipped"
         );
     }
 
@@ -276,15 +276,15 @@ mod tests {
     }
 
     #[test]
-    fn url_passthrough_rides_register_wire() {
+    fn url_forward_keys_rides_register_wire() {
         use ratatui::crossterm::event::{KeyCode, KeyModifiers};
-        let wv = Webview::url("https://example.com").passthrough([KeyChord {
+        let wv = Webview::url("https://example.com").forward_keys([KeyChord {
             mods: KeyModifiers::ALT,
             code: KeyCode::Char('h'),
         }]);
         let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
         assert_eq!(v["kind"], "url");
-        assert_eq!(v["passthrough"][0]["key"], "h");
+        assert_eq!(v["forward_keys"][0]["key"], "h");
     }
 
     #[test]

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -25,7 +25,7 @@ mod protocol;
 
 pub(crate) use protocol::PushMsg;
 
-/// A passthrough chord normalized to host input types: a bevy `KeyCode` plus
+/// A forward-key chord normalized to host input types: a bevy `KeyCode` plus
 /// modifier booleans. Used to suppress CEF double-delivery and to match keys
 /// for PTY forwarding (design spec §E type normalization).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,10 +90,10 @@ pub(crate) struct DynamicView {
     pub(crate) owner_surface: Entity,
     /// The control-plane connection that registered it.
     pub(crate) connection_id: u64,
-    /// The normalized passthrough chords for this view, derived from the
+    /// The normalized forward-key chords for this view, derived from the
     /// `register` wire payload. Copied onto the mounted webview entity as
-    /// `PassthroughKeys` so Phase-4 systems can read them off the focused child.
-    pub(crate) passthrough: Vec<NormalizedChord>,
+    /// `ForwardKeys` so Phase-4 systems can read them off the focused child.
+    pub(crate) forward_keys: Vec<NormalizedChord>,
 }
 
 /// Stamped on a Tier 1 inline webview entity at mount: the control-plane
@@ -588,7 +588,7 @@ fn build_view(
             root,
             entry,
             interactive,
-            passthrough,
+            forward_keys,
         } => {
             let root_path = PathBuf::from(&root);
             if !root_path.is_absolute() || !root_path.is_dir() {
@@ -603,13 +603,13 @@ fn build_view(
                 interactive,
                 owner_surface,
                 connection_id,
-                passthrough: passthrough.iter().filter_map(normalize_chord).collect(),
+                forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
             })
         }
         RegisterKind::Inline {
             html,
             interactive,
-            passthrough,
+            forward_keys,
         } => {
             if html.len() > MAX_INLINE_HTML {
                 return Err("html_too_large");
@@ -620,14 +620,14 @@ fn build_view(
                 interactive,
                 owner_surface,
                 connection_id,
-                passthrough: passthrough.iter().filter_map(normalize_chord).collect(),
+                forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
             })
         }
         RegisterKind::Url {
             url,
             interactive,
             bridge,
-            passthrough,
+            forward_keys,
         } => {
             let url = validate_url_source(&url)?;
             Ok(DynamicView {
@@ -636,7 +636,7 @@ fn build_view(
                 interactive,
                 owner_surface,
                 connection_id,
-                passthrough: passthrough.iter().filter_map(normalize_chord).collect(),
+                forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
             })
         }
     }
@@ -672,7 +672,7 @@ fn validate_url_source(url: &str) -> Result<String, &'static str> {
 /// Converts a wire [`HostKeyChord`] to a [`NormalizedChord`], returning `None`
 /// for unrecognized key names. Note that `"backtab"` maps to [`KeyCode::Tab`]
 /// (the same as `"tab"`): the shift distinction is carried in the modifier bits,
-/// so a passthrough `BackTab` and `Tab` are indistinguishable at the host.
+/// so a forward-key `BackTab` and `Tab` are indistinguishable at the host.
 fn normalize_chord(chord: &HostKeyChord) -> Option<NormalizedChord> {
     let code = match chord.key.as_str() {
         "tab" | "backtab" => KeyCode::Tab,
@@ -858,7 +858,7 @@ mod token_tests {
                 interactive: true,
                 owner_surface: pane,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         dyn_assets.insert_dir("h", "/x".into());
@@ -901,7 +901,7 @@ mod registry_tests {
                 interactive: true,
                 owner_surface: surface(1),
                 connection_id: 7,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         assert_eq!(reg.get("h1").map(|v| v.interactive), Some(true));
@@ -948,7 +948,7 @@ mod registry_tests {
             interactive: true,
             owner_surface: owner,
             connection_id: conn,
-            passthrough: vec![],
+            forward_keys: vec![],
         }
     }
 }
@@ -979,7 +979,7 @@ mod apply_tests {
                     root: dir.path().to_string_lossy().into_owned(),
                     entry: "index.html".into(),
                     interactive: true,
-                    passthrough: vec![],
+                    forward_keys: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1024,7 +1024,7 @@ mod apply_tests {
                 kind: RegisterKind::Inline {
                     html: "<h1>x</h1>".into(),
                     interactive: true,
-                    passthrough: vec![],
+                    forward_keys: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1061,7 +1061,7 @@ mod apply_tests {
                     root: "/nonexistent/abs/xyz".into(),
                     entry: "index.html".into(),
                     interactive: true,
-                    passthrough: vec![],
+                    forward_keys: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1087,7 +1087,7 @@ mod apply_tests {
                 interactive: true,
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         dyn_assets.insert_dir("h", "/x".into());
@@ -1130,7 +1130,7 @@ mod apply_tests {
                 interactive: true,
                 owner_surface: Entity::from_bits(1),
                 connection_id: 9,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
@@ -1274,7 +1274,7 @@ mod apply_tests {
                 interactive: true,
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         app.world_mut().spawn(InlineWebview {
@@ -1328,7 +1328,7 @@ mod apply_tests {
                     url: "https://example.com".into(),
                     interactive: true,
                     bridge: false,
-                    passthrough: vec![],
+                    forward_keys: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1366,7 +1366,7 @@ mod apply_tests {
                 interactive: true,
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         let mounted = app
@@ -1444,7 +1444,7 @@ mod focus_tests {
                 interactive: true,
                 owner_surface: surface,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         let child = app
@@ -1508,7 +1508,7 @@ mod focus_tests {
                 interactive: true,
                 owner_surface: surface,
                 connection_id: 99,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         // Spawn a VALID interactive inline child that WOULD be focused if the
@@ -1564,7 +1564,7 @@ mod focus_tests {
                 interactive: true,
                 owner_surface: surface_a,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         // Spawn the matching interactive inline child on surface_a.
@@ -1675,7 +1675,7 @@ mod focus_tests {
                 interactive: true,
                 owner_surface: surface,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         let child = app
@@ -1816,7 +1816,7 @@ mod normalize_tests {
     }
 
     #[test]
-    fn normalize_chord_maps_passthrough_keys() {
+    fn normalize_chord_maps_forward_keys_keys() {
         let cases: &[(&str, KeyCode)] = &[
             ("esc", KeyCode::Escape),
             (" ", KeyCode::Space),
@@ -1898,7 +1898,7 @@ mod url_source_tests {
                 url: "https://example.com".into(),
                 interactive: true,
                 bridge: true,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
             Entity::from_bits(1),
             7,
@@ -1917,7 +1917,7 @@ mod url_source_tests {
                 url: "file:///etc/passwd".into(),
                 interactive: true,
                 bridge: false,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
             Entity::from_bits(1),
             7,

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -59,7 +59,7 @@ pub(crate) enum ClientMsg {
     },
 }
 
-/// A passthrough chord as received on the register wire (host side).
+/// A forward-key chord as received on the register wire (host side).
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct HostKeyChord {
     /// Modifier names: any of `alt`, `ctrl`, `shift`, `meta`.
@@ -83,7 +83,7 @@ pub(crate) enum RegisterKind {
         interactive: bool,
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
-        passthrough: Vec<HostKeyChord>,
+        forward_keys: Vec<HostKeyChord>,
     },
     /// Serve a single dynamic HTML document supplied inline.
     Inline {
@@ -94,7 +94,7 @@ pub(crate) enum RegisterKind {
         interactive: bool,
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
-        passthrough: Vec<HostKeyChord>,
+        forward_keys: Vec<HostKeyChord>,
     },
     /// Load a remote `http(s)` URL as the top-level document.
     Url {
@@ -108,7 +108,7 @@ pub(crate) enum RegisterKind {
         bridge: bool,
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
-        passthrough: Vec<HostKeyChord>,
+        forward_keys: Vec<HostKeyChord>,
     },
 }
 
@@ -191,7 +191,7 @@ mod tests {
                 root: "/abs".into(),
                 entry: "index.html".into(),
                 interactive: true,
-                passthrough: vec![],
+                forward_keys: vec![],
             })
         );
     }
@@ -207,7 +207,7 @@ mod tests {
             ClientMsg::Register(RegisterKind::Inline {
                 html: "<h1>x</h1>".into(),
                 interactive: false,
-                passthrough: vec![],
+                forward_keys: vec![],
             })
         );
     }
@@ -296,16 +296,16 @@ mod tests {
     }
 
     #[test]
-    fn parses_register_with_passthrough() {
+    fn parses_register_with_forward_keys() {
         let m: ClientMsg = serde_json::from_str(
-            r#"{"op":"register","kind":"inline","html":"x","passthrough":[{"mods":["alt"],"key":"h"}]}"#,
+            r#"{"op":"register","kind":"inline","html":"x","forward_keys":[{"mods":["alt"],"key":"h"}]}"#,
         )
         .unwrap();
         match m {
-            ClientMsg::Register(RegisterKind::Inline { passthrough, .. }) => {
-                assert_eq!(passthrough.len(), 1);
-                assert_eq!(passthrough[0].key, "h");
-                assert_eq!(passthrough[0].mods, vec!["alt".to_string()]);
+            ClientMsg::Register(RegisterKind::Inline { forward_keys, .. }) => {
+                assert_eq!(forward_keys.len(), 1);
+                assert_eq!(forward_keys[0].key, "h");
+                assert_eq!(forward_keys[0].mods, vec!["alt".to_string()]);
             }
             _ => panic!("expected inline register"),
         }
@@ -322,7 +322,7 @@ mod tests {
                 url: "https://example.com".into(),
                 interactive: true,
                 bridge: false,
-                passthrough: vec![],
+                forward_keys: vec![],
             })
         );
     }
@@ -339,7 +339,7 @@ mod tests {
                 url: "https://app.example.com".into(),
                 interactive: true,
                 bridge: true,
-                passthrough: vec![],
+                forward_keys: vec![],
             })
         );
     }
@@ -354,7 +354,7 @@ mod tests {
                 url: "https://example.com".into(),
                 interactive: true,
                 bridge: false,
-                passthrough: vec![],
+                forward_keys: vec![],
             })
         );
     }

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -19,7 +19,7 @@ use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
 use crate::ui::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
-use crate::webview::inline::{InlineWebview, PassthroughKeys, focused_inline_of, inline_hit_at};
+use crate::webview::inline::{ForwardKeys, InlineWebview, focused_inline_of, inline_hit_at};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -136,7 +136,7 @@ fn forward_keys_to_tmux(
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     copy_modes: Query<(), With<CopyModeState>>,
     windows: Query<&Window, With<PrimaryWindow>>,
-    passthrough_keys: Query<&PassthroughKeys>,
+    forward_keys: Query<&ForwardKeys>,
 ) {
     // NOTE: while the picker is open it owns the keyboard; forwarding would
     // leak picker-navigation keys to the active tmux pane. Drain (don't replay).
@@ -213,12 +213,12 @@ fn forward_keys_to_tmux(
     // so this drain is load-bearing whenever an inline webview is focused —
     // removing it would double-send keystrokes to the page and the pane.
     if let Some(focused_entity) = focused_webview.0 {
-        let pass_chords = passthrough_keys
+        let forward_chords = forward_keys
             .get(focused_entity)
             .map(|pk| pk.0.as_slice())
             .unwrap_or(&[]);
 
-        let mut pass_names: Vec<String> = Vec::new();
+        let mut forward_names: Vec<String> = Vec::new();
         for ev in events.read() {
             if ev.state != ButtonState::Pressed {
                 continue;
@@ -227,8 +227,8 @@ fn forward_keys_to_tmux(
                 focused_webview.0 = None;
                 break;
             }
-            if !pass_chords.is_empty()
-                && pass_chords.iter().any(|c| {
+            if !forward_chords.is_empty()
+                && forward_chords.iter().any(|c| {
                     c.code == ev.key_code
                         && c.ctrl == mods.ctrl
                         && c.shift == mods.shift
@@ -237,12 +237,12 @@ fn forward_keys_to_tmux(
                 })
                 && let Some(name) = bevy_key_to_tmux_name(&ev.logical_key, ev.key_code, mods)
             {
-                pass_names.push(name);
+                forward_names.push(name);
             }
         }
 
-        if !pass_names.is_empty() {
-            let actions = plan_forward(&mut prefix_pending, &bindings, pass_names);
+        if !forward_names.is_empty() {
+            let actions = plan_forward(&mut prefix_pending, &bindings, forward_names);
             if let (Some(target), Some(client)) = (target.as_deref(), connection.client()) {
                 let handle = client.handle();
                 for action in actions {
@@ -251,7 +251,7 @@ fn forward_keys_to_tmux(
                         Forwarded::Keys(names) => send_pane_keys_command(target, &names),
                     };
                     if let Err(e) = handle.send(&cmd) {
-                        tracing::warn!(?e, "passthrough forward failed");
+                        tracing::warn!(?e, "forward-key send failed");
                         break;
                     }
                 }

--- a/src/webview/inline.rs
+++ b/src/webview/inline.rs
@@ -24,11 +24,11 @@ use ozma_tty_renderer::material::{TerminalMaterialSystems, TerminalUiMaterial};
 use ozma_tty_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
 use ozma_tty_renderer::schema::TerminalGrid;
 
-/// The normalized passthrough chords for a mounted inline webview, copied from
+/// The normalized forward-key chords for a mounted inline webview, copied from
 /// its registration. Read by the focused-key filter-fill and PTY-forward
 /// systems (Phase 4) off the focused child entity.
 #[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct PassthroughKeys(pub(crate) Vec<NormalizedChord>);
+pub(crate) struct ForwardKeys(pub(crate) Vec<NormalizedChord>);
 
 /// Marks an inline webview entity and records its identity: the mounted
 /// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
@@ -154,10 +154,10 @@ pub(crate) struct ResolvedWebviewMount {
     /// the registration is bridged; a display-only `Url` view leaves it `None`,
     /// which is the gate that also withholds the preload at mount.
     pub(crate) owner: Option<(u64, String)>,
-    /// The normalized passthrough chords copied from the registration, stamped
-    /// as a `PassthroughKeys` component so the focused-key systems read them off
+    /// The normalized forward-key chords copied from the registration, stamped
+    /// as a `ForwardKeys` component so the focused-key systems read them off
     /// the webview entity without a registry lookup (design spec §C).
-    pub(crate) passthrough: Vec<NormalizedChord>,
+    pub(crate) forward_keys: Vec<NormalizedChord>,
 }
 
 /// Resolves a `mount-inline` `<handle>` against the `DynamicRegistry` (Tier 1).
@@ -189,7 +189,7 @@ pub(crate) fn resolve_mount(
         url: Some(url),
         interactive: view.interactive,
         owner,
-        passthrough: view.passthrough.clone(),
+        forward_keys: view.forward_keys.clone(),
     })
 }
 
@@ -304,7 +304,7 @@ pub(crate) fn mount_inline(
     params
         .commands
         .entity(webview)
-        .insert(PassthroughKeys(resolved.passthrough.clone()));
+        .insert(ForwardKeys(resolved.forward_keys.clone()));
     tracing::debug!(
         view_id = %ctx.view_id,
         terminal = ?ctx.terminal_surface,
@@ -717,7 +717,7 @@ mod tests {
                 interactive,
                 owner_surface,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
     }
@@ -735,7 +735,7 @@ mod tests {
                 interactive: true,
                 owner_surface,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
     }
@@ -1912,7 +1912,7 @@ mod tests {
                 interactive: true,
                 owner_surface,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
     }
@@ -1956,7 +1956,7 @@ mod tests {
                 interactive: false,
                 owner_surface: owner,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
 
@@ -1984,7 +1984,7 @@ mod tests {
                 interactive: true,
                 owner_surface: owner,
                 connection_id: 1,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         let r = resolve_mount("INLINEH", owner, &dynamic).expect("inline resolves");
@@ -2005,7 +2005,7 @@ mod tests {
                 interactive: true,
                 owner_surface: terminal,
                 connection_id: 42,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
 
@@ -2108,7 +2108,7 @@ mod tests {
                 interactive: true,
                 owner_surface: surface,
                 connection_id: 7,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
         reg.insert(
@@ -2122,7 +2122,7 @@ mod tests {
                 interactive: true,
                 owner_surface: surface,
                 connection_id: 7,
-                passthrough: vec![],
+                forward_keys: vec![],
             },
         );
 


### PR DESCRIPTION
## Problem

The webview key-forwarding feature was named **`passthrough`** throughout the
stack — the `ratatui-ozma` SDK builder, the control-plane `register` wire field,
and the host-side components. The name reads as "let the key pass through the
page untouched", which is the opposite of what it does: the listed chords are
**forwarded to the app/PTY** (so the app can read them via
`crossterm::event::read` and move focus out of a focused webview). Rename to
`forward_keys` so the API says what it does.

## Solution

Pure rename, no behavior change — `passthrough` → `forward_keys` across every
layer:

- **SDK (`sdk/ratatui-ozma`):** `Webview::passthrough()` builder →
  `Webview::forward_keys()`; the `RegisterKind::{Inline,Dir,Url}` `passthrough`
  field → `forward_keys`; doc comments and tests updated.
- **Wire protocol (`src/control_plane/protocol.rs`):** the `register` payload
  field `passthrough` → `forward_keys` (host `HostKeyChord` list).
- **Host (`src/control_plane.rs`, `src/webview/inline.rs`):**
  `DynamicView.passthrough` → `forward_keys`, the `PassthroughKeys` component →
  `ForwardKeys`, and `ResolvedWebviewMount.passthrough` → `forward_keys`.
- **Input (`src/tmux/input.rs`):** local `passthrough_keys` query / `pass_*`
  bindings renamed to `forward_keys` / `forward_*`; warning text updated.
- **Consumers:** `apps/ozbrowser` and the `focus_grid` / `ratatui_webview`
  examples switched to the new builder name.

`cargo check --workspace --all-targets` passes clean.

### Breaking Changes

- **SDK:** `Webview::passthrough(...)` is gone — callers must use
  `.forward_keys(...)`.
- **Wire:** the control-plane `register` field is renamed `passthrough` →
  `forward_keys`. The host deserializes with `#[serde(default)]`, so an older
  client still sending `passthrough` will be silently treated as having no
  forwarded chords rather than erroring. The SDK and host move together here, so
  in-tree consumers are unaffected.
