### PR TITLE
feat(copy-mode): Default-mode copy mode (Alacritty vi mode)

### DIFF
--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -22,6 +22,7 @@ use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::Line;
 use alacritty_terminal::index::Side as ASide;
 use alacritty_terminal::term::{Config, TermMode};
+use alacritty_terminal::vi_mode::ViMotion;
 use alacritty_terminal::vte::ansi::Processor;
 use alacritty_terminal::vte::ansi::{Color as AColor, Rgb};
 use bevy::ecs::component::Component;
@@ -334,9 +335,29 @@ impl TerminalHandle {
         self.stage_full_damage_and_arm(coalescer);
     }
 
-    /// Snaps the viewport to the live tail and arms an emit.
+    /// Snaps the viewport to the live tail and arms an emit. While in vi mode,
+    /// also places the vi cursor on the first occupied cell of the last line,
+    /// mirroring alacritty's scroll-to-bottom action.
     pub fn scroll_to_bottom(&mut self, coalescer: &mut Coalescer) {
         self.term.scroll_display(Scroll::Bottom);
+        if self.term.mode().contains(TermMode::VI) {
+            let bottom = self.term.bottommost_line();
+            self.term.vi_mode_cursor.point.line = bottom;
+            self.term.vi_motion(ViMotion::FirstOccupied);
+        }
+        self.stage_full_damage_and_arm(coalescer);
+    }
+
+    /// Snaps the viewport to the top of scrollback and arms an emit. While in
+    /// vi mode, also places the vi cursor on the first occupied cell of the
+    /// first line, mirroring alacritty's scroll-to-top action.
+    pub fn scroll_to_top(&mut self, coalescer: &mut Coalescer) {
+        self.term.scroll_display(Scroll::Top);
+        if self.term.mode().contains(TermMode::VI) {
+            let top = self.term.topmost_line();
+            self.term.vi_mode_cursor.point.line = top;
+            self.term.vi_motion(ViMotion::FirstOccupied);
+        }
         self.stage_full_damage_and_arm(coalescer);
     }
 
@@ -3074,5 +3095,71 @@ mod accessor_tests {
         let handle = new_handle();
         let modes = handle.current_modes();
         assert!(!modes.contains(alacritty_terminal::term::TermMode::ALT_SCREEN));
+    }
+
+    #[test]
+    fn scroll_to_top_in_vi_mode_places_cursor_on_first_line() {
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) =
+            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let mut h = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            ctrl_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let mut coalescer = Coalescer::default();
+        h.advance(
+            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
+              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
+        );
+        h.enter_vi_mode(&mut coalescer);
+        h.scroll_to_top(&mut coalescer);
+        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.topmost_line());
+        assert!(
+            h.term.grid().display_offset() > 0,
+            "scroll_to_top must move the viewport up into history",
+        );
+    }
+
+    #[test]
+    fn scroll_to_bottom_in_vi_mode_places_cursor_on_last_line() {
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) =
+            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let mut h = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            ctrl_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let mut coalescer = Coalescer::default();
+        h.advance(
+            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
+              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
+        );
+        h.enter_vi_mode(&mut coalescer);
+        h.scroll_to_top(&mut coalescer);
+        h.scroll_to_bottom(&mut coalescer);
+        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.bottommost_line());
+        assert_eq!(
+            h.term.grid().display_offset(),
+            0,
+            "scroll_to_bottom must pin the viewport to the live tail",
+        );
     }
 }

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -1462,6 +1462,72 @@ mod tests {
     }
 
     #[test]
+    fn scroll_to_top_in_vi_mode_places_cursor_on_first_line() {
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) =
+            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let mut h = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            ctrl_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let mut coalescer = Coalescer::default();
+        h.advance(
+            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
+              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
+        );
+        h.enter_vi_mode(&mut coalescer);
+        h.scroll_to_top(&mut coalescer);
+        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.topmost_line());
+        assert!(
+            h.term.grid().display_offset() > 0,
+            "scroll_to_top must move the viewport up into history",
+        );
+    }
+
+    #[test]
+    fn scroll_to_bottom_in_vi_mode_places_cursor_on_last_line() {
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) =
+            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let mut h = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            ctrl_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let mut coalescer = Coalescer::default();
+        h.advance(
+            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
+              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
+        );
+        h.enter_vi_mode(&mut coalescer);
+        h.scroll_to_top(&mut coalescer);
+        h.scroll_to_bottom(&mut coalescer);
+        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.bottommost_line());
+        assert_eq!(
+            h.term.grid().display_offset(),
+            0,
+            "scroll_to_bottom must pin the viewport to the live tail",
+        );
+    }
+
+    #[test]
     fn scroll_page_up_grows_display_offset() {
         let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
         let (ctrl_tx, ctrl_rx) =
@@ -3095,71 +3161,5 @@ mod accessor_tests {
         let handle = new_handle();
         let modes = handle.current_modes();
         assert!(!modes.contains(alacritty_terminal::term::TermMode::ALT_SCREEN));
-    }
-
-    #[test]
-    fn scroll_to_top_in_vi_mode_places_cursor_on_first_line() {
-        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
-        let (ctrl_tx, ctrl_rx) =
-            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
-        let listener = crate::vt::listener::TermListener {
-            reply_tx,
-            control_tx: ctrl_tx.clone(),
-        };
-        let mut h = TerminalHandle::new(
-            10,
-            5,
-            listener,
-            reply_rx,
-            ctrl_rx,
-            ctrl_tx,
-            Arc::new(AtomicBool::new(false)),
-        );
-        let mut coalescer = Coalescer::default();
-        h.advance(
-            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
-              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
-        );
-        h.enter_vi_mode(&mut coalescer);
-        h.scroll_to_top(&mut coalescer);
-        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.topmost_line());
-        assert!(
-            h.term.grid().display_offset() > 0,
-            "scroll_to_top must move the viewport up into history",
-        );
-    }
-
-    #[test]
-    fn scroll_to_bottom_in_vi_mode_places_cursor_on_last_line() {
-        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
-        let (ctrl_tx, ctrl_rx) =
-            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
-        let listener = crate::vt::listener::TermListener {
-            reply_tx,
-            control_tx: ctrl_tx.clone(),
-        };
-        let mut h = TerminalHandle::new(
-            10,
-            5,
-            listener,
-            reply_rx,
-            ctrl_rx,
-            ctrl_tx,
-            Arc::new(AtomicBool::new(false)),
-        );
-        let mut coalescer = Coalescer::default();
-        h.advance(
-            b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6\r\nL7\r\nL8\r\nL9\r\nL10\r\n\
-              L11\r\nL12\r\nL13\r\nL14\r\nL15\r\nL16\r\nL17\r\nL18\r\nL19\r\nL20\r\n",
-        );
-        h.enter_vi_mode(&mut coalescer);
-        h.scroll_to_top(&mut coalescer);
-        h.scroll_to_bottom(&mut coalescer);
-        assert_eq!(h.term.vi_mode_cursor.point.line, h.term.bottommost_line());
-        assert_eq!(
-            h.term.grid().display_offset(),
-            0,
-            "scroll_to_bottom must pin the viewport to the live tail",
-        );
     }
 }

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -22,7 +22,7 @@ use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::Line;
 use alacritty_terminal::index::Side as ASide;
 use alacritty_terminal::term::{Config, TermMode};
-use alacritty_terminal::vi_mode::ViMotion;
+use alacritty_terminal::vi_mode::{ViModeCursor, ViMotion};
 use alacritty_terminal::vte::ansi::Processor;
 use alacritty_terminal::vte::ansi::{Color as AColor, Rgb};
 use bevy::ecs::component::Component;
