### PR TITLE
feat(ratatui-ozma): preload scripts for webviews

### DIFF
--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -80,6 +80,9 @@ pub(crate) enum RegisterKind {
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         forward_keys: Vec<KeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        preload: Vec<String>,
     },
     /// A directory of assets served at `ozma-dyn://<handle>/`.
     Dir {
@@ -92,6 +95,9 @@ pub(crate) enum RegisterKind {
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         forward_keys: Vec<KeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        preload: Vec<String>,
     },
     /// Load a remote `http(s)` URL as the top-level document.
     Url {
@@ -104,6 +110,9 @@ pub(crate) enum RegisterKind {
         /// Chords the page lets through to the app while focused.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         forward_keys: Vec<KeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        preload: Vec<String>,
     },
 }
 
@@ -176,6 +185,7 @@ mod tests {
             html: "<h1>hi</h1>".into(),
             interactive: true,
             forward_keys: Vec::new(),
+            preload: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["op"], "register");
@@ -269,6 +279,7 @@ mod tests {
             interactive: true,
             bridge: false,
             forward_keys: Vec::new(),
+            preload: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["op"], "register");
@@ -289,6 +300,7 @@ mod tests {
             interactive: true,
             bridge: true,
             forward_keys: Vec::new(),
+            preload: Vec::new(),
         }))
         .unwrap();
         assert_eq!(v["kind"], "url");

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -29,6 +29,7 @@ impl Webview {
                 html: html.into(),
                 interactive: true,
                 forward_keys: Vec::new(),
+                preload: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -46,6 +47,7 @@ impl Webview {
                 interactive: true,
                 bridge: false,
                 forward_keys: Vec::new(),
+                preload: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -59,6 +61,7 @@ impl Webview {
                 entry: entry.into(),
                 interactive: true,
                 forward_keys: Vec::new(),
+                preload: Vec::new(),
             },
             handlers: HashMap::new(),
         }
@@ -90,6 +93,29 @@ impl Webview {
             RegisterKind::Inline { forward_keys, .. }
             | RegisterKind::Dir { forward_keys, .. }
             | RegisterKind::Url { forward_keys, .. } => forward_keys.extend(keys),
+        }
+        self
+    }
+
+    /// Declares JavaScript injected before the page's own scripts run, in the
+    /// order supplied. Runs after the host's `window.ozma` bridge (and the
+    /// link-hint engine for url views), so a script may use `window.ozma` when
+    /// the view is bridged. Additive across calls; applies to all view kinds,
+    /// including display-only `url` views.
+    ///
+    /// Each entry should be a complete, self-contained statement: the host
+    /// concatenates all preload scripts with `;` and evaluates them as one
+    /// script in the page's shared context, so a trailing `//` line comment, a
+    /// top-level redeclaration colliding with the bridge's identifiers, or a
+    /// syntax error can break the whole eval. Wrapping each entry in an IIFE
+    /// (`(() => { … })();`) is the safe idiom.
+    pub fn preload(mut self, scripts: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        match &mut self.kind {
+            RegisterKind::Inline { preload, .. }
+            | RegisterKind::Dir { preload, .. }
+            | RegisterKind::Url { preload, .. } => {
+                preload.extend(scripts.into_iter().map(Into::into));
+            }
         }
         self
     }
