### PR TITLE
fix(ui): scope UI tree per AppMode so the tmux window bar despawns on mode exit

### DIFF
--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -227,12 +227,15 @@ fn on_connection_reset(
     mut keybindings: ResMut<KeyBindings>,
     mut copy_queries: ResMut<CopyModeQueries>,
 ) {
+    // NOTE: try_despawn, not despawn: on a mode exit DespawnOnExit(Tmux) may have already removed
+    // these window entities (they are ChildOf the WorkspaceUiRoot subtree); plain despawn would
+    // warn per already-gone entity.
     for (_, e) in index.windows.drain() {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
     index.panes.clear();
     if let Some(e) = index.session.take() {
-        commands.entity(e).despawn();
+        commands.entity(e).try_despawn();
     }
     index.pending_active_pane = None;
     *enumeration = EnumerationState::default();
@@ -301,7 +304,7 @@ fn despawn_window(commands: &mut Commands, index: &mut TmuxProjection, id: Windo
         return;
     };
     index.panes.retain(|_, (_, w)| *w != id);
-    commands.entity(e).despawn();
+    commands.entity(e).try_despawn();
 }
 
 fn set_marker<T: Component + Default>(
@@ -322,7 +325,10 @@ mod tests {
 
     fn app() -> App {
         let mut app = App::new();
-        app.init_resource::<TmuxProjection>();
+        app.init_resource::<TmuxProjection>()
+            .init_resource::<EnumerationState>()
+            .init_resource::<KeyBindings>()
+            .init_resource::<CopyModeQueries>();
         register_observers(&mut app);
         app
     }

--- a/crates/tmux_session/src/observers.rs
+++ b/crates/tmux_session/src/observers.rs
@@ -227,15 +227,17 @@ fn on_connection_reset(
     mut keybindings: ResMut<KeyBindings>,
     mut copy_queries: ResMut<CopyModeQueries>,
 ) {
-    // NOTE: try_despawn, not despawn: on a mode exit DespawnOnExit(Tmux) may have already removed
-    // these window entities (they are ChildOf the WorkspaceUiRoot subtree); plain despawn would
-    // warn per already-gone entity.
+    // NOTE: try_despawn for the window entities only. They are reparented
+    // ChildOf the WorkspaceUiRoot subtree, so on a mode exit DespawnOnExit(Tmux)
+    // may have already removed them and plain despawn would warn per already-gone
+    // entity. The session entity below is NOT under that subtree, so it keeps
+    // plain despawn — a warning there would flag a genuine index/world desync.
     for (_, e) in index.windows.drain() {
         commands.entity(e).try_despawn();
     }
     index.panes.clear();
     if let Some(e) = index.session.take() {
-        commands.entity(e).try_despawn();
+        commands.entity(e).despawn();
     }
     index.pending_active_pane = None;
     *enumeration = EnumerationState::default();
@@ -304,7 +306,7 @@ fn despawn_window(commands: &mut Commands, index: &mut TmuxProjection, id: Windo
         return;
     };
     index.panes.retain(|_, (_, w)| *w != id);
-    commands.entity(e).try_despawn();
+    commands.entity(e).despawn();
 }
 
 fn set_marker<T: Component + Default>(

--- a/src/app_mode.rs
+++ b/src/app_mode.rs
@@ -2,7 +2,6 @@
 
 use crate::ui::UiRoot;
 use bevy::prelude::*;
-use bevy::ui::Val;
 use ozma_terminal::{KeyboardFocused, OzmaSpawnOptions, OzmaTerminalBundle, OzmaTerminalConfig};
 
 /// Application mode. `Default` is the default (single PTY, no tmux).
@@ -26,23 +25,21 @@ struct DefaultModeUi;
 /// `OzmaTerminal` under `DefaultModeUi`) exists while in `AppMode::Default`.
 ///
 /// The subtree is built by `ensure_default_mode_ui`, gated
-/// `run_if(in_state(Default).and(no_default_mode_ui))` so it spawns once `UiRoot`
-/// exists (boot-safe: `Update` always runs after `Startup`) and re-fires on
-/// re-entry. Teardown is `DespawnOnExit`. `OzmaTerminalPlugin` must be added
-/// first (it inserts the `OzmaTerminalConfig` this reads).
+/// `run_if(in_state(AppMode::Default).and(not(any_with_component::<DefaultModeUi>)))`:
+/// it runs in `Update` (always after `Startup` spawns `UiRoot`) and re-fires on
+/// re-entry once the previous subtree is gone. Teardown is `DespawnOnExit`.
+/// `OzmaTerminalPlugin` must be added first (it inserts the `OzmaTerminalConfig`
+/// this reads).
 pub(crate) struct DefaultModePlugin;
 
 impl Plugin for DefaultModePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            ensure_default_mode_ui.run_if(in_state(AppMode::Default).and(no_default_mode_ui)),
+            ensure_default_mode_ui
+                .run_if(in_state(AppMode::Default).and(not(any_with_component::<DefaultModeUi>))),
         );
     }
-}
-
-fn no_default_mode_ui(roots: Query<(), With<DefaultModeUi>>) -> bool {
-    roots.is_empty()
 }
 
 fn ensure_default_mode_ui(
@@ -54,17 +51,11 @@ fn ensure_default_mode_ui(
     let Ok(ui_root) = ui_root.single() else {
         return;
     };
-    let bundle = match OzmaTerminalBundle::spawn(OzmaSpawnOptions {
-        shell: config.shell.clone(),
-        ..default()
-    }) {
-        Ok(bundle) => bundle,
-        Err(e) => {
-            tracing::error!(?e, "failed to spawn ozma terminal");
-            exit.write(AppExit::Success);
-            return;
-        }
-    };
+    // NOTE: spawn the DefaultModeUi container before attempting the PTY spawn.
+    // The run condition gates on `DefaultModeUi` being absent; if the PTY spawn
+    // failed and we returned without the container, this Update system would
+    // re-fire every frame — re-attempting the PTY and re-writing AppExit.
+    // Spawning the container first makes a failure a single attempt.
     let mode_ui = commands
         .spawn((
             Name::new("Default Mode UI"),
@@ -78,20 +69,16 @@ fn ensure_default_mode_ui(
             ChildOf(ui_root),
         ))
         .id();
-    commands.spawn((bundle, KeyboardFocused, ChildOf(mode_ui)));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bevy::ecs::system::RunSystemOnce;
-
-    #[test]
-    fn no_default_mode_ui_is_true_until_one_exists() {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
-        assert!(app.world_mut().run_system_once(no_default_mode_ui).unwrap());
-        app.world_mut().spawn(DefaultModeUi);
-        assert!(!app.world_mut().run_system_once(no_default_mode_ui).unwrap());
+    match OzmaTerminalBundle::spawn(OzmaSpawnOptions {
+        shell: config.shell.clone(),
+        ..default()
+    }) {
+        Ok(bundle) => {
+            commands.spawn((bundle, KeyboardFocused, ChildOf(mode_ui)));
+        }
+        Err(e) => {
+            tracing::error!(?e, "failed to spawn ozma terminal");
+            exit.write(AppExit::Success);
+        }
     }
 }

--- a/src/app_mode.rs
+++ b/src/app_mode.rs
@@ -1,9 +1,9 @@
-//! AppMode state enum and the Default-mode single-terminal lifecycle plugin.
+//! AppMode state enum and the Default-mode UI subtree lifecycle plugin.
 
+use crate::ui::UiRoot;
 use bevy::prelude::*;
-use ozma_terminal::{
-    KeyboardFocused, OzmaSpawnOptions, OzmaTerminal, OzmaTerminalBundle, OzmaTerminalConfig,
-};
+use bevy::ui::Val;
+use ozma_terminal::{KeyboardFocused, OzmaSpawnOptions, OzmaTerminalBundle, OzmaTerminalConfig};
 
 /// Application mode. `Default` is the default (single PTY, no tmux).
 /// `Tmux` activates the tmux multiplexer backend.
@@ -16,43 +16,82 @@ pub(crate) enum AppMode {
     Tmux,
 }
 
-/// Bevy plugin that registers the `AppMode::Default` spawn/despawn lifecycle.
+/// Root of the Default-mode UI subtree, mounted under `UiRoot` while in
+/// `AppMode::Default`. Carries `DespawnOnExit(AppMode::Default)`, so leaving
+/// Default mode removes the subtree (including its child terminal).
+#[derive(Component)]
+struct DefaultModeUi;
+
+/// Bevy plugin that ensures the Default-mode UI subtree (a single
+/// `OzmaTerminal` under `DefaultModeUi`) exists while in `AppMode::Default`.
 ///
-/// Spawns one `OzmaTerminal` entity (marked `KeyboardFocused`, the keyboard
-/// target) on `OnEnter(AppMode::Default)` and despawns it on
-/// `OnExit(AppMode::Default)`. Requires `AppMode` to be inserted via
-/// `App::insert_state` before this plugin runs, and `OzmaTerminalPlugin` must
-/// be added first (it inserts `OzmaTerminalConfig` that `spawn_terminal` reads).
+/// The subtree is built by `ensure_default_mode_ui`, gated
+/// `run_if(in_state(Default).and(no_default_mode_ui))` so it spawns once `UiRoot`
+/// exists (boot-safe: `Update` always runs after `Startup`) and re-fires on
+/// re-entry. Teardown is `DespawnOnExit`. `OzmaTerminalPlugin` must be added
+/// first (it inserts the `OzmaTerminalConfig` this reads).
 pub(crate) struct DefaultModePlugin;
 
 impl Plugin for DefaultModePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(OnEnter(AppMode::Default), spawn_terminal)
-            .add_systems(OnExit(AppMode::Default), despawn_terminal);
+        app.add_systems(
+            Update,
+            ensure_default_mode_ui.run_if(in_state(AppMode::Default).and(no_default_mode_ui)),
+        );
     }
 }
 
-fn spawn_terminal(
+fn no_default_mode_ui(roots: Query<(), With<DefaultModeUi>>) -> bool {
+    roots.is_empty()
+}
+
+fn ensure_default_mode_ui(
     mut commands: Commands,
     mut exit: MessageWriter<AppExit>,
+    ui_root: Query<Entity, With<UiRoot>>,
     config: Res<OzmaTerminalConfig>,
 ) {
-    match OzmaTerminalBundle::spawn(OzmaSpawnOptions {
+    let Ok(ui_root) = ui_root.single() else {
+        return;
+    };
+    let bundle = match OzmaTerminalBundle::spawn(OzmaSpawnOptions {
         shell: config.shell.clone(),
         ..default()
     }) {
-        Ok(bundle) => {
-            commands.spawn((bundle, KeyboardFocused));
-        }
+        Ok(bundle) => bundle,
         Err(e) => {
             tracing::error!(?e, "failed to spawn ozma terminal");
             exit.write(AppExit::Success);
+            return;
         }
-    }
+    };
+    let mode_ui = commands
+        .spawn((
+            Name::new("Default Mode UI"),
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..default()
+            },
+            DespawnOnExit(AppMode::Default),
+            DefaultModeUi,
+            ChildOf(ui_root),
+        ))
+        .id();
+    commands.spawn((bundle, KeyboardFocused, ChildOf(mode_ui)));
 }
 
-fn despawn_terminal(mut commands: Commands, terminals: Query<Entity, With<OzmaTerminal>>) {
-    for entity in terminals.iter() {
-        commands.entity(entity).despawn();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+
+    #[test]
+    fn no_default_mode_ui_is_true_until_one_exists() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        assert!(app.world_mut().run_system_once(no_default_mode_ui).unwrap());
+        app.world_mut().spawn(DefaultModeUi);
+        assert!(!app.world_mut().run_system_once(no_default_mode_ui).unwrap());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,10 +44,10 @@ use ui::{
 fn main() {
     let pre_configs = ozmux_configs::OzmuxConfigs::load().unwrap_or_default();
     // NOTE: start in AppMode::Tmux as a boot-dispatch state; dispatch_startup_mode
-    // (OnEnter(Tmux), gated to run once) routes to the real mode. Routing to Default
-    // via a queued NextState — rather than booting straight into Default — defers
-    // OnEnter(AppMode::Default) (spawn_terminal) to a post-Startup StateTransition, so
-    // Startup deferred commands (e.g. init_atlas_image inserting AtlasImage) flush first.
+    // (registered on OnEnter(Tmux), gated to run once) routes to the real startup
+    // mode. The initial state MUST be Tmux for that OnEnter(Tmux) hook to fire;
+    // routing out of it (to Default when configured) is a queued NextState applied
+    // at the first post-Startup StateTransition.
     let initial_mode = match pre_configs.startup_mode {
         StartupMode::Default | StartupMode::Tmux | StartupMode::TmuxAutoAttach => AppMode::Tmux,
     };

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -6,6 +6,7 @@ mod divider_handle;
 mod forward;
 mod gate;
 mod input;
+mod mode_ui;
 mod mouse;
 mod pane_focus;
 pub(crate) mod pane_hit;
@@ -22,6 +23,7 @@ use divider_handle::DividerHandlePlugin;
 use forward::ForwardPlugin;
 use gate::GatePlugin;
 use input::InputPlugin;
+use mode_ui::TmuxModeUiPlugin;
 use mouse::MousePlugin;
 use ozmux_tmux::{
     TmuxConnection, TmuxConnectionClosed, TmuxConnectionReset, TmuxPresence, TmuxSessionPlugin,
@@ -57,6 +59,7 @@ impl Plugin for OzmuxTmuxPlugin {
                 PaneFocusPlugin,
                 GatePlugin,
                 WebviewTokensPlugin,
+                TmuxModeUiPlugin,
             ));
     }
 }

--- a/src/tmux/mode_ui.rs
+++ b/src/tmux/mode_ui.rs
@@ -1,0 +1,94 @@
+//! Mode-scoped UI for `AppMode::Tmux`: spawns the Tmux subtree under `UiRoot`
+//! while in Tmux mode and relies on `DespawnOnExit` to remove it on exit.
+
+use crate::app_mode::AppMode;
+use crate::ui::UiRoot;
+use bevy::prelude::*;
+use bevy::ui::Val;
+
+/// Root of the Tmux-mode UI subtree, mounted under `UiRoot` while in
+/// `AppMode::Tmux`. Carries `DespawnOnExit(AppMode::Tmux)`, so leaving Tmux mode
+/// removes the whole subtree.
+#[derive(Component)]
+struct TmuxModeUi;
+
+/// Bevy plugin that ensures the Tmux-mode UI subtree exists while in Tmux mode.
+pub(crate) struct TmuxModeUiPlugin;
+
+impl Plugin for TmuxModeUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            ensure_tmux_mode_ui.run_if(in_state(AppMode::Tmux).and(no_tmux_mode_ui)),
+        );
+    }
+}
+
+fn no_tmux_mode_ui(roots: Query<(), With<TmuxModeUi>>) -> bool {
+    roots.is_empty()
+}
+
+fn ensure_tmux_mode_ui(mut commands: Commands, ui_root: Query<Entity, With<UiRoot>>) {
+    let Ok(ui_root) = ui_root.single() else {
+        return;
+    };
+    commands.spawn((
+        Name::new("Tmux Mode UI"),
+        Node {
+            flex_direction: FlexDirection::Column,
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            ..default()
+        },
+        DespawnOnExit(AppMode::Tmux),
+        TmuxModeUi,
+        ChildOf(ui_root),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::state::app::StatesPlugin;
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin));
+        app.insert_state(AppMode::Tmux);
+        app.world_mut().spawn((Node::default(), UiRoot));
+        app.add_plugins(TmuxModeUiPlugin);
+        app
+    }
+
+    #[test]
+    fn no_tmux_mode_ui_is_true_until_one_exists() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        assert!(app.world_mut().run_system_once(no_tmux_mode_ui).unwrap());
+        app.world_mut().spawn(TmuxModeUi);
+        assert!(!app.world_mut().run_system_once(no_tmux_mode_ui).unwrap());
+    }
+
+    #[test]
+    fn spawns_tmux_mode_ui_under_ui_root_in_tmux() {
+        let mut app = build_app();
+        app.update();
+        let world = app.world_mut();
+        let mut q = world.query_filtered::<(), With<TmuxModeUi>>();
+        assert_eq!(q.iter(world).count(), 1, "exactly one TmuxModeUi");
+    }
+
+    #[test]
+    fn despawns_tmux_mode_ui_on_exit_to_default() {
+        let mut app = build_app();
+        app.update();
+        app.world_mut()
+            .resource_mut::<NextState<AppMode>>()
+            .set(AppMode::Default);
+        app.update();
+        let world = app.world_mut();
+        let mut q = world.query_filtered::<(), With<TmuxModeUi>>();
+        assert_eq!(q.iter(world).count(), 0, "TmuxModeUi removed on exit");
+    }
+}

