### PR TITLE
refactor(webview): rename OSC verb to mount/unmount and "inline webview" → "webview"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The workspace root package is the one and only binary; library crates live under
 - `ozmux-gui` (workspace root, `src/main.rs`) — the single binary: a Bevy 0.18 app. `main()` builds one `App` and adds `DefaultPlugins` (configured with a `WindowPlugin` titled "ozmux") plus `cef_plugin(&asset_endpoint)` (from `bevy_cef`), then the ozmux plugins:
   - `TerminalHandlePlugin` (from `ozma_tty_engine`), `TerminalRendererPlugin` (from `ozma_tty_renderer`), `TmuxSessionPlugin` (from `ozmux_tmux`, the sole multiplexer), `OzmuxTmuxPickerPlugin`, `OzmuxConfigsPlugin`, `FontBridgePlugin`, `OzmuxBootstrapPlugin`, `OzmuxShortcutPlugin`, `OzmuxUiPlugin`, `OzmuxWebviewPlugin`, `CopyModePlugin`, `CopyModeIndicatorPlugin`, and the tmux UI/IO plugins `CopyPromptPlugin`, `ConfirmPromptPlugin`, `TmuxDialogPlugin`, `OzmuxTmuxRenderPlugin`, `OzmuxTmuxInputPlugin`, `OzmuxTmuxWindowBarPlugin`, `OzmuxTmuxPaneFocusPlugin`, `OzmuxTmuxCopyModePlugin`, `OzmuxTmuxMousePlugin`, `OzmuxTmuxDividerHandlePlugin`;
   - the input plugins `HyperlinkInputPlugin`, `ImePlugin`, and `ImeOverlayPlugin`;
-  - and `OzmuxControlPlanePlugin` (the control-socket listener that mints Tier 1 dynamic webview handles). The in-process webview feature — CEF render wiring, the `window.ozma` back-channel, OSC 5379 `mount-inline` / `unmount-inline`, and inline webviews — is aggregated under `OzmuxWebviewPlugin` (above).
+  - and `OzmuxControlPlanePlugin` (the control-socket listener that mints Tier 1 dynamic webview handles). The in-process webview feature — CEF render wiring, the `window.ozma` back-channel, OSC 5379 `mount` / `unmount`, and inline webviews — is aggregated under `OzmuxWebviewPlugin` (above).
 
   The root `Cargo.toml` depends on `bevy_cef` (path dep, `features = ["debug"]`) and on `ozmux_webview_host` with the `cef` feature enabled. A root `[features] debug` flag enables the CEF `remote-debugging-port` (a local Chromium DevTools / CDP endpoint on `127.0.0.1:9222`) for inspecting the embedded webview; it is off by default (`cargo run --features debug`).
 