@@ -319,6 +345,38 @@ mod tests {
         let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
         assert_eq!(v["kind"], "url");
         assert_eq!(v["forward_keys"][0]["key"], "h");
+    }
+
+    #[test]
+    fn preload_accumulates_across_calls_and_rides_register_wire() {
+        let wv = Webview::inline("x")
+            .preload(["window.A = 1;"])
+            .preload(["window.B = 2;"]);
+        let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
+        assert_eq!(v["preload"][0], "window.A = 1;");
+        assert_eq!(v["preload"][1], "window.B = 2;");
+    }
+
+    #[test]
+    fn preload_rides_wire_for_every_kind() {
+        for wv in [
+            Webview::inline("x").preload(["a"]),
+            Webview::dir("/abs/ui", "index.html").preload(["a"]),
+            Webview::url("https://example.com").preload(["a"]),
+        ] {
+            let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
+            assert_eq!(
+                v["preload"][0], "a",
+                "preload must ride the wire for every kind"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_preload_is_omitted_from_wire() {
+        let wv = Webview::inline("x");
+        let v = serde_json::to_value(crate::protocol::ClientMsg::Register(wv.kind)).unwrap();
+        assert!(v.get("preload").is_none(), "empty preload must be skipped");
     }
 
     #[test]

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -100,6 +100,11 @@ pub(crate) struct DynamicView {
     /// `register` wire payload. Copied onto the mounted webview entity as
     /// `ForwardKeys` so Phase-4 systems can read them off the focused child.
     pub(crate) forward_keys: Vec<NormalizedChord>,
+    /// User-supplied preload scripts, copied verbatim from the register wire
+    /// and injected onto the mounted webview's `PreloadScripts` after the host
+    /// bridge/hints. No size cap or validation (the registering program is
+    /// local and trusted).
+    pub(crate) preload: Vec<String>,
 }
 
 /// Stamped on a Tier 1 webview entity at mount: the control-plane
@@ -649,6 +654,7 @@ fn build_view(
             entry,
             interactive,
             forward_keys,
+            preload,
         } => {
             let root_path = PathBuf::from(&root);
             if !root_path.is_absolute() || !root_path.is_dir() {
@@ -664,12 +670,14 @@ fn build_view(
                 owner_surface,
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
+                preload,
             })
         }
         RegisterKind::Inline {
             html,
             interactive,
             forward_keys,
+            preload,
         } => {
             if html.len() > MAX_INLINE_HTML {
                 return Err("html_too_large");
@@ -681,6 +689,7 @@ fn build_view(
                 owner_surface,
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
+                preload,
             })
         }
         RegisterKind::Url {
@@ -688,6 +697,7 @@ fn build_view(
             interactive,
             bridge,
             forward_keys,
+            preload,
         } => {
             let url = validate_url_source(&url)?;
             Ok(DynamicView {
@@ -697,6 +707,7 @@ fn build_view(
                 owner_surface,
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
+                preload,
             })
         }
     }
@@ -919,6 +930,7 @@ mod token_tests {
                 owner_surface: pane,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         dyn_assets.insert_dir("h", "/x".into());
@@ -962,6 +974,7 @@ mod registry_tests {
                 owner_surface: surface(1),
                 connection_id: 7,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         assert_eq!(reg.get("h1").map(|v| v.interactive), Some(true));
@@ -1009,6 +1022,7 @@ mod registry_tests {
             owner_surface: owner,
             connection_id: conn,
             forward_keys: vec![],
+            preload: vec![],
         }
     }
 }
@@ -1040,6 +1054,7 @@ mod apply_tests {
                     entry: "index.html".into(),
                     interactive: true,
                     forward_keys: vec![],
+                    preload: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1085,6 +1100,7 @@ mod apply_tests {
                     html: "<h1>x</h1>".into(),
                     interactive: true,
                     forward_keys: vec![],
+                    preload: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1122,6 +1138,7 @@ mod apply_tests {
                     entry: "index.html".into(),
                     interactive: true,
                     forward_keys: vec![],
+                    preload: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1148,6 +1165,7 @@ mod apply_tests {
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         dyn_assets.insert_dir("h", "/x".into());
@@ -1191,6 +1209,7 @@ mod apply_tests {
                 owner_surface: Entity::from_bits(1),
                 connection_id: 9,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
@@ -1335,6 +1354,7 @@ mod apply_tests {
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         app.world_mut().spawn(Webview {
@@ -1389,6 +1409,7 @@ mod apply_tests {
                     interactive: true,
                     bridge: false,
                     forward_keys: vec![],
+                    preload: vec![],
                 },
                 reply: reply_tx,
             })
@@ -1427,6 +1448,7 @@ mod apply_tests {
                 owner_surface: Entity::from_bits(1),
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let mounted = app
@@ -1496,6 +1518,7 @@ mod apply_tests {
                 owner_surface: surface,
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let child = app
@@ -1551,6 +1574,7 @@ mod apply_tests {
                 owner_surface: surface,
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let child = app
@@ -1607,6 +1631,7 @@ mod apply_tests {
                 owner_surface: surface,
                 connection_id: 5,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let child = app
@@ -1673,6 +1698,7 @@ mod focus_tests {
                 owner_surface: surface,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let child = app
@@ -1737,6 +1763,7 @@ mod focus_tests {
                 owner_surface: surface,
                 connection_id: 99,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         // Spawn a VALID interactive inline child that WOULD be focused if the
@@ -1793,6 +1820,7 @@ mod focus_tests {
                 owner_surface: surface_a,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         // Spawn the matching interactive inline child on surface_a.
@@ -1904,6 +1932,7 @@ mod focus_tests {
                 owner_surface: surface,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let child = app
@@ -2127,6 +2156,7 @@ mod url_source_tests {
                 interactive: true,
                 bridge: true,
                 forward_keys: vec![],
+                preload: vec![],
             },
             Entity::from_bits(1),
             7,
@@ -2146,11 +2176,28 @@ mod url_source_tests {
                 interactive: true,
                 bridge: false,
                 forward_keys: vec![],
+                preload: vec![],
             },
             Entity::from_bits(1),
             7,
         )
         .unwrap_err();
         assert_eq!(err, "unsupported_scheme");
+    }
+
+    #[test]
+    fn build_view_copies_preload_through() {
+        let view = build_view(
+            RegisterKind::Inline {
+                html: "<h1>x</h1>".into(),
+                interactive: true,
+                forward_keys: vec![],
+                preload: vec!["window.A=1;".into()],
+            },
+            Entity::from_bits(1),
+            1,
+        )
+        .expect("valid inline");
+        assert_eq!(view.preload, vec!["window.A=1;".to_string()]);
     }
 }

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -105,6 +105,9 @@ pub(crate) enum RegisterKind {
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
         forward_keys: Vec<HostKeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(default)]
+        preload: Vec<String>,
     },
     /// Serve a single dynamic HTML document supplied inline.
     Inline {
@@ -116,6 +119,9 @@ pub(crate) enum RegisterKind {
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
         forward_keys: Vec<HostKeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(default)]
+        preload: Vec<String>,
     },
     /// Load a remote `http(s)` URL as the top-level document.
     Url {
@@ -130,6 +136,9 @@ pub(crate) enum RegisterKind {
         /// Chords the host passes through to PTY instead of consuming in CEF.
         #[serde(default)]
         forward_keys: Vec<HostKeyChord>,
+        /// User-supplied scripts injected before the page's own scripts run.
+        #[serde(default)]
+        preload: Vec<String>,
     },
 }
 
@@ -213,6 +222,7 @@ mod tests {
                 entry: "index.html".into(),
                 interactive: true,
                 forward_keys: vec![],
+                preload: vec![],
             })
         );
     }
@@ -229,6 +239,7 @@ mod tests {
                 html: "<h1>x</h1>".into(),
                 interactive: false,
                 forward_keys: vec![],
+                preload: vec![],
             })
         );
     }
@@ -344,6 +355,7 @@ mod tests {
                 interactive: true,
                 bridge: false,
                 forward_keys: vec![],
+                preload: vec![],
             })
         );
     }
@@ -361,6 +373,7 @@ mod tests {
                 interactive: true,
                 bridge: true,
                 forward_keys: vec![],
+                preload: vec![],
             })
         );
     }
@@ -376,6 +389,7 @@ mod tests {
                 interactive: true,
                 bridge: false,
                 forward_keys: vec![],
+                preload: vec![],
             })
         );
     }