@@ -331,7 +331,10 @@ impl TerminalHandle {
     /// and the coalescer is armed so the new viewport reaches the
     /// renderer even when the shell is idle.
     pub fn scroll(&mut self, coalescer: &mut Coalescer, delta: i32) {
+        let before = self.term.grid().display_offset() as i32;
+        let original = self.term.vi_mode_cursor;
         self.term.scroll_display(Scroll::Delta(delta));
+        self.track_vi_cursor_after_scroll(before, original);
         self.stage_full_damage_and_arm(coalescer);
     }
 
@@ -451,16 +454,34 @@ impl TerminalHandle {
     /// clamps the vi cursor into the new viewport automatically. Stages
     /// a Full damage emit.
     pub fn scroll_page_up(&mut self, coalescer: &mut Coalescer) {
-        self.term
-            .scroll_display(alacritty_terminal::grid::Scroll::PageUp);
+        let before = self.term.grid().display_offset() as i32;
+        let original = self.term.vi_mode_cursor;
+        self.term.scroll_display(Scroll::PageUp);
+        self.track_vi_cursor_after_scroll(before, original);
         self.stage_full_damage_and_arm(coalescer);
     }
 
     /// Scrolls the viewport one page down (`Scroll::PageDown`).
     pub fn scroll_page_down(&mut self, coalescer: &mut Coalescer) {
-        self.term
-            .scroll_display(alacritty_terminal::grid::Scroll::PageDown);
+        let before = self.term.grid().display_offset() as i32;
+        let original = self.term.vi_mode_cursor;
+        self.term.scroll_display(Scroll::PageDown);
+        self.track_vi_cursor_after_scroll(before, original);
         self.stage_full_damage_and_arm(coalescer);
+    }
+
+    /// Moves the vi cursor to track a viewport scroll, keeping it on the same
+    /// screen row before snapping to the first occupied cell — mirroring
+    /// alacritty's per-scroll vi-cursor handling. `Term::scroll_display` only
+    /// clamps the vi cursor into the viewport, so without this a relative scroll
+    /// (half/line/page) would leave the cursor stuck at the viewport edge
+    /// instead of moving with the content. No-op outside vi mode.
+    fn track_vi_cursor_after_scroll(&mut self, before_offset: i32, original: ViModeCursor) {
+        if !self.term.mode().contains(TermMode::VI) {
+            return;
+        }
+        let moved = self.term.grid().display_offset() as i32 - before_offset;
+        self.term.vi_mode_cursor = original.scroll(&self.term, moved);
     }
 
     /// Start a selection of `ty` anchored at `viewport_point` with
@@ -1524,6 +1545,50 @@ mod tests {
             h.term.grid().display_offset(),
             0,
             "scroll_to_bottom must pin the viewport to the live tail",
+        );
+    }
+
+    #[test]
+    fn page_scroll_in_vi_mode_keeps_cursor_screen_row() {
+        use alacritty_terminal::vi_mode::ViMotion;
+        let (reply_tx, reply_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (ctrl_tx, ctrl_rx) =
+            crossbeam_channel::unbounded::<crate::vt::listener::ControlFrame>();
+        let listener = crate::vt::listener::TermListener {
+            reply_tx,
+            control_tx: ctrl_tx.clone(),
+        };
+        let mut h = TerminalHandle::new(
+            10,
+            5,
+            listener,
+            reply_rx,
+            ctrl_rx,
+            ctrl_tx,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let mut coalescer = Coalescer::default();
+        let mut payload = Vec::new();
+        for i in 1..=40 {
+            payload.extend_from_slice(format!("L{i}\r\n").as_bytes());
+        }
+        h.advance(&payload);
+        h.enter_vi_mode(&mut coalescer);
+        // Move to a middle screen row without scrolling (stays within the viewport).
+        h.vi_motion(&mut coalescer, ViMotion::Up);
+        h.vi_motion(&mut coalescer, ViMotion::Up);
+        let before_offset = h.term.grid().display_offset() as i32;
+        let before_row = h.term.vi_mode_cursor.point.line.0 + before_offset;
+        h.scroll_page_up(&mut coalescer);
+        let after_row = h.term.vi_mode_cursor.point.line.0 + h.term.grid().display_offset() as i32;
+        assert!(
+            h.term.grid().display_offset() as i32 > before_offset,
+            "page-up must scroll further into history",
+        );
+        assert_eq!(
+            after_row, before_row,
+            "vi cursor must move with the viewport (same screen row), \
+             not snap to the viewport edge",
         );
     }
 

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -421,11 +421,9 @@ pub struct Bindings {
     /// release.
     #[serde(default, skip_serializing, deserialize_with = "deser_chord_or_unbind")]
     pub focus_surface_next: Option<KeyChord>,
-    /// Deprecated and ignored: copy mode is now owned by tmux, so this entry
-    /// no longer maps to an ozmux action. Accepted so existing configs
-    /// carrying it still parse under `deny_unknown_fields`. Remove after one
-    /// release.
-    #[serde(default, skip_serializing, deserialize_with = "deser_chord_or_unbind")]
+    /// Enters copy mode (Alacritty vi mode) on the focused terminal in
+    /// `AppMode::Default`.
+    #[serde(deserialize_with = "deser_chord_or_unbind")]
     pub enter_copy_mode: Option<KeyChord>,
     /// Deprecated and ignored: the copy action moved to tmux's own copy mode.
     /// Accepted so existing configs carrying it still parse under
@@ -465,7 +463,7 @@ impl Default for Bindings {
             new_terminal_surface: None,
             focus_surface_prev: None,
             focus_surface_next: None,
-            enter_copy_mode: None,
+            enter_copy_mode: Some(parse_default_chord("Cmd+S")),
             copy: None,
             detach_session: Some(parse_default_chord("Ctrl+Shift+D")),
         }
@@ -489,6 +487,11 @@ impl Bindings {
             ),
             ("open-picker", &self.open_picker, ShortcutAction::OpenPicker),
             ("quit", &self.quit, ShortcutAction::Quit),
+            (
+                "enter-copy-mode",
+                &self.enter_copy_mode,
+                ShortcutAction::EnterCopyMode,
+            ),
             (
                 "detach-session",
                 &self.detach_session,
@@ -532,6 +535,9 @@ pub enum ShortcutAction {
     Quit,
     /// Detaches from the tmux session and returns to Default single-terminal mode.
     DetachSession,
+    /// Enters copy mode (Alacritty vi mode) on the focused terminal in
+    /// `AppMode::Default`.
+    EnterCopyMode,
 }
 
 #[cfg(test)]
@@ -787,9 +793,9 @@ mod tests {
     }
 
     #[test]
-    fn iter_yields_5_entries() {
+    fn iter_yields_6_entries() {
         let b = Bindings::default();
-        assert_eq!(b.iter().count(), 5);
+        assert_eq!(b.iter().count(), 6);
     }
 
     #[test]
@@ -798,7 +804,7 @@ mod tests {
         // The Bindings struct serializes its fields in declaration order.
         // The kebab-case rename applies. Deprecated fields carry
         // `skip_serializing`, so only the active bindings appear here.
-        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-webview-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
+        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-webview-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"open-picker":{"key":"p","modifiers":{"ctrl":false,"shift":true,"alt":false,"meta":true}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"enter-copy-mode":{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
         assert_eq!(json, expected);
     }
 
@@ -850,13 +856,12 @@ close-surface = \"Cmd+Shift+F\"
 new-terminal-surface = \"Cmd+Shift+T\"
 focus-surface-prev = \"Cmd+Shift+G\"
 focus-surface-next = \"Cmd+Shift+B\"
-enter-copy-mode = \"Cmd+U\"
 copy = \"Cmd+C\"
 ";
         let parsed: Shortcuts = toml::from_str(toml).expect("deprecated keys must still parse");
         assert_eq!(
             parsed.bindings.iter().count(),
-            5,
+            6,
             "ignored keys must not enter the active set"
         );
     }

--- a/src/default_input.rs
+++ b/src/default_input.rs
@@ -154,7 +154,7 @@ fn apply_ime_commit_to_terminal(
     });
 }
 
-fn should_disable_input(
+pub(crate) fn should_disable_input(
     picker_open: bool,
     composing: bool,
     window_focused: bool,

--- a/src/default_input.rs
+++ b/src/default_input.rs
@@ -9,13 +9,15 @@ use crate::input::ime::{ImeCommit, ImeState};
 use crate::input::shortcuts::ResolvedShortcuts;
 use crate::input::{InputPhase, current_modifiers};
 use crate::picker::SessionPicker;
+use crate::ui::copy_mode::EnterCopyModeActionEvent;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
 use ozma_terminal::{
-    KeyboardDisabled, MouseDisabled, OzmaTerminal, OzmaTerminalInputSet, OzmaTerminalMouseSet,
+    KeyboardDisabled, KeyboardFocused, MouseDisabled, OzmaTerminal, OzmaTerminalInputSet,
+    OzmaTerminalMouseSet,
 };
 use ozma_tty_engine::{TerminalKey, TerminalKeyInput, TerminalModifiers};
 use ozmux_configs::shortcuts::ShortcutAction;
@@ -74,6 +76,7 @@ fn maintain_input_gates(
 }
 
 fn app_shortcut_handler(
+    mut commands: Commands,
     mut exit: MessageWriter<AppExit>,
     mut events: MessageReader<KeyboardInput>,
     mut picker: ResMut<SessionPicker>,
@@ -82,6 +85,7 @@ fn app_shortcut_handler(
     ime: Res<ImeState>,
     bevy_keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
+    terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
 ) {
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if picker.open || ime.is_composing() || !focused {
@@ -110,6 +114,11 @@ fn app_shortcut_handler(
             }
             ShortcutAction::OpenPicker => {
                 picker.open = true;
+            }
+            ShortcutAction::EnterCopyMode => {
+                if let Ok(entity) = terminal.single() {
+                    commands.trigger(EnterCopyModeActionEvent { entity });
+                }
             }
             ShortcutAction::DetachSession => {}
             ShortcutAction::Paste | ShortcutAction::ReleaseWebviewFocus => {}

--- a/src/default_input.rs
+++ b/src/default_input.rs
@@ -9,7 +9,7 @@ use crate::input::ime::{ImeCommit, ImeState};
 use crate::input::shortcuts::ResolvedShortcuts;
 use crate::input::{InputPhase, current_modifiers};
 use crate::picker::SessionPicker;
-use crate::ui::copy_mode::EnterCopyModeActionEvent;
+use crate::ui::copy_mode::{CopyModeState, EnterCopyModeActionEvent};
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
@@ -52,16 +52,25 @@ fn maintain_input_gates(
     ime: Res<ImeState>,
     focused_webview: Res<FocusedWebview>,
     windows: Query<&Window, With<PrimaryWindow>>,
-    terminals: Query<(Entity, Has<KeyboardDisabled>, Has<MouseDisabled>), With<OzmaTerminal>>,
+    terminals: Query<
+        (
+            Entity,
+            Has<KeyboardDisabled>,
+            Has<MouseDisabled>,
+            Has<CopyModeState>,
+        ),
+        With<OzmaTerminal>,
+    >,
 ) {
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
-    let disable = should_disable_input(
+    let global_disable = should_disable_input(
         picker.open,
         ime.is_composing(),
         focused,
         focused_webview.0.is_some(),
     );
-    for (entity, has_keyboard, has_mouse) in terminals.iter() {
+    for (entity, has_keyboard, has_mouse, in_copy_mode) in terminals.iter() {
+        let disable = global_disable || in_copy_mode;
         if disable && !has_keyboard {
             commands.entity(entity).insert(KeyboardDisabled);
         } else if !disable && has_keyboard {

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,7 @@
 //! table comes from the loaded `OzmuxConfigsResource`; this module owns
 //! no chord data.
 
+pub(crate) mod copy_mode;
 pub(crate) mod hyperlink;
 pub(crate) mod ime;
 pub(crate) mod option_as_alt;

--- a/src/input/copy_mode.rs
+++ b/src/input/copy_mode.rs
@@ -1,0 +1,465 @@
+//! In-copy-mode key handling for `AppMode::Default`: a pure key→intent
+//! decider, a gather system that reads `KeyboardInput` for the focused
+//! copy-mode terminal, and an observer that applies each intent through the
+//! engine's vi/selection/scroll API. Entry (`Cmd+S`) lives in
+//! `app_shortcut_handler` (`src/default_input.rs`); this module owns only the
+//! keys handled WHILE copy mode is active.
+
+use crate::app_mode::AppMode;
+use crate::input::InputPhase;
+use crate::input::current_modifiers;
+use crate::input::ime::ImeState;
+use crate::picker::SessionPicker;
+use crate::ui::copy_mode::{CopyModeState, ExitCopyMode};
+use bevy::ecs::message::MessageReader;
+use bevy::input::ButtonState;
+use bevy::input::keyboard::{Key, KeyboardInput};
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, Window};
+use bevy_cef::prelude::FocusedWebview;
+use ozma_terminal::{Clipboard, KeyboardFocused, OzmaTerminal};
+use ozma_tty_engine::{Coalescer, SelectionType, TerminalHandle, ViMotion};
+use ozmux_configs::shortcuts::Modifiers;
+
+/// Registers the in-copy-mode key gather system and apply observer.
+pub(crate) struct CopyModeInputPlugin;
+
+impl Plugin for CopyModeInputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            copy_mode_keys
+                .in_set(InputPhase::FocusedKey)
+                .run_if(in_state(AppMode::Default))
+                .run_if(on_message::<KeyboardInput>),
+        )
+        .add_observer(on_copy_mode_key_action);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollKind {
+    PageUp,
+    PageDown,
+    HalfUp,
+    HalfDown,
+    LineUp,
+    LineDown,
+    Top,
+    Bottom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectionOp {
+    Start(SelectionType),
+    Change(SelectionType),
+    Clear,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopyModeIntent {
+    Motion(ViMotion),
+    Scroll(ScrollKind),
+    Selection(SelectionOp),
+    Yank,
+    Exit,
+    Ignore,
+}
+
+#[derive(EntityEvent, Debug)]
+struct CopyModeKeyAction {
+    entity: Entity,
+    intent: CopyModeIntent,
+}
+
+/// Resolves a `v`/`V` keypress into a selection op given the current
+/// selection: same kind clears, a different kind switches, none starts.
+fn resolve_selection_toggle(
+    current: Option<SelectionType>,
+    requested: SelectionType,
+) -> SelectionOp {
+    match current {
+        Some(c) if c == requested => SelectionOp::Clear,
+        Some(_) => SelectionOp::Change(requested),
+        None => SelectionOp::Start(requested),
+    }
+}
+
+/// Maps one keypress to a copy-mode intent. Pure (no world access).
+/// `meta`/`alt` chords are app shortcuts (or Option-as-Meta), never vi keys.
+fn decide_copy_mode_key(
+    logical_key: &Key,
+    key_code: KeyCode,
+    mods: Modifiers,
+    selection: Option<SelectionType>,
+) -> CopyModeIntent {
+    if mods.meta || mods.alt {
+        return CopyModeIntent::Ignore;
+    }
+    if mods.ctrl {
+        return match key_code {
+            KeyCode::KeyF => CopyModeIntent::Scroll(ScrollKind::PageDown),
+            KeyCode::KeyB => CopyModeIntent::Scroll(ScrollKind::PageUp),
+            KeyCode::KeyD => CopyModeIntent::Scroll(ScrollKind::HalfDown),
+            KeyCode::KeyU => CopyModeIntent::Scroll(ScrollKind::HalfUp),
+            KeyCode::KeyE => CopyModeIntent::Scroll(ScrollKind::LineDown),
+            KeyCode::KeyY => CopyModeIntent::Scroll(ScrollKind::LineUp),
+            KeyCode::KeyC => CopyModeIntent::Exit,
+            _ => CopyModeIntent::Ignore,
+        };
+    }
+    match logical_key {
+        Key::Escape => return CopyModeIntent::Exit,
+        Key::Enter => return CopyModeIntent::Yank,
+        Key::ArrowLeft => return CopyModeIntent::Motion(ViMotion::Left),
+        Key::ArrowDown => return CopyModeIntent::Motion(ViMotion::Down),
+        Key::ArrowUp => return CopyModeIntent::Motion(ViMotion::Up),
+        Key::ArrowRight => return CopyModeIntent::Motion(ViMotion::Right),
+        _ => {}
+    }
+    let Key::Character(s) = logical_key else {
+        return CopyModeIntent::Ignore;
+    };
+    match s.as_str() {
+        "h" => CopyModeIntent::Motion(ViMotion::Left),
+        "j" => CopyModeIntent::Motion(ViMotion::Down),
+        "k" => CopyModeIntent::Motion(ViMotion::Up),
+        "l" => CopyModeIntent::Motion(ViMotion::Right),
+        "0" => CopyModeIntent::Motion(ViMotion::First),
+        "$" => CopyModeIntent::Motion(ViMotion::Last),
+        "^" => CopyModeIntent::Motion(ViMotion::FirstOccupied),
+        "w" => CopyModeIntent::Motion(ViMotion::SemanticRight),
+        "b" => CopyModeIntent::Motion(ViMotion::SemanticLeft),
+        "e" => CopyModeIntent::Motion(ViMotion::SemanticRightEnd),
+        "W" => CopyModeIntent::Motion(ViMotion::WordRight),
+        "B" => CopyModeIntent::Motion(ViMotion::WordLeft),
+        "E" => CopyModeIntent::Motion(ViMotion::WordRightEnd),
+        "H" => CopyModeIntent::Motion(ViMotion::High),
+        "M" => CopyModeIntent::Motion(ViMotion::Middle),
+        "L" => CopyModeIntent::Motion(ViMotion::Low),
+        "{" => CopyModeIntent::Motion(ViMotion::ParagraphUp),
+        "}" => CopyModeIntent::Motion(ViMotion::ParagraphDown),
+        "%" => CopyModeIntent::Motion(ViMotion::Bracket),
+        "g" => CopyModeIntent::Scroll(ScrollKind::Top),
+        "G" => CopyModeIntent::Scroll(ScrollKind::Bottom),
+        "v" => {
+            CopyModeIntent::Selection(resolve_selection_toggle(selection, SelectionType::Simple))
+        }
+        "V" => CopyModeIntent::Selection(resolve_selection_toggle(selection, SelectionType::Lines)),
+        "y" => CopyModeIntent::Yank,
+        "q" => CopyModeIntent::Exit,
+        _ => CopyModeIntent::Ignore,
+    }
+}
+
+/// Gather system: reads `KeyboardInput` for the focused copy-mode terminal,
+/// decides an intent per key, and triggers `CopyModeKeyAction`. Suspends
+/// (and drains events) while the picker is open, IME is composing, a webview
+/// holds focus, or the window is unfocused.
+fn copy_mode_keys(
+    mut commands: Commands,
+    mut events: MessageReader<KeyboardInput>,
+    picker: Res<SessionPicker>,
+    ime: Res<ImeState>,
+    focused_webview: Res<FocusedWebview>,
+    bevy_keys: Res<ButtonInput<KeyCode>>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    terminal: Query<
+        (Entity, &TerminalHandle),
+        (
+            With<OzmaTerminal>,
+            With<KeyboardFocused>,
+            With<CopyModeState>,
+        ),
+    >,
+) {
+    let Ok((entity, handle)) = terminal.single() else {
+        events.clear();
+        return;
+    };
+    let focused = windows.single().map(|w| w.focused).unwrap_or(false);
+    if picker.open || ime.is_composing() || focused_webview.0.is_some() || !focused {
+        events.clear();
+        return;
+    }
+    let mods = current_modifiers(&bevy_keys);
+    let selection = handle.selection_type();
+    for ev in events.read() {
+        if ev.state != ButtonState::Pressed {
+            continue;
+        }
+        let intent = decide_copy_mode_key(&ev.logical_key, ev.key_code, mods, selection);
+        if intent == CopyModeIntent::Ignore {
+            continue;
+        }
+        commands.trigger(CopyModeKeyAction { entity, intent });
+    }
+}
+
+/// Observer: applies a `CopyModeKeyAction` to the target terminal's engine
+/// handle. `Yank`/`Exit` additionally trigger `ExitCopyMode`.
+fn on_copy_mode_key_action(
+    ev: On<CopyModeKeyAction>,
+    mut commands: Commands,
+    mut clipboard: ResMut<Clipboard>,
+    mut terminals: Query<(&mut TerminalHandle, &mut Coalescer)>,
+) {
+    let Ok((mut handle, mut coalescer)) = terminals.get_mut(ev.entity) else {
+        return;
+    };
+    match ev.intent {
+        CopyModeIntent::Motion(m) => handle.vi_motion(&mut coalescer, m),
+        CopyModeIntent::Scroll(kind) => apply_scroll(&mut handle, &mut coalescer, kind),
+        CopyModeIntent::Selection(op) => apply_selection(&mut handle, &mut coalescer, op),
+        CopyModeIntent::Yank => {
+            if let Some(text) = handle.selection_to_string() {
+                clipboard.write(text);
+            }
+            commands.trigger(ExitCopyMode { entity: ev.entity });
+        }
+        CopyModeIntent::Exit => {
+            commands.trigger(ExitCopyMode { entity: ev.entity });
+        }
+        CopyModeIntent::Ignore => {}
+    }
+}
+
+/// Applies a scroll intent. Half-page uses half the visible row count;
+/// positive deltas move into history, negative toward the live tail.
+fn apply_scroll(handle: &mut TerminalHandle, coalescer: &mut Coalescer, kind: ScrollKind) {
+    let rows = handle.read_geometry().1 as i32;
+    let half = (rows / 2).max(1);
+    match kind {
+        ScrollKind::PageUp => handle.scroll_page_up(coalescer),
+        ScrollKind::PageDown => handle.scroll_page_down(coalescer),
+        ScrollKind::HalfUp => handle.scroll(coalescer, half),
+        ScrollKind::HalfDown => handle.scroll(coalescer, -half),
+        ScrollKind::LineUp => handle.scroll(coalescer, 1),
+        ScrollKind::LineDown => handle.scroll(coalescer, -1),
+        ScrollKind::Top => handle.scroll_to_top(coalescer),
+        ScrollKind::Bottom => handle.scroll_to_bottom(coalescer),
+    }
+}
+
+/// Applies a selection op. `Change` falls back to `Start` when no selection
+/// anchor exists (per `TerminalHandle::selection_change_type`).
+fn apply_selection(handle: &mut TerminalHandle, coalescer: &mut Coalescer, op: SelectionOp) {
+    match op {
+        SelectionOp::Start(ty) => handle.selection_start(coalescer, ty),
+        SelectionOp::Change(ty) => {
+            if !handle.selection_change_type(coalescer, ty) {
+                handle.selection_start(coalescer, ty);
+            }
+        }
+        SelectionOp::Clear => handle.selection_clear(coalescer),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::ecs::system::RunSystemOnce;
+
+    fn mods(ctrl: bool, shift: bool, alt: bool, meta: bool) -> Modifiers {
+        Modifiers {
+            ctrl,
+            shift,
+            alt,
+            meta,
+        }
+    }
+
+    fn ch(s: &str) -> Key {
+        Key::Character(s.into())
+    }
+
+    #[test]
+    fn plain_motions_map_to_vi_motions() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("h"), KeyCode::KeyH, n, None),
+            CopyModeIntent::Motion(ViMotion::Left)
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("$"), KeyCode::Digit4, n, None),
+            CopyModeIntent::Motion(ViMotion::Last)
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("w"), KeyCode::KeyW, n, None),
+            CopyModeIntent::Motion(ViMotion::SemanticRight)
+        );
+        assert_eq!(
+            decide_copy_mode_key(
+                &ch("W"),
+                KeyCode::KeyW,
+                mods(false, true, false, false),
+                None
+            ),
+            CopyModeIntent::Motion(ViMotion::WordRight)
+        );
+    }
+
+    #[test]
+    fn ctrl_combos_map_to_scroll_and_exit() {
+        let c = mods(true, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("f"), KeyCode::KeyF, c, None),
+            CopyModeIntent::Scroll(ScrollKind::PageDown)
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("u"), KeyCode::KeyU, c, None),
+            CopyModeIntent::Scroll(ScrollKind::HalfUp)
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("c"), KeyCode::KeyC, c, None),
+            CopyModeIntent::Exit
+        );
+    }
+
+    #[test]
+    fn g_and_shift_g_map_to_top_and_bottom() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("g"), KeyCode::KeyG, n, None),
+            CopyModeIntent::Scroll(ScrollKind::Top)
+        );
+        assert_eq!(
+            decide_copy_mode_key(
+                &ch("G"),
+                KeyCode::KeyG,
+                mods(false, true, false, false),
+                None
+            ),
+            CopyModeIntent::Scroll(ScrollKind::Bottom)
+        );
+    }
+
+    #[test]
+    fn named_keys_map() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&Key::Escape, KeyCode::Escape, n, None),
+            CopyModeIntent::Exit
+        );
+        assert_eq!(
+            decide_copy_mode_key(&Key::Enter, KeyCode::Enter, n, None),
+            CopyModeIntent::Yank
+        );
+        assert_eq!(
+            decide_copy_mode_key(&Key::ArrowDown, KeyCode::ArrowDown, n, None),
+            CopyModeIntent::Motion(ViMotion::Down)
+        );
+    }
+
+    #[test]
+    fn meta_and_alt_chords_are_ignored() {
+        assert_eq!(
+            decide_copy_mode_key(
+                &ch("q"),
+                KeyCode::KeyQ,
+                mods(false, false, false, true),
+                None
+            ),
+            CopyModeIntent::Ignore
+        );
+        assert_eq!(
+            decide_copy_mode_key(
+                &ch("j"),
+                KeyCode::KeyJ,
+                mods(false, false, true, false),
+                None
+            ),
+            CopyModeIntent::Ignore
+        );
+    }
+
+    #[test]
+    fn selection_toggle_resolves_against_current() {
+        assert_eq!(
+            resolve_selection_toggle(None, SelectionType::Simple),
+            SelectionOp::Start(SelectionType::Simple)
+        );
+        assert_eq!(
+            resolve_selection_toggle(Some(SelectionType::Simple), SelectionType::Simple),
+            SelectionOp::Clear
+        );
+        assert_eq!(
+            resolve_selection_toggle(Some(SelectionType::Lines), SelectionType::Simple),
+            SelectionOp::Change(SelectionType::Simple)
+        );
+    }
+
+    #[test]
+    fn yank_and_exit_keys() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("y"), KeyCode::KeyY, n, None),
+            CopyModeIntent::Yank
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("q"), KeyCode::KeyQ, n, None),
+            CopyModeIntent::Exit
+        );
+    }
+
+    #[test]
+    fn unbound_keys_are_ignored() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("z"), KeyCode::KeyZ, n, None),
+            CopyModeIntent::Ignore
+        );
+    }
+
+    #[test]
+    fn yank_writes_selection_to_clipboard_and_exits() {
+        use crate::ui::copy_mode::{CopyModePlugin, EnterCopyModeActionEvent};
+        use ozma_tty_engine::{SpawnOptions, TerminalBundle};
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(CopyModePlugin);
+        app.add_observer(on_copy_mode_key_action);
+
+        let opts = SpawnOptions {
+            cols: 20,
+            rows: 5,
+            shell: "/bin/sh".into(),
+            cwd: None,
+            env: Vec::new(),
+            osc_webview_gate: Arc::new(AtomicBool::new(false)),
+        };
+        let bundle = TerminalBundle::spawn(opts).expect("spawn /bin/sh");
+        let entity = app.world_mut().spawn(bundle).id();
+
+        // Enter vi mode, write content, start a selection, then move so the
+        // selection is non-empty.
+        app.world_mut().trigger(EnterCopyModeActionEvent { entity });
+        app.update();
+        app.world_mut()
+            .run_system_once(move |mut q: Query<(&mut TerminalHandle, &mut Coalescer)>| {
+                let (mut h, mut c) = q.get_mut(entity).unwrap();
+                h.advance(b"hello world");
+                h.selection_start(&mut c, SelectionType::Simple);
+                h.vi_motion(&mut c, ViMotion::Last);
+            })
+            .unwrap();
+
+        app.world_mut().trigger(CopyModeKeyAction {
+            entity,
+            intent: CopyModeIntent::Yank,
+        });
+        app.update();
+
+        // Yank exits copy mode...
+        assert!(app.world().get::<CopyModeState>(entity).is_none());
+        // ...and writes the selection to the clipboard.
+        let text = app.world_mut().resource_mut::<Clipboard>().read();
+        assert!(
+            text.is_some_and(|t| !t.is_empty()),
+            "yank must populate the clipboard"
+        );
+    }
+}

