### PR TITLE
refactor: rename AppMode (Default/Tmux) and startup_mode config values

### DIFF
--- a/crates/ozmux_configs/src/lib.rs
+++ b/crates/ozmux_configs/src/lib.rs
@@ -290,21 +290,21 @@ resize-pane-down = "Cmd+Shift+J"
     }
 
     #[test]
-    fn startup_mode_defaults_to_ozma() {
+    fn startup_mode_defaults_to_default() {
         let c = parse("");
-        assert_eq!(c.startup_mode, StartupMode::Ozma);
+        assert_eq!(c.startup_mode, StartupMode::Default);
     }
 
     #[test]
-    fn startup_mode_auto_attach_parses() {
-        let c = parse(r#"startup_mode = "auto-attach""#);
-        assert_eq!(c.startup_mode, StartupMode::AutoAttach);
+    fn startup_mode_tmux_auto_attach_parses() {
+        let c = parse(r#"startup_mode = "tmux-auto-attach""#);
+        assert_eq!(c.startup_mode, StartupMode::TmuxAutoAttach);
     }
 
     #[test]
-    fn startup_mode_ozmux_parses() {
-        let c = parse(r#"startup_mode = "ozmux""#);
-        assert_eq!(c.startup_mode, StartupMode::Ozmux);
+    fn startup_mode_tmux_parses() {
+        let c = parse(r#"startup_mode = "tmux""#);
+        assert_eq!(c.startup_mode, StartupMode::Tmux);
     }
 
     #[test]

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -432,7 +432,7 @@ pub struct Bindings {
     /// `deny_unknown_fields`. Remove after one release.
     #[serde(default, skip_serializing, deserialize_with = "deser_chord_or_unbind")]
     pub copy: Option<KeyChord>,
-    /// Detach the current tmux session and switch to Ozma mode.
+    /// Detach the current tmux session and switch to Default mode.
     #[serde(deserialize_with = "deser_chord_or_unbind", default)]
     pub detach_session: Option<KeyChord>,
 }
@@ -530,7 +530,7 @@ pub enum ShortcutAction {
     OpenPicker,
     /// Quits the ozmux application.
     Quit,
-    /// Detaches from the tmux session and returns to Ozma single-terminal mode.
+    /// Detaches from the tmux session and returns to Default single-terminal mode.
     DetachSession,
 }
 

--- a/crates/ozmux_configs/src/startup.rs
+++ b/crates/ozmux_configs/src/startup.rs
@@ -8,9 +8,9 @@ use serde::Deserialize;
 pub enum StartupMode {
     /// Single PTY terminal, no tmux (default).
     #[default]
-    Ozma,
+    Default,
     /// Show the tmux session picker.
-    Ozmux,
+    Tmux,
     /// Auto-attach to the most recently active tmux session.
-    AutoAttach,
+    TmuxAutoAttach,
 }

--- a/crates/tmux_session/src/events.rs
+++ b/crates/tmux_session/src/events.rs
@@ -92,7 +92,7 @@ pub struct TmuxConnectionReset;
 
 /// Fired specifically when the tmux transport closes from the tmux side (not
 /// app-initiated). Consumed in `src/tmux.rs` to transition `AppMode` back to
-/// `Ozma`. Keeping this separate from `TmuxConnectionReset` avoids a double
+/// `Default`. Keeping this separate from `TmuxConnectionReset` avoids a double
 /// mode-set when the app itself initiates the detach.
 #[derive(Event, Debug, Clone)]
 pub struct TmuxConnectionClosed;

--- a/src/app_mode.rs
+++ b/src/app_mode.rs
@@ -1,4 +1,4 @@
-//! AppMode state enum and the Ozma single-terminal lifecycle plugin.
+//! AppMode state enum and the Default-mode single-terminal lifecycle plugin.
 
 use bevy::prelude::*;
 use ozma_terminal::{
@@ -23,9 +23,9 @@ pub(crate) enum AppMode {
 /// `OnExit(AppMode::Default)`. Requires `AppMode` to be inserted via
 /// `App::insert_state` before this plugin runs, and `OzmaTerminalPlugin` must
 /// be added first (it inserts `OzmaTerminalConfig` that `spawn_terminal` reads).
-pub(crate) struct OzmaModePlugin;
+pub(crate) struct DefaultModePlugin;
 
-impl Plugin for OzmaModePlugin {
+impl Plugin for DefaultModePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(OnEnter(AppMode::Default), spawn_terminal)
             .add_systems(OnExit(AppMode::Default), despawn_terminal);

--- a/src/default_input.rs
+++ b/src/default_input.rs
@@ -20,9 +20,9 @@ use ozma_terminal::{
 use ozmux_configs::shortcuts::ShortcutAction;
 
 /// Registers the host-side input systems for `AppMode::Default`.
-pub(crate) struct OzmaHostInputPlugin;
+pub(crate) struct DefaultHostInputPlugin;
 
-impl Plugin for OzmaHostInputPlugin {
+impl Plugin for DefaultHostInputPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,

--- a/src/default_input.rs
+++ b/src/default_input.rs
@@ -4,10 +4,10 @@
 //! OpenPicker, DetachSession, ReleaseWebviewFocus). Raw-key forwarding and paste
 //! are owned by `ozma_terminal`'s dispatcher and `PasteAction`.
 
+use crate::app_mode::AppMode;
 use crate::input::ime::ImeState;
 use crate::input::shortcuts::ResolvedShortcuts;
 use crate::input::{InputPhase, current_modifiers};
-use crate::app_mode::AppMode;
 use crate::picker::SessionPicker;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -7,7 +7,7 @@
 //! `Window::ime_enabled` and `.ime_position`).
 
 use crate::input::InputPhase;
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::hierarchy::ChildOf;

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -225,7 +225,7 @@ pub(crate) fn ime_policy_system(
 
     let surface = match active_surface {
         Some(entity) => Some(entity),
-        // NOTE: Ozma mode has no tmux ActivePane; fall back to the focused terminal.
+        // NOTE: Default mode has no tmux ActivePane; fall back to the focused terminal.
         None if *current_mode.get() == AppMode::Default => ozma_terminal.single().ok(),
         None => None,
     };

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -148,7 +148,7 @@ pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
 /// `ime_enabled` is `true` iff a CEF webview owns focus (it drives its own
 /// IME through bevy_cef's `Ime` → CEF bridge), OR a surface exists that does
 /// NOT have `CopyModeState`. The surface is the active tmux pane, or — in
-/// `AppMode::Ozma` with no active pane — the `KeyboardFocused` terminal; both
+/// `AppMode::Default` with no active pane — the `KeyboardFocused` terminal; both
 /// flow through the same copy-mode gate below.
 ///
 /// `ime_position` is the logical-pixel anchor for the OS candidate
@@ -226,7 +226,7 @@ pub(crate) fn ime_policy_system(
     let surface = match active_surface {
         Some(entity) => Some(entity),
         // NOTE: Ozma mode has no tmux ActivePane; fall back to the focused terminal.
-        None if *current_mode.get() == AppMode::Ozma => ozma_terminal.single().ok(),
+        None if *current_mode.get() == AppMode::Default => ozma_terminal.single().ok(),
         None => None,
     };
     let Some(entity) = surface else {
@@ -328,7 +328,7 @@ pub(crate) fn read_ime_events(
                 continue;
             }
             match current_mode.get() {
-                AppMode::Ozmux => {
+                AppMode::Tmux => {
                     let Some((entity, pane)) = active else {
                         tracing::warn!(
                             target: "ozmux::input::ime",
@@ -353,7 +353,7 @@ pub(crate) fn read_ime_events(
                         tracing::warn!(?e, "IME commit send failed");
                     }
                 }
-                AppMode::Ozma => {
+                AppMode::Default => {
                     // NOTE: bevy_cef delivers the commit to the webview independently; suppress here to prevent duplicate input.
                     if focused_webview.0.is_some() {
                         continue;

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -6,8 +6,8 @@
 //! the active tmux pane), and `ime_policy_system` (toggles
 //! `Window::ime_enabled` and `.ime_position`).
 
-use crate::input::InputPhase;
 use crate::app_mode::AppMode;
+use crate::input::InputPhase;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::hierarchy::ChildOf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod cef_profile;
 mod configs;
 mod font;
 mod input;
-mod ozma;
+mod app_mode;
 mod ozma_input;
 mod picker;
 mod system_set;
@@ -16,7 +16,7 @@ mod window_title;
 
 use crate::cef_profile::CefProfileDir;
 use crate::input::hyperlink::HyperlinkInputPlugin;
-use crate::ozma::{AppMode, OzmaModePlugin};
+use crate::app_mode::{AppMode, DefaultModePlugin};
 use crate::window_title::WindowTitlePlugin;
 use bevy::prelude::*;
 use bootstrap::OzmuxBootstrapPlugin;
@@ -70,7 +70,7 @@ fn main() {
             OzmaTerminalPlugin {
                 config_shell: pre_configs.ozma.shell.clone(),
             },
-            OzmaModePlugin,
+            DefaultModePlugin,
             TerminalHandlePlugin,
             TerminalRendererPlugin,
             OzmuxTmuxPlugin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,13 @@ use ui::{
 
 fn main() {
     let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
-    // NOTE: start in AppMode::Ozmux as a boot-dispatch state; dispatch_startup_mode
+    // NOTE: start in AppMode::Tmux as a boot-dispatch state; dispatch_startup_mode
     // (OnEnter(Ozmux), gated to run once) routes to the real mode. Routing to Ozma
     // via a queued NextState — rather than booting straight into Ozma — defers
-    // OnEnter(AppMode::Ozma) (spawn_terminal) to a post-Startup StateTransition, so
+    // OnEnter(AppMode::Default) (spawn_terminal) to a post-Startup StateTransition, so
     // Startup deferred commands (e.g. init_atlas_image inserting AtlasImage) flush first.
     let initial_mode = match pre_configs.startup_mode {
-        StartupMode::Default | StartupMode::Tmux | StartupMode::TmuxAutoAttach => AppMode::Ozmux,
+        StartupMode::Default | StartupMode::Tmux | StartupMode::TmuxAutoAttach => AppMode::Tmux,
     };
     let dyn_registry = WebviewAssetRegistry::default();
     let cef_profile = CefProfileDir::acquire().expect("create per-process CEF profile directory");

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
     // OnEnter(AppMode::Ozma) (spawn_terminal) to a post-Startup StateTransition, so
     // Startup deferred commands (e.g. init_atlas_image inserting AtlasImage) flush first.
     let initial_mode = match pre_configs.startup_mode {
-        StartupMode::Ozma | StartupMode::Ozmux | StartupMode::AutoAttach => AppMode::Ozmux,
+        StartupMode::Default | StartupMode::Tmux | StartupMode::TmuxAutoAttach => AppMode::Ozmux,
     };
     let dyn_registry = WebviewAssetRegistry::default();
     let cef_profile = CefProfileDir::acquire().expect("create per-process CEF profile directory");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 //! ozmux Bevy GUI entry point.
 
+mod app_mode;
 mod bootstrap;
 mod cef_profile;
 mod configs;
+mod default_input;
 mod font;
 mod input;
-mod app_mode;
-mod default_input;
 mod picker;
 mod system_set;
 mod theme;
@@ -14,18 +14,18 @@ mod tmux;
 mod ui;
 mod window_title;
 
+use crate::app_mode::{AppMode, DefaultModePlugin};
 use crate::cef_profile::CefProfileDir;
 use crate::input::hyperlink::HyperlinkInputPlugin;
-use crate::app_mode::{AppMode, DefaultModePlugin};
 use crate::window_title::WindowTitlePlugin;
 use bevy::prelude::*;
 use bootstrap::OzmuxBootstrapPlugin;
 use configs::OzmuxConfigsPlugin;
+use default_input::DefaultHostInputPlugin;
 use font::FontBridgePlugin;
 use input::OzmuxShortcutPlugin;
 use input::ime::ImePlugin;
 use input::option_as_alt::OptionAsAltPlugin;
-use default_input::DefaultHostInputPlugin;
 use ozma_terminal::OzmaTerminalPlugin;
 use ozma_tty_engine::TerminalHandlePlugin;
 use ozma_tty_renderer::TerminalRendererPlugin;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ use ui::{
 fn main() {
     let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
     // NOTE: start in AppMode::Tmux as a boot-dispatch state; dispatch_startup_mode
-    // (OnEnter(Ozmux), gated to run once) routes to the real mode. Routing to Ozma
-    // via a queued NextState — rather than booting straight into Ozma — defers
+    // (OnEnter(Tmux), gated to run once) routes to the real mode. Routing to Default
+    // via a queued NextState — rather than booting straight into Default — defers
     // OnEnter(AppMode::Default) (spawn_terminal) to a post-Startup StateTransition, so
     // Startup deferred commands (e.g. init_atlas_image inserting AtlasImage) flush first.
     let initial_mode = match pre_configs.startup_mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod configs;
 mod font;
 mod input;
 mod app_mode;
-mod ozma_input;
+mod default_input;
 mod picker;
 mod system_set;
 mod theme;
@@ -25,7 +25,7 @@ use font::FontBridgePlugin;
 use input::OzmuxShortcutPlugin;
 use input::ime::ImePlugin;
 use input::option_as_alt::OptionAsAltPlugin;
-use ozma_input::OzmaHostInputPlugin;
+use default_input::DefaultHostInputPlugin;
 use ozma_terminal::OzmaTerminalPlugin;
 use ozma_tty_engine::TerminalHandlePlugin;
 use ozma_tty_renderer::TerminalRendererPlugin;
@@ -96,7 +96,7 @@ fn main() {
             ImePlugin,
             ImeOverlayPlugin,
             OptionAsAltPlugin,
-            OzmaHostInputPlugin,
+            DefaultHostInputPlugin,
         ))
         .run();
 }

--- a/src/ozma.rs
+++ b/src/ozma.rs
@@ -5,30 +5,30 @@ use ozma_terminal::{
     KeyboardFocused, OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig,
 };
 
-/// Application mode. `Ozma` is the default (single PTY, no tmux).
-/// `Ozmux` activates the tmux multiplexer backend.
+/// Application mode. `Default` is the default (single PTY, no tmux).
+/// `Tmux` activates the tmux multiplexer backend.
 #[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub(crate) enum AppMode {
     /// Single PTY terminal, Alacritty VT emulation, no tmux.
     #[default]
-    Ozma,
+    Default,
     /// tmux backend, multiplexer layout.
-    Ozmux,
+    Tmux,
 }
 
-/// Bevy plugin that registers the `AppMode::Ozma` spawn/despawn lifecycle.
+/// Bevy plugin that registers the `AppMode::Default` spawn/despawn lifecycle.
 ///
 /// Spawns one `OzmaTerminal` entity (marked `KeyboardFocused`, the keyboard
-/// target) on `OnEnter(AppMode::Ozma)` and despawns it on
-/// `OnExit(AppMode::Ozma)`. Requires `AppMode` to be inserted via
+/// target) on `OnEnter(AppMode::Default)` and despawns it on
+/// `OnExit(AppMode::Default)`. Requires `AppMode` to be inserted via
 /// `App::insert_state` before this plugin runs, and `OzmaTerminalPlugin` must
 /// be added first (it inserts `OzmaTerminalConfig` that `spawn_terminal` reads).
 pub(crate) struct OzmaModePlugin;
 
 impl Plugin for OzmaModePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(OnEnter(AppMode::Ozma), spawn_terminal)
-            .add_systems(OnExit(AppMode::Ozma), despawn_terminal);
+        app.add_systems(OnEnter(AppMode::Default), spawn_terminal)
+            .add_systems(OnExit(AppMode::Default), despawn_terminal);
     }
 }
 

--- a/src/ozma_input.rs
+++ b/src/ozma_input.rs
@@ -1,4 +1,4 @@
-//! Host-side input for `AppMode::Ozma`: maintains the crate's `KeyboardDisabled` / `MouseDisabled`
+//! Host-side input for `AppMode::Default`: maintains the crate's `KeyboardDisabled` / `MouseDisabled`
 //! markers from the coarse guards (picker, IME, focus, webview), and handles the
 //! application-level GUI shortcuts the terminal crate does not own (Quit,
 //! OpenPicker, DetachSession, ReleaseWebviewFocus). Raw-key forwarding and paste
@@ -19,7 +19,7 @@ use ozma_terminal::{
 };
 use ozmux_configs::shortcuts::ShortcutAction;
 
-/// Registers the host-side input systems for `AppMode::Ozma`.
+/// Registers the host-side input systems for `AppMode::Default`.
 pub(crate) struct OzmaHostInputPlugin;
 
 impl Plugin for OzmaHostInputPlugin {
@@ -29,13 +29,13 @@ impl Plugin for OzmaHostInputPlugin {
             maintain_input_gates
                 .before(OzmaTerminalInputSet)
                 .before(OzmaTerminalMouseSet)
-                .run_if(in_state(AppMode::Ozma)),
+                .run_if(in_state(AppMode::Default)),
         )
         .add_systems(
             Update,
             app_shortcut_handler
                 .in_set(InputPhase::FocusedKey)
-                .run_if(in_state(AppMode::Ozma))
+                .run_if(in_state(AppMode::Default))
                 .run_if(on_message::<KeyboardInput>),
         );
     }

--- a/src/ozma_input.rs
+++ b/src/ozma_input.rs
@@ -7,7 +7,7 @@
 use crate::input::ime::ImeState;
 use crate::input::shortcuts::ResolvedShortcuts;
 use crate::input::{InputPhase, current_modifiers};
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use crate::picker::SessionPicker;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -98,7 +98,7 @@ pub(crate) struct SessionPicker {
 }
 
 /// Inserted on the first `OnEnter(AppMode::Tmux)` (boot) so the startup-mode
-/// dispatch routes only once and later Ozmux entries skip it.
+/// dispatch routes only once and later Tmux entries skip it.
 #[derive(Resource)]
 struct StartupDispatched;
 
@@ -163,10 +163,10 @@ fn refresh_picker_on_open(mut picker: ResMut<SessionPicker>, configs: Res<OzmuxC
     }
 }
 
-/// Boot-time startup-mode routing, run once. Registered on `OnEnter(Ozmux)`
+/// Boot-time startup-mode routing, run once. Registered on `OnEnter(Tmux)`
 /// behind `run_if(not(resource_exists::<StartupDispatched>))`; it inserts
-/// `StartupDispatched` on its first (boot) run so later Ozmux entries skip it
-/// and do not bounce a picker-driven Ozma -> Ozmux transition back to Ozma.
+/// `StartupDispatched` on its first (boot) run so later Tmux entries skip it
+/// and do not bounce a picker-driven Default -> Tmux transition back to Default.
 fn dispatch_startup_mode(
     mut commands: Commands,
     mut connection: NonSendMut<TmuxConnection>,
@@ -785,9 +785,9 @@ fn apply_attach(
 /// [`AppMode::Tmux`]: true only when the attach succeeded and the app is
 /// currently in [`AppMode::Default`].
 ///
-/// The `Ozma` guard is correctness-critical, not an optimization: under Bevy
+/// The `Default` guard is correctness-critical, not an optimization: under Bevy
 /// 0.18 `NextState::set` to the current value re-runs `OnExit`/`OnEnter`, so
-/// setting `Ozmux` while already in `Ozmux` would run `on_exit_tmux`
+/// setting `Tmux` while already in `Tmux` would run `on_exit_tmux`
 /// (`connection.take()` + `detach-client`) and tear down the live client.
 fn should_enter_tmux(attached: bool, current: &AppMode) -> bool {
     attached && *current == AppMode::Default
@@ -1151,10 +1151,10 @@ mod tests {
     fn dispatch_runs_once_at_boot_and_marks_dispatched() {
         let mut app = dispatch_app();
         enter_tmux(&mut app);
-        // The boot dispatch ran: marker inserted, and (default startup_mode = Ozma)
-        // it queued a transition back to Ozma.
+        // The boot dispatch ran: marker inserted, and (default startup_mode = Default)
+        // it queued a transition back to Default.
         assert!(app.world().get_resource::<StartupDispatched>().is_some());
-        app.update(); // apply the queued Ozmux -> Ozma transition
+        app.update(); // apply the queued Tmux -> Default transition
         assert_eq!(
             *app.world().resource::<State<AppMode>>().get(),
             AppMode::Default
@@ -1167,7 +1167,7 @@ mod tests {
         app.insert_resource(StartupDispatched);
         enter_tmux(&mut app);
         // run_if(not(resource_exists)) is false, so dispatch never ran and the
-        // Ozma -> Ozmux transition is NOT bounced back to Ozma.
+        // Default -> Tmux transition is NOT bounced back to Default.
         assert_eq!(
             *app.world().resource::<State<AppMode>>().get(),
             AppMode::Tmux

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -32,7 +32,7 @@ impl Plugin for OzmuxPickerPlugin {
         app.init_resource::<SessionPicker>()
             .add_systems(Startup, spawn_picker_ui)
             .add_systems(
-                OnEnter(AppMode::Ozmux),
+                OnEnter(AppMode::Tmux),
                 dispatch_startup_mode.run_if(not(resource_exists::<StartupDispatched>)),
             )
             .add_systems(
@@ -97,7 +97,7 @@ pub(crate) struct SessionPicker {
     last_open: bool,
 }
 
-/// Inserted on the first `OnEnter(AppMode::Ozmux)` (boot) so the startup-mode
+/// Inserted on the first `OnEnter(AppMode::Tmux)` (boot) so the startup-mode
 /// dispatch routes only once and later Ozmux entries skip it.
 #[derive(Resource)]
 struct StartupDispatched;
@@ -179,7 +179,7 @@ fn dispatch_startup_mode(
     commands.insert_resource(StartupDispatched);
     match &configs.startup_mode {
         StartupMode::Default => {
-            next_mode.set(AppMode::Ozma);
+            next_mode.set(AppMode::Default);
         }
         StartupMode::Tmux => {
             let server = build_server(&configs);
@@ -663,7 +663,7 @@ fn activate_row(
     } else {
         let attached = apply_attach(connection, state, configs, control, picker, row);
         if should_enter_ozmux(attached, current_mode) {
-            next_mode.set(AppMode::Ozmux);
+            next_mode.set(AppMode::Tmux);
         }
     }
 }
@@ -782,15 +782,15 @@ fn apply_attach(
 }
 
 /// Whether a successful picker attach should transition the app into
-/// [`AppMode::Ozmux`]: true only when the attach succeeded and the app is
-/// currently in [`AppMode::Ozma`].
+/// [`AppMode::Tmux`]: true only when the attach succeeded and the app is
+/// currently in [`AppMode::Default`].
 ///
 /// The `Ozma` guard is correctness-critical, not an optimization: under Bevy
 /// 0.18 `NextState::set` to the current value re-runs `OnExit`/`OnEnter`, so
 /// setting `Ozmux` while already in `Ozmux` would run `on_exit_ozmux`
 /// (`connection.take()` + `detach-client`) and tear down the live client.
 fn should_enter_ozmux(attached: bool, current: &AppMode) -> bool {
-    attached && *current == AppMode::Ozma
+    attached && *current == AppMode::Default
 }
 
 /// Refreshes `$OZMA_SOCK` to this ozmux's live control socket across the whole
@@ -1030,10 +1030,10 @@ mod tests {
 
     #[test]
     fn should_enter_ozmux_only_when_attached_from_ozma() {
-        assert!(should_enter_ozmux(true, &AppMode::Ozma));
-        assert!(!should_enter_ozmux(false, &AppMode::Ozma));
-        assert!(!should_enter_ozmux(true, &AppMode::Ozmux));
-        assert!(!should_enter_ozmux(false, &AppMode::Ozmux));
+        assert!(should_enter_ozmux(true, &AppMode::Default));
+        assert!(!should_enter_ozmux(false, &AppMode::Default));
+        assert!(!should_enter_ozmux(true, &AppMode::Tmux));
+        assert!(!should_enter_ozmux(false, &AppMode::Tmux));
     }
 
     fn key_press(code: KeyCode) -> bevy::input::keyboard::KeyboardInput {
@@ -1050,7 +1050,7 @@ mod tests {
     fn picker_input_app() -> App {
         let mut app = App::new();
         app.add_plugins(StatesPlugin);
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.add_message::<bevy::input::keyboard::KeyboardInput>();
         app.insert_resource(SessionPicker {
             sessions: vec![fake_session(0, "alpha"), fake_session(1, "beta")],
@@ -1130,20 +1130,20 @@ mod tests {
     fn dispatch_app() -> App {
         let mut app = App::new();
         app.add_plugins(StatesPlugin);
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.init_resource::<SessionPicker>();
         app.init_resource::<ConnectionState>();
         app.init_resource::<OzmuxConfigsResource>();
         app.insert_non_send_resource(TmuxConnection::default());
         app.add_systems(
-            OnEnter(AppMode::Ozmux),
+            OnEnter(AppMode::Tmux),
             dispatch_startup_mode.run_if(not(resource_exists::<StartupDispatched>)),
         );
         app
     }
 
     fn enter_ozmux(app: &mut App) {
-        app.insert_resource(NextState::Pending(AppMode::Ozmux));
+        app.insert_resource(NextState::Pending(AppMode::Tmux));
         app.update();
     }
 
@@ -1157,7 +1157,7 @@ mod tests {
         app.update(); // apply the queued Ozmux -> Ozma transition
         assert_eq!(
             *app.world().resource::<State<AppMode>>().get(),
-            AppMode::Ozma
+            AppMode::Default
         );
     }
 
@@ -1170,7 +1170,7 @@ mod tests {
         // Ozma -> Ozmux transition is NOT bounced back to Ozma.
         assert_eq!(
             *app.world().resource::<State<AppMode>>().get(),
-            AppMode::Ozmux
+            AppMode::Tmux
         );
     }
 
@@ -1186,7 +1186,7 @@ mod tests {
     fn hover_moves_selection_only_after_the_mouse_moves() {
         let mut app = App::new();
         app.add_plugins(StatesPlugin);
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.add_message::<CursorMoved>();
         app.insert_resource(SessionPicker {
             sessions: vec![fake_session(0, "alpha"), fake_session(1, "beta")],

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -42,7 +42,7 @@ impl Plugin for OzmuxPickerPlugin {
                     refresh_picker_on_open,
                     refresh_session_ozmux_sock
                         .run_if(resource_exists_and_changed::<ConnectionState>)
-                        .in_set(crate::tmux::OzmuxActiveSet),
+                        .in_set(crate::tmux::TmuxActiveSet),
                     // NOTE: handle_picker_row_interaction and picker_row_hover_cursor
                     // are deliberately NOT gated by run_if(picker_is_open): both must
                     // observe the picker's closed state to reset per-open state

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -178,10 +178,10 @@ fn dispatch_startup_mode(
 ) {
     commands.insert_resource(StartupDispatched);
     match &configs.startup_mode {
-        StartupMode::Ozma => {
+        StartupMode::Default => {
             next_mode.set(AppMode::Ozma);
         }
-        StartupMode::Ozmux => {
+        StartupMode::Tmux => {
             let server = build_server(&configs);
             match server.list_sessions() {
                 Ok(sessions) => {
@@ -196,7 +196,7 @@ fn dispatch_startup_mode(
                 }
             }
         }
-        StartupMode::AutoAttach => {
+        StartupMode::TmuxAutoAttach => {
             let mut server = build_server(&configs);
             if let Some(handle) = &control {
                 server = server.env("OZMA_SOCK", &handle.sock_path.to_string_lossy());

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -3,7 +3,7 @@
 
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use crate::theme;
 use bevy::ecs::hierarchy::Children;
 use bevy::ecs::message::MessageReader;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -662,7 +662,7 @@ fn activate_row(
         apply_switch(connection, state, configs, control, picker, row);
     } else {
         let attached = apply_attach(connection, state, configs, control, picker, row);
-        if should_enter_ozmux(attached, current_mode) {
+        if should_enter_tmux(attached, current_mode) {
             next_mode.set(AppMode::Tmux);
         }
     }
@@ -787,9 +787,9 @@ fn apply_attach(
 ///
 /// The `Ozma` guard is correctness-critical, not an optimization: under Bevy
 /// 0.18 `NextState::set` to the current value re-runs `OnExit`/`OnEnter`, so
-/// setting `Ozmux` while already in `Ozmux` would run `on_exit_ozmux`
+/// setting `Ozmux` while already in `Ozmux` would run `on_exit_tmux`
 /// (`connection.take()` + `detach-client`) and tear down the live client.
-fn should_enter_ozmux(attached: bool, current: &AppMode) -> bool {
+fn should_enter_tmux(attached: bool, current: &AppMode) -> bool {
     attached && *current == AppMode::Default
 }
 
@@ -1029,11 +1029,11 @@ mod tests {
     }
 
     #[test]
-    fn should_enter_ozmux_only_when_attached_from_ozma() {
-        assert!(should_enter_ozmux(true, &AppMode::Default));
-        assert!(!should_enter_ozmux(false, &AppMode::Default));
-        assert!(!should_enter_ozmux(true, &AppMode::Tmux));
-        assert!(!should_enter_ozmux(false, &AppMode::Tmux));
+    fn should_enter_tmux_only_when_attached_from_default() {
+        assert!(should_enter_tmux(true, &AppMode::Default));
+        assert!(!should_enter_tmux(false, &AppMode::Default));
+        assert!(!should_enter_tmux(true, &AppMode::Tmux));
+        assert!(!should_enter_tmux(false, &AppMode::Tmux));
     }
 
     fn key_press(code: KeyCode) -> bevy::input::keyboard::KeyboardInput {
@@ -1142,7 +1142,7 @@ mod tests {
         app
     }
 
-    fn enter_ozmux(app: &mut App) {
+    fn enter_tmux(app: &mut App) {
         app.insert_resource(NextState::Pending(AppMode::Tmux));
         app.update();
     }
@@ -1150,7 +1150,7 @@ mod tests {
     #[test]
     fn dispatch_runs_once_at_boot_and_marks_dispatched() {
         let mut app = dispatch_app();
-        enter_ozmux(&mut app);
+        enter_tmux(&mut app);
         // The boot dispatch ran: marker inserted, and (default startup_mode = Ozma)
         // it queued a transition back to Ozma.
         assert!(app.world().get_resource::<StartupDispatched>().is_some());
@@ -1165,7 +1165,7 @@ mod tests {
     fn dispatch_skipped_when_already_dispatched_does_not_bounce() {
         let mut app = dispatch_app();
         app.insert_resource(StartupDispatched);
-        enter_ozmux(&mut app);
+        enter_tmux(&mut app);
         // run_if(not(resource_exists)) is false, so dispatch never ran and the
         // Ozma -> Ozmux transition is NOT bounced back to Ozma.
         assert_eq!(

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,9 +1,9 @@
 //! Startup tmux session picker: lists sessions, shows a keyboard-navigable
 //! overlay, and attaches only after the user selects an entry (or "New session").
 
+use crate::app_mode::AppMode;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
-use crate::app_mode::AppMode;
 use crate::theme;
 use bevy::ecs::hierarchy::Children;
 use bevy::ecs::message::MessageReader;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -31,7 +31,7 @@ use render::RenderPlugin;
 use webview_tokens::WebviewTokensPlugin;
 use window_bar::WindowBarPlugin;
 
-/// SystemSet applied to every tmux Update system. Runs only in `AppMode::Ozmux`.
+/// SystemSet applied to every tmux Update system. Runs only in `AppMode::Tmux`.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct OzmuxActiveSet;
 
@@ -40,9 +40,9 @@ pub struct OzmuxTmuxPlugin;
 
 impl Plugin for OzmuxTmuxPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(Update, OzmuxActiveSet.run_if(in_state(AppMode::Ozmux)))
-            .add_systems(OnEnter(AppMode::Ozmux), on_enter_ozmux)
-            .add_systems(OnExit(AppMode::Ozmux), on_exit_ozmux)
+        app.configure_sets(Update, OzmuxActiveSet.run_if(in_state(AppMode::Tmux)))
+            .add_systems(OnEnter(AppMode::Tmux), on_enter_ozmux)
+            .add_systems(OnExit(AppMode::Tmux), on_exit_ozmux)
             .add_observer(on_tmux_connection_closed)
             .add_plugins((
                 TmuxSessionPlugin,
@@ -65,7 +65,7 @@ fn on_tmux_connection_closed(
     _ev: On<TmuxConnectionClosed>,
     mut next_mode: ResMut<NextState<AppMode>>,
 ) {
-    next_mode.set(AppMode::Ozma);
+    next_mode.set(AppMode::Default);
 }
 
 fn on_enter_ozmux(mut commands: Commands) {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -41,8 +41,8 @@ pub struct OzmuxTmuxPlugin;
 impl Plugin for OzmuxTmuxPlugin {
     fn build(&self, app: &mut App) {
         app.configure_sets(Update, TmuxActiveSet.run_if(in_state(AppMode::Tmux)))
-            .add_systems(OnEnter(AppMode::Tmux), on_enter_ozmux)
-            .add_systems(OnExit(AppMode::Tmux), on_exit_ozmux)
+            .add_systems(OnEnter(AppMode::Tmux), on_enter_tmux)
+            .add_systems(OnExit(AppMode::Tmux), on_exit_tmux)
             .add_observer(on_tmux_connection_closed)
             .add_plugins((
                 TmuxSessionPlugin,
@@ -68,11 +68,11 @@ fn on_tmux_connection_closed(
     next_mode.set(AppMode::Default);
 }
 
-fn on_enter_ozmux(mut commands: Commands) {
+fn on_enter_tmux(mut commands: Commands) {
     commands.insert_resource(TmuxPresence);
 }
 
-fn on_exit_ozmux(mut commands: Commands, mut connection: NonSendMut<TmuxConnection>) {
+fn on_exit_tmux(mut commands: Commands, mut connection: NonSendMut<TmuxConnection>) {
     if let Some(client) = connection.client() {
         let _ = client.handle().send("detach-client");
     }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -14,7 +14,7 @@ mod webview_tokens;
 mod window_bar;
 mod window_bar_input;
 
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use bevy::prelude::*;
 use copy_mode::CopyModePlugin;
 use dialog::DialogPlugin;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -33,14 +33,14 @@ use window_bar::WindowBarPlugin;
 
 /// SystemSet applied to every tmux Update system. Runs only in `AppMode::Tmux`.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct OzmuxActiveSet;
+pub(crate) struct TmuxActiveSet;
 
 /// Bevy plugin aggregating all tmux runtime sub-plugins.
 pub struct OzmuxTmuxPlugin;
 
 impl Plugin for OzmuxTmuxPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets(Update, OzmuxActiveSet.run_if(in_state(AppMode::Tmux)))
+        app.configure_sets(Update, TmuxActiveSet.run_if(in_state(AppMode::Tmux)))
             .add_systems(OnEnter(AppMode::Tmux), on_enter_ozmux)
             .add_systems(OnExit(AppMode::Tmux), on_exit_ozmux)
             .add_observer(on_tmux_connection_closed)

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -49,7 +49,7 @@ impl Plugin for CopyModePlugin {
                     .after(consume_copy_reply),
             )
                 .after(TmuxProjectionSet)
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
     }
 }

--- a/src/tmux/dialog.rs
+++ b/src/tmux/dialog.rs
@@ -1,6 +1,6 @@
 //! A modal overlay shown when the tmux backend reports an error.
 
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use bevy::app::{App, Plugin, PostUpdate, Startup};
 use bevy::color::Color;
 use bevy::ecs::component::Component;

--- a/src/tmux/dialog.rs
+++ b/src/tmux/dialog.rs
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn dialog_hidden_on_exit_ozmux() {
+    fn dialog_hidden_on_exit_tmux() {
         let mut app = App::new();
         app.add_plugins(bevy::state::app::StatesPlugin);
         app.insert_state(AppMode::Tmux);

--- a/src/tmux/dialog.rs
+++ b/src/tmux/dialog.rs
@@ -23,12 +23,12 @@ pub(crate) struct DialogPlugin;
 impl Plugin for DialogPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, spawn_tmux_dialog)
-            .add_systems(OnExit(AppMode::Ozmux), hide_tmux_dialog)
+            .add_systems(OnExit(AppMode::Tmux), hide_tmux_dialog)
             .add_systems(
                 PostUpdate,
                 sync_tmux_dialog
                     .run_if(resource_exists_and_changed::<ConnectionState>)
-                    .run_if(in_state(AppMode::Ozmux)),
+                    .run_if(in_state(AppMode::Tmux)),
             );
     }
 }
@@ -103,7 +103,7 @@ mod tests {
     fn dialog_shows_on_error_and_detached() {
         let mut app = App::new();
         app.add_plugins(bevy::state::app::StatesPlugin);
-        app.insert_state(AppMode::Ozmux);
+        app.insert_state(AppMode::Tmux);
         app.init_resource::<ConnectionState>();
         app.add_plugins(DialogPlugin);
         app.update();
@@ -136,7 +136,7 @@ mod tests {
     fn dialog_hidden_on_exit_ozmux() {
         let mut app = App::new();
         app.add_plugins(bevy::state::app::StatesPlugin);
-        app.insert_state(AppMode::Ozmux);
+        app.insert_state(AppMode::Tmux);
         app.init_resource::<ConnectionState>();
         app.add_plugins(DialogPlugin);
         app.update();
@@ -152,7 +152,7 @@ mod tests {
         app.update();
         assert_eq!(backdrop_display(&mut app), Display::Flex);
 
-        app.insert_resource(bevy::prelude::NextState::Pending(AppMode::Ozma));
+        app.insert_resource(bevy::prelude::NextState::Pending(AppMode::Default));
         app.update();
         assert_eq!(backdrop_display(&mut app), Display::None);
     }

--- a/src/tmux/divider_handle.rs
+++ b/src/tmux/divider_handle.rs
@@ -29,7 +29,7 @@ impl Plugin for DividerHandlePlugin {
                 reconcile_divider_handles.after(TmuxProjectionSet),
                 divider_hover_feedback.after(InputPhase::Hover),
             )
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
     }
 }

--- a/src/tmux/gate.rs
+++ b/src/tmux/gate.rs
@@ -1,4 +1,4 @@
-//! Per-pane input gating for `AppMode::Ozmux`: every pane is `KeyboardDisabled`
+//! Per-pane input gating for `AppMode::Tmux`: every pane is `KeyboardDisabled`
 //! (keys pass through to tmux), and `MouseDisabled` whenever a modal owns input,
 //! the pane is in copy mode, the focused webview belongs to the pane, or
 //! an interactive webview under the cursor claims the press — so
@@ -31,7 +31,7 @@ impl Plugin for GatePlugin {
             maintain_tmux_input_gates
                 .before(OzmaTerminalInputSet)
                 .before(OzmaTerminalMouseSet)
-                .run_if(in_state(AppMode::Ozmux)),
+                .run_if(in_state(AppMode::Tmux)),
         );
     }
 }

--- a/src/tmux/gate.rs
+++ b/src/tmux/gate.rs
@@ -21,7 +21,7 @@ use ozma_tty_renderer::prelude::TerminalOverlays;
 use ozma_webview::{NonInteractive, Webview, webview_hit_at};
 use ozmux_tmux::TmuxPane;
 
-/// Registers the Ozmux-mode per-pane input gate maintainer.
+/// Registers the Tmux-mode per-pane input gate maintainer.
 pub(crate) struct GatePlugin;
 
 impl Plugin for GatePlugin {

--- a/src/tmux/gate.rs
+++ b/src/tmux/gate.rs
@@ -5,8 +5,8 @@
 //! `ozma_terminal`'s shared mouse systems yield to the tmux-specific gestures.
 
 use super::pane_hit::tmux_pane_at_phys;
-use crate::input::ime::ImeState;
 use crate::app_mode::AppMode;
+use crate::input::ime::ImeState;
 use crate::picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;

--- a/src/tmux/gate.rs
+++ b/src/tmux/gate.rs
@@ -6,7 +6,7 @@
 
 use super::pane_hit::tmux_pane_at_phys;
 use crate::input::ime::ImeState;
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use crate::picker::SessionPicker;
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::CopyPrompt;

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -50,7 +50,7 @@ impl Plugin for InputPlugin {
             (
                 forward_keys_to_tmux
                     .in_set(InputPhase::FocusedKey)
-                    .run_if(in_state(AppMode::Ozmux))
+                    .run_if(in_state(AppMode::Tmux))
                     .run_if(on_message::<KeyboardInput>),
                 forward_wheel_to_tmux
                     .in_set(InputPhase::Dispatch)
@@ -315,7 +315,7 @@ fn forward_keys_to_tmux(
                 }
                 ShortcutAction::ReleaseWebviewFocus => {}
                 ShortcutAction::DetachSession => {
-                    next_mode.set(AppMode::Ozma);
+                    next_mode.set(AppMode::Default);
                 }
             }
             continue;

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -10,10 +10,10 @@
 //! same way the native terminal path does); every other case is ceded to ozma.
 
 use super::pane_hit::tmux_pane_at_phys;
+use crate::app_mode::AppMode;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
 use crate::input::shortcuts::ResolvedShortcuts;
-use crate::app_mode::AppMode;
 use crate::picker::SessionPicker;
 use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -13,7 +13,7 @@ use super::pane_hit::tmux_pane_at_phys;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
 use crate::input::shortcuts::ResolvedShortcuts;
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use crate::picker::SessionPicker;
 use crate::ui::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::ui::copy_mode::CopyModeState;

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -56,7 +56,7 @@ impl Plugin for InputPlugin {
                     .in_set(InputPhase::Dispatch)
                     .run_if(on_message::<MouseWheel>),
             )
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
     }
 }

--- a/src/tmux/mouse.rs
+++ b/src/tmux/mouse.rs
@@ -51,7 +51,7 @@ impl Plugin for MousePlugin {
                     .run_if(pointer_active)
                     .after(tmux_webview_pointer)
                     .in_set(InputPhase::Dispatch)
-                    .in_set(super::OzmuxActiveSet),
+                    .in_set(super::TmuxActiveSet),
             )
             .add_plugins((webview::WebviewPointerPlugin, apply::ApplyPlugin));
     }

--- a/src/tmux/mouse/webview.rs
+++ b/src/tmux/mouse/webview.rs
@@ -4,7 +4,7 @@
 //! forward left-button press/release and pointer motion to the inline CEF
 //! child under the cursor.
 
-use super::super::OzmuxActiveSet;
+use super::super::TmuxActiveSet;
 use super::super::pane_hit::{phys_to_pane_local, tmux_pane_at_phys};
 use super::effect::{TmuxMouseEffect, TmuxMouseEffects};
 use super::{GestureState, TmuxGestureButtons, TmuxMouseGesture, cell_dims};
@@ -36,13 +36,13 @@ impl Plugin for WebviewPointerPlugin {
                 Update,
                 tmux_webview_pointer
                     .in_set(InputPhase::Dispatch)
-                    .in_set(OzmuxActiveSet),
+                    .in_set(TmuxActiveSet),
             )
             .add_systems(
                 Update,
                 forward_tmux_webview_mouse_moves
                     .in_set(InputPhase::Hover)
-                    .in_set(OzmuxActiveSet),
+                    .in_set(TmuxActiveSet),
             );
     }
 }
@@ -71,7 +71,7 @@ pub(super) struct TmuxWebviewRouteParams<'w, 's> {
 /// handing off the non-consumed ones through `TmuxGestureButtons`.
 ///
 /// This system owns the single `MouseButtonInput` reader for the tmux pointer
-/// pipeline and runs EVERY frame within `OzmuxActiveSet` (it is NOT gated by
+/// pipeline and runs EVERY frame within `TmuxActiveSet` (it is NOT gated by
 /// `pointer_active`); it computes the suppressed/active decision in-body. On a
 /// suppressed frame (no focused primary window, or a picker / copy-search prompt
 /// owns input) it drains the reader and the buffer, resets the gesture to

--- a/src/tmux/pane_focus.rs
+++ b/src/tmux/pane_focus.rs
@@ -27,7 +27,7 @@ impl Plugin for PaneFocusPlugin {
                 sync_inactive_pane_style.run_if(pane_active_state_changed),
                 sync_keyboard_focus_to_active_pane.run_if(pane_active_state_changed),
             )
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
     }
 }

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -49,13 +49,13 @@ impl Plugin for RenderPlugin {
                 )
                     .chain()
                     .after(TmuxProjectionSet)
-                    .in_set(super::OzmuxActiveSet),
+                    .in_set(super::TmuxActiveSet),
             )
             .add_systems(
                 Update,
                 sync_client_size
                     .after(TmuxProjectionSet)
-                    .in_set(super::OzmuxActiveSet),
+                    .in_set(super::TmuxActiveSet),
             );
     }
 }

--- a/src/tmux/webview_tokens.rs
+++ b/src/tmux/webview_tokens.rs
@@ -8,13 +8,13 @@ use bevy::prelude::*;
 use ozma_webview::ControlPlaneHandle;
 use ozmux_tmux::TmuxPane;
 
-/// Registers the tmux `%N` token binder, gated to `AppMode::Ozmux` via
-/// `OzmuxActiveSet`.
+/// Registers the tmux `%N` token binder, gated to `AppMode::Tmux` via
+/// `TmuxActiveSet`.
 pub(crate) struct WebviewTokensPlugin;
 
 impl Plugin for WebviewTokensPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, bind_tmux_pane_tokens.in_set(super::OzmuxActiveSet));
+        app.add_systems(Update, bind_tmux_pane_tokens.in_set(super::TmuxActiveSet));
     }
 }
 

--- a/src/tmux/window_bar.rs
+++ b/src/tmux/window_bar.rs
@@ -77,7 +77,7 @@ impl Plugin for WindowBarPlugin {
             rebuild_window_bar
                 .run_if(window_bar_dirty)
                 .after(TmuxProjectionSet)
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
         app.add_systems(
             Update,
@@ -85,7 +85,7 @@ impl Plugin for WindowBarPlugin {
                 switch_window_on_click.in_set(InputPhase::Dispatch),
                 window_entry_hover_cursor.after(InputPhase::Hover),
             )
-                .in_set(super::OzmuxActiveSet),
+                .in_set(super::TmuxActiveSet),
         );
     }
 }

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -19,14 +19,14 @@ impl Plugin for WindowTitlePlugin {
         app.add_systems(
             Update,
             (
-                update_ozma_window_title.run_if(in_state(AppMode::Default)),
-                update_ozmux_window_title
+                update_default_window_title.run_if(in_state(AppMode::Default)),
+                update_tmux_window_title
                     .run_if(in_state(AppMode::Tmux))
                     .run_if(ozmux_title_dirty)
                     .after(TmuxProjectionSet),
             ),
         )
-        .add_systems(OnEnter(AppMode::Tmux), update_ozmux_window_title);
+        .add_systems(OnEnter(AppMode::Tmux), update_tmux_window_title);
     }
 }
 
@@ -34,7 +34,7 @@ const APP_NAME: &str = "ozmux";
 
 const SUFFIX: &str = " — ozmux";
 
-fn update_ozma_window_title(
+fn update_default_window_title(
     mut window: Query<&mut Window, With<PrimaryWindow>>,
     focused: Query<&TerminalTitle, (With<OzmaTerminal>, With<KeyboardFocused>)>,
     terminals: Query<(), With<OzmaTerminal>>,
@@ -54,7 +54,7 @@ fn update_ozma_window_title(
     }
 }
 
-fn update_ozmux_window_title(
+fn update_tmux_window_title(
     mut window: Query<&mut Window, With<PrimaryWindow>>,
     sessions: Query<&TmuxSession>,
     active_windows: Query<&TmuxWindow, With<ActiveWindow>>,

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -180,10 +180,7 @@ mod tests {
 
     #[test]
     fn tmux_trims_session_and_window() {
-        assert_eq!(
-            format_tmux("  main  ", Some("  vim  ")),
-            "main:vim — ozmux"
-        );
+        assert_eq!(format_tmux("  main  ", Some("  vim  ")), "main:vim — ozmux");
     }
 
     fn primary_window_title(app: &mut App) -> String {

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -22,7 +22,7 @@ impl Plugin for WindowTitlePlugin {
                 update_default_window_title.run_if(in_state(AppMode::Default)),
                 update_tmux_window_title
                     .run_if(in_state(AppMode::Tmux))
-                    .run_if(ozmux_title_dirty)
+                    .run_if(tmux_title_dirty)
                     .after(TmuxProjectionSet),
             ),
         )
@@ -48,9 +48,9 @@ fn update_default_window_title(
     // at all, so a stale cross-mode title cannot linger after entering Default
     // before the deferred terminal spawn flushes.
     if let Ok(title) = focused.single() {
-        apply_title(&mut window, format_ozma(title.0.as_deref()));
+        apply_title(&mut window, format_default(title.0.as_deref()));
     } else if terminals.is_empty() {
-        apply_title(&mut window, format_ozma(None));
+        apply_title(&mut window, format_default(None));
     }
 }
 
@@ -73,12 +73,12 @@ fn update_tmux_window_title(
         .iter()
         .next()
         .map(|w| sanitize_title(&w.name));
-    apply_title(&mut window, format_ozmux(&session, active.as_deref()));
+    apply_title(&mut window, format_tmux(&session, active.as_deref()));
 }
 
 /// True when the tmux session name, the active window, or the active window's
 /// name may have changed this frame — the inputs to the Tmux window title.
-fn ozmux_title_dirty(
+fn tmux_title_dirty(
     mut removed_session: RemovedComponents<TmuxSession>,
     mut removed_active: RemovedComponents<ActiveWindow>,
     changed_session: Query<(), Changed<TmuxSession>>,
@@ -97,14 +97,14 @@ fn ozmux_title_dirty(
         || active_removed
 }
 
-fn format_ozma(title: Option<&str>) -> String {
+fn format_default(title: Option<&str>) -> String {
     match title.map(str::trim) {
         Some(t) if !t.is_empty() => format!("{t}{SUFFIX}"),
         _ => APP_NAME.to_string(),
     }
 }
 
-fn format_ozmux(session: &str, window: Option<&str>) -> String {
+fn format_tmux(session: &str, window: Option<&str>) -> String {
     let session = session.trim();
     if session.is_empty() {
         return APP_NAME.to_string();
@@ -128,60 +128,60 @@ mod tests {
     use ozmux_tmux::{SessionId, WindowId};
 
     #[test]
-    fn ozma_some_title_gets_suffix() {
-        assert_eq!(format_ozma(Some("vim")), "vim — ozmux");
+    fn default_some_title_gets_suffix() {
+        assert_eq!(format_default(Some("vim")), "vim — ozmux");
     }
 
     #[test]
-    fn ozma_empty_title_is_app_name() {
-        assert_eq!(format_ozma(Some("")), "ozmux");
+    fn default_empty_title_is_app_name() {
+        assert_eq!(format_default(Some("")), "ozmux");
     }
 
     #[test]
-    fn ozma_none_title_is_app_name() {
-        assert_eq!(format_ozma(None), "ozmux");
+    fn default_none_title_is_app_name() {
+        assert_eq!(format_default(None), "ozmux");
     }
 
     #[test]
-    fn ozmux_session_and_window() {
-        assert_eq!(format_ozmux("main", Some("vim")), "main:vim — ozmux");
+    fn tmux_session_and_window() {
+        assert_eq!(format_tmux("main", Some("vim")), "main:vim — ozmux");
     }
 
     #[test]
-    fn ozmux_session_only_when_window_absent() {
-        assert_eq!(format_ozmux("main", None), "main — ozmux");
+    fn tmux_session_only_when_window_absent() {
+        assert_eq!(format_tmux("main", None), "main — ozmux");
     }
 
     #[test]
-    fn ozmux_session_only_when_window_empty() {
-        assert_eq!(format_ozmux("main", Some("")), "main — ozmux");
+    fn tmux_session_only_when_window_empty() {
+        assert_eq!(format_tmux("main", Some("")), "main — ozmux");
     }
 
     #[test]
-    fn ozmux_empty_session_is_app_name() {
-        assert_eq!(format_ozmux("", Some("vim")), "ozmux");
-        assert_eq!(format_ozmux("", None), "ozmux");
+    fn tmux_empty_session_is_app_name() {
+        assert_eq!(format_tmux("", Some("vim")), "ozmux");
+        assert_eq!(format_tmux("", None), "ozmux");
     }
 
     #[test]
-    fn ozma_whitespace_only_title_is_app_name() {
-        assert_eq!(format_ozma(Some("   ")), "ozmux");
+    fn default_whitespace_only_title_is_app_name() {
+        assert_eq!(format_default(Some("   ")), "ozmux");
     }
 
     #[test]
-    fn ozma_trims_surrounding_whitespace() {
-        assert_eq!(format_ozma(Some("  vim  ")), "vim — ozmux");
+    fn default_trims_surrounding_whitespace() {
+        assert_eq!(format_default(Some("  vim  ")), "vim — ozmux");
     }
 
     #[test]
-    fn ozmux_whitespace_session_is_app_name() {
-        assert_eq!(format_ozmux("   ", Some("vim")), "ozmux");
+    fn tmux_whitespace_session_is_app_name() {
+        assert_eq!(format_tmux("   ", Some("vim")), "ozmux");
     }
 
     #[test]
-    fn ozmux_trims_session_and_window() {
+    fn tmux_trims_session_and_window() {
         assert_eq!(
-            format_ozmux("  main  ", Some("  vim  ")),
+            format_tmux("  main  ", Some("  vim  ")),
             "main:vim — ozmux"
         );
     }
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn ozma_system_sets_focused_terminal_title() {
+    fn default_system_sets_focused_terminal_title() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Default);
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn ozmux_system_sets_session_and_active_window() {
+    fn tmux_system_sets_session_and_active_window() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Tmux);
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn ozma_resets_to_app_name_when_no_terminal_exists() {
+    fn default_resets_to_app_name_when_no_terminal_exists() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Default);
@@ -260,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn ozma_holds_last_title_when_terminal_exists_but_unfocused() {
+    fn default_holds_last_title_when_terminal_exists_but_unfocused() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Default);
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn ozmux_sanitizes_window_name() {
+    fn tmux_sanitizes_window_name() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Tmux);
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn ozmux_title_is_not_recomputed_when_nothing_changed() {
+    fn tmux_title_is_not_recomputed_when_nothing_changed() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Tmux);

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -19,14 +19,14 @@ impl Plugin for WindowTitlePlugin {
         app.add_systems(
             Update,
             (
-                update_ozma_window_title.run_if(in_state(AppMode::Ozma)),
+                update_ozma_window_title.run_if(in_state(AppMode::Default)),
                 update_ozmux_window_title
-                    .run_if(in_state(AppMode::Ozmux))
+                    .run_if(in_state(AppMode::Tmux))
                     .run_if(ozmux_title_dirty)
                     .after(TmuxProjectionSet),
             ),
         )
-        .add_systems(OnEnter(AppMode::Ozmux), update_ozmux_window_title);
+        .add_systems(OnEnter(AppMode::Tmux), update_ozmux_window_title);
     }
 }
 
@@ -201,7 +201,7 @@ mod tests {
     fn ozma_system_sets_focused_terminal_title() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((Window::default(), PrimaryWindow));
         app.world_mut().spawn((
@@ -219,7 +219,7 @@ mod tests {
     fn ozmux_system_sets_session_and_active_window() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozmux);
+        app.insert_state(AppMode::Tmux);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((Window::default(), PrimaryWindow));
         app.world_mut().spawn(TmuxSession {
@@ -244,7 +244,7 @@ mod tests {
     fn ozma_resets_to_app_name_when_no_terminal_exists() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((
             Window {
@@ -263,7 +263,7 @@ mod tests {
     fn ozma_holds_last_title_when_terminal_exists_but_unfocused() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozma);
+        app.insert_state(AppMode::Default);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((
             Window {
@@ -284,7 +284,7 @@ mod tests {
     fn ozmux_sanitizes_window_name() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozmux);
+        app.insert_state(AppMode::Tmux);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((Window::default(), PrimaryWindow));
         app.world_mut().spawn(TmuxSession {
@@ -309,7 +309,7 @@ mod tests {
     fn ozmux_title_is_not_recomputed_when_nothing_changed() {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
-        app.insert_state(AppMode::Ozmux);
+        app.insert_state(AppMode::Tmux);
         app.add_plugins(WindowTitlePlugin);
         app.world_mut().spawn((Window::default(), PrimaryWindow));
         let session = app

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -1,6 +1,6 @@
 //! Dynamic OS window-title sync: reflects the active context per `AppMode`
-//! into the primary window's title bar — `session:window — ozmux` in Ozmux
-//! mode, the focused terminal's OSC title + ` — ozmux` in Ozma mode.
+//! into the primary window's title bar — `session:window — ozmux` in Tmux
+//! mode, the focused terminal's OSC title + ` — ozmux` in Default mode.
 
 use crate::app_mode::AppMode;
 use bevy::prelude::*;
@@ -10,8 +10,8 @@ use ozma_tty_engine::{TerminalTitle, sanitize_title};
 use ozmux_tmux::{ActiveWindow, TmuxProjectionSet, TmuxSession, TmuxWindow};
 
 /// Keeps the primary OS window title in sync with the active `AppMode`
-/// context: the tmux `session:window` in Ozmux mode, and the focused
-/// terminal's OSC title in Ozma mode.
+/// context: the tmux `session:window` in Tmux mode, and the focused
+/// terminal's OSC title in Default mode.
 pub(crate) struct WindowTitlePlugin;
 
 impl Plugin for WindowTitlePlugin {
@@ -45,7 +45,7 @@ fn update_default_window_title(
     // NOTE: the no-focus branch is deliberately asymmetric. Hold the last title
     // when terminals exist but focus is transiently absent (a handoff — avoids a
     // one-frame flicker); reset to the app-name fallback when no terminal exists
-    // at all, so a stale cross-mode title cannot linger after entering Ozma
+    // at all, so a stale cross-mode title cannot linger after entering Default
     // before the deferred terminal spawn flushes.
     if let Ok(title) = focused.single() {
         apply_title(&mut window, format_ozma(title.0.as_deref()));
@@ -77,7 +77,7 @@ fn update_tmux_window_title(
 }
 
 /// True when the tmux session name, the active window, or the active window's
-/// name may have changed this frame — the inputs to the Ozmux window title.
+/// name may have changed this frame — the inputs to the Tmux window title.
 fn ozmux_title_dirty(
     mut removed_session: RemovedComponents<TmuxSession>,
     mut removed_active: RemovedComponents<ActiveWindow>,

--- a/src/window_title.rs
+++ b/src/window_title.rs
@@ -2,7 +2,7 @@
 //! into the primary window's title bar — `session:window — ozmux` in Ozmux
 //! mode, the focused terminal's OSC title + ` — ozmux` in Ozma mode.
 
-use crate::ozma::AppMode;
+use crate::app_mode::AppMode;
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, Window};
 use ozma_terminal::{KeyboardFocused, OzmaTerminal};


### PR DESCRIPTION
## What

Makes the application-mode names self-describing. The two `AppMode` variants were `Ozma` (single PTY, no tmux) and `Ozmux` (tmux backend) — names that collide visually with each other and with the product/engine brands. This renames them to `Default` and `Tmux`, and aligns the user-facing `startup_mode` config values.

Pure rename refactor — **no behavior changes**.

### Enum / config renames
- `AppMode::Ozma` → `AppMode::Default`, `AppMode::Ozmux` → `AppMode::Tmux`
- `StartupMode` variants → `Default` / `Tmux` / `TmuxAutoAttach`

### ⚠️ Breaking config change
`startup_mode` values change (hard break, no aliases):

| old | new |
| --- | --- |
| `"ozma"` | `"default"` |
| `"ozmux"` | `"tmux"` |
| `"auto-attach"` | `"tmux-auto-attach"` |

### Cascade (mode-tied identifiers/files/docs)
- `OzmaModePlugin` → `DefaultModePlugin`; `src/ozma.rs` → `src/app_mode.rs`
- `OzmaHostInputPlugin` → `DefaultHostInputPlugin`; `src/ozma_input.rs` → `src/default_input.rs`
- `OzmuxActiveSet` → `TmuxActiveSet`
- `on_enter/exit_ozmux` → `on_enter/exit_tmux`, `should_enter_ozmux` → `should_enter_tmux`
- `window_title.rs`: `format_ozma`/`format_ozmux`/`ozmux_title_dirty` (+ test fns) → `format_default`/`format_tmux`/`tmux_title_dirty`
- Mode-tied doc comments across `src/` and `crates/{ozmux_configs,tmux_session}`

### Deliberately NOT renamed (brand/engine names)
`ozma_terminal`/`OzmaTerminal*`, `ozma_tty_*`, `window.ozma` + `"ozma"`/`"ozma.call"`/`"ozma.emit"` channels, `OZMA_SOCK`/`*_ozmux_sock`, `ozma-dyn://`, `ratatui-ozma`, the `[ozma]` config section, all `ozmux_*` crates / `Ozmux*Plugin`/`OzmuxRpc`/`OzmuxFrame` product types, `WheelOwner::CededToOzma`, and the `" — ozmux"` window-title brand literal.

## Verification
- `cargo check --workspace --tests` ✅
- `cargo clippy --workspace --all-targets` ✅ clean
- `cargo test -p ozmux_configs` → 113 passed
- `cargo test --bin ozmux` → 305 passed, 0 failed, 3 ignored

## Notes
Rebased onto current `main` (which had merged #182, the `ozma_webview` extraction). Conflicts in `main.rs` were resolved, and #182's newly-added `src/tmux/webview_tokens.rs` (which still referenced the pre-rename `OzmuxActiveSet`/`AppMode::Ozmux`) was updated to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)