--- a/src/tmux/mode_ui.rs
+++ b/src/tmux/mode_ui.rs
@@ -2,9 +2,11 @@
 //! while in Tmux mode and relies on `DespawnOnExit` to remove it on exit.
 
 use crate::app_mode::AppMode;
+use crate::tmux::window_bar::spawn_window_bar;
 use crate::ui::UiRoot;
 use bevy::prelude::*;
 use bevy::ui::Val;
+use ozma_tty_renderer::TerminalCellMetricsResource;
 
 /// Root of the Tmux-mode UI subtree, mounted under `UiRoot` while in
 /// `AppMode::Tmux`. Carries `DespawnOnExit(AppMode::Tmux)`, so leaving Tmux mode
@@ -34,7 +36,11 @@ fn no_tmux_mode_ui(roots: Query<(), With<TmuxModeUi>>) -> bool {
     roots.is_empty()
 }
 
-fn ensure_tmux_mode_ui(mut commands: Commands, ui_root: Query<Entity, With<UiRoot>>) {
+fn ensure_tmux_mode_ui(
+    mut commands: Commands,
+    ui_root: Query<Entity, With<UiRoot>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
+) {
     let Ok(ui_root) = ui_root.single() else {
         return;
     };
@@ -64,18 +70,34 @@ fn ensure_tmux_mode_ui(mut commands: Commands, ui_root: Query<Entity, With<UiRoo
         WorkspaceUiRoot,
         ChildOf(tmux_ui),
     ));
+
+    spawn_window_bar(&mut commands, tmux_ui, metrics.as_deref());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tmux::window_bar::WindowBarRoot;
     use bevy::ecs::system::RunSystemOnce;
     use bevy::state::app::StatesPlugin;
 
     fn build_app() -> App {
+        use ozma_tty_renderer::{CellMetrics, TerminalCellMetricsResource};
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Tmux);
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: CellMetrics {
+                advance_phys: 8.0,
+                line_height_phys: 16.0,
+                ascent_phys: 12.0,
+                descent_phys: 4.0,
+                underline_position_phys: -2.0,
+                underline_thickness_phys: 1.0,
+                max_overflow_phys: 0.0,
+            },
+            phys_font_size: 12,
+        });
         app.world_mut().spawn((Node::default(), UiRoot));
         app.add_plugins(TmuxModeUiPlugin);
         app