--- a/src/input/copy_mode.rs
+++ b/src/input/copy_mode.rs
@@ -434,8 +434,6 @@ mod tests {
         let bundle = TerminalBundle::spawn(opts).expect("spawn /bin/sh");
         let entity = app.world_mut().spawn(bundle).id();
 
-        // Enter vi mode, write content, start a selection, then move so the
-        // selection is non-empty.
         app.world_mut().trigger(EnterCopyModeActionEvent { entity });
         app.update();
         app.world_mut()
@@ -453,9 +451,7 @@ mod tests {
         });
         app.update();
 
-        // Yank exits copy mode...
         assert!(app.world().get::<CopyModeState>(entity).is_none());
-        // ...and writes the selection to the clipboard.
         let text = app.world_mut().resource_mut::<Clipboard>().read();
         assert!(
             text.is_some_and(|t| !t.is_empty()),

--- a/src/input/copy_mode.rs
+++ b/src/input/copy_mode.rs
@@ -6,6 +6,7 @@
 //! keys handled WHILE copy mode is active.
 
 use crate::app_mode::AppMode;
+use crate::default_input::should_disable_input;
 use crate::input::InputPhase;
 use crate::input::current_modifiers;
 use crate::input::ime::ImeState;
@@ -60,10 +61,9 @@ enum SelectionOp {
 enum CopyModeIntent {
     Motion(ViMotion),
     Scroll(ScrollKind),
-    Selection(SelectionOp),
+    SelectionToggle(SelectionType),
     Yank,
     Exit,
-    Ignore,
 }
 
 #[derive(EntityEvent, Debug)]
@@ -85,42 +85,42 @@ fn resolve_selection_toggle(
     }
 }
 
-/// Maps one keypress to a copy-mode intent. Pure (no world access).
-/// `meta`/`alt` chords are app shortcuts (or Option-as-Meta), never vi keys.
+/// Maps one keypress to a copy-mode intent, or `None` when the key is unbound
+/// in copy mode. Pure (no world access). `meta`/`alt` chords are app shortcuts
+/// (or Option-as-Meta), never vi keys.
 fn decide_copy_mode_key(
     logical_key: &Key,
     key_code: KeyCode,
     mods: Modifiers,
-    selection: Option<SelectionType>,
-) -> CopyModeIntent {
+) -> Option<CopyModeIntent> {
     if mods.meta || mods.alt {
-        return CopyModeIntent::Ignore;
+        return None;
     }
     if mods.ctrl {
         return match key_code {
-            KeyCode::KeyF => CopyModeIntent::Scroll(ScrollKind::PageDown),
-            KeyCode::KeyB => CopyModeIntent::Scroll(ScrollKind::PageUp),
-            KeyCode::KeyD => CopyModeIntent::Scroll(ScrollKind::HalfDown),
-            KeyCode::KeyU => CopyModeIntent::Scroll(ScrollKind::HalfUp),
-            KeyCode::KeyE => CopyModeIntent::Scroll(ScrollKind::LineDown),
-            KeyCode::KeyY => CopyModeIntent::Scroll(ScrollKind::LineUp),
-            KeyCode::KeyC => CopyModeIntent::Exit,
-            _ => CopyModeIntent::Ignore,
+            KeyCode::KeyF => Some(CopyModeIntent::Scroll(ScrollKind::PageDown)),
+            KeyCode::KeyB => Some(CopyModeIntent::Scroll(ScrollKind::PageUp)),
+            KeyCode::KeyD => Some(CopyModeIntent::Scroll(ScrollKind::HalfDown)),
+            KeyCode::KeyU => Some(CopyModeIntent::Scroll(ScrollKind::HalfUp)),
+            KeyCode::KeyE => Some(CopyModeIntent::Scroll(ScrollKind::LineDown)),
+            KeyCode::KeyY => Some(CopyModeIntent::Scroll(ScrollKind::LineUp)),
+            KeyCode::KeyC => Some(CopyModeIntent::Exit),
+            _ => None,
         };
     }
     match logical_key {
-        Key::Escape => return CopyModeIntent::Exit,
-        Key::Enter => return CopyModeIntent::Yank,
-        Key::ArrowLeft => return CopyModeIntent::Motion(ViMotion::Left),
-        Key::ArrowDown => return CopyModeIntent::Motion(ViMotion::Down),
-        Key::ArrowUp => return CopyModeIntent::Motion(ViMotion::Up),
-        Key::ArrowRight => return CopyModeIntent::Motion(ViMotion::Right),
+        Key::Escape => return Some(CopyModeIntent::Exit),
+        Key::Enter => return Some(CopyModeIntent::Yank),
+        Key::ArrowLeft => return Some(CopyModeIntent::Motion(ViMotion::Left)),
+        Key::ArrowDown => return Some(CopyModeIntent::Motion(ViMotion::Down)),
+        Key::ArrowUp => return Some(CopyModeIntent::Motion(ViMotion::Up)),
+        Key::ArrowRight => return Some(CopyModeIntent::Motion(ViMotion::Right)),
         _ => {}
     }
     let Key::Character(s) = logical_key else {
-        return CopyModeIntent::Ignore;
+        return None;
     };
-    match s.as_str() {
+    Some(match s.as_str() {
         "h" => CopyModeIntent::Motion(ViMotion::Left),
         "j" => CopyModeIntent::Motion(ViMotion::Down),
         "k" => CopyModeIntent::Motion(ViMotion::Up),
@@ -142,20 +142,19 @@ fn decide_copy_mode_key(
         "%" => CopyModeIntent::Motion(ViMotion::Bracket),
         "g" => CopyModeIntent::Scroll(ScrollKind::Top),
         "G" => CopyModeIntent::Scroll(ScrollKind::Bottom),
-        "v" => {
-            CopyModeIntent::Selection(resolve_selection_toggle(selection, SelectionType::Simple))
-        }
-        "V" => CopyModeIntent::Selection(resolve_selection_toggle(selection, SelectionType::Lines)),
+        "v" => CopyModeIntent::SelectionToggle(SelectionType::Simple),
+        "V" => CopyModeIntent::SelectionToggle(SelectionType::Lines),
         "y" => CopyModeIntent::Yank,
         "q" => CopyModeIntent::Exit,
-        _ => CopyModeIntent::Ignore,
-    }
+        _ => return None,
+    })
 }
 
 /// Gather system: reads `KeyboardInput` for the focused copy-mode terminal,
 /// decides an intent per key, and triggers `CopyModeKeyAction`. Suspends
-/// (and drains events) while the picker is open, IME is composing, a webview
-/// holds focus, or the window is unfocused.
+/// (and drains events) while input is disabled (picker open, IME composing,
+/// webview focused, or window unfocused) — the same coarse guard
+/// `maintain_input_gates` uses (`should_disable_input`).
 fn copy_mode_keys(
     mut commands: Commands,
     mut events: MessageReader<KeyboardInput>,
@@ -165,7 +164,7 @@ fn copy_mode_keys(
     bevy_keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     terminal: Query<
-        (Entity, &TerminalHandle),
+        Entity,
         (
             With<OzmaTerminal>,
             With<KeyboardFocused>,
@@ -173,31 +172,36 @@ fn copy_mode_keys(
         ),
     >,
 ) {
-    let Ok((entity, handle)) = terminal.single() else {
+    let Ok(entity) = terminal.single() else {
         events.clear();
         return;
     };
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
-    if picker.open || ime.is_composing() || focused_webview.0.is_some() || !focused {
+    if should_disable_input(
+        picker.open,
+        ime.is_composing(),
+        focused,
+        focused_webview.0.is_some(),
+    ) {
         events.clear();
         return;
     }
     let mods = current_modifiers(&bevy_keys);
-    let selection = handle.selection_type();
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
         }
-        let intent = decide_copy_mode_key(&ev.logical_key, ev.key_code, mods, selection);
-        if intent == CopyModeIntent::Ignore {
-            continue;
+        if let Some(intent) = decide_copy_mode_key(&ev.logical_key, ev.key_code, mods) {
+            commands.trigger(CopyModeKeyAction { entity, intent });
         }
-        commands.trigger(CopyModeKeyAction { entity, intent });
     }
 }
 
 /// Observer: applies a `CopyModeKeyAction` to the target terminal's engine
-/// handle. `Yank`/`Exit` additionally trigger `ExitCopyMode`.
+/// handle. The `v`/`V` toggle resolves against the LIVE selection at apply
+/// time (observers for queued triggers run sequentially, so two same-frame
+/// toggles see each other's effect). `Yank`/`Exit` additionally trigger
+/// `ExitCopyMode`.
 fn on_copy_mode_key_action(
     ev: On<CopyModeKeyAction>,
     mut commands: Commands,
@@ -210,7 +214,10 @@ fn on_copy_mode_key_action(
     match ev.intent {
         CopyModeIntent::Motion(m) => handle.vi_motion(&mut coalescer, m),
         CopyModeIntent::Scroll(kind) => apply_scroll(&mut handle, &mut coalescer, kind),
-        CopyModeIntent::Selection(op) => apply_selection(&mut handle, &mut coalescer, op),
+        CopyModeIntent::SelectionToggle(kind) => {
+            let op = resolve_selection_toggle(handle.selection_type(), kind);
+            apply_selection(&mut handle, &mut coalescer, op);
+        }
         CopyModeIntent::Yank => {
             if let Some(text) = handle.selection_to_string() {
                 clipboard.write(text);
@@ -220,25 +227,34 @@ fn on_copy_mode_key_action(
         CopyModeIntent::Exit => {
             commands.trigger(ExitCopyMode { entity: ev.entity });
         }
-        CopyModeIntent::Ignore => {}
     }
 }
 
-/// Applies a scroll intent. Half-page uses half the visible row count;
-/// positive deltas move into history, negative toward the live tail.
+/// Applies a scroll intent. Relative scrolls (half/line/page) move the vi
+/// cursor with the viewport; `Top`/`Bottom` snap it to the buffer extremes.
 fn apply_scroll(handle: &mut TerminalHandle, coalescer: &mut Coalescer, kind: ScrollKind) {
-    let rows = handle.read_geometry().1 as i32;
-    let half = (rows / 2).max(1);
     match kind {
         ScrollKind::PageUp => handle.scroll_page_up(coalescer),
         ScrollKind::PageDown => handle.scroll_page_down(coalescer),
-        ScrollKind::HalfUp => handle.scroll(coalescer, half),
-        ScrollKind::HalfDown => handle.scroll(coalescer, -half),
+        ScrollKind::HalfUp => {
+            let half = half_page(handle);
+            handle.scroll(coalescer, half);
+        }
+        ScrollKind::HalfDown => {
+            let half = half_page(handle);
+            handle.scroll(coalescer, -half);
+        }
         ScrollKind::LineUp => handle.scroll(coalescer, 1),
         ScrollKind::LineDown => handle.scroll(coalescer, -1),
         ScrollKind::Top => handle.scroll_to_top(coalescer),
         ScrollKind::Bottom => handle.scroll_to_bottom(coalescer),
     }
+}
+
+/// Half the visible row count (at least 1), for half-page scrolling. Read
+/// lazily so the non-half scroll keys do not pay for a geometry read.
+fn half_page(handle: &TerminalHandle) -> i32 {
+    (handle.read_geometry().1 as i32 / 2).max(1)
 }
 
 /// Applies a selection op. `Change` falls back to `Start` when no selection
@@ -277,25 +293,20 @@ mod tests {
     fn plain_motions_map_to_vi_motions() {
         let n = mods(false, false, false, false);
         assert_eq!(
-            decide_copy_mode_key(&ch("h"), KeyCode::KeyH, n, None),
-            CopyModeIntent::Motion(ViMotion::Left)
+            decide_copy_mode_key(&ch("h"), KeyCode::KeyH, n),
+            Some(CopyModeIntent::Motion(ViMotion::Left))
         );
         assert_eq!(
-            decide_copy_mode_key(&ch("$"), KeyCode::Digit4, n, None),
-            CopyModeIntent::Motion(ViMotion::Last)
+            decide_copy_mode_key(&ch("$"), KeyCode::Digit4, n),
+            Some(CopyModeIntent::Motion(ViMotion::Last))
         );
         assert_eq!(
-            decide_copy_mode_key(&ch("w"), KeyCode::KeyW, n, None),
-            CopyModeIntent::Motion(ViMotion::SemanticRight)
+            decide_copy_mode_key(&ch("w"), KeyCode::KeyW, n),
+            Some(CopyModeIntent::Motion(ViMotion::SemanticRight))
         );
         assert_eq!(
-            decide_copy_mode_key(
-                &ch("W"),
-                KeyCode::KeyW,
-                mods(false, true, false, false),
-                None
-            ),
-            CopyModeIntent::Motion(ViMotion::WordRight)
+            decide_copy_mode_key(&ch("W"), KeyCode::KeyW, mods(false, true, false, false)),
+            Some(CopyModeIntent::Motion(ViMotion::WordRight))
         );
     }
 
@@ -303,16 +314,16 @@ mod tests {
     fn ctrl_combos_map_to_scroll_and_exit() {
         let c = mods(true, false, false, false);
         assert_eq!(
-            decide_copy_mode_key(&ch("f"), KeyCode::KeyF, c, None),
-            CopyModeIntent::Scroll(ScrollKind::PageDown)
+            decide_copy_mode_key(&ch("f"), KeyCode::KeyF, c),
+            Some(CopyModeIntent::Scroll(ScrollKind::PageDown))
         );
         assert_eq!(
-            decide_copy_mode_key(&ch("u"), KeyCode::KeyU, c, None),
-            CopyModeIntent::Scroll(ScrollKind::HalfUp)
+            decide_copy_mode_key(&ch("u"), KeyCode::KeyU, c),
+            Some(CopyModeIntent::Scroll(ScrollKind::HalfUp))
         );
         assert_eq!(
-            decide_copy_mode_key(&ch("c"), KeyCode::KeyC, c, None),
-            CopyModeIntent::Exit
+            decide_copy_mode_key(&ch("c"), KeyCode::KeyC, c),
+            Some(CopyModeIntent::Exit)
         );
     }
 
@@ -320,17 +331,25 @@ mod tests {
     fn g_and_shift_g_map_to_top_and_bottom() {
         let n = mods(false, false, false, false);
         assert_eq!(
-            decide_copy_mode_key(&ch("g"), KeyCode::KeyG, n, None),
-            CopyModeIntent::Scroll(ScrollKind::Top)
+            decide_copy_mode_key(&ch("g"), KeyCode::KeyG, n),
+            Some(CopyModeIntent::Scroll(ScrollKind::Top))
         );
         assert_eq!(
-            decide_copy_mode_key(
-                &ch("G"),
-                KeyCode::KeyG,
-                mods(false, true, false, false),
-                None
-            ),
-            CopyModeIntent::Scroll(ScrollKind::Bottom)
+            decide_copy_mode_key(&ch("G"), KeyCode::KeyG, mods(false, true, false, false)),
+            Some(CopyModeIntent::Scroll(ScrollKind::Bottom))
+        );
+    }
+
+    #[test]
+    fn selection_keys_map_to_toggle() {
+        let n = mods(false, false, false, false);
+        assert_eq!(
+            decide_copy_mode_key(&ch("v"), KeyCode::KeyV, n),
+            Some(CopyModeIntent::SelectionToggle(SelectionType::Simple))
+        );
+        assert_eq!(
+            decide_copy_mode_key(&ch("V"), KeyCode::KeyV, mods(false, true, false, false)),
+            Some(CopyModeIntent::SelectionToggle(SelectionType::Lines))
         );
     }
 
@@ -338,38 +357,28 @@ mod tests {
     fn named_keys_map() {
         let n = mods(false, false, false, false);
         assert_eq!(
-            decide_copy_mode_key(&Key::Escape, KeyCode::Escape, n, None),
-            CopyModeIntent::Exit
+            decide_copy_mode_key(&Key::Escape, KeyCode::Escape, n),
+            Some(CopyModeIntent::Exit)
         );
         assert_eq!(
-            decide_copy_mode_key(&Key::Enter, KeyCode::Enter, n, None),
-            CopyModeIntent::Yank
+            decide_copy_mode_key(&Key::Enter, KeyCode::Enter, n),
+            Some(CopyModeIntent::Yank)
         );
         assert_eq!(
-            decide_copy_mode_key(&Key::ArrowDown, KeyCode::ArrowDown, n, None),
-            CopyModeIntent::Motion(ViMotion::Down)
+            decide_copy_mode_key(&Key::ArrowDown, KeyCode::ArrowDown, n),
+            Some(CopyModeIntent::Motion(ViMotion::Down))
         );
     }
 
     #[test]
-    fn meta_and_alt_chords_are_ignored() {
+    fn meta_and_alt_chords_return_none() {
         assert_eq!(
-            decide_copy_mode_key(
-                &ch("q"),
-                KeyCode::KeyQ,
-                mods(false, false, false, true),
-                None
-            ),
-            CopyModeIntent::Ignore
+            decide_copy_mode_key(&ch("q"), KeyCode::KeyQ, mods(false, false, false, true)),
+            None
         );
         assert_eq!(
-            decide_copy_mode_key(
-                &ch("j"),
-                KeyCode::KeyJ,
-                mods(false, false, true, false),
-                None
-            ),
-            CopyModeIntent::Ignore
+            decide_copy_mode_key(&ch("j"), KeyCode::KeyJ, mods(false, false, true, false)),
+            None
         );
     }
 
@@ -393,22 +402,19 @@ mod tests {
     fn yank_and_exit_keys() {
         let n = mods(false, false, false, false);
         assert_eq!(
-            decide_copy_mode_key(&ch("y"), KeyCode::KeyY, n, None),
-            CopyModeIntent::Yank
+            decide_copy_mode_key(&ch("y"), KeyCode::KeyY, n),
+            Some(CopyModeIntent::Yank)
         );
         assert_eq!(
-            decide_copy_mode_key(&ch("q"), KeyCode::KeyQ, n, None),
-            CopyModeIntent::Exit
+            decide_copy_mode_key(&ch("q"), KeyCode::KeyQ, n),
+            Some(CopyModeIntent::Exit)
         );
     }
 
     #[test]
-    fn unbound_keys_are_ignored() {
+    fn unbound_keys_return_none() {
         let n = mods(false, false, false, false);
-        assert_eq!(
-            decide_copy_mode_key(&ch("z"), KeyCode::KeyZ, n, None),
-            CopyModeIntent::Ignore
-        );
+        assert_eq!(decide_copy_mode_key(&ch("z"), KeyCode::KeyZ, n), None);
     }
 
     #[test]

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -248,9 +248,9 @@ mod tests {
     }
 
     #[test]
-    fn default_bindings_resolve_to_five() {
+    fn default_bindings_resolve_to_six() {
         let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
-        assert_eq!(r.0.len(), 5);
+        assert_eq!(r.0.len(), 6);
     }
 
     #[test]
@@ -342,8 +342,8 @@ mod tests {
         assert!(b.paste.meta && !b.paste.ctrl && !b.paste.shift && !b.paste.alt);
         assert_eq!(
             b.reserved.len(),
-            4,
-            "Quit, OpenPicker, ReleaseWebviewFocus, DetachSession"
+            5,
+            "Quit, OpenPicker, ReleaseWebviewFocus, DetachSession, EnterCopyMode"
         );
         assert!(
             !b.reserved

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use configs::OzmuxConfigsPlugin;
 use default_input::DefaultHostInputPlugin;
 use font::FontBridgePlugin;
 use input::OzmuxShortcutPlugin;
+use input::copy_mode::CopyModeInputPlugin;
 use input::ime::ImePlugin;
 use input::option_as_alt::OptionAsAltPlugin;
 use ozma_terminal::OzmaTerminalPlugin;
@@ -112,6 +113,7 @@ fn main() {
             ImeOverlayPlugin,
             OptionAsAltPlugin,
             DefaultHostInputPlugin,
+            CopyModeInputPlugin,
         ))
         .run();
 }

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -317,6 +317,7 @@ fn forward_keys_to_tmux(
                 ShortcutAction::DetachSession => {
                     next_mode.set(AppMode::Default);
                 }
+                ShortcutAction::EnterCopyMode => {}
             }
             continue;
         }

--- a/src/ui/copy_mode.rs
+++ b/src/ui/copy_mode.rs
@@ -124,7 +124,6 @@ mod tests {
 
     #[test]
     fn enter_observer_disables_keyboard_and_mouse() {
-        use ozma_terminal::{KeyboardDisabled, MouseDisabled};
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_observer(handle_enter_copy_mode_request);
@@ -137,7 +136,6 @@ mod tests {
 
     #[test]
     fn exit_observer_reenables_keyboard_and_mouse() {
-        use ozma_terminal::{KeyboardDisabled, MouseDisabled};
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_observer(handle_enter_copy_mode_request);

--- a/src/ui/copy_mode.rs
+++ b/src/ui/copy_mode.rs
@@ -11,7 +11,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::event::EntityEvent;
 use bevy::ecs::observer::On;
 use bevy::ecs::system::{Commands, Query};
-use ozma_terminal::Clipboard;
+use ozma_terminal::{Clipboard, KeyboardDisabled, MouseDisabled};
 use ozma_tty_engine::{Coalescer, TerminalHandle};
 
 /// Bevy Plugin: registers the two observers and ensures the global
@@ -58,7 +58,9 @@ pub(crate) fn handle_enter_copy_mode_request(
         return;
     };
     handle.enter_vi_mode(&mut coalescer);
-    commands.entity(ev.entity).insert(CopyModeState);
+    commands
+        .entity(ev.entity)
+        .insert((CopyModeState, KeyboardDisabled, MouseDisabled));
 }
 
 /// Observer for `ExitCopyMode`. Removes `CopyModeState`, clears any
@@ -74,7 +76,11 @@ pub(crate) fn handle_exit_copy_mode(
     };
     handle.selection_clear(&mut coalescer);
     handle.exit_vi_mode(&mut coalescer);
-    commands.entity(ev.entity).remove::<CopyModeState>();
+    commands
+        .entity(ev.entity)
+        .remove::<CopyModeState>()
+        .remove::<KeyboardDisabled>()
+        .remove::<MouseDisabled>();
 }
 
 #[cfg(test)]
@@ -114,6 +120,35 @@ mod tests {
             h.selection_type().is_none(),
             "enter must not auto-create a selection",
         );
+    }
+
+    #[test]
+    fn enter_observer_disables_keyboard_and_mouse() {
+        use ozma_terminal::{KeyboardDisabled, MouseDisabled};
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(handle_enter_copy_mode_request);
+        let entity = spawn_terminal_entity(&mut app);
+        app.world_mut().trigger(EnterCopyModeActionEvent { entity });
+        app.update();
+        assert!(app.world().get::<KeyboardDisabled>(entity).is_some());
+        assert!(app.world().get::<MouseDisabled>(entity).is_some());
+    }
+
+    #[test]
+    fn exit_observer_reenables_keyboard_and_mouse() {
+        use ozma_terminal::{KeyboardDisabled, MouseDisabled};
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(handle_enter_copy_mode_request);
+        app.add_observer(handle_exit_copy_mode);
+        let entity = spawn_terminal_entity(&mut app);
+        app.world_mut().trigger(EnterCopyModeActionEvent { entity });
+        app.update();
+        app.world_mut().trigger(ExitCopyMode { entity });
+        app.update();
+        assert!(app.world().get::<KeyboardDisabled>(entity).is_none());
+        assert!(app.world().get::<MouseDisabled>(entity).is_none());
     }
 
     #[test]

--- a/src/ui/copy_mode.rs
+++ b/src/ui/copy_mode.rs
@@ -49,7 +49,7 @@ pub struct ExitCopyMode {
 
 /// Observer for `EnterCopyModeActionEvent`. Inserts `CopyModeState` on the
 /// target entity and calls `TerminalHandle::enter_vi_mode`.
-pub(crate) fn handle_enter_copy_mode_request(
+fn handle_enter_copy_mode_request(
     ev: On<EnterCopyModeActionEvent>,
     mut commands: Commands,
     mut q: Query<(&mut TerminalHandle, &mut Coalescer)>,
@@ -66,7 +66,7 @@ pub(crate) fn handle_enter_copy_mode_request(
 /// Observer for `ExitCopyMode`. Removes `CopyModeState`, clears any
 /// selection, and calls `TerminalHandle::exit_vi_mode` (which snaps
 /// the viewport to the live tail).
-pub(crate) fn handle_exit_copy_mode(
+fn handle_exit_copy_mode(
     ev: On<ExitCopyMode>,
     mut commands: Commands,
     mut q: Query<(&mut TerminalHandle, &mut Coalescer)>,


### PR DESCRIPTION
## Problem

`AppMode::Default` (single PTY, no tmux) had no copy mode. A focused Default-mode terminal forwarded every key straight to the PTY, so there was no way to freeze the viewport, move a cursor through scrollback, select text, and copy it.

## Solution

Add a keyboard-driven copy mode for Default mode built on Alacritty's **native vi mode**, reusing the engine's existing vi/selection API and the host's existing `CopyModeState` enter/exit plumbing.

- **Entry:** `Cmd+S` — new `ShortcutAction::EnterCopyMode`; the previously-deprecated `enter_copy_mode` config binding is revived (default `Cmd+S`).
- **Input interception:** while in copy mode the focused terminal is `KeyboardDisabled` / `MouseDisabled`, so `dispatch_input` stops forwarding to the PTY. The enter/exit observers toggle the gate synchronously (closing the 1-frame deferred-command seam) and `maintain_input_gates` remains the steady-state owner.
- **Keys (vi):** `h/j/k/l` + arrows; `0` `$` `^`; `w/b/e` (semantic) and `W/B/E` (whitespace); `H/M/L`; `{` `}`; `%`; `Ctrl-f/b` (page), `Ctrl-d/u` (half-page), `Ctrl-e/y` (line); `g`/`G` (buffer top/bottom); `v`/`V` (char/line selection toggle); `y`/`Enter` (copy selection to clipboard, then exit); `Esc`/`q`/`Ctrl-c` (exit). A pure `decide_copy_mode_key` maps keys → intents; an observer applies them through the engine.
- **Engine:** added `TerminalHandle::scroll_to_top`; `scroll_to_top`/`scroll_to_bottom` now also place the vi cursor on the first occupied cell of the first/last line while in vi mode (mirroring Alacritty's scroll-to-top/bottom actions).
- **Rendering:** free — the engine already emits `vi_cursor` / `selection` into the grid, so the cursor and selection highlight appear automatically (no capture detour like tmux mode).

**Affected:** engine (`crates/ozma_tty_engine`), config (`crates/ozmux_configs`), binary (`src/input/copy_mode.rs`, `src/ui/copy_mode.rs`, `src/default_input.rs`, `src/tmux/input.rs`, `src/main.rs`). The tmux backend's own copy mode is untouched apart from an inert `EnterCopyMode => {}` match arm.

**Scope (v1):** keyboard-only. Search (`/ ? n N`), mouse copy-mode, block/rectangle selection, and count prefixes are deferred.

### Note for reviewers

Because `Bindings` carries a struct-level `#[serde(default)]`, **omitting** `enter-copy-mode` from a config now yields the `Cmd+S` default (consistent with how `paste`/`quit`/etc. already behave). To disable the binding, set `enter-copy-mode = ""`.

## Testing

- `cargo test` — engine 224, binary 331, configs 113, all green; `cargo clippy --workspace` clean.
- Added: pure decider unit tests (full keymap + the `v`/`V` toggle resolver), enter/exit gate-toggle observer tests, a `y` → clipboard + exit integration test, engine `scroll_to_top`/`scroll_to_bottom` vi-cursor tests, and updated config count/snapshot tests.
- ⚠️ **Manual GUI smoke pending:** live `cargo run` → `Cmd+S` → navigate / select / `y` / exit has not yet been run interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJjrVAhkZRzTznqfTKMV2u
