### PR TITLE
feat(ratatui-ozma): one-way Webview→app inbound events (+ ozmd migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,7 +4931,6 @@ name = "ozmd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "crossbeam-channel",
  "notify-debouncer-full",
  "pulldown-cmark",
  "ratatui",

--- a/apps/ozmd/Cargo.toml
+++ b/apps/ozmd/Cargo.toml
@@ -21,7 +21,6 @@ pulldown-cmark = "0.12"
 notify-debouncer-full = "0.3"
 rust-embed = "8"
 tempfile = { workspace = true }
-crossbeam-channel = "0.5"
 
 [lints]
 workspace = true

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -12,7 +12,6 @@ mod watcher;
 use crate::app::{App, Cmd};
 use crate::protocol::{Content, Scroll, ScrollState, Search, SearchCount, SearchNav};
 use crate::ui::LiveStatus;
-use crossbeam_channel::{Receiver, Sender};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{self, Event};
@@ -26,12 +25,6 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-/// Messages forwarded from page→controller `.on` handlers to the main loop.
-enum PageMsg {
-    SearchCount(SearchCount),
-    ScrollState(ScrollState),
-}
 
 fn main() {
     if let Err(e) = run() {
@@ -57,8 +50,7 @@ fn run() -> anyhow::Result<()> {
 
     let asset_dir = assets::materialize()?;
 
-    let (page_tx, page_rx) = crossbeam_channel::unbounded::<PageMsg>();
-    let view = register_view(&ozma, &asset_dir, Arc::clone(&shared), page_tx)?;
+    let view = register_view(&ozma, &asset_dir, Arc::clone(&shared))?;
 
     let (reload_tx, reload_rx) = mpsc::channel::<()>();
     let _watcher = watcher::watch(&path, reload_tx)?;
@@ -70,7 +62,7 @@ fn run() -> anyhow::Result<()> {
     }
     install_panic_hook();
 
-    let result = event_loop(&ozma, &view, &shared, &path, &page_rx, &reload_rx);
+    let result = event_loop(&ozma, &view, &shared, &path, &reload_rx);
 
     let _ = disable_raw_mode();
     let _ = execute!(stdout(), LeaveAlternateScreen);
@@ -81,11 +73,8 @@ fn register_view(
     ozma: &Ozma,
     asset_dir: &tempfile::TempDir,
     shared: Arc<Mutex<document::Document>>,
-    page_tx: Sender<PageMsg>,
 ) -> anyhow::Result<WebviewHandle> {
     let ready_doc = Arc::clone(&shared);
-    let count_tx = page_tx.clone();
-    let state_tx = page_tx;
     let view = ozma.register(
         Webview::dir(asset_dir.path(), "index.html")
             .interactive(true)
@@ -93,20 +82,8 @@ fn register_view(
                 let doc = ready_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
                 Ok(content_of(&doc))
             })
-            .on(
-                "searchCount",
-                move |c: SearchCount| -> Result<(), RpcError> {
-                    let _ = count_tx.send(PageMsg::SearchCount(c));
-                    Ok(())
-                },
-            )
-            .on(
-                "scrollState",
-                move |s: ScrollState| -> Result<(), RpcError> {
-                    let _ = state_tx.send(PageMsg::ScrollState(s));
-                    Ok(())
-                },
-            ),
+            .add_event::<SearchCount>("searchCount")
+            .add_event::<ScrollState>("scrollState"),
     )?;
     Ok(view)
 }
@@ -116,7 +93,6 @@ fn event_loop(
     view: &WebviewHandle,
     shared: &Arc<Mutex<document::Document>>,
     path: &Path,
-    page_rx: &Receiver<PageMsg>,
     reload_rx: &mpsc::Receiver<()>,
 ) -> anyhow::Result<()> {
     let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), ozma);
@@ -134,14 +110,12 @@ fn event_loop(
         .unwrap_or_default();
 
     loop {
-        while let Ok(msg) = page_rx.try_recv() {
-            match msg {
-                PageMsg::SearchCount(c) => search_status = Some(c),
-                PageMsg::ScrollState(s) => {
-                    scroll_percent = (s.ratio.clamp(0.0, 1.0) * 100.0).round() as u16;
-                    state.set_current_heading_index(s.current_heading_index);
-                }
-            }
+        for c in view.read_events::<SearchCount>() {
+            search_status = Some(c);
+        }
+        for s in view.read_events::<ScrollState>() {
+            scroll_percent = (s.ratio.clamp(0.0, 1.0) * 100.0).round() as u16;
+            state.set_current_heading_index(s.current_heading_index);
         }
 
         let mut reload = false;

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -35,7 +35,7 @@ pub(crate) struct Content {
     pub(crate) base_dir: String,
 }
 
-/// Search-result counts the page reports back (`searchCount` call).
+/// Search-result counts the page reports back (`searchCount` event).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SearchCount {
@@ -45,7 +45,7 @@ pub(crate) struct SearchCount {
     pub(crate) current: usize,
 }
 
-/// Viewport state the page reports back (`scrollState` call).
+/// Viewport state the page reports back (`scrollState` event).
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ScrollState {

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -75,7 +75,7 @@ function reportScrollState(): void {
       currentHeadingIndex = i;
     }
   }
-  void ozma.call('scrollState', { ratio, currentHeadingIndex });
+  ozma.emit('scrollState', { ratio, currentHeadingIndex });
 }
 
 async function renderMermaid(): Promise<void> {
@@ -163,11 +163,11 @@ ozma.on('scrollToHeading', (p) => {
 });
 ozma.on('search', (p) => {
   const { query } = p as { query: string };
-  void ozma.call('searchCount', search.run(content, query));
+  ozma.emit('searchCount', search.run(content, query));
 });
 ozma.on('searchNav', (p) => {
   const { dir } = p as { dir: 'next' | 'prev' };
-  void ozma.call('searchCount', search.navigate(dir));
+  ozma.emit('searchCount', search.navigate(dir));
 });
 ozma.on('clearSearch', () => {
   search.clear(content);

--- a/docs/superpowers/plans/2026-06-21-ratatui-ozma-inbound-events.md
+++ b/docs/superpowers/plans/2026-06-21-ratatui-ozma-inbound-events.md
@@ -1,0 +1,1312 @@
+# ratatui-ozma inbound events (Webview → app) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a one-way, poll-based event channel so a webview page can notify its host ratatui app via `window.ozma.emit(name, payload)` and the app drains a typed queue with `view.read_events::<T>()`.
+
+**Architecture:** Page `emit` → CEF bridge `cef.emit({kind:'ozma.emit',…})` → a new host observer forwards `{"op":"event",…}` over the owning control connection → the SDK reader thread routes the payload into a per-handle bounded ring → `read_events::<T>()` drains and deserializes on the UI thread. It mirrors the existing `call` RPC path but strips reqId/reply/RPC tracking.
+
+**Tech Stack:** Rust (edition 2024, toolchain 1.95, Bevy 0.18, serde/serde_json, tracing), TypeScript (`@ozma/web`, vitest, biome), JS bridge (CEF).
+
+Spec: `docs/superpowers/specs/2026-06-21-ratatui-ozma-inbound-events-design.md`.
+
+## Global Constraints
+
+- **Rust edition 2024, toolchain pinned 1.95.** No `mod.rs` (use `foo.rs` + `foo/`).
+- **Comment taxonomy (Rust):** only `// TODO:`, `// NOTE:` (critical caveats only), `// SAFETY:`. All comments in English.
+- **Doc comments:** every externally-`pub` item needs `///`; every file-level module needs `//!`. `#![warn(missing_docs)]` is on in `ratatui-ozma`.
+- **Imports:** all `use` at the top of the file, one contiguous block, no blank-line grouping, no inline fully-qualified paths in signatures/bodies.
+- **Visibility:** narrowest that compiles. SDK-internal items are `pub(crate)`; only the public API (`add_event`, `read_events`) is `pub`.
+- **Item ordering:** `pub` items before private; private helpers last. **Parameter ordering:** mutable params before immutable (the `On<E>` trigger stays first).
+- **`Plugin::build`:** single method chain off `app.`.
+- **TypeScript:** biome-enforced ordering; JSDoc on every `export`; comment taxonomy `// TODO:` / `// NOTE:` / `// biome-ignore` / `// @ts-expect-error` (each with a reason). ECMAScript-erasable only in `ozma.ts` (no enum/namespace/param-properties).
+- **Lint gate per task:** `cargo clippy --workspace --all-targets` clean and `cargo fmt` applied for Rust changes; `pnpm lint` + `pnpm check-types` for TS changes.
+- **Host-side caveat:** building/testing the root `ozmux-gui` binary (Tasks 6–7) requires CEF provisioned once via `make setup-cef` (macOS). The SDK crate (`ratatui-ozma`) and `@ozma/web` build without CEF.
+
+## File Structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `sdk/ratatui-ozma/src/events.rs` (new) | `EventQueues` rings: bounded ingest (drop-oldest + throttle), type-keyed drain | 1 |
+| `sdk/ratatui-ozma/src/lib.rs` | declare `mod events;` | 1 |
+| `sdk/ratatui-ozma/src/protocol.rs` | `IncomingEvent` wire type | 2 |
+| `sdk/ratatui-ozma/src/webview.rs` | `Webview::add_event`, `WebviewHandle::read_events` + `events` field | 3, 4 |
+| `sdk/ratatui-ozma/src/session.rs` | build/install `EventQueues`, reader `op=="event"` branch, reconnect replay | 4, 5 |
+| `src/webview/render/ozma_bridge.js` | page-side `window.ozma.emit` | 6 |
+| `src/webview/render/preload.rs` | preload assertion for `ozma.emit` | 6 |
+| `src/webview/render.rs` | host `on_ozmux_emit_frame` forwarder | 7 |
+| `sdk/ozma-web/src/ozma.ts` + `ozma.test.ts` | `@ozma/web` `emit` client | 8 |
+| `sdk/ratatui-ozma/tests/integration.rs` | end-to-end emit → read_events | 9 |
+| `sdk/ratatui-ozma/examples/ratatui_webview.rs` | round-trip demo | 10 |
+
+Tasks 1→5 are sequential (SDK core). Tasks 6, 7, 8 are independent of 1–5 and of each other. Task 9 depends on 1–5; Task 10 depends on 1–4.
+
+---
+
+### Task 1: `EventQueues` bounded-ring core
+
+**Files:**
+- Create: `sdk/ratatui-ozma/src/events.rs`
+- Modify: `sdk/ratatui-ozma/src/lib.rs` (add `mod events;`)
+- Test: inline `#[cfg(test)] mod tests` in `events.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub(crate) struct EventDecl { name: String, type_id: TypeId }` (fields `pub(crate)`)
+  - `pub(crate) struct EventQueues` with `fn from_decls(decls: &[EventDecl]) -> Self`, `fn ingest(&self, name: &str, payload: Value) -> bool`, `fn drain_type(&self, type_id: TypeId) -> Vec<Value>`, and `impl Default`
+  - `pub(crate) type EventRegistry = Arc<Mutex<HashMap<String, Arc<EventQueues>>>>`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `sdk/ratatui-ozma/src/lib.rs`, add `mod events;` to the module list (alphabetical, after `mod error;`):
+
+```rust
+mod backend;
+mod error;
+mod events;
+mod handler;
+mod keychord;
+mod osc;
+mod protocol;
+mod session;
+mod webview;
+mod widget;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `sdk/ratatui-ozma/src/events.rs` with only the tests first (the types don't exist yet, so it won't compile — that is the "red" state for this data-structure task):
+
+```rust
+//! Per-handle inbound event queues: bounded rings the reader thread fills from
+//! `op == "event"` lines and `WebviewHandle::read_events` drains by type.
+
+use serde_json::Value;
+use std::any::TypeId;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct A;
+    struct B;
+
+    fn decls() -> Vec<EventDecl> {
+        vec![
+            EventDecl { name: "a".into(), type_id: TypeId::of::<A>() },
+            EventDecl { name: "b".into(), type_id: TypeId::of::<B>() },
+        ]
+    }
+
+    #[test]
+    fn ingest_then_drain_by_type_is_fifo() {
+        let q = EventQueues::from_decls(&decls());
+        assert!(q.ingest("a", json!(1)));
+        assert!(q.ingest("a", json!(2)));
+        let drained = q.drain_type(TypeId::of::<A>());
+        assert_eq!(drained, vec![json!(1), json!(2)]);
+        // A second drain is empty; the ring was consumed.
+        assert!(q.drain_type(TypeId::of::<A>()).is_empty());
+    }
+
+    #[test]
+    fn drain_is_isolated_per_type() {
+        let q = EventQueues::from_decls(&decls());
+        q.ingest("a", json!("x"));
+        q.ingest("b", json!("y"));
+        assert_eq!(q.drain_type(TypeId::of::<A>()), vec![json!("x")]);
+        assert_eq!(q.drain_type(TypeId::of::<B>()), vec![json!("y")]);
+    }
+
+    #[test]
+    fn ingest_for_undeclared_name_returns_false() {
+        let q = EventQueues::from_decls(&decls());
+        assert!(!q.ingest("missing", json!(1)));
+    }
+
+    #[test]
+    fn drain_for_undeclared_type_is_empty() {
+        struct C;
+        let q = EventQueues::from_decls(&decls());
+        assert!(q.drain_type(TypeId::of::<C>()).is_empty());
+    }
+
+    #[test]
+    fn overflow_drops_oldest_and_keeps_cap() {
+        let q = EventQueues::from_decls_with_cap(&decls(), 2);
+        q.ingest("a", json!(1));
+        q.ingest("a", json!(2));
+        q.ingest("a", json!(3)); // evicts 1
+        let drained = q.drain_type(TypeId::of::<A>());
+        assert_eq!(drained, vec![json!(2), json!(3)]);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p ratatui-ozma events::`
+Expected: FAIL to compile — `EventDecl`, `EventQueues`, `from_decls`, etc. not found.
+
+- [ ] **Step 4: Write the implementation**
+
+Insert the implementation between the `use` block and the `#[cfg(test)] mod tests` in `events.rs`:
+
+```rust
+/// The default per-event ring capacity. Overflow drops the oldest payload.
+const DEFAULT_CAP: usize = 1024;
+
+/// Minimum interval between overflow warnings for a single saturated ring.
+const WARN_EVERY: Duration = Duration::from_secs(5);
+
+/// A builder-time declaration binding a wire event name to a Rust type.
+pub(crate) struct EventDecl {
+    /// The wire event name the page sends via `window.ozma.emit`.
+    pub(crate) name: String,
+    /// `TypeId::of::<T>()` for the declared event type `T`.
+    pub(crate) type_id: TypeId,
+}
+
+/// One bounded ring of raw payloads plus throttled-overflow bookkeeping.
+#[derive(Default, Debug)]
+struct RingBuf {
+    buf: VecDeque<Value>,
+    dropped: u64,
+    last_warn: Option<Instant>,
+}
+
+type Ring = Arc<Mutex<RingBuf>>;
+
+/// The per-handle set of inbound event rings, declared at `register` and shared
+/// between the reader thread (`by_name` ingest) and the `WebviewHandle`
+/// (`by_type` drain). Each ring is shared by both maps via one `Arc`, so each
+/// side reaches it in a single lookup. Both maps are frozen after construction;
+/// only ring contents mutate, so the whole struct is shared behind one `Arc`
+/// with no outer lock.
+#[derive(Default, Debug)]
+pub(crate) struct EventQueues {
+    by_name: HashMap<String, Ring>,
+    by_type: HashMap<TypeId, Ring>,
+    cap: usize,
+}
+
+/// Maps a registration handle to its `EventQueues`, the inbound-event peer of
+/// the SDK's per-handle handler registry.
+pub(crate) type EventRegistry = Arc<Mutex<HashMap<String, Arc<EventQueues>>>>;
+
+impl EventQueues {
+    /// Builds the rings for `decls` at the default capacity, inserting each ring
+    /// into both lookup maps.
+    pub(crate) fn from_decls(decls: &[EventDecl]) -> Self {
+        Self::from_decls_with_cap(decls, DEFAULT_CAP)
+    }
+
+    /// Routes `payload` into the ring named `name`. When the ring is at
+    /// capacity, drops the oldest payload first (with a per-ring throttled
+    /// warning). Returns `false` when `name` was never declared.
+    pub(crate) fn ingest(&self, name: &str, payload: Value) -> bool {
+        let Some(ring) = self.by_name.get(name) else {
+            return false;
+        };
+        let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
+        if ring.buf.len() >= self.cap {
+            ring.buf.pop_front();
+            ring.dropped += 1;
+            if ring.last_warn.is_none_or(|t| t.elapsed() >= WARN_EVERY) {
+                tracing::warn!(
+                    event = name,
+                    dropped = ring.dropped,
+                    "inbound event ring saturated; dropping oldest"
+                );
+                ring.last_warn = Some(Instant::now());
+            }
+        }
+        ring.buf.push_back(payload);
+        true
+    }
+
+    /// Drains every buffered payload for the ring keyed by `type_id`, oldest
+    /// first. Returns an empty `Vec` when the type was never declared. The ring
+    /// lock is released before the caller deserializes, so a slow `from_value`
+    /// never blocks the reader thread's ingest.
+    pub(crate) fn drain_type(&self, type_id: TypeId) -> Vec<Value> {
+        let Some(ring) = self.by_type.get(&type_id) else {
+            return Vec::new();
+        };
+        let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
+        Vec::from(std::mem::take(&mut ring.buf))
+    }
+
+    fn from_decls_with_cap(decls: &[EventDecl], cap: usize) -> Self {
+        let mut by_name = HashMap::new();
+        let mut by_type = HashMap::new();
+        for decl in decls {
+            let ring: Ring = Arc::new(Mutex::new(RingBuf::default()));
+            by_name.insert(decl.name.clone(), ring.clone());
+            by_type.insert(decl.type_id, ring);
+        }
+        Self { by_name, by_type, cap }
+    }
+}
+```
+
+Note: `from_decls_with_cap` is `fn` (private) — used by `from_decls` and the tests in the same module, so it needs no visibility modifier.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p ratatui-ozma events::`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cargo fmt
+cargo clippy -p ratatui-ozma --all-targets
+git add sdk/ratatui-ozma/src/events.rs sdk/ratatui-ozma/src/lib.rs
+git commit -m "feat(ratatui-ozma): add EventQueues bounded-ring inbound event buffer"
+```
+
+---
+
+### Task 2: `IncomingEvent` wire type
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/protocol.rs`
+- Test: inline `#[cfg(test)] mod tests` in `protocol.rs`
+
+**Interfaces:**
+- Produces: `pub(crate) struct IncomingEvent { handle: String, event: String, payload: Value }` (fields `pub(crate)`), deserialized from `{"op":"event","handle":…,"event":…,"payload":…}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `sdk/ratatui-ozma/src/protocol.rs`:
+
+```rust
+    #[test]
+    fn incoming_event_deserializes() {
+        let e: IncomingEvent = serde_json::from_str(
+            r#"{"op":"event","handle":"h","event":"hello","payload":{"message":"hi"}}"#,
+        )
+        .unwrap();
+        assert_eq!(e.handle, "h");
+        assert_eq!(e.event, "hello");
+        assert_eq!(e.payload, serde_json::json!({"message":"hi"}));
+    }
+
+    #[test]
+    fn incoming_event_without_payload_is_null() {
+        let e: IncomingEvent =
+            serde_json::from_str(r#"{"op":"event","handle":"h","event":"ping"}"#).unwrap();
+        assert_eq!(e.payload, Value::Null);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p ratatui-ozma protocol::tests::incoming_event`
+Expected: FAIL to compile — `IncomingEvent` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Add after the `IncomingCall` struct in `sdk/ratatui-ozma/src/protocol.rs` (the `Value` and `Deserialize` imports are already present at the top):
+
+```rust
+/// An inbound one-way `event` frame forwarded from a page's `window.ozma.emit`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct IncomingEvent {
+    /// The view handle the event targets.
+    pub(crate) handle: String,
+    /// The declared event name (`add_event::<T>(name)`).
+    pub(crate) event: String,
+    /// The single payload value (any JSON shape; absent deserializes as null).
+    #[serde(default)]
+    pub(crate) payload: Value,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p ratatui-ozma protocol::tests::incoming_event`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add sdk/ratatui-ozma/src/protocol.rs
+git commit -m "feat(ratatui-ozma): add IncomingEvent wire type for one-way page events"
+```
+
+---
+
+### Task 3: `Webview::add_event` builder
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/webview.rs`
+- Test: inline `#[cfg(test)] mod tests` in `webview.rs`
+
+**Interfaces:**
+- Consumes: `EventDecl` (Task 1).
+- Produces: `pub fn add_event<T: DeserializeOwned + 'static>(self, name: impl Into<String>) -> Self` on `Webview`; a private `event_decls: Vec<EventDecl>` field on `Webview` (read by `Ozma::register` in Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `sdk/ratatui-ozma/src/webview.rs`:
+
+```rust
+    #[test]
+    fn add_event_records_decl() {
+        struct Hello;
+        let wv = Webview::inline("x").add_event::<Hello>("hello");
+        assert_eq!(wv.event_decls.len(), 1);
+        assert_eq!(wv.event_decls[0].name, "hello");
+        assert_eq!(wv.event_decls[0].type_id, std::any::TypeId::of::<Hello>());
+    }
+
+    #[test]
+    fn add_event_enables_bridge_for_url() {
+        struct Hello;
+        let wv = Webview::url("https://example.com").add_event::<Hello>("hello");
+        match &wv.kind {
+            RegisterKind::Url { bridge, .. } => assert!(*bridge),
+            _ => panic!("expected url"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered")]
+    fn add_event_rejects_duplicate_name() {
+        struct A;
+        struct B;
+        let _ = Webview::inline("x")
+            .add_event::<A>("dup")
+            .add_event::<B>("dup");
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered")]
+    fn add_event_rejects_duplicate_type() {
+        struct A;
+        let _ = Webview::inline("x")
+            .add_event::<A>("one")
+            .add_event::<A>("two");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p ratatui-ozma webview::tests::add_event`
+Expected: FAIL to compile — `add_event` / `event_decls` not found.
+
+- [ ] **Step 3: Add the field and import**
+
+In `sdk/ratatui-ozma/src/webview.rs`, add to the top `use` block:
+
+```rust
+use crate::events::EventDecl;
+use std::any::TypeId;
+```
+
+Add the field to the `Webview` struct and initialize it in all three constructors (`inline`, `url`, `dir`):
+
+```rust
+pub struct Webview {
+    pub(crate) kind: RegisterKind,
+    pub(crate) handlers: HashMap<String, BoxedHandler>,
+    pub(crate) event_decls: Vec<EventDecl>,
+}
+```
+
+Each constructor currently ends `handlers: HashMap::new(),` inside its `Self { … }`; add `event_decls: Vec::new(),` alongside it in `inline`, `url`, and `dir`.
+
+- [ ] **Step 4: Write the `add_event` method**
+
+Add this method to `impl Webview`, placed after `on` (keep `pub` methods grouped):
+
+```rust
+    /// Declares an inbound event the page may send via `window.ozma.emit(name, …)`,
+    /// binding the wire `name` to the Rust type `T`. The app later drains it with
+    /// [`WebviewHandle::read_events::<T>`]. Enables the `window.ozma` bridge for
+    /// `url` webviews (like [`Webview::on`]); a no-op for `inline`/`dir`, which
+    /// are always bridged.
+    ///
+    /// # Panics
+    /// Panics if `name` or the type `T` is already registered on this builder —
+    /// the type ↔ name mapping must be 1:1. (`on` silently overwrites a
+    /// duplicate method; `add_event` enforces uniqueness instead.)
+    pub fn add_event<T: DeserializeOwned + 'static>(mut self, name: impl Into<String>) -> Self {
+        let name = name.into();
+        let type_id = TypeId::of::<T>();
+        assert!(
+            !self.event_decls.iter().any(|d| d.name == name),
+            "event name {name:?} is already registered"
+        );
+        assert!(
+            !self.event_decls.iter().any(|d| d.type_id == type_id),
+            "event type {} is already registered",
+            std::any::type_name::<T>()
+        );
+        self.event_decls.push(EventDecl { name, type_id });
+        if let RegisterKind::Url { bridge, .. } = &mut self.kind {
+            *bridge = true;
+        }
+        self
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p ratatui-ozma webview::tests::add_event`
+Expected: PASS (4 tests). The existing `webview::tests` continue to pass.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cargo fmt
+cargo clippy -p ratatui-ozma --all-targets
+git add sdk/ratatui-ozma/src/webview.rs
+git commit -m "feat(ratatui-ozma): add Webview::add_event builder for inbound events"
+```
+
+---
+
+### Task 4: `read_events` + reader-thread ingest wiring
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/webview.rs` (`WebviewHandle` gains `events`, `read_events`, updated `new_shared`)
+- Modify: `sdk/ratatui-ozma/src/session.rs` (`EventRegistry` threaded through `connect`/`spawn_reader`; `PendingRegister.events`; `register` builds + installs `EventQueues`; reader `op=="event"` branch)
+- Test: inline tests in `webview.rs` and `session.rs`
+
+**Interfaces:**
+- Consumes: `EventQueues`, `EventRegistry` (Task 1); `IncomingEvent` (Task 2); `Webview.event_decls` (Task 3).
+- Produces: `pub fn read_events<T: DeserializeOwned + 'static>(&self) -> Vec<T>` on `WebviewHandle`; `WebviewHandle::new_shared(id, events, writer)` signature gains an `Arc<EventQueues>` second parameter.
+
+- [ ] **Step 1: Write the failing `read_events` test (webview.rs)**
+
+Add to `#[cfg(test)] mod tests` in `sdk/ratatui-ozma/src/webview.rs`:
+
+```rust
+    #[test]
+    fn read_events_drains_and_deserializes_and_skips_bad() {
+        use crate::events::{EventDecl, EventQueues};
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Hello {
+            message: String,
+        }
+        let decls = vec![EventDecl {
+            name: "hello".into(),
+            type_id: std::any::TypeId::of::<Hello>(),
+        }];
+        let events = Arc::new(EventQueues::from_decls(&decls));
+        events.ingest("hello", json!({"message": "a"}));
+        events.ingest("hello", json!({"nope": 1})); // fails to deserialize -> skipped
+        events.ingest("hello", json!({"message": "b"}));
+
+        let (sock, _b) = std::os::unix::net::UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(sock));
+        let handle = WebviewHandle::new_shared(
+            Arc::new(Mutex::new("h".to_owned())),
+            events,
+            writer,
+        );
+
+        let got = handle.read_events::<Hello>();
+        assert_eq!(
+            got,
+            vec![
+                Hello { message: "a".into() },
+                Hello { message: "b".into() }
+            ]
+        );
+        // Drained: a second read is empty.
+        assert!(handle.read_events::<Hello>().is_empty());
+    }
+```
+
+The existing `id_reflects_slot_update` test calls `WebviewHandle::new_shared(slot.clone(), writer)` — update it to pass an empty queues arg:
+
+```rust
+        let handle = WebviewHandle::new_shared(
+            slot.clone(),
+            Arc::new(crate::events::EventQueues::default()),
+            writer,
+        );
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ratatui-ozma webview::tests::read_events`
+Expected: FAIL to compile — `read_events` / new `new_shared` signature not present.
+
+- [ ] **Step 3: Implement the `WebviewHandle` changes (webview.rs)**
+
+Add to the top `use` block:
+
+```rust
+use crate::events::EventQueues;
+```
+
+Add the field to the struct:
+
+```rust
+pub struct WebviewHandle {
+    id: Arc<Mutex<String>>,
+    events: Arc<EventQueues>,
+    writer: SharedWriter,
+}
+```
+
+Add `read_events` to `impl WebviewHandle` after `emit` (keep `pub` methods first):
+
+```rust
+    /// Drains and returns every buffered event of type `T`, oldest first.
+    /// Payloads that fail to deserialize into `T` are dropped and logged; the
+    /// result is empty if `T` was never declared via [`Webview::add_event`].
+    pub fn read_events<T: DeserializeOwned + 'static>(&self) -> Vec<T> {
+        self.events
+            .drain_type(TypeId::of::<T>())
+            .into_iter()
+            .filter_map(|v| match serde_json::from_value::<T>(v) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    tracing::warn!(error = %e, "dropping inbound event that failed to deserialize");
+                    None
+                }
+            })
+            .collect()
+    }
+```
+
+Add `use std::any::TypeId;` to the top `use` block (if not already present from another edit).
+
+Update `new_shared` (still `pub(crate)`, declared after `pub` methods) to take and store `events`, with mutable/structural params unchanged (all by-value, none mutable):
+
+```rust
+    pub(crate) fn new_shared(
+        id: Arc<Mutex<String>>,
+        events: Arc<EventQueues>,
+        writer: SharedWriter,
+    ) -> Self {
+        Self { id, events, writer }
+    }
+```
+
+- [ ] **Step 4: Run the webview test to verify it passes**
+
+Run: `cargo test -p ratatui-ozma webview::tests::read_events`
+Expected: PASS. (`session.rs` will not compile yet — that is fixed in the next steps; run the targeted webview test which only needs `webview.rs`.)
+
+- [ ] **Step 5: Write the failing reader-routing test (session.rs)**
+
+Add to `#[cfg(test)] mod tests` in `sdk/ratatui-ozma/src/session.rs` (mirrors `reader_thread_inserts_compositing_into_shared_map`):
+
+```rust
+    #[test]
+    fn reader_thread_routes_event_into_registered_queues() {
+        use crate::events::{EventDecl, EventQueues, EventRegistry};
+        use std::os::unix::net::UnixListener;
+
+        struct Hello;
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("ev.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let decls = vec![EventDecl {
+            name: "hello".into(),
+            type_id: std::any::TypeId::of::<Hello>(),
+        }];
+        let queues = Arc::new(EventQueues::from_decls(&decls));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+        events.lock().unwrap().insert("h1".to_owned(), queues.clone());
+
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
+
+        let client = UnixStream::connect(&sock_path).unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(client.try_clone().unwrap()));
+        let (server_conn, _) = listener.accept().unwrap();
+
+        spawn_reader(
+            client,
+            writer.clone(),
+            handlers,
+            pending,
+            pending_compositing,
+            events.clone(),
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        let mut server = server_conn;
+        writeln!(
+            server,
+            r#"{{"op":"event","handle":"h1","event":"hello","payload":{{"n":7}}}}"#
+        )
+        .unwrap();
+        server.flush().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        assert_eq!(queues.drain_type(std::any::TypeId::of::<Hello>()), vec![serde_json::json!({"n":7})]);
+    }
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `cargo test -p ratatui-ozma session::tests::reader_thread_routes_event`
+Expected: FAIL to compile — `spawn_reader` has no `events` parameter; the `op=="event"` branch does not exist.
+
+- [ ] **Step 7: Thread `EventRegistry` and add the reader branch (session.rs)**
+
+The registry is owned by `Ozma` and installed at `register()` time (direct install on the registering thread). The reader thread receives a clone purely to **route** inbound events; reconnect re-install is added in Task 5. This keeps Task 4 fully compiling on its own and leaves reconnect as a clean red→green for Task 5.
+
+Add to the top `use` block:
+
+```rust
+use crate::events::{EventQueues, EventRegistry};
+```
+
+and add `IncomingEvent` to the existing `use crate::protocol::{…}` line (do not add a second `crate::protocol::` line).
+
+**7a.** Add an `events` field to `Registration` (NOT `PendingRegister`):
+
+```rust
+struct Registration {
+    kind: RegisterKind,
+    handle_slot: Arc<Mutex<String>>,
+    handlers: Arc<HashMap<String, BoxedHandler>>,
+    events: Arc<EventQueues>,
+}
+```
+
+**7b.** Add an `events: EventRegistry` field to the `Ozma` struct, and in `connect()` create the registry next to `handlers`/`registrations`:
+
+```rust
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+```
+
+Pass `events.clone()` into the initial `spawn_reader(...)` call (new 6th arg, before `disconnected.clone()`); capture a clone for the reconnect thread closure (`let events2 = events.clone();`) and pass `&events2` into `attempt_reconnect(...)`; and set `events` in the returned `Ozma { … }`.
+
+**7c.** In `register()`, destructure `event_decls`, build the queues, and install them under the minted handle directly:
+
+```rust
+        let Webview { kind, handlers, event_decls } = webview;
+        let handlers = Arc::new(handlers);
+        let events = Arc::new(EventQueues::from_decls(&event_decls));
+```
+
+After `let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;`, install the queues, then store/return them:
+
+```rust
+        if let Ok(mut map) = self.events.lock() {
+            map.insert(handle.clone(), events.clone());
+        }
+        let handle_slot = Arc::new(Mutex::new(handle));
+```
+
+Add `events: events.clone()` to the `Registration { … }` it stores, and pass `events` as the new second arg to `WebviewHandle::new_shared(handle_slot, events, self.writer.clone())`.
+
+NOTE: a view cannot be mounted (and so cannot `emit`) until after `register()` returns and the app draws the mount OSC, so no inbound event can arrive before this install — direct install has no lost-event window in practice.
+
+**7d.** Change `spawn_reader`'s signature to accept the registry for routing (all params are owned by-value shares, none `mut`; insert `events` before `disconnected` to match the `connect`/`attempt_reconnect` call sites):
+
+```rust
+fn spawn_reader(
+    stream: UnixStream,
+    writer: SharedWriter,
+    handlers: HandlerRegistry,
+    pending: PendingRegisters,
+    pending_compositing: PendingCompositing,
+    events: EventRegistry,
+    disconnected: Arc<AtomicBool>,
+) {
+```
+
+**7e.** Add the `op=="event"` branch to the op ladder, after the `compositing` branch and before the `else if let Ok(reply)` register-reply branch:
+
+```rust
+            } else if op == "event" {
+                if let Ok(ev) = serde_json::from_str::<IncomingEvent>(trimmed) {
+                    let queues = events
+                        .lock()
+                        .ok()
+                        .and_then(|map| map.get(&ev.handle).cloned());
+                    if let Some(queues) = queues
+                        && !queues.ingest(&ev.event, ev.payload)
+                    {
+                        tracing::debug!(
+                            handle = ev.handle,
+                            event = ev.event,
+                            "inbound event for an undeclared name dropped"
+                        );
+                    }
+                }
+```
+
+**7f.** Add the `events` parameter to `attempt_reconnect` so its `spawn_reader(...)` call compiles (the install/replay body is added in Task 5). Place `events: &EventRegistry` after `registrations`, before `token`:
+
+```rust
+fn attempt_reconnect(
+    writer: &SharedWriter,
+    handlers: &HandlerRegistry,
+    pending: &PendingRegisters,
+    pending_compositing: &PendingCompositing,
+    disconnected: &Arc<AtomicBool>,
+    generation: &Arc<AtomicU64>,
+    registrations: &Arc<Mutex<Vec<Registration>>>,
+    events: &EventRegistry,
+    token: &str,
+) {
+```
+
+Pass `events.clone()` into the `spawn_reader(...)` call inside `attempt_reconnect` (new 6th arg, before `disconnected.clone()`).
+
+- [ ] **Step 8: Run the full SDK test suite to verify everything passes**
+
+Run: `cargo test -p ratatui-ozma`
+Expected: PASS — the new `reader_thread_routes_event_into_registered_queues`, `read_events_drains_…`, the updated `id_reflects_slot_update`, and all pre-existing tests. The crate compiles fully (initial-connect routing works); reconnect re-install is completed in Task 5.
+
+- [ ] **Step 9: Lint + commit**
+
+```bash
+cargo fmt
+cargo clippy -p ratatui-ozma --all-targets
+git add sdk/ratatui-ozma/src/webview.rs sdk/ratatui-ozma/src/session.rs
+git commit -m "feat(ratatui-ozma): route inbound events to per-handle queues and add read_events"
+```
+
+---
+
+### Task 5: Reconnect replay of event queues
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/src/session.rs` (`attempt_reconnect` threads `EventRegistry`; replays `events`; removes the old handle key)
+- Test: `sdk/ratatui-ozma/tests/integration.rs` (reconnect preserves a working `read_events`)
+
+**Interfaces:**
+- Consumes: `EventRegistry`, `Registration.events`, and the `events` parameter already threaded into `attempt_reconnect` (Task 4).
+- Produces: no new public surface; completes `attempt_reconnect`'s re-install of per-handle queues under the new handle.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `sdk/ratatui-ozma/tests/integration.rs`:
+
+```rust
+#[test]
+fn reconnect_preserves_inbound_events() {
+    use std::time::Duration;
+    #[derive(serde::Deserialize, PartialEq, Debug)]
+    struct Hello {
+        message: String,
+    }
+
+    let pair = support::ReconnectPair::start("view-ev1", "view-ev2");
+    with_env(&pair.first.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma
+            .register(Webview::inline("x").add_event::<Hello>("hello"))
+            .unwrap();
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &ozma);
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        drop(pair.first);
+        std::thread::sleep(Duration::from_millis(200));
+        // NOTE: ENV_LOCK is held by with_env, serializing env var access.
+        unsafe { std::env::set_var("OZMA_SOCK", &pair.second.sock_path) };
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while handle.id() == "view-ev1" {
+            assert!(std::time::Instant::now() < deadline, "reconnect did not complete");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // The page emits to the NEW handle after reconnect; read_events must see it.
+        pair.second.send(json!({
+            "op": "event", "handle": "view-ev2", "event": "hello", "payload": { "message": "post" }
+        }));
+
+        let got = loop {
+            let evs = handle.read_events::<Hello>();
+            if !evs.is_empty() {
+                break evs;
+            }
+            assert!(std::time::Instant::now() < deadline, "event never arrived after reconnect");
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(got, vec![Hello { message: "post".into() }]);
+    });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ratatui-ozma --test integration reconnect_preserves_inbound_events`
+Expected: FAIL — Task 4 threaded the `events` param into `attempt_reconnect` (so it compiles) but does not yet re-install the per-handle queues under the new handle, so the post-reconnect event finds no queues for `view-ev2` and is dropped; the read loop times out.
+
+- [ ] **Step 3: Re-install the queues under the new handle in `attempt_reconnect`**
+
+After the existing handler-map swap inside the re-registration loop (`map.remove(&old); map.insert(new_handle.clone(), reg.handlers.clone());`), add the matching event-registry swap. Re-installing under the new handle is what makes post-reconnect events reach `read_events`; removing the old key prevents a stale-handle leak across repeated reconnects:
+
+```rust
+        if let Ok(mut map) = events.lock() {
+            map.remove(&old);
+            map.insert(new_handle.clone(), reg.events.clone());
+        }
+```
+
+(`old` is the prior handle already read from `reg.handle_slot` for the handler swap; `reg.events` is the same `Arc<EventQueues>` the `WebviewHandle` holds, so buffered events survive the reconnect.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p ratatui-ozma --test integration reconnect_preserves_inbound_events`
+Expected: PASS.
+
+- [ ] **Step 5: Full SDK suite + lint + commit**
+
+```bash
+cargo test -p ratatui-ozma
+cargo fmt
+cargo clippy -p ratatui-ozma --all-targets
+git add sdk/ratatui-ozma/src/session.rs sdk/ratatui-ozma/tests/integration.rs
+git commit -m "feat(ratatui-ozma): replay inbound event queues across reconnect"
+```
+
+---
+
+### Task 6: Page bridge `emit` + preload assertion
+
+**Files:**
+- Modify: `src/webview/render/ozma_bridge.js`
+- Modify: `src/webview/render/preload.rs`
+- Test: `src/webview/render/preload.rs` (existing `dynamic_preload_injects_only_the_ozma_bridge`)
+
+**Interfaces:**
+- Produces: a `window.ozma.emit(event, payload)` page method emitting `{ kind: 'ozma.emit', event, payload }` via `cef.emit`.
+
+- [ ] **Step 1: Write the failing assertion**
+
+In `src/webview/render/preload.rs`, add to `dynamic_preload_injects_only_the_ozma_bridge` (after the existing `kind: 'ozma.call'` assert):
+
+```rust
+        assert!(OZMA_BRIDGE_JS.contains("kind: 'ozma.emit'"));
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozmux-gui webview::render::preload::tests::dynamic_preload_injects_only_the_ozma_bridge`
+Expected: FAIL — the bridge does not yet contain `kind: 'ozma.emit'`.
+
+- [ ] **Step 3: Add `emit` to the bridge**
+
+In `src/webview/render/ozma_bridge.js`, add an `emit` method to the `api` object, immediately after the `off:` function (before the closing `};` of `var api = { … }`):
+
+```js
+    emit: function (event, payload) {
+      cef.emit({ kind: 'ozma.emit', event: event, payload: encodeParam(payload) });
+    },
+```
+
+(`encodeParam` is already defined above and tags a top-level `Uint8Array`; `emit` sends no `reqId` and creates no `calls` entry, so it cannot leak.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p ozmux-gui webview::render::preload::tests`
+Expected: PASS (all three preload tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make fix-lint
+git add src/webview/render/ozma_bridge.js src/webview/render/preload.rs
+git commit -m "feat(webview): add window.ozma.emit one-way page->host bridge method"
+```
+
+---
+
+### Task 7: Host `on_ozmux_emit_frame` forwarder
+
+**Files:**
+- Modify: `src/webview/render.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/webview/render.rs`
+
+**Interfaces:**
+- Consumes: `OzmuxFrame`, `WebviewOwner`, `ConnectionWriters` (existing).
+- Produces: the observer `on_ozmux_emit_frame`, registered in `RenderPlugin::build`, that forwards `kind:"ozma.emit"` frames as `{"op":"event",…}` to the owning connection.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `#[cfg(test)] mod tests` in `src/webview/render.rs` (mirrors `ozmux_call_frame_pushes_call_to_owner_connection`):
+
+```rust
+    #[test]
+    fn ozmux_emit_frame_pushes_event_to_owner_connection() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_emit_frame);
+
+        let webview = app
+            .world_mut()
+            .spawn(WebviewOwner {
+                connection_id: 7,
+                handle: "H".into(),
+            })
+            .id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozma.emit", "event": "hello", "payload": {"message": "hi"}
+            })),
+        });
+
+        let line = rx.try_recv().expect("an event was pushed");
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["op"], "event");
+        assert_eq!(v["handle"], "H");
+        assert_eq!(v["event"], "hello");
+        assert_eq!(v["payload"]["message"], "hi");
+    }
+
+    #[test]
+    fn ozmux_emit_frame_without_owner_is_dropped() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_emit_frame);
+
+        // A webview entity with no WebviewOwner component.
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozma.emit", "event": "hello", "payload": null
+            })),
+        });
+
+        assert!(rx.try_recv().is_err(), "no owner ⇒ nothing forwarded");
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p ozmux-gui webview::render::tests::ozmux_emit_frame`
+Expected: FAIL to compile — `on_ozmux_emit_frame` not found.
+
+- [ ] **Step 3: Add the kind constant and observer**
+
+In `src/webview/render.rs`, add the constant next to `OZMA_CALL_KIND`:
+
+```rust
+/// The `kind` discriminator routing a `Receive<OzmuxFrame>` to the one-way
+/// inbound-event forwarder (`on_ozmux_emit_frame`). Emitted by `ozma_bridge.js`.
+const OZMA_EMIT_KIND: &str = "ozma.emit";
+```
+
+Add the observer (place it after `on_ozmux_call_frame` and its `reject_ozmux_call` helper, before the load loggers):
+
+```rust
+/// Inbound (one-way): a `window.ozma.emit` arrives as a `Receive<OzmuxFrame>`
+/// with `kind:"ozma.emit"`. The trusted caller is `frame.webview` (bound per
+/// webview by `bevy_cef`); its `WebviewOwner` names the registering connection.
+/// The event is forwarded as a fire-and-forget `{op:"event"}` line — no reqId,
+/// no reply, no `OzmuxRpc` tracking. A missing owner or unavailable connection
+/// drops the event (debug-logged); there is no page Promise to settle.
+///
+/// Registered on the shared `Receive<OzmuxFrame>` event (not a second
+/// `JsEmitEventPlugin`); non-`ozma.emit` frames return early on `OZMA_EMIT_KIND`.
+fn on_ozmux_emit_frame(
+    frame: On<Receive<OzmuxFrame>>,
+    writers: Res<ConnectionWriters>,
+    owners: Query<&WebviewOwner>,
+) {
+    let payload = &frame.payload.0;
+    if payload.get("kind").and_then(Value::as_str) != Some(OZMA_EMIT_KIND) {
+        return;
+    }
+    let event = payload
+        .get("event")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let body = payload.get("payload").cloned().unwrap_or(Value::Null);
+
+    let Ok(owner) = owners.get(frame.webview) else {
+        tracing::debug!("ozma.emit frame for a webview with no owner; dropping");
+        return;
+    };
+    let line = serde_json::json!({
+        "op": "event", "handle": owner.handle, "event": event, "payload": body
+    })
+    .to_string();
+    if !writers.send(owner.connection_id, line) {
+        tracing::debug!(handle = owner.handle, "ozma.emit owner connection unavailable; dropping");
+    }
+}
+```
+
+Register it in `RenderPlugin::build`, extending the existing observer chain:
+
+```rust
+        app.add_plugins(JsEmitEventPlugin::<OzmuxFrame>::default())
+            .add_observer(on_ozmux_call_frame)
+            .add_observer(on_ozmux_emit_frame)
+            .add_observer(on_webview_address_changed)
+            .add_observer(drop_ozmux_inflight_on_webview_despawn)
+            .add_observer(log_webview_load_started)
+            .add_observer(log_webview_load_finished)
+            .add_observer(log_webview_load_error)
+            .add_systems(Update, sync_focused_webview.after(OzmuxSystems::Input));
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p ozmux-gui webview::render::tests::ozmux_emit_frame`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cargo fmt
+cargo clippy -p ozmux-gui --all-targets
+git add src/webview/render.rs
+git commit -m "feat(webview): forward one-way ozma.emit page events to the owning connection"
+```
+
+---
+
+### Task 8: `@ozma/web` `emit` client
+
+**Files:**
+- Modify: `sdk/ozma-web/src/ozma.ts`
+- Modify: `sdk/ozma-web/src/ozma.test.ts`
+
+**Interfaces:**
+- Produces: `OzmaApi.emit(event: string, payload?: unknown): void` and the `ozma.emit` delegate.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `sdk/ozma-web/src/ozma.test.ts`, extend the delegation test's mock and assertions, and add `emit` to the throw test:
+
+In `delegates call/on/off to the injected bridge`, add an `emit` mock and assertion:
+
+```ts
+    const emit = vi.fn();
+    g.ozma = { call, on, off, emit } as unknown as OzmaApi;
+```
+```ts
+    ozma.emit('hello', { message: 'hi' });
+```
+```ts
+    expect(emit).toHaveBeenCalledWith('hello', { message: 'hi' });
+```
+
+In `throws a descriptive error when the bridge is absent`, add:
+
+```ts
+    expect(() => ozma.emit('hello', {})).toThrow(/window\.ozma is unavailable/);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @ozma/web test`
+Expected: FAIL — `ozma.emit` is not a function / type error.
+
+- [ ] **Step 3: Add `emit` to the interface and the const**
+
+In `sdk/ozma-web/src/ozma.ts`, add to the `OzmaApi` interface (after `off`):
+
+```ts
+  /** Sends a one-way event to the host app (fire-and-forget; no reply). */
+  emit(event: string, payload?: unknown): void;
+```
+
+And to the `ozma` const object (after `off`):
+
+```ts
+  emit(event: string, payload?: unknown): void {
+    resolve().emit(event, payload);
+  },
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @ozma/web test`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+```bash
+pnpm check-types
+pnpm lint:fix
+git add sdk/ozma-web/src/ozma.ts sdk/ozma-web/src/ozma.test.ts
+git commit -m "feat(ozma-web): add ozma.emit one-way event client method"
+```
+
+---
+
+### Task 9: End-to-end integration test
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/tests/integration.rs`
+
+**Interfaces:**
+- Consumes: the full SDK inbound-event path (Tasks 1–5).
+
+- [ ] **Step 1: Write the test**
+
+Add to `sdk/ratatui-ozma/tests/integration.rs` (peer of `emit_reaches_the_server`):
+
+```rust
+#[test]
+fn inbound_event_is_buffered_and_read() {
+    use std::time::{Duration, Instant};
+    #[derive(serde::Deserialize, PartialEq, Debug)]
+    struct Hello {
+        message: String,
+    }
+
+    let server = FakeServer::start("view-ev");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma
+            .register(Webview::inline("x").add_event::<Hello>("hello"))
+            .unwrap();
+
+        server.send(json!({
+            "op": "event", "handle": "view-ev", "event": "hello", "payload": { "message": "hi" }
+        }));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let events = loop {
+            let evs = handle.read_events::<Hello>();
+            if !evs.is_empty() {
+                break evs;
+            }
+            assert!(Instant::now() < deadline, "inbound event never arrived");
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(events, vec![Hello { message: "hi".into() }]);
+    });
+}
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cargo test -p ratatui-ozma --test integration inbound_event_is_buffered_and_read`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sdk/ratatui-ozma/tests/integration.rs
+git commit -m "test(ratatui-ozma): end-to-end inbound event buffered and read"
+```
+
+---
+
+### Task 10: Round-trip example
+
+**Files:**
+- Modify: `sdk/ratatui-ozma/examples/ratatui_webview.rs`
+
+**Interfaces:**
+- Consumes: `Webview::add_event`, `WebviewHandle::read_events` (Tasks 3–4).
+
+- [ ] **Step 1: Add an inbound event type and declare it**
+
+In `sdk/ratatui-ozma/examples/ratatui_webview.rs`, add near the top of `main` an event type:
+
+```rust
+    #[derive(serde::Deserialize)]
+    struct HelloMsg {
+        message: String,
+    }
+```
+
+Update the inline HTML's `<script>` so the input emits on Enter (replace the existing `<script>…</script>` block):
+
+```rust
+        "<script>",
+        "window.ozma.call('ping','hi').then(v=>out.textContent='ping → '+v);",
+        "window.ozma.on('tick',n=>tick.textContent='tick #'+n);",
+        "var inp=document.getElementById('in');",
+        "inp.addEventListener('keydown',function(e){",
+        "  if(e.key==='Enter'){ window.ozma.emit('hello',{message:inp.value}); inp.value=''; }",
+        "});",
+        "inp.focus();",
+        "</script></body>"
+```
+
+Register the event on the builder (add `.add_event::<HelloMsg>("hello")` to the `Webview::inline(html)` chain, after `.on("ping", …)`):
+
+```rust
+            .on("ping", |arg: String| {
+                Ok::<_, RpcError>(format!("pong:{arg}"))
+            })
+            .add_event::<HelloMsg>("hello"),
+```
+
+- [ ] **Step 2: Drain the events in the loop**
+
+Pass the new type into `run` via the loop. In `run`, add a `last_msg` string state and drain each frame. Add after the existing tick block inside `loop`:
+
+```rust
+        for HelloMsg { message } in view.read_events::<HelloMsg>() {
+            last_msg = message;
+        }
+```
+
+Declare `let mut last_msg = String::new();` near `let mut web_focused = false;`, and render it — change the status `Paragraph` row to include the last message:
+
+```rust
+            f.render_widget(
+                Paragraph::new(format!(
+                    "Alt+l focus webview · Alt+h leave · q quit · last: {last_msg}"
+                )),
+                rows[0],
+            );
+```
+
+Because `HelloMsg` is declared inside `main`, move its `#[derive(serde::Deserialize)] struct HelloMsg { … }` to module scope (above `fn main`) so `run` can name it, and reference it as `HelloMsg` in both places.
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `cargo build -p ratatui-ozma --example ratatui_webview`
+Expected: builds with no errors or warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt
+git add sdk/ratatui-ozma/examples/ratatui_webview.rs
+git commit -m "docs(ratatui-ozma): demonstrate window.ozma.emit round trip in the example"
+```
+
+---
+
+## Final verification
+
+After all tasks:
+
+- [ ] `cargo test -p ratatui-ozma` — all SDK unit + integration tests pass.
+- [ ] `cargo test -p ozmux-gui webview::render` — host forwarder + preload tests pass (requires `make setup-cef`).
+- [ ] `pnpm --filter @ozma/web test && pnpm check-types && pnpm lint` — TS green.
+- [ ] `cargo clippy --workspace --all-targets` clean; `cargo fmt --check` clean.
+- [ ] Manual E2E (optional): `cargo run --features debug`, then in a pane run the example and type into the input + Enter; confirm the `last:` status updates.

--- a/docs/superpowers/specs/2026-06-21-ratatui-ozma-inbound-events-design.md
+++ b/docs/superpowers/specs/2026-06-21-ratatui-ozma-inbound-events-design.md
@@ -1,0 +1,313 @@
+# ratatui-ozma inbound events (Webview → app, one-way)
+
+Status: design (2026-06-21). Produced via the brainstorming flow; pending a
+spec review.
+
+## 1. Goal & problem
+
+`ratatui-ozma` today has three of the four page/app channels:
+
+| Direction | Mechanism | Shape |
+| --- | --- | --- |
+| app → page | `WebviewHandle::emit(event, payload)` → page `window.ozma.on` | one-way, fire-and-forget |
+| page → app | `window.ozma.call(method, params)` → `Webview::on(method, closure)` | request/response RPC |
+| app ↔ host | OSC mount + control-socket focus/navigate | — |
+
+The missing quadrant is **page → app, one-way, poll-based**: a webview wants to
+*notify* the host program of something (a button press, a form value, a
+selection) without the host having to register a reply-producing closure that
+runs on the SDK reader thread and shares state with the UI through an
+`Arc<Mutex<…>>`. The memo sketch (`docs/memo.md`) asks for:
+
+```rust
+#[derive(Deserialize)]
+struct HelloEvent { message: String }
+
+let view = Webview::url("…").add_event::<HelloEvent>();
+loop {
+    let events = view.read_events::<HelloEvent>();
+}
+```
+
+i.e. the app declares the events it accepts, then **drains a typed queue in its
+own render loop** — the same ergonomic shape ratatui apps already use for
+`crossterm` events.
+
+This is purely additive. It coexists with `.on` (RPC) and `emit` (app→page);
+nothing about those changes.
+
+## 2. Design decisions (locked)
+
+| # | Decision | Choice |
+| --- | --- | --- |
+| 1 | Transport | **Full-stack one-way `emit`**: a genuine fire-and-forget primitive across all four layers (page SDK, bridge JS, host forwarder, SDK drain). No reqId, no reply, no RPC tracking. |
+| 2 | Name binding | **Explicit string** at `add_event::<T>("name")`; `read_events::<T>()` keyed by `TypeId`. Invariant: **1:1 type ↔ name**. |
+| 3 | Read API | `read_events::<T>() -> Vec<T>`; a payload that fails to deserialize into `T` is **dropped + `tracing::warn!`**, never surfaced to the caller. |
+| 4 | Buffering | **Bounded ring per type** (default cap 1024). Overflow drops the **oldest** event + a throttled `tracing::warn!`. |
+
+## 3. End-to-end data path
+
+A page emit travels four layers; it mirrors the existing `call` path but strips
+reqId/reply/`OzmuxRpc`:
+
+```
+window.ozma.emit("hello", { message })                      // @ozma/web  (NEW)
+  └─ cef.emit({ kind:'ozma.emit', event, payload })          // bridge JS  (NEW kind)
+       └─ host observer on Receive<OzmuxFrame>, kind=="ozma.emit"   // src/webview/render.rs (NEW)
+            owner = WebviewOwner(frame.webview)              // trusted, bevy_cef-bound (never page-supplied)
+            writers.send(owner.connection_id,
+                {"op":"event","handle":owner.handle,"event":…,"payload":…})   // NEW wire line
+                 └─ SDK reader thread: op=="event"           // session.rs (NEW branch)
+                      route payload into the handle's named ring buffer (bounded)
+                           └─ view.read_events::<T>()        // WebviewHandle (NEW)
+```
+
+Trust model is unchanged from `call`: the caller identity is `frame.webview`
+(bound per-webview by `bevy_cef`, never the JS payload); its `WebviewOwner`
+names the registering connection; only that connection receives the forwarded
+line. The event name and payload are untrusted page data — the app decides what
+to do with them, and only **declared** names are buffered (unknown names
+dropped).
+
+## 4. SDK public API (`ratatui-ozma`)
+
+```rust
+impl Webview {
+    /// Declares an inbound event the page may send, binding wire name → type `T`.
+    /// Enables the `window.ozma` bridge for `url` webviews (like `on`); a no-op
+    /// for `inline`/`dir`, which are always bridged.
+    ///
+    /// # Panics
+    /// Panics if `name` (or the type `T`) is already registered on this builder
+    /// — the type ↔ name mapping must be 1:1.
+    pub fn add_event<T: DeserializeOwned + 'static>(self, name: impl Into<String>) -> Self;
+}
+
+impl WebviewHandle {
+    /// Drains and returns every buffered event of type `T`, oldest first.
+    /// Payloads that fail to deserialize into `T` are dropped and logged.
+    /// Returns an empty `Vec` if `T` was never declared via `add_event`.
+    pub fn read_events<T: DeserializeOwned + 'static>(&self) -> Vec<T>;
+}
+```
+
+Concrete usage:
+
+```rust
+#[derive(Deserialize)]
+struct HelloEvent { message: String }
+
+let view = ozma.register(
+    Webview::url("https://app.example")
+        .add_event::<HelloEvent>("hello"),
+)?;
+
+loop {
+    terminal.draw(/* … */)?;
+    for e in view.read_events::<HelloEvent>() {
+        // handle each event in the app's own loop, alongside crossterm events
+    }
+}
+```
+
+Page side:
+
+```js
+window.ozma.emit("hello", { message: "hi" });
+```
+
+Rules:
+
+- **1:1 type ↔ name.** Duplicate type *or* duplicate name on the same builder
+  **panics at builder time**. This reuses the *panic mechanism* of
+  `Webview::on`'s reserved-namespace `assert!`, but the duplicate check is a
+  **new invariant** `add_event` enforces — `on` itself silently overwrites a
+  duplicate method in its `HashMap`. (Want two events with the same shape? Use
+  two newtypes.)
+- **`add_event` flips `bridge` on** for `RegisterKind::Url` (without the bridge
+  the page has no `window.ozma.emit`). No-op for inline/dir.
+- **Coexists with `.on`**: different page API (`emit` vs `call`), different
+  frame kind (`ozma.emit` vs `ozma.call`), separate name maps. An event name
+  and a method name never collide.
+
+## 5. SDK internals
+
+### 5.1 Per-handle event queues
+
+A new structure, built at `register` time from the builder's declarations and
+shared (`Arc`) between the reader thread (ingest) and the handle (drain):
+
+```rust
+// One bounded ring of raw payloads, shared (Arc) by both lookup maps.
+// RingBuf = { buf: VecDeque<Value>, dropped: u64, last_warn: Option<Instant> }
+type Ring = Arc<Mutex<RingBuf>>;
+
+pub(crate) struct EventQueues {
+    by_name: HashMap<String, Ring>,   // ingest routing (reader thread): wire name → ring
+    by_type: HashMap<TypeId, Ring>,   // read_events: TypeId::of::<T>() → the same ring
+    cap: usize,                       // default 1024
+}
+```
+
+- The builder accumulates `Vec<EventDecl { name: String, type_id: TypeId }>`.
+  `register` builds one `Ring` per declared event and inserts a clone of that
+  `Arc` into **both** `by_name` (for the reader) and `by_type` (for
+  `read_events`) — each side reaches the ring in a **single** lookup, no
+  `TypeId → name → ring` double hash. Both outer maps are frozen after
+  `register` (only ring *contents* mutate), so the whole `EventQueues` is shared
+  as an `Arc` with **no outer lock** — only the per-ring `Mutex` is ever
+  contended (the shape `HandlerRegistry` uses to install an `Arc<HashMap<…>>`
+  whole).
+- A bounded `crossbeam_channel` was considered (already a dependency) and
+  **rejected**: its bounded channel drops the *newest* message on overflow — the
+  opposite of decision #4's drop-oldest — and a one-shot `mem::take` drain beats
+  N `try_recv` calls. `Mutex<VecDeque>` keeps drop-oldest atomic under one lock.
+- **Deserialization is deferred to read time** (the UI thread): the reader
+  thread only routes a `serde_json::Value` by name, so it stays a cheap router
+  and `T`-typed work happens where `T` is known. This also localizes
+  deserialize errors to `read_events`.
+
+### 5.2 Reader thread (`session.rs`)
+
+Add an `op=="event"` branch to the reader loop (peer of the existing `call` /
+`compositing` branches):
+
+1. Parse the line into a typed `IncomingEvent { handle, event, #[serde(default)]
+   payload: Value }` added to `sdk/ratatui-ozma/src/protocol.rs`, mirroring the
+   existing `IncomingCall` struct (the `call` path already parses into a typed
+   struct rather than indexing raw `Value`).
+2. Look up the handle's `Arc<EventQueues>` in a new
+   `EventRegistry: Arc<Mutex<HashMap<String /*handle*/, Arc<EventQueues>>>>`
+   (installed under the minted handle at register-reply time, exactly like
+   `HandlerRegistry`); **clone the `Arc` and release the registry lock** before
+   touching any ring, so a burst from one page holds the global lock only briefly.
+3. `by_name.get(event)` → lock that ring, `push_back`; if `len == cap`,
+   `pop_front()` (drop oldest) first. Overflow bumps a **per-ring** dropped
+   counter and emits a `tracing::warn!` throttled per ring (via the ring's
+   `last_warn`/`dropped` fields) so one noisy event type can't suppress warnings
+   for another. An event for an unregistered name is dropped + `tracing::debug!`.
+
+### 5.3 `read_events::<T>()` (`WebviewHandle`)
+
+The `WebviewHandle` holds the `Arc<EventQueues>` directly (captured at
+`register`), so no handle lookup is needed:
+
+1. `ring = by_type.get(&TypeId::of::<T>())` — `None` ⇒ return `vec![]` (a single
+   lookup; no `TypeId → name` indirection).
+2. Lock the ring, `std::mem::take` its `VecDeque` into an owned local, then
+   **release the lock**. Deserialization in step 3 must not run while the lock
+   is held, or a slow/large payload would block the reader thread's ingest for
+   that event type.
+3. `serde_json::from_value::<T>` each payload; on `Err`, skip + `tracing::warn!`.
+4. Return `Vec<T>`, oldest first.
+
+`WebviewHandle` is `Clone` and clones share the same `Arc<EventQueues>`; an event
+is consumed by whichever clone drains first (the normal case is a single
+draining loop). This is documented, not guarded.
+
+### 5.4 Reconnect
+
+`Registration` (the replay record in `session.rs`) gains an `Arc<EventQueues>`
+field alongside `handlers`, and the new `EventRegistry` threads through the same
+three sites the existing shared maps already pass through: `connect()`'s
+reconnect-thread closure, `spawn_reader`, and `attempt_reconnect` (the same
+churn `pending_compositing` already pays). On reconnect, mirror exactly what the
+handler map does at `session.rs:662-672` — `registry.remove(old_handle)` then
+`registry.insert(new_handle, same_arc)` — re-installing the **same `Arc`** under
+the freshly minted handle. Removing the old key matters: it stops a stale handle
+entry from leaking and ensures a late `op=="event"` line addressed to the
+now-defunct old handle is dropped. Buffered events survive (the `Arc` is
+unchanged); the handle slot's id updates as it already does for handlers.
+
+### 5.5 Documented limitation — instance merging
+
+A handle may be mounted as multiple instances (`(view_id, instance_id)`). The
+forwarded line carries only the **handle**, so events from *all* instances of a
+handle merge into one per-handle buffer; `read_events::<T>()` has no
+per-instance filter (matching the memo's no-instance API). Acceptable for
+one-way notifications; noted for future work if per-instance routing is needed.
+
+## 6. Host + page-side layers
+
+### 6.1 `@ozma/web` (`sdk/ozma-web/src/ozma.ts`)
+
+Add to `OzmaApi` and the `ozma` const:
+
+```ts
+/** Sends a one-way event to the host app (fire-and-forget; no reply). */
+emit(event: string, payload?: unknown): void;
+```
+
+Delegates through `resolve()`; throws the same "window.ozma unavailable" error
+when the bridge is absent. Returns `void`. A vitest case asserts it forwards to
+the bridge with the right shape and throws when the bridge is missing.
+
+### 6.2 Bridge JS (`src/webview/render/ozma_bridge.js`)
+
+Add `emit` to the frozen `api` object:
+
+```js
+emit: function (event, payload) {
+  cef.emit({ kind: 'ozma.emit', event: event, payload: encodeParam(payload) });
+},
+```
+
+Reuses the existing top-level-`Uint8Array` tagging (`encodeParam`); no `reqId`,
+no Promise, no `calls` entry, so it cannot leak. `preload.rs` gains an assertion
+that the injected bundle contains `kind: 'ozma.emit'` (next to the existing
+`'ozma.call'` assert).
+
+### 6.3 Host forwarder (`src/webview/render.rs`)
+
+A new observer on `Receive<OzmuxFrame>` gated to `kind == "ozma.emit"` (peer of
+`on_ozmux_call_frame`):
+
+1. Resolve `WebviewOwner` for `frame.webview`. Missing owner ⇒ drop +
+   `tracing::debug!` (no Promise to reject).
+2. `writers.send(owner.connection_id, line)` where `line` is built with **raw
+   `serde_json::json!`**:
+   `{"op":"event","handle":owner.handle,"event":event,"payload":payload}`.
+   Building it raw (not via a typed `PushMsg` variant) keeps `PushMsg`'s `Eq`
+   derive — exactly the precedent `on_ozmux_call_frame` already sets for the
+   `call` line (a `Value` payload would otherwise break `Eq`).
+3. No `OzmuxRpc::mint`/`note`, no reply routing — strictly fire-and-forget. A
+   `writers.send` failure is dropped + `tracing::debug!`.
+
+No change to the **host** `src/control_plane/protocol.rs`: the host builds the
+line with raw `json!` (the `call`-forward precedent). The **SDK** side parses it
+into a typed `IncomingEvent` struct added to `sdk/ratatui-ozma/src/protocol.rs`,
+mirroring the existing `IncomingCall` — so the reader branch deserializes rather
+than indexing raw `Value` (see §5.2).
+
+## 7. Testing
+
+- **SDK unit (`webview.rs` / `session.rs`)**:
+  - `add_event` records the decl; duplicate type **and** duplicate name panic.
+  - `add_event` flips `bridge` for `url`; no-op for inline.
+  - reader-thread `op=="event"` routes a payload into the buffer (same paired-
+    socket harness as `reader_thread_inserts_compositing_into_shared_map`).
+  - `read_events` drains in order and deserializes; malformed payload skipped;
+    unknown type returns `vec![]`.
+  - ring drops the oldest past `cap`.
+  - reconnect replays `EventQueues` under the new handle and preserves buffered
+    events.
+- **Host (`src/webview/render.rs`)**: a `kind:"ozma.emit"` frame produces the
+  `{"op":"event",…}` line on the owner's writer; missing owner drops silently
+  (paralleling the `call`-forward test).
+- **Bridge JS (`preload.rs`)**: bundle contains `kind: 'ozma.emit'`.
+- **`@ozma/web` (vitest)**: `emit` delegates with the right shape; throws when
+  the bridge is absent.
+- **Integration (`tests/integration.rs`)**: end-to-end page emit → `read_events`
+  over a paired socket.
+- **Example (`examples/ratatui_webview.rs`)**: extend with an `<input>` that
+  calls `window.ozma.emit("hello", …)` and an app loop that renders the latest
+  received message, demonstrating the round trip.
+
+## 8. Out of scope
+
+- Per-instance event routing (see §5.5).
+- Configurable per-event buffer caps (the 1024 default is fixed for now; the
+  `cap` field leaves room to expose it later).
+- Backpressure signalling to the page (drops are silent to the page; only the
+  app sees the throttled warn).
+- Any change to the `call` RPC path or the app→page `emit` path.

--- a/sdk/ozma-web/src/ozma.test.ts
+++ b/sdk/ozma-web/src/ozma.test.ts
@@ -12,22 +12,26 @@ describe('@ozma/web client', () => {
     const call = vi.fn(async () => 'pong');
     const on = vi.fn();
     const off = vi.fn();
-    g.ozma = { call, on, off } as unknown as OzmaApi;
+    const emit = vi.fn();
+    g.ozma = { call, on, off, emit } as unknown as OzmaApi;
 
     const handler = (): void => {};
     await expect(ozma.call('ping', 'hi')).resolves.toBe('pong');
     ozma.on('tick', handler);
     ozma.off('tick', handler);
+    ozma.emit('hello', { message: 'hi' });
 
     expect(call).toHaveBeenCalledWith('ping', 'hi');
     expect(on).toHaveBeenCalledWith('tick', handler);
     expect(off).toHaveBeenCalledWith('tick', handler);
+    expect(emit).toHaveBeenCalledWith('hello', { message: 'hi' });
   });
 
   it('throws a descriptive error when the bridge is absent', () => {
     expect(() => ozma.call('ping')).toThrow(/window\.ozma is unavailable/);
     expect(() => ozma.on('tick', () => {})).toThrow(/window\.ozma is unavailable/);
     expect(() => ozma.off('tick', () => {})).toThrow(/window\.ozma is unavailable/);
+    expect(() => ozma.emit('hello', {})).toThrow(/window\.ozma is unavailable/);
   });
 
   it('reports bridge availability', () => {

--- a/sdk/ozma-web/src/ozma.ts
+++ b/sdk/ozma-web/src/ozma.ts
@@ -14,6 +14,8 @@ export interface OzmaApi {
   on(event: string, handler: (payload: unknown) => void): void;
   /** Removes a previously-registered event handler by reference equality. */
   off(event: string, handler: (payload: unknown) => void): void;
+  /** Sends a one-way event to the host app (fire-and-forget; no reply). */
+  emit(event: string, payload?: unknown): void;
 }
 
 // NOTE: augments `window.ozma` for browser consumers whose tsconfig includes the "dom" lib;
@@ -46,6 +48,9 @@ export const ozma: OzmaApi = {
   },
   off(event: string, handler: (payload: unknown) => void): void {
     resolve().off(event, handler);
+  },
+  emit(event: string, payload?: unknown): void {
+    resolve().emit(event, payload);
   },
 };
 

--- a/sdk/ratatui-ozma/examples/ratatui_webview.rs
+++ b/sdk/ratatui-ozma/examples/ratatui_webview.rs
@@ -7,6 +7,10 @@
 //! `event::read`) and suppresses them from the page even while the webview is
 //! focused. `WebviewWidget::focused` tells the SDK the current focus; the
 //! `OzmaBackend` wrapping the terminal emits the control-plane focus op on change.
+//!
+//! The inline page emits a `hello` event when the user presses Enter in the input;
+//! the app drains `view.read_events::<HelloMsg>()` each frame and displays the
+//! latest message in the status line.
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
@@ -23,6 +27,11 @@ use std::time::{Duration, Instant};
 
 type Backend = OzmaBackend<CrosstermBackend<Stdout>>;
 
+#[derive(serde::Deserialize)]
+struct HelloMsg {
+    message: String,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut ozma = Ozma::connect()?;
     let html = concat!(
@@ -32,7 +41,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "<script>",
         "window.ozma.call('ping','hi').then(v=>out.textContent='ping → '+v);",
         "window.ozma.on('tick',n=>tick.textContent='tick #'+n);",
-        "document.getElementById('in').focus();",
+        "var inp=document.getElementById('in');",
+        "inp.addEventListener('keydown',function(e){",
+        "  if(e.key==='Enter'){ window.ozma.emit('hello',{message:inp.value}); inp.value=''; }",
+        "});",
+        "inp.focus();",
         "</script></body>"
     );
 
@@ -50,7 +63,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ])
             .on("ping", |arg: String| {
                 Ok::<_, RpcError>(format!("pong:{arg}"))
-            }),
+            })
+            .add_event::<HelloMsg>("hello"),
     )?;
 
     enable_raw_mode()?;
@@ -78,6 +92,7 @@ fn run(
     view: &WebviewHandle,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut web_focused = false;
+    let mut last_msg = String::new();
     let mut n: u64 = 0;
     let mut last = Instant::now();
     loop {
@@ -85,7 +100,9 @@ fn run(
             let rows =
                 Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
             f.render_widget(
-                Paragraph::new("Alt+l focus webview · Alt+h leave · q quit (when not focused)"),
+                Paragraph::new(format!(
+                    "Alt+l focus webview · Alt+h leave · q quit · last: {last_msg}"
+                )),
                 rows[0],
             );
             f.render_stateful_widget(
@@ -101,6 +118,10 @@ fn run(
             n += 1;
             let _ = view.emit("tick", &n);
             last = Instant::now();
+        }
+
+        for HelloMsg { message } in view.read_events::<HelloMsg>() {
+            last_msg = message;
         }
 
         if event::poll(Duration::from_millis(50))?

--- a/sdk/ratatui-ozma/src/events.rs
+++ b/sdk/ratatui-ozma/src/events.rs
@@ -4,6 +4,7 @@
 use serde_json::Value;
 use std::any::TypeId;
 use std::collections::{HashMap, VecDeque};
+use std::mem;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -37,7 +38,7 @@ type Ring = Arc<Mutex<RingBuf>>;
 /// side reaches it in a single lookup. Both maps are frozen after construction;
 /// only ring contents mutate, so the whole struct is shared behind one `Arc`
 /// with no outer lock.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct EventQueues {
     by_name: HashMap<String, Ring>,
     by_type: HashMap<TypeId, Ring>,
@@ -88,7 +89,7 @@ impl EventQueues {
             return Vec::new();
         };
         let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
-        Vec::from(std::mem::take(&mut ring.buf))
+        Vec::from(mem::take(&mut ring.buf))
     }
 
     fn from_decls_with_cap(decls: &[EventDecl], cap: usize) -> Self {
@@ -104,6 +105,12 @@ impl EventQueues {
             by_type,
             cap,
         }
+    }
+}
+
+impl Default for EventQueues {
+    fn default() -> Self {
+        Self::from_decls(&[])
     }
 }
 
@@ -135,7 +142,6 @@ mod tests {
         assert!(q.ingest("a", json!(2)));
         let drained = q.drain_type(TypeId::of::<A>());
         assert_eq!(drained, vec![json!(1), json!(2)]);
-        // A second drain is empty; the ring was consumed.
         assert!(q.drain_type(TypeId::of::<A>()).is_empty());
     }
 

--- a/sdk/ratatui-ozma/src/events.rs
+++ b/sdk/ratatui-ozma/src/events.rs
@@ -1,0 +1,173 @@
+//! Per-handle inbound event queues: bounded rings the reader thread fills from
+//! `op == "event"` lines and `WebviewHandle::read_events` drains by type.
+
+use serde_json::Value;
+use std::any::TypeId;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// The default per-event ring capacity. Overflow drops the oldest payload.
+const DEFAULT_CAP: usize = 1024;
+
+/// Minimum interval between overflow warnings for a single saturated ring.
+const WARN_EVERY: Duration = Duration::from_secs(5);
+
+/// A builder-time declaration binding a wire event name to a Rust type.
+pub(crate) struct EventDecl {
+    /// The wire event name the page sends via `window.ozma.emit`.
+    pub(crate) name: String,
+    /// `TypeId::of::<T>()` for the declared event type `T`.
+    pub(crate) type_id: TypeId,
+}
+
+/// One bounded ring of raw payloads plus throttled-overflow bookkeeping.
+#[derive(Default, Debug)]
+struct RingBuf {
+    buf: VecDeque<Value>,
+    dropped: u64,
+    last_warn: Option<Instant>,
+}
+
+type Ring = Arc<Mutex<RingBuf>>;
+
+/// The per-handle set of inbound event rings, declared at `register` and shared
+/// between the reader thread (`by_name` ingest) and the `WebviewHandle`
+/// (`by_type` drain). Each ring is shared by both maps via one `Arc`, so each
+/// side reaches it in a single lookup. Both maps are frozen after construction;
+/// only ring contents mutate, so the whole struct is shared behind one `Arc`
+/// with no outer lock.
+#[derive(Default, Debug)]
+pub(crate) struct EventQueues {
+    by_name: HashMap<String, Ring>,
+    by_type: HashMap<TypeId, Ring>,
+    cap: usize,
+}
+
+/// Maps a registration handle to its `EventQueues`, the inbound-event peer of
+/// the SDK's per-handle handler registry.
+pub(crate) type EventRegistry = Arc<Mutex<HashMap<String, Arc<EventQueues>>>>;
+
+impl EventQueues {
+    /// Builds the rings for `decls` at the default capacity, inserting each ring
+    /// into both lookup maps.
+    pub(crate) fn from_decls(decls: &[EventDecl]) -> Self {
+        Self::from_decls_with_cap(decls, DEFAULT_CAP)
+    }
+
+    /// Routes `payload` into the ring named `name`. When the ring is at
+    /// capacity, drops the oldest payload first (with a per-ring throttled
+    /// warning). Returns `false` when `name` was never declared.
+    pub(crate) fn ingest(&self, name: &str, payload: Value) -> bool {
+        let Some(ring) = self.by_name.get(name) else {
+            return false;
+        };
+        let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
+        if ring.buf.len() >= self.cap {
+            ring.buf.pop_front();
+            ring.dropped += 1;
+            if ring.last_warn.is_none_or(|t| t.elapsed() >= WARN_EVERY) {
+                tracing::warn!(
+                    event = name,
+                    dropped = ring.dropped,
+                    "inbound event ring saturated; dropping oldest"
+                );
+                ring.last_warn = Some(Instant::now());
+            }
+        }
+        ring.buf.push_back(payload);
+        true
+    }
+
+    /// Drains every buffered payload for the ring keyed by `type_id`, oldest
+    /// first. Returns an empty `Vec` when the type was never declared. The ring
+    /// lock is released before the caller deserializes, so a slow `from_value`
+    /// never blocks the reader thread's ingest.
+    pub(crate) fn drain_type(&self, type_id: TypeId) -> Vec<Value> {
+        let Some(ring) = self.by_type.get(&type_id) else {
+            return Vec::new();
+        };
+        let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
+        Vec::from(std::mem::take(&mut ring.buf))
+    }
+
+    fn from_decls_with_cap(decls: &[EventDecl], cap: usize) -> Self {
+        let mut by_name = HashMap::new();
+        let mut by_type = HashMap::new();
+        for decl in decls {
+            let ring: Ring = Arc::new(Mutex::new(RingBuf::default()));
+            by_name.insert(decl.name.clone(), ring.clone());
+            by_type.insert(decl.type_id, ring);
+        }
+        Self {
+            by_name,
+            by_type,
+            cap,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct A;
+    struct B;
+
+    fn decls() -> Vec<EventDecl> {
+        vec![
+            EventDecl {
+                name: "a".into(),
+                type_id: TypeId::of::<A>(),
+            },
+            EventDecl {
+                name: "b".into(),
+                type_id: TypeId::of::<B>(),
+            },
+        ]
+    }
+
+    #[test]
+    fn ingest_then_drain_by_type_is_fifo() {
+        let q = EventQueues::from_decls(&decls());
+        assert!(q.ingest("a", json!(1)));
+        assert!(q.ingest("a", json!(2)));
+        let drained = q.drain_type(TypeId::of::<A>());
+        assert_eq!(drained, vec![json!(1), json!(2)]);
+        // A second drain is empty; the ring was consumed.
+        assert!(q.drain_type(TypeId::of::<A>()).is_empty());
+    }
+
+    #[test]
+    fn drain_is_isolated_per_type() {
+        let q = EventQueues::from_decls(&decls());
+        q.ingest("a", json!("x"));
+        q.ingest("b", json!("y"));
+        assert_eq!(q.drain_type(TypeId::of::<A>()), vec![json!("x")]);
+        assert_eq!(q.drain_type(TypeId::of::<B>()), vec![json!("y")]);
+    }
+
+    #[test]
+    fn ingest_for_undeclared_name_returns_false() {
+        let q = EventQueues::from_decls(&decls());
+        assert!(!q.ingest("missing", json!(1)));
+    }
+
+    #[test]
+    fn drain_for_undeclared_type_is_empty() {
+        struct C;
+        let q = EventQueues::from_decls(&decls());
+        assert!(q.drain_type(TypeId::of::<C>()).is_empty());
+    }
+
+    #[test]
+    fn overflow_drops_oldest_and_keeps_cap() {
+        let q = EventQueues::from_decls_with_cap(&decls(), 2);
+        q.ingest("a", json!(1));
+        q.ingest("a", json!(2));
+        q.ingest("a", json!(3)); // evicts 1
+        let drained = q.drain_type(TypeId::of::<A>());
+        assert_eq!(drained, vec![json!(2), json!(3)]);
+    }
+}

--- a/sdk/ratatui-ozma/src/events.rs
+++ b/sdk/ratatui-ozma/src/events.rs
@@ -108,12 +108,6 @@ impl EventQueues {
     }
 }
 
-impl Default for EventQueues {
-    fn default() -> Self {
-        Self::from_decls(&[])
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/ratatui-ozma/src/lib.rs
+++ b/sdk/ratatui-ozma/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod backend;
 mod error;
+mod events;
 mod handler;
 mod keychord;
 mod osc;

--- a/sdk/ratatui-ozma/src/protocol.rs
+++ b/sdk/ratatui-ozma/src/protocol.rs
@@ -135,6 +135,18 @@ pub(crate) struct IncomingCall {
     pub(crate) params: Value,
 }
 
+/// An inbound one-way `event` frame forwarded from a page's `window.ozma.emit`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct IncomingEvent {
+    /// The view handle the event targets.
+    pub(crate) handle: String,
+    /// The declared event name (`add_event::<T>(name)`).
+    pub(crate) event: String,
+    /// The single payload value (any JSON shape; absent deserializes as null).
+    #[serde(default)]
+    pub(crate) payload: Value,
+}
+
 mod reply_result {
     use serde::Serializer;
     use serde::ser::SerializeMap;
@@ -316,5 +328,23 @@ mod tests {
         .unwrap();
         assert_eq!(v["op"], "navigate");
         assert_eq!(v["action"]["to"], "https://example.com/x");
+    }
+
+    #[test]
+    fn incoming_event_deserializes() {
+        let e: IncomingEvent = serde_json::from_str(
+            r#"{"op":"event","handle":"h","event":"hello","payload":{"message":"hi"}}"#,
+        )
+        .unwrap();
+        assert_eq!(e.handle, "h");
+        assert_eq!(e.event, "hello");
+        assert_eq!(e.payload, serde_json::json!({"message":"hi"}));
+    }
+
+    #[test]
+    fn incoming_event_without_payload_is_null() {
+        let e: IncomingEvent =
+            serde_json::from_str(r#"{"op":"event","handle":"h","event":"ping"}"#).unwrap();
+        assert_eq!(e.payload, Value::Null);
     }
 }

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -108,10 +108,12 @@ type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandle
 type PendingRegisters = Arc<Mutex<VecDeque<PendingRegister>>>;
 
 /// One in-flight `register` awaiting its untagged reply: the oneshot to wake the
-/// caller, plus the handlers to install once the control plane mints the handle.
+/// caller, plus the handlers and event queues to install once the control plane
+/// mints the handle.
 struct PendingRegister {
     reply: Sender<OzmaResult<String>>,
     handlers: Arc<HashMap<String, BoxedHandler>>,
+    events: Arc<EventQueues>,
 }
 
 type PendingCompositing = Arc<Mutex<HashMap<String, bool>>>;
@@ -140,7 +142,6 @@ pub struct Ozma {
     disconnected: Arc<AtomicBool>,
     generation: Arc<AtomicU64>,
     registrations: Arc<Mutex<Vec<Registration>>>,
-    events: EventRegistry,
     reconnect_tx: crossbeam_channel::Sender<()>,
 }
 
@@ -230,7 +231,6 @@ impl Ozma {
             disconnected,
             generation,
             registrations,
-            events,
             reconnect_tx,
         })
     }
@@ -254,6 +254,7 @@ impl Ozma {
             self.pending.lock()?.push_back(PendingRegister {
                 reply: tx,
                 handlers: handlers.clone(),
+                events: events.clone(),
             });
             if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
                 // The register never went out, so no reply will arrive for this
@@ -263,10 +264,11 @@ impl Ozma {
             }
         }
 
+        // NOTE: the reader thread installs the event queues under the minted
+        // handle BEFORE sending this reply (mirroring the handler install), so an
+        // event pipelined right behind the register reply finds its queues rather
+        // than racing this main thread; do not move the install back here.
         let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
-        if let Ok(mut map) = self.events.lock() {
-            map.insert(handle.clone(), events.clone());
-        }
         let handle_slot = Arc::new(Mutex::new(handle));
         if let Ok(mut regs) = self.registrations.lock() {
             regs.push(Registration {
@@ -516,18 +518,25 @@ fn spawn_reader(
                 }
             } else if op == "event" {
                 if let Ok(ev) = serde_json::from_str::<IncomingEvent>(trimmed) {
-                    let queues = events
+                    match events
                         .lock()
                         .ok()
-                        .and_then(|map| map.get(&ev.handle).cloned());
-                    if let Some(queues) = queues
-                        && !queues.ingest(&ev.event, ev.payload)
+                        .and_then(|map| map.get(&ev.handle).cloned())
                     {
-                        tracing::debug!(
+                        Some(queues) => {
+                            if !queues.ingest(&ev.event, ev.payload) {
+                                tracing::debug!(
+                                    handle = ev.handle,
+                                    event = ev.event,
+                                    "inbound event for an undeclared name dropped"
+                                );
+                            }
+                        }
+                        None => tracing::debug!(
                             handle = ev.handle,
                             event = ev.event,
-                            "inbound event for an undeclared name dropped"
-                        );
+                            "inbound event for an unknown handle dropped"
+                        ),
                     }
                 }
             } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed)
@@ -542,6 +551,9 @@ fn spawn_reader(
                         Some(h) => {
                             if let Ok(mut map) = handlers.lock() {
                                 map.insert(h.clone(), reg.handlers);
+                            }
+                            if let Ok(mut map) = events.lock() {
+                                map.insert(h.clone(), reg.events);
                             }
                             Ok(h)
                         }
@@ -673,6 +685,7 @@ fn attempt_reconnect(
             pq.push_back(PendingRegister {
                 reply: tx,
                 handlers: reg.handlers.clone(),
+                events: reg.events.clone(),
             });
         }
         let line = match serde_json::to_string(&ClientMsg::Register(reg.kind.clone())) {

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -708,6 +708,10 @@ fn attempt_reconnect(
             map.remove(&old);
             map.insert(new_handle.clone(), reg.handlers.clone());
         }
+        if let Ok(mut map) = events.lock() {
+            map.remove(&old);
+            map.insert(new_handle.clone(), reg.events.clone());
+        }
         if let Ok(mut slot) = reg.handle_slot.lock() {
             *slot = new_handle;
         }

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -229,7 +229,11 @@ impl Ozma {
 
     /// Registers a webview, blocking until the control plane mints its handle.
     pub fn register(&self, webview: Webview) -> OzmaResult<WebviewHandle> {
-        let Webview { kind, handlers } = webview;
+        let Webview {
+            kind,
+            handlers,
+            event_decls: _,
+        } = webview;
         let handlers = Arc::new(handlers);
         let (tx, rx) = bounded(1);
         let line = serde_json::to_string(&ClientMsg::Register(kind.clone()))?;

--- a/sdk/ratatui-ozma/src/session.rs
+++ b/sdk/ratatui-ozma/src/session.rs
@@ -1,9 +1,10 @@
 //! The Ozma session: socket connection, reader thread, flush.
 
 use crate::error::{OzmaError, OzmaResult};
+use crate::events::{EventQueues, EventRegistry};
 use crate::handler::BoxedHandler;
 use crate::osc::{clamp_dims, cursor_to, mount, unmount, valid_handle};
-use crate::protocol::{ClientMsg, IncomingCall, RegisterKind, RegisterReply};
+use crate::protocol::{ClientMsg, IncomingCall, IncomingEvent, RegisterKind, RegisterReply};
 use crate::webview::{SharedWriter, Webview, WebviewHandle};
 use crossbeam_channel::{Sender, bounded};
 use ratatui::layout::Rect;
@@ -120,6 +121,7 @@ struct Registration {
     kind: RegisterKind,
     handle_slot: Arc<Mutex<String>>,
     handlers: Arc<HashMap<String, BoxedHandler>>,
+    events: Arc<EventQueues>,
 }
 
 /// The minimal shared state passed to [`OzmaBackend`] for reconnect signalling.
@@ -138,6 +140,7 @@ pub struct Ozma {
     disconnected: Arc<AtomicBool>,
     generation: Arc<AtomicU64>,
     registrations: Arc<Mutex<Vec<Registration>>>,
+    events: EventRegistry,
     reconnect_tx: crossbeam_channel::Sender<()>,
 }
 
@@ -170,6 +173,7 @@ impl Ozma {
         let disconnected: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let generation: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
         let registrations: Arc<Mutex<Vec<Registration>>> = Arc::new(Mutex::new(Vec::new()));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (reconnect_tx, reconnect_rx) = crossbeam_channel::bounded::<()>(1);
 
         {
@@ -187,6 +191,7 @@ impl Ozma {
             handlers.clone(),
             pending.clone(),
             pending_compositing.clone(),
+            events.clone(),
             disconnected.clone(),
         );
 
@@ -198,6 +203,7 @@ impl Ozma {
             let disconnected2 = disconnected.clone();
             let generation2 = generation.clone();
             let registrations2 = registrations.clone();
+            let events2 = events.clone();
             let token2 = token.clone();
             thread::spawn(move || {
                 while let Ok(()) = reconnect_rx.recv() {
@@ -209,6 +215,7 @@ impl Ozma {
                         &disconnected2,
                         &generation2,
                         &registrations2,
+                        &events2,
                         &token2,
                     );
                 }
@@ -223,6 +230,7 @@ impl Ozma {
             disconnected,
             generation,
             registrations,
+            events,
             reconnect_tx,
         })
     }
@@ -232,9 +240,10 @@ impl Ozma {
         let Webview {
             kind,
             handlers,
-            event_decls: _,
+            event_decls,
         } = webview;
         let handlers = Arc::new(handlers);
+        let events = Arc::new(EventQueues::from_decls(&event_decls));
         let (tx, rx) = bounded(1);
         let line = serde_json::to_string(&ClientMsg::Register(kind.clone()))?;
         {
@@ -255,15 +264,23 @@ impl Ozma {
         }
 
         let handle = rx.recv().map_err(|_| OzmaError::Disconnected)??;
+        if let Ok(mut map) = self.events.lock() {
+            map.insert(handle.clone(), events.clone());
+        }
         let handle_slot = Arc::new(Mutex::new(handle));
         if let Ok(mut regs) = self.registrations.lock() {
             regs.push(Registration {
                 kind,
                 handle_slot: handle_slot.clone(),
                 handlers: handlers.clone(),
+                events: events.clone(),
             });
         }
-        Ok(WebviewHandle::new_shared(handle_slot, self.writer.clone()))
+        Ok(WebviewHandle::new_shared(
+            handle_slot,
+            events,
+            self.writer.clone(),
+        ))
     }
 
     /// Locks and clears the per-frame placement collector for `render_stateful_widget`.
@@ -467,6 +484,7 @@ fn spawn_reader(
     handlers: HandlerRegistry,
     pending: PendingRegisters,
     pending_compositing: PendingCompositing,
+    events: EventRegistry,
     disconnected: Arc<AtomicBool>,
 ) {
     thread::spawn(move || {
@@ -495,6 +513,22 @@ fn spawn_reader(
                     && let Ok(mut map) = pending_compositing.lock()
                 {
                     map.insert(handle.to_owned(), active);
+                }
+            } else if op == "event" {
+                if let Ok(ev) = serde_json::from_str::<IncomingEvent>(trimmed) {
+                    let queues = events
+                        .lock()
+                        .ok()
+                        .and_then(|map| map.get(&ev.handle).cloned());
+                    if let Some(queues) = queues
+                        && !queues.ingest(&ev.event, ev.payload)
+                    {
+                        tracing::debug!(
+                            handle = ev.handle,
+                            event = ev.event,
+                            "inbound event for an undeclared name dropped"
+                        );
+                    }
                 }
             } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed)
                 && let Some(reg) = pending.lock().ok().and_then(|mut q| q.pop_front())
@@ -573,6 +607,7 @@ fn attempt_reconnect(
     disconnected: &Arc<AtomicBool>,
     generation: &Arc<AtomicU64>,
     registrations: &Arc<Mutex<Vec<Registration>>>,
+    events: &EventRegistry,
     token: &str,
 ) {
     let candidates = resolve_ozma_sock_candidates();
@@ -621,6 +656,7 @@ fn attempt_reconnect(
         handlers.clone(),
         pending.clone(),
         pending_compositing.clone(),
+        events.clone(),
         disconnected.clone(),
     );
     let Ok(regs) = registrations.lock() else {
@@ -956,6 +992,7 @@ mod tests {
             handlers,
             pending,
             pending_compositing.clone(),
+            Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicBool::new(false)),
         );
 
@@ -997,6 +1034,7 @@ mod tests {
             handlers,
             pending,
             pending_compositing.clone(),
+            Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicBool::new(false)),
         );
 
@@ -1013,5 +1051,62 @@ mod tests {
 
         let map = pending_compositing.lock().unwrap();
         assert_eq!(map.get("h1"), Some(&false));
+    }
+
+    #[test]
+    fn reader_thread_routes_event_into_registered_queues() {
+        use crate::events::{EventDecl, EventQueues, EventRegistry};
+        use std::any::TypeId;
+        use std::io::Write;
+        use std::os::unix::net::UnixListener;
+
+        struct Hello;
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("ev.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let decls = vec![EventDecl {
+            name: "hello".into(),
+            type_id: TypeId::of::<Hello>(),
+        }];
+        let queues = Arc::new(EventQueues::from_decls(&decls));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+        events
+            .lock()
+            .unwrap()
+            .insert("h1".to_owned(), queues.clone());
+
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
+
+        let client = UnixStream::connect(&sock_path).unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(client.try_clone().unwrap()));
+        let (server_conn, _) = listener.accept().unwrap();
+
+        spawn_reader(
+            client,
+            writer.clone(),
+            handlers,
+            pending,
+            pending_compositing,
+            events.clone(),
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        let mut server = server_conn;
+        writeln!(
+            server,
+            r#"{{"op":"event","handle":"h1","event":"hello","payload":{{"n":7}}}}"#
+        )
+        .unwrap();
+        server.flush().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        assert_eq!(
+            queues.drain_type(TypeId::of::<Hello>()),
+            vec![serde_json::json!({"n":7})]
+        );
     }
 }

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -120,9 +120,7 @@ impl Webview {
             "method {method:?} uses the reserved __ozma. namespace"
         );
         self.handlers.insert(method, make_handler(f));
-        if let RegisterKind::Url { bridge, .. } = &mut self.kind {
-            *bridge = true;
-        }
+        self.enable_bridge_for_url();
         self
     }
 
@@ -149,10 +147,17 @@ impl Webview {
             std::any::type_name::<T>()
         );
         self.event_decls.push(EventDecl { name, type_id });
+        self.enable_bridge_for_url();
+        self
+    }
+
+    /// Force-enables the `window.ozma` bridge for a `url` webview; a no-op for
+    /// `inline`/`dir`, which are always bridged. Shared by `on` and `add_event`,
+    /// both of which require the bridge for the page-side channel they wire.
+    fn enable_bridge_for_url(&mut self) {
         if let RegisterKind::Url { bridge, .. } = &mut self.kind {
             *bridge = true;
         }
-        self
     }
 }
 
@@ -385,7 +390,7 @@ mod tests {
         let writer: SharedWriter = Arc::new(Mutex::new(a));
         let handle = WebviewHandle::new_shared(
             slot.clone(),
-            Arc::new(crate::events::EventQueues::default()),
+            Arc::new(crate::events::EventQueues::from_decls(&[])),
             writer,
         );
         assert_eq!(handle.id(), "old-id");

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,7 +1,7 @@
 //! Webview builder and registered handle.
 
 use crate::error::OzmaResult;
-use crate::events::EventDecl;
+use crate::events::{EventDecl, EventQueues};
 use crate::handler::{BoxedHandler, make_handler};
 use crate::keychord::KeyChord;
 use crate::protocol::{ClientMsg, NavAction, RegisterKind};
@@ -160,6 +160,7 @@ impl Webview {
 #[derive(Clone, Debug)]
 pub struct WebviewHandle {
     id: Arc<Mutex<String>>,
+    events: Arc<EventQueues>,
     writer: SharedWriter,
 }
 
@@ -213,10 +214,31 @@ impl WebviewHandle {
         self.send_nav(NavAction::Reload)
     }
 
+    /// Drains and returns every buffered event of type `T`, oldest first.
+    /// Payloads that fail to deserialize into `T` are dropped and logged; the
+    /// result is empty if `T` was never declared via [`Webview::add_event`].
+    pub fn read_events<T: DeserializeOwned + 'static>(&self) -> Vec<T> {
+        self.events
+            .drain_type(TypeId::of::<T>())
+            .into_iter()
+            .filter_map(|v| match serde_json::from_value::<T>(v) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    tracing::warn!(error = %e, "dropping inbound event that failed to deserialize");
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Creates a handle from a pre-existing shared ID slot for callers that need
     /// to share the ID slot across threads.
-    pub(crate) fn new_shared(id: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
-        Self { id, writer }
+    pub(crate) fn new_shared(
+        id: Arc<Mutex<String>>,
+        events: Arc<EventQueues>,
+        writer: SharedWriter,
+    ) -> Self {
+        Self { id, events, writer }
     }
 
     fn send_nav(&self, action: NavAction) -> OzmaResult<()> {
@@ -361,10 +383,51 @@ mod tests {
         let slot = Arc::new(Mutex::new("old-id".to_owned()));
         let (a, _b) = std::os::unix::net::UnixStream::pair().unwrap();
         let writer: SharedWriter = Arc::new(Mutex::new(a));
-        let handle = WebviewHandle::new_shared(slot.clone(), writer);
+        let handle = WebviewHandle::new_shared(
+            slot.clone(),
+            Arc::new(crate::events::EventQueues::default()),
+            writer,
+        );
         assert_eq!(handle.id(), "old-id");
         *slot.lock().unwrap() = "new-id".to_owned();
         assert_eq!(handle.id(), "new-id");
+    }
+
+    #[test]
+    fn read_events_drains_and_deserializes_and_skips_bad() {
+        use crate::events::{EventDecl, EventQueues};
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Hello {
+            message: String,
+        }
+        let decls = vec![EventDecl {
+            name: "hello".into(),
+            type_id: std::any::TypeId::of::<Hello>(),
+        }];
+        let events = Arc::new(EventQueues::from_decls(&decls));
+        events.ingest("hello", json!({"message": "a"}));
+        events.ingest("hello", json!({"nope": 1})); // fails to deserialize -> skipped
+        events.ingest("hello", json!({"message": "b"}));
+
+        let (sock, _b) = std::os::unix::net::UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(sock));
+        let handle =
+            WebviewHandle::new_shared(Arc::new(Mutex::new("h".to_owned())), events, writer);
+
+        let got = handle.read_events::<Hello>();
+        assert_eq!(
+            got,
+            vec![
+                Hello {
+                    message: "a".into()
+                },
+                Hello {
+                    message: "b".into()
+                }
+            ]
+        );
+        // Drained: a second read is empty.
+        assert!(handle.read_events::<Hello>().is_empty());
     }
 
     #[test]

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -1,11 +1,13 @@
 //! Webview builder and registered handle.
 
 use crate::error::OzmaResult;
+use crate::events::EventDecl;
 use crate::handler::{BoxedHandler, make_handler};
 use crate::keychord::KeyChord;
 use crate::protocol::{ClientMsg, NavAction, RegisterKind};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
@@ -19,6 +21,7 @@ pub(crate) type SharedWriter = Arc<Mutex<UnixStream>>;
 pub struct Webview {
     pub(crate) kind: RegisterKind,
     pub(crate) handlers: HashMap<String, BoxedHandler>,
+    pub(crate) event_decls: Vec<EventDecl>,
 }
 
 impl Webview {
@@ -31,6 +34,7 @@ impl Webview {
                 forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
+            event_decls: Vec::new(),
         }
     }
 
@@ -48,6 +52,7 @@ impl Webview {
                 forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
+            event_decls: Vec::new(),
         }
     }
 
@@ -61,6 +66,7 @@ impl Webview {
                 forward_keys: Vec::new(),
             },
             handlers: HashMap::new(),
+            event_decls: Vec::new(),
         }
     }
 
@@ -114,6 +120,35 @@ impl Webview {
             "method {method:?} uses the reserved __ozma. namespace"
         );
         self.handlers.insert(method, make_handler(f));
+        if let RegisterKind::Url { bridge, .. } = &mut self.kind {
+            *bridge = true;
+        }
+        self
+    }
+
+    /// Declares an inbound event the page may send via `window.ozma.emit(name, …)`,
+    /// binding the wire `name` to the Rust type `T`. The app later drains it with
+    /// [`WebviewHandle::read_events::<T>`]. Enables the `window.ozma` bridge for
+    /// `url` webviews (like [`Webview::on`]); a no-op for `inline`/`dir`, which
+    /// are always bridged.
+    ///
+    /// # Panics
+    /// Panics if `name` or the type `T` is already registered on this builder —
+    /// the type ↔ name mapping must be 1:1. (`on` silently overwrites a
+    /// duplicate method; `add_event` enforces uniqueness instead.)
+    pub fn add_event<T: DeserializeOwned + 'static>(mut self, name: impl Into<String>) -> Self {
+        let name = name.into();
+        let type_id = TypeId::of::<T>();
+        assert!(
+            !self.event_decls.iter().any(|d| d.name == name),
+            "event name {name:?} is already registered"
+        );
+        assert!(
+            !self.event_decls.iter().any(|d| d.type_id == type_id),
+            "event type {} is already registered",
+            std::any::type_name::<T>()
+        );
+        self.event_decls.push(EventDecl { name, type_id });
         if let RegisterKind::Url { bridge, .. } = &mut self.kind {
             *bridge = true;
         }
@@ -330,5 +365,48 @@ mod tests {
         assert_eq!(handle.id(), "old-id");
         *slot.lock().unwrap() = "new-id".to_owned();
         assert_eq!(handle.id(), "new-id");
+    }
+
+    #[test]
+    fn add_event_records_decl() {
+        #[derive(serde::Deserialize)]
+        struct Hello;
+        let wv = Webview::inline("x").add_event::<Hello>("hello");
+        assert_eq!(wv.event_decls.len(), 1);
+        assert_eq!(wv.event_decls[0].name, "hello");
+        assert_eq!(wv.event_decls[0].type_id, std::any::TypeId::of::<Hello>());
+    }
+
+    #[test]
+    fn add_event_enables_bridge_for_url() {
+        #[derive(serde::Deserialize)]
+        struct Hello;
+        let wv = Webview::url("https://example.com").add_event::<Hello>("hello");
+        match &wv.kind {
+            RegisterKind::Url { bridge, .. } => assert!(*bridge),
+            _ => panic!("expected url"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered")]
+    fn add_event_rejects_duplicate_name() {
+        #[derive(serde::Deserialize)]
+        struct A;
+        #[derive(serde::Deserialize)]
+        struct B;
+        let _ = Webview::inline("x")
+            .add_event::<A>("dup")
+            .add_event::<B>("dup");
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered")]
+    fn add_event_rejects_duplicate_type() {
+        #[derive(serde::Deserialize)]
+        struct A;
+        let _ = Webview::inline("x")
+            .add_event::<A>("one")
+            .add_event::<A>("two");
     }
 }

--- a/sdk/ratatui-ozma/src/webview.rs
+++ b/sdk/ratatui-ozma/src/webview.rs
@@ -406,7 +406,7 @@ mod tests {
         }];
         let events = Arc::new(EventQueues::from_decls(&decls));
         events.ingest("hello", json!({"message": "a"}));
-        events.ingest("hello", json!({"nope": 1})); // fails to deserialize -> skipped
+        events.ingest("hello", json!({"nope": 1}));
         events.ingest("hello", json!({"message": "b"}));
 
         let (sock, _b) = std::os::unix::net::UnixStream::pair().unwrap();

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -420,6 +420,65 @@ fn tmux_with_ozma_sock(label: &str, value: &str) -> (TmuxServerGuard, String) {
 }
 
 #[test]
+fn reconnect_preserves_inbound_events() {
+    use std::time::Duration;
+    #[derive(serde::Deserialize, PartialEq, Debug)]
+    struct Hello {
+        message: String,
+    }
+
+    let pair = support::ReconnectPair::start("view-ev1", "view-ev2");
+    with_env(&pair.first.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma
+            .register(Webview::inline("x").add_event::<Hello>("hello"))
+            .unwrap();
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &ozma);
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        drop(pair.first);
+        std::thread::sleep(Duration::from_millis(200));
+        // NOTE: ENV_LOCK is held by with_env, serializing env var access.
+        unsafe { std::env::set_var("OZMA_SOCK", &pair.second.sock_path) };
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while handle.id() == "view-ev1" {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reconnect did not complete"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // The page emits to the NEW handle after reconnect; read_events must see it.
+        pair.second.send(json!({
+            "op": "event", "handle": "view-ev2", "event": "hello", "payload": { "message": "post" }
+        }));
+
+        let got = loop {
+            let evs = handle.read_events::<Hello>();
+            if !evs.is_empty() {
+                break evs;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "event never arrived after reconnect"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(
+            got,
+            vec![Hello {
+                message: "post".into()
+            }]
+        );
+    });
+}
+
+#[test]
 #[ignore = "requires a real tmux binary"]
 fn connect_prefers_live_tmux_value_over_stale_env() {
     // The reported bug: the pane inherited a STALE $OZMA_SOCK (an exited ozmux),

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -138,6 +138,43 @@ fn emit_reaches_the_server() {
 }
 
 #[test]
+fn inbound_event_is_buffered_and_read() {
+    use std::time::{Duration, Instant};
+    #[derive(serde::Deserialize, PartialEq, Debug)]
+    struct Hello {
+        message: String,
+    }
+
+    let server = FakeServer::start("view-ev");
+    with_env(&server.sock_path.clone(), || {
+        let ozma = Ozma::connect().unwrap();
+        let handle = ozma
+            .register(Webview::inline("x").add_event::<Hello>("hello"))
+            .unwrap();
+
+        server.send(json!({
+            "op": "event", "handle": "view-ev", "event": "hello", "payload": { "message": "hi" }
+        }));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let events = loop {
+            let evs = handle.read_events::<Hello>();
+            if !evs.is_empty() {
+                break evs;
+            }
+            assert!(Instant::now() < deadline, "inbound event never arrived");
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(
+            events,
+            vec![Hello {
+                message: "hi".into()
+            }]
+        );
+    });
+}
+
+#[test]
 fn register_returns_disconnected_when_socket_closes() {
     // Regression: a register whose reply never arrives because the socket closes
     // must return Disconnected, not block forever on the pending reply.

--- a/sdk/ratatui-ozma/tests/integration.rs
+++ b/sdk/ratatui-ozma/tests/integration.rs
@@ -495,13 +495,16 @@ fn reconnect_preserves_inbound_events() {
             "op": "event", "handle": "view-ev2", "event": "hello", "payload": { "message": "post" }
         }));
 
+        // A fresh deadline: the reconnect loop above may have consumed most of the
+        // first budget on a slow machine, which must not starve this wait.
+        let event_deadline = std::time::Instant::now() + Duration::from_secs(5);
         let got = loop {
             let evs = handle.read_events::<Hello>();
             if !evs.is_empty() {
                 break evs;
             }
             assert!(
-                std::time::Instant::now() < deadline,
+                std::time::Instant::now() < event_deadline,
                 "event never arrived after reconnect"
             );
             std::thread::sleep(Duration::from_millis(20));

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -32,6 +32,10 @@ struct OzmuxFrame(serde_json::Value);
 /// back-channel (`on_ozmux_call_frame`). The page side emits it in `ozma_bridge.js`.
 const OZMA_CALL_KIND: &str = "ozma.call";
 
+/// The `kind` discriminator routing a `Receive<OzmuxFrame>` to the one-way
+/// inbound-event forwarder (`on_ozmux_emit_frame`). Emitted by `ozma_bridge.js`.
+const OZMA_EMIT_KIND: &str = "ozma.emit";
+
 /// Builds the `CefPlugin` with the `ozma-dyn://` (dynamic, Tier 1) scheme bound
 /// to its shared `WebviewAssetRegistry`, using `root_cache_path` as this process's
 /// unique CEF profile directory (one Chromium singleton lock per instance).
@@ -65,6 +69,7 @@ impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(JsEmitEventPlugin::<OzmuxFrame>::default())
             .add_observer(on_ozmux_call_frame)
+            .add_observer(on_ozmux_emit_frame)
             .add_observer(on_webview_address_changed)
             .add_observer(drop_ozmux_inflight_on_webview_despawn)
             .add_observer(log_webview_load_started)
@@ -174,6 +179,46 @@ fn on_ozmux_call_frame(
 fn reject_ozmux_call(commands: &mut Commands, webview: Entity, req_id: &str, error: &str) {
     let payload = serde_json::json!({ "reqId": req_id, "ok": false, "error": error });
     commands.trigger(HostEmitEvent::new(webview, "ozma", &payload));
+}
+
+/// Inbound (one-way): a `window.ozma.emit` arrives as a `Receive<OzmuxFrame>`
+/// with `kind:"ozma.emit"`. The trusted caller is `frame.webview` (bound per
+/// webview by `bevy_cef`); its `WebviewOwner` names the registering connection.
+/// The event is forwarded as a fire-and-forget `{op:"event"}` line — no reqId,
+/// no reply, no `OzmuxRpc` tracking. A missing owner or unavailable connection
+/// drops the event (debug-logged); there is no page Promise to settle.
+///
+/// Registered on the shared `Receive<OzmuxFrame>` event (not a second
+/// `JsEmitEventPlugin`); non-`ozma.emit` frames return early on `OZMA_EMIT_KIND`.
+fn on_ozmux_emit_frame(
+    frame: On<Receive<OzmuxFrame>>,
+    writers: Res<ConnectionWriters>,
+    owners: Query<&WebviewOwner>,
+) {
+    let payload = &frame.payload.0;
+    if payload.get("kind").and_then(Value::as_str) != Some(OZMA_EMIT_KIND) {
+        return;
+    }
+    let event = payload
+        .get("event")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let body = payload.get("payload").cloned().unwrap_or(Value::Null);
+
+    let Ok(owner) = owners.get(frame.webview) else {
+        tracing::debug!("ozma.emit frame for a webview with no owner; dropping");
+        return;
+    };
+    let line = serde_json::json!({
+        "op": "event", "handle": owner.handle, "event": event, "payload": body
+    })
+    .to_string();
+    if !writers.send(owner.connection_id, line) {
+        tracing::debug!(
+            handle = owner.handle,
+            "ozma.emit owner connection unavailable; dropping"
+        );
+    }
 }
 
 /// Outbound (Tier 1 back-channel): when a webview's top-level URL changes (CEF
@@ -446,6 +491,65 @@ mod tests {
             None,
             "a despawned inline child must be GC'd out of FocusedWebview",
         );
+    }
+
+    #[test]
+    fn ozmux_emit_frame_pushes_event_to_owner_connection() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_emit_frame);
+
+        let webview = app
+            .world_mut()
+            .spawn(WebviewOwner {
+                connection_id: 7,
+                handle: "H".into(),
+            })
+            .id();
+
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozma.emit", "event": "hello", "payload": {"message": "hi"}
+            })),
+        });
+
+        let line = rx.try_recv().expect("an event was pushed");
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["op"], "event");
+        assert_eq!(v["handle"], "H");
+        assert_eq!(v["event"], "hello");
+        assert_eq!(v["payload"]["message"], "hi");
+    }
+
+    #[test]
+    fn ozmux_emit_frame_without_owner_is_dropped() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_emit_frame);
+
+        // A webview entity with no WebviewOwner component.
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozma.emit", "event": "hello", "payload": null
+            })),
+        });
+
+        assert!(rx.try_recv().is_err(), "no owner ⇒ nothing forwarded");
     }
 
     #[test]

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -203,12 +203,16 @@ fn on_ozmux_emit_frame(
         .get("event")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let body = payload.get("payload").cloned().unwrap_or(Value::Null);
+    if event.is_empty() {
+        tracing::debug!("ozma.emit frame with an empty event name; dropping");
+        return;
+    }
 
     let Ok(owner) = owners.get(frame.webview) else {
         tracing::debug!("ozma.emit frame for a webview with no owner; dropping");
         return;
     };
+    let body = payload.get("payload").cloned().unwrap_or(Value::Null);
     let line = serde_json::json!({
         "op": "event", "handle": owner.handle, "event": event, "payload": body
     })
@@ -550,6 +554,38 @@ mod tests {
         });
 
         assert!(rx.try_recv().is_err(), "no owner ⇒ nothing forwarded");
