### PR TITLE
fix(webview): suppress Chromium Safe Storage keychain prompt in bundled macOS builds

### DIFF
--- a/crates/ozma_webview/src/webview/render.rs
+++ b/crates/ozma_webview/src/webview/render.rs
@@ -47,13 +47,26 @@ pub fn cef_plugin(ozma_registry: WebviewAssetRegistry, root_cache_path: &Path) -
     }
 }
 
-/// CEF command-line switches for the embedded webview. The `debug` feature adds
-/// `remote-debugging-port` — a local Chromium DevTools (CDP) endpoint on
-/// `127.0.0.1:9222` for inspecting the embedded webview — and is off by default
-/// so that endpoint is never exposed in normal builds. `CommandLineConfig::default()`
-/// already carries the macOS `use-mock-keychain` switch in either case.
+/// CEF command-line switches for the embedded webview.
+///
+/// On macOS we always append `use-mock-keychain` so CEF's OSCrypt layer derives
+/// its cookie / Local State encryption key from a mock keychain rather than the
+/// real login keychain. Without it, release / bundled builds pop the "ozmux
+/// wants to use … Chromium Safe Storage" keychain prompt on launch:
+/// `bevy_cef_core`'s `CommandLineConfig::default()` only carries this switch under
+/// `debug_assertions`, so it is absent from the `dist` profile. ozmux's CEF
+/// profile is an ephemeral per-process temp dir (see `cef_profile`), so a mock
+/// key costs no real persistence. `effective_command_line_config` de-duplicates,
+/// so re-adding it on debug builds is harmless.
+///
+/// The `debug` feature additionally exposes `remote-debugging-port` — a local
+/// Chromium DevTools (CDP) endpoint on `127.0.0.1:9222` for inspecting the
+/// embedded webview — and is off by default so that endpoint is never exposed in
+/// normal builds.
 fn cef_command_line_config() -> CommandLineConfig {
     let config = CommandLineConfig::default();
+    #[cfg(target_os = "macos")]
+    let config = config.with_switch("use-mock-keychain");
     #[cfg(feature = "debug")]
     let config = config.with_switch_value("remote-debugging-port", "9222");
     config


### PR DESCRIPTION
## Problem

Launching the **bundled** `ozmux.app` (built via `just bundle-macos`) for the first time pops a macOS keychain dialog:

> ozmux がキーチェーン内の "Chromium Safe Storage" に保存されている機密情報を使用しようとしています。
> (ozmux wants to use your confidential information stored in "Chromium Safe Storage" in your keychain.)

`cargo run` (dev) never shows it.

## Root cause

CEF's OSCrypt layer encrypts its cookie / Local State store with an AES key it stores in the macOS login keychain under the item **"Chromium Safe Storage"** (the name is hardcoded for unbranded Chromium — it is not derived from our bundle id / product name). The only thing keeping ozmux from touching that keychain item is CEF's `use-mock-keychain` switch.

`bevy_cef_core` 0.11.0 puts `use-mock-keychain` in `CommandLineConfig::default()` **only under `#[cfg(all(target_os = "macos", debug_assertions))]`** — debug builds only. `just bundle-macos` builds the `dist` profile (`inherits = "release"`, `debug_assertions` off) with `--no-default-features`, so the switch is compiled out and CEF reaches for the real keychain → the prompt. It then recurs every launch because the default bundle is ad-hoc signed (`-`), whose unstable code identity means the keychain ACL's "Always Allow" never sticks.

## Fix

Append `use-mock-keychain` on macOS unconditionally in `cef_command_line_config()`, so it is present in release/bundled builds too. CEF then derives its encryption key from a mock keychain and never prompts.

- ozmux's CEF cache is an ephemeral per-process temp dir (`cef_profile`), wiped on exit, so a mock key costs no real persistence.
- `effective_command_line_config` de-duplicates switches, so re-adding it on debug builds (where the default already includes it) is harmless.
- Also corrects the doc comment that wrongly claimed `CommandLineConfig::default()` already carried the switch "in either case".

## Verification

- `cargo check -p ozma_webview` (default macOS, no debug) — ✅ Finished
- `cargo check -p ozma_webview --features debug` — ✅ Finished
- `cargo clippy -p ozma_webview --all-targets` — ✅ no warnings
- `cargo fmt -- --check` — ✅ clean

Runtime confirmation (re-bundle via `just bundle-macos` and launch — dialog should no longer appear) is still pending manual GUI smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFhd4yCYMbXMqVRNN7MsCp