### PR TITLE
build(deps): depend on bevy_cef 0.11.0 (secure-by-default CEF)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "bevy_cef"
 version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=passthrough#700c4a64b4f3b6cb3aa661fd51034c68404d1344"
+source = "git+https://github.com/not-elm/bevy_cef?branch=security#552dbd055e3fdf498d0b6d778a8b27f167aff305"
 dependencies = [
  "async-channel",
  "bevy",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "bevy_cef_core"
 version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=passthrough#700c4a64b4f3b6cb3aa661fd51034c68404d1344"
+source = "git+https://github.com/not-elm/bevy_cef?branch=security#552dbd055e3fdf498d0b6d778a8b27f167aff305"
 dependencies = [
  "async-channel",
  "bevy",
@@ -2195,7 +2195,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2850,7 +2850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4207,7 +4207,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4414,7 +4414,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4857,7 +4857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5678,7 +5678,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6267,7 +6267,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7261,7 +7261,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -660,8 +660,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef"
-version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=security#552dbd055e3fdf498d0b6d778a8b27f167aff305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae24a3cff9b63c82e51c9e3a7f1bfe9db266c89df810d57b15e4fcc5cae06708"
 dependencies = [
  "async-channel",
  "bevy",
@@ -676,8 +677,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_core"
-version = "0.11.0-dev"
-source = "git+https://github.com/not-elm/bevy_cef?branch=security#552dbd055e3fdf498d0b6d778a8b27f167aff305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2da9caa95038624f5defe19078b45dbbf2704bc9d67c909a9891bf98c0405c"
 dependencies = [
  "async-channel",
  "bevy",
@@ -2195,7 +2197,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2850,7 +2852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4207,7 +4209,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4414,7 +4416,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4857,7 +4859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5678,7 +5680,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6267,7 +6269,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7261,7 +7263,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = ["ozma_webview/debug"]
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+bevy_cef = "0.11"
 bevy_cef_core = { workspace = true }
 ozma_terminal = { path = "crates/ozma_terminal" }
 ozma_tty_renderer = { path = "crates/ozma_tty_renderer" }
@@ -89,7 +89,7 @@ toml = "0.8"
 dirs = "5"
 unicode-width = "0.2"
 open = "5"
-bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+bevy_cef_core = "0.11"
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = ["ozma_webview/debug"]
 ab_glyph = "0.2"
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "passthrough" }
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
 bevy_cef_core = { workspace = true }
 ozma_terminal = { path = "crates/ozma_terminal" }
 ozma_tty_renderer = { path = "crates/ozma_tty_renderer" }
@@ -89,7 +89,7 @@ toml = "0.8"
 dirs = "5"
 unicode-width = "0.2"
 open = "5"
-bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "passthrough" }
+bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/crates/ozma_webview/Cargo.toml
+++ b/crates/ozma_webview/Cargo.toml
@@ -14,7 +14,7 @@ debug = ["bevy_cef/debug"]
 
 [dependencies]
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "passthrough" }
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
 bevy_cef_core = { workspace = true }
 ozma_terminal = { path = "../ozma_terminal" }
 ozma_tty_engine = { path = "../ozma_tty_engine" }

--- a/crates/ozma_webview/Cargo.toml
+++ b/crates/ozma_webview/Cargo.toml
@@ -14,7 +14,7 @@ debug = ["bevy_cef/debug"]
 
 [dependencies]
 bevy = { workspace = true }
-bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+bevy_cef = "0.11"
 bevy_cef_core = { workspace = true }
 ozma_terminal = { path = "../ozma_terminal" }
 ozma_tty_engine = { path = "../ozma_tty_engine" }

--- a/docs/superpowers/plans/2026-06-21-bevy-cef-security-branch.md
+++ b/docs/superpowers/plans/2026-06-21-bevy-cef-security-branch.md
@@ -241,5 +241,5 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Notes for the executor
 
-- **Release bundling** (out of band): when next bundling the macOS `.app`, re-run `just setup-cef-release` so the release render process is rebuilt from the `security` branch (the `justfile:11` bump in Task 1 wires this). Dev runs (`cargo run --features debug`) use the crates.io debug render process and need no extra step.
-- **After PR #61 merges to `main`:** re-point the four `branch = "security"` strings to `"main"` and re-run `cargo update` (post-merge `main ⊇ security`). One-line follow-up; not part of this plan.
+- **Release bundling** (out of band): when next bundling the macOS `.app`, re-run `just setup-cef-release` so the release render process is installed from crates.io pinned to `bevy_cef_version` (`0.11.0`). Dev runs (`cargo run --features debug`) install the matching `bevy_cef_debug_render_process@0.11.0` via `just setup-cef`.
+- **Superseded — finalized to published `0.11.0` (2026-06-22):** PR #61 merged and released as `bevy_cef 0.11.0`. ozmux now depends on the published version (`bevy_cef = "0.11"` / `bevy_cef_core = "0.11"`, registry-pinned in `Cargo.lock`) instead of the `security` git branch, and the `justfile` installs the render processes from crates.io at `0.11.0`. See the spec's "Update (2026-06-22)" section. This replaces the earlier "re-point to `main`" follow-up.

--- a/docs/superpowers/plans/2026-06-21-bevy-cef-security-branch.md
+++ b/docs/superpowers/plans/2026-06-21-bevy-cef-security-branch.md
@@ -1,0 +1,245 @@
+# bevy_cef security branch switch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move ozmux's `bevy_cef` / `bevy_cef_core` dependency from the `passthrough` branch to the `security` branch (PR #61), removing the inherited `disable-web-security` / `ignore-certificate-errors` / `ignore-ssl-errors` / `allow-running-insecure-content` switches and making CEF secure-by-default.
+
+**Architecture:** Pure dependency-metadata change in the base case — flip four `branch = "passthrough"` strings to `"security"` and re-pin `Cargo.lock`. Verify the secure default does not break ozmux's webview (static audit + manual runtime check). Source changes occur only as a contingency (CORS headers on the `ozma-dyn://` scheme) if verification surfaces a genuine cross-origin dependency.
+
+**Tech Stack:** Rust 2024 / Cargo (git deps + lockfile pinning), `just` task runner, `bevy_cef` (CEF v145), ozmux `ozma-dyn://` custom scheme.
+
+## Global Constraints
+
+- **Branch label in `Cargo.toml`, exact sha in `Cargo.lock`** — keep the repo's existing convention (human-readable `branch = "…"` in manifests; the precise commit is pinned by the lockfile).
+- **Never re-enable `disable-web-security`** — if a cross-origin need appears, fix forward by emitting `Access-Control-*` headers from the `ozma-dyn://` handler, not by opting back into the risky switch.
+- **Leave the sandbox at `SandboxMode::PlatformDefault`** — do not set `CefPlugin::sandbox` (the macOS render process is not yet linked against `cef_sandbox`; `Enabled` would only `warn!`). `PlatformDefault` is documented as "no behavior change".
+- **`docs/` is gitignored but force-added by convention** — use `git add -f` for any file under `docs/`.
+- **Rust rules apply to any source change** (comment taxonomy `// TODO:` / `// NOTE:` / `// SAFETY:` only; doc comments on `pub` items; imports at top; no `mod.rs`) — relevant only to the contingency task.
+- **Commit messages** end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Switch the bevy_cef dependency to the `security` branch
+
+**Files:**
+- Modify: `Cargo.toml:26` (`bevy_cef` git dep)
+- Modify: `Cargo.toml:92` (`[workspace.dependencies] bevy_cef_core`)
+- Modify: `crates/ozma_webview/Cargo.toml:17` (`bevy_cef` git dep)
+- Modify: `justfile:11` (`bevy_cef_branch`)
+- Modify (regenerated): `Cargo.lock`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: a workspace that compiles against `bevy_cef` / `bevy_cef_core` at `branch = "security"`, with `Cargo.lock` repinned to the `security` HEAD. The secure-by-default behavior (no risky CEF switches) is now in effect. No new symbols.
+
+- [ ] **Step 1: Flip the four `passthrough` strings to `security`**
+
+There are exactly four occurrences (verified). Apply each edit:
+
+`Cargo.toml:26`
+```toml
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+```
+
+`Cargo.toml:92`
+```toml
+bevy_cef_core = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+```
+
+`crates/ozma_webview/Cargo.toml:17`
+```toml
+bevy_cef = { git = "https://github.com/not-elm/bevy_cef", branch = "security" }
+```
+
+`justfile:11`
+```just
+bevy_cef_branch := "security"
+```
+
+- [ ] **Step 2: Verify no `passthrough` reference remains in manifests/justfile**
+
+Run: `grep -rn 'passthrough' Cargo.toml crates/ozma_webview/Cargo.toml justfile`
+Expected: no output (exit code 1).
+
+- [ ] **Step 3: Re-pin the lockfile to the `security` branch HEAD**
+
+Run: `cargo update -p bevy_cef -p bevy_cef_core`
+Expected: cargo reports updating `bevy_cef` and `bevy_cef_core` to a new git commit (the `security` HEAD, currently `552dbd0`).
+
+If cargo errors that the package source changed and cannot be updated in place, run `cargo build` instead — it re-resolves and rewrites `Cargo.lock` from the new manifest source. Either path must leave the lockfile pointing at `?branch=security`.
+
+- [ ] **Step 4: Verify the lockfile now pins the `security` branch**
+
+Run: `grep -A2 'name = "bevy_cef"' Cargo.lock | grep source; grep -A2 'name = "bevy_cef_core"' Cargo.lock | grep source`
+Expected: both `source` lines read `source = "git+https://github.com/not-elm/bevy_cef?branch=security#<sha>"` (no `passthrough`).
+
+- [ ] **Step 5: Build the workspace**
+
+Run: `cargo build`
+Expected: compiles successfully. (First build re-fetches the `security` branch; allow time for the CEF crates to rebuild.)
+
+- [ ] **Step 6: Run the workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS. ozmux's own tests are unaffected by the switch; the upstream `bevy_cef_core` security unit tests (`risky_present`, `effective_command_line_config`, `resolve_no_sandbox`) also run and pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml crates/ozma_webview/Cargo.toml justfile Cargo.lock
+git commit -m "build(deps): switch bevy_cef to security branch (PR #61)
+
+Removes the inherited disable-web-security / ignore-certificate-errors /
+ignore-ssl-errors / allow-running-insecure-content switches; CEF is now
+secure-by-default. Sandbox stays at PlatformDefault (no behavior change).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Static audit — confirm the secure default holds
+
+**Files:**
+- Read-only audit (no file changes): `crates/ozma_webview/src/webview/render/ozma_bridge.js`, `sdk/ozma-web/src/`, `crates/webview_host/src/dyn_scheme.rs`, `crates/ozma_webview/src/webview/`.
+
+**Interfaces:**
+- Consumes: the switched dependency from Task 1.
+- Produces: a go/no-go verdict for the contingency. **Clean verdict** → Task 3 (runtime check) proceeds and Contingency C1 is skipped. **Cross-origin found** → Contingency C1 runs.
+
+- [ ] **Step 1: Confirm the injected bridge and SDK use no HTTP/cross-origin**
+
+Run: `grep -rn "fetch(\|XMLHttpRequest\|http://\|https://\|Access-Control\|crossorigin" crates/ozma_webview/src/webview/render/ozma_bridge.js sdk/ozma-web/src/`
+Expected: no output. The `window.ozma` bridge is pure CEF process-message IPC (`cef.emit` → `Receive<OzmuxFrame>`); the Same-Origin Policy does not touch it.
+
+- [ ] **Step 2: Confirm the `ozma-dyn://` scheme serves same-origin assets**
+
+Run: `grep -n "CefSchemeOptions::\|headers" crates/webview_host/src/dyn_scheme.rs`
+Expected: the scheme is registered `STANDARD | SECURE | CORS_ENABLED | FETCH_ENABLED | DISPLAY_ISOLATED`, and responses set `headers: Vec::new()`. Each handle is its own origin (`ozma-dyn://<handle>/…`), so asset loads are same-origin and need no relaxed SOP.
+
+- [ ] **Step 3: Record the verdict**
+
+State the conclusion explicitly in the task report:
+- **No cross-origin usage found** (expected): the secure default holds for `ozma-dyn://`; remote `Webview::url(...)` pages now correctly enforce SOP + TLS (a proper-browser improvement, not a regression). Proceed to Task 3; skip Contingency C1.
+- **Cross-origin usage found:** name the exact file/line and the origin pair; execute Contingency C1.
+
+No commit (audit only).
+
+---
+
+### Task 3: Manual runtime verification (macOS GUI — requires the user)
+
+**Files:** none (observation only).
+
+**Interfaces:**
+- Consumes: the built binary from Task 1 and the clean verdict from Task 2.
+- Produces: human confirmation that webview rendering, `ozma-dyn://` asset loading, and the `window.ozma` bridge still work with the secure default, plus confirmation that the risky-switch `warn!` does not fire.
+
+> This task cannot be performed by a subagent — it needs a display and a human observer. The orchestrator hands this to the user to run.
+
+- [ ] **Step 1: Launch ozmux with logging**
+
+Run: `RUST_LOG=info,bevy_cef=warn cargo run --features debug`
+Expected: the app window opens; a `tmux -CC` session attaches.
+
+- [ ] **Step 2: Mount a dynamic (`ozma-dyn://`) webview and a remote page**
+
+Inside the running session, mount a webview. Easiest paths:
+- Dynamic asset / bridge: run the `sdk/ratatui-ozma` flow that registers inline/dynamic content and exercises `window.ozma.call`/`on`.
+- Remote page: run the `ratatui_remote_url` example (`sdk/ratatui-ozma/examples/ratatui_remote_url.rs`, mounts `https://github.com/...`) or `apps/ozbrowser`.
+
+- [ ] **Step 3: Observe and confirm**
+
+Confirm all of:
+1. The mounted page renders.
+2. `ozma-dyn://` assets load (no blank/404 page for dynamic content).
+3. The `window.ozma.call` / `on` round-trip works (the registering program receives the call and the page receives the response/event).
+4. A remote `https://` page loads and renders (SOP/TLS now enforced — valid sites still work).
+
+- [ ] **Step 4: Confirm no risky switch is active**
+
+In the captured logs, confirm the new one-time bevy_cef startup `warn!` about risk-relaxing switches **does not appear**. Its absence is positive proof that `disable-web-security` and friends are off.
+
+- [ ] **Step 5: Record the result**
+
+If all confirmations pass → the switch is complete; close out. If any webview feature genuinely fails due to a cross-origin block → execute Contingency C1 and re-run this task.
+
+---
+
+### Contingency C1: CORS headers on the `ozma-dyn://` handler (run ONLY if Task 2 or Task 3 finds a real cross-origin block)
+
+**Files:**
+- Modify: `crates/webview_host/src/dyn_scheme.rs` (the `OzmuxDynScheme::handle` responses + a unit test in the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: the failing cross-origin scenario identified in Task 2/3 (exact origin pair).
+- Produces: `ozma-dyn://` responses that carry `Access-Control-Allow-Origin`, mirroring how the upstream `cef://localhost/` scheme sends permissive CORS headers — without disabling web security.
+
+> Do not run this task unless verification surfaced a concrete cross-origin failure. The static audit (Task 2) is expected to come back clean, in which case this task is skipped.
+
+- [ ] **Step 1: Write the failing test**
+
+In the `#[cfg(test)] mod tests` block of `crates/webview_host/src/dyn_scheme.rs`, assert the served responses carry a CORS header. Use the existing test helpers/fixtures in that module (e.g. the registry + `resolve_request`/handler path already used by the surrounding tests) to build a served response, then:
+
+```rust
+#[test]
+fn served_dyn_response_carries_cors_header() {
+    let reg = sample_registry_with_inline("i1");
+    let resp = serve_via_scheme(&reg, "ozma-dyn://i1/index.html");
+    assert!(
+        resp.headers
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("Access-Control-Allow-Origin") && v == "*"),
+        "ozma-dyn responses must advertise CORS to match cef://localhost/ behavior"
+    );
+}
+```
+
+Adapt `sample_registry_with_inline` / `serve_via_scheme` to the exact fixture and entry point already present in the module (match the names used by neighboring tests).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux_webview_host --features cef served_dyn_response_carries_cors_header`
+Expected: FAIL (responses currently set `headers: Vec::new()`).
+
+- [ ] **Step 3: Add the CORS header to served responses**
+
+In `OzmuxDynScheme::handle`, replace the empty `headers: Vec::new()` on the inline-HTML and static-asset success arms with a shared header set:
+
+```rust
+fn cors_headers() -> Vec<(String, String)> {
+    vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
+}
+```
+
+Use `headers: cors_headers()` on the success responses. Place the helper as a private `fn` after the trait `impl` (private items last). Keep error responses (`not_found`, `status_text`) as-is unless the failing scenario requires CORS on errors too.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozmux_webview_host --features cef served_dyn_response_carries_cors_header`
+Expected: PASS.
+
+- [ ] **Step 5: Run the crate's full suite + lints**
+
+Run: `cargo test -p ozmux_webview_host --features cef && cargo clippy -p ozmux_webview_host --features cef --all-targets`
+Expected: PASS, clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/webview_host/src/dyn_scheme.rs
+git commit -m "fix(webview): send CORS headers from ozma-dyn handler
+
+Fixes a cross-origin block surfaced after dropping disable-web-security;
+mirrors the upstream cef://localhost/ CORS behavior instead of re-enabling
+the risky switch.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the executor
+
+- **Release bundling** (out of band): when next bundling the macOS `.app`, re-run `just setup-cef-release` so the release render process is rebuilt from the `security` branch (the `justfile:11` bump in Task 1 wires this). Dev runs (`cargo run --features debug`) use the crates.io debug render process and need no extra step.
+- **After PR #61 merges to `main`:** re-point the four `branch = "security"` strings to `"main"` and re-run `cargo update` (post-merge `main ⊇ security`). One-line follow-up; not part of this plan.

--- a/docs/superpowers/specs/2026-06-21-bevy-cef-security-branch-design.md
+++ b/docs/superpowers/specs/2026-06-21-bevy-cef-security-branch-design.md
@@ -1,0 +1,134 @@
+# Switch ozmux to the bevy_cef `security` branch (PR #61)
+
+Date: 2026-06-21
+Status: Approved (design) — pending implementation
+
+## Goal
+
+Eliminate the security-relaxing Chromium switches ozmux inherits from
+`bevy_cef` by moving its dependency from the `passthrough` branch to the
+`security` branch ([not-elm/bevy_cef#61]). The PR makes CEF
+secure-by-default: it removes the hardcoded `disable-web-security` (×2),
+`allow-running-insecure-content`, `ignore-certificate-errors`, and
+`ignore-ssl-errors` switches from `on_before_child_process_launch`, and the
+malformed `enable-logging=stderr`.
+
+ozmux itself never sets any risky switch — they come entirely from
+`bevy_cef`'s hardcoded child-process launch path, which is exactly what
+PR #61 removes. This is therefore a dependency + hardening change, not a
+feature change.
+
+[not-elm/bevy_cef#61]: https://github.com/not-elm/bevy_cef/pull/61
+
+## Background: branch topology
+
+ozmux currently depends on `bevy_cef` / `bevy_cef_core` at
+`branch = "passthrough"`, pinned in `Cargo.lock` to `700c4a6`.
+
+Verified content relationships across the three branches:
+
+- `main` already contains every feature `passthrough` has —
+  `WebviewTextureTarget` and `CefKeyboardFilter` were squash-merged into
+  `main` via PR #59. `main` is in fact *ahead* of `passthrough`: it also
+  carries PR #60's macOS ⌘C/X/V/A/Z clipboard shortcuts, which
+  `passthrough` does not yet have.
+- The `security` branch (PR #61) is based on `main`.
+- Therefore the file-level delta `passthrough → security` is purely
+  **additive**: `security` = passthrough's features + PR #60 clipboard
+  shortcuts + the security hardening. Switching ozmux loses nothing; it
+  gains clipboard support and the secure defaults.
+
+Consequence: `passthrough` can effectively be retired. ozmux tracks the
+`security` branch now (decision below); once #61 merges to `main`, a
+one-line follow-up re-points ozmux to `main`.
+
+## Decisions
+
+1. **Target branch:** track `security` directly and immediately (not
+   "merge to main first", not "merge security into passthrough").
+2. **Secure default:** keep it — change nothing in ozmux's
+   `CommandLineConfig`. Verify by running the app; fix forward if a real
+   cross-origin need appears (do **not** re-enable `disable-web-security`).
+3. **Sandbox:** leave `CefPlugin::sandbox` unset → `SandboxMode::PlatformDefault`
+   ("no behavior change" per the PR). Do not opt into `Enabled` (the macOS
+   render process is not yet linked against `cef_sandbox`; `Enabled` would
+   only `warn!`).
+
+## Changes
+
+### Dependency switch (the mechanical change)
+
+Flip `passthrough` → `security` in four places, then re-pin the lockfile:
+
+| File | Line | Change |
+| --- | --- | --- |
+| `Cargo.toml` | 26 | `bevy_cef` git dep `branch = "passthrough"` → `"security"` |
+| `Cargo.toml` | 92 | `[workspace.dependencies] bevy_cef_core` `branch` → `"security"` |
+| `crates/ozma_webview/Cargo.toml` | 17 | `bevy_cef` `branch` → `"security"` |
+| `justfile` | 11 | `bevy_cef_branch := "passthrough"` → `"security"` |
+
+Then `cargo update -p bevy_cef -p bevy_cef_core` to repin `Cargo.lock` from
+`700c4a6` to the `security` HEAD (currently `552dbd0`). This matches the
+existing convention: human-readable `branch` in `Cargo.toml`, exact sha
+pinned in `Cargo.lock`.
+
+`justfile:11` (`bevy_cef_branch`) feeds only the **release** render-process
+build (`setup-cef-release` / bundling). Keeping it consistent avoids a
+version skew between the bundled render process and the linked CEF crate.
+
+### Source changes
+
+None in the base case. ozmux source changes materialize **only if**
+verification (below) finds a genuine cross-origin dependency. In that case
+the fix is to emit `Access-Control-*` headers from
+`OzmuxDynScheme::handle` in `crates/webview_host/src/dyn_scheme.rs` (today
+it returns `headers: Vec::new()`), mirroring how the upstream
+`cef://localhost/` scheme already sends permissive CORS headers — **not**
+re-enabling `disable-web-security`.
+
+## Why the secure default should hold for ozmux
+
+- The `window.ozma` back-channel rides CEF **process messages**
+  (`cef.emit` → `Receive<OzmuxFrame>`), not HTTP/`fetch`. The Same-Origin
+  Policy does not touch it.
+- Webview assets are served **same-origin per handle**
+  (`ozma-dyn://<handle>/…`, one origin per handle), and the scheme is
+  registered `STANDARD | SECURE | CORS_ENABLED | FETCH_ENABLED |
+  DISPLAY_ISOLATED` (`crates/webview_host/src/dyn_scheme.rs`).
+
+Same-origin asset loading and process-message IPC do not require a relaxed
+SOP. This is the same reasoning PR #61 applied to `cef://localhost/`; the
+only thing the PR could not do was a runtime check, which §Verification
+covers here.
+
+## Verification
+
+1. `cargo build` and `cargo test --workspace` — compiles and unit tests
+   pass against the `security` branch.
+2. Static diligence: grep `sdk/`, the webview preload/bridge, and any
+   mounted page assets for cross-origin `fetch(` / absolute-URL loads;
+   confirm nothing assumes a relaxed Same-Origin Policy.
+3. Runtime (macOS GUI, `cargo run`): mount a webview and confirm
+   (a) the page renders, (b) `ozma-dyn://` assets load, (c)
+   `window.ozma.call` / `on` round-trips end-to-end.
+4. Confirm the new one-time startup `warn!` for risky switches does **not**
+   fire — positive proof that no risk-relaxing switch is active.
+
+## Operational notes
+
+- **Debug render process** comes from crates.io
+  (`bevy_cef_debug_render_process`); the PR does not change the pinned CEF
+  version, so dev (`cargo run --features debug`) only needs a rebuild.
+- **Release render process** is built from the branch; `just
+  setup-cef-release` must be re-run before bundling (covered by the
+  `justfile` bump above).
+
+## Risks & rollback
+
+- **Primary risk:** a mounted page needs cross-origin access → caught in
+  Verification, fixed via CORS headers (above).
+- **Branch churn:** `security` is an in-flight PR branch; a force-push /
+  rebase is absorbed by re-running `cargo update`. After #61 merges to
+  `main`, re-point ozmux to `main` (post-merge `main ⊇ security`).
+- **Rollback:** revert the four-line branch change plus `Cargo.lock` —
+  fully reversible, with no ozmux source changes in the base case.

--- a/docs/superpowers/specs/2026-06-21-bevy-cef-security-branch-design.md
+++ b/docs/superpowers/specs/2026-06-21-bevy-cef-security-branch-design.md
@@ -132,3 +132,21 @@ covers here.
   `main`, re-point ozmux to `main` (post-merge `main ⊇ security`).
 - **Rollback:** revert the four-line branch change plus `Cargo.lock` —
   fully reversible, with no ozmux source changes in the base case.
+
+## Update (2026-06-22): finalized to published `bevy_cef 0.11.0`
+
+PR #61 merged into `bevy_cef`'s `main` on 2026-06-21 and was released as
+**`bevy_cef 0.11.0`** (crate `bevy_cef_core 0.11.0`, render processes
+`bevy_cef_render_process` / `bevy_cef_debug_render_process` 0.11.0; git tag
+`v0.11.0`). The released `0.11.0` was verified to contain both the security
+hardening (no hardcoded `disable-web-security` in child launch; `SandboxMode`
+and `risky_present` present) and the features ozmux relies on
+(`WebviewTextureTarget`, `CefKeyboardFilter`).
+
+ozmux therefore depends on the **published version** rather than a git branch:
+`bevy_cef = "0.11"` / `bevy_cef_core = "0.11"` in the manifests (pinned to
+`0.11.0` in `Cargo.lock`, registry source), and the `justfile` installs the
+render processes from crates.io pinned to `bevy_cef_version := "0.11.0"`
+(the `bevy_cef_git` / `bevy_cef_branch` variables are removed). This supersedes
+the "re-point to `main`" follow-up noted above — the published release is the
+durable target.

--- a/justfile
+++ b/justfile
@@ -7,8 +7,7 @@ cef_dir := home_directory() / ".local/share/cef"
 cef_framework_lib := cef_dir / "Chromium Embedded Framework.framework" / "Libraries"
 cef_debug_render_process := "bevy_cef_debug_render_process"
 bevy_cef_render_process := "bevy_cef_render_process"
-bevy_cef_git := "https://github.com/not-elm/bevy_cef"
-bevy_cef_branch := "security"
+bevy_cef_version := "0.11.0"
 
 # CARGO_HOME/bin when CARGO_HOME is set and non-empty, else ~/.cargo/bin.
 # env(key, default) returns the default only when the var is ABSENT, so the
@@ -53,7 +52,7 @@ ozmd: ozmd-web
 setup-cef:
     cargo install export-cef-dir@{{ cef_version }} --force
     export-cef-dir --force "{{ cef_dir }}"
-    cargo install {{ cef_debug_render_process }}
+    cargo install {{ cef_debug_render_process }}@{{ bevy_cef_version }}
     cp "{{ cargo_bin_dir }}/{{ cef_debug_render_process }}" "{{ cef_framework_lib }}/{{ cef_debug_render_process }}"
 
 # install arm64 CEF + release render process (for bundling)
@@ -61,7 +60,7 @@ setup-cef:
 setup-cef-release:
     cargo install export-cef-dir@{{ cef_version }} --force
     export-cef-dir --force "{{ cef_dir }}"
-    cargo install --git {{ bevy_cef_git }} --branch {{ bevy_cef_branch }} {{ bevy_cef_render_process }}
+    cargo install {{ bevy_cef_render_process }}@{{ bevy_cef_version }}
 
 # build and package the ozmux .app (extra args pass through, e.g. --version 1.2.3)
 [macos]

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ cef_framework_lib := cef_dir / "Chromium Embedded Framework.framework" / "Librar
 cef_debug_render_process := "bevy_cef_debug_render_process"
 bevy_cef_render_process := "bevy_cef_render_process"
 bevy_cef_git := "https://github.com/not-elm/bevy_cef"
-bevy_cef_branch := "passthrough"
+bevy_cef_branch := "security"
 
 # CARGO_HOME/bin when CARGO_HOME is set and non-empty, else ~/.cargo/bin.
 # env(key, default) returns the default only when the var is ABSENT, so the


### PR DESCRIPTION
## Problem

ozmux embeds CEF webviews via `bevy_cef`. The `bevy_cef` versions we depended on unconditionally enabled several security-relaxing Chromium switches on every CEF child process — `disable-web-security` (×2), `allow-running-insecure-content`, `ignore-certificate-errors`, `ignore-ssl-errors` — plus a malformed `enable-logging=stderr`. ozmux never set these itself; they were inherited from `bevy_cef`'s hardcoded `on_before_child_process_launch`. The effect: every embedded webview ran with the Same-Origin Policy and TLS certificate validation disabled.

Upstream not-elm/bevy_cef#61 makes `bevy_cef` secure-by-default by removing those switches. It has since **merged and shipped as `bevy_cef 0.11.0`**.

## Solution

Depend on the published **`bevy_cef 0.11.0`** / **`bevy_cef_core 0.11.0`** from crates.io instead of a git branch.

**Affected:** build metadata only — `Cargo.toml` (×2), `crates/ozma_webview/Cargo.toml`, `justfile`, `Cargo.lock`. No ozmux source changes. (Plus design/plan notes under `docs/superpowers/`.)

- Manifests now use `bevy_cef = "0.11"` / `bevy_cef_core = "0.11"` (registry source, pinned to `0.11.0` in `Cargo.lock`).
- `justfile` installs the render processes from crates.io pinned to `bevy_cef_version := "0.11.0"` (`bevy_cef_render_process@0.11.0` and `bevy_cef_debug_render_process@0.11.0`); the `bevy_cef_git` / `bevy_cef_branch` variables are removed.
- Verified that `0.11.0` (git tag `v0.11.0`) carries **both** the security hardening (no hardcoded `disable-web-security` in child launch; `SandboxMode` + `risky_present` present) and the features ozmux relies on (`WebviewTextureTarget`, `CefKeyboardFilter`) — so ozmux compiles unchanged.
- ozmux sets no risky switch itself (`cef_command_line_config()` builds from `CommandLineConfig::default()` plus a debug-only `remote-debugging-port`), so moving to `0.11.0` is the complete fix. Sandbox stays at `SandboxMode::PlatformDefault` (the field is left unset — no behavior change).

**Why the embedded webview keeps working without `disable-web-security`:** a static audit confirmed ozmux's own injected content makes no cross-origin requests — the `window.ozma` bridge (`ozma_bridge.js`) and the `sdk/ozma-web` client use CEF process-message IPC, not HTTP, and the `ozma-dyn://` scheme serves assets same-origin per handle (`DISPLAY_ISOLATED`). No CORS opt-in was needed.

### Breaking Changes

Embedded webviews now enforce the Same-Origin Policy and TLS certificate validation (proper-browser behavior). ozmux's own content is unaffected (audited clean). Programs that mount pages relying on cross-origin `fetch` or on invalid TLS certificates will now see them blocked; the fix-forward is to emit `Access-Control-*` headers from the `ozma-dyn://` asset handler — **not** to re-enable `disable-web-security`.

### Verification

- `cargo build` and `cargo test --workspace` pass against `bevy_cef 0.11.0`. One pre-existing, unrelated failure (`ozmux_tmux::observers::tests::connection_reset_clears_everything` — missing `EnumerationState` init in that test's harness) reproduces independently of this change (`ozmux_tmux` has no `bevy_cef` dependency) and is out of scope.
- `Cargo.lock` repinned to registry `bevy_cef 0.11.0` / `bevy_cef_core 0.11.0`; no git source remains.
- Static cross-origin audit: clean. Whole-branch code review: ready to merge.
- ⚠️ **Not yet run (needs a display):** GUI runtime check that a mounted `ozma-dyn://` page, the `window.ozma` bridge, and a remote `https://` page all render with the secure default, and that the risky-switch `warn!` does not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