+    }
+
+    #[test]
+    fn ozmux_emit_frame_with_empty_event_is_dropped() {
+        use crossbeam_channel::unbounded;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let writers = ConnectionWriters::default();
+        let (tx, rx) = unbounded::<String>();
+        writers.insert(7, tx);
+        app.insert_resource(writers);
+        app.add_observer(on_ozmux_emit_frame);
+
+        let webview = app
+            .world_mut()
+            .spawn(WebviewOwner {
+                connection_id: 7,
+                handle: "H".into(),
+            })
+            .id();
+        app.world_mut().trigger(Receive {
+            webview,
+            payload: OzmuxFrame(serde_json::json!({
+                "kind": "ozma.emit", "event": "", "payload": {"message": "hi"}
+            })),
+        });
+
+        assert!(
+            rx.try_recv().is_err(),
+            "an empty event name must be dropped, not forwarded"
+        );
     }
 
     #[test]

--- a/src/webview/render.rs
+++ b/src/webview/render.rs
@@ -189,7 +189,7 @@ fn reject_ozmux_call(commands: &mut Commands, webview: Entity, req_id: &str, err
 /// drops the event (debug-logged); there is no page Promise to settle.
 ///
 /// Registered on the shared `Receive<OzmuxFrame>` event (not a second
-/// `JsEmitEventPlugin`); non-`ozma.emit` frames return early on `OZMA_EMIT_KIND`.
+/// `JsEmitEventPlugin`); frames whose `kind` is not `ozma.emit` are ignored.
 fn on_ozmux_emit_frame(
     frame: On<Receive<OzmuxFrame>>,
     writers: Res<ConnectionWriters>,

--- a/src/webview/render/ozma_bridge.js
+++ b/src/webview/render/ozma_bridge.js
@@ -72,6 +72,9 @@
       var hs = listeners.get(event);
       if (hs) listeners.set(event, hs.filter(function (h) { return h !== handler; }));
     },
+    emit: function (event, payload) {
+      cef.emit({ kind: 'ozma.emit', event: event, payload: encodeParam(payload) });
+    },
   };
 
   Object.defineProperty(window, 'ozma', { value: Object.freeze(api), configurable: false, writable: false });