@@ -127,5 +149,29 @@ mod tests {
         let world = app.world_mut();
         let mut q = world.query_filtered::<(), With<TmuxModeUi>>();
         assert_eq!(q.iter(world).count(), 0, "TmuxModeUi removed on exit");
+    }
+
+    #[test]
+    fn tmux_subtree_includes_window_bar() {
+        let mut app = build_app();
+        app.update();
+        let world = app.world_mut();
+        let mut q = world.query_filtered::<(), With<WindowBarRoot>>();
+        assert_eq!(q.iter(world).count(), 1, "window bar mounts in Tmux mode");
+    }
+
+    #[test]
+    fn leaving_tmux_removes_window_bar() {
+        let mut app = build_app();
+        app.update();
+        app.world_mut()
+            .resource_mut::<NextState<AppMode>>()
+            .set(AppMode::Default);
+        app.update();
+        let world = app.world_mut();
+        let mut bar = world.query_filtered::<(), With<WindowBarRoot>>();
+        let mut ws = world.query_filtered::<(), With<WorkspaceUiRoot>>();
+        assert_eq!(bar.iter(world).count(), 0, "window bar removed on exit");
+        assert_eq!(ws.iter(world).count(), 0, "workspace removed on exit");
     }
 }

--- a/src/tmux/mode_ui.rs
+++ b/src/tmux/mode_ui.rs
@@ -5,7 +5,6 @@ use crate::app_mode::AppMode;
 use crate::tmux::window_bar::spawn_window_bar;
 use crate::ui::UiRoot;
 use bevy::prelude::*;