@@ -442,5 +456,31 @@ mod tests {
                 action: NavAction::To("https://example.com".into()),
             }
         );
+    }
+
+    #[test]
+    fn parses_register_with_preload() {
+        let m: ClientMsg = serde_json::from_str(
+            r#"{"op":"register","kind":"inline","html":"x","preload":["window.A=1;"]}"#,
+        )
+        .unwrap();
+        match m {
+            ClientMsg::Register(RegisterKind::Inline { preload, .. }) => {
+                assert_eq!(preload, vec!["window.A=1;".to_string()]);
+            }
+            _ => panic!("expected inline register"),
+        }
+    }
+
+    #[test]
+    fn preload_defaults_empty_when_absent() {
+        let m: ClientMsg =
+            serde_json::from_str(r#"{"op":"register","kind":"inline","html":"x"}"#).unwrap();
+        match m {
+            ClientMsg::Register(RegisterKind::Inline { preload, .. }) => {
+                assert!(preload.is_empty())
+            }
+            _ => panic!("expected inline register"),
+        }
     }
 }

--- a/src/control_plane/protocol.rs
+++ b/src/control_plane/protocol.rs
@@ -478,7 +478,7 @@ mod tests {
             serde_json::from_str(r#"{"op":"register","kind":"inline","html":"x"}"#).unwrap();
         match m {
             ClientMsg::Register(RegisterKind::Inline { preload, .. }) => {
-                assert!(preload.is_empty())
+                assert!(preload.is_empty());
             }
             _ => panic!("expected inline register"),
         }

--- a/src/webview/mount.rs
+++ b/src/webview/mount.rs
@@ -728,6 +728,7 @@ mod tests {
                 owner_surface,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
     }
@@ -746,6 +747,7 @@ mod tests {
                 owner_surface,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
     }
@@ -1921,6 +1923,7 @@ mod tests {
                 owner_surface,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
     }
@@ -1969,6 +1972,7 @@ mod tests {
                 owner_surface: owner,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
 
@@ -1997,6 +2001,7 @@ mod tests {
                 owner_surface: owner,
                 connection_id: 1,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         let r = resolve_mount("INLINEH", owner, &dynamic).expect("inline resolves");
@@ -2018,6 +2023,7 @@ mod tests {
                 owner_surface: terminal,
                 connection_id: 42,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
 
@@ -2121,6 +2127,7 @@ mod tests {
                 owner_surface: surface,
                 connection_id: 7,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
         reg.insert(
@@ -2135,6 +2142,7 @@ mod tests {
                 owner_surface: surface,
                 connection_id: 7,
                 forward_keys: vec![],
+                preload: vec![],
             },
         );
 

--- a/src/webview/mount.rs
+++ b/src/webview/mount.rs
@@ -16,7 +16,8 @@ use bevy::render::{Render, RenderApp, render_asset::prepare_assets};
 use bevy::ui_render::PreparedUiMaterial;
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::{
-    FocusedWebview, WebviewGpuImageInjectSet, WebviewSize, WebviewSource, WebviewTextureTarget,
+    FocusedWebview, PreloadScripts, WebviewGpuImageInjectSet, WebviewSize, WebviewSource,
+    WebviewTextureTarget,
 };
 use ozma_tty_engine::{AnchorMode, InlineAnchor, TerminalModeChanged};
 use ozma_tty_renderer::TerminalCellMetricsResource;
@@ -161,6 +162,9 @@ pub(crate) struct ResolvedWebviewMount {
     /// as a `ForwardKeys` component so the focused-key systems read them off
     /// the webview entity without a registry lookup (design spec §C).
     pub(crate) forward_keys: Vec<NormalizedChord>,
+    /// User-supplied preload scripts, injected after the host bridge/hints
+    /// (and as the only scripts for a display-only view).
+    pub(crate) preload: Vec<String>,
 }
 
 /// Resolves a `mount` `<handle>` against the `DynamicRegistry` (Tier 1).
@@ -195,6 +199,7 @@ pub(crate) fn resolve_mount(
         owner,
         is_url,
         forward_keys: view.forward_keys.clone(),
+        preload: view.preload.clone(),
     })
 }
 
@@ -293,15 +298,15 @@ pub(crate) fn mount(
         params.commands.entity(webview).insert(NonInteractive);
     }
     // NOTE: the ozma bridge script (window.ozma) and WebviewOwner (the
-    // inbound-call gate) are inserted only for a bridged registration. A
-    // display-only view (owner None) gets no bridge script (PreloadScripts
-    // remains the empty default from WebviewSource #[require]) and no
-    // WebviewOwner.
+    // inbound-call gate) are inserted only for a bridged registration; the
+    // user's preload scripts ride after the bridge/hints. A display-only view
+    // (owner None) gets no bridge and no WebviewOwner, but still receives its
+    // own preload scripts when it declared any.
     if let Some((connection_id, handle)) = resolved.owner {
         let preload = if resolved.is_url {
-            build_url_preload()
+            build_url_preload(&resolved.preload)
         } else {
-            build_dynamic_preload()
+            build_dynamic_preload(&resolved.preload)
         };
         params.commands.entity(webview).insert((
             preload,
@@ -310,6 +315,11 @@ pub(crate) fn mount(
                 handle,
             },
         ));
+    } else if !resolved.preload.is_empty() {
+        params
+            .commands
+            .entity(webview)
+            .insert(PreloadScripts::from(resolved.preload.clone()));
     }
     params
         .commands
@@ -2389,6 +2399,117 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "despawning a never-projected entity must NOT send a stop notification"
+        );
+    }
+
+    #[test]
+    fn mount_bridged_inline_appends_user_preload_after_bridge() {
+        use crate::control_plane::{DynSource, DynamicView};
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        app.world_mut().resource_mut::<DynamicRegistry>().insert(
+            "h".into(),
+            DynamicView {
+                source: DynSource::Inline("<h1>x</h1>".into()),
+                entry: "index.html".into(),
+                interactive: true,
+                owner_surface: terminal,
+                connection_id: 1,
+                forward_keys: vec![],
+                preload: vec!["window.USER = 1;".into()],
+            },
+        );
+
+        mount(&mut app, terminal, "h", Some(test_anchor()));
+
+        let child = webview_children_of(&app, terminal)[0];
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("PreloadScripts present");
+        assert!(preload.0.len() >= 2, "bridge + user script");
+        assert_eq!(
+            preload.0.last().map(String::as_str),
+            Some("window.USER = 1;"),
+            "the user script must come last, after the ozma bridge"
+        );
+    }
+
+    #[test]
+    fn mount_bridged_url_appends_user_preload_after_bridge_and_hints() {
+        use crate::control_plane::{DynSource, DynamicView};
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        app.world_mut().resource_mut::<DynamicRegistry>().insert(
+            "u".into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: "https://app.example.com".into(),
+                    bridge: true,
+                },
+                entry: String::new(),
+                interactive: true,
+                owner_surface: terminal,
+                connection_id: 1,
+                forward_keys: vec![],
+                preload: vec!["window.USER = 1;".into()],
+            },
+        );
+
+        mount(&mut app, terminal, "u", Some(test_anchor()));
+
+        let child = webview_children_of(&app, terminal)[0];
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("PreloadScripts present");
+        assert!(
+            preload.0.iter().any(|s| s.contains("hints:show")),
+            "a bridged url view keeps the link-hint engine"
+        );
+        assert_eq!(
+            preload.0.last().map(String::as_str),
+            Some("window.USER = 1;"),
+            "the user script must come last, after bridge + hints"
+        );
+    }
+
+    #[test]
+    fn mount_display_only_url_with_preload_injects_user_scripts_only() {
+        use crate::control_plane::{DynSource, DynamicView, WebviewOwner};
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        app.world_mut().resource_mut::<DynamicRegistry>().insert(
+            "disp".into(),
+            DynamicView {
+                source: DynSource::Url {
+                    url: "https://example.com".into(),
+                    bridge: false,
+                },
+                entry: String::new(),
+                interactive: true,
+                owner_surface: terminal,
+                connection_id: 1,
+                forward_keys: vec![],
+                preload: vec!["window.USER = 1;".into()],
+            },
+        );
+
+        mount(&mut app, terminal, "disp", Some(test_anchor()));
+
+        let child = webview_children_of(&app, terminal)[0];
+        let preload = app
+            .world()
+            .get::<PreloadScripts>(child)
+            .expect("PreloadScripts present");
+        assert_eq!(
+            preload.0,
+            vec!["window.USER = 1;".to_string()],
+            "a display-only url with preload must carry only the user scripts"
+        );
+        assert!(
+            app.world().get::<WebviewOwner>(child).is_none(),
+            "a display-only url must carry no WebviewOwner even with preload"
         );
     }
 }