--- a/src/webview/render/ozma_bridge.js
+++ b/src/webview/render/ozma_bridge.js
@@ -1,6 +1,8 @@
 // NOTE: bevy_cef contract — Rust->JS cef.listen delivers a JSON *string* (hence
 // JSON.parse); JS->Rust cef.emit serializes only its FIRST argument. Replies
 // arrive on the "ozma" channel keyed by reqId; push events on "ozma.event".
+// Page->host one-way events use ozma.emit -> cef.emit({kind:'ozma.emit'}):
+// fire-and-forget, no reqId and no calls entry, so they cannot leak.
 // The {__u8} base64 tag carries a Uint8Array, but only as a top-level value (the
 // `params` sent, or a reply `value`/event `payload` received via decodeValue) —
 // bytes nested inside an object/array param are NOT tagged and won't round-trip.

--- a/src/webview/render/preload.rs
+++ b/src/webview/render/preload.rs
@@ -41,6 +41,7 @@ mod tests {
             OZMA_BRIDGE_JS.contains("window, 'ozma'") && OZMA_BRIDGE_JS.contains("defineProperty")
         );
         assert!(OZMA_BRIDGE_JS.contains("kind: 'ozma.call'"));
+        assert!(OZMA_BRIDGE_JS.contains("kind: 'ozma.emit'"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ratatui-ozma` had three of the four page/app channels — app→page push (`emit`), page→app RPC (`Webview::on` + `window.ozma.call`), and app↔host control — but **no one-way, poll-based page→app event channel**. A webview that just wants to *notify* its host program (a button press, a search count, a scroll position) had to register a reply-producing `Webview::on` RPC closure that runs on the SDK reader thread and plumbs its result through a shared channel — heavier than a fire-and-forget notification warrants.

## Solution

Add the missing quadrant — a one-way Webview(page) → host-app event channel — full-stack, then migrate ozmd's eligible handlers onto it.

**SDK (`sdk/ratatui-ozma`)**
- `Webview::add_event::<T>(name)` declares an inbound event, binding a wire name to a Rust type (1:1).
- `WebviewHandle::read_events::<T>() -> Vec<T>` drains a per-handle **bounded ring buffer** (drop-oldest, throttled warn) in the app loop — the same shape apps already use for crossterm events.
- Events route on the reader thread, installed under the minted handle at register-reply time (race-safe, like the RPC handler install) and **replayed across reconnect**.

**Page client (`sdk/ozma-web`)** — `window.ozma.emit(name, payload)`: fire-and-forget, no reply.

**Engine (`src/webview`)** — the CEF bridge emits `{kind:'ozma.emit'}`; a new host observer (`on_ozmux_emit_frame`) forwards it as a `{op:"event"}` line to the owning control connection. Trust model is identical to the `call` path (caller bound by `bevy_cef`, never page-supplied; only the owning connection receives it).

**App (`apps/ozmd`)** — migrated the two fire-and-forget notifications `searchCount`/`scrollState` from `Webview::on` RPC to `add_event`/`read_events` + `ozma.emit`, deleting the intermediate `PageMsg` channel. `ready` stays RPC (the page awaits the rendered document).

Affected: `sdk/ratatui-ozma`, `sdk/ozma-web`, `src/webview` (engine), `apps/ozmd`, plus design docs under `docs/superpowers`.

**Not a breaking change** — purely additive to the SDK; the ozmd migration is behavior-preserving.

**Testing** — SDK unit + integration (incl. reconnect), host `webview::render`, and `@ozma/web` vitest all pass; `cargo clippy --workspace --all-targets` + `cargo fmt` clean; `pnpm lint`/`check-types` clean. Reviewed via a whole-branch review plus a max-effort multi-agent `/code-review`; findings addressed or triaged. (The ozmd live TUI check — scroll %/search count updating in a real pane — has not been run headlessly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGaKjosVrws3Bo9hs35grM