-use bevy::ui::Val;
 use ozma_tty_renderer::TerminalCellMetricsResource;
 
 /// Root of the Tmux-mode UI subtree, mounted under `UiRoot` while in
@@ -27,13 +26,10 @@ impl Plugin for TmuxModeUiPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            ensure_tmux_mode_ui.run_if(in_state(AppMode::Tmux).and(no_tmux_mode_ui)),
+            ensure_tmux_mode_ui
+                .run_if(in_state(AppMode::Tmux).and(not(any_with_component::<TmuxModeUi>))),
         );
     }
-}
-
-fn no_tmux_mode_ui(roots: Query<(), With<TmuxModeUi>>) -> bool {
-    roots.is_empty()
 }
 
 fn ensure_tmux_mode_ui(
@@ -78,11 +74,10 @@ fn ensure_tmux_mode_ui(
 mod tests {
     use super::*;
     use crate::tmux::window_bar::WindowBarRoot;
-    use bevy::ecs::system::RunSystemOnce;
     use bevy::state::app::StatesPlugin;
 
     fn build_app() -> App {
-        use ozma_tty_renderer::{CellMetrics, TerminalCellMetricsResource};
+        use ozma_tty_renderer::CellMetrics;
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, StatesPlugin));
         app.insert_state(AppMode::Tmux);
@@ -118,15 +113,6 @@ mod tests {
             .expect("WorkspaceUiRoot present")
             .parent();
         assert_eq!(parent, tmux_ui, "WorkspaceUiRoot under TmuxModeUi");
-    }
-
-    #[test]
-    fn no_tmux_mode_ui_is_true_until_one_exists() {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
-        assert!(app.world_mut().run_system_once(no_tmux_mode_ui).unwrap());
-        app.world_mut().spawn(TmuxModeUi);
-        assert!(!app.world_mut().run_system_once(no_tmux_mode_ui).unwrap());
     }
 
     #[test]

--- a/src/tmux/mode_ui.rs
+++ b/src/tmux/mode_ui.rs
@@ -12,6 +12,12 @@ use bevy::ui::Val;
 #[derive(Component)]
 struct TmuxModeUi;
 
+/// Workspace container under `TmuxModeUi` where the tmux render layer parents
+/// each window container. Spawned with the Tmux subtree; removed with it via
+/// `DespawnOnExit`.
+#[derive(Component)]
+pub(super) struct WorkspaceUiRoot;
+
 /// Bevy plugin that ensures the Tmux-mode UI subtree exists while in Tmux mode.
 pub(crate) struct TmuxModeUiPlugin;
 
@@ -32,17 +38,31 @@ fn ensure_tmux_mode_ui(mut commands: Commands, ui_root: Query<Entity, With<UiRoo
     let Ok(ui_root) = ui_root.single() else {
         return;
     };
+    let tmux_ui = commands
+        .spawn((
+            Name::new("Tmux Mode UI"),
+            Node {
+                flex_direction: FlexDirection::Column,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..default()
+            },
+            DespawnOnExit(AppMode::Tmux),
+            TmuxModeUi,
+            ChildOf(ui_root),
+        ))
+        .id();
+
     commands.spawn((
-        Name::new("Tmux Mode UI"),
+        Name::new("Workspace UI Root"),
         Node {
-            flex_direction: FlexDirection::Column,
+            flex_grow: 1.0,
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
             ..default()
         },
-        DespawnOnExit(AppMode::Tmux),
-        TmuxModeUi,
-        ChildOf(ui_root),
+        WorkspaceUiRoot,
+        ChildOf(tmux_ui),
     ));
 }
 
@@ -59,6 +79,23 @@ mod tests {
         app.world_mut().spawn((Node::default(), UiRoot));
         app.add_plugins(TmuxModeUiPlugin);
         app
+    }
+
+    #[test]
+    fn workspace_ui_root_is_child_of_tmux_mode_ui() {
+        let mut app = build_app();
+        app.update();
+        let world = app.world_mut();
+        let tmux_ui = world
+            .query_filtered::<Entity, With<TmuxModeUi>>()
+            .single(world)
+            .expect("TmuxModeUi present");
+        let parent = world
+            .query_filtered::<&ChildOf, With<WorkspaceUiRoot>>()
+            .single(world)
+            .expect("WorkspaceUiRoot present")
+            .parent();
+        assert_eq!(parent, tmux_ui, "WorkspaceUiRoot under TmuxModeUi");
     }
 
     #[test]

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -3,7 +3,7 @@
 //! into the handle. Lives in the binary so `ozmux_tmux` stays renderer-free.
 
 use crate::theme;
-use crate::ui::WorkspaceUiRoot;
+use crate::tmux::mode_ui::WorkspaceUiRoot;
 use bevy::ecs::message::MessageReader;
 use bevy::math::Rect;
 use bevy::prelude::*;

--- a/src/tmux/window_bar.rs
+++ b/src/tmux/window_bar.rs
@@ -6,18 +6,17 @@ use super::window_bar_input::{switch_window_on_click, window_entry_hover_cursor}
 use crate::font::{PowerlineFont, TerminalUiFont};
 use crate::input::InputPhase;
 use crate::theme;
-use crate::ui::UiRoot;
 use crate::ui::palette;
 use bevy::prelude::*;
 use bevy::ui::{AlignItems, FlexDirection, UiRect, Val};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozmux_tmux::{ActiveWindow, TmuxProjectionSet, TmuxSession, TmuxWindow, WindowFlags, WindowId};
 
-/// Marker on the tmux window bar root Node — the fixed-height Row mounted at the
-/// bottom of `UiRoot`. `spawn_window_bar` inserts it once; `rebuild_window_bar`
+/// Marker on the tmux window bar root Node — the fixed-height Row mounted as a
+/// child of `TmuxModeUi`. `spawn_window_bar` inserts it once; `rebuild_window_bar`
 /// queries it to find the bar and despawn its children before rebuilding.
 #[derive(Component)]
-struct WindowBarRoot;
+pub(super) struct WindowBarRoot;
 
 /// On a window-list entry button: records the tmux window the entry selects.
 /// Read by the window-bar click handler (`switch_window_on_click`) to issue
@@ -52,34 +51,25 @@ pub(crate) struct WindowEntryActive(
 #[derive(Component)]
 struct SessionLabel;
 
-/// Wires the tmux window status bar: spawns the bar once after `UiRoot` exists
-/// and rebuilds its children whenever the window set, active window, or session
-/// name changes.
+/// Wires the tmux window status bar: rebuilds its children whenever the window
+/// set, active window, or session name changes. The bar itself is spawned by
+/// `spawn_window_bar`, called from `ensure_tmux_mode_ui`.
 pub(crate) struct WindowBarPlugin;
 
 impl Plugin for WindowBarPlugin {
     fn build(&self, app: &mut App) {
-        // NOTE: PostStartup, not Startup. `UiRoot` is spawned by `spawn_root_ui`
-        // (a different plugin) via deferred Commands in Startup; with no ordering
-        // edge between the two systems Bevy inserts no sync point, so a Startup
-        // `spawn_window_bar` queries `UiRoot` before that spawn flushes, finds
-        // nothing, and silently bails — the bar never mounts. PostStartup runs
-        // after Startup's command flush, when `UiRoot` is guaranteed to exist.
-        app.add_systems(PostStartup, spawn_window_bar);
         // NOTE: after the projection drain. `window_bar_dirty` reads
         // `RemovedComponents<TmuxWindow>` — one-frame events cleared at frame end.
-        // The drain despawns windows on close (`%window-close` /
-        // `%unlinked-window-close`); if the rebuild's run condition evaluated
-        // before the drain it would miss the removal (gone by the next frame) and
-        // a killed window's tab would linger in the bar.
+        // The drain despawns windows on close; gating the rebuild before the drain
+        // would miss the removal and leave a killed window's tab in the bar.
         app.add_systems(
             Update,
             rebuild_window_bar
                 .run_if(window_bar_dirty)
                 .after(TmuxProjectionSet)
                 .in_set(super::TmuxActiveSet),
-        );
-        app.add_systems(
+        )
+        .add_systems(
             Update,
             (
                 switch_window_on_click.in_set(InputPhase::Dispatch),
@@ -90,15 +80,15 @@ impl Plugin for WindowBarPlugin {
     }
 }
 
-fn spawn_window_bar(
-    mut commands: Commands,
-    ui_root: Query<Entity, With<UiRoot>>,
-    metrics: Option<Res<TerminalCellMetricsResource>>,
+/// Spawns the tmux window status bar (a fixed-height bottom row) as a child of
+/// `parent`. Called by the Tmux-mode UI builder; `rebuild_window_bar` fills its
+/// children.
+pub(super) fn spawn_window_bar(
+    commands: &mut Commands,
+    parent: Entity,
+    metrics: Option<&TerminalCellMetricsResource>,
 ) {
-    let Ok(ui_root) = ui_root.single() else {
-        return;
-    };
-    let height = bar_height_px(metrics.as_deref());
+    let height = bar_height_px(metrics);
     commands.spawn((
         Name::new("Tmux Window Bar"),
         Node {
@@ -112,7 +102,7 @@ fn spawn_window_bar(
         },
         BackgroundColor(palette::PANEL),
         WindowBarRoot,
-        ChildOf(ui_root),
+        ChildOf(parent),
     ));
 }
 
@@ -446,29 +436,24 @@ mod tests {
     }
 
     #[test]
-    fn bar_mounts_when_ui_root_is_spawned_in_startup() {
-        // Regression: UiRoot is created by another Startup system via deferred
-        // Commands. spawn_window_bar also ran in Startup, with no ordering edge,
-        // so it queried UiRoot before that spawn flushed and silently bailed —
-        // the bar never appeared. It must mount regardless of that race.
+    fn spawn_window_bar_mounts_under_parent() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.insert_resource(metrics_fixture());
-        app.insert_non_send_resource(ozmux_tmux::TmuxConnection::default());
-        app.add_systems(Startup, |mut commands: Commands| {
-            commands.spawn((Node::default(), UiRoot));
-        });
-        app.add_plugins(WindowBarPlugin);
-
-        app.update();
-
-        let world = app.world_mut();
-        let mut bar_q = world.query_filtered::<(), With<WindowBarRoot>>();
-        assert_eq!(
-            bar_q.iter(world).count(),
-            1,
-            "window bar root must mount even when UiRoot is spawned in Startup"
+        let parent = app.world_mut().spawn(Node::default()).id();
+        app.add_systems(
+            Startup,
+            move |mut commands: Commands, metrics: Option<Res<TerminalCellMetricsResource>>| {
+                spawn_window_bar(&mut commands, parent, metrics.as_deref());
+            },
         );
+        app.update();
+        let world = app.world_mut();
+        let child_of = world
+            .query_filtered::<&ChildOf, With<WindowBarRoot>>()
+            .single(world)
+            .expect("bar present");
+        assert_eq!(child_of.parent(), parent, "bar mounts under parent");
     }
 
     #[test]
@@ -519,7 +504,13 @@ mod tests {
         app.add_plugins(WindowBarPlugin);
         app.insert_resource(metrics_fixture());
         app.insert_non_send_resource(ozmux_tmux::TmuxConnection::default());
-        app.world_mut().spawn((Node::default(), UiRoot));
+        app.add_systems(
+            Startup,
+            |mut commands: Commands, metrics: Option<Res<TerminalCellMetricsResource>>| {
+                let parent = commands.spawn(Node::default()).id();
+                spawn_window_bar(&mut commands, parent, metrics.as_deref());
+            },
+        );
         app.world_mut().spawn(TmuxSession {
             id: SessionId(1),
             name: "main".into(),
@@ -572,7 +563,13 @@ mod tests {
         app.add_plugins(WindowBarPlugin);
         app.insert_resource(metrics_fixture());
         app.insert_non_send_resource(ozmux_tmux::TmuxConnection::default());
-        app.world_mut().spawn((Node::default(), UiRoot));
+        app.add_systems(
+            Startup,
+            |mut commands: Commands, metrics: Option<Res<TerminalCellMetricsResource>>| {
+                let parent = commands.spawn(Node::default()).id();
+                spawn_window_bar(&mut commands, parent, metrics.as_deref());
+            },
+        );
 
         app.world_mut().spawn(TmuxWindow {
             id: WindowId(1),

--- a/src/tmux/window_bar.rs
+++ b/src/tmux/window_bar.rs
@@ -107,7 +107,8 @@ pub(super) fn spawn_window_bar(
 }
 
 /// True when the window set, any window's metadata or flags, the active window,
-/// or the session name may have changed this frame.
+/// or the session name may have changed this frame — or when the bar itself was
+/// just spawned and must be populated from current state.
 fn window_bar_dirty(
     mut removed_windows: RemovedComponents<TmuxWindow>,
     mut removed_active: RemovedComponents<ActiveWindow>,
@@ -115,6 +116,7 @@ fn window_bar_dirty(
     changed_flags: Query<(), Changed<WindowFlags>>,
     added_active: Query<(), Added<ActiveWindow>>,
     changed_session: Query<(), Changed<TmuxSession>>,
+    added_bar: Query<(), Added<WindowBarRoot>>,
 ) -> bool {
     // NOTE: drain both RemovedComponents readers up front, not inside the `||`
     // chain — a short-circuit on an earlier `Changed`/`Added` term would leave
@@ -122,12 +124,21 @@ fn window_bar_dirty(
     // spurious rebuild) on the next frame.
     let window_removed = removed_windows.read().next().is_some();
     let active_removed = removed_active.read().next().is_some();
+    // NOTE: include `Added<WindowBarRoot>`. The bar is spawned lazily by
+    // `ensure_tmux_mode_ui` with no ordering edge to this rebuild; the first
+    // projection's one-shot `Changed`/`Added` signals can be consumed (by this
+    // run condition) on a frame the bar entity does not yet exist, after which
+    // they never re-fire. Triggering a rebuild when the bar first appears
+    // repopulates it from the full current window/session state, closing that
+    // race (`rebuild_window_bar` reads the full set, not just changes).
+    let bar_spawned = !added_bar.is_empty();
     !changed_windows.is_empty()
         || !changed_flags.is_empty()
         || !added_active.is_empty()
         || !changed_session.is_empty()
         || window_removed
         || active_removed
+        || bar_spawned
 }
 
 /// Despawns the window bar's children and rebuilds the powerline layout: a

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,5 @@
-//! Bevy UI Plugin and shared UI markers. Spawns the singleton `UiRoot` /
-//! `WorkspaceUiRoot` Node tree (via `OzmuxUiRootPlugin`) that the tmux render
-//! layer attaches its window container under.
+//! Bevy UI Plugin and shared UI markers. Spawns the singleton `UiRoot` Node
+//! (via `OzmuxUiRootPlugin`) that each mode's UI subtree attaches under.
 
 use crate::ui::root::OzmuxUiRootPlugin;
 use bevy::prelude::*;
@@ -14,18 +13,11 @@ pub mod palette;
 pub(crate) mod rename_prompt;
 pub mod root;
 
-/// Marker for the single root UI Node entity. Spawned once in Startup,
-/// never despawned. Hosts `WorkspaceUiRoot` (the tmux window container's
-/// attachment point) and the tmux window status bar (`WindowBarRoot`) as
-/// direct children.
+/// Marker for the single root UI Node entity. Spawned once in Startup, never
+/// despawned. Hosts each mode's UI subtree (`DefaultModeUi` / `TmuxModeUi`) as a
+/// child while that mode is active.
 #[derive(Component)]
 pub struct UiRoot;
-
-/// Marker for the single attachment-point `Node` child of `UiRoot` under
-/// which the tmux render layer parents its window container. Spawned once in
-/// Startup; never despawned.
-#[derive(Component)]
-pub struct WorkspaceUiRoot;
 
 /// Bevy Plugin spawning the singleton UI root Node tree.
 pub struct OzmuxUiPlugin;

--- a/src/ui/root.rs
+++ b/src/ui/root.rs
@@ -1,11 +1,11 @@
 //! Spawns the singleton UiRoot Node and a 2D Camera under PrimaryWindow.
-//! Runs after bootstrap, but no longer depends on AttachedWorkspace (which
-//! now lives on workspace entities, not on the OS window).
+//! Runs after bootstrap. Each mode's UI subtree attaches under `UiRoot` while
+//! that mode is active.
 
-use crate::ui::{UiRoot, WorkspaceUiRoot};
+use crate::ui::UiRoot;
 use bevy::camera::RenderTarget;
 use bevy::prelude::*;
-use bevy::ui::{FlexDirection, IsDefaultUiCamera, Val};
+use bevy::ui::{IsDefaultUiCamera, Val};
 use bevy::window::{PrimaryWindow, WindowRef};
 
 /// Marker for the `Camera2d` entity that renders the primary GUI window.
@@ -38,36 +38,20 @@ fn spawn_camera(mut commands: Commands, primary: Query<Entity, With<PrimaryWindo
 }
 
 fn spawn_root_ui(mut commands: Commands) {
-    let ui_root_entity = commands
-        .spawn((
-            Name::new("UI Root"),
-            Node {
-                flex_direction: FlexDirection::Column,
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                ..default()
-            },
-            UiRoot,
-        ))
-        .id();
-
     commands.spawn((
-        Name::new("Workspace UI Root"),
+        Name::new("UI Root"),
         Node {
-            flex_grow: 1.0,
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
             ..default()
         },
-        WorkspaceUiRoot,
-        ChildOf(ui_root_entity),
+        UiRoot,
     ));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ui::WorkspaceUiRoot;
     use bevy::window::{PrimaryWindow, WindowResolution};
 
     fn build_app() -> App {
@@ -86,21 +70,10 @@ mod tests {
     }
 
     #[test]
-    fn setup_spawns_workspace_ui_root_under_ui_root() {
+    fn setup_spawns_ui_root() {
         let mut app = build_app();
         let world = app.world_mut();
-        let ui_root = world
-            .query_filtered::<Entity, With<crate::ui::UiRoot>>()
-            .single(world)
-            .expect("UiRoot present");
-        let workspace_ui_root = world
-            .query_filtered::<Entity, With<WorkspaceUiRoot>>()
-            .single(world)
-            .expect("WorkspaceUiRoot present");
-        let parent = world
-            .get::<ChildOf>(workspace_ui_root)
-            .expect("WorkspaceUiRoot has ChildOf")
-            .parent();
-        assert_eq!(parent, ui_root, "WorkspaceUiRoot must be a child of UiRoot");
+        let mut q = world.query_filtered::<(), With<UiRoot>>();
+        assert_eq!(q.iter(world).count(), 1, "UiRoot present");
     }
 }


### PR DESCRIPTION
## Problem

Transitioning from Tmux mode to Default mode left the tmux **Window Bar visible** — a stale strip with old window tabs lingered at the bottom of the Default-mode terminal.

Root cause was structural: the Bevy UI node tree was not scoped to the active `AppMode`. `WindowBarRoot` (and `WorkspaceUiRoot`) were mounted once under the always-on `UiRoot` and never despawned; only their rebuild/input systems were gated to Tmux mode, so the node itself survived the transition.

## Solution

Restructure the UI node tree so each `AppMode` owns its own subtree under `UiRoot`:

```
UiRoot
├── DefaultModeUi  → OzmaTerminal
└── TmuxModeUi     → WorkspaceUiRoot + WindowBarRoot
```

- Each mode subtree is spawned by an idempotent **ensure** system gated `run_if(in_state(mode).and(not(any_with_component::<root>)))` in `Update`. This is boot-safe: `Update` always runs after `Startup` creates `UiRoot`, whereas a pure `OnEnter` spawn fires *before* `Startup` at boot (`bevy_state` registers the first `StateTransition` before `PreStartup`).
- Teardown uses Bevy 0.18's built-in **`DespawnOnExit<AppMode>`** — leaving a mode despawns its whole subtree, so the Window Bar is removed **by construction**.
- Removed the broad `despawn_terminal` (it despawned *all* `OzmaTerminal` entities — a footgun, since tmux panes are also `OzmaTerminal`); Default-mode teardown is now scoped to `DefaultModeUi`.
- The tmux reset/teardown path uses `try_despawn` only for the window entities the `DespawnOnExit(Tmux)` cascade may already have removed, avoiding warning spam on exit.

Affected (engine/binary + tmux session crate): new `src/tmux/mode_ui.rs`, plus `src/app_mode.rs`, `src/ui.rs`, `src/ui/root.rs`, `src/tmux.rs`, `src/tmux/window_bar.rs`, `src/tmux/render.rs`, `crates/tmux_session/src/observers.rs`.

Designed via spec-review and verified by a max-effort multi-agent code review; follow-up fixes applied for a window-bar first-entry race (rebuild on `Added<WindowBarRoot>`) and a PTY-spawn retry storm (spawn the container before the PTY attempt).

<details><summary>Testing</summary>

- `cargo clippy --workspace --all-targets` clean.
- New/updated tests: `mode_ui` — TmuxModeUi spawn/despawn, `WorkspaceUiRoot`/`WindowBarRoot` children, and the bug regression **`leaving_tmux_removes_window_bar`**; `window_bar` helper + rebuild tests; `ozmux_tmux` 142 passing incl. connection-reset / window-close.
- ⚠️ **Manual macOS GUI smoke still pending** (can't run headless): enter tmux (bar shows) → exit to Default (bar gone, terminal full-screen, no warning spam) → re-enter tmux (bar back). Screenshots to be added after the smoke.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