@@ -34,7 +34,7 @@ In-process webview rendering is provided by the external `bevy_cef` crate (a pat
 ### How the pieces connect at runtime
 
 1. `ozmux-gui` boots a single Bevy `App`. `TmuxSessionPlugin` (`ozmux_tmux`) attaches to (or creates) a `tmux -CC` session and projects its session/window/pane state as ECS entities; `ozma_tty_engine` runs the PTY/VT emulation behind it, emitting frame snapshots/deltas that `ozma_tty_renderer` (and the tmux render plugins in `src/`) draw on the GPU. Layout, input, copy-mode, IME, and shortcuts are all plugins in the same world.
-2. A program registers webview content over the control socket (Tier 1, `OzmuxControlPlanePlugin`) to mint an opaque handle, then writes an OSC 5379 `mount-inline;<handle>` sequence to mount it as an in-process `bevy_cef` inline webview (assets served from disk/memory via `ozma-dyn://`, one origin per handle). The page talks back to the registering program through `window.ozma.call/on` routed over the control socket.
+2. A program registers webview content over the control socket (Tier 1, `OzmuxControlPlanePlugin`) to mint an opaque handle, then writes an OSC 5379 `mount;<handle>` sequence to mount it as an in-process `bevy_cef` inline webview (assets served from disk/memory via `ozma-dyn://`, one origin per handle). The page talks back to the registering program through `window.ozma.call/on` routed over the control socket.
 
 ### `src/` module map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The workspace root package is the one and only binary; library crates live under
 - `ozmux-gui` (workspace root, `src/main.rs`) — the single binary: a Bevy 0.18 app. `main()` builds one `App` and adds `DefaultPlugins` (configured with a `WindowPlugin` titled "ozmux") plus `cef_plugin(&asset_endpoint)` (from `bevy_cef`), then the ozmux plugins:
   - `TerminalHandlePlugin` (from `ozma_tty_engine`), `TerminalRendererPlugin` (from `ozma_tty_renderer`), `TmuxSessionPlugin` (from `ozmux_tmux`, the sole multiplexer), `OzmuxTmuxPickerPlugin`, `OzmuxConfigsPlugin`, `FontBridgePlugin`, `OzmuxBootstrapPlugin`, `OzmuxShortcutPlugin`, `OzmuxUiPlugin`, `OzmuxWebviewPlugin`, `CopyModePlugin`, `CopyModeIndicatorPlugin`, and the tmux UI/IO plugins `CopyPromptPlugin`, `ConfirmPromptPlugin`, `TmuxDialogPlugin`, `OzmuxTmuxRenderPlugin`, `OzmuxTmuxInputPlugin`, `OzmuxTmuxWindowBarPlugin`, `OzmuxTmuxPaneFocusPlugin`, `OzmuxTmuxCopyModePlugin`, `OzmuxTmuxMousePlugin`, `OzmuxTmuxDividerHandlePlugin`;
   - the input plugins `HyperlinkInputPlugin`, `ImePlugin`, and `ImeOverlayPlugin`;
-  - and `OzmuxControlPlanePlugin` (the control-socket listener that mints Tier 1 dynamic webview handles). The in-process webview feature — CEF render wiring, the `window.ozma` back-channel, OSC 5379 `mount` / `unmount`, and inline webviews — is aggregated under `OzmuxWebviewPlugin` (above).
+  - and `OzmuxControlPlanePlugin` (the control-socket listener that mints Tier 1 dynamic webview handles). The in-process webview feature — CEF render wiring, the `window.ozma` back-channel, OSC 5379 `mount` / `unmount`, and webviews — is aggregated under `OzmuxWebviewPlugin` (above).
 
   The root `Cargo.toml` depends on `bevy_cef` (path dep, `features = ["debug"]`) and on `ozmux_webview_host` with the `cef` feature enabled. A root `[features] debug` flag enables the CEF `remote-debugging-port` (a local Chromium DevTools / CDP endpoint on `127.0.0.1:9222`) for inspecting the embedded webview; it is off by default (`cargo run --features debug`).
 
@@ -34,7 +34,7 @@ In-process webview rendering is provided by the external `bevy_cef` crate (a pat
 ### How the pieces connect at runtime
 
 1. `ozmux-gui` boots a single Bevy `App`. `TmuxSessionPlugin` (`ozmux_tmux`) attaches to (or creates) a `tmux -CC` session and projects its session/window/pane state as ECS entities; `ozma_tty_engine` runs the PTY/VT emulation behind it, emitting frame snapshots/deltas that `ozma_tty_renderer` (and the tmux render plugins in `src/`) draw on the GPU. Layout, input, copy-mode, IME, and shortcuts are all plugins in the same world.
-2. A program registers webview content over the control socket (Tier 1, `OzmuxControlPlanePlugin`) to mint an opaque handle, then writes an OSC 5379 `mount;<handle>` sequence to mount it as an in-process `bevy_cef` inline webview (assets served from disk/memory via `ozma-dyn://`, one origin per handle). The page talks back to the registering program through `window.ozma.call/on` routed over the control socket.
+2. A program registers webview content over the control socket (Tier 1, `OzmuxControlPlanePlugin`) to mint an opaque handle, then writes an OSC 5379 `mount;<handle>` sequence to mount it as an in-process `bevy_cef` webview (assets served from disk/memory via `ozma-dyn://`, one origin per handle). The page talks back to the registering program through `window.ozma.call/on` routed over the control socket.
 
 ### `src/` module map
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ cargo run               # or: make run
 A program in the shell can render a webview **inline in the terminal text flow**
 (a live CEF webview composited in the terminal shader, scrolling with the text).
 It registers content over the control plane to mint a handle, then writes an OSC
-5379 `mount-inline;<handle>` sequence:
+5379 `mount;<handle>` sequence:
 
 ```sh
-printf '\033]5379;mount-inline;%s;12;48\033\\' "$handle"
+printf '\033]5379;mount;%s;12;48\033\\' "$handle"
 printf '\n%.0s' $(seq 12)
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cargo run               # or: make run
 - `crates/` — `ozma_tty_engine`, `ozma_tty_renderer`, `extension_host`, `multiplexer`, `configs`
 - `sdk/ozma-web` — `@ozma/web` (in-page `window.ozma` bridge client for webview pages)
 
-## Inline webviews
+## Webviews
 
 A program in the shell can render a webview **inline in the terminal text flow**
 (a live CEF webview composited in the terminal shader, scrolling with the text).
@@ -59,7 +59,7 @@ see [`examples/dyn_webview_client.rs`](examples/dyn_webview_client.rs). Click th
 view to focus it; keys, wheel, and IME then route to the page; `Ctrl+Shift+Escape`
 returns focus to the terminal. Full protocol, focus model, and limits:
 [`docs/dyn-webview.md`](docs/dyn-webview.md) and
-[`docs/inline-webview.md`](docs/inline-webview.md).
+[`docs/webview.md`](docs/webview.md).
 
 ## Development
 

--- a/crates/ozma_tty_engine/src/events.rs
+++ b/crates/ozma_tty_engine/src/events.rs
@@ -75,7 +75,7 @@ pub struct OscWebviewRequest {
     pub entity: Entity,
     /// The inline mount/unmount verb parsed from the OSC 5379 payload.
     pub verb: OscWebviewVerb,
-    /// Anchor metadata for `MountInline` (absolute line + column + frame seq);
+    /// Anchor metadata for `Mount` (absolute line + column + frame seq);
     /// `None` for every other verb.
     pub anchor: Option<InlineAnchor>,
 }

--- a/crates/ozma_tty_engine/src/events.rs
+++ b/crates/ozma_tty_engine/src/events.rs
@@ -73,7 +73,7 @@ pub struct TerminalCurrentDir {
 pub struct OscWebviewRequest {
     #[event_target]
     pub entity: Entity,
-    /// The verb (tab or inline mount/unmount) parsed from the OSC 5379 payload.
+    /// The inline mount/unmount verb parsed from the OSC 5379 payload.
     pub verb: OscWebviewVerb,
     /// Anchor metadata for `MountInline` (absolute line + column + frame seq);
     /// `None` for every other verb.

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -1063,8 +1063,7 @@ impl TerminalHandle {
         // synchronized-update (CSI ?2026) buffer flushed before the anchor is
         // read. Flushing for the other verbs would force-end an in-flight
         // synchronized update and tear a partial frame for no benefit.
-        if matches!(verb, OscWebviewVerb::Mount { .. }) && self.parser.sync_bytes_count() > 0
-        {
+        if matches!(verb, OscWebviewVerb::Mount { .. }) && self.parser.sync_bytes_count() > 0 {
             self.parser.stop_sync(&mut self.term);
         }
         // NOTE: maintenance (fold) must run BEFORE the anchor is stamped —
@@ -2567,10 +2566,7 @@ mod tests {
             "unmount-all fires exactly once while saturated"
         );
         h.advance(b"\x1b]5379;mount;memo;2;5\x1b\\");
-        assert!(
-            rx.try_recv().is_err(),
-            "mount rejected while saturated"
-        );
+        assert!(rx.try_recv().is_err(), "mount rejected while saturated");
         h.advance(b"\x1b[3J");
         let fold = rx.try_recv().expect("fold unmount on clear");
         assert!(matches!(

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -2365,22 +2365,6 @@ mod tests {
     }
 
     #[test]
-    fn legacy_mount_still_arrives_without_anchor() {
-        let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x1b]5379;mount;dash\x1b\\");
-        let ControlFrame::OscWebview { verb, anchor } = rx.try_recv().expect("frame") else {
-            panic!("expected OscWebview");
-        };
-        assert_eq!(
-            verb,
-            OscWebviewVerb::Mount {
-                view_id: "dash".into()
-            }
-        );
-        assert!(anchor.is_none());
-    }
-
-    #[test]
     fn osc_split_across_two_chunks_still_anchors_correctly() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         let full = b"\x1b]5379;mount-inline;memo;3;10\x1b\\";

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -1139,7 +1139,7 @@ impl TerminalHandle {
     }
 
     /// Saturation policy (spec §3): once `history_size` reaches the
-    /// scrollback cap, trims become unobservable, so all inline webviews
+    /// scrollback cap, trims become unobservable, so all webviews
     /// are unmounted once and further mounts are rejected until the
     /// history shrinks below the cap again (e.g. CSI 3 J).
     ///
@@ -1150,7 +1150,7 @@ impl TerminalHandle {
         if self.scroll_cap > 0 && history_size >= self.scroll_cap {
             if !self.saturated {
                 self.saturated = true;
-                tracing::debug!("scrollback saturated: unmounting all inline webviews");
+                tracing::debug!("scrollback saturated: unmounting all webviews");
                 self.send_synthetic_unmount_all();
             }
         } else {

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -2805,7 +2805,7 @@ mod tests {
     }
 
     #[test]
-    fn drain_forwards_mount_inline_anchor_to_request() {
+    fn drain_forwards_mount_anchor_to_request() {
         use crate::events::OscWebviewRequest;
         use crate::title::TerminalTitle;
         use crate::vt::listener::{AnchorMode, ControlFrame, InlineAnchor, OscWebviewVerb};

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -1059,19 +1059,19 @@ impl TerminalHandle {
     /// Stamps the anchor / applies state gates for a buffered OSC 5379 verb
     /// at an `advance_until_terminated` stop point, then forwards the frame.
     fn handle_webview_verb(&mut self, verb: OscWebviewVerb) {
-        // NOTE: only MountInline samples the cursor, so only it needs the
+        // NOTE: only Mount samples the cursor, so only it needs the
         // synchronized-update (CSI ?2026) buffer flushed before the anchor is
         // read. Flushing for the other verbs would force-end an in-flight
         // synchronized update and tear a partial frame for no benefit.
-        if matches!(verb, OscWebviewVerb::MountInline { .. }) && self.parser.sync_bytes_count() > 0
+        if matches!(verb, OscWebviewVerb::Mount { .. }) && self.parser.sync_bytes_count() > 0
         {
             self.parser.stop_sync(&mut self.term);
         }
         // NOTE: maintenance (fold) must run BEFORE the anchor is stamped —
-        // same-chunk "CSI 3 J then mount-inline" depends on this order
+        // same-chunk "CSI 3 J then mount" depends on this order
         // (spec §3).
         self.run_history_maintenance();
-        let anchor = if matches!(verb, OscWebviewVerb::MountInline { .. }) {
+        let anchor = if matches!(verb, OscWebviewVerb::Mount { .. }) {
             let cursor = self.term.grid().cursor.point;
             let col = cursor.column.0 as u16;
             let mode = if self.term.mode().contains(TermMode::ALT_SCREEN) {
@@ -1081,7 +1081,7 @@ impl TerminalHandle {
                 }
             } else {
                 if self.saturated {
-                    tracing::debug!("mount-inline rejected: scrollback saturated");
+                    tracing::debug!("mount rejected: scrollback saturated");
                     return;
                 }
                 AnchorMode::Scrollback {
@@ -1162,14 +1162,14 @@ impl TerminalHandle {
     /// the saturation first-arrival rule.
     fn send_synthetic_unmount_all(&mut self) {
         let frame = ControlFrame::OscWebview {
-            verb: OscWebviewVerb::UnmountInline {
+            verb: OscWebviewVerb::Unmount {
                 view_id: None,
                 instance_id: None,
             },
             anchor: None,
         };
         if let Err(e) = self.control_tx.send(frame) {
-            tracing::warn!(?e, "control_tx send(synthetic UnmountInline) failed");
+            tracing::warn!(?e, "control_tx send(synthetic Unmount) failed");
         }
     }
 
@@ -2327,17 +2327,17 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_anchor_is_cursor_at_osc_byte_position_not_chunk_end() {
+    fn mount_anchor_is_cursor_at_osc_byte_position_not_chunk_end() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        let mut payload = b"\x1b]5379;mount-inline;memo;3;10\x1b\\".to_vec();
+        let mut payload = b"\x1b]5379;mount;memo;3;10\x1b\\".to_vec();
         payload.extend_from_slice(b"\r\n\r\n\r\n");
         h.advance(&payload);
-        let frame = rx.try_recv().expect("MountInline frame");
+        let frame = rx.try_recv().expect("Mount frame");
         let ControlFrame::OscWebview { verb, anchor } = frame else {
             panic!("expected OscWebview, got {frame:?}");
         };
-        assert!(matches!(verb, OscWebviewVerb::MountInline { .. }));
-        let anchor = anchor.expect("MountInline carries an anchor");
+        assert!(matches!(verb, OscWebviewVerb::Mount { .. }));
+        let anchor = anchor.expect("Mount carries an anchor");
         let AnchorMode::Scrollback { line, col } = anchor.mode else {
             panic!("expected scrollback anchor, got {:?}", anchor.mode);
         };
@@ -2349,10 +2349,10 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_anchor_accounts_for_prior_output_in_same_chunk() {
+    fn mount_anchor_accounts_for_prior_output_in_same_chunk() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         let mut payload = b"\r\n\r\n".to_vec();
-        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x07");
+        payload.extend_from_slice(b"\x1b]5379;mount;memo;2;10\x07");
         payload.extend_from_slice(b"\r\n\r\n");
         h.advance(&payload);
         let ControlFrame::OscWebview { anchor, .. } = rx.try_recv().expect("frame") else {
@@ -2367,7 +2367,7 @@ mod tests {
     #[test]
     fn osc_split_across_two_chunks_still_anchors_correctly() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        let full = b"\x1b]5379;mount-inline;memo;3;10\x1b\\";
+        let full = b"\x1b]5379;mount;memo;3;10\x1b\\";
         let (a, b) = full.split_at(10);
         h.advance(a);
         h.advance(b);
@@ -2383,9 +2383,9 @@ mod tests {
     #[test]
     fn two_mounts_in_one_chunk_each_get_their_own_anchor() {
         let (mut h, rx) = handle_with_gate_on(20, 6);
-        let mut payload = b"\x1b]5379;mount-inline;a1;2;10\x1b\\".to_vec();
+        let mut payload = b"\x1b]5379;mount;a1;2;10\x1b\\".to_vec();
         payload.extend_from_slice(b"\r\n\r\n");
-        payload.extend_from_slice(b"\x1b]5379;mount-inline;b2;2;10\x1b\\");
+        payload.extend_from_slice(b"\x1b]5379;mount;b2;2;10\x1b\\");
         h.advance(&payload);
         let first = rx.try_recv().expect("first frame");
         let second = rx.try_recv().expect("second frame");
@@ -2419,11 +2419,11 @@ mod tests {
         let hist_before = h.vi_indicator_snapshot().history_size;
         assert!(hist_before > 0, "precondition: scrollback non-empty");
         h.advance(b"\x1b[3J");
-        let frame = rx.try_recv().expect("synthesized UnmountInline");
+        let frame = rx.try_recv().expect("synthesized Unmount");
         assert_eq!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline {
+                verb: OscWebviewVerb::Unmount {
                     view_id: None,
                     instance_id: None,
                 },
@@ -2438,13 +2438,13 @@ mod tests {
         seed_scrollback(&mut h, 30);
         let hist = h.vi_indicator_snapshot().history_size as u64;
         let mut payload = b"\x1b[3J".to_vec();
-        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        payload.extend_from_slice(b"\x1b]5379;mount;memo;2;10\x1b\\");
         h.advance(&payload);
         let first = rx.try_recv().expect("fold unmount first");
         assert!(matches!(
             first,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline {
+                verb: OscWebviewVerb::Unmount {
                     view_id: None,
                     instance_id: None,
                 },
@@ -2493,7 +2493,7 @@ mod tests {
         assert!(matches!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline {
+                verb: OscWebviewVerb::Unmount {
                     view_id: None,
                     instance_id: None,
                 },
@@ -2517,7 +2517,7 @@ mod tests {
     #[test]
     fn bel_terminated_mount_at_exact_chunk_end_is_drained_in_same_call() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x07");
+        h.advance(b"\x1b]5379;mount;memo;2;10\x07");
         assert!(
             matches!(rx.try_recv(), Ok(ControlFrame::OscWebview { .. })),
             "verb must be drained in the same advance call even when the chunk ends at BEL"
@@ -2527,7 +2527,7 @@ mod tests {
     #[test]
     fn mount_anchor_col_reflects_text_before_osc_on_same_row() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"ab\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(b"ab\x1b]5379;mount;memo;2;10\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(a), ..
         } = rx.try_recv().expect("frame")
@@ -2555,7 +2555,7 @@ mod tests {
         assert!(matches!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline {
+                verb: OscWebviewVerb::Unmount {
                     view_id: None,
                     instance_id: None,
                 },
@@ -2566,40 +2566,40 @@ mod tests {
             rx.try_recv().is_err(),
             "unmount-all fires exactly once while saturated"
         );
-        h.advance(b"\x1b]5379;mount-inline;memo;2;5\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;5\x1b\\");
         assert!(
             rx.try_recv().is_err(),
-            "mount-inline rejected while saturated"
+            "mount rejected while saturated"
         );
         h.advance(b"\x1b[3J");
         let fold = rx.try_recv().expect("fold unmount on clear");
         assert!(matches!(
             fold,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::UnmountInline {
+                verb: OscWebviewVerb::Unmount {
                     view_id: None,
                     instance_id: None,
                 },
                 ..
             }
         ));
-        h.advance(b"\x1b]5379;mount-inline;memo;2;5\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;5\x1b\\");
         let frame = rx.try_recv().expect("mount accepted after clear");
         assert!(matches!(
             frame,
             ControlFrame::OscWebview {
-                verb: OscWebviewVerb::MountInline { .. },
+                verb: OscWebviewVerb::Mount { .. },
                 anchor: Some(_)
             }
         ));
     }
 
     #[test]
-    fn mount_inline_on_alt_screen_stamps_fixed_screen_anchor() {
+    fn mount_on_alt_screen_stamps_fixed_screen_anchor() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         h.advance(b"\x1b[?1049h");
         h.advance(b"\r\n\r\n");
-        h.advance(b"\x1b]5379;mount-inline;v;3;5\x1b\\");
+        h.advance(b"\x1b]5379;mount;v;3;5\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2618,7 +2618,7 @@ mod tests {
     fn alt_screen_mount_then_primary_uses_scrollback() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         h.advance(b"\x1b[?1049h");
-        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;10\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2632,7 +2632,7 @@ mod tests {
             anchor.mode
         );
         h.advance(b"\x1b[?1049l");
-        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;10\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2652,7 +2652,7 @@ mod tests {
     #[test]
     fn same_chunk_alt_enter_then_mount_stamps_fixed_screen() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x1b[?1049h\x1b]5379;mount-inline;v;3;5\x1b\\");
+        h.advance(b"\x1b[?1049h\x1b]5379;mount;v;3;5\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2675,7 +2675,7 @@ mod tests {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         h.advance(b"\x1b[?1049h");
         h.saturated = true;
-        h.advance(b"\x1b]5379;mount-inline;v;3;5\x1b\\");
+        h.advance(b"\x1b]5379;mount;v;3;5\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2696,7 +2696,7 @@ mod tests {
     fn mount_inside_synchronized_update_samples_flushed_state() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
         let mut payload = b"\x1b[?2026h\r\n\r\n".to_vec();
-        payload.extend_from_slice(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        payload.extend_from_slice(b"\x1b]5379;mount;memo;2;10\x1b\\");
         h.advance(&payload);
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
@@ -2718,7 +2718,7 @@ mod tests {
     fn mount_stamps_next_emit_seq_and_force_flag_bypasses_noop() {
         use bevy::ecs::world::{CommandQueue, World};
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;10\x1b\\");
         let ControlFrame::OscWebview {
             anchor: Some(anchor),
             ..
@@ -2773,7 +2773,7 @@ mod tests {
     fn force_flag_survives_a_no_damage_abort() {
         use bevy::ecs::world::{CommandQueue, World};
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x1b]5379;mount-inline;memo;2;10\x1b\\");
+        h.advance(b"\x1b]5379;mount;memo;2;10\x1b\\");
         let _ = rx.try_recv().expect("mount frame");
         assert!(h.test_force_next_emit());
 
@@ -2844,7 +2844,7 @@ mod tests {
 
         inject_tx
             .send(ControlFrame::OscWebview {
-                verb: OscWebviewVerb::MountInline {
+                verb: OscWebviewVerb::Mount {
                     view_id: "memo".into(),
                     rows: 3,
                     cols: 10,
@@ -2876,14 +2876,14 @@ mod tests {
         assert!(
             matches!(
                 req.verb,
-                OscWebviewVerb::MountInline {
+                OscWebviewVerb::Mount {
                     ref view_id,
                     rows: 3,
                     cols: 10,
                     instance_id: None,
                 } if view_id == "memo"
             ),
-            "verb must be MountInline{{memo, 3, 10}}, got {:?}",
+            "verb must be Mount{{memo, 3, 10}}, got {:?}",
             req.verb
         );
         assert_eq!(
@@ -2899,7 +2899,7 @@ mod tests {
     #[test]
     fn c1_osc_introducer_is_rejected_not_parsed() {
         let (mut h, rx) = handle_with_gate_on(20, 5);
-        h.advance(b"\x9d5379;mount-inline;memo;3;10\x9c");
+        h.advance(b"\x9d5379;mount;memo;3;10\x9c");
         assert!(
             rx.try_recv().is_err(),
             "8-bit C1 OSC introducer must not reach the capture (spec section 2: 7-bit ESC ] only)"

--- a/crates/ozma_tty_engine/src/osc_webview.rs
+++ b/crates/ozma_tty_engine/src/osc_webview.rs
@@ -73,23 +73,6 @@ impl Perform for OscWebviewCapture {
             return;
         }
         let verb = match params.get(1).copied() {
-            Some(b"mount") => match params.get(2).copied().and_then(valid_view_id) {
-                Some(view_id) => OscWebviewVerb::Mount { view_id },
-                None => return,
-            },
-            Some(b"unmount") => {
-                // NOTE: a present-but-invalid view-id is a malformed sequence, not
-                // an implicit "unmount any". Drop it; only an ABSENT third param
-                // means "unmount the pane's OSC webview".
-                let view_id = match params.get(2).copied() {
-                    Some(raw) => match valid_view_id(raw) {
-                        Some(v) => Some(v),
-                        None => return,
-                    },
-                    None => None,
-                };
-                OscWebviewVerb::Unmount { view_id }
-            }
             Some(b"mount-inline") => {
                 let Some(view_id) = params.get(2).copied().and_then(valid_view_id) else {
                     return;
@@ -165,20 +148,29 @@ mod tests {
     #[test]
     fn gate_off_drops_sequence() {
         let mut c = cap(false);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            true,
+        );
         assert!(c.take_pending().is_none());
     }
 
     #[test]
-    fn gate_on_buffers_mount_and_terminated_reflects_pending() {
+    fn gate_on_buffers_verb_and_terminated_reflects_pending() {
         let mut c = cap(true);
         assert!(!Perform::terminated(&c));
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"dash"], true);
+        c.osc_dispatch(
+            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            true,
+        );
         assert!(Perform::terminated(&c), "pending verb must set terminated");
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::Mount {
-                view_id: "dash".into()
+            Some(OscWebviewVerb::MountInline {
+                view_id: "memo".into(),
+                rows: 3,
+                cols: 20,
+                instance_id: None,
             })
         );
         assert!(
@@ -197,24 +189,16 @@ mod tests {
     #[test]
     fn bad_view_id_rejected() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"../etc/passwd"], true);
-        assert!(c.take_pending().is_none());
-    }
-
-    #[test]
-    fn unmount_without_view_id_targets_any() {
-        let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount"], true);
-        assert_eq!(
-            c.take_pending(),
-            Some(OscWebviewVerb::Unmount { view_id: None })
+        c.osc_dispatch(
+            &[
+                OSC_WEBVIEW_CODE,
+                b"mount-inline",
+                b"../etc/passwd",
+                b"3",
+                b"20",
+            ],
+            true,
         );
-    }
-
-    #[test]
-    fn unmount_with_invalid_view_id_dropped() {
-        let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"../etc/passwd"], true);
         assert!(c.take_pending().is_none());
     }
 

--- a/crates/ozma_tty_engine/src/osc_webview.rs
+++ b/crates/ozma_tty_engine/src/osc_webview.rs
@@ -73,7 +73,7 @@ impl Perform for OscWebviewCapture {
             return;
         }
         let verb = match params.get(1).copied() {
-            Some(b"mount-inline") => {
+            Some(b"mount") => {
                 let Some(view_id) = params.get(2).copied().and_then(valid_view_id) else {
                     return;
                 };
@@ -90,17 +90,17 @@ impl Perform for OscWebviewCapture {
                     },
                     None => None,
                 };
-                OscWebviewVerb::MountInline {
+                OscWebviewVerb::Mount {
                     view_id,
                     rows,
                     cols,
                     instance_id,
                 }
             }
-            Some(b"unmount-inline") => {
+            Some(b"unmount") => {
                 // NOTE: a present-but-invalid view id is malformed, not "unmount
                 // any"; only an ABSENT third param means "all inline on this
-                // terminal". An empty third param (`unmount-inline ; ;`) is
+                // terminal". An empty third param (`unmount ; ;`) is
                 // rejected by valid_view_id.
                 let view_id = match params.get(2).copied() {
                     Some(raw) => match valid_view_id(raw) {
@@ -122,7 +122,7 @@ impl Perform for OscWebviewCapture {
                     },
                     None => None,
                 };
-                OscWebviewVerb::UnmountInline {
+                OscWebviewVerb::Unmount {
                     view_id,
                     instance_id,
                 }
@@ -149,7 +149,7 @@ mod tests {
     fn gate_off_drops_sequence() {
         let mut c = cap(false);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
             true,
         );
         assert!(c.take_pending().is_none());
@@ -160,13 +160,13 @@ mod tests {
         let mut c = cap(true);
         assert!(!Perform::terminated(&c));
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
             true,
         );
         assert!(Perform::terminated(&c), "pending verb must set terminated");
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 3,
                 cols: 20,
@@ -192,7 +192,7 @@ mod tests {
         c.osc_dispatch(
             &[
                 OSC_WEBVIEW_CODE,
-                b"mount-inline",
+                b"mount",
                 b"../etc/passwd",
                 b"3",
                 b"20",
@@ -203,15 +203,15 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_parses_rows_cols() {
+    fn mount_parses_rows_cols() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
             true,
         );
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 3,
                 cols: 20,
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_out_of_range_dims_dropped() {
+    fn mount_out_of_range_dims_dropped() {
         for (r, w) in [
             ("0", "20"),
             ("201", "20"),
@@ -233,7 +233,7 @@ mod tests {
             c.osc_dispatch(
                 &[
                     OSC_WEBVIEW_CODE,
-                    b"mount-inline",
+                    b"mount",
                     b"memo",
                     r.as_bytes(),
                     w.as_bytes(),
@@ -248,15 +248,15 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_minimum_dims_accepted() {
+    fn mount_minimum_dims_accepted() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"1", b"1"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"1", b"1"],
             true,
         );
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 1,
                 cols: 1,
@@ -266,15 +266,15 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_maximum_dims_accepted() {
+    fn mount_maximum_dims_accepted() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"200", b"400"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"200", b"400"],
             true,
         );
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 200,
                 cols: 400,
@@ -284,13 +284,13 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_non_digit_dims_dropped() {
+    fn mount_non_digit_dims_dropped() {
         for (r, w) in [("3", "y"), ("+3", "20"), ("3", "+20")] {
             let mut c = cap(true);
             c.osc_dispatch(
                 &[
                     OSC_WEBVIEW_CODE,
-                    b"mount-inline",
+                    b"mount",
                     b"memo",
                     r.as_bytes(),
                     w.as_bytes(),
@@ -305,22 +305,22 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_missing_dims_dropped() {
+    fn mount_missing_dims_dropped() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount-inline", b"memo"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo"], true);
         assert!(c.take_pending().is_none());
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3"], true);
         assert!(c.take_pending().is_none());
     }
 
     #[test]
-    fn mount_inline_parses_instance_id() {
+    fn mount_parses_instance_id() {
         let mut c = cap(true);
         c.osc_dispatch(
             &[
                 OSC_WEBVIEW_CODE,
-                b"mount-inline",
+                b"mount",
                 b"memo",
                 b"3",
                 b"20",
@@ -330,7 +330,7 @@ mod tests {
         );
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 3,
                 cols: 20,
@@ -340,15 +340,15 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_absent_instance_id_is_none() {
+    fn mount_absent_instance_id_is_none() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20"],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
             true,
         );
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::MountInline {
+            Some(OscWebviewVerb::Mount {
                 view_id: "memo".into(),
                 rows: 3,
                 cols: 20,
@@ -358,25 +358,25 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_trailing_empty_instance_id_dropped() {
+    fn mount_trailing_empty_instance_id_dropped() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount-inline", b"memo", b"3", b"20", b""],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20", b""],
             true,
         );
         assert!(
             c.take_pending().is_none(),
-            "a trailing empty instance id (mount-inline;memo;3;20;) is malformed"
+            "a trailing empty instance id (mount;memo;3;20;) is malformed"
         );
     }
 
     #[test]
-    fn mount_inline_bad_instance_id_dropped() {
+    fn mount_bad_instance_id_dropped() {
         let mut c = cap(true);
         c.osc_dispatch(
             &[
                 OSC_WEBVIEW_CODE,
-                b"mount-inline",
+                b"mount",
                 b"memo",
                 b"3",
                 b"20",
@@ -391,27 +391,27 @@ mod tests {
     }
 
     #[test]
-    fn unmount_inline_absent_param_is_all_but_empty_param_is_malformed() {
+    fn unmount_absent_param_is_all_but_empty_param_is_malformed() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount"], true);
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::UnmountInline {
+            Some(OscWebviewVerb::Unmount {
                 view_id: None,
                 instance_id: None,
             })
         );
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b""], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b""], true);
         assert!(
             c.take_pending().is_none(),
             "empty third param is malformed, not unmount-all"
         );
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"memo"], true);
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::UnmountInline {
+            Some(OscWebviewVerb::Unmount {
                 view_id: Some("memo".into()),
                 instance_id: None,
             })
@@ -419,12 +419,12 @@ mod tests {
     }
 
     #[test]
-    fn unmount_inline_parses_view_and_instance() {
+    fn unmount_parses_view_and_instance() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b"a"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"memo", b"a"], true);
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::UnmountInline {
+            Some(OscWebviewVerb::Unmount {
                 view_id: Some("memo".into()),
                 instance_id: Some("a".into()),
             })
@@ -432,12 +432,12 @@ mod tests {
     }
 
     #[test]
-    fn unmount_inline_view_only_has_no_instance() {
+    fn unmount_view_only_has_no_instance() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"memo"], true);
         assert_eq!(
             c.take_pending(),
-            Some(OscWebviewVerb::UnmountInline {
+            Some(OscWebviewVerb::Unmount {
                 view_id: Some("memo".into()),
                 instance_id: None,
             })
@@ -445,30 +445,30 @@ mod tests {
     }
 
     #[test]
-    fn unmount_inline_trailing_empty_instance_dropped() {
+    fn unmount_trailing_empty_instance_dropped() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b""], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"memo", b""], true);
         assert!(
             c.take_pending().is_none(),
-            "unmount-inline;memo; (empty instance) is malformed"
+            "unmount;memo; (empty instance) is malformed"
         );
     }
 
     #[test]
-    fn unmount_inline_empty_view_with_instance_dropped() {
+    fn unmount_empty_view_with_instance_dropped() {
         let mut c = cap(true);
-        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount-inline", b"", b"a"], true);
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"", b"a"], true);
         assert!(
             c.take_pending().is_none(),
-            "unmount-inline;;a (empty view id + instance) is malformed"
+            "unmount;;a (empty view id + instance) is malformed"
         );
     }
 
     #[test]
-    fn unmount_inline_bad_instance_dropped() {
+    fn unmount_bad_instance_dropped() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"unmount-inline", b"memo", b"../x"],
+            &[OSC_WEBVIEW_CODE, b"unmount", b"memo", b"../x"],
             true,
         );
         assert!(

--- a/crates/ozma_tty_engine/src/osc_webview.rs
+++ b/crates/ozma_tty_engine/src/osc_webview.rs
@@ -148,10 +148,7 @@ mod tests {
     #[test]
     fn gate_off_drops_sequence() {
         let mut c = cap(false);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"], true);
         assert!(c.take_pending().is_none());
     }
 
@@ -159,10 +156,7 @@ mod tests {
     fn gate_on_buffers_verb_and_terminated_reflects_pending() {
         let mut c = cap(true);
         assert!(!Perform::terminated(&c));
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"], true);
         assert!(Perform::terminated(&c), "pending verb must set terminated");
         assert_eq!(
             c.take_pending(),
@@ -190,13 +184,7 @@ mod tests {
     fn bad_view_id_rejected() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[
-                OSC_WEBVIEW_CODE,
-                b"mount",
-                b"../etc/passwd",
-                b"3",
-                b"20",
-            ],
+            &[OSC_WEBVIEW_CODE, b"mount", b"../etc/passwd", b"3", b"20"],
             true,
         );
         assert!(c.take_pending().is_none());
@@ -205,10 +193,7 @@ mod tests {
     #[test]
     fn mount_parses_rows_cols() {
         let mut c = cap(true);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"], true);
         assert_eq!(
             c.take_pending(),
             Some(OscWebviewVerb::Mount {
@@ -250,10 +235,7 @@ mod tests {
     #[test]
     fn mount_minimum_dims_accepted() {
         let mut c = cap(true);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"1", b"1"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"1", b"1"], true);
         assert_eq!(
             c.take_pending(),
             Some(OscWebviewVerb::Mount {
@@ -268,10 +250,7 @@ mod tests {
     #[test]
     fn mount_maximum_dims_accepted() {
         let mut c = cap(true);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"200", b"400"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"200", b"400"], true);
         assert_eq!(
             c.take_pending(),
             Some(OscWebviewVerb::Mount {
@@ -318,14 +297,7 @@ mod tests {
     fn mount_parses_instance_id() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[
-                OSC_WEBVIEW_CODE,
-                b"mount",
-                b"memo",
-                b"3",
-                b"20",
-                b"a",
-            ],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20", b"a"],
             true,
         );
         assert_eq!(
@@ -342,10 +314,7 @@ mod tests {
     #[test]
     fn mount_absent_instance_id_is_none() {
         let mut c = cap(true);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20"], true);
         assert_eq!(
             c.take_pending(),
             Some(OscWebviewVerb::Mount {
@@ -374,14 +343,7 @@ mod tests {
     fn mount_bad_instance_id_dropped() {
         let mut c = cap(true);
         c.osc_dispatch(
-            &[
-                OSC_WEBVIEW_CODE,
-                b"mount",
-                b"memo",
-                b"3",
-                b"20",
-                b"../etc",
-            ],
+            &[OSC_WEBVIEW_CODE, b"mount", b"memo", b"3", b"20", b"../etc"],
             true,
         );
         assert!(
@@ -467,10 +429,7 @@ mod tests {
     #[test]
     fn unmount_bad_instance_dropped() {
         let mut c = cap(true);
-        c.osc_dispatch(
-            &[OSC_WEBVIEW_CODE, b"unmount", b"memo", b"../x"],
-            true,
-        );
+        c.osc_dispatch(&[OSC_WEBVIEW_CODE, b"unmount", b"memo", b"../x"], true);
         assert!(
             c.take_pending().is_none(),
             "an out-of-charset instance id is malformed"

--- a/crates/ozma_tty_engine/src/palette.rs
+++ b/crates/ozma_tty_engine/src/palette.rs
@@ -9,7 +9,7 @@
 //! `AColor::Named(Foreground)` maps to `Color::WHITE` as a sentinel.
 //! `AColor::Named(Background)` maps to `Color::NONE` (transparent) so that
 //! cells with the terminal default background let the pane background
-//! (`bg_padding_color`) and any inline webview overlays show through.
+//! (`bg_padding_color`) and any webview overlays show through.
 //! Cells with an explicit ANSI color are fully opaque and occlude overlays.
 
 use alacritty_terminal::vte::ansi::{Color as AColor, NamedColor};

--- a/crates/ozma_tty_engine/src/vt/listener.rs
+++ b/crates/ozma_tty_engine/src/vt/listener.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OscWebviewVerb {
     /// Mount a registered webview INLINE at the cursor anchor, sized in cells.
-    MountInline {
+    Mount {
         view_id: String,
         rows: u16,
         cols: u16,
@@ -28,7 +28,7 @@ pub enum OscWebviewVerb {
     /// # Invariants
     /// `view_id == None` implies `instance_id == None` (an instance is
     /// addressable only alongside its view id; enforced at the capture stage).
-    UnmountInline {
+    Unmount {
         view_id: Option<String>,
         instance_id: Option<String>,
     },
@@ -56,7 +56,7 @@ pub enum AnchorMode {
 }
 
 /// Anchor stamped by the VT thread at the exact byte position of a
-/// `mount-inline` OSC: the anchor mode (scrollback vs alternate-screen) and
+/// `mount` OSC: the anchor mode (scrollback vs alternate-screen) and
 /// the `frame_seq` the next grid emit will carry (used by the GUI to defer
 /// first projection until the grid catches up).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,7 +81,7 @@ pub(crate) enum ControlFrame {
     /// A new current working directory reported via OSC 7.
     CurrentDir(PathBuf),
     /// An OSC-driven webview mount/unmount request from the PTY.
-    /// `anchor` is `Some` only for `MountInline` (stamped in `handle.rs`).
+    /// `anchor` is `Some` only for `Mount` (stamped in `handle.rs`).
     OscWebview {
         verb: OscWebviewVerb,
         anchor: Option<InlineAnchor>,

--- a/crates/ozma_tty_engine/src/vt/listener.rs
+++ b/crates/ozma_tty_engine/src/vt/listener.rs
@@ -22,7 +22,7 @@ pub enum OscWebviewVerb {
         /// implicit default instance. `(view_id, instance_id)` is the address.
         instance_id: Option<String>,
     },
-    /// Unmount inline webview(s): a specific `(view_id, instance_id)`, all
+    /// Unmount webview(s): a specific `(view_id, instance_id)`, all
     /// instances of a `view_id`, or all for this terminal.
     ///
     /// # Invariants
@@ -34,7 +34,7 @@ pub enum OscWebviewVerb {
     },
 }
 
-/// How an inline webview is anchored to its terminal.
+/// How a webview is anchored to its terminal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnchorMode {
     /// Anchored to an absolute scrollback line; scrolls with the text

--- a/crates/ozma_tty_engine/src/vt/listener.rs
+++ b/crates/ozma_tty_engine/src/vt/listener.rs
@@ -10,13 +10,9 @@
 use crossbeam_channel::Sender;
 use std::path::PathBuf;
 
-/// Verb carried by `ControlFrame::OscWebview`: tab mount/unmount or inline mount/unmount of a registered view.
+/// Verb carried by `ControlFrame::OscWebview`: inline mount/unmount of a registered view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OscWebviewVerb {
-    /// Mount a registered webview by its unique identifier.
-    Mount { view_id: String },
-    /// Unmount the active webview, optionally scoped to a specific view id.
-    Unmount { view_id: Option<String> },
     /// Mount a registered webview INLINE at the cursor anchor, sized in cells.
     MountInline {
         view_id: String,

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -147,7 +147,7 @@ impl Default for PaneInactiveStyle {
 pub const OVERLAY_SLOTS: usize = 4;
 
 /// Per-terminal overlay placements + textures, derived every frame by the
-/// consumer (e.g. ozmux-gui's inline-webview projection) and consumed by
+/// consumer (e.g. ozmux-gui's webview projection) and consumed by
 /// `update_terminal_material` — the only material mutation site. The renderer
 /// knows nothing about what the textures contain.
 ///

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -107,7 +107,7 @@ const GLYPH_NONE: u32 = 0xFFFFFFFFu;
 // blends toward `params.inactive_tint.rgb` by `params.inactive_tint.a`; alpha
 // is preserved. Active pane => `inactive_tint.a == 0.0` (no-op). Applied only
 // at background-establishment points (before glyphs/overlays paint), so text
-// and inline-webview overlays keep their full color. Runs in LINEAR space —
+// and webview overlays keep their full color. Runs in LINEAR space —
 // `inactive_tint.rgb` is uploaded pre-linearized by the host.
 fn tint_bg(c: vec4<f32>) -> vec4<f32> {
     // NOTE: alpha=0 means transparent (terminal default bg sentinel); preserve
@@ -156,7 +156,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 // inline overlays → cell background → primary glyph → left-neighbor
 // overdraw → text decorations → cursor → selection.
 //
-// The pane background (fallback) is the base layer. Inline webview overlays
+// The pane background (fallback) is the base layer. Webview overlays
 // composite over it next. The cell's own background then composites OVER the
 // overlay result: a transparent cell background (the terminal default) lets
 // the webview show through, while an opaque cell background (set by a TUI
@@ -413,7 +413,7 @@ fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
 // linearizes on read, so values mix in linear space with no manual
 // conversion. The cell's own background composites OVER this result in
 // `paint_grid_cell`, so an opaque widget background occludes the webview.
-// Glyphs paint last, so terminal text sits on top of an inline webview.
+// Glyphs paint last, so terminal text sits on top of a webview.
 //
 // uv derives from the UNCLIPPED rect (rect.x may be negative when the rect
 // is partially scrolled above the viewport), so partial visibility never

--- a/crates/ozmux_configs/src/inactive_pane.rs
+++ b/crates/ozmux_configs/src/inactive_pane.rs
@@ -25,11 +25,11 @@ pub struct InactivePaneConfig {
     /// and overlays are untouched.
     pub tint: f32,
     /// Inactive-webview brightness multiplier in `0.0..=1.0` (lower = darker);
-    /// `1.0` leaves brightness untouched. Applied to inline-webview overlays
+    /// `1.0` leaves brightness untouched. Applied to webview overlays
     /// only, so the background tint can stay background-only.
     pub webview_dim: f32,
     /// Inactive-webview desaturation in `0.0..=1.0`: `0.0` keeps full color,
-    /// `1.0` is fully grey. Applied to inline-webview overlays alongside
+    /// `1.0` is fully grey. Applied to webview overlays alongside
     /// `webview_dim`.
     pub webview_desaturate: f32,
 }

--- a/crates/ozmux_configs/src/lib.rs
+++ b/crates/ozmux_configs/src/lib.rs
@@ -169,7 +169,7 @@ mod validate_tests {
     fn validate_detects_chord_conflict() {
         let toml_str = r#"
 [shortcuts.bindings]
-release-inline-focus = "Cmd+V"
+release-webview-focus = "Cmd+V"
 "#;
         let mut configs: OzmuxConfigs = toml::from_str(toml_str).unwrap();
         configs.normalize();
@@ -178,7 +178,7 @@ release-inline-focus = "Cmd+V"
             OzmuxConfigsError::DuplicateChords(dupes) => {
                 assert_eq!(dupes.len(), 1);
                 assert!(dupes[0].actions.contains(&"paste"));
-                assert!(dupes[0].actions.contains(&"release-inline-focus"));
+                assert!(dupes[0].actions.contains(&"release-webview-focus"));
             }
             _ => panic!("expected DuplicateChords, got {err:?}"),
         }

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -386,6 +386,11 @@ pub struct Bindings {
     pub paste: Option<KeyChord>,
     /// Releases keyboard focus from a focused inline webview back to the terminal.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
+    pub release_webview_focus: Option<KeyChord>,
+    /// Deprecated and ignored: renamed to `release_webview_focus`. Accepted so
+    /// existing configs carrying it still parse under `deny_unknown_fields`.
+    /// Remove after one release.
+    #[serde(default, skip_serializing, deserialize_with = "deser_chord_or_unbind")]
     pub release_inline_focus: Option<KeyChord>,
     /// Opens the tmux session/window picker overlay.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
@@ -452,7 +457,8 @@ impl Default for Bindings {
             focus_workspace_prev: None,
             focus_workspace_next: None,
             paste: Some(parse_default_chord("Cmd+V")),
-            release_inline_focus: Some(parse_default_chord("Ctrl+Shift+Escape")),
+            release_webview_focus: Some(parse_default_chord("Ctrl+Shift+Escape")),
+            release_inline_focus: None,
             open_picker: Some(parse_default_chord("Cmd+Shift+P")),
             quit: Some(parse_default_chord("Cmd+Q")),
             close_surface: None,
@@ -477,9 +483,9 @@ impl Bindings {
         [
             ("paste", &self.paste, ShortcutAction::Paste),
             (
-                "release-inline-focus",
-                &self.release_inline_focus,
-                ShortcutAction::ReleaseInlineFocus,
+                "release-webview-focus",
+                &self.release_webview_focus,
+                ShortcutAction::ReleaseWebviewFocus,
             ),
             ("open-picker", &self.open_picker, ShortcutAction::OpenPicker),
             ("quit", &self.quit, ShortcutAction::Quit),
@@ -519,7 +525,7 @@ pub enum ShortcutAction {
     /// Paste the system clipboard into the active terminal.
     Paste,
     /// Releases keyboard focus from a focused inline webview back to the terminal.
-    ReleaseInlineFocus,
+    ReleaseWebviewFocus,
     /// Opens the tmux session/window picker overlay.
     OpenPicker,
     /// Quits the ozmux application.
@@ -739,7 +745,7 @@ mod tests {
     fn bindings_default_has_active_fields_some() {
         let b = Bindings::default();
         assert!(b.paste.is_some());
-        assert!(b.release_inline_focus.is_some());
+        assert!(b.release_webview_focus.is_some());
         assert!(b.open_picker.is_some());
         assert!(b.quit.is_some());
         assert!(b.detach_session.is_some());
@@ -777,7 +783,7 @@ mod tests {
         let err = b.validate_no_conflicts().unwrap_err();
         assert_eq!(err.len(), 1, "exactly one duplicate-chord entry");
         assert!(err[0].actions.contains(&"paste"));
-        assert!(err[0].actions.contains(&"release-inline-focus"));
+        assert!(err[0].actions.contains(&"release-webview-focus"));
     }
 
     #[test]
@@ -792,7 +798,7 @@ mod tests {
         // The Bindings struct serializes its fields in declaration order.
         // The kebab-case rename applies. Deprecated fields carry
         // `skip_serializing`, so only the active bindings appear here.
-        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-inline-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
+        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-webview-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
         assert_eq!(json, expected);
     }
 
@@ -853,6 +859,20 @@ copy = \"Cmd+C\"
             5,
             "ignored keys must not enter the active set"
         );
+    }
+
+    #[test]
+    fn deprecated_release_inline_focus_key_still_parses_and_is_ignored() {
+        // Old configs carrying the renamed key must still parse under
+        // deny_unknown_fields, and must not appear in the active binding set.
+        let toml = "[bindings]\nrelease-inline-focus = \"Cmd+E\"\n";
+        let parsed: Shortcuts = toml::from_str(toml).expect("deprecated key must still parse");
+        assert!(
+            parsed.bindings.iter().all(|(label, _, _)| label != "release-inline-focus"),
+            "deprecated key must not enter the active set"
+        );
+        // The new field falls back to its default chord.
+        assert!(parsed.bindings.release_webview_focus.is_some());
     }
 
     #[test]

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -868,7 +868,10 @@ copy = \"Cmd+C\"
         let toml = "[bindings]\nrelease-inline-focus = \"Cmd+E\"\n";
         let parsed: Shortcuts = toml::from_str(toml).expect("deprecated key must still parse");
         assert!(
-            parsed.bindings.iter().all(|(label, _, _)| label != "release-inline-focus"),
+            parsed
+                .bindings
+                .iter()
+                .all(|(label, _, _)| label != "release-inline-focus"),
             "deprecated key must not enter the active set"
         );
         // The new field falls back to its default chord.

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -384,7 +384,7 @@ pub struct Bindings {
     /// Paste the system clipboard into the active terminal.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
     pub paste: Option<KeyChord>,
-    /// Releases keyboard focus from a focused inline webview back to the terminal.
+    /// Releases keyboard focus from a focused webview back to the terminal.
     #[serde(deserialize_with = "deser_chord_or_unbind")]
     pub release_webview_focus: Option<KeyChord>,
     /// Deprecated and ignored: renamed to `release_webview_focus`. Accepted so
@@ -524,7 +524,7 @@ impl Bindings {
 pub enum ShortcutAction {
     /// Paste the system clipboard into the active terminal.
     Paste,
-    /// Releases keyboard focus from a focused inline webview back to the terminal.
+    /// Releases keyboard focus from a focused webview back to the terminal.
     ReleaseWebviewFocus,
     /// Opens the tmux session/window picker overlay.
     OpenPicker,

--- a/crates/ozmux_configs/tests/fixtures/duplicate_binding.toml
+++ b/crates/ozmux_configs/tests/fixtures/duplicate_binding.toml
@@ -1,3 +1,3 @@
 [shortcuts.bindings]
 paste = "Cmd+V"
-release-inline-focus = "Cmd+V"
+release-webview-focus = "Cmd+V"

--- a/docs/dyn-webview.md
+++ b/docs/dyn-webview.md
@@ -130,10 +130,10 @@ After receiving the handle, print this sequence to stdout at the cursor
 position:
 
 ```
-ESC ] 5379 ; mount-inline ; <handle> ; <rows> ; <cols> ESC \
+ESC ] 5379 ; mount ; <handle> ; <rows> ; <cols> ESC \
 ```
 
-In Rust string syntax: `"\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"`.
+In Rust string syntax: `"\x1b]5379;mount;{handle};{rows};{cols}\x1b\\"`.
 
 Then print `<rows>` newlines to reserve vertical space so subsequent output
 lands below the webview.
@@ -144,8 +144,8 @@ lands below the webview.
   whose `$OZMA_TOKEN` was used in `hello`). Mounting from a different surface
   is silently dropped.
 
-For the full OSC 5379 protocol (including `unmount-inline`, geometry limits,
-focus, and scrollback caveats) see [`docs/inline-webview.md`](inline-webview.md).
+For the full OSC 5379 protocol (including `unmount`, geometry limits,
+focus, and scrollback caveats) see [`docs/webview.md`](webview.md).
 
 ## Reference client
 
@@ -171,7 +171,7 @@ cargo run --features debug
 cargo run --example dyn_webview_client
 ```
 