--- a/src/webview/render/preload.rs
+++ b/src/webview/render/preload.rs
@@ -15,17 +15,23 @@ pub(super) const OZMA_BRIDGE_JS: &str = include_str!("ozma_bridge.js");
 const OZMA_HINTS_JS: &str = include_str!("ozma_hints.js");
 
 /// Builds the preload for a Tier 1 dynamic webview: the `window.ozma`
-/// back-channel bridge. No capability grant — the bridge routes to the
-/// registering program, not the host.
-pub(crate) fn build_dynamic_preload() -> PreloadScripts {
-    PreloadScripts::from([OZMA_BRIDGE_JS.to_string()])
+/// back-channel bridge, followed by the registering program's user scripts.
+/// No capability grant — the bridge routes to the registering program, not the
+/// host.
+pub(crate) fn build_dynamic_preload(user: &[String]) -> PreloadScripts {
+    let mut scripts = vec![OZMA_BRIDGE_JS.to_string()];
+    scripts.extend(user.iter().cloned());
+    PreloadScripts::from(scripts)
 }
 
-/// Builds the preload for a bridged URL webview: the `window.ozma` bridge
-/// followed by the link-hint engine. Order matters — the hint engine consumes
-/// `window.ozma`, which the bridge defines, so the bridge entry is first.
-pub(crate) fn build_url_preload() -> PreloadScripts {
-    PreloadScripts::from([OZMA_BRIDGE_JS.to_string(), OZMA_HINTS_JS.to_string()])
+/// Builds the preload for a bridged URL webview: the `window.ozma` bridge, then
+/// the link-hint engine, then the registering program's user scripts. Order
+/// matters — the hint engine consumes `window.ozma` (defined by the bridge), and
+/// user scripts run last so they may use both.
+pub(crate) fn build_url_preload(user: &[String]) -> PreloadScripts {
+    let mut scripts = vec![OZMA_BRIDGE_JS.to_string(), OZMA_HINTS_JS.to_string()];
+    scripts.extend(user.iter().cloned());
+    PreloadScripts::from(scripts)
 }
 
 #[cfg(test)]
@@ -34,7 +40,7 @@ mod tests {
 
     #[test]
     fn dynamic_preload_injects_only_the_ozma_bridge() {
-        let preload = build_dynamic_preload();
+        let preload = build_dynamic_preload(&[]);
         assert_eq!(preload.0.len(), 1, "ozma bridge only");
         assert_eq!(preload.0[0], OZMA_BRIDGE_JS);
         assert!(
@@ -45,7 +51,7 @@ mod tests {
 
     #[test]
     fn url_preload_injects_bridge_then_hints_in_order() {
-        let preload = build_url_preload();
+        let preload = build_url_preload(&[]);
         assert_eq!(preload.0.len(), 2, "bridge + hints");
         assert_eq!(preload.0[0], OZMA_BRIDGE_JS, "bridge must run first");
         assert_eq!(preload.0[1], OZMA_HINTS_JS, "hints run after the bridge");
@@ -55,10 +61,29 @@ mod tests {
 
     #[test]
     fn dynamic_preload_has_no_hints() {
-        let preload = build_dynamic_preload();
+        let preload = build_dynamic_preload(&[]);
         assert!(
             !preload.0.iter().any(|s| s.contains("hints:show")),
             "inline/dir webviews must not carry the hint engine"
+        );
+    }
+
+    #[test]
+    fn user_scripts_are_appended_after_host_scripts() {
+        let user = vec!["window.USER = 1;".to_string()];
+
+        let dynamic = build_dynamic_preload(&user);
+        assert_eq!(dynamic.0.len(), 2);
+        assert_eq!(dynamic.0[0], OZMA_BRIDGE_JS, "bridge first");
+        assert_eq!(dynamic.0[1], "window.USER = 1;", "user script last");
+
+        let url = build_url_preload(&user);
+        assert_eq!(url.0.len(), 3);
+        assert_eq!(url.0[0], OZMA_BRIDGE_JS);
+        assert_eq!(url.0[1], OZMA_HINTS_JS);
+        assert_eq!(
+            url.0[2], "window.USER = 1;",
+            "user script after bridge+hints"
         );
     }
 }


### PR DESCRIPTION
## Problem

A program embedding an ozmux webview could not inject its own JavaScript to run before the page's own scripts. The host already builds a per-webview `bevy_cef` `PreloadScripts` vector (the `window.ozma` bridge, plus the link-hint engine for bridged URL views), but its contents were fixed by the host — there was no SDK surface for the registering program to add to it.

## Solution

Thread a new `preload: Vec<String>` field along the exact path the existing `forward_keys` field already travels, then append the user scripts after the host-built bridge/hints when inserting `PreloadScripts`.

Affected parts:
- **SDK (`sdk/ratatui-ozma`)** — `Webview::preload(scripts)` builder (additive across calls, all view kinds) + a `preload` field on the wire `RegisterKind` (serialized, omitted when empty).
- **Control plane (`src/control_plane.rs`, `src/control_plane/protocol.rs`)** — `preload` on the host wire `RegisterKind` (`#[serde(default)]`) carried verbatim through `build_view` into `DynamicView`.
- **Webview mount (`src/webview/mount.rs`, `src/webview/render/preload.rs`)** — `build_dynamic_preload`/`build_url_preload` append the user scripts last (bridge → hints → user); the mount-time gate is relaxed so a display-only `url` view with preload also receives a `PreloadScripts` (user scripts only — no bridge, no `WebviewOwner`).

Ordering invariant: user scripts always run after the host bridge/hints, so a bridged page's script may use `window.ozma`. Each entry should be a self-contained statement (the host concatenates entries with `;` and evals once) — documented on the builder with an IIFE recommendation.

### Non-breaking

An empty `preload` is omitted on the SDK wire and defaults to empty on the host, so existing clients and register frames are unaffected. No size cap (consistent with `forward_keys`; the registering program is local and trusted).

Tests: `ratatui-ozma` 87 passing, `ozmux-gui` 405 passing (incl. new SDK wire, host parse, `build_view`, builder-order, and four mount-behavior tests); pre-existing display-only/bridged regression tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
