### PR TITLE
feat(ozma-web): typed per-call generics for the window.ozma bridge

### DIFF
--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -150,24 +150,21 @@ function scrollByAction(action: string): void {
   reportScrollState();
 }
 
-ozma.on('content', (p) => {
-  void setContent(p as ContentPayload).catch(console.error);
+ozma.on('content', (p: ContentPayload) => {
+  void setContent(p).catch(console.error);
 });
-ozma.on('scroll', (p) => {
-  scrollByAction((p as { action: string }).action);
+ozma.on('scroll', (p: { action: string }) => {
+  scrollByAction(p.action);
 });
-ozma.on('scrollToHeading', (p) => {
-  const { index } = p as { index: number };
-  document.getElementById(`h${index}`)?.scrollIntoView({ block: 'start' });
+ozma.on('scrollToHeading', (p: { index: number }) => {
+  document.getElementById(`h${p.index}`)?.scrollIntoView({ block: 'start' });
   reportScrollState();
 });
-ozma.on('search', (p) => {
-  const { query } = p as { query: string };
-  ozma.emit('searchCount', search.run(content, query));
+ozma.on('search', (p: { query: string }) => {
+  ozma.emit('searchCount', search.run(content, p.query));
 });
-ozma.on('searchNav', (p) => {
-  const { dir } = p as { dir: 'next' | 'prev' };
-  ozma.emit('searchCount', search.navigate(dir));
+ozma.on('searchNav', (p: { dir: 'next' | 'prev' }) => {
+  ozma.emit('searchCount', search.navigate(p.dir));
 });
 ozma.on('clearSearch', () => {
   search.clear(content);

--- a/sdk/ozma-web/src/ozma.test.ts
+++ b/sdk/ozma-web/src/ozma.test.ts
@@ -36,7 +36,7 @@ describe('@ozma/web client', () => {
 
   it('reports bridge availability', () => {
     expect(isOzmaAvailable()).toBe(false);
-    g.ozma = { call: vi.fn(), on: vi.fn(), off: vi.fn() } as unknown as OzmaApi;
+    g.ozma = { call: vi.fn(), on: vi.fn(), off: vi.fn(), emit: vi.fn() } as unknown as OzmaApi;
     expect(isOzmaAvailable()).toBe(true);
   });
 });

--- a/sdk/ozma-web/src/ozma.test.ts
+++ b/sdk/ozma-web/src/ozma.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { isOzmaAvailable, type OzmaApi, ozma } from './ozma.ts';
 
 const g = globalThis as typeof globalThis & { ozma?: OzmaApi };
@@ -38,5 +38,41 @@ describe('@ozma/web client', () => {
     expect(isOzmaAvailable()).toBe(false);
     g.ozma = { call: vi.fn(), on: vi.fn(), off: vi.fn() } as unknown as OzmaApi;
     expect(isOzmaAvailable()).toBe(true);
+  });
+});
+
+describe('@ozma/web types (compile-time)', () => {
+  beforeEach(() => {
+    g.ozma = { call: vi.fn(), on: vi.fn(), off: vi.fn(), emit: vi.fn() } as unknown as OzmaApi;
+  });
+
+  it('infers the on() handler payload from a parameter annotation', () => {
+    ozma.on('content', (p: { markdown: string }) => {
+      expectTypeOf(p).toEqualTypeOf<{ markdown: string }>();
+    });
+  });
+
+  it('accepts an explicit payload generic on on()', () => {
+    ozma.on<{ x: number }>('e', (p) => {
+      expectTypeOf(p).toEqualTypeOf<{ x: number }>();
+    });
+  });
+
+  it('defaults the on() payload to unknown without a type', () => {
+    ozma.on('content', (p) => {
+      expectTypeOf(p).toBeUnknown();
+    });
+  });
+
+  it('types emit payloads and call params/results', () => {
+    ozma.emit('scrollState', { ratio: 0.5 });
+    ozma.emit<{ ratio: number }>('scrollState', { ratio: 0.5 });
+    void ozma.call<string, { path: string }>('save', { path: '/tmp' });
+    expectTypeOf(ozma.call<string>('ready')).resolves.toEqualTypeOf<string>();
+  });
+
+  it('rejects a payload that mismatches an explicit generic', () => {
+    // @ts-expect-error payload must satisfy the declared <{ ratio: number }> generic
+    ozma.emit<{ ratio: number }>('scrollState', { ratio: 'not-a-number' });
   });
 });

--- a/sdk/ozma-web/src/ozma.ts
+++ b/sdk/ozma-web/src/ozma.ts
@@ -5,17 +5,33 @@ export interface OzmaApi {
   /**
    * Invokes a host-routed method and resolves with its reply.
    *
-   * A top-level `Uint8Array` in `params` and in the resolved value round-trips
-   * (the bridge base64-tags it). NOTE: bytes nested inside an object or array do
-   * NOT round-trip and are silently lost.
+   * Supply `<R>` for the reply type — it sits in a return position and cannot be
+   * inferred; `<P>` (params) is inferred from the argument. A top-level
+   * `Uint8Array` in `params` and in the resolved value round-trips (the bridge
+   * base64-tags it). NOTE: bytes nested inside an object or array do NOT
+   * round-trip and are silently lost.
    */
-  call<R = unknown>(method: string, params?: unknown): Promise<R>;
-  /** Subscribes `handler` to a named host event. */
-  on(event: string, handler: (payload: unknown) => void): void;
-  /** Removes a previously-registered event handler by reference equality. */
-  off(event: string, handler: (payload: unknown) => void): void;
-  /** Sends a one-way event to the host app (fire-and-forget; no reply). */
-  emit(event: string, payload?: unknown): void;
+  call<R = unknown, P = unknown>(method: string, params?: P): Promise<R>;
+  /**
+   * Subscribes `handler` to a named host event.
+   *
+   * Annotate the handler parameter (`(payload: T) => …`) to type `payload`; `P`
+   * is inferred from that annotation and defaults to `unknown`.
+   */
+  on<P = unknown>(event: string, handler: (payload: P) => void): void;
+  /**
+   * Removes a previously-registered event handler by reference equality.
+   *
+   * `P` is generic so a typed handler stays assignable here under
+   * `strictFunctionTypes`; it should match the type used at `on`.
+   */
+  off<P = unknown>(event: string, handler: (payload: P) => void): void;
+  /**
+   * Sends a one-way event to the host app (fire-and-forget; no reply).
+   *
+   * `P` (payload) is inferred from the argument and defaults to `unknown`.
+   */
+  emit<P = unknown>(event: string, payload?: P): void;
 }
 
 // NOTE: augments `window.ozma` for browser consumers whose tsconfig includes the "dom" lib;
@@ -40,17 +56,17 @@ function resolve(): OzmaApi {
 
 /** Typed accessor for the host-injected `window.ozma` bridge; throws if absent. */
 export const ozma: OzmaApi = {
-  call<R = unknown>(method: string, params?: unknown): Promise<R> {
-    return resolve().call<R>(method, params);
+  call<R = unknown, P = unknown>(method: string, params?: P): Promise<R> {
+    return resolve().call<R, P>(method, params);
   },
-  on(event: string, handler: (payload: unknown) => void): void {
-    resolve().on(event, handler);
+  on<P = unknown>(event: string, handler: (payload: P) => void): void {
+    resolve().on<P>(event, handler);
   },
-  off(event: string, handler: (payload: unknown) => void): void {
-    resolve().off(event, handler);
+  off<P = unknown>(event: string, handler: (payload: P) => void): void {
+    resolve().off<P>(event, handler);
   },
-  emit(event: string, payload?: unknown): void {
-    resolve().emit(event, payload);
+  emit<P = unknown>(event: string, payload?: P): void {
+    resolve().emit<P>(event, payload);
   },
 };
 

--- a/sdk/ozma-web/src/ozma.ts
+++ b/sdk/ozma-web/src/ozma.ts
@@ -57,16 +57,16 @@ function resolve(): OzmaApi {
 /** Typed accessor for the host-injected `window.ozma` bridge; throws if absent. */
 export const ozma: OzmaApi = {
   call<R = unknown, P = unknown>(method: string, params?: P): Promise<R> {
-    return resolve().call<R, P>(method, params);
+    return resolve().call<R>(method, params);
   },
   on<P = unknown>(event: string, handler: (payload: P) => void): void {
-    resolve().on<P>(event, handler);
+    resolve().on(event, handler);
   },
   off<P = unknown>(event: string, handler: (payload: P) => void): void {
-    resolve().off<P>(event, handler);
+    resolve().off(event, handler);
   },
   emit<P = unknown>(event: string, payload?: P): void {
-    resolve().emit<P>(event, payload);
+    resolve().emit(event, payload);
   },
 };
 


### PR DESCRIPTION
## Summary

Adds per-call payload type parameters to the `@ozma/web` `window.ozma` bridge client so consumers declare payload types idiomatically instead of casting. Compile-time only — generics are type-erased; the host bridge and wire protocol are untouched.

`OzmaApi` methods gain a payload generic that **defaults to `unknown`**, making the new surface a strict superset of today's:

```ts
call<R = unknown, P = unknown>(method: string, params?: P): Promise<R>;
on<P = unknown>(event: string, handler: (payload: P) => void): void;
off<P = unknown>(event: string, handler: (payload: P) => void): void;
emit<P = unknown>(event: string, payload?: P): void;
```

`P` is inferred from a handler's parameter annotation (`on`/`off`) or the payload argument (`emit`); `R` is supplied for `call` (a return position, so not inferable).

## Changes

- **`sdk/ozma-web`**: payload generics on `OzmaApi` + the `ozma` singleton; refreshed JSDoc; compile-time `expectTypeOf` assertions (enforced by `pnpm check-types`).
- **`apps/ozmd/web/main.ts`**: migrated handlers to annotated, cast-free params — every `p as T` removed (behavior identical).
- **Tidy**: completed the availability-test bridge mock with `emit`; dropped redundant inferred `<P>` in the singleton's internal forwarding (only `call<R>` is load-bearing).

## Backward compatibility

Strict superset — every existing call site compiles unchanged (`call('ping','hi')`, `call<ContentPayload>('ready')`, zero-arg handlers, inferred `emit`).

## Deliberate trade-offs (not oversights)

- Event/method **names** stay free `string`s (not linked to payload types); a future `createOzma<Contract>()` could add name↔type checking additively without changing these signatures.
- `params?`/`payload?` stay optional — an explicitly-typed `emit<T>('e')` may omit the value. Overloads would force it; deferred for minimalism.
- Runtime payload validation is out of scope.

## Test plan

- `pnpm -r test` — 23 passing (8 `@ozma/web` + 15 `@ozma/ozmd-web`)
- `pnpm check-types` — clean
- `pnpm lint` (biome) — clean
- Reviewed via per-task reviews, a whole-branch review, and a max-effort multi-agent `/code-review` (no production bugs found; one redundancy cleanup applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwxeKvwk3cFswbTJxmD2u6