-Expected behavior: an inline webview reading "hello from a TUI app" renders at
+Expected behavior: a webview reading "hello from a TUI app" renders at
 the cursor, scrolls with the scrollback buffer, and disappears when the client
 is killed (`Ctrl-C` → socket disconnect → automatic registration teardown).
 

--- a/docs/webview.md
+++ b/docs/webview.md
@@ -1,4 +1,4 @@
-# Inline webviews
+# Webviews
 
 ozmux can render a registered webview **inline in the terminal text
 flow** — like the Kitty image protocol, but the surface is a live CEF webview.
@@ -9,7 +9,7 @@ rides the IOSurface accelerated-paint pipeline).
 
 ## Enabling it
 
-- Inline webviews ride the OSC 5379 gate: `osc_webview.enabled` in
+- Webviews ride the OSC 5379 gate: `osc_webview.enabled` in
   `~/.config/ozmux/config.toml` (default **on**).
 - The mounted `<handle>` must first be registered over the control plane (see
   [`dyn-webview.md`](dyn-webview.md)); a program registers content, receives an
@@ -22,8 +22,8 @@ sequence to stdout. The 7-bit `ESC ]` introducer and `ESC \` (ST) terminator
 are the canonical forms.
 
 ```
-mount-inline:    ESC ] 5379 ; mount-inline ; <view_id> ; <rows> ; <cols> [ ; <instance_id> ] ESC \
-unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> [ ; <instance_id> ] ] ESC \
+mount:    ESC ] 5379 ; mount ; <view_id> ; <rows> ; <cols> [ ; <instance_id> ] ESC \
+unmount:  ESC ] 5379 ; unmount [ ; <view_id> [ ; <instance_id> ] ] ESC \
 ```
 
 - `<view_id>` — an opaque handle minted by the control-plane registration that
@@ -38,10 +38,10 @@ unmount-inline:  ESC ] 5379 ; unmount-inline [ ; <view_id> [ ; <instance_id> ] ]
   default instance (the original "one per view_id" behavior is unchanged).
 - Out-of-range, non-numeric, or malformed sequences are silently dropped by the
   VT layer.
-- `unmount-inline` scopes by how many fields are present: `; <view_id> ;
+- `unmount` scopes by how many fields are present: `; <view_id> ;
   <instance_id>` removes that one instance; `; <view_id>` removes *every*
   instance of that view; **no third parameter** (and no trailing `;`) removes
-  *every* inline webview on the terminal. A present-but-empty field — a
+  *every* webview on the terminal. A present-but-empty field — a
   trailing `;`, or `; ; <instance_id>` with no view id — is malformed and
   dropped.
 
@@ -54,7 +54,7 @@ newlines after the mount sequence so following output lands below the view.
 
 ```sh
 # raw printf: heading, then mount memo.main as a 12×48 cell rect + 12 newlines
-printf 'memo:\n\033]5379;mount-inline;memo.main;12;48\033\\'
+printf 'memo:\n\033]5379;mount;memo.main;12;48\033\\'
 printf '\n%.0s' $(seq 12)
 ```
 
@@ -65,8 +65,8 @@ Caveats (the rect is anchored to an absolute scrollback line, not reflowed):
   mounts are rejected).
 - There is no automatic text reflow on width resize; the anchor stays on its
   absolute line and the layout is manual.
-- `clear` (CSI 3 J) and scrollback saturation unmount all inline webviews on
-  the terminal. While the scrollback stays saturated, new `mount-inline`
+- `clear` (CSI 3 J) and scrollback saturation unmount all webviews on
+  the terminal. While the scrollback stays saturated, new `mount`
   sequences are rejected until the history drops below the limit (e.g. after
   `clear`).
 
@@ -77,20 +77,20 @@ Write OSC 5379 directly to stdout from any language. Example in shell:
 ```sh
 # anchor heading, then mount memo.main as a 12×48 cell rect + 12 newlines
 printf 'memo:\n'
-printf '\033]5379;mount-inline;memo.main;12;48\033\\'
+printf '\033]5379;mount;memo.main;12;48\033\\'
 printf '\n%.0s' $(seq 12)
 
 # a second instance of the same view (instanceId = 'b'):
 printf '\nmemo (second):\n'
-printf '\033]5379;mount-inline;memo.main;12;48;b\033\\'
+printf '\033]5379;mount;memo.main;12;48;b\033\\'
 printf '\n%.0s' $(seq 12)
 
 # later — unmount instance 'b' only:
-printf '\033]5379;unmount-inline;memo.main;b\033\\'
+printf '\033]5379;unmount;memo.main;b\033\\'
 # unmount every instance of memo.main:
-printf '\033]5379;unmount-inline;memo.main\033\\'
-# unmount every inline webview on the terminal:
-printf '\033]5379;unmount-inline\033\\'
+printf '\033]5379;unmount;memo.main\033\\'
+# unmount every webview on the terminal:
+printf '\033]5379;unmount\033\\'
 ```
 
 The `@ozma/web` npm package (`sdk/ozma-web`) is the page-side TypeScript client
@@ -102,7 +102,7 @@ For a runnable end-to-end client (register over the control plane → mount →
 
 ## Focus and input
 
-An inline webview starts render-only. Interaction follows a click-to-focus
+A webview starts render-only. Interaction follows a click-to-focus
 model (this matches the `interactive` flag in the control-plane registration;
 a non-interactive view never takes focus or input):
 
@@ -114,7 +114,7 @@ a non-interactive view never takes focus or input):
   the pointer is over the rect (focus or not) — though before the page is first
   focused, hover events may not reach it until CEF establishes its focused
   frame.
-- **`Ctrl+Shift+Escape`** (the configurable `release_inline_focus` shortcut)
+- **`Ctrl+Shift+Escape`** (the configurable `release_webview_focus` shortcut)
   returns focus to the terminal; clicking on terminal text outside the rect
   also releases focus.
 
@@ -124,11 +124,11 @@ Two intentional behaviors worth knowing:
   events are broadcast, the focused page **also** receives those keystrokes.
 - A plain `Escape` typed into a focused page does **not** snap the terminal
   viewport to the bottom (the scroll-to-bottom shortcut is suppressed while an
-  inline webview of the active surface holds focus).
+  webview of the active surface holds focus).
 
 ## Limits
 
-- Up to **4** inline webviews per terminal surface.
+- Up to **4** webviews per terminal surface.
 - macOS only (the headless GPU compositing path).
-- One terminal pane composites its inline webviews in its own shader pass; the
+- One terminal pane composites its webviews in its own shader pass; the
   text always draws on top of the webview.

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -8,7 +8,7 @@
 //!   - emitting a `tick` event every second (`window.ozma.on`)
 //!
 //! The page also has an `<input>`, so clicking it shows the focus ring and typing
-//! (routed to the focused inline webview) echoes back into the page.
+//! (routed to the focused webview) echoes back into the page.
 //!
 //! Usage (inside an ozmux pane, with the control plane up):
 //!   cargo run --example dyn_webview_client

--- a/examples/dyn_webview_client.rs
+++ b/examples/dyn_webview_client.rs
@@ -2,7 +2,7 @@
 //! ozmux pane: it resolves `$OZMA_SOCK` (falling back to `tmux show-environment`
 //! for a pre-existing tmux pane) and the pane identity (`$OZMA_TOKEN`, else
 //! `$TMUX_PANE`), registers an inline HTML
-//! view over the control socket, prints the `mount-inline` OSC at the cursor,
+//! view over the control socket, prints the `mount` OSC at the cursor,
 //! then demonstrates the back-channel by:
 //!   - replying to `ping` calls from the page (`window.ozma.call`)
 //!   - emitting a `tick` event every second (`window.ozma.on`)
@@ -71,7 +71,7 @@ fn main() -> std::io::Result<()> {
 
     let rows = 8u16;
     let cols = 48u16;
-    print!("dynamic webview:\n\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\");
+    print!("dynamic webview:\n\x1b]5379;mount;{handle};{rows};{cols}\x1b\\");
     for _ in 0..rows {
         println!();
     }

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -1,4 +1,4 @@
-//! ratatui widget + RPC handler for embedding an ozmux inline webview.
+//! ratatui widget + RPC handler for embedding an ozmux webview.
 //!
 //! Run inside an ozmux pane: [`Ozma::connect`] dials `$OZMA_SOCK`, [`Webview`]
 //! registers content (minting a handle), [`WebviewWidget`] renders it as a

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -16,9 +16,7 @@ pub(crate) fn mount(handle: &str, rows: u16, cols: u16) -> OzmaResult<String> {
             reason: format!("geometry out of range: {rows}x{cols}"),
         });
     }
-    Ok(format!(
-        "\x1b]5379;mount;{handle};{rows};{cols}\x1b\\"
-    ))
+    Ok(format!("\x1b]5379;mount;{handle};{rows};{cols}\x1b\\"))
 }
 
 /// Returns the `unmount` OSC 5379 sequence for a single view handle.
