### PR TITLE
fix: set a fallback TERM at startup so bundled launches keep line editing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,22 +42,9 @@ use ui::{
 };
 
 fn main() {
-    // Mirror alacritty_terminal::tty::setup_env: a child shell (a tmux pane or
-    // the native ozma PTY) whose TERM is empty/unset cannot load terminfo, so
-    // zsh's line editor (ZLE) — Backspace included — silently breaks. A bundled
-    // .app launched from Finder inherits launchd's empty TERM, so fill a portable
-    // default before any PTY child is spawned. `xterm-256color` is exactly what
-    // Alacritty falls back to when the `alacritty` terminfo is absent (it is, on
-    // stock macOS); `COLORTERM` advertises the 24-bit color that entry omits.
-    if let Some(term) = term_fallback(std::env::var("TERM").ok().as_deref()) {
-        // SAFETY: this runs at the very top of main(), before App::new() spawns
-        // any task-pool threads, so no other thread can read the environment
-        // concurrently with these writes.
-        unsafe {
-            std::env::set_var("TERM", term);
-            std::env::set_var("COLORTERM", "truecolor");
-        }
-    }
+    // NOTE: must run before App::new() spawns any thread — it writes process
+    // env vars, which is unsound once other threads may read the environment.
+    ensure_terminfo_env();
 
     let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
     // NOTE: start in AppMode::Tmux as a boot-dispatch state; dispatch_startup_mode
@@ -116,6 +103,35 @@ fn main() {
             DefaultHostInputPlugin,
         ))
         .run();
+}
+
+/// Fills `TERM`/`COLORTERM` with a portable default when the inherited `TERM`
+/// is unset or empty, mirroring `alacritty_terminal::tty::setup_env`.
+///
+/// A child shell (a tmux pane or the native ozma PTY) whose `TERM` is empty
+/// cannot load terminfo, so zsh's line editor (ZLE) — Backspace included —
+/// silently breaks; a bundled `.app` launched from Finder inherits launchd's
+/// empty `TERM`. `xterm-256color` is exactly Alacritty's fallback when the
+/// `alacritty` terminfo is absent (it is, on stock macOS); `COLORTERM`
+/// advertises the 24-bit color that entry omits. A usable inherited `TERM` is
+/// left untouched, so terminal launches are unchanged.
+///
+/// # Invariants
+///
+/// Must be called before any thread is spawned (i.e. at the very top of
+/// `main()`): it writes process environment variables, which is unsound once
+/// another thread may read the environment concurrently.
+fn ensure_terminfo_env() {
+    let Some(term) = term_fallback(std::env::var("TERM").ok().as_deref()) else {
+        return;
+    };
+    // SAFETY: the caller invokes this before App::new() spawns any task-pool
+    // thread, so no other thread can read the environment concurrently with
+    // these writes (see # Invariants).
+    unsafe {
+        std::env::set_var("TERM", term);
+        std::env::set_var("COLORTERM", "truecolor");
+    }
 }
 
 /// The portable `TERM` ozmux substitutes when the inherited one cannot resolve

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,23 @@ use ui::{
 };
 
 fn main() {
+    // Mirror alacritty_terminal::tty::setup_env: a child shell (a tmux pane or
+    // the native ozma PTY) whose TERM is empty/unset cannot load terminfo, so
+    // zsh's line editor (ZLE) — Backspace included — silently breaks. A bundled
+    // .app launched from Finder inherits launchd's empty TERM, so fill a portable
+    // default before any PTY child is spawned. `xterm-256color` is exactly what
+    // Alacritty falls back to when the `alacritty` terminfo is absent (it is, on
+    // stock macOS); `COLORTERM` advertises the 24-bit color that entry omits.
+    if let Some(term) = term_fallback(std::env::var("TERM").ok().as_deref()) {
+        // SAFETY: this runs at the very top of main(), before App::new() spawns
+        // any task-pool threads, so no other thread can read the environment
+        // concurrently with these writes.
+        unsafe {
+            std::env::set_var("TERM", term);
+            std::env::set_var("COLORTERM", "truecolor");
+        }
+    }
+
     let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
     // NOTE: start in AppMode::Tmux as a boot-dispatch state; dispatch_startup_mode
     // (OnEnter(Tmux), gated to run once) routes to the real mode. Routing to Default
@@ -99,4 +116,36 @@ fn main() {
             DefaultHostInputPlugin,
         ))
         .run();
+}
+
+/// The portable `TERM` ozmux substitutes when the inherited one cannot resolve
+/// terminfo, or `None` to keep a usable inherited value. Returns the fallback
+/// for an unset (`None`) or empty `TERM`; otherwise `None`.
+fn term_fallback(current: Option<&str>) -> Option<&'static str> {
+    match current {
+        Some(term) if !term.is_empty() => None,
+        _ => Some("xterm-256color"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_term_gets_fallback() {
+        assert_eq!(term_fallback(None), Some("xterm-256color"));
+    }
+
+    #[test]
+    fn empty_term_gets_fallback() {
+        assert_eq!(term_fallback(Some("")), Some("xterm-256color"));
+    }
+
+    #[test]
+    fn valid_term_is_preserved() {
+        assert_eq!(term_fallback(Some("tmux-256color")), None);
+        assert_eq!(term_fallback(Some("xterm-256color")), None);
+        assert_eq!(term_fallback(Some("screen")), None);
+    }
 }


### PR DESCRIPTION
## Problem

Running ozmux from the bundled `.app` (Finder/`open`), **Backspace stops deleting** — the character stays and the cursor advances — while `cargo run` (debug) is fine.

## Root cause

A Finder-launched `.app` inherits launchd's minimal environment where **`TERM` is empty**. ozmux spawns `tmux -CC` (and the native ozma PTY) with that environment, so the pane shells come up with an **empty `$TERM`**. With no `TERM`, zsh can't load terminfo and its line editor (ZLE) silently degrades — Backspace included — even though `bindkey '^?'` (`backward-delete-char`), `stty erase` (`^?`), and the delivered `0x7f` byte are all correct. `cargo run` only worked because it inherits a real `TERM` from the launching terminal.

Investigation ruled out every other layer with evidence: winit→ozmux→tmux key encoding (`send-keys -- BSpace` → `0x7f`), tmux key translation, `stty erase`, the `--no-default-features`/`dist` build difference (only the CEF `debug` feature), and IME (separate pre-existing issue). A pane forced to an empty `$TERM` reproduces the broken Backspace exactly.

## Fix

Mirror [`alacritty_terminal::tty::setup_env`](https://github.com/alacritty/alacritty): at the top of `main()` (before any task-pool thread spawns), fill `TERM=xterm-256color` + `COLORTERM=truecolor` **only when the inherited `TERM` is unset or empty**.

- `xterm-256color` is exactly Alacritty's fallback when the `alacritty` terminfo is absent (it is, on stock macOS), and is a system-standard entry in `/usr/share/terminfo`.
- A usable inherited `TERM` is left untouched → terminal launches unchanged.
- Process-wide placement covers both the tmux panes and the native ozma PTY.

This direction was cross-checked against Alacritty's source via parallel research (Codex + agent), both High confidence.

## Verification

- `cargo test --bin ozmux` → 16 passed (incl. 3 new `term_fallback` tests)
- `cargo clippy --bin ozmux` → no warnings
- Rebuilt the `dist` bundle and confirmed Backspace deletes (and `$TERM` is non-empty) in a Finder-launched pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuPjM8h6GDuJHiSF9pSoJ5