### PR TITLE
fix(tmux): render a new session's first prompt at the top, not mid-screen

### DIFF
--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -39,6 +39,7 @@ pub struct TmuxServer {
     program: String,
     socket: Socket,
     env: Vec<(String, String)>,
+    initial_size: Option<(u16, u16)>,
 }
 
 impl TmuxServer {
@@ -48,7 +49,21 @@ impl TmuxServer {
             program: "tmux".to_string(),
             socket: Socket::Default,
             env: Vec::new(),
+            initial_size: None,
         }
+    }
+
+    /// Sets the control-client PTY's birth size in cells (`(cols, rows)`).
+    ///
+    /// The PTY size is the size tmux uses for the client's initial window, so
+    /// births a `new-session` (or `attach`) at the real GUI window size instead
+    /// of the legacy 24x80 default. This avoids a later grow of the per-pane
+    /// display grid, which `alacritty_terminal`'s resize would otherwise satisfy
+    /// by pulling scrollback onto the screen — pushing a fresh prompt down to
+    /// mid-screen until the next repaint.
+    pub fn initial_size(mut self, cols: u16, rows: u16) -> Self {
+        self.initial_size = Some((cols, rows));
+        self
     }
 
     /// Overrides the tmux binary path.
@@ -227,6 +242,12 @@ impl TmuxServer {
         let mut argv = self.socket_args();
         argv.push("new-session".to_string());
         argv.push("-d".to_string());
+        if let Some((cols, rows)) = self.initial_size {
+            argv.push("-x".to_string());
+            argv.push(cols.to_string());
+            argv.push("-y".to_string());
+            argv.push(rows.to_string());
+        }
         self.push_env_flags(&mut argv);
         argv.push("-P".to_string());
         argv.push("-F".to_string());
@@ -251,12 +272,7 @@ impl TmuxServer {
 
     fn spawn(&self, subcommand: &[&str]) -> TmuxResult<TmuxClient> {
         let pair = native_pty_system()
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
+            .openpty(pty_size(self.initial_size))
             .map_err(spawn_err)?;
 
         // NOTE: disable PTY echo before tmux starts. Otherwise our command
@@ -389,6 +405,18 @@ fn spawn_err(e: impl std::fmt::Display) -> TmuxError {
     TmuxError::Spawn(std::io::Error::other(e.to_string()))
 }
 
+/// Builds the control-client PTY size from an optional `(cols, rows)` override,
+/// falling back to the legacy 24x80 default when unset.
+fn pty_size(initial: Option<(u16, u16)>) -> PtySize {
+    let (cols, rows) = initial.unwrap_or((80, 24));
+    PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    }
+}
+
 fn classify_list_result(ok: bool, stdout: &[u8], stderr: &[u8]) -> TmuxResult<Vec<SessionInfo>> {
     if ok {
         return SessionInfo::parse_list(stdout);
@@ -485,6 +513,20 @@ mod tests {
 
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn initial_size_overrides_the_default_pty_size() {
+        // A fresh server births its control-client PTY at the legacy 24x80
+        // default, so a new session starts small and must be grown later (the
+        // grow triggers the alacritty history-pull misrender).
+        let default = pty_size(TmuxServer::new().initial_size);
+        assert_eq!((default.cols, default.rows), (80, 24));
+
+        // Declaring the real window cell size births the PTY at that size, so
+        // the new session is the right size from the first frame — no grow.
+        let sized = pty_size(TmuxServer::new().initial_size(120, 40).initial_size);
+        assert_eq!((sized.cols, sized.rows), (120, 40));
     }
 
     struct ScriptedReader {
@@ -820,6 +862,30 @@ mod tests {
         assert_eq!(
             TmuxServer::new().create_detached_session_argv(),
             argv(&["new-session", "-d", "-P", "-F", "#{session_name}"])
+        );
+    }
+
+    #[test]
+    fn create_detached_session_argv_includes_initial_size() {
+        // Without an explicit size, `new-session -d` births the session at tmux's
+        // 80x24 default-size; switching the live client to it then grows the pane,
+        // and the per-pane display grid's grow pulls scrollback onto the screen.
+        // `-x/-y` births it at the real window size so reconciliation is a shrink.
+        assert_eq!(
+            TmuxServer::new()
+                .initial_size(182, 48)
+                .create_detached_session_argv(),
+            argv(&[
+                "new-session",
+                "-d",
+                "-x",
+                "182",
+                "-y",
+                "48",
+                "-P",
+                "-F",
+                "#{session_name}",
+            ])
         );
     }
 

--- a/crates/tmux_control/src/transport.rs
+++ b/crates/tmux_control/src/transport.rs
@@ -66,6 +66,16 @@ impl TmuxServer {
         self
     }
 
+    /// Like [`TmuxServer::initial_size`] but takes an optional `(cols, rows)`;
+    /// a `None` leaves the default unchanged. Lets call sites that compute the
+    /// size optionally apply it without an `if let` at every site.
+    pub fn maybe_initial_size(self, size: Option<(u16, u16)>) -> Self {
+        match size {
+            Some((cols, rows)) => self.initial_size(cols, rows),
+            None => self,
+        }
+    }
+
     /// Overrides the tmux binary path.
     pub fn program(mut self, path: &str) -> Self {
         self.program = path.to_string();

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -137,60 +137,71 @@ fn request_pane_capture(enumeration: &mut EnumerationState, client: &TmuxClient,
     }
 }
 
-/// Per-pane size tracking for [`recapture_settled_panes`].
+/// Per-pane state for [`recapture_settled_panes`].
 #[derive(Default)]
-struct PaneSizeWatch {
-    last: HashMap<PaneId, (u32, u32)>,
-    settle: HashMap<PaneId, u8>,
+struct PaneRecaptureState {
+    /// Last-seen cell dims, to detect size changes.
+    dims: (u32, u32),
+    /// Frames the dims have held steady since the last change.
+    stable: u8,
+    /// Whether this pane has already been re-seeded once.
+    done: bool,
 }
 
-/// Frames a pane's size must hold steady after a change before its mirror is
-/// re-seeded from tmux. Debounces a window-drag resize so it re-seeds once the
-/// drag stops, not every frame.
+/// Frames a pane's size must hold steady before its mirror is re-seeded from
+/// tmux. Lets a born-small pane finish growing (and a window-drag finish) before
+/// the one-shot re-seed fires.
 const RECAPTURE_SETTLE_FRAMES: u8 = 3;
 
-/// Re-seeds a pane's display mirror from tmux's authoritative grid a few frames
-/// after its size settles following a change.
+/// Re-seeds each pane's display mirror from tmux's authoritative grid exactly
+/// once, a few frames after the pane's size first settles.
 ///
 /// NOTE: the display-only `alacritty_terminal` mirror diverges from tmux by one
 /// row on a fresh session's first prompt — zsh's `PROMPT_EOL_MARK` over-fills the
 /// line by one column and alacritty wraps the cursor to the next row where tmux
-/// does not, so the replayed `%output` lands the prompt one row low. A new
-/// session is born small and grown to the window, so this fires after that
-/// resize settles and overwrites the wrapped local cursor with tmux's real
-/// cursor position via the capture-pane + cursor seed. First sight of a pane is
-/// left to [`request_pane_captures`]; only a *change* arms the re-seed.
+/// does not, so the replayed `%output` lands the prompt one row low. A one-shot
+/// capture-pane + cursor seed after the pane settles overwrites the wrapped local
+/// cursor with tmux's real position. Fires once per pane — re-seeding on every
+/// later resize would flash the screen and discard local state, and an
+/// established pane's grow already matches tmux — and fires regardless of whether
+/// the size changed, since a pane born at its final size still wraps its first
+/// prompt. Skipped while an earlier capture for the pane is still in flight so
+/// the two capture/cursor pairs never collide.
 fn recapture_settled_panes(
-    mut watch: Local<PaneSizeWatch>,
+    mut watch: Local<HashMap<PaneId, PaneRecaptureState>>,
     mut enumeration: ResMut<EnumerationState>,
     connection: NonSend<TmuxConnection>,
     panes: Query<&TmuxPane>,
 ) {
+    // Prune departed panes every frame, even while the control client is absent,
+    // so a reconnect that reuses a pane id starts from a clean slate.
+    let present: HashSet<PaneId> = panes.iter().map(|pane| pane.id).collect();
+    watch.retain(|id, _| present.contains(id));
+
     let Some(client) = connection.client() else {
         return;
     };
-    let mut present: HashSet<PaneId> = HashSet::new();
     for pane in panes.iter() {
-        present.insert(pane.id);
         let dims = (pane.dims.width, pane.dims.height);
-        match watch.last.insert(pane.id, dims) {
-            Some(prev) if prev != dims => {
-                watch.settle.insert(pane.id, RECAPTURE_SETTLE_FRAMES);
-            }
-            Some(_) => {
-                if let Some(remaining) = watch.settle.get_mut(&pane.id) {
-                    *remaining -= 1;
-                    if *remaining == 0 {
-                        watch.settle.remove(&pane.id);
-                        request_pane_capture(&mut enumeration, client, pane.id);
-                    }
-                }
-            }
-            None => {}
+        let state = watch.entry(pane.id).or_insert(PaneRecaptureState {
+            dims,
+            stable: 0,
+            done: false,
+        });
+        if state.dims != dims {
+            state.dims = dims;
+            state.stable = 0;
+        } else {
+            state.stable = state.stable.saturating_add(1);
+        }
+        if !state.done
+            && state.stable >= RECAPTURE_SETTLE_FRAMES
+            && !enumeration.panes_with_cursor_pending.contains(&pane.id)
+        {
+            state.done = true;
+            request_pane_capture(&mut enumeration, client, pane.id);
         }
     }
-    watch.last.retain(|id, _| present.contains(id));
-    watch.settle.retain(|id, _| present.contains(id));
 }
 
 fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -22,7 +22,9 @@ use crate::observers::{TmuxProjection, register_observers};
 use crate::output::{PaneOutput, collect_pane_outputs};
 use crate::state::ConnectionState;
 use bevy::prelude::*;
+use std::collections::{HashMap, HashSet};
 use tmux_control::{ClientEvent, TmuxClient, TransportEvent};
+use tmux_control_parser::PaneId;
 
 /// Marker resource inserted when the tmux backend is active. Drain systems are
 /// gated on its presence; insert it to activate tmux mode, remove it to idle.
@@ -68,7 +70,7 @@ impl Plugin for TmuxSessionPlugin {
             )
             .add_systems(
                 Update,
-                request_pane_captures
+                (request_pane_captures, recapture_settled_panes)
                     .after(TmuxProjectionSet)
                     .run_if(resource_exists::<TmuxPresence>),
             );
@@ -104,28 +106,91 @@ fn request_pane_captures(
         return;
     };
     for pane in new_panes.iter() {
-        match client.handle().send(CapturePane { id: pane.id }) {
-            Ok(cap_id) => {
-                enumeration
-                    .pending
-                    .insert(cap_id, PendingReply::Capture { pane: pane.id });
-                match client.handle().send(CursorQuery { id: pane.id }) {
-                    Ok(cur_id) => {
-                        enumeration
-                            .pending
-                            .insert(cur_id, PendingReply::Cursor { pane: pane.id });
-                        enumeration.panes_with_cursor_pending.insert(pane.id);
-                    }
-                    Err(error) => {
-                        tracing::warn!(?error, pane = pane.id.0, "failed to send cursor query");
+        request_pane_capture(&mut enumeration, client, pane.id);
+    }
+}
+
+/// Sends a `capture-pane` + cursor-position query for `pane` and registers the
+/// pending replies so [`apply_reply`] seeds the mirror from tmux's authoritative
+/// grid (clear-screen + rows + the real cursor position).
+fn request_pane_capture(enumeration: &mut EnumerationState, client: &TmuxClient, pane: PaneId) {
+    match client.handle().send(CapturePane { id: pane }) {
+        Ok(cap_id) => {
+            enumeration
+                .pending
+                .insert(cap_id, PendingReply::Capture { pane });
+            match client.handle().send(CursorQuery { id: pane }) {
+                Ok(cur_id) => {
+                    enumeration
+                        .pending
+                        .insert(cur_id, PendingReply::Cursor { pane });
+                    enumeration.panes_with_cursor_pending.insert(pane);
+                }
+                Err(error) => {
+                    tracing::warn!(?error, pane = pane.0, "failed to send cursor query");
+                }
+            }
+        }
+        Err(error) => {
+            tracing::warn!(?error, pane = pane.0, "failed to send capture-pane")
+        }
+    }
+}
+
+/// Per-pane size tracking for [`recapture_settled_panes`].
+#[derive(Default)]
+struct PaneSizeWatch {
+    last: HashMap<PaneId, (u32, u32)>,
+    settle: HashMap<PaneId, u8>,
+}
+
+/// Frames a pane's size must hold steady after a change before its mirror is
+/// re-seeded from tmux. Debounces a window-drag resize so it re-seeds once the
+/// drag stops, not every frame.
+const RECAPTURE_SETTLE_FRAMES: u8 = 3;
+
+/// Re-seeds a pane's display mirror from tmux's authoritative grid a few frames
+/// after its size settles following a change.
+///
+/// NOTE: the display-only `alacritty_terminal` mirror diverges from tmux by one
+/// row on a fresh session's first prompt — zsh's `PROMPT_EOL_MARK` over-fills the
+/// line by one column and alacritty wraps the cursor to the next row where tmux
+/// does not, so the replayed `%output` lands the prompt one row low. A new
+/// session is born small and grown to the window, so this fires after that
+/// resize settles and overwrites the wrapped local cursor with tmux's real
+/// cursor position via the capture-pane + cursor seed. First sight of a pane is
+/// left to [`request_pane_captures`]; only a *change* arms the re-seed.
+fn recapture_settled_panes(
+    mut watch: Local<PaneSizeWatch>,
+    mut enumeration: ResMut<EnumerationState>,
+    connection: NonSend<TmuxConnection>,
+    panes: Query<&TmuxPane>,
+) {
+    let Some(client) = connection.client() else {
+        return;
+    };
+    let mut present: HashSet<PaneId> = HashSet::new();
+    for pane in panes.iter() {
+        present.insert(pane.id);
+        let dims = (pane.dims.width, pane.dims.height);
+        match watch.last.insert(pane.id, dims) {
+            Some(prev) if prev != dims => {
+                watch.settle.insert(pane.id, RECAPTURE_SETTLE_FRAMES);
+            }
+            Some(_) => {
+                if let Some(remaining) = watch.settle.get_mut(&pane.id) {
+                    *remaining -= 1;
+                    if *remaining == 0 {
+                        watch.settle.remove(&pane.id);
+                        request_pane_capture(&mut enumeration, client, pane.id);
                     }
                 }
             }
-            Err(error) => {
-                tracing::warn!(?error, pane = pane.id.0, "failed to send capture-pane")
-            }
+            None => {}
         }
     }
+    watch.last.retain(|id, _| present.contains(id));
+    watch.settle.retain(|id, _| present.contains(id));
 }
 
 fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -14,6 +14,8 @@ use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, ScrollPosition, UiGlobalTransform, UiSystems};
 use bevy::window::{CursorIcon, PrimaryWindow, SystemCursorIcon, WindowResized};
+use ozma_terminal::cells_for;
+use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_webview::ControlPlaneHandle;
 use ozmux_configs::StartupMode;
 use ozmux_tmux::{
@@ -137,6 +139,37 @@ fn build_server(configs: &OzmuxConfigsResource) -> TmuxServer {
     server
 }
 
+/// The control-client PTY birth size in cells for the current GUI window — the
+/// FULL window, with no status-bar row reserved.
+///
+/// NOTE: birth at the full window size, not the bar-reserved pane size that
+/// [`sync_client_size`] later pins. The PTY is the whole GUI window's terminal;
+/// reserving the bar row is the pin's job. Birthing at the full size keeps the
+/// birth size `>=` the eventual pinned pane size, so reconciliation is always a
+/// SHRINK — and `alacritty_terminal`'s shrink does not pull scrollback onto the
+/// screen, whereas a grow does. Birthing at the smaller pane size risks a 1-row
+/// GROW (status line, or a 1-row window-settle race at startup), which pulls one
+/// scrollback row and leaves a one-row top margin.
+///
+/// Returns `None` when the window or cell metrics are not yet available (e.g.
+/// the very first frames), in which case the caller falls back to tmux's default
+/// PTY size — the pre-existing behavior, so no regression.
+fn picker_client_size(
+    window: &Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<&TerminalCellMetricsResource>,
+) -> Option<(u16, u16)> {
+    let window = window.single().ok()?;
+    let metrics = metrics?;
+    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
+    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    Some(cells_for(
+        window.resolution.physical_width(),
+        window.resolution.physical_height(),
+        cell_w,
+        cell_h,
+    ))
+}
+
 /// Refreshes the chooser's session + window lists on the closed→open edge via
 /// one-shot `TmuxServer` subprocess queries against the same socket. The
 /// subprocess sees the live server whether or not a control client is attached,
@@ -175,8 +208,11 @@ fn dispatch_startup_mode(
     mut next_mode: ResMut<NextState<AppMode>>,
     configs: Res<OzmuxConfigsResource>,
     control: Option<Res<ControlPlaneHandle>>,
+    window: Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
 ) {
     commands.insert_resource(StartupDispatched);
+    let client_size = picker_client_size(&window, metrics.as_deref());
     match &configs.startup_mode {
         StartupMode::Default => {
             next_mode.set(AppMode::Default);
@@ -198,6 +234,9 @@ fn dispatch_startup_mode(
         }
         StartupMode::TmuxAutoAttach => {
             let mut server = build_server(&configs);
+            if let Some((cols, rows)) = client_size {
+                server = server.initial_size(cols, rows);
+            }
             if let Some(handle) = &control {
                 server = server.env("OZMA_SOCK", &handle.sock_path.to_string_lossy());
             }
@@ -434,6 +473,8 @@ fn handle_picker_row_interaction(
     configs: Res<OzmuxConfigsResource>,
     current_mode: Res<State<AppMode>>,
     control: Option<Res<ControlPlaneHandle>>,
+    window: Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
 ) {
     let opened = picker.open && !*was_open;
     *was_open = picker.open;
@@ -447,6 +488,7 @@ fn handle_picker_row_interaction(
     if cursor_moved.read().count() > 0 {
         *hover_armed = true;
     }
+    let client_size = picker_client_size(&window, metrics.as_deref());
 
     for (interaction, label) in rows.iter() {
         match interaction {
@@ -465,6 +507,7 @@ fn handle_picker_row_interaction(
                     control.as_deref(),
                     &picker,
                     current_mode.get(),
+                    client_size,
                     row,
                 );
                 picker.open = false;
@@ -597,11 +640,14 @@ fn handle_picker_input(
     configs: Res<OzmuxConfigsResource>,
     current_mode: Res<State<AppMode>>,
     control: Option<Res<ControlPlaneHandle>>,
+    window: Query<&Window, With<PrimaryWindow>>,
+    metrics: Option<Res<TerminalCellMetricsResource>>,
 ) {
     if !picker.open {
         keys.clear();
         return;
     }
+    let client_size = picker_client_size(&window, metrics.as_deref());
     let rows = build_rows(&picker.sessions, &picker.windows);
     let entry_count = rows.len();
     for ev in keys.read() {
@@ -632,6 +678,7 @@ fn handle_picker_input(
                     control.as_deref(),
                     &picker,
                     current_mode.get(),
+                    client_size,
                     row,
                 );
                 picker.open = false;
@@ -656,12 +703,29 @@ fn activate_row(
     control: Option<&ControlPlaneHandle>,
     picker: &SessionPicker,
     current_mode: &AppMode,
+    client_size: Option<(u16, u16)>,
     row: PickerRow,
 ) {
     if connection.client().is_some() {
-        apply_switch(connection, state, configs, control, picker, row);
+        apply_switch(
+            connection,
+            state,
+            configs,
+            control,
+            picker,
+            client_size,
+            row,
+        );
     } else {
-        let attached = apply_attach(connection, state, configs, control, picker, row);
+        let attached = apply_attach(
+            connection,
+            state,
+            configs,
+            control,
+            picker,
+            client_size,
+            row,
+        );
         if should_enter_tmux(attached, current_mode) {
             next_mode.set(AppMode::Tmux);
         }
@@ -677,6 +741,7 @@ fn apply_switch(
     configs: &OzmuxConfigsResource,
     control: Option<&ControlPlaneHandle>,
     picker: &SessionPicker,
+    client_size: Option<(u16, u16)>,
     row: PickerRow,
 ) {
     if connection.client().is_none() {
@@ -718,6 +783,13 @@ fn apply_switch(
         }
         None => {
             let mut server = build_server(configs);
+            // NOTE: birth the detached session at the real window size (`-x/-y`)
+            // so switching the live client to it does not grow the per-pane
+            // display grid — a grow pulls scrollback onto the screen and pushes
+            // the fresh prompt down. See `picker_client_size`.
+            if let Some((cols, rows)) = client_size {
+                server = server.initial_size(cols, rows);
+            }
             if let Some(sock) = &ozma_sock {
                 server = server.env("OZMA_SOCK", sock);
             }
@@ -753,6 +825,7 @@ fn apply_attach(
     configs: &OzmuxConfigsResource,
     control: Option<&ControlPlaneHandle>,
     picker: &SessionPicker,
+    client_size: Option<(u16, u16)>,
     row: PickerRow,
 ) -> bool {
     let target = match row {
@@ -763,6 +836,13 @@ fn apply_attach(
         PickerRow::NewSession => AttachTarget::CreateNew,
     };
     let mut server = build_server(configs);
+    // NOTE: birth the control-client PTY at the real GUI window size so a freshly
+    // created session starts at the right size and the per-pane display grid is
+    // never grown later — a grow pulls scrollback onto the screen and pushes the
+    // fresh prompt down until the next repaint.
+    if let Some((cols, rows)) = client_size {
+        server = server.initial_size(cols, rows);
+    }
     if let Some(handle) = control {
         server = server.env("OZMA_SOCK", &handle.sock_path.to_string_lossy());
     }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -233,10 +233,7 @@ fn dispatch_startup_mode(
             }
         }
         StartupMode::TmuxAutoAttach => {
-            let mut server = build_server(&configs);
-            if let Some((cols, rows)) = client_size {
-                server = server.initial_size(cols, rows);
-            }
+            let mut server = build_server(&configs).maybe_initial_size(client_size);
             if let Some(handle) = &control {
                 server = server.env("OZMA_SOCK", &handle.sock_path.to_string_lossy());
             }
@@ -782,14 +779,11 @@ fn apply_switch(
             cmds
         }
         None => {
-            let mut server = build_server(configs);
             // NOTE: birth the detached session at the real window size (`-x/-y`)
             // so switching the live client to it does not grow the per-pane
             // display grid — a grow pulls scrollback onto the screen and pushes
             // the fresh prompt down. See `picker_client_size`.
-            if let Some((cols, rows)) = client_size {
-                server = server.initial_size(cols, rows);
-            }
+            let mut server = build_server(configs).maybe_initial_size(client_size);
             if let Some(sock) = &ozma_sock {
                 server = server.env("OZMA_SOCK", sock);
             }
@@ -835,14 +829,11 @@ fn apply_attach(
         }
         PickerRow::NewSession => AttachTarget::CreateNew,
     };
-    let mut server = build_server(configs);
     // NOTE: birth the control-client PTY at the real GUI window size so a freshly
     // created session starts at the right size and the per-pane display grid is
     // never grown later — a grow pulls scrollback onto the screen and pushes the
     // fresh prompt down until the next repaint.
-    if let Some((cols, rows)) = client_size {
-        server = server.initial_size(cols, rows);
-    }
+    let mut server = build_server(configs).maybe_initial_size(client_size);
     if let Some(handle) = control {
         server = server.env("OZMA_SOCK", &handle.sock_path.to_string_lossy());
     }

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -476,6 +476,16 @@ fn rows_for_panes(total_rows: u16) -> u16 {
     total_rows.saturating_sub(1).max(1)
 }
 
+/// The pinned tmux pane cell size (`(cols, rows)`) for the current GUI window,
+/// with one row reserved for the ozmux status bar. [`sync_client_size`] pins
+/// tmux to this. The session picker deliberately births new sessions one row
+/// larger (the full window, no bar reservation) so reconciliation to this size
+/// is a shrink, never a grow — see `picker_client_size`.
+fn client_cell_size(phys_w: u32, phys_h: u32, cell_w_phys: f32, cell_h_phys: f32) -> (u16, u16) {
+    let (cols, rows) = cells_for(phys_w, phys_h, cell_w_phys, cell_h_phys);
+    (cols, rows_for_panes(rows))
+}
+
 /// Size-declaration command for `win` chosen by the tmux per-window
 /// `refresh-client` capability. `None` (capability not yet known) falls back to
 /// the global `refresh-client -C W,H`.
@@ -553,13 +563,12 @@ fn sync_client_size(
     };
     let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
-    let (cols, rows) = cells_for(
+    let (cols, rows) = client_cell_size(
         window.resolution.physical_width(),
         window.resolution.physical_height(),
         cell_w,
         cell_h,
     );
-    let rows = rows_for_panes(rows);
     let desired = (cols, rows);
     let reported = layout.map(|l| {
         let d = l.0.root.dims();
@@ -732,6 +741,17 @@ mod tests {
         assert_eq!(rows_for_panes(24), 23);
         assert_eq!(rows_for_panes(1), 1); // never zero
         assert_eq!(rows_for_panes(2), 1);
+    }
+
+    #[test]
+    fn client_cell_size_matches_the_pinned_size_one_row_reserved() {
+        // 1280x752 phys, 8x16 cells -> 160 cols x 47 rows; one row reserved for
+        // the ozmux status bar -> 46 pane rows. Birthing the new session's PTY at
+        // this size makes the first pane geometry equal the size sync_client_size
+        // will pin, so no grow happens.
+        assert_eq!(client_cell_size(1280, 752, 8.0, 16.0), (160, 46));
+        // Degenerate tiny window still yields a usable >=1 size.
+        assert_eq!(client_cell_size(1, 1, 8.0, 16.0), (1, 1));
     }
 
     fn dims() -> CellDims {


### PR DESCRIPTION
## Problem

Creating a session from the picker rendered the new session's shell prompt from the **vertical middle** of the window, with the rest of the screen blank. The terminal content visibly "started from the bottom half." It happened only for **New Session** (attaching to an existing session was fine) and corrected itself on the next keystroke — a transient misrender on first paint.

Root cause was a two-part divergence between each tmux `-CC` pane and its **display-only `alacritty_terminal` mirror** (ozmux feeds tmux `%output` into a local alacritty grid and renders that):

1. **Sizing.** New sessions were born at tmux's `80x24` default-size and then grown to the real window size. `alacritty_terminal`'s grow pulls scrollback back onto the screen, pushing the fresh prompt down — far for the original 24→~47 grow, then one row after a partial fix.
2. **EOL-mark wrap parity.** zsh's `PROMPT_EOL_MARK` over-fills the line by one column; alacritty wraps the cursor to the next row where tmux does not, so the replayed `%output` lands the prompt one row low even with no resize.

## Solution

Two layers, each independently verified (real `tmux -CC` + `alacritty_terminal` repros of the wrap; unit tests for the sizing helpers):

- **Birth at the real window size** so reconciliation to the pinned pane size is a *shrink* (which does not pull scrollback), never a *grow*:
  - `crates/tmux_control` — `TmuxServer::initial_size` opens the control-client PTY at the given size (was hardcoded `24x80`); `create_detached_session` adds `new-session -x/-y`. Both creation paths (`new_session` for the unattached picker, `create_detached_session` for the attached-switch path) are covered.
  - `src/picker.rs` — wires the current GUI window's cell size into both paths; falls back to the old default when metrics aren't available yet (no regression).
- **Re-seed each pane's mirror from tmux's authoritative grid once, after its size settles** (`crates/tmux_session` `recapture_settled_panes`), reusing the existing `capture-pane` + cursor seed. This overwrites the wrapped local cursor with tmux's real row-0 position. Fires once per pane (not on every later resize, which would flash the screen) and skips while an earlier capture is in flight.

Affected: `crates/tmux_control`, `crates/tmux_session`, and the binary's tmux render/picker layers (`src/tmux/render.rs`, `src/picker.rs`). No breaking changes.

A second commit applies the `/code-review` findings: re-seed once-per-pane instead of per-resize, prune the watch state before the client-absent early return, and collapse the duplicated `initial_size` plumbing behind `TmuxServer::maybe_initial_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3RdK7nteFhivocA8ezp6Y