@@ -66,10 +64,7 @@ mod tests {
 
     #[test]
     fn unmount_sequence_is_canonical() {
-        assert_eq!(
-            unmount("memo.main"),
-            "\x1b]5379;unmount;memo.main\x1b\\"
-        );
+        assert_eq!(unmount("memo.main"), "\x1b]5379;unmount;memo.main\x1b\\");
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -7,9 +7,9 @@ pub(crate) const MAX_ROWS: u16 = 200;
 /// Max inline-webview cols accepted by the VT layer (`1..=MAX_COLS`).
 pub(crate) const MAX_COLS: u16 = 400;
 
-/// Returns the `mount-inline` OSC 5379 sequence, or an error if the handle
+/// Returns the `mount` OSC 5379 sequence, or an error if the handle
 /// charset is invalid or the dimensions are out of range.
-pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> OzmaResult<String> {
+pub(crate) fn mount(handle: &str, rows: u16, cols: u16) -> OzmaResult<String> {
     validate_handle(handle)?;
     if !(1..=MAX_ROWS).contains(&rows) || !(1..=MAX_COLS).contains(&cols) {
         return Err(OzmaError::Register {
@@ -17,13 +17,13 @@ pub(crate) fn mount_inline(handle: &str, rows: u16, cols: u16) -> OzmaResult<Str
         });
     }
     Ok(format!(
-        "\x1b]5379;mount-inline;{handle};{rows};{cols}\x1b\\"
+        "\x1b]5379;mount;{handle};{rows};{cols}\x1b\\"
     ))
 }
 
-/// Returns the `unmount-inline` OSC 5379 sequence for a single view handle.
-pub(crate) fn unmount_inline(handle: &str) -> String {
-    format!("\x1b]5379;unmount-inline;{handle}\x1b\\")
+/// Returns the `unmount` OSC 5379 sequence for a single view handle.
+pub(crate) fn unmount(handle: &str) -> String {
+    format!("\x1b]5379;unmount;{handle}\x1b\\")
 }
 
 /// Returns a CUP (cursor position) sequence for a 0-based viewport cell.
@@ -60,15 +60,15 @@ mod tests {
 
     #[test]
     fn mount_sequence_is_canonical() {
-        let s = mount_inline("memo.main", 12, 48).unwrap();
-        assert_eq!(s, "\x1b]5379;mount-inline;memo.main;12;48\x1b\\");
+        let s = mount("memo.main", 12, 48).unwrap();
+        assert_eq!(s, "\x1b]5379;mount;memo.main;12;48\x1b\\");
     }
 
     #[test]
     fn unmount_sequence_is_canonical() {
         assert_eq!(
-            unmount_inline("memo.main"),
-            "\x1b]5379;unmount-inline;memo.main\x1b\\"
+            unmount("memo.main"),
+            "\x1b]5379;unmount;memo.main\x1b\\"
         );
     }
 
@@ -80,15 +80,15 @@ mod tests {
 
     #[test]
     fn rejects_out_of_range_dims() {
-        assert!(mount_inline("h", 0, 10).is_err());
-        assert!(mount_inline("h", 201, 10).is_err());
-        assert!(mount_inline("h", 10, 401).is_err());
+        assert!(mount("h", 0, 10).is_err());
+        assert!(mount("h", 201, 10).is_err());
+        assert!(mount("h", 10, 401).is_err());
     }
 
     #[test]
     fn rejects_bad_handle_charset() {
-        assert!(mount_inline("bad handle", 10, 10).is_err());
-        assert!(mount_inline("", 10, 10).is_err());
+        assert!(mount("bad handle", 10, 10).is_err());
+        assert!(mount("", 10, 10).is_err());
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/osc.rs
+++ b/sdk/ratatui-ozma/src/osc.rs
@@ -2,9 +2,9 @@
 
 use crate::error::{OzmaError, OzmaResult};
 
-/// Max inline-webview rows accepted by the VT layer (`1..=MAX_ROWS`).
+/// Max webview rows accepted by the VT layer (`1..=MAX_ROWS`).
 pub(crate) const MAX_ROWS: u16 = 200;
-/// Max inline-webview cols accepted by the VT layer (`1..=MAX_COLS`).
+/// Max webview cols accepted by the VT layer (`1..=MAX_COLS`).
 pub(crate) const MAX_COLS: u16 = 400;
 
 /// Returns the `mount` OSC 5379 sequence, or an error if the handle

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -819,11 +819,7 @@ mod tests {
         placements[0].area = rect(2, 3, 50, 12);
         let mut buf3 = Vec::new();
         flush_placements(&mut buf3, &mut state, &placements).unwrap();
-        assert!(
-            String::from_utf8(buf3)
-                .unwrap()
-                .contains("mount;h1;12;50")
-        );
+        assert!(String::from_utf8(buf3).unwrap().contains("mount;h1;12;50"));
     }
 
     #[test]
@@ -837,11 +833,7 @@ mod tests {
 
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &[]).unwrap();
-        assert!(
-            String::from_utf8(buf)
-                .unwrap()
-                .contains("unmount;h1")
-        );
+        assert!(String::from_utf8(buf).unwrap().contains("unmount;h1"));
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{OzmaError, OzmaResult};
 use crate::handler::BoxedHandler;
-use crate::osc::{clamp_dims, cursor_to, mount_inline, unmount_inline, valid_handle};
+use crate::osc::{clamp_dims, cursor_to, mount, unmount, valid_handle};
 use crate::protocol::{ClientMsg, IncomingCall, RegisterKind, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
@@ -397,7 +397,7 @@ fn connect_first_reachable(candidates: &[String]) -> OzmaResult<UnixStream> {
     Err(OzmaError::SocketUnavailable { path, cause })
 }
 
-/// Emits CUP + mount-inline for new/changed placements and unmount for vanished
+/// Emits CUP + mount for new/changed placements and unmount for vanished
 /// handles, updating `state` to the new frame. Degenerate rects are skipped.
 fn flush_placements(
     out: &mut impl Write,
@@ -422,13 +422,13 @@ fn flush_placements(
         };
         current.insert(p.handle.clone(), key);
         if state.last.get(&p.handle) != Some(&key) {
-            let seq = mount_inline(&p.handle, rows, cols)?;
+            let seq = mount(&p.handle, rows, cols)?;
             write!(out, "{}{}", cursor_to(p.area.y, p.area.x), seq)?;
         }
     }
     for handle in state.last.keys() {
         if !current.contains_key(handle) {
-            write!(out, "{}", unmount_inline(handle))?;
+            write!(out, "{}", unmount(handle))?;
         }
     }
     out.flush()?;
@@ -807,7 +807,7 @@ mod tests {
         flush_placements(&mut buf, &mut state, &placements).unwrap();
         let first = String::from_utf8(buf).unwrap();
         assert!(first.contains("\x1b[4;3H"));
-        assert!(first.contains("mount-inline;h1;12;48"));
+        assert!(first.contains("mount;h1;12;48"));
 
         let mut buf2 = Vec::new();
         flush_placements(&mut buf2, &mut state, &placements).unwrap();
@@ -822,7 +822,7 @@ mod tests {
         assert!(
             String::from_utf8(buf3)
                 .unwrap()
-                .contains("mount-inline;h1;12;50")
+                .contains("mount;h1;12;50")
         );
     }
 
@@ -840,7 +840,7 @@ mod tests {
         assert!(
             String::from_utf8(buf)
                 .unwrap()
-                .contains("unmount-inline;h1")
+                .contains("unmount;h1")
         );
     }
 

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -76,7 +76,7 @@ fn backend_draw_emits_mount_osc_and_focus_op() {
 
         let out = String::from_utf8(term_bytes.0.lock().unwrap().clone()).unwrap();
         assert!(
-            out.contains("mount-inline;view-1;12;48"),
+            out.contains("mount;view-1;12;48"),
             "terminal output missing mount OSC: {out:?}"
         );
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -5,7 +5,7 @@
 
 use crate::control_plane::listener::{ControlEvent, spawn_listener};
 use crate::control_plane::protocol::{HostKeyChord, RegisterKind, ServerMsg};
-use crate::webview::inline::Webview;
+use crate::webview::mount::Webview;
 use crate::webview::osc::NonInteractive;
 use bevy::prelude::*;
 use bevy_cef::prelude::FocusedWebview;
@@ -1118,7 +1118,7 @@ mod apply_tests {
 
     #[test]
     fn disconnect_despawns_mounted_webviews_for_its_handles() {
-        use crate::webview::inline::Webview;
+        use crate::webview::mount::Webview;
         let mut app = App::new();
         let dyn_assets = WebviewAssetRegistry::default();
         let mut reg = DynamicRegistry::default();

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -5,7 +5,7 @@
 
 use crate::control_plane::listener::{ControlEvent, spawn_listener};
 use crate::control_plane::protocol::{HostKeyChord, RegisterKind, ServerMsg};
-use crate::webview::inline::InlineWebview;
+use crate::webview::inline::Webview;
 use crate::webview::osc::NonInteractive;
 use bevy::prelude::*;
 use bevy_cef::prelude::FocusedWebview;
@@ -415,7 +415,7 @@ fn apply_control_events(
     mut focused: Option<ResMut<FocusedWebview>>,
     events: Option<Res<ControlEvents>>,
     dyn_assets: Res<WebviewAssetRegistryRes>,
-    inline: Query<(Entity, &InlineWebview)>,
+    inline: Query<(Entity, &Webview)>,
     child_of: Query<&ChildOf>,
     non_interactive: Query<(), With<NonInteractive>>,
 ) {
@@ -566,7 +566,7 @@ fn apply_control_events(
 
 fn despawn_mounted(
     commands: &mut Commands,
-    inline: &Query<(Entity, &InlineWebview)>,
+    inline: &Query<(Entity, &Webview)>,
     removed: &[String],
 ) {
     for (entity, view) in inline {
@@ -1118,7 +1118,7 @@ mod apply_tests {
 
     #[test]
     fn disconnect_despawns_mounted_webviews_for_its_handles() {
-        use crate::webview::inline::InlineWebview;
+        use crate::webview::inline::Webview;
         let mut app = App::new();
         let dyn_assets = WebviewAssetRegistry::default();
         let mut reg = DynamicRegistry::default();
@@ -1136,7 +1136,7 @@ mod apply_tests {
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
         let mounted = app
             .world_mut()
-            .spawn(InlineWebview {
+            .spawn(Webview {
                 view_id: "HMOUNT".into(),
                 instance_id: None,
                 slot: 0,
@@ -1277,7 +1277,7 @@ mod apply_tests {
                 passthrough: vec![],
             },
         );
-        app.world_mut().spawn(InlineWebview {
+        app.world_mut().spawn(Webview {
             view_id: "disp".into(),
             instance_id: None,
             slot: 0,
@@ -1372,7 +1372,7 @@ mod apply_tests {
         let mounted = app
             .world_mut()
             .spawn((
-                InlineWebview {
+                Webview {
                     view_id: "H".into(),
                     instance_id: None,
                     slot: 0,
@@ -1451,7 +1451,7 @@ mod focus_tests {
             .world_mut()
             .spawn((
                 ChildOf(surface),
-                InlineWebview {
+                Webview {
                     view_id: "h1".into(),
                     instance_id: None,
                     slot: 0,
@@ -1517,7 +1517,7 @@ mod focus_tests {
         // this assertion would FAIL.
         app.world_mut().spawn((
             ChildOf(surface),
-            InlineWebview {
+            Webview {
                 view_id: "h1".into(),
                 instance_id: None,
                 slot: 0,
@@ -1572,7 +1572,7 @@ mod focus_tests {
             .world_mut()
             .spawn((
                 ChildOf(surface_a),
-                InlineWebview {
+                Webview {
                     view_id: "ha".into(),
                     instance_id: None,
                     slot: 0,
@@ -1682,7 +1682,7 @@ mod focus_tests {
             .world_mut()
             .spawn((
                 ChildOf(surface),
-                InlineWebview {
+                Webview {
                     view_id: "h1".into(),
                     instance_id: None,
                     slot: 0,

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -84,7 +84,7 @@ pub(crate) struct DynamicView {
     pub(crate) entry: String,
     /// Whether the mounted webview accepts pointer/keyboard input.
     pub(crate) interactive: bool,
-    /// The terminal surface a `mount-inline;<handle>` must originate from. The
+    /// The terminal surface a `mount;<handle>` must originate from. The
     /// registering program's PTY env token resolved to this surface, so only
     /// that surface may mount the handle (tighter than the spec's pane wording).
     pub(crate) owner_surface: Entity,
@@ -286,7 +286,7 @@ impl ConnectionWriters {
 
 /// Mints an opaque 128-bit identifier (CSPRNG), base32-encoded (unpadded) and
 /// lowercased. The alphabet `a-z2-7` is a subset of the OSC `view_id` charset
-/// `^[A-Za-z0-9._-]{1,128}$`, so a minted handle is a valid `mount-inline;<id>`.
+/// `^[A-Za-z0-9._-]{1,128}$`, so a minted handle is a valid `mount;<id>`.
 ///
 /// # Invariants
 /// The output MUST be lowercase. A handle is used as the host of the

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -415,7 +415,7 @@ fn apply_control_events(
     mut focused: Option<ResMut<FocusedWebview>>,
     events: Option<Res<ControlEvents>>,
     dyn_assets: Res<WebviewAssetRegistryRes>,
-    inline: Query<(Entity, &Webview)>,
+    webviews: Query<(Entity, &Webview)>,
     child_of: Query<&ChildOf>,
     non_interactive: Query<(), With<NonInteractive>>,
 ) {
@@ -464,14 +464,14 @@ fn apply_control_events(
                 } else {
                     vec![]
                 };
-                despawn_mounted(&mut commands, &inline, &removed);
+                despawn_mounted(&mut commands, &webviews, &removed);
             }
             ControlEvent::Disconnect { connection_id } => {
                 let removed = registry.remove_by_connection(connection_id);
                 for h in &removed {
                     dyn_assets.0.remove(h);
                 }
-                despawn_mounted(&mut commands, &inline, &removed);
+                despawn_mounted(&mut commands, &webviews, &removed);
                 for (webview, page_req) in rpc.drain_connection(connection_id) {
                     let payload = serde_json::json!({ "reqId": page_req, "ok": false, "error": "owner_disconnected" });
                     commands.trigger(HostEmitEvent::new(webview, "ozma", &payload));
@@ -512,7 +512,7 @@ fn apply_control_events(
                     continue;
                 }
                 let frame = serde_json::json!({ "event": event, "payload": payload });
-                for (entity, view) in &inline {
+                for (entity, view) in &webviews {
                     if view.view_id == handle {
                         commands.trigger(HostEmitEvent::new(entity, "ozma.event", &frame));
                     }
@@ -536,7 +536,7 @@ fn apply_control_events(
                             tracing::debug!(handle = %h, "focus op for unowned handle, dropping");
                             continue;
                         }
-                        let target = inline.iter().find(|(entity, view)| {
+                        let target = webviews.iter().find(|(entity, view)| {
                             view.view_id == h
                                 && view.instance_id.as_deref() == instance.as_deref()
                                 && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
@@ -566,10 +566,10 @@ fn apply_control_events(
 
 fn despawn_mounted(
     commands: &mut Commands,
-    inline: &Query<(Entity, &Webview)>,
+    webviews: &Query<(Entity, &Webview)>,
     removed: &[String],
 ) {
-    for (entity, view) in inline {
+    for (entity, view) in webviews {
         if removed.contains(&view.view_id) {
             commands.entity(entity).despawn();
         }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -96,7 +96,7 @@ pub(crate) struct DynamicView {
     pub(crate) passthrough: Vec<NormalizedChord>,
 }
 
-/// Stamped on a Tier 1 inline webview entity at mount: the control-plane
+/// Stamped on a Tier 1 webview entity at mount: the control-plane
 /// connection that registered it (back-channel routing target) and its handle.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WebviewOwner {

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -120,7 +120,7 @@ pub(crate) enum ServerMsg {
     Ok {
         /// Always `true`.
         ok: bool,
-        /// The opaque handle to mount via `OSC mount-inline;<handle>`.
+        /// The opaque handle to mount via `OSC mount;<handle>`.
         handle: String,
     },
     /// A rejected request.

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -155,7 +155,7 @@ impl ServerMsg {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub(crate) enum PushMsg {
-    /// Fired when the inline webview first composites (`active: true`) or is
+    /// Fired when the webview first composites (`active: true`) or is
     /// unmounted after compositing (`active: false`).
     Compositing {
         /// The registered handle whose compositing state changed.

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -319,7 +319,8 @@ pub(crate) fn read_ime_events(
             // pane — doing so double-delivers the composition (once to the page,
             // once to the terminal). The state machine above still ran, so
             // `ImeState` stays consistent; only the pane write is skipped.
-            if focused_webview_of(Some(&focused_webview), &webview_parents, active_surface).is_some()
+            if focused_webview_of(Some(&focused_webview), &webview_parents, active_surface)
+                .is_some()
             {
                 continue;
             }
@@ -829,7 +830,7 @@ mod tests {
             .spawn((
                 ChildOf(pane),
                 Webview {
-                    view_id: "inline".into(),
+                    view_id: "webview".into(),
                     instance_id: None,
                     slot: 0,
                 },
@@ -874,7 +875,7 @@ mod tests {
             .spawn((
                 ChildOf(pane_entity),
                 Webview {
-                    view_id: "inline".into(),
+                    view_id: "webview".into(),
                     instance_id: None,
                     slot: 0,
                 },

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -288,7 +288,7 @@ pub(crate) fn ime_policy_system(
 }
 
 /// Drains `Ime` events, mutates `ImeState`, and forwards `Ime::Commit`
-/// text to the active tmux pane — UNLESS an inline webview owns focus, in
+/// text to the active tmux pane — UNLESS a webview owns focus, in
 /// which case the commit-to-pane write is suppressed (bevy_cef commits it to
 /// the page; see spec §7).
 ///
@@ -375,7 +375,7 @@ pub(crate) fn read_ime_events(
     }
 }
 
-/// The logical-pixel anchor for the OS candidate window when an inline webview
+/// The logical-pixel anchor for the OS candidate window when a webview
 /// owns focus: the owning terminal node's top-left (physical px) plus the
 /// child's active overlay rect origin (`rect.y × cell_w`, `rect.x × cell_h`),
 /// divided by the window scale factor. `None` when the focus chain is gone
@@ -855,7 +855,7 @@ mod tests {
         let window = q.single(app.world()).expect("primary window");
         assert!(
             window.ime_enabled,
-            "IME must stay enabled while an inline webview owns focus"
+            "IME must stay enabled while a webview owns focus"
         );
         assert!(
             window.ime_position.abs_diff_eq(Vec2::new(24.0, 32.0), 1e-3),

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -9,7 +9,7 @@
 use crate::input::InputPhase;
 use crate::ozma::AppMode;
 use crate::ui::copy_mode::CopyModeState;
-use crate::webview::inline::{Webview, focused_webview_of};
+use crate::webview::mount::{Webview, focused_webview_of};
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -156,7 +156,7 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 /// translation + `TerminalGrid.cursor` × cell pitch, then divided by
 /// the window scale factor. When the focused webview is an INLINE child of
 /// the active pane, the anchor instead comes from that child's overlay
-/// rect origin (`inline_ime_position`), since inline entities carry no UI
+/// rect origin (`webview_ime_position`), since inline entities carry no UI
 /// node for `webview_anchors` to read (spec §7).
 pub(crate) fn ime_policy_system(
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
@@ -167,7 +167,7 @@ pub(crate) fn ime_policy_system(
     focused_webview: Res<FocusedWebview>,
     webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
     webview_parents: Query<&ChildOf, With<Webview>>,
-    inline_slots: Query<&Webview>,
+    webview_slots: Query<&Webview>,
     overlays: Query<&TerminalOverlays>,
     current_mode: Res<State<AppMode>>,
     ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
@@ -197,10 +197,10 @@ pub(crate) fn ime_policy_system(
         // composition appears at the inline rect, not the terminal cursor.
         if let Some(child) =
             focused_webview_of(Some(&focused_webview), &webview_parents, active_surface)
-            && let Some(pos) = inline_ime_position(
+            && let Some(pos) = webview_ime_position(
                 window.resolution.scale_factor(),
                 &webview_parents,
-                &inline_slots,
+                &webview_slots,
                 &anchors,
                 &overlays,
                 &metrics,
@@ -381,17 +381,17 @@ pub(crate) fn read_ime_events(
 /// divided by the window scale factor. `None` when the focus chain is gone
 /// (child/terminal despawned, no terminal node, or a sentinel rect) — the
 /// caller then leaves `ime_position` unchanged rather than mis-anchoring.
-fn inline_ime_position(
+fn webview_ime_position(
     scale_factor: f32,
     webview_parents: &Query<&ChildOf, With<Webview>>,
-    inline_slots: &Query<&Webview>,
+    webview_slots: &Query<&Webview>,
     anchors: &Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     overlays: &Query<&TerminalOverlays>,
     metrics: &TerminalCellMetricsResource,
     child: Entity,
 ) -> Option<Vec2> {
     let terminal = webview_parents.get(child).ok()?.parent();
-    let slot = inline_slots.get(child).ok()?.slot;
+    let slot = webview_slots.get(child).ok()?.slot;
     let (node, ui_xform, _) = anchors.get(terminal).ok()?;
     let rect = *overlays.get(terminal).ok()?.rects.get(usize::from(slot))?;
     if rect.z == 0 {

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -9,7 +9,7 @@
 use crate::input::InputPhase;
 use crate::ozma::AppMode;
 use crate::ui::copy_mode::CopyModeState;
-use crate::webview::inline::{InlineWebview, focused_inline_of};
+use crate::webview::inline::{Webview, focused_inline_of};
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
@@ -166,8 +166,8 @@ pub(crate) fn ime_policy_system(
     metrics: Res<TerminalCellMetricsResource>,
     focused_webview: Res<FocusedWebview>,
     webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
-    inline_parents: Query<&ChildOf, With<InlineWebview>>,
-    inline_slots: Query<&InlineWebview>,
+    inline_parents: Query<&ChildOf, With<Webview>>,
+    inline_slots: Query<&Webview>,
     overlays: Query<&TerminalOverlays>,
     current_mode: Res<State<AppMode>>,
     ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
@@ -304,7 +304,7 @@ pub(crate) fn read_ime_events(
     connection: NonSend<TmuxConnection>,
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     focused_webview: Res<FocusedWebview>,
-    inline_parents: Query<&ChildOf, With<InlineWebview>>,
+    inline_parents: Query<&ChildOf, With<Webview>>,
     current_mode: Res<State<AppMode>>,
     ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
     copy_modes: Query<(), With<CopyModeState>>,
@@ -383,8 +383,8 @@ pub(crate) fn read_ime_events(
 /// caller then leaves `ime_position` unchanged rather than mis-anchoring.
 fn inline_ime_position(
     scale_factor: f32,
-    inline_parents: &Query<&ChildOf, With<InlineWebview>>,
-    inline_slots: &Query<&InlineWebview>,
+    inline_parents: &Query<&ChildOf, With<Webview>>,
+    inline_slots: &Query<&Webview>,
     anchors: &Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     overlays: &Query<&TerminalOverlays>,
     metrics: &TerminalCellMetricsResource,
@@ -828,7 +828,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane),
-                InlineWebview {
+                Webview {
                     view_id: "inline".into(),
                     instance_id: None,
                     slot: 0,
@@ -873,7 +873,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane_entity),
-                InlineWebview {
+                Webview {
                     view_id: "inline".into(),
                     instance_id: None,
                     slot: 0,

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -9,7 +9,7 @@
 use crate::input::InputPhase;
 use crate::ozma::AppMode;
 use crate::ui::copy_mode::CopyModeState;
-use crate::webview::inline::{Webview, focused_inline_of};
+use crate::webview::inline::{Webview, focused_webview_of};
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::hierarchy::ChildOf;
 use bevy::ecs::message::MessageReader;
@@ -166,7 +166,7 @@ pub(crate) fn ime_policy_system(
     metrics: Res<TerminalCellMetricsResource>,
     focused_webview: Res<FocusedWebview>,
     webview_anchors: Query<(&ComputedNode, &UiGlobalTransform)>,
-    inline_parents: Query<&ChildOf, With<Webview>>,
+    webview_parents: Query<&ChildOf, With<Webview>>,
     inline_slots: Query<&Webview>,
     overlays: Query<&TerminalOverlays>,
     current_mode: Res<State<AppMode>>,
@@ -193,13 +193,13 @@ pub(crate) fn ime_policy_system(
         // tab-webview `webview_anchors` arm below cannot anchor it. Derive the
         // candidate-window position from the owning terminal's node transform
         // plus the inline placement rect's origin — the SAME px conversion the
-        // wheel/click hit-test uses (`inline_local_dip`'s `origin_phys`), so
+        // wheel/click hit-test uses (`webview_local_dip`'s `origin_phys`), so
         // composition appears at the inline rect, not the terminal cursor.
         if let Some(child) =
-            focused_inline_of(Some(&focused_webview), &inline_parents, active_surface)
+            focused_webview_of(Some(&focused_webview), &webview_parents, active_surface)
             && let Some(pos) = inline_ime_position(
                 window.resolution.scale_factor(),
-                &inline_parents,
+                &webview_parents,
                 &inline_slots,
                 &anchors,
                 &overlays,
@@ -304,7 +304,7 @@ pub(crate) fn read_ime_events(
     connection: NonSend<TmuxConnection>,
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     focused_webview: Res<FocusedWebview>,
-    inline_parents: Query<&ChildOf, With<Webview>>,
+    webview_parents: Query<&ChildOf, With<Webview>>,
     current_mode: Res<State<AppMode>>,
     ozma_terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
     copy_modes: Query<(), With<CopyModeState>>,
@@ -319,7 +319,7 @@ pub(crate) fn read_ime_events(
             // pane — doing so double-delivers the composition (once to the page,
             // once to the terminal). The state machine above still ran, so
             // `ImeState` stays consistent; only the pane write is skipped.
-            if focused_inline_of(Some(&focused_webview), &inline_parents, active_surface).is_some()
+            if focused_webview_of(Some(&focused_webview), &webview_parents, active_surface).is_some()
             {
                 continue;
             }
@@ -383,14 +383,14 @@ pub(crate) fn read_ime_events(
 /// caller then leaves `ime_position` unchanged rather than mis-anchoring.
 fn inline_ime_position(
     scale_factor: f32,
-    inline_parents: &Query<&ChildOf, With<Webview>>,
+    webview_parents: &Query<&ChildOf, With<Webview>>,
     inline_slots: &Query<&Webview>,
     anchors: &Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     overlays: &Query<&TerminalOverlays>,
     metrics: &TerminalCellMetricsResource,
     child: Entity,
 ) -> Option<Vec2> {
-    let terminal = inline_parents.get(child).ok()?.parent();
+    let terminal = webview_parents.get(child).ok()?.parent();
     let slot = inline_slots.get(child).ok()?.slot;
     let (node, ui_xform, _) = anchors.get(terminal).ok()?;
     let rect = *overlays.get(terminal).ok()?.rects.get(usize::from(slot))?;

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -27,7 +27,7 @@ pub(crate) struct ResolvedShortcuts(Vec<ResolvedShortcut>);
 
 impl ResolvedShortcuts {
     /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
-    /// `ReleaseWebviewFocus`, which is meaningful only while an inline webview
+    /// `ReleaseWebviewFocus`, which is meaningful only while a webview
     /// holds focus and is matched separately via `is_release_webview_focus`.
     pub(crate) fn match_gui_action(
         &self,

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -27,8 +27,8 @@ pub(crate) struct ResolvedShortcuts(Vec<ResolvedShortcut>);
 
 impl ResolvedShortcuts {
     /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
-    /// `ReleaseInlineFocus`, which is meaningful only while an inline webview
-    /// holds focus and is matched separately via `is_release_inline_focus`.
+    /// `ReleaseWebviewFocus`, which is meaningful only while an inline webview
+    /// holds focus and is matched separately via `is_release_webview_focus`.
     pub(crate) fn match_gui_action(
         &self,
         keycode: KeyCode,
@@ -37,18 +37,18 @@ impl ResolvedShortcuts {
         self.0
             .iter()
             .find(|s| {
-                s.action != ShortcutAction::ReleaseInlineFocus
+                s.action != ShortcutAction::ReleaseWebviewFocus
                     && s.keycode == keycode
                     && s.modifiers == mods
             })
             .map(|s| s.action)
     }
 
-    /// True when `(keycode, mods)` matches the configured release-inline-focus
+    /// True when `(keycode, mods)` matches the configured release-webview-focus
     /// chord.
-    pub(crate) fn is_release_inline_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool {
+    pub(crate) fn is_release_webview_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool {
         self.0.iter().any(|s| {
-            s.action == ShortcutAction::ReleaseInlineFocus
+            s.action == ShortcutAction::ReleaseWebviewFocus
                 && s.keycode == keycode
                 && s.modifiers == mods
         })
@@ -308,8 +308,8 @@ mod tests {
     #[test]
     fn is_release_inline_focus_matches_default_chord() {
         let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
-        assert!(r.is_release_inline_focus(KeyCode::Escape, mods(true, true, false, false)));
-        assert!(!r.is_release_inline_focus(KeyCode::KeyV, mods(false, false, false, true)));
+        assert!(r.is_release_webview_focus(KeyCode::Escape, mods(true, true, false, false)));
+        assert!(!r.is_release_webview_focus(KeyCode::KeyV, mods(false, false, false, true)));
     }
 
     #[test]
@@ -343,7 +343,7 @@ mod tests {
         assert_eq!(
             b.reserved.len(),
             4,
-            "Quit, OpenPicker, ReleaseInlineFocus, DetachSession"
+            "Quit, OpenPicker, ReleaseWebviewFocus, DetachSession"
         );
         assert!(
             !b.reserved

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn match_gui_action_excludes_release_inline_focus() {
+    fn match_gui_action_excludes_release_webview_focus() {
         let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
         assert_eq!(
             r.match_gui_action(KeyCode::Escape, mods(true, true, false, false)),
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn is_release_inline_focus_matches_default_chord() {
+    fn is_release_webview_focus_matches_default_chord() {
         let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
         assert!(r.is_release_webview_focus(KeyCode::Escape, mods(true, true, false, false)));
         assert!(!r.is_release_webview_focus(KeyCode::KeyV, mods(false, false, false, true)));

--- a/src/ozma_input.rs
+++ b/src/ozma_input.rs
@@ -1,7 +1,7 @@
 //! Host-side input for `AppMode::Ozma`: maintains the crate's `KeyboardDisabled` / `MouseDisabled`
 //! markers from the coarse guards (picker, IME, focus, webview), and handles the
 //! application-level GUI shortcuts the terminal crate does not own (Quit,
-//! OpenPicker, DetachSession, ReleaseInlineFocus). Raw-key forwarding and paste
+//! OpenPicker, DetachSession, ReleaseWebviewFocus). Raw-key forwarding and paste
 //! are owned by `ozma_terminal`'s dispatcher and `PasteAction`.
 
 use crate::input::ime::ImeState;
@@ -91,7 +91,7 @@ fn app_shortcut_handler(
         if ev.state != ButtonState::Pressed {
             continue;
         }
-        if webview_focused && shortcuts.is_release_inline_focus(ev.key_code, mods) {
+        if webview_focused && shortcuts.is_release_webview_focus(ev.key_code, mods) {
             focused_webview.0 = None;
             continue;
         }
@@ -109,7 +109,7 @@ fn app_shortcut_handler(
                 picker.open = true;
             }
             ShortcutAction::DetachSession => {}
-            ShortcutAction::Paste | ShortcutAction::ReleaseInlineFocus => {}
+            ShortcutAction::Paste | ShortcutAction::ReleaseWebviewFocus => {}
         }
     }
 }
@@ -124,7 +124,7 @@ fn should_disable_input(
 }
 
 fn gui_action_suppressed_by_webview(webview_focused: bool, action: ShortcutAction) -> bool {
-    webview_focused && action != ShortcutAction::ReleaseInlineFocus
+    webview_focused && action != ShortcutAction::ReleaseWebviewFocus
 }
 
 #[cfg(test)]
@@ -153,7 +153,7 @@ mod tests {
         ));
         assert!(!gui_action_suppressed_by_webview(
             true,
-            ShortcutAction::ReleaseInlineFocus
+            ShortcutAction::ReleaseWebviewFocus
         ));
         assert!(!gui_action_suppressed_by_webview(
             false,

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -16,7 +16,7 @@ use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
 use crate::ui::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
-use crate::webview::inline::{Webview, PassthroughKeys, focused_webview_of, webview_hit_at};
+use crate::webview::mount::{Webview, PassthroughKeys, focused_webview_of, webview_hit_at};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -16,7 +16,7 @@ use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
 use crate::ui::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
-use crate::webview::inline::{Webview, PassthroughKeys, focused_inline_of, inline_hit_at};
+use crate::webview::inline::{Webview, PassthroughKeys, focused_webview_of, webview_hit_at};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -501,7 +501,7 @@ struct TmuxInlineWheelTarget {
 #[derive(SystemParam)]
 struct TmuxInlineWheelParams<'w, 's> {
     focused_webview: Res<'w, FocusedWebview>,
-    inline_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
+    webview_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     panes: Query<
         'w,
         's,
@@ -563,13 +563,13 @@ fn resolve_tmux_inline_wheel_target(
     scale_factor: f32,
 ) -> Option<TmuxInlineWheelTarget> {
     let (terminal, _pane_id, local_phys) = tmux_pane_at_phys(&params.panes, cursor_phys)?;
-    let focused_child = focused_inline_of(
+    let focused_child = focused_webview_of(
         Some(&params.focused_webview),
-        &params.inline_parents,
+        &params.webview_parents,
         Some(terminal),
     )?;
     let overlays = params.overlay_rects.get(terminal).ok()?;
-    let hit = inline_hit_at(
+    let hit = webview_hit_at(
         &params.children,
         &params.inline,
         overlays,

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -16,7 +16,7 @@ use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
 use crate::ui::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
-use crate::webview::inline::{InlineWebview, PassthroughKeys, focused_inline_of, inline_hit_at};
+use crate::webview::inline::{Webview, PassthroughKeys, focused_inline_of, inline_hit_at};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -501,7 +501,7 @@ struct TmuxInlineWheelTarget {
 #[derive(SystemParam)]
 struct TmuxInlineWheelParams<'w, 's> {
     focused_webview: Res<'w, FocusedWebview>,
-    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     panes: Query<
         'w,
         's,
@@ -513,7 +513,7 @@ struct TmuxInlineWheelParams<'w, 's> {
         ),
     >,
     children: Query<'w, 's, &'static Children>,
-    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
+    inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
 }
@@ -892,7 +892,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane),
-                InlineWebview {
+                Webview {
                     view_id: "inline".into(),
                     instance_id: None,
                     slot: 0,

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -513,7 +513,7 @@ struct TmuxWebviewWheelParams<'w, 's> {
         ),
     >,
     children: Query<'w, 's, &'static Children>,
-    inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
+    webviews: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
 }
@@ -571,7 +571,7 @@ fn resolve_tmux_webview_wheel_target(
     let overlays = params.overlay_rects.get(terminal).ok()?;
     let hit = webview_hit_at(
         &params.children,
-        &params.inline,
+        &params.webviews,
         overlays,
         terminal,
         local_phys,
@@ -610,7 +610,7 @@ fn forward_wheel_to_tmux(
     mut wheel: MessageReader<MouseWheel>,
     mut accumulator: ResMut<TmuxWheelAccumulator>,
     mut handles: Query<&mut TerminalHandle>,
-    inline: TmuxWebviewWheelParams,
+    wheel_params: TmuxWebviewWheelParams,
     connection: NonSend<TmuxConnection>,
     picker: Res<SessionPicker>,
     copy_prompt: Res<CopyPrompt>,
@@ -630,13 +630,14 @@ fn forward_wheel_to_tmux(
     let cell_h_phys = metrics.metrics.line_height_phys.floor().max(1.0);
     let cursor_phys = window.cursor_position().map(|c| c * dpr);
 
-    let target = cursor_phys
-        .and_then(|c| resolve_tmux_webview_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr));
+    let target = cursor_phys.and_then(|c| {
+        resolve_tmux_webview_wheel_target(&wheel_params, c, cell_w_phys, cell_h_phys, dpr)
+    });
 
     let Some(delta_cells) = aggregate_tmux_wheel_cells(
         &mut wheel,
         target,
-        inline.browsers.as_deref(),
+        wheel_params.browsers.as_deref(),
         cell_h_logical,
     ) else {
         // NOTE: an all-inline frame must reset the residual — leaving carried

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -16,7 +16,7 @@ use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
 use crate::ui::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
-use crate::webview::mount::{Webview, PassthroughKeys, focused_webview_of, webview_hit_at};
+use crate::webview::mount::{PassthroughKeys, Webview, focused_webview_of, webview_hit_at};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -911,7 +911,10 @@ mod tests {
         (app, pane, child)
     }
 
-    fn run_resolve_wheel_target(app: &mut App, cursor_phys: Vec2) -> Option<TmuxWebviewWheelTarget> {
+    fn run_resolve_wheel_target(
+        app: &mut App,
+        cursor_phys: Vec2,
+    ) -> Option<TmuxWebviewWheelTarget> {
         app.world_mut()
             .run_system_once(move |params: TmuxWebviewWheelParams| {
                 resolve_tmux_webview_wheel_target(&params, cursor_phys, 8.0, 16.0, 1.0)

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -202,12 +202,12 @@ fn forward_keys_to_tmux(
         None => (None, None, None),
     };
 
-    // When an inline webview holds focus it owns the keyboard (bevy_cef routes
+    // When a webview holds focus it owns the keyboard (bevy_cef routes
     // keystrokes to it); forwarding to tmux too would double-send. The configured
     // release-webview-focus chord releases focus back to the terminal. NOTE: under the tmux backend
     // `FocusedWebview` is live (set by the inline-click router, the control-plane
     // `SetFocus` op, and the focus-preservation arm in `sync_focused_webview`),
-    // so this drain is load-bearing whenever an inline webview is focused —
+    // so this drain is load-bearing whenever a webview is focused —
     // removing it would double-send keystrokes to the page and the pane.
     if let Some(focused_entity) = focused_webview.0 {
         let pass_chords = passthrough_keys
@@ -488,7 +488,7 @@ struct TmuxWheelAccumulator {
     last_pane: Option<Entity>,
 }
 
-/// A focused inline webview claiming the wheel: the child to forward to and
+/// A focused webview claiming the wheel: the child to forward to and
 /// the pointer in its webview-local DIP.
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct TmuxWebviewWheelTarget {
@@ -551,7 +551,7 @@ fn resolve_rename_subject(kind: RenameKind, rename: &RenameParams) -> Option<Ren
     }
 }
 
-/// Resolves the focused inline webview under the pointer, or `None` (the tmux
+/// Resolves the focused webview under the pointer, or `None` (the tmux
 /// path runs). `Some` only when `FocusedWebview` holds an inline child of the
 /// pane under the pointer AND the pointer is over that child's rect — the tmux
 /// analog of native `resolve_inline_wheel_target`.
@@ -596,7 +596,7 @@ fn tmux_webview_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
 
 /// Forwards mouse-wheel events to the active tmux pane.
 ///
-/// A focused inline webview under the pointer claims the wheel first
+/// A focused webview under the pointer claims the wheel first
 /// (`resolve_tmux_webview_wheel_target`): each event is forwarded RAW to that
 /// child's CEF browser and dropped before the tmux accumulator.
 ///

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -491,7 +491,7 @@ struct TmuxWheelAccumulator {
 /// A focused inline webview claiming the wheel: the child to forward to and
 /// the pointer in its webview-local DIP.
 #[derive(Debug, Clone, Copy, PartialEq)]
-struct TmuxInlineWheelTarget {
+struct TmuxWebviewWheelTarget {
     child: Entity,
     position_dip: Vec2,
 }
@@ -499,7 +499,7 @@ struct TmuxInlineWheelTarget {
 /// Wheel-routing params bundled to stay within Bevy's system-parameter limit.
 /// `browsers` is optional so CEF-less tests construct the system.
 #[derive(SystemParam)]
-struct TmuxInlineWheelParams<'w, 's> {
+struct TmuxWebviewWheelParams<'w, 's> {
     focused_webview: Res<'w, FocusedWebview>,
     webview_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     panes: Query<
@@ -555,13 +555,13 @@ fn resolve_rename_subject(kind: RenameKind, rename: &RenameParams) -> Option<Ren
 /// path runs). `Some` only when `FocusedWebview` holds an inline child of the
 /// pane under the pointer AND the pointer is over that child's rect — the tmux
 /// analog of native `resolve_inline_wheel_target`.
-fn resolve_tmux_inline_wheel_target(
-    params: &TmuxInlineWheelParams,
+fn resolve_tmux_webview_wheel_target(
+    params: &TmuxWebviewWheelParams,
     cursor_phys: Vec2,
     cell_w_phys: f32,
     cell_h_phys: f32,
     scale_factor: f32,
-) -> Option<TmuxInlineWheelTarget> {
+) -> Option<TmuxWebviewWheelTarget> {
     let (terminal, _pane_id, local_phys) = tmux_pane_at_phys(&params.panes, cursor_phys)?;
     let focused_child = focused_webview_of(
         Some(&params.focused_webview),
@@ -579,7 +579,7 @@ fn resolve_tmux_inline_wheel_target(
         cell_h_phys,
         scale_factor,
     )?;
-    (hit.child == focused_child).then_some(TmuxInlineWheelTarget {
+    (hit.child == focused_child).then_some(TmuxWebviewWheelTarget {
         child: hit.child,
         position_dip: hit.local_dip,
     })
@@ -587,7 +587,7 @@ fn resolve_tmux_inline_wheel_target(
 
 /// Converts one `MouseWheel` event to the RAW CEF wheel delta (`Line → ×120`,
 /// `Pixel` unchanged, NO sign flip) — identical to native `inline_wheel_delta`.
-fn tmux_inline_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
+fn tmux_webview_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
     match unit {
         MouseScrollUnit::Line => Vec2::new(x, y) * 120.0,
         MouseScrollUnit::Pixel => Vec2::new(x, y),
@@ -597,7 +597,7 @@ fn tmux_inline_wheel_delta(unit: MouseScrollUnit, x: f32, y: f32) -> Vec2 {
 /// Forwards mouse-wheel events to the active tmux pane.
 ///
 /// A focused inline webview under the pointer claims the wheel first
-/// (`resolve_tmux_inline_wheel_target`): each event is forwarded RAW to that
+/// (`resolve_tmux_webview_wheel_target`): each event is forwarded RAW to that
 /// child's CEF browser and dropped before the tmux accumulator.
 ///
 /// Otherwise events are accumulated into a cell-delta and quantized into integer
@@ -610,7 +610,7 @@ fn forward_wheel_to_tmux(
     mut wheel: MessageReader<MouseWheel>,
     mut accumulator: ResMut<TmuxWheelAccumulator>,
     mut handles: Query<&mut TerminalHandle>,
-    inline: TmuxInlineWheelParams,
+    inline: TmuxWebviewWheelParams,
     connection: NonSend<TmuxConnection>,
     picker: Res<SessionPicker>,
     copy_prompt: Res<CopyPrompt>,
@@ -631,7 +631,7 @@ fn forward_wheel_to_tmux(
     let cursor_phys = window.cursor_position().map(|c| c * dpr);
 
     let target = cursor_phys
-        .and_then(|c| resolve_tmux_inline_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr));
+        .and_then(|c| resolve_tmux_webview_wheel_target(&inline, c, cell_w_phys, cell_h_phys, dpr));
 
     let Some(delta_cells) = aggregate_tmux_wheel_cells(
         &mut wheel,
@@ -722,10 +722,10 @@ const MAX_NOTCHES_PER_FRAME: usize = 10;
 /// scroll up / toward older lines); `Pixel` units (macOS trackpads,
 /// high-resolution wheels) are divided by the cell height so a fixed pixel
 /// travel maps to a consistent number of lines. Inline-routed events are
-/// forwarded RAW to CEF via `tmux_inline_wheel_delta` (no sign flip).
+/// forwarded RAW to CEF via `tmux_webview_wheel_delta` (no sign flip).
 fn aggregate_tmux_wheel_cells(
     wheel: &mut MessageReader<MouseWheel>,
-    target: Option<TmuxInlineWheelTarget>,
+    target: Option<TmuxWebviewWheelTarget>,
     browsers: Option<&Browsers>,
     cell_h_logical: f32,
 ) -> Option<f32> {
@@ -737,7 +737,7 @@ fn aggregate_tmux_wheel_cells(
                 browsers.send_mouse_wheel(
                     &target.child,
                     target.position_dip,
-                    tmux_inline_wheel_delta(ev.unit, ev.x, ev.y),
+                    tmux_webview_wheel_delta(ev.unit, ev.x, ev.y),
                 );
             }
             continue;
@@ -911,10 +911,10 @@ mod tests {
         (app, pane, child)
     }
 
-    fn run_resolve_wheel_target(app: &mut App, cursor_phys: Vec2) -> Option<TmuxInlineWheelTarget> {
+    fn run_resolve_wheel_target(app: &mut App, cursor_phys: Vec2) -> Option<TmuxWebviewWheelTarget> {
         app.world_mut()
-            .run_system_once(move |params: TmuxInlineWheelParams| {
-                resolve_tmux_inline_wheel_target(&params, cursor_phys, 8.0, 16.0, 1.0)
+            .run_system_once(move |params: TmuxWebviewWheelParams| {
+                resolve_tmux_webview_wheel_target(&params, cursor_phys, 8.0, 16.0, 1.0)
             })
             .unwrap()
     }

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -204,7 +204,7 @@ fn forward_keys_to_tmux(
 
     // When an inline webview holds focus it owns the keyboard (bevy_cef routes
     // keystrokes to it); forwarding to tmux too would double-send. The configured
-    // release-inline-focus chord releases focus back to the terminal. NOTE: under the tmux backend
+    // release-webview-focus chord releases focus back to the terminal. NOTE: under the tmux backend
     // `FocusedWebview` is live (set by the inline-click router, the control-plane
     // `SetFocus` op, and the focus-preservation arm in `sync_focused_webview`),
     // so this drain is load-bearing whenever an inline webview is focused —
@@ -220,7 +220,7 @@ fn forward_keys_to_tmux(
             if ev.state != ButtonState::Pressed {
                 continue;
             }
-            if resolved.is_release_inline_focus(ev.key_code, cfg_mods) {
+            if resolved.is_release_webview_focus(ev.key_code, cfg_mods) {
                 focused_webview.0 = None;
                 break;
             }
@@ -306,7 +306,7 @@ fn forward_keys_to_tmux(
                         }
                     }
                 }
-                ShortcutAction::ReleaseInlineFocus => {}
+                ShortcutAction::ReleaseWebviewFocus => {}
                 ShortcutAction::DetachSession => {
                     next_mode.set(AppMode::Ozma);
                 }

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -21,7 +21,7 @@ use crate::input::hyperlink::{link_modifier_held, should_open_at, try_open_uri};
 use crate::picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;
-use crate::webview::inline::{Webview, inline_hit_at, inline_local_dip};
+use crate::webview::inline::{Webview, webview_hit_at, webview_local_dip};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -859,7 +859,7 @@ struct TmuxInlineRouteParams<'w, 's> {
     focused_webview: Option<ResMut<'w, FocusedWebview>>,
     children: Query<'w, 's, &'static Children>,
     inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
-    inline_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
+    webview_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
 }
@@ -925,7 +925,7 @@ fn route_tmux_inline_left_click(
         ButtonState::Pressed => {
             gesture.inline_press = None;
             let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
-                inline_hit_at(
+                webview_hit_at(
                     &route.children,
                     &route.inline,
                     overlays,
@@ -940,7 +940,7 @@ fn route_tmux_inline_left_click(
                 if let Some(focused) = route.focused_webview.as_deref_mut()
                     && focused
                         .0
-                        .is_some_and(|current| route.inline_parents.contains(current))
+                        .is_some_and(|current| route.webview_parents.contains(current))
                 {
                     focused.0 = None;
                 }
@@ -992,11 +992,11 @@ fn tmux_inline_release_dip(
     cell_h_phys: f32,
     scale: f32,
 ) -> Option<Vec2> {
-    let terminal = route.inline_parents.get(child).ok()?.parent();
+    let terminal = route.webview_parents.get(child).ok()?.parent();
     let (_, _, node, transform) = panes.get(terminal).ok()?;
     let local_phys = phys_to_pane_local(node, transform, cursor_phys)?;
     let (view, _) = route.inline.get(child).ok()?;
-    inline_local_dip(
+    webview_local_dip(
         route.overlay_rects.get(terminal).ok()?,
         view.slot,
         local_phys,
@@ -1044,7 +1044,7 @@ fn forward_tmux_inline_mouse_moves(
     let Ok(overlays) = overlay_rects.get(terminal) else {
         return;
     };
-    let Some(hit) = inline_hit_at(
+    let Some(hit) = webview_hit_at(
         &children, &inline, overlays, terminal, local_phys, cell_w, cell_h, scale,
     ) else {
         return;
@@ -1296,7 +1296,7 @@ mod tests {
         );
     }
 
-    fn make_arbiter_inline_app() -> (App, Entity, Entity) {
+    fn make_arbiter_webview_app() -> (App, Entity, Entity) {
         use bevy::window::WindowResolution;
         use tmux_control_parser::CellDims;
 
@@ -1388,7 +1388,7 @@ mod tests {
 
     #[test]
     fn inline_press_focuses_child_and_consumes() {
-        let (mut app, _pane, child) = make_arbiter_inline_app();
+        let (mut app, _pane, child) = make_arbiter_webview_app();
         set_cursor(&mut app, Vec2::new(40.0, 48.0));
         write_button(
             &mut app,
@@ -1412,7 +1412,7 @@ mod tests {
     fn move_resolves_inline_child_over_rect() {
         use bevy::ecs::system::RunSystemOnce;
 
-        let (mut app, _pane, child) = make_arbiter_inline_app();
+        let (mut app, _pane, child) = make_arbiter_webview_app();
         let hit = app
             .world_mut()
             .run_system_once(
@@ -1422,7 +1422,7 @@ mod tests {
                       overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(40.0, 48.0)).unwrap();
-                    inline_hit_at(
+                    webview_hit_at(
                         &children,
                         &inline,
                         overlays.get(terminal).unwrap(),
@@ -1447,7 +1447,7 @@ mod tests {
     fn move_resolves_nothing_off_rect() {
         use bevy::ecs::system::RunSystemOnce;
 
-        let (mut app, _pane, _child) = make_arbiter_inline_app();
+        let (mut app, _pane, _child) = make_arbiter_webview_app();
         let hit = app
             .world_mut()
             .run_system_once(
@@ -1457,7 +1457,7 @@ mod tests {
                  overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(400.0, 400.0)).unwrap();
-                    inline_hit_at(
+                    webview_hit_at(
                         &children,
                         &inline,
                         overlays.get(terminal).unwrap(),
@@ -1479,7 +1479,7 @@ mod tests {
 
     #[test]
     fn inline_off_rect_press_releases_focus_and_falls_through() {
-        let (mut app, pane, child) = make_arbiter_inline_app();
+        let (mut app, pane, child) = make_arbiter_webview_app();
         app.world_mut().resource_mut::<FocusedWebview>().0 = Some(child);
         set_cursor(&mut app, Vec2::new(400.0, 400.0));
         write_button(

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -21,7 +21,7 @@ use crate::input::hyperlink::{link_modifier_held, should_open_at, try_open_uri};
 use crate::picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;
-use crate::webview::inline::{InlineWebview, inline_hit_at, inline_local_dip};
+use crate::webview::inline::{Webview, inline_hit_at, inline_local_dip};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
@@ -858,8 +858,8 @@ fn arbiter(
 struct TmuxInlineRouteParams<'w, 's> {
     focused_webview: Option<ResMut<'w, FocusedWebview>>,
     children: Query<'w, 's, &'static Children>,
-    inline: Query<'w, 's, (&'static InlineWebview, Has<NonInteractive>)>,
-    inline_parents: Query<'w, 's, &'static ChildOf, With<InlineWebview>>,
+    inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
+    inline_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
 }
@@ -1016,7 +1016,7 @@ fn forward_tmux_inline_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     children: Query<&Children>,
-    inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+    inline: Query<(&Webview, Has<NonInteractive>)>,
     overlay_rects: Query<&TerminalOverlays>,
     windows: Query<&Window, With<PrimaryWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
@@ -1343,7 +1343,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane),
-                InlineWebview {
+                Webview {
                     view_id: "inline".into(),
                     instance_id: None,
                     slot: 0,
@@ -1418,7 +1418,7 @@ mod tests {
             .run_system_once(
                 move |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
                       children: Query<&Children>,
-                      inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+                      inline: Query<(&Webview, Has<NonInteractive>)>,
                       overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(40.0, 48.0)).unwrap();
@@ -1453,7 +1453,7 @@ mod tests {
             .run_system_once(
                 |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
                  children: Query<&Children>,
-                 inline: Query<(&InlineWebview, Has<NonInteractive>)>,
+                 inline: Query<(&Webview, Has<NonInteractive>)>,
                  overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(400.0, 400.0)).unwrap();

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -858,7 +858,7 @@ fn arbiter(
 struct TmuxWebviewRouteParams<'w, 's> {
     focused_webview: Option<ResMut<'w, FocusedWebview>>,
     children: Query<'w, 's, &'static Children>,
-    inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
+    webviews: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
     webview_parents: Query<'w, 's, &'static ChildOf, With<Webview>>,
     overlay_rects: Query<'w, 's, &'static TerminalOverlays>,
     browsers: Option<NonSend<'w, Browsers>>,
@@ -927,7 +927,7 @@ fn route_tmux_webview_left_click(
             let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
                 webview_hit_at(
                     &route.children,
-                    &route.inline,
+                    &route.webviews,
                     overlays,
                     terminal,
                     local_phys,
@@ -995,7 +995,7 @@ fn tmux_webview_release_dip(
     let terminal = route.webview_parents.get(child).ok()?.parent();
     let (_, _, node, transform) = panes.get(terminal).ok()?;
     let local_phys = phys_to_pane_local(node, transform, cursor_phys)?;
-    let (view, _) = route.inline.get(child).ok()?;
+    let (view, _) = route.webviews.get(child).ok()?;
     webview_local_dip(
         route.overlay_rects.get(terminal).ok()?,
         view.slot,
@@ -1016,7 +1016,7 @@ fn forward_tmux_webview_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     children: Query<&Children>,
-    inline: Query<(&Webview, Has<NonInteractive>)>,
+    webviews: Query<(&Webview, Has<NonInteractive>)>,
     overlay_rects: Query<&TerminalOverlays>,
     windows: Query<&Window, With<PrimaryWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
@@ -1045,7 +1045,7 @@ fn forward_tmux_webview_mouse_moves(
         return;
     };
     let Some(hit) = webview_hit_at(
-        &children, &inline, overlays, terminal, local_phys, cell_w, cell_h, scale,
+        &children, &webviews, overlays, terminal, local_phys, cell_w, cell_h, scale,
     ) else {
         return;
     };
@@ -1344,7 +1344,7 @@ mod tests {
             .spawn((
                 ChildOf(pane),
                 Webview {
-                    view_id: "inline".into(),
+                    view_id: "webview".into(),
                     instance_id: None,
                     slot: 0,
                 },
@@ -1387,7 +1387,7 @@ mod tests {
     }
 
     #[test]
-    fn inline_press_focuses_child_and_consumes() {
+    fn webview_press_focuses_child_and_consumes() {
         let (mut app, _pane, child) = make_arbiter_webview_app();
         set_cursor(&mut app, Vec2::new(40.0, 48.0));
         write_button(
@@ -1418,13 +1418,13 @@ mod tests {
             .run_system_once(
                 move |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
                       children: Query<&Children>,
-                      inline: Query<(&Webview, Has<NonInteractive>)>,
+                      webviews: Query<(&Webview, Has<NonInteractive>)>,
                       overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(40.0, 48.0)).unwrap();
                     webview_hit_at(
                         &children,
-                        &inline,
+                        &webviews,
                         overlays.get(terminal).unwrap(),
                         terminal,
                         local,
@@ -1453,13 +1453,13 @@ mod tests {
             .run_system_once(
                 |panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
                  children: Query<&Children>,
-                 inline: Query<(&Webview, Has<NonInteractive>)>,
+                 webviews: Query<(&Webview, Has<NonInteractive>)>,
                  overlays: Query<&TerminalOverlays>| {
                     let (terminal, _pane_id, local) =
                         tmux_pane_at_phys(&panes, Vec2::new(400.0, 400.0)).unwrap();
                     webview_hit_at(
                         &children,
-                        &inline,
+                        &webviews,
                         overlays.get(terminal).unwrap(),
                         terminal,
                         local,

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -21,7 +21,7 @@ use crate::input::hyperlink::{link_modifier_held, should_open_at, try_open_uri};
 use crate::picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;
-use crate::webview::inline::{Webview, webview_hit_at, webview_local_dip};
+use crate::webview::mount::{Webview, webview_hit_at, webview_local_dip};
 use crate::webview::osc::NonInteractive;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -60,7 +60,7 @@ impl Plugin for MousePlugin {
         );
         app.add_systems(
             Update,
-            forward_tmux_inline_mouse_moves
+            forward_tmux_webview_mouse_moves
                 .in_set(InputPhase::Hover)
                 .in_set(super::OzmuxActiveSet),
         );
@@ -70,7 +70,7 @@ impl Plugin for MousePlugin {
 /// Modal-input gate: the resources whose presence means another surface owns
 /// input and the arbiter must drain events without mutating tmux. The
 /// focused-webview case is NOT gated here — the inline click pre-step
-/// (`route_tmux_inline_left_click`) owns webview focus instead.
+/// (`route_tmux_webview_left_click`) owns webview focus instead.
 #[derive(SystemParam)]
 struct ModalGate<'w> {
     picker: Res<'w, SessionPicker>,
@@ -169,7 +169,7 @@ pub(crate) struct TmuxMouseGesture {
     /// The in-flight inline-webview press: the child a left press inside an
     /// interactive inline rect was forwarded to, so the matching release's
     /// click-up routes to the SAME child even if the pointer drifted off-rect.
-    inline_press: Option<Entity>,
+    webview_press: Option<Entity>,
 }
 
 /// Tracks consecutive-click count using a timeout + positional drift gate.
@@ -261,7 +261,7 @@ fn resize_target_size(near: i32, pointer_cell: i32) -> u32 {
 /// queued events are drained and the state is reset.
 ///
 /// Each left press/release is first offered to the inline-webview layer
-/// (`route_tmux_inline_left_click`): a press inside an interactive inline rect
+/// (`route_tmux_webview_left_click`): a press inside an interactive inline rect
 /// focuses + forwards to the child's CEF browser and never reaches the tmux
 /// gesture pipeline; a press outside every rect drops inline focus and falls
 /// through to the normal pane gesture.
@@ -270,7 +270,7 @@ fn arbiter(
     mut buttons: MessageReader<MouseButtonInput>,
     mut commands: Commands,
     mut queries: ResMut<CopyModeQueries>,
-    mut inline_route: TmuxInlineRouteParams,
+    mut webview_route: TmuxWebviewRouteParams,
     mut vt_select: VtSelectionParams,
     connection: NonSend<TmuxConnection>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
@@ -292,7 +292,7 @@ fn arbiter(
         // NOTE: no window means no cursor/scale to synthesize the CEF mouse-up,
         // so just drop any in-flight inline press — leaving it set would let a
         // later release act on a stale child.
-        gesture.inline_press = None;
+        gesture.webview_press = None;
         if let GestureState::SelectingVt { pane, .. } = gesture.state
             && let Ok(mut handle) = vt_select.handles.get_mut(pane)
         {
@@ -308,9 +308,9 @@ fn arbiter(
     let guard_cursor_phys = window.cursor_position().map(|c| c * scale);
     if !window.focused {
         buttons.clear();
-        release_inline_press(
+        release_webview_press(
             &mut gesture,
-            &inline_route,
+            &webview_route,
             &panes,
             guard_cursor_phys,
             cell_w,
@@ -333,9 +333,9 @@ fn arbiter(
     // the focused page does not stay logically pressed (no matching mouse-up).
     if picker.open || copy_prompt.open.is_some() {
         buttons.clear();
-        release_inline_press(
+        release_webview_press(
             &mut gesture,
-            &inline_route,
+            &webview_route,
             &panes,
             guard_cursor_phys,
             cell_w,
@@ -377,9 +377,9 @@ fn arbiter(
         if let Some(cursor_phys) = window.cursor_position().map(|c| c * scale)
             && let Some((terminal, _pane_id, local_phys)) = tmux_pane_at_phys(&panes, cursor_phys)
         {
-            let consumed = route_tmux_inline_left_click(
+            let consumed = route_tmux_webview_left_click(
                 &mut gesture,
-                &mut inline_route,
+                &mut webview_route,
                 &panes,
                 terminal,
                 local_phys,
@@ -855,7 +855,7 @@ fn arbiter(
 /// system-parameter limit. `focused_webview` / `browsers` are optional so
 /// CEF-less tests construct the system (state effects still apply).
 #[derive(SystemParam)]
-struct TmuxInlineRouteParams<'w, 's> {
+struct TmuxWebviewRouteParams<'w, 's> {
     focused_webview: Option<ResMut<'w, FocusedWebview>>,
     children: Query<'w, 's, &'static Children>,
     inline: Query<'w, 's, (&'static Webview, Has<NonInteractive>)>,
@@ -868,21 +868,21 @@ struct TmuxInlineRouteParams<'w, 's> {
 /// cursor) and clears the marker. Called when an arbiter guard drains the
 /// queued release (modal open / window unfocused) so the focused web page is
 /// not left logically pressed with no matching mouse-up.
-fn release_inline_press(
+fn release_webview_press(
     gesture: &mut TmuxMouseGesture,
-    route: &TmuxInlineRouteParams,
+    route: &TmuxWebviewRouteParams,
     panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     cursor_phys: Option<Vec2>,
     cell_w_phys: f32,
     cell_h_phys: f32,
     scale: f32,
 ) {
-    let Some(child) = gesture.inline_press.take() else {
+    let Some(child) = gesture.webview_press.take() else {
         return;
     };
     if let Some(cursor_phys) = cursor_phys
         && let Some(browsers) = route.browsers.as_deref()
-        && let Some(dip) = tmux_inline_release_dip(
+        && let Some(dip) = tmux_webview_release_dip(
             route,
             panes,
             child,
@@ -909,9 +909,9 @@ fn release_inline_press(
     clippy::too_many_arguments,
     reason = "inline routing needs the gesture state, route params, and pointer geometry"
 )]
-fn route_tmux_inline_left_click(
+fn route_tmux_webview_left_click(
     gesture: &mut TmuxMouseGesture,
-    route: &mut TmuxInlineRouteParams,
+    route: &mut TmuxWebviewRouteParams,
     panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     terminal: Entity,
     local_phys: Vec2,
@@ -923,7 +923,7 @@ fn route_tmux_inline_left_click(
 ) -> bool {
     match button_state {
         ButtonState::Pressed => {
-            gesture.inline_press = None;
+            gesture.webview_press = None;
             let hit = route.overlay_rects.get(terminal).ok().and_then(|overlays| {
                 webview_hit_at(
                     &route.children,
@@ -955,15 +955,15 @@ fn route_tmux_inline_left_click(
                 browsers.set_focus(&hit.child, true);
                 browsers.send_mouse_click(&hit.child, hit.local_dip, PointerButton::Primary, false);
             }
-            gesture.inline_press = Some(hit.child);
+            gesture.webview_press = Some(hit.child);
             true
         }
         ButtonState::Released => {
-            let Some(child) = gesture.inline_press.take() else {
+            let Some(child) = gesture.webview_press.take() else {
                 return false;
             };
             if let Some(browsers) = route.browsers.as_deref()
-                && let Some(dip) = tmux_inline_release_dip(
+                && let Some(dip) = tmux_webview_release_dip(
                     route,
                     panes,
                     child,
@@ -983,8 +983,8 @@ fn route_tmux_inline_left_click(
 /// Webview-local DIP for a release on `child`, WITHOUT containment (a pointer
 /// that drifted off the rect still produces a release position). `None` when
 /// the child/terminal/rect chain is gone.
-fn tmux_inline_release_dip(
-    route: &TmuxInlineRouteParams,
+fn tmux_webview_release_dip(
+    route: &TmuxWebviewRouteParams,
     panes: &Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     child: Entity,
     cursor_phys: Vec2,
@@ -1012,7 +1012,7 @@ fn tmux_inline_release_dip(
 /// in-rect drag. `CursorMoved`-driven (one forward per frame, latest position), and
 /// focus-gated inside `bevy_cef` so motion over an unfocused browser is
 /// dropped browser-side. `Browsers` is optional so CEF-less tests construct it.
-fn forward_tmux_inline_mouse_moves(
+fn forward_tmux_webview_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     children: Query<&Children>,

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -166,7 +166,7 @@ enum GestureState {
 pub(crate) struct TmuxMouseGesture {
     state: GestureState,
     click: ClickTracker,
-    /// The in-flight inline-webview press: the child a left press inside an
+    /// The in-flight webview press: the child a left press inside an
     /// interactive inline rect was forwarded to, so the matching release's
     /// click-up routes to the SAME child even if the pointer drifted off-rect.
     webview_press: Option<Entity>,
@@ -260,7 +260,7 @@ fn resize_target_size(near: i32, pointer_cell: i32) -> u32 {
 /// window is not focused, or a modal (picker / copy-search prompt) owns input,
 /// queued events are drained and the state is reset.
 ///
-/// Each left press/release is first offered to the inline-webview layer
+/// Each left press/release is first offered to the webview layer
 /// (`route_tmux_webview_left_click`): a press inside an interactive inline rect
 /// focuses + forwards to the child's CEF browser and never reaches the tmux
 /// gesture pipeline; a press outside every rect drops inline focus and falls
@@ -390,7 +390,7 @@ fn arbiter(
                 scale,
             );
             if consumed {
-                // NOTE: a press that focused an inline webview must also make its
+                // NOTE: a press that focused a webview must also make its
                 // host pane the tmux-active pane. ActivePane is the keyboard/paste
                 // target, so it has to follow the pane the user clicked into —
                 // without this, after focus is released keystrokes route to the
@@ -864,7 +864,7 @@ struct TmuxWebviewRouteParams<'w, 's> {
     browsers: Option<NonSend<'w, Browsers>>,
 }
 
-/// Releases an in-flight inline-webview press to CEF (mouse-up at the last
+/// Releases an in-flight webview press to CEF (mouse-up at the last
 /// cursor) and clears the marker. Called when an arbiter guard drains the
 /// queued release (modal open / window unfocused) so the focused web page is
 /// not left logically pressed with no matching mouse-up.
@@ -896,7 +896,7 @@ fn release_webview_press(
     }
 }
 
-/// Routes a left press/release through the inline-webview layer, returning
+/// Routes a left press/release through the webview layer, returning
 /// `true` when the event was consumed and must NOT reach the tmux gesture
 /// pipeline. A press inside an
 /// interactive rect sets `FocusedWebview`, issues the UNGATED `set_focus`

--- a/src/tmux/pane_focus.rs
+++ b/src/tmux/pane_focus.rs
@@ -86,7 +86,7 @@ fn sync_inactive_pane_style(
 
 /// Returns the [`PaneInactiveStyle`] applied to inactive panes when the
 /// treatment is enabled: background tint (`tint_color` linearized + `tint`
-/// amount) and the inline-webview overlay treatment (`webview_dim` /
+/// amount) and the webview overlay treatment (`webview_dim` /
 /// `webview_desaturate`). Disabled or absent config yields the no-op default.
 fn inactive_style(configs: Option<&OzmuxConfigsResource>) -> PaneInactiveStyle {
     match configs {

--- a/src/tmux/pane_hit.rs
+++ b/src/tmux/pane_hit.rs
@@ -1,6 +1,6 @@
 //! Shared tmux pane hit-testing and cell geometry. One home for the pointer
 //! → (pane, local-physical-px, cell) math used by hyperlink hover, the mouse
-//! arbiter, inline-webview pointer routing, and copy-mode.
+//! arbiter, webview pointer routing, and copy-mode.
 
 use bevy::ecs::entity::Entity;
 use bevy::ecs::system::Query;

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -113,8 +113,8 @@ fn attach_tmux_window_container(
 /// Attaches a detached `TerminalHandle`, a `TerminalRenderBundle`, and a
 /// placeholder absolute `Node` to each `TmuxPane` that lacks a `TerminalHandle`.
 /// The `TerminalGrid` lives on the pane entity itself, so `flush_emit` /
-/// `emit_pending` and the inline-webview overlay projection all target it
-/// directly (an inline webview mounts as a `ChildOf` the pane).
+/// `emit_pending` and the webview overlay projection all target it
+/// directly (a webview mounts as a `ChildOf` the pane).
 ///
 /// Runs every frame but targets each pane exactly once. `ChildOf` is NOT set
 /// here — the projection observers already establish the correct
@@ -126,7 +126,7 @@ fn attach_tmux_pane_terminal(
     panes: Query<(Entity, &TmuxPane), Without<TerminalHandle>>,
 ) {
     // NOTE: clone the SHARED OscWebviewGate so a tmux pane captures OSC 5379 when
-    // the feature is enabled; a fresh `false` atomic would leave inline-webview
+    // the feature is enabled; a fresh `false` atomic would leave webview
     // capture permanently off for tmux panes. The fallback is only reached in
     // tests that do not install the gate resource.
     let gate = gate
@@ -191,7 +191,7 @@ fn route_tmux_output(
         // NOTE: drain captured control frames — crucially the OSC 5379
         // mount/unmount verbs — into observer triggers. The engine's own control
         // drain runs only for PtyHandle-backed terminals; tmux panes have no
-        // PtyHandle, so without this call a pane program's inline-webview mount
+        // PtyHandle, so without this call a pane program's webview mount
         // OSC is parsed and then silently dropped (no webview ever mounts).
         handle.drain_control_events(&mut commands, entity, &mut title);
         // NOTE: skip the live flush while in copy mode — `apply_copy_overlay` paints

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -843,7 +843,7 @@ mod tests {
     }
 
     #[test]
-    fn mount_inline_osc_from_pane_triggers_webview_request() {
+    fn mount_osc_from_pane_triggers_webview_request() {
         use ozma_tty_engine::OscWebviewRequest;
 
         #[derive(Resource, Default)]
@@ -879,19 +879,19 @@ mod tests {
         // Frame 1: attach the handle + TerminalTitle (no output yet).
         app.update();
 
-        // Frame 2: deliver a mount-inline OSC and route it.
+        // Frame 2: deliver a mount OSC and route it.
         app.world_mut()
             .resource_mut::<bevy::ecs::message::Messages<PaneOutput>>()
             .write(PaneOutput {
                 pane: pane_id,
-                data: b"\x1b]5379;mount-inline;memo;3;10\x1b\\".to_vec(),
+                data: b"\x1b]5379;mount;memo;3;10\x1b\\".to_vec(),
             });
         app.update();
 
         assert_eq!(
             app.world().resource::<Seen>().0,
             1,
-            "a mount-inline OSC from a tmux pane must trigger exactly one OscWebviewRequest",
+            "a mount OSC from a tmux pane must trigger exactly one OscWebviewRequest",
         );
     }
 

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -1,6 +1,6 @@
 //! In-process webview feature: CEF render wiring and the window.ozma Tier 1
-//! back-channel (render), OSC mount/unmount of inline webviews (osc), and
-//! inline webviews rendered into the terminal text flow (mount). Aggregated
+//! back-channel (render), OSC mount/unmount of webviews (osc), and
+//! webviews rendered into the terminal text flow (mount). Aggregated
 //! behind OzmuxWebviewPlugin.
 
 pub(crate) mod mount;

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -8,7 +8,7 @@ pub(crate) mod osc;
 pub(crate) mod render;
 
 use bevy::prelude::*;
-use inline::InlinePlugin;
+use inline::WebviewPlugin;
 use osc::OscPlugin;
 use render::RenderPlugin;
 
@@ -17,6 +17,6 @@ pub struct OzmuxWebviewPlugin;
 
 impl Plugin for OzmuxWebviewPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((RenderPlugin, OscPlugin, InlinePlugin));
+        app.add_plugins((RenderPlugin, OscPlugin, WebviewPlugin));
     }
 }

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -1,14 +1,14 @@
 //! In-process webview feature: CEF render wiring and the window.ozma Tier 1
 //! back-channel (render), OSC mount/unmount of inline webviews (osc), and
-//! inline webviews rendered into the terminal text flow (inline). Aggregated
+//! inline webviews rendered into the terminal text flow (mount). Aggregated
 //! behind OzmuxWebviewPlugin.
 
-pub(crate) mod inline;
+pub(crate) mod mount;
 pub(crate) mod osc;
 pub(crate) mod render;
 
 use bevy::prelude::*;
-use inline::WebviewPlugin;
+use mount::WebviewPlugin;
 use osc::OscPlugin;
 use render::RenderPlugin;
 

--- a/src/webview/inline.rs
+++ b/src/webview/inline.rs
@@ -2,7 +2,7 @@
 //! registered view into the terminal's text flow. This module owns the
 //! components, the mount/unmount policy executed by the `Mount` /
 //! `Unmount` arms of `osc::on_osc_webview_request`, and the
-//! `InlinePlugin` runtime systems that keep `WebviewSize` in
+//! `WebviewPlugin` runtime systems that keep `WebviewSize` in
 //! sync with cell metrics and project placements into `TerminalOverlays`.
 
 use super::osc::NonInteractive;
@@ -37,7 +37,7 @@ pub(crate) struct PassthroughKeys(pub(crate) Vec<NormalizedChord>);
 /// back-references" convention. Each child's `slot` is the single source of
 /// truth for slot allocation (no separate allocation table).
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
-pub(crate) struct InlineWebview {
+pub(crate) struct Webview {
     /// The registered view id this inline webview was mounted from.
     pub(crate) view_id: String,
     /// The client-assigned instance id; `None` is the implicit default
@@ -52,7 +52,7 @@ pub(crate) struct InlineWebview {
 /// grid emit carries (`project_inline_overlays` defers first projection until
 /// the grid catches up).
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct InlinePlacement {
+pub(crate) struct WebviewPlacement {
     /// Where the rect is anchored.
     pub(crate) anchor: AnchorMode,
     /// Rect height in terminal cells.
@@ -82,9 +82,9 @@ pub(crate) struct CompositeNotified;
 /// `Update` (the PTY drain systems flush the `FrameSnapshot` / `FrameDelta`
 /// observers there), so projecting just before the material rebuild hands the
 /// same frame's overlays to the shader.
-pub(super) struct InlinePlugin;
+pub(super) struct WebviewPlugin;
 
-impl Plugin for InlinePlugin {
+impl Plugin for WebviewPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Update, sync_inline_webview_size);
         app.add_systems(
@@ -112,7 +112,7 @@ impl Plugin for InlinePlugin {
 
 /// Everything the `Mount` verb carries into `mount`: the target
 /// terminal surface and the parsed verb + anchor payload.
-pub(crate) struct InlineMountContext<'a> {
+pub(crate) struct WebviewMountContext<'a> {
     /// The requesting terminal surface — the `ChildOf` parent of the mount.
     pub(crate) terminal_surface: Entity,
     /// The registered view id to mount.
@@ -130,12 +130,12 @@ pub(crate) struct InlineMountContext<'a> {
 /// The system params `mount` / `unmount` need, bundled so the
 /// `on_osc_webview_request` observer gains a single extra parameter.
 #[derive(SystemParam)]
-pub(crate) struct InlineWebviewParams<'w, 's> {
+pub(crate) struct WebviewParams<'w, 's> {
     commands: Commands<'w, 's>,
     images: ResMut<'w, Assets<Image>>,
-    placements: Query<'w, 's, &'static mut InlinePlacement>,
+    placements: Query<'w, 's, &'static mut WebviewPlacement>,
     children: Query<'w, 's, &'static Children>,
-    views: Query<'w, 's, &'static InlineWebview>,
+    views: Query<'w, 's, &'static Webview>,
     metrics: Option<Res<'w, TerminalCellMetricsResource>>,
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
@@ -212,9 +212,9 @@ pub(crate) fn resolve_mount(
 /// a placeholder cell of 8×16 physical px at scale 1.0 is used —
 /// `sync_inline_webview_size` corrects it once real metrics arrive.
 pub(crate) fn mount(
-    params: &mut InlineWebviewParams,
+    params: &mut WebviewParams,
     dynamic: &DynamicRegistry,
-    ctx: InlineMountContext<'_>,
+    ctx: WebviewMountContext<'_>,
 ) {
     let Some(anchor) = ctx.anchor else {
         tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount without anchor, dropping");
@@ -225,7 +225,7 @@ pub(crate) fn mount(
         .iter()
         .find(|(_, v)| v.view_id == ctx.view_id && v.instance_id.as_deref() == ctx.instance_id)
     {
-        let next = InlinePlacement {
+        let next = WebviewPlacement {
             anchor: anchor.mode,
             rows: ctx.rows,
             cols: ctx.cols,
@@ -272,12 +272,12 @@ pub(crate) fn mount(
         source,
         texture,
         WebviewSize(size),
-        InlineWebview {
+        Webview {
             view_id: ctx.view_id.to_string(),
             instance_id: ctx.instance_id.map(str::to_string),
             slot,
         },
-        InlinePlacement {
+        WebviewPlacement {
             anchor: anchor.mode,
             rows: ctx.rows,
             cols: ctx.cols,
@@ -322,7 +322,7 @@ pub(crate) fn mount(
 /// (the VT-synthesized fold/saturation `Unmount { view_id: None }`
 /// frames take this path).
 pub(crate) fn unmount(
-    params: &mut InlineWebviewParams,
+    params: &mut WebviewParams,
     terminal_surface: Entity,
     view_id: Option<&str>,
     instance_id: Option<&str>,
@@ -346,12 +346,12 @@ pub(crate) fn unmount(
 
 /// Returns the inline webview entity that currently holds keyboard focus on
 /// `active_surface`: `Some(e)` iff `FocusedWebview` points at `e`, `e` carries
-/// `InlineWebview`, and its `ChildOf` parent is the active surface. The input
+/// `Webview`, and its `ChildOf` parent is the active surface. The input
 /// dispatcher uses this to hoist the release-chord check, restrict the Escape
 /// scroll-to-bottom pre-handler, and suppress PTY key forwarding (spec §7).
 pub(crate) fn focused_inline_of(
     focused: Option<&FocusedWebview>,
-    inline_parents: &Query<&ChildOf, With<InlineWebview>>,
+    inline_parents: &Query<&ChildOf, With<Webview>>,
     active_surface: Option<Entity>,
 ) -> Option<Entity> {
     let candidate = focused?.0?;
@@ -362,7 +362,7 @@ pub(crate) fn focused_inline_of(
 /// A pointer hit on an interactive inline webview rect: the child entity that
 /// owns the rect and the pointer position in webview-local DIP (logical px).
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct InlineHit {
+pub(crate) struct WebviewHit {
     /// The interactive inline webview child under the pointer.
     pub(crate) child: Entity,
     /// `(local_phys − rect_origin_phys) / scale_factor` — the pointer in
@@ -384,14 +384,14 @@ pub(crate) struct InlineHit {
 /// the hit-test, so their rects pass through as plain terminal input.
 pub(crate) fn inline_hit_at(
     children: &Query<&Children>,
-    inline: &Query<(&InlineWebview, Has<NonInteractive>)>,
+    inline: &Query<(&Webview, Has<NonInteractive>)>,
     overlays: &TerminalOverlays,
     terminal: Entity,
     local_phys: Vec2,
     cell_w_phys: f32,
     cell_h_phys: f32,
     scale_factor: f32,
-) -> Option<InlineHit> {
+) -> Option<WebviewHit> {
     let row = (local_phys.y / cell_h_phys).floor() as i32;
     let col = (local_phys.x / cell_w_phys).floor() as i32;
     let kids = children.get(terminal).ok()?;
@@ -419,7 +419,7 @@ pub(crate) fn inline_hit_at(
             cell_h_phys,
             scale_factor,
         )?;
-        Some(InlineHit { child, local_dip })
+        Some(WebviewHit { child, local_dip })
     })
 }
 
@@ -457,7 +457,7 @@ fn despawn_fixed_screen_on_alt_exit(
     event: On<TerminalModeChanged>,
     mut commands: Commands,
     children: Query<&Children>,
-    placements: Query<&InlinePlacement>,
+    placements: Query<&WebviewPlacement>,
 ) {
     if !event.removed.iter().any(|m| m == ALT_SCREEN_MODE) {
         return;
@@ -477,9 +477,9 @@ fn despawn_fixed_screen_on_alt_exit(
 /// The live inline-webview children of a terminal surface.
 fn live_inline_children<'a>(
     children: &Query<&Children>,
-    views: &'a Query<&'static InlineWebview>,
+    views: &'a Query<&'static Webview>,
     terminal_surface: Entity,
-) -> Vec<(Entity, &'a InlineWebview)> {
+) -> Vec<(Entity, &'a Webview)> {
     let Ok(kids) = children.get(terminal_surface) else {
         return Vec::new();
     };
@@ -490,7 +490,7 @@ fn live_inline_children<'a>(
 
 /// The smallest slot in `0..OVERLAY_SLOTS` not occupied by a live child, or
 /// `None` when every slot is taken.
-fn smallest_free_slot(live: &[(Entity, &InlineWebview)]) -> Option<u8> {
+fn smallest_free_slot(live: &[(Entity, &Webview)]) -> Option<u8> {
     (0..OVERLAY_SLOTS as u8).find(|slot| live.iter().all(|(_, v)| v.slot != *slot))
 }
 
@@ -529,7 +529,7 @@ fn seed_logical_size(
 /// frame-to-frame unless metrics/scale actually changed, and this math is
 /// deterministic.
 fn sync_inline_webview_size(
-    mut sizes: Query<(&mut WebviewSize, &InlinePlacement)>,
+    mut sizes: Query<(&mut WebviewSize, &WebviewPlacement)>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
@@ -583,8 +583,8 @@ fn project_inline_overlays(
         Has<TerminalOverlays>,
     )>,
     inline: Query<(
-        &InlineWebview,
-        &InlinePlacement,
+        &Webview,
+        &WebviewPlacement,
         &WebviewTextureTarget,
         Has<CompositeNotified>,
         Option<&WebviewOwner>,
@@ -669,7 +669,7 @@ fn project_inline_overlays(
 /// (i.e., after its first successful projection). Entities that were never
 /// projected (never stamped `CompositeNotified`) are silently ignored.
 fn on_placement_removed(
-    event: On<Remove, InlinePlacement>,
+    event: On<Remove, WebviewPlacement>,
     owners: Query<(&WebviewOwner, Has<CompositeNotified>)>,
     writers: Res<ConnectionWriters>,
 ) {
@@ -788,7 +788,7 @@ mod tests {
             .map(|children| {
                 children
                     .iter()
-                    .filter(|child| world.get::<InlineWebview>(*child).is_some())
+                    .filter(|child| world.get::<Webview>(*child).is_some())
                     .collect()
             })
             .unwrap_or_default()
@@ -799,7 +799,7 @@ mod tests {
             .into_iter()
             .find_map(|child| {
                 app.world()
-                    .get::<InlineWebview>(child)
+                    .get::<Webview>(child)
                     .filter(|v| v.view_id == view_id)
                     .map(|v| v.slot)
             })
@@ -848,7 +848,7 @@ mod tests {
             .into_iter()
             .find_map(|child| {
                 app.world()
-                    .get::<InlineWebview>(child)
+                    .get::<Webview>(child)
                     .filter(|v| v.view_id == view_id && v.instance_id.as_deref() == instance_id)
                     .map(|v| v.slot)
             })
@@ -872,16 +872,16 @@ mod tests {
             "the inline webview must be a ChildOf the terminal surface"
         );
         assert_eq!(
-            app.world().get::<InlineWebview>(child),
-            Some(&InlineWebview {
+            app.world().get::<Webview>(child),
+            Some(&Webview {
                 view_id: "dash".into(),
                 instance_id: None,
                 slot: 0
             }),
         );
         assert_eq!(
-            app.world().get::<InlinePlacement>(child),
-            Some(&InlinePlacement {
+            app.world().get::<WebviewPlacement>(child),
+            Some(&WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -929,7 +929,7 @@ mod tests {
         let before = inline_children_of(&app, terminal);
         assert_eq!(before.len(), 1, "first mount spawns one child");
         let entity = before[0];
-        let slot_before = app.world().get::<InlineWebview>(entity).unwrap().slot;
+        let slot_before = app.world().get::<Webview>(entity).unwrap().slot;
 
         // Re-mount the same handle with a different anchor.
         app.world_mut().trigger(OscWebviewRequest {
@@ -954,8 +954,8 @@ mod tests {
             "re-mount must reuse the same entity (no reload)"
         );
         assert_eq!(
-            app.world().get::<InlinePlacement>(entity),
-            Some(&InlinePlacement {
+            app.world().get::<WebviewPlacement>(entity),
+            Some(&WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 99, col: 7 },
                 rows: 12,
                 cols: 50,
@@ -964,7 +964,7 @@ mod tests {
             "re-mount updates the placement in place"
         );
         assert_eq!(
-            app.world().get::<InlineWebview>(entity).unwrap().slot,
+            app.world().get::<Webview>(entity).unwrap().slot,
             slot_before,
             "re-mount preserves the overlay slot"
         );
@@ -1239,7 +1239,7 @@ mod tests {
         app: &mut App,
         terminal: Entity,
         slot: u8,
-        placement: InlinePlacement,
+        placement: WebviewPlacement,
     ) -> Handle<Image> {
         let handle = app
             .world_mut()
@@ -1247,7 +1247,7 @@ mod tests {
             .add(Image::default());
         app.world_mut().spawn((
             ChildOf(terminal),
-            InlineWebview {
+            Webview {
                 view_id: format!("view-{slot}"),
                 instance_id: None,
                 slot,
@@ -1290,7 +1290,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -1327,8 +1327,8 @@ mod tests {
         }
     }
 
-    fn formula_placement() -> InlinePlacement {
-        InlinePlacement {
+    fn formula_placement() -> WebviewPlacement {
+        WebviewPlacement {
             anchor: AnchorMode::Scrollback { line: 30, col: 2 },
             rows: 4,
             cols: 10,
@@ -1389,19 +1389,19 @@ mod tests {
                 ..Default::default()
             })
             .id();
-        let above = InlinePlacement {
+        let above = WebviewPlacement {
             anchor: AnchorMode::Scrollback { line: 10, col: 0 },
             rows: 10,
             cols: 10,
             frame_seq: 0,
         };
-        let below = InlinePlacement {
+        let below = WebviewPlacement {
             anchor: AnchorMode::Scrollback { line: 100, col: 0 },
             rows: 10,
             cols: 10,
             frame_seq: 0,
         };
-        let col_out = InlinePlacement {
+        let col_out = WebviewPlacement {
             anchor: AnchorMode::Scrollback { line: 35, col: 80 },
             rows: 10,
             cols: 10,
@@ -1423,7 +1423,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 79 },
                 rows: 10,
                 cols: 10,
@@ -1453,7 +1453,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -1491,7 +1491,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::FixedScreen { row: 5, col: 2 },
                 rows: 4,
                 cols: 10,
@@ -1515,7 +1515,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::FixedScreen { row: 5, col: 2 },
                 rows: 4,
                 cols: 10,
@@ -1535,7 +1535,7 @@ mod tests {
             &mut app,
             terminal,
             2,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -1561,7 +1561,7 @@ mod tests {
     fn projection_draws_two_instances_in_their_own_slots() {
         let mut app = make_test_app();
         let terminal = app.world_mut().spawn(projection_grid(7)).id();
-        let placement = InlinePlacement {
+        let placement = WebviewPlacement {
             anchor: AnchorMode::Scrollback { line: 42, col: 3 },
             rows: 10,
             cols: 40,
@@ -1614,7 +1614,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -1723,7 +1723,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(terminal),
-                InlineWebview {
+                Webview {
                     view_id: format!("view-{slot}"),
                     instance_id: None,
                     slot,
@@ -1750,11 +1750,11 @@ mod tests {
         terminal: Entity,
         local_phys: Vec2,
         scale: f32,
-    ) -> Option<InlineHit> {
+    ) -> Option<WebviewHit> {
         app.world_mut()
             .run_system_once(
                 move |children: Query<&Children>,
-                      inline: Query<(&InlineWebview, Has<NonInteractive>)>| {
+                      inline: Query<(&Webview, Has<NonInteractive>)>| {
                     inline_hit_at(
                         &children, &inline, &overlays, terminal, local_phys, HIT_CELL_W,
                         HIT_CELL_H, scale,
@@ -1775,7 +1775,7 @@ mod tests {
         let hit = run_hit(&mut app, overlays, terminal, Vec2::new(100.0, 100.0), 1.0);
         assert_eq!(
             hit,
-            Some(InlineHit {
+            Some(WebviewHit {
                 child,
                 local_dip: Vec2::new(100.0 - 24.0, 100.0 - 32.0),
             }),
@@ -1810,7 +1810,7 @@ mod tests {
             .expect("the point lies inside slot 1's rect");
         assert_eq!(
             hit.child, slot1,
-            "the hit must resolve slot → child via InlineWebview.slot"
+            "the hit must resolve slot → child via Webview.slot"
         );
         assert_eq!(hit.local_dip, Vec2::new(36.0 - 32.0, 72.0 - 64.0));
     }
@@ -2037,7 +2037,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::FixedScreen { row: 1, col: 0 },
                 rows: 4,
                 cols: 10,
@@ -2048,7 +2048,7 @@ mod tests {
             &mut app,
             terminal,
             1,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 0 },
                 rows: 4,
                 cols: 10,
@@ -2059,7 +2059,7 @@ mod tests {
             .into_iter()
             .find(|e| {
                 matches!(
-                    app.world().get::<InlinePlacement>(*e).unwrap().anchor,
+                    app.world().get::<WebviewPlacement>(*e).unwrap().anchor,
                     AnchorMode::FixedScreen { .. }
                 )
             })
@@ -2085,7 +2085,7 @@ mod tests {
         );
         assert!(matches!(
             app.world()
-                .get::<InlinePlacement>(remaining[0])
+                .get::<WebviewPlacement>(remaining[0])
                 .unwrap()
                 .anchor,
             AnchorMode::Scrollback { .. }
@@ -2213,7 +2213,7 @@ mod tests {
         app: &mut App,
         terminal: Entity,
         slot: u8,
-        placement: InlinePlacement,
+        placement: WebviewPlacement,
         connection_id: u64,
         handle: &str,
     ) -> Entity {
@@ -2224,7 +2224,7 @@ mod tests {
         app.world_mut()
             .spawn((
                 ChildOf(terminal),
-                InlineWebview {
+                Webview {
                     view_id: format!("view-{slot}"),
                     instance_id: None,
                     slot,
@@ -2249,7 +2249,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -2284,7 +2284,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -2314,7 +2314,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,
@@ -2349,7 +2349,7 @@ mod tests {
             &mut app,
             terminal,
             0,
-            InlinePlacement {
+            WebviewPlacement {
                 anchor: AnchorMode::Scrollback { line: 42, col: 3 },
                 rows: 10,
                 cols: 40,

--- a/src/webview/inline.rs
+++ b/src/webview/inline.rs
@@ -49,7 +49,7 @@ pub(crate) struct Webview {
 
 /// Where an inline webview sits: its anchor mode (scrollback line vs fixed
 /// viewport cell), the rect extent in cells, and the VT `frame_seq` the next
-/// grid emit carries (`project_inline_overlays` defers first projection until
+/// grid emit carries (`project_webview_overlays` defers first projection until
 /// the grid catches up).
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WebviewPlacement {
@@ -86,10 +86,10 @@ pub(super) struct WebviewPlugin;
 
 impl Plugin for WebviewPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, sync_inline_webview_size);
+        app.add_systems(Update, sync_webview_size);
         app.add_systems(
             PostUpdate,
-            project_inline_overlays.before(TerminalMaterialSystems::UpdateMaterial),
+            project_webview_overlays.before(TerminalMaterialSystems::UpdateMaterial),
         );
         // NOTE: without this edge, `TerminalUiMaterial`'s bind-group rebuild
         // can run between bevy_cef's rebind image-touch (which re-uploads the
@@ -202,7 +202,7 @@ pub(crate) fn resolve_mount(
 /// `TmuxPane` entity itself: `tmux_render::attach_tmux_pane_terminal` inserts
 /// both the `TerminalHandle` (which emits the OSC request) and the
 /// `TerminalRenderBundle` (`TerminalGrid`) onto that one entity, so the
-/// `ChildOf` parent is also the entity `project_inline_overlays` reads grid
+/// `ChildOf` parent is also the entity `project_webview_overlays` reads grid
 /// state from.
 ///
 /// `WebviewSize` is seeded here because `bevy_cef` builds the CEF browser
@@ -210,7 +210,7 @@ pub(crate) fn resolve_mount(
 /// scale_factor` in logical px from `TerminalCellMetricsResource` and the
 /// primary window; when neither exists yet (headless tests, pre-first-render)
 /// a placeholder cell of 8×16 physical px at scale 1.0 is used —
-/// `sync_inline_webview_size` corrects it once real metrics arrive.
+/// `sync_webview_size` corrects it once real metrics arrive.
 pub(crate) fn mount(
     params: &mut WebviewParams,
     dynamic: &DynamicRegistry,
@@ -220,7 +220,7 @@ pub(crate) fn mount(
         tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount without anchor, dropping");
         return;
     };
-    let live = live_inline_children(&params.children, &params.views, ctx.terminal_surface);
+    let live = live_webview_children(&params.children, &params.views, ctx.terminal_surface);
     if let Some((existing, _)) = live
         .iter()
         .find(|(_, v)| v.view_id == ctx.view_id && v.instance_id.as_deref() == ctx.instance_id)
@@ -328,7 +328,7 @@ pub(crate) fn unmount(
     instance_id: Option<&str>,
 ) {
     let targets: Vec<Entity> =
-        live_inline_children(&params.children, &params.views, terminal_surface)
+        live_webview_children(&params.children, &params.views, terminal_surface)
             .into_iter()
             .filter(|(_, v)| match (view_id, instance_id) {
                 (Some(vid), Some(inst)) => {
@@ -349,13 +349,13 @@ pub(crate) fn unmount(
 /// `Webview`, and its `ChildOf` parent is the active surface. The input
 /// dispatcher uses this to hoist the release-chord check, restrict the Escape
 /// scroll-to-bottom pre-handler, and suppress PTY key forwarding (spec §7).
-pub(crate) fn focused_inline_of(
+pub(crate) fn focused_webview_of(
     focused: Option<&FocusedWebview>,
-    inline_parents: &Query<&ChildOf, With<Webview>>,
+    webview_parents: &Query<&ChildOf, With<Webview>>,
     active_surface: Option<Entity>,
 ) -> Option<Entity> {
     let candidate = focused?.0?;
-    let parent = inline_parents.get(candidate).ok()?.parent();
+    let parent = webview_parents.get(candidate).ok()?.parent();
     (Some(parent) == active_surface).then_some(candidate)
 }
 
@@ -382,7 +382,7 @@ pub(crate) struct WebviewHit {
 /// visible cells (its DIP origin lies above the viewport, so `local_dip.y`
 /// lands past the clipped rows). `NonInteractive` children are invisible to
 /// the hit-test, so their rects pass through as plain terminal input.
-pub(crate) fn inline_hit_at(
+pub(crate) fn webview_hit_at(
     children: &Query<&Children>,
     inline: &Query<(&Webview, Has<NonInteractive>)>,
     overlays: &TerminalOverlays,
@@ -411,7 +411,7 @@ pub(crate) fn inline_hit_at(
         if !contains {
             return None;
         }
-        let local_dip = inline_local_dip(
+        let local_dip = webview_local_dip(
             overlays,
             view.slot,
             local_phys,
@@ -429,7 +429,7 @@ pub(crate) fn inline_hit_at(
 /// drifted off the rect still produces a (possibly out-of-view) release
 /// position. Returns `None` for an out-of-range slot or a `rows == 0`
 /// sentinel rect.
-pub(crate) fn inline_local_dip(
+pub(crate) fn webview_local_dip(
     overlays: &TerminalOverlays,
     slot: u8,
     local_phys: Vec2,
@@ -475,7 +475,7 @@ fn despawn_fixed_screen_on_alt_exit(
 }
 
 /// The live inline-webview children of a terminal surface.
-fn live_inline_children<'a>(
+fn live_webview_children<'a>(
     children: &Query<&Children>,
     views: &'a Query<&'static Webview>,
     terminal_surface: Entity,
@@ -528,7 +528,7 @@ fn seed_logical_size(
 /// IOSurface) every frame. Exact equality suffices: the inputs are identical
 /// frame-to-frame unless metrics/scale actually changed, and this math is
 /// deterministic.
-fn sync_inline_webview_size(
+fn sync_webview_size(
     mut sizes: Query<(&mut WebviewSize, &WebviewPlacement)>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -574,7 +574,7 @@ const ALT_SCREEN_MODE: &str = "alt-screen";
 /// OR already carries `TerminalOverlays`, so a terminal whose last inline
 /// child despawned converges to all-sentinel / all-`None` instead of keeping
 /// stale texture handles alive.
-fn project_inline_overlays(
+fn project_webview_overlays(
     mut commands: Commands,
     terminals: Query<(
         Entity,
@@ -600,14 +600,14 @@ fn project_inline_overlays(
         // delta can therefore never carry an alt-screen flip past this check.
         let on_alt_screen = grid.modes.iter().any(|m| m == ALT_SCREEN_MODE);
         let mut overlays = TerminalOverlays::default();
-        let mut has_inline_child = false;
+        let mut has_webview_child = false;
         if let Some(kids) = children {
             for child in kids.iter() {
                 let Ok((view, placement, texture, already_notified, owner)) = inline.get(child)
                 else {
                     continue;
                 };
-                has_inline_child = true;
+                has_webview_child = true;
                 if (grid.last_seq.wrapping_sub(placement.frame_seq) as i32) < 0 {
                     continue;
                 }
@@ -658,7 +658,7 @@ fn project_inline_overlays(
                 }
             }
         }
-        if has_inline_child || has_overlays {
+        if has_webview_child || has_overlays {
             commands.entity(terminal).insert(overlays);
         }
     }
@@ -781,7 +781,7 @@ mod tests {
         app.update();
     }
 
-    fn inline_children_of(app: &App, terminal: Entity) -> Vec<Entity> {
+    fn webview_children_of(app: &App, terminal: Entity) -> Vec<Entity> {
         let world = app.world();
         world
             .get::<Children>(terminal)
@@ -795,7 +795,7 @@ mod tests {
     }
 
     fn slot_of(app: &App, terminal: Entity, view_id: &str) -> Option<u8> {
-        inline_children_of(app, terminal)
+        webview_children_of(app, terminal)
             .into_iter()
             .find_map(|child| {
                 app.world()
@@ -844,7 +844,7 @@ mod tests {
         view_id: &str,
         instance_id: Option<&str>,
     ) -> Option<u8> {
-        inline_children_of(app, terminal)
+        webview_children_of(app, terminal)
             .into_iter()
             .find_map(|child| {
                 app.world()
@@ -862,7 +862,7 @@ mod tests {
 
         mount(&mut app, terminal, "dash", Some(test_anchor()));
 
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1, "mount must spawn one inline child");
         let child = children[0];
 
@@ -926,7 +926,7 @@ mod tests {
         register_dyn(&mut app, "dash", terminal, true);
 
         mount(&mut app, terminal, "dash", Some(test_anchor()));
-        let before = inline_children_of(&app, terminal);
+        let before = webview_children_of(&app, terminal);
         assert_eq!(before.len(), 1, "first mount spawns one child");
         let entity = before[0];
         let slot_before = app.world().get::<Webview>(entity).unwrap().slot;
@@ -947,7 +947,7 @@ mod tests {
         });
         app.world_mut().flush();
 
-        let after = inline_children_of(&app, terminal);
+        let after = webview_children_of(&app, terminal);
         assert_eq!(after.len(), 1, "re-mount must NOT spawn a second child");
         assert_eq!(
             after[0], entity,
@@ -988,7 +988,7 @@ mod tests {
 
         mount(&mut app, terminal, "e", Some(test_anchor()));
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
             "a fifth mount must be rejected once all slots are taken"
         );
@@ -1007,7 +1007,7 @@ mod tests {
         mount(&mut app, terminal, "b", Some(test_anchor()));
         unmount(&mut app, terminal, Some("a"));
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             1,
             "unmounting one view must despawn exactly its child"
         );
@@ -1030,13 +1030,13 @@ mod tests {
         }
         mount(&mut app, terminal, "a", Some(test_anchor()));
         mount(&mut app, terminal, "b", Some(test_anchor()));
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 2);
 
         unmount(&mut app, terminal, None);
 
         assert!(
-            inline_children_of(&app, terminal).is_empty(),
+            webview_children_of(&app, terminal).is_empty(),
             "unmount-all must despawn every inline child of the terminal"
         );
         for child in children {
@@ -1055,7 +1055,7 @@ mod tests {
 
         mount(&mut app, terminal, "hud", Some(test_anchor()));
 
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1);
         assert!(
             app.world().get::<NonInteractive>(children[0]).is_some(),
@@ -1072,7 +1072,7 @@ mod tests {
         mount(&mut app, terminal, "dash", None);
 
         assert!(
-            inline_children_of(&app, terminal).is_empty(),
+            webview_children_of(&app, terminal).is_empty(),
             "a mount without an anchor must be dropped"
         );
     }
@@ -1085,7 +1085,7 @@ mod tests {
         mount(&mut app, terminal, "ghost", Some(test_anchor()));
 
         assert!(
-            inline_children_of(&app, terminal).is_empty(),
+            webview_children_of(&app, terminal).is_empty(),
             "a mount for an unregistered view must be dropped"
         );
     }
@@ -1100,7 +1100,7 @@ mod tests {
         mount_instance(&mut app, terminal, "memo", "b", Some(test_anchor()));
 
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             2,
             "two distinct (view_id, instance_id) tuples must both mount"
         );
@@ -1118,7 +1118,7 @@ mod tests {
         mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
 
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             1,
             "a duplicate (view_id, instance_id) mount must be dropped"
         );
@@ -1134,7 +1134,7 @@ mod tests {
         mount_instance(&mut app, terminal, "memo", "a", Some(test_anchor()));
 
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             2,
             "the default (None) instance and a named instance are distinct"
         );
@@ -1154,7 +1154,7 @@ mod tests {
         unmount_instance(&mut app, terminal, "memo", "a");
 
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             1,
             "unmounting one instance must despawn exactly that instance"
         );
@@ -1176,7 +1176,7 @@ mod tests {
         unmount(&mut app, terminal, Some("memo"));
 
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             1,
             "view-scoped unmount must despawn every instance of that view_id only"
         );
@@ -1192,11 +1192,11 @@ mod tests {
         for inst in ["a", "b", "c", "d"] {
             mount_instance(&mut app, terminal, "memo", inst, Some(test_anchor()));
         }
-        assert_eq!(inline_children_of(&app, terminal).len(), OVERLAY_SLOTS);
+        assert_eq!(webview_children_of(&app, terminal).len(), OVERLAY_SLOTS);
 
         mount_instance(&mut app, terminal, "memo", "e", Some(test_anchor()));
         assert_eq!(
-            inline_children_of(&app, terminal).len(),
+            webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
             "the 4-slot cap is per-terminal across all instances; a 5th is rejected"
         );
@@ -1260,7 +1260,7 @@ mod tests {
 
     fn project(app: &mut App) {
         app.world_mut()
-            .run_system_once(project_inline_overlays)
+            .run_system_once(project_webview_overlays)
             .unwrap();
     }
 
@@ -1643,7 +1643,7 @@ mod tests {
         let terminal = spawn_terminal(&mut app);
         register_dyn(&mut app, "dash", terminal, true);
         mount(&mut app, terminal, "dash", Some(test_anchor()));
-        let child = inline_children_of(&app, terminal)[0];
+        let child = webview_children_of(&app, terminal)[0];
         assert_eq!(
             app.world().get::<WebviewSize>(child),
             Some(&WebviewSize(Vec2::new(320.0, 160.0))),
@@ -1663,7 +1663,7 @@ mod tests {
             phys_font_size: 24,
         });
         app.world_mut()
-            .run_system_once(sync_inline_webview_size)
+            .run_system_once(sync_webview_size)
             .unwrap();
 
         assert_eq!(
@@ -1689,7 +1689,7 @@ mod tests {
         app.init_resource::<SizeChangeProbe>();
         app.add_systems(
             Update,
-            (sync_inline_webview_size, probe_webview_size_changed).chain(),
+            (sync_webview_size, probe_webview_size_changed).chain(),
         );
         let terminal = spawn_terminal(&mut app);
         register_dyn(&mut app, "dash", terminal, true);
@@ -1706,7 +1706,7 @@ mod tests {
             !app.world().resource::<SizeChangeProbe>().0,
             "a second run with identical inputs must not change-flag WebviewSize"
         );
-        let child = inline_children_of(&app, terminal)[0];
+        let child = webview_children_of(&app, terminal)[0];
         assert_eq!(
             app.world().get::<WebviewSize>(child),
             Some(&WebviewSize(Vec2::new(320.0, 160.0))),
@@ -1755,7 +1755,7 @@ mod tests {
             .run_system_once(
                 move |children: Query<&Children>,
                       inline: Query<(&Webview, Has<NonInteractive>)>| {
-                    inline_hit_at(
+                    webview_hit_at(
                         &children, &inline, &overlays, terminal, local_phys, HIT_CELL_W,
                         HIT_CELL_H, scale,
                     )
@@ -1884,19 +1884,19 @@ mod tests {
     }
 
     #[test]
-    fn inline_local_dip_rejects_sentinel_and_out_of_range_slots() {
+    fn webview_local_dip_rejects_sentinel_and_out_of_range_slots() {
         let overlays = overlays_with(&[(0, IVec4::new(2, 3, 10, 40))]);
         assert_eq!(
-            inline_local_dip(&overlays, 0, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
+            webview_local_dip(&overlays, 0, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
             Some(Vec2::new(76.0, 68.0)),
         );
         assert_eq!(
-            inline_local_dip(&overlays, 1, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
+            webview_local_dip(&overlays, 1, Vec2::new(100.0, 100.0), 8.0, 16.0, 1.0),
             None,
             "a sentinel slot has no DIP mapping"
         );
         assert_eq!(
-            inline_local_dip(&overlays, OVERLAY_SLOTS as u8, Vec2::ZERO, 8.0, 16.0, 1.0),
+            webview_local_dip(&overlays, OVERLAY_SLOTS as u8, Vec2::ZERO, 8.0, 16.0, 1.0),
             None,
             "an out-of-range slot has no DIP mapping"
         );
@@ -1925,7 +1925,7 @@ mod tests {
 
         mount(&mut app, terminal, "DYN1", Some(test_anchor()));
 
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(
             children.len(),
             1,
@@ -2011,7 +2011,7 @@ mod tests {
 
         mount(&mut app, terminal, "HANDLE", Some(test_anchor()));
 
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(
             children.len(),
             1,
@@ -2055,7 +2055,7 @@ mod tests {
                 frame_seq: 7,
             },
         );
-        let fixed_entity = inline_children_of(&app, terminal)
+        let fixed_entity = webview_children_of(&app, terminal)
             .into_iter()
             .find(|e| {
                 matches!(
@@ -2073,7 +2073,7 @@ mod tests {
         app.world_mut().flush();
         app.update();
 
-        let remaining = inline_children_of(&app, terminal);
+        let remaining = webview_children_of(&app, terminal);
         assert_eq!(
             remaining.len(),
             1,
@@ -2143,7 +2143,7 @@ mod tests {
 
         mount(&mut app, terminal, "disp", Some(test_anchor()));
 
-        let children = inline_children_of(&app, terminal);
+        let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1);
         let child = children[0];
         match app
@@ -2181,7 +2181,7 @@ mod tests {
 
         mount(&mut app, terminal, "appv", Some(test_anchor()));
 
-        let child = inline_children_of(&app, terminal)[0];
+        let child = webview_children_of(&app, terminal)[0];
         let preload = app
             .world()
             .get::<PreloadScripts>(child)

--- a/src/webview/inline.rs
+++ b/src/webview/inline.rs
@@ -1,7 +1,7 @@
 //! Inline webviews: `ChildOf` children of a terminal surface that render a
 //! registered view into the terminal's text flow. This module owns the
-//! components, the mount/unmount policy executed by the `MountInline` /
-//! `UnmountInline` arms of `osc::on_osc_webview_request`, and the
+//! components, the mount/unmount policy executed by the `Mount` /
+//! `Unmount` arms of `osc::on_osc_webview_request`, and the
 //! `InlinePlugin` runtime systems that keep `WebviewSize` in
 //! sync with cell metrics and project placements into `TerminalOverlays`.
 
@@ -110,7 +110,7 @@ impl Plugin for InlinePlugin {
     }
 }
 
-/// Everything the `MountInline` verb carries into `mount_inline`: the target
+/// Everything the `Mount` verb carries into `mount`: the target
 /// terminal surface and the parsed verb + anchor payload.
 pub(crate) struct InlineMountContext<'a> {
     /// The requesting terminal surface — the `ChildOf` parent of the mount.
@@ -127,7 +127,7 @@ pub(crate) struct InlineMountContext<'a> {
     pub(crate) anchor: Option<InlineAnchor>,
 }
 
-/// The system params `mount_inline` / `unmount_inline` need, bundled so the
+/// The system params `mount` / `unmount` need, bundled so the
 /// `on_osc_webview_request` observer gains a single extra parameter.
 #[derive(SystemParam)]
 pub(crate) struct InlineWebviewParams<'w, 's> {
@@ -140,7 +140,7 @@ pub(crate) struct InlineWebviewParams<'w, 's> {
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
 
-/// The resolved content + trust facts for a `mount-inline;<handle>`: the URL to
+/// The resolved content + trust facts for a `mount;<handle>`: the URL to
 /// load (an `ozma-dyn://<handle>/…` origin for `Dir`/`Inline` sources, or the
 /// verbatim remote URL for a `Url` source), the input policy, and the
 /// registering program's `(connection_id, handle)` for back-channel routing.
@@ -160,7 +160,7 @@ pub(crate) struct ResolvedWebviewMount {
     pub(crate) passthrough: Vec<NormalizedChord>,
 }
 
-/// Resolves a `mount-inline` `<handle>` against the `DynamicRegistry` (Tier 1).
+/// Resolves a `mount` `<handle>` against the `DynamicRegistry` (Tier 1).
 /// `Dir`/`Inline` handles resolve to an `ozma-dyn://<handle>/…` URL (one origin
 /// per handle); a `Url` handle resolves to its verbatim remote URL. A handle
 /// resolves ONLY when `requesting_surface` is its `owner_surface` — the scoping
@@ -211,13 +211,13 @@ pub(crate) fn resolve_mount(
 /// primary window; when neither exists yet (headless tests, pre-first-render)
 /// a placeholder cell of 8×16 physical px at scale 1.0 is used —
 /// `sync_inline_webview_size` corrects it once real metrics arrive.
-pub(crate) fn mount_inline(
+pub(crate) fn mount(
     params: &mut InlineWebviewParams,
     dynamic: &DynamicRegistry,
     ctx: InlineMountContext<'_>,
 ) {
     let Some(anchor) = ctx.anchor else {
-        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount-inline without anchor, dropping");
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount without anchor, dropping");
         return;
     };
     let live = live_inline_children(&params.children, &params.views, ctx.terminal_surface);
@@ -239,7 +239,7 @@ pub(crate) fn mount_inline(
         return;
     }
     let Some(resolved) = resolve_mount(ctx.view_id, ctx.terminal_surface, dynamic) else {
-        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount-inline for unregistered or unowned id, dropping");
+        tracing::debug!(view_id = %ctx.view_id, "osc-webview: mount for unregistered or unowned id, dropping");
         return;
     };
     let Some(slot) = smallest_free_slot(&live) else {
@@ -319,9 +319,9 @@ pub(crate) fn mount_inline(
 /// Despawns the inline child(ren) of `terminal_surface` matching the scope:
 /// `(Some(vid), Some(inst))` removes that one instance; `(Some(vid), None)`
 /// removes every instance of `vid`; `(None, _)` removes all inline children
-/// (the VT-synthesized fold/saturation `UnmountInline { view_id: None }`
+/// (the VT-synthesized fold/saturation `Unmount { view_id: None }`
 /// frames take this path).
-pub(crate) fn unmount_inline(
+pub(crate) fn unmount(
     params: &mut InlineWebviewParams,
     terminal_surface: Entity,
     view_id: Option<&str>,
@@ -756,7 +756,7 @@ mod tests {
     fn mount(app: &mut App, terminal: Entity, view_id: &str, anchor: Option<InlineAnchor>) {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
-            verb: OscWebviewVerb::MountInline {
+            verb: OscWebviewVerb::Mount {
                 view_id: view_id.into(),
                 rows: 10,
                 cols: 40,
@@ -770,7 +770,7 @@ mod tests {
     fn unmount(app: &mut App, terminal: Entity, view_id: Option<&str>) {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
-            verb: OscWebviewVerb::UnmountInline {
+            verb: OscWebviewVerb::Unmount {
                 view_id: view_id.map(str::to_string),
                 instance_id: None,
             },
@@ -814,7 +814,7 @@ mod tests {
     ) {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
-            verb: OscWebviewVerb::MountInline {
+            verb: OscWebviewVerb::Mount {
                 view_id: view_id.into(),
                 rows: 10,
                 cols: 40,
@@ -828,7 +828,7 @@ mod tests {
     fn unmount_instance(app: &mut App, terminal: Entity, view_id: &str, instance_id: &str) {
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
-            verb: OscWebviewVerb::UnmountInline {
+            verb: OscWebviewVerb::Unmount {
                 view_id: Some(view_id.into()),
                 instance_id: Some(instance_id.into()),
             },
@@ -934,7 +934,7 @@ mod tests {
         // Re-mount the same handle with a different anchor.
         app.world_mut().trigger(OscWebviewRequest {
             entity: terminal,
-            verb: OscWebviewVerb::MountInline {
+            verb: OscWebviewVerb::Mount {
                 view_id: "dash".into(),
                 rows: 12,
                 cols: 50,
@@ -1073,7 +1073,7 @@ mod tests {
 
         assert!(
             inline_children_of(&app, terminal).is_empty(),
-            "a mount-inline without an anchor must be dropped"
+            "a mount without an anchor must be dropped"
         );
     }
 
@@ -1086,7 +1086,7 @@ mod tests {
 
         assert!(
             inline_children_of(&app, terminal).is_empty(),
-            "a mount-inline for an unregistered view must be dropped"
+            "a mount for an unregistered view must be dropped"
         );
     }
 

--- a/src/webview/mount.rs
+++ b/src/webview/mount.rs
@@ -384,7 +384,7 @@ pub(crate) struct WebviewHit {
 /// the hit-test, so their rects pass through as plain terminal input.
 pub(crate) fn webview_hit_at(
     children: &Query<&Children>,
-    inline: &Query<(&Webview, Has<NonInteractive>)>,
+    webviews: &Query<(&Webview, Has<NonInteractive>)>,
     overlays: &TerminalOverlays,
     terminal: Entity,
     local_phys: Vec2,
@@ -396,7 +396,7 @@ pub(crate) fn webview_hit_at(
     let col = (local_phys.x / cell_w_phys).floor() as i32;
     let kids = children.get(terminal).ok()?;
     kids.iter().find_map(|child| {
-        let Ok((view, non_interactive)) = inline.get(child) else {
+        let Ok((view, non_interactive)) = webviews.get(child) else {
             return None;
         };
         if non_interactive {
@@ -582,7 +582,7 @@ fn project_webview_overlays(
         Option<&Children>,
         Has<TerminalOverlays>,
     )>,
-    inline: Query<(
+    webviews: Query<(
         &Webview,
         &WebviewPlacement,
         &WebviewTextureTarget,
@@ -603,7 +603,7 @@ fn project_webview_overlays(
         let mut has_webview_child = false;
         if let Some(kids) = children {
             for child in kids.iter() {
-                let Ok((view, placement, texture, already_notified, owner)) = inline.get(child)
+                let Ok((view, placement, texture, already_notified, owner)) = webviews.get(child)
                 else {
                     continue;
                 };
@@ -1662,9 +1662,7 @@ mod tests {
             },
             phys_font_size: 24,
         });
-        app.world_mut()
-            .run_system_once(sync_webview_size)
-            .unwrap();
+        app.world_mut().run_system_once(sync_webview_size).unwrap();
 
         assert_eq!(
             app.world().get::<WebviewSize>(child),
@@ -1754,9 +1752,9 @@ mod tests {
         app.world_mut()
             .run_system_once(
                 move |children: Query<&Children>,
-                      inline: Query<(&Webview, Has<NonInteractive>)>| {
+                      webviews: Query<(&Webview, Has<NonInteractive>)>| {
                     webview_hit_at(
-                        &children, &inline, &overlays, terminal, local_phys, HIT_CELL_W,
+                        &children, &webviews, &overlays, terminal, local_phys, HIT_CELL_W,
                         HIT_CELL_H, scale,
                     )
                 },

--- a/src/webview/mount.rs
+++ b/src/webview/mount.rs
@@ -24,13 +24,13 @@ use ozma_tty_renderer::material::{TerminalMaterialSystems, TerminalUiMaterial};
 use ozma_tty_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
 use ozma_tty_renderer::schema::TerminalGrid;
 
-/// The normalized passthrough chords for a mounted inline webview, copied from
+/// The normalized passthrough chords for a mounted webview, copied from
 /// its registration. Read by the focused-key filter-fill and PTY-forward
 /// systems (Phase 4) off the focused child entity.
 #[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct PassthroughKeys(pub(crate) Vec<NormalizedChord>);
 
-/// Marks an inline webview entity and records its identity: the mounted
+/// Marks a webview entity and records its identity: the mounted
 /// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
 /// on its parent terminal. The owning terminal surface is NOT duplicated
 /// here — it is the `ChildOf` parent, per the multiplexer's "no typed
@@ -38,7 +38,7 @@ pub(crate) struct PassthroughKeys(pub(crate) Vec<NormalizedChord>);
 /// truth for slot allocation (no separate allocation table).
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Webview {
-    /// The registered view id this inline webview was mounted from.
+    /// The registered view id this webview was mounted from.
     pub(crate) view_id: String,
     /// The client-assigned instance id; `None` is the implicit default
     /// instance. `(view_id, instance_id)` is the per-terminal address.
@@ -47,7 +47,7 @@ pub(crate) struct Webview {
     pub(crate) slot: u8,
 }
 
-/// Where an inline webview sits: its anchor mode (scrollback line vs fixed
+/// Where a webview sits: its anchor mode (scrollback line vs fixed
 /// viewport cell), the rect extent in cells, and the VT `frame_seq` the next
 /// grid emit carries (`project_webview_overlays` defers first projection until
 /// the grid catches up).
@@ -64,16 +64,16 @@ pub(crate) struct WebviewPlacement {
     pub(crate) frame_seq: u32,
 }
 
-/// Marks a bridged inline webview entity after it has produced its first
+/// Marks a bridged webview entity after it has produced its first
 /// successful projection into `TerminalOverlays` and the `Compositing { active:
 /// true }` push notification has been sent. Prevents duplicate start
 /// notifications on subsequent frames where the same rect re-projects.
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CompositeNotified;
 
-/// Registers the inline-webview runtime systems: the `WebviewSize` size sync
+/// Registers the webview runtime systems: the `WebviewSize` size sync
 /// (`Update`), the per-frame projection that derives `TerminalOverlays` from
-/// inline-webview children (spec §5), and the render-world ordering edge that
+/// webview children (spec §5), and the render-world ordering edge that
 /// keeps webview GPU texture injection ahead of the terminal material's
 /// bind-group rebuild.
 ///
@@ -193,7 +193,7 @@ pub(crate) fn resolve_mount(
     })
 }
 
-/// Mounts a registered view as an inline webview child of the requesting
+/// Mounts a registered view as a webview child of the requesting
 /// terminal surface, applying the policy gates in order (each rejection is a
 /// `tracing::debug!` + return): missing anchor, unregistered view, duplicate
 /// `view_id` on this terminal, overlay-slot exhaustion.
@@ -312,7 +312,7 @@ pub(crate) fn mount(
         rows = ctx.rows,
         cols = ctx.cols,
         anchor = ?anchor.mode,
-        "osc-webview: inline webview mounted"
+        "osc-webview: webview mounted"
     );
 }
 
@@ -344,7 +344,7 @@ pub(crate) fn unmount(
     }
 }
 
-/// Returns the inline webview entity that currently holds keyboard focus on
+/// Returns the webview entity that currently holds keyboard focus on
 /// `active_surface`: `Some(e)` iff `FocusedWebview` points at `e`, `e` carries
 /// `Webview`, and its `ChildOf` parent is the active surface. The input
 /// dispatcher uses this to hoist the release-chord check, restrict the Escape
@@ -359,11 +359,11 @@ pub(crate) fn focused_webview_of(
     (Some(parent) == active_surface).then_some(candidate)
 }
 
-/// A pointer hit on an interactive inline webview rect: the child entity that
+/// A pointer hit on an interactive webview rect: the child entity that
 /// owns the rect and the pointer position in webview-local DIP (logical px).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct WebviewHit {
-    /// The interactive inline webview child under the pointer.
+    /// The interactive webview child under the pointer.
     pub(crate) child: Entity,
     /// `(local_phys − rect_origin_phys) / scale_factor` — the pointer in
     /// webview-local DIP, the coordinate space CEF mouse events expect.
@@ -474,7 +474,7 @@ fn despawn_fixed_screen_on_alt_exit(
     }
 }
 
-/// The live inline-webview children of a terminal surface.
+/// The live webview children of a terminal surface.
 fn live_webview_children<'a>(
     children: &Query<&Children>,
     views: &'a Query<&'static Webview>,
@@ -521,7 +521,7 @@ fn seed_logical_size(
         / scale_factor.max(f32::EPSILON)
 }
 
-/// Recomputes every inline webview's `WebviewSize` from the current cell
+/// Recomputes every webview's `WebviewSize` from the current cell
 /// metrics and primary-window scale factor (spec §6.5), writing only when the
 /// value differs — `bevy_cef` commits sizes to CEF on `Changed<WebviewSize>`,
 /// so a spurious write each frame would re-commit (and re-create the
@@ -555,7 +555,7 @@ fn sync_webview_size(
 /// `TermMode::ALT_SCREEN`.
 const ALT_SCREEN_MODE: &str = "alt-screen";
 
-/// Derives each terminal's `TerminalOverlays` from its live inline-webview
+/// Derives each terminal's `TerminalOverlays` from its live webview
 /// children, every frame, starting from the all-sentinel default (spec §5).
 ///
 /// Per-child projection rules, in order:
@@ -665,7 +665,7 @@ fn project_webview_overlays(
 }
 
 /// Sends a `Compositing { active: false }` push notification when a bridged
-/// inline webview entity is despawned after having been notified at least once
+/// webview entity is despawned after having been notified at least once
 /// (i.e., after its first successful projection). Entities that were never
 /// projected (never stamped `CompositeNotified`) are silently ignored.
 fn on_placement_removed(
@@ -869,7 +869,7 @@ mod tests {
         assert_eq!(
             app.world().get::<ChildOf>(child).map(|c| c.parent()),
             Some(terminal),
-            "the inline webview must be a ChildOf the terminal surface"
+            "the webview must be a ChildOf the terminal surface"
         );
         assert_eq!(
             app.world().get::<Webview>(child),
@@ -891,19 +891,19 @@ mod tests {
         match app
             .world()
             .get::<WebviewSource>(child)
-            .expect("inline webview must carry WebviewSource")
+            .expect("webview must carry WebviewSource")
         {
             WebviewSource::Url(url) => assert_eq!(url, "ozma-dyn://dash/index.html"),
             other => panic!("unexpected WebviewSource: {other:?}"),
         }
         assert!(
             app.world().get::<WebviewTextureTarget>(child).is_some(),
-            "inline webview must carry a headless WebviewTextureTarget"
+            "webview must carry a headless WebviewTextureTarget"
         );
         let preload = app
             .world()
             .get::<PreloadScripts>(child)
-            .expect("inline webview must carry PreloadScripts");
+            .expect("webview must carry PreloadScripts");
         assert!(
             !preload.0.is_empty(),
             "an inline (bridged) webview must carry the populated window.ozma preload"

--- a/src/webview/mount.rs
+++ b/src/webview/mount.rs
@@ -1,4 +1,4 @@
-//! Inline webviews: `ChildOf` children of a terminal surface that render a
+//! Webview mount module: `ChildOf` children of a terminal surface that render a
 //! registered view into the terminal's text flow. This module owns the
 //! components, the mount/unmount policy executed by the `Mount` /
 //! `Unmount` arms of `osc::on_osc_webview_request`, and the

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[derive(Resource, Clone)]
 pub(crate) struct OscWebviewGate(pub(crate) Arc<AtomicBool>);
 
-/// Marks an inline webview as render-only (no pointer or keyboard input
+/// Marks a webview as render-only (no pointer or keyboard input
 /// forwarded to the embedded page).
 #[derive(Component, Debug, Default)]
 pub(crate) struct NonInteractive;

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -2,7 +2,7 @@
 //! at the requesting terminal's cursor (the `Mount` / `Unmount`
 //! verbs).
 
-use super::inline::{InlineMountContext, InlineWebviewParams, mount, unmount};
+use super::inline::{WebviewMountContext, WebviewParams, mount, unmount};
 use crate::control_plane::DynamicRegistry;
 use bevy::prelude::*;
 use ozma_tty_engine::{OscWebviewRequest, OscWebviewVerb};
@@ -39,7 +39,7 @@ fn init_gate_from_config(
 
 pub(crate) fn on_osc_webview_request(
     ev: On<OscWebviewRequest>,
-    mut inline: InlineWebviewParams,
+    mut inline: WebviewParams,
     dynamic: Res<DynamicRegistry>,
 ) {
     let req = ev.event();
@@ -54,7 +54,7 @@ pub(crate) fn on_osc_webview_request(
             mount(
                 &mut inline,
                 &dynamic,
-                InlineMountContext {
+                WebviewMountContext {
                     terminal_surface,
                     view_id,
                     instance_id: instance_id.as_deref(),

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -1,8 +1,8 @@
 //! Observes `OscWebviewRequest` and mounts/unmounts an inline dynamic webview
-//! at the requesting terminal's cursor (the `MountInline` / `UnmountInline`
+//! at the requesting terminal's cursor (the `Mount` / `Unmount`
 //! verbs).
 
-use super::inline::{InlineMountContext, InlineWebviewParams, mount_inline, unmount_inline};
+use super::inline::{InlineMountContext, InlineWebviewParams, mount, unmount};
 use crate::control_plane::DynamicRegistry;
 use bevy::prelude::*;
 use ozma_tty_engine::{OscWebviewRequest, OscWebviewVerb};
@@ -45,13 +45,13 @@ pub(crate) fn on_osc_webview_request(
     let req = ev.event();
     let terminal_surface = req.entity;
     match &req.verb {
-        OscWebviewVerb::MountInline {
+        OscWebviewVerb::Mount {
             view_id,
             rows,
             cols,
             instance_id,
         } => {
-            mount_inline(
+            mount(
                 &mut inline,
                 &dynamic,
                 InlineMountContext {
@@ -64,11 +64,11 @@ pub(crate) fn on_osc_webview_request(
                 },
             );
         }
-        OscWebviewVerb::UnmountInline {
+        OscWebviewVerb::Unmount {
             view_id,
             instance_id,
         } => {
-            unmount_inline(
+            unmount(
                 &mut inline,
                 terminal_surface,
                 view_id.as_deref(),

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -1,6 +1,6 @@
 //! Observes `OscWebviewRequest` and mounts/unmounts an inline dynamic webview
 //! at the requesting terminal's cursor (the `MountInline` / `UnmountInline`
-//! verbs); the non-inline tab verbs are accepted but no longer acted on.
+//! verbs).
 
 use super::inline::{InlineMountContext, InlineWebviewParams, mount_inline, unmount_inline};
 use crate::control_plane::DynamicRegistry;
@@ -73,15 +73,6 @@ pub(crate) fn on_osc_webview_request(
                 terminal_surface,
                 view_id.as_deref(),
                 instance_id.as_deref(),
-            );
-        }
-        // The non-inline tab-mount verbs are still parsed by the VT layer but no
-        // longer act on anything (their tab-surface path was removed). Log the
-        // drop so a program still emitting them isn't met with total silence.
-        OscWebviewVerb::Mount { .. } | OscWebviewVerb::Unmount { .. } => {
-            tracing::debug!(
-                verb = ?req.verb,
-                "osc-webview: non-inline mount/unmount verb is no longer supported, dropping"
             );
         }
     }

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -39,7 +39,7 @@ fn init_gate_from_config(
 
 pub(crate) fn on_osc_webview_request(
     ev: On<OscWebviewRequest>,
-    mut inline: WebviewParams,
+    mut webview: WebviewParams,
     dynamic: Res<DynamicRegistry>,
 ) {
     let req = ev.event();
@@ -52,7 +52,7 @@ pub(crate) fn on_osc_webview_request(
             instance_id,
         } => {
             mount(
-                &mut inline,
+                &mut webview,
                 &dynamic,
                 WebviewMountContext {
                     terminal_surface,
@@ -69,7 +69,7 @@ pub(crate) fn on_osc_webview_request(
             instance_id,
         } => {
             unmount(
-                &mut inline,
+                &mut webview,
                 terminal_surface,
                 view_id.as_deref(),
                 instance_id.as_deref(),

--- a/src/webview/osc.rs
+++ b/src/webview/osc.rs
@@ -2,7 +2,7 @@
 //! at the requesting terminal's cursor (the `Mount` / `Unmount`
 //! verbs).
 
-use super::inline::{WebviewMountContext, WebviewParams, mount, unmount};
+use super::mount::{WebviewMountContext, WebviewParams, mount, unmount};
 use crate::control_plane::DynamicRegistry;
 use bevy::prelude::*;
 use ozma_tty_engine::{OscWebviewRequest, OscWebviewVerb};

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -3,7 +3,7 @@
 //! step with the active pane, and routes the `ozma.call` frames the page bridge
 //! emits to the registering program over the control socket.
 
-use super::inline::InlineWebview;
+use super::inline::Webview;
 use super::osc::NonInteractive;
 use crate::control_plane::{ConnectionWriters, OzmuxRpc, WebviewOwner};
 use crate::system_set::OzmuxSystems;
@@ -84,7 +84,7 @@ impl Plugin for RenderPlugin {
 /// CEF focus when `FocusedWebview` becomes `None`).
 ///
 /// One case is PRESERVED instead of driven: when `FocusedWebview` holds an
-/// inline webview child (`InlineWebview`) whose `ChildOf` parent is a live
+/// inline webview child (`Webview`) whose `ChildOf` parent is a live
 /// `TmuxPane` — active or not — that inline focus stands (spec §7, single
 /// focus source). This covers click-granted focus and the app-declared focus
 /// set via the control-plane `SetFocus` op, and means switching the active
@@ -97,7 +97,7 @@ pub(crate) fn sync_focused_webview(
     active_pane: Query<Entity, (With<TmuxPane>, With<ActivePane>)>,
     webviews: Query<(), With<WebviewSource>>,
     non_interactive: Query<(), With<NonInteractive>>,
-    inline_parents: Query<&ChildOf, With<InlineWebview>>,
+    inline_parents: Query<&ChildOf, With<Webview>>,
     tmux_panes: Query<(), With<TmuxPane>>,
 ) {
     // NOTE: a despawned inline child fails `inline_parents.get` here and so
@@ -350,7 +350,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane),
-                InlineWebview {
+                Webview {
                     view_id: "v".into(),
                     instance_id: None,
                     slot: 0,
@@ -394,7 +394,7 @@ mod tests {
             .world_mut()
             .spawn((
                 ChildOf(pane),
-                InlineWebview {
+                Webview {
                     view_id: "v".into(),
                     instance_id: None,
                     slot: 0,

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -97,16 +97,16 @@ pub(crate) fn sync_focused_webview(
     active_pane: Query<Entity, (With<TmuxPane>, With<ActivePane>)>,
     webviews: Query<(), With<WebviewSource>>,
     non_interactive: Query<(), With<NonInteractive>>,
-    inline_parents: Query<&ChildOf, With<Webview>>,
+    webview_parents: Query<&ChildOf, With<Webview>>,
     tmux_panes: Query<(), With<TmuxPane>>,
 ) {
-    // NOTE: a despawned inline child fails `inline_parents.get` here and so
+    // NOTE: a despawned inline child fails `webview_parents.get` here and so
     // falls through to the clear path below, which resolves to `None` and
     // clears it — that fall-through is the GC for tmux-pane inline focus; a
     // later edit that short-circuits this arm before the despawn check would
     // leak focus.
     if let Some(child) = focused.0
-        && let Ok(parent) = inline_parents.get(child)
+        && let Ok(parent) = webview_parents.get(child)
         && tmux_panes.contains(parent.parent())
     {
         return;

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -3,7 +3,7 @@
 //! step with the active pane, and routes the `ozma.call` frames the page bridge
 //! emits to the registering program over the control socket.
 
-use super::inline::Webview;
+use super::mount::Webview;
 use super::osc::NonInteractive;
 use crate::control_plane::{ConnectionWriters, OzmuxRpc, WebviewOwner};
 use crate::system_set::OzmuxSystems;

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -84,11 +84,11 @@ impl Plugin for RenderPlugin {
 /// CEF focus when `FocusedWebview` becomes `None`).
 ///
 /// One case is PRESERVED instead of driven: when `FocusedWebview` holds an
-/// inline webview child (`Webview`) whose `ChildOf` parent is a live
+/// webview child (`Webview`) whose `ChildOf` parent is a live
 /// `TmuxPane` — active or not — that inline focus stands (spec §7, single
 /// focus source). This covers click-granted focus and the app-declared focus
 /// set via the control-plane `SetFocus` op, and means switching the active
-/// pane does NOT clear an inline webview's focus: the webview keeps keyboard
+/// pane does NOT clear a webview's focus: the webview keeps keyboard
 /// focus until its child despawns (or focus moves off it), at which point the
 /// sync falls through to the clear path below, which maps the active terminal
 /// pane to `None`.


### PR DESCRIPTION
## Problem

With the legacy tab-webview path gone, the OSC 5379 webview verbs and the
"inline webview" feature still carried a now-redundant `-inline` qualifier —
inline is the only webview placement left, so the qualifier no longer
distinguished anything, and the bare verb/identifier naming had drifted from the
feature it describes.

## Solution

A **pure mechanical rename** across every layer (no behavior change anywhere,
except one intentional config back-compat shim), preceded by a baseline commit
removing the unused legacy non-inline `mount`/`unmount` (tab) verbs.

- **OSC verb:** `mount-inline`/`unmount-inline` → `mount`/`unmount` — wire token,
  `OscWebviewVerb::MountInline/UnmountInline` → `Mount/Unmount`, the VT parser,
  and the SDK/example emitters.
- **Feature → "webview":** types (`InlineWebview`→`Webview`,
  `InlinePlacement`→`WebviewPlacement`, `InlineWebviewParams`→`WebviewParams`,
  `InlineMountContext`→`WebviewMountContext`, `InlinePlugin`→`WebviewPlugin`,
  `InlineHit`→`WebviewHit`), functions, query/field identifiers, the
  `src/webview/inline.rs` → `src/webview/mount.rs` module, and the docs
  (`docs/inline-webview.md` → `docs/webview.md`).
- **Config:** shortcut key `release-inline-focus` → `release-webview-focus`.

Intentionally **kept** (the established principle: feature-name → renamed,
placement-descriptor / unrelated → kept): the `kind:"inline"` register **source
kind** (plus `Webview::inline`, `*::Inline`, `insert_inline`, `#[inline]`,
"inline HTML"), `InlineAnchor`/`AnchorMode` (they describe scrollback-vs-fixed
placement, not the feature), and adjectival "inline" in comments.

**Affected:** `ozma_tty_engine`, `ozmux-gui` (`src/`), `ozmux_configs`,
`ratatui-ozma` SDK, `examples/`, docs. (Design spec + implementation plan live
under `docs/superpowers/`.)

**Verified:** `cargo build --all-features`, `cargo test` (every renamed crate
green — 1004 workspace tests pass; `cargo clippy --workspace --all-targets`
clean; `cargo fmt` applied), plus a `--no-ignore` "no residual feature `inline`"
gate. One pre-existing, unrelated `ozmux_tmux` test
(`observers::tests::connection_reset_clears_everything`) fails identically on
`main` — `crates/tmux_session` has zero diff on this branch and depends on none
of the renamed crates.

### Breaking Changes

- **OSC wire protocol:** emit `ESC ] 5379 ; mount ; <view_id> ; <rows> ; <cols>`
  / `ESC ] 5379 ; unmount [ ; <view_id> [ ; <instance_id> ] ]`. The old
  `mount-inline`/`unmount-inline` verbs are no longer recognized (silently
  dropped). Semantics, validation, and geometry limits are unchanged.
- **Config:** rename `release-inline-focus` → `release-webview-focus` in
  `~/.config/ozmux/config.toml`. The old key is accepted-and-ignored for one
  release so existing configs still parse under `deny_unknown_fields`, but it no
  longer binds the shortcut — migrate to the new key (default chord
  `Ctrl+Shift+Escape` unchanged).
- **SDK / public API:** `ratatui-ozma` emitters `osc::mount_inline`/`unmount_inline`
  → `osc::mount`/`osc::unmount`; engine `OscWebviewVerb` variants and the GUI
  webview types renamed as listed above (`InlineAnchor` retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
