### PR TITLE
feat(shortcuts): configurable tmux-command shortcut overrides

### DIFF
--- a/crates/ozmux_configs/src/error.rs
+++ b/crates/ozmux_configs/src/error.rs
@@ -28,9 +28,9 @@ pub enum OzmuxConfigsError {
         source: toml::de::Error,
     },
 
-    /// One or more KeyChord collisions across the `[shortcuts.bindings]` table.
-    /// Collected in a single pass; reported all-at-once to avoid whack-a-mole.
-    #[error("duplicate chord(s) in shortcuts.bindings: {}", format_dupes(.0))]
+    /// One or more KeyChord collisions across `[shortcuts.bindings]` and
+    /// `[shortcuts.commands]`. Collected in a single pass; reported all-at-once.
+    #[error("duplicate chord(s) in shortcuts.bindings/commands: {}", format_dupes(.0))]
     DuplicateChords(Vec<crate::shortcuts::DuplicateChord>),
 
     /// The configured font size is outside the supported range.

--- a/crates/ozmux_configs/src/lib.rs
+++ b/crates/ozmux_configs/src/lib.rs
@@ -92,7 +92,7 @@ impl OzmuxConfigs {
     }
 
     fn validate(&self) -> OzmuxConfigsResult<()> {
-        if let Err(dupes) = self.shortcuts.bindings.validate_no_conflicts() {
+        if let Err(dupes) = self.shortcuts.validate_no_conflicts() {
             return Err(OzmuxConfigsError::DuplicateChords(dupes));
         }
         let size = self.font.size;
@@ -170,11 +170,51 @@ release-webview-focus = "Cmd+V"
         match err {
             OzmuxConfigsError::DuplicateChords(dupes) => {
                 assert_eq!(dupes.len(), 1);
-                assert!(dupes[0].actions.contains(&"paste"));
-                assert!(dupes[0].actions.contains(&"release-webview-focus"));
+                assert!(dupes[0].actions.iter().any(|a| a == "paste"));
+                assert!(
+                    dupes[0]
+                        .actions
+                        .iter()
+                        .any(|a| a == "release-webview-focus")
+                );
             }
             _ => panic!("expected DuplicateChords, got {err:?}"),
         }
+    }
+
+    #[test]
+    fn validate_detects_command_vs_builtin_conflict() {
+        // Cmd+S is the default enter-copy-mode chord; binding it as a command
+        // override too must be rejected.
+        let toml_str = r#"
+[shortcuts.commands]
+"Cmd+S" = "copy-mode"
+"#;
+        let mut configs: OzmuxConfigs = toml::from_str(toml_str).unwrap();
+        configs.normalize();
+        let err = configs.validate().unwrap_err();
+        match err {
+            OzmuxConfigsError::DuplicateChords(dupes) => {
+                assert_eq!(dupes.len(), 1);
+                assert!(dupes[0].actions.iter().any(|a| a == "enter-copy-mode"));
+                assert!(dupes[0].actions.iter().any(|a| a == "copy-mode"));
+            }
+            _ => panic!("expected DuplicateChords, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_allows_command_after_unbinding_builtin() {
+        let toml_str = r#"
+[shortcuts.bindings]
+enter-copy-mode = ""
+
+[shortcuts.commands]
+"Cmd+S" = "copy-mode"
+"#;
+        let mut configs: OzmuxConfigs = toml::from_str(toml_str).unwrap();
+        configs.normalize();
+        assert!(configs.validate().is_ok());
     }
 }
 

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -288,8 +288,9 @@ where
 pub struct DuplicateChord {
     /// The chord that has multiple bindings.
     pub chord: KeyChord,
-    /// Action labels (kebab-case TOML keys) that share this chord. Length >= 2.
-    pub actions: Vec<&'static str>,
+    /// Labels (kebab-case built-in action names and/or command text) that share
+    /// this chord. Length >= 2.
+    pub actions: Vec<String>,
 }
 
 fn parse_modifier_to_bit(token: &str) -> Option<(Modifiers, &'static str)> {
@@ -337,6 +338,24 @@ pub struct Shortcuts {
     pub bindings: Bindings,
     /// Single-chord → tmux-command overrides (`[shortcuts.commands]`). Empty by default.
     pub commands: CommandOverrides,
+}
+
+impl Shortcuts {
+    /// Detects chord collisions across both the built-in `bindings` and the
+    /// `commands` overrides. Built-in entries are labeled by their kebab-case
+    /// action name; command entries by their command text. Returns the
+    /// colliding chords sorted for deterministic error output.
+    pub fn validate_no_conflicts(&self) -> Result<(), Vec<DuplicateChord>> {
+        let binding_entries = self
+            .bindings
+            .iter()
+            .filter_map(|(label, bound, _)| bound.as_ref().map(|c| (label.to_string(), c)));
+        let command_entries = self
+            .commands
+            .iter()
+            .map(|(chord, cmd)| (cmd.to_string(), chord));
+        collect_duplicate_chords(binding_entries.chain(command_entries))
+    }
 }
 
 /// User-facing shortcut configuration. Each Action gets its own named
@@ -415,23 +434,30 @@ impl Bindings {
         .into_iter()
     }
 
-    /// Detects chord collisions across fields. Returns a `Vec` sorted by chord
-    /// (via BTreeMap key order) for deterministic error output. Caller maps
-    /// the Vec into `OzmuxConfigsError::DuplicateChords`.
-    pub fn validate_no_conflicts(&self) -> Result<(), Vec<DuplicateChord>> {
-        let mut by_chord: BTreeMap<KeyChord, Vec<&'static str>> = BTreeMap::new();
-        for (label, bound, _action) in self.iter() {
-            if let Some(chord) = bound {
-                by_chord.entry(chord.clone()).or_default().push(label);
-            }
-        }
-        let dupes: Vec<DuplicateChord> = by_chord
-            .into_iter()
-            .filter(|(_, labels)| labels.len() >= 2)
-            .map(|(chord, actions)| DuplicateChord { chord, actions })
-            .collect();
-        if dupes.is_empty() { Ok(()) } else { Err(dupes) }
+    #[cfg(test)]
+    fn validate_no_conflicts(&self) -> Result<(), Vec<DuplicateChord>> {
+        collect_duplicate_chords(
+            self.iter()
+                .filter_map(|(label, bound, _)| bound.as_ref().map(|c| (label.to_string(), c))),
+        )
     }
+}
+
+/// Groups `(label, chord)` entries by chord and returns any chord shared by two
+/// or more entries, sorted by chord for deterministic output.
+fn collect_duplicate_chords<'a>(
+    entries: impl Iterator<Item = (String, &'a KeyChord)>,
+) -> Result<(), Vec<DuplicateChord>> {
+    let mut by_chord: BTreeMap<KeyChord, Vec<String>> = BTreeMap::new();
+    for (label, chord) in entries {
+        by_chord.entry(chord.clone()).or_default().push(label);
+    }
+    let dupes: Vec<DuplicateChord> = by_chord
+        .into_iter()
+        .filter(|(_, labels)| labels.len() >= 2)
+        .map(|(chord, actions)| DuplicateChord { chord, actions })
+        .collect();
+    if dupes.is_empty() { Ok(()) } else { Err(dupes) }
 }
 
 /// Shortcut actions reachable under forward-only key routing. tmux owns the
@@ -682,8 +708,8 @@ mod tests {
         };
         let err = b.validate_no_conflicts().unwrap_err();
         assert_eq!(err.len(), 1, "exactly one duplicate-chord entry");
-        assert!(err[0].actions.contains(&"paste"));
-        assert!(err[0].actions.contains(&"release-webview-focus"));
+        assert!(err[0].actions.iter().any(|a| a == "paste"));
+        assert!(err[0].actions.iter().any(|a| a == "release-webview-focus"));
     }
 
     #[test]

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -144,6 +144,48 @@ impl fmt::Display for KeyChord {
     }
 }
 
+/// A table of single-chord → tmux-command overrides (`[shortcuts.commands]`).
+/// Each chord, when pressed in tmux mode, runs its command instead of tmux's
+/// own binding for that key. Named `CommandOverrides` to avoid confusion with
+/// Bevy's `Commands`.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct CommandOverrides(BTreeMap<KeyChord, String>);
+
+impl CommandOverrides {
+    /// Yields each `(chord, command)` entry.
+    pub fn iter(&self) -> impl Iterator<Item = (&KeyChord, &str)> + '_ {
+        self.0.iter().map(|(k, v)| (k, v.as_str()))
+    }
+}
+
+impl FromIterator<(KeyChord, String)> for CommandOverrides {
+    fn from_iter<I: IntoIterator<Item = (KeyChord, String)>>(iter: I) -> Self {
+        CommandOverrides(iter.into_iter().collect())
+    }
+}
+
+impl serde::Serialize for CommandOverrides {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_map(self.0.iter().map(|(k, v)| (k.to_string(), v)))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CommandOverrides {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let raw = BTreeMap::<String, String>::deserialize(de)?;
+        let mut map = BTreeMap::new();
+        for (key, command) in raw {
+            let chord = parse_key_chord(&key).map_err(DeError::custom)?;
+            if map.insert(chord, command).is_some() {
+                return Err(DeError::custom(format!(
+                    "chord {key:?} normalizes to an already-bound override chord"
+                )));
+            }
+        }
+        Ok(CommandOverrides(map))
+    }
+}
+
 /// Reason a `parse_key_chord` invocation failed. Surfaced via
 /// `D::Error::custom` from serde's `deserialize_with`.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -293,6 +335,8 @@ fn parse_modifier_to_bit(token: &str) -> Option<(Modifiers, &'static str)> {
 pub struct Shortcuts {
     /// The named-field binding table. See `Bindings` for the field list and merge semantics.
     pub bindings: Bindings,
+    /// Single-chord → tmux-command overrides (`[shortcuts.commands]`). Empty by default.
+    pub commands: CommandOverrides,
 }
 
 /// User-facing shortcut configuration. Each Action gets its own named
@@ -653,7 +697,7 @@ mod tests {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
         // The Bindings struct serializes its fields in declaration order.
         // The kebab-case rename applies.
-        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-webview-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"enter-copy-mode":{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}}}"#;
+        let expected = r#"{"bindings":{"paste":{"key":"v","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"release-webview-focus":{"key":"Escape","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}},"quit":{"key":"q","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"enter-copy-mode":{"key":"s","modifiers":{"ctrl":false,"shift":false,"alt":false,"meta":true}},"detach-session":{"key":"d","modifiers":{"ctrl":true,"shift":true,"alt":false,"meta":false}}},"commands":{}}"#;
         assert_eq!(json, expected);
     }
 
@@ -684,5 +728,41 @@ mod tests {
             .find_map(|(_, bound, action)| (bound.as_ref() == Some(&chord)).then_some(action))
             .expect("Cmd+V must resolve");
         assert!(matches!(action, ShortcutAction::Paste));
+    }
+
+    #[test]
+    fn command_overrides_parse_chord_to_command() {
+        let m: CommandOverrides = toml::from_str(r#""Cmd+D" = "split-window -h""#).unwrap();
+        let got: Vec<(KeyChord, String)> =
+            m.iter().map(|(k, v)| (k.clone(), v.to_string())).collect();
+        assert_eq!(
+            got,
+            vec![(
+                parse_key_chord("Cmd+D").unwrap(),
+                "split-window -h".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn command_overrides_reject_malformed_chord() {
+        assert!(toml::from_str::<CommandOverrides>(r#""Cmd+Foo" = "x""#).is_err());
+    }
+
+    #[test]
+    fn command_overrides_reject_normalized_duplicate() {
+        // "Cmd+S" and "cmd+s" normalize to the same chord.
+        let toml_str = "\"Cmd+S\" = \"a\"\n\"cmd+s\" = \"b\"\n";
+        assert!(toml::from_str::<CommandOverrides>(toml_str).is_err());
+    }
+
+    #[test]
+    fn command_overrides_default_is_empty() {
+        assert_eq!(CommandOverrides::default().iter().count(), 0);
+    }
+
+    #[test]
+    fn shortcuts_default_has_empty_commands() {
+        assert_eq!(Shortcuts::default().commands.iter().count(), 0);
     }
 }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -8,7 +8,9 @@ use bevy::prelude::*;
 use ozma_terminal::{FineModifier, OzmaMouseConfig, ReservedChord, TerminalInputBindings};
 use ozma_tty_engine::{ButtonConfig, WheelConfig};
 use ozmux_configs::mouse::{FineModifier as CfgFineModifier, MouseConfig};
-use ozmux_configs::shortcuts::{Bindings, Key as ConfigKey, Modifiers, ShortcutAction};
+use ozmux_configs::shortcuts::{
+    Bindings, CommandOverrides, Key as ConfigKey, Modifiers, ShortcutAction,
+};
 use std::time::Duration;
 
 /// One configured shortcut resolved to a physical key: the `KeyCode` to match,
@@ -20,10 +22,24 @@ struct ResolvedShortcut {
     action: ShortcutAction,
 }
 
-/// The startup-resolved ozmux shortcut table. Built once from
+/// One configured command override resolved to a physical key: the `KeyCode` to
+/// match, the exact modifier set required, and the tmux command to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedCommand {
+    keycode: KeyCode,
+    modifiers: Modifiers,
+    command: String,
+}
+
+/// The startup-resolved ozmux shortcut tables. Built once from
 /// `OzmuxConfigsResource`; consumed by the tmux keyboard dispatcher.
+/// `actions` are the built-in GUI actions; `commands` are the tmux-command
+/// overrides (`[shortcuts.commands]`).
 #[derive(Resource, Default, Debug, Clone)]
-pub(crate) struct ResolvedShortcuts(Vec<ResolvedShortcut>);
+pub(crate) struct ResolvedShortcuts {
+    actions: Vec<ResolvedShortcut>,
+    commands: Vec<ResolvedCommand>,
+}
 
 impl ResolvedShortcuts {
     /// Returns the GUI action bound to `(keycode, mods)`, if any. Excludes
@@ -34,7 +50,7 @@ impl ResolvedShortcuts {
         keycode: KeyCode,
         mods: Modifiers,
     ) -> Option<ShortcutAction> {
-        self.0
+        self.actions
             .iter()
             .find(|s| {
                 s.action != ShortcutAction::ReleaseWebviewFocus
@@ -47,11 +63,21 @@ impl ResolvedShortcuts {
     /// True when `(keycode, mods)` matches the configured release-webview-focus
     /// chord.
     pub(crate) fn is_release_webview_focus(&self, keycode: KeyCode, mods: Modifiers) -> bool {
-        self.0.iter().any(|s| {
+        self.actions.iter().any(|s| {
             s.action == ShortcutAction::ReleaseWebviewFocus
                 && s.keycode == keycode
                 && s.modifiers == mods
         })
+    }
+
+    /// Returns the tmux command bound to `(keycode, mods)` as a command
+    /// override, if any. Exact modifier equality, consistent with
+    /// `match_gui_action`.
+    pub(crate) fn match_command(&self, keycode: KeyCode, mods: Modifiers) -> Option<&str> {
+        self.commands
+            .iter()
+            .find(|c| c.keycode == keycode && c.modifiers == mods)
+            .map(|c| c.command.as_str())
     }
 
     /// Derives the crate's `TerminalInputBindings` from the resolved table:
@@ -60,7 +86,7 @@ impl ResolvedShortcuts {
     pub(crate) fn input_bindings(&self) -> TerminalInputBindings {
         let mut paste = None;
         let mut reserved = Vec::new();
-        for s in &self.0 {
+        for s in &self.actions {
             let chord = ReservedChord {
                 key_code: s.keycode,
                 ctrl: s.modifiers.ctrl,
@@ -103,6 +129,27 @@ fn resolve_from_bindings(bindings: &Bindings) -> Vec<ResolvedShortcut> {
     out
 }
 
+/// Resolves every override chord in `commands` to a `ResolvedCommand`, skipping
+/// (with a warning) any chord whose logical key has no physical `KeyCode`.
+fn resolve_from_commands(commands: &CommandOverrides) -> Vec<ResolvedCommand> {
+    let mut out = Vec::new();
+    for (chord, command) in commands.iter() {
+        match key_to_keycode(&chord.key) {
+            Some(keycode) => out.push(ResolvedCommand {
+                keycode,
+                modifiers: chord.modifiers,
+                command: command.to_string(),
+            }),
+            None => tracing::warn!(
+                chord = %chord,
+                command,
+                "command-override key has no physical KeyCode mapping; ignoring"
+            ),
+        }
+    }
+    out
+}
+
 /// `Startup` system: resolves the configured shortcut bindings into
 /// `ResolvedShortcuts`, replacing the empty default inserted at plugin build.
 ///
@@ -114,7 +161,10 @@ pub(crate) fn build_resolved_shortcuts(
     mut resolved: ResMut<ResolvedShortcuts>,
     configs: Res<OzmuxConfigsResource>,
 ) {
-    resolved.0 = resolve_from_bindings(&configs.shortcuts.bindings);
+    *resolved = ResolvedShortcuts {
+        actions: resolve_from_bindings(&configs.shortcuts.bindings),
+        commands: resolve_from_commands(&configs.shortcuts.commands),
+    };
 }
 
 /// `Startup` system: inserts `TerminalInputBindings` derived from the resolved
@@ -214,6 +264,14 @@ fn key_to_keycode(key: &ConfigKey) -> Option<KeyCode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ozmux_configs::shortcuts::{CommandOverrides as ConfigCommandOverrides, parse_key_chord};
+
+    fn from_bindings(b: &Bindings) -> ResolvedShortcuts {
+        ResolvedShortcuts {
+            actions: resolve_from_bindings(b),
+            commands: Vec::new(),
+        }
+    }
 
     fn mods(ctrl: bool, shift: bool, alt: bool, meta: bool) -> Modifiers {
         Modifiers {
@@ -249,13 +307,13 @@ mod tests {
 
     #[test]
     fn default_bindings_resolve_to_five() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
-        assert_eq!(r.0.len(), 5);
+        let r = from_bindings(&Bindings::default());
+        assert_eq!(r.actions.len(), 5);
     }
 
     #[test]
     fn match_gui_action_resolves_defaults() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         assert_eq!(
             r.match_gui_action(KeyCode::KeyV, mods(false, false, false, true)),
             Some(ShortcutAction::Paste)
@@ -272,7 +330,7 @@ mod tests {
 
     #[test]
     fn match_gui_action_requires_exact_modifiers() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         assert_eq!(
             r.match_gui_action(KeyCode::KeyV, mods(false, true, false, true)),
             None
@@ -285,7 +343,7 @@ mod tests {
 
     #[test]
     fn match_gui_action_excludes_release_webview_focus() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         assert_eq!(
             r.match_gui_action(KeyCode::Escape, mods(true, true, false, false)),
             None
@@ -294,7 +352,7 @@ mod tests {
 
     #[test]
     fn unmatched_chord_is_none() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         assert_eq!(
             r.match_gui_action(KeyCode::KeyH, mods(false, false, false, true)),
             None
@@ -307,7 +365,7 @@ mod tests {
 
     #[test]
     fn is_release_webview_focus_matches_default_chord() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         assert!(r.is_release_webview_focus(KeyCode::Escape, mods(true, true, false, false)));
         assert!(!r.is_release_webview_focus(KeyCode::KeyV, mods(false, false, false, true)));
     }
@@ -336,7 +394,7 @@ mod tests {
 
     #[test]
     fn input_bindings_excludes_paste_from_reserved() {
-        let r = ResolvedShortcuts(resolve_from_bindings(&Bindings::default()));
+        let r = from_bindings(&Bindings::default());
         let b = r.input_bindings();
         assert_eq!(b.paste.key_code, KeyCode::KeyV);
         assert!(b.paste.meta && !b.paste.ctrl && !b.paste.shift && !b.paste.alt);
@@ -350,6 +408,56 @@ mod tests {
                 .iter()
                 .any(|c| c.key_code == KeyCode::KeyV && c.meta),
             "the paste chord must not appear in reserved",
+        );
+    }
+
+    #[test]
+    fn resolve_from_commands_maps_chord_to_command() {
+        let commands: ConfigCommandOverrides = [(
+            parse_key_chord("Cmd+D").unwrap(),
+            "split-window -h".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let resolved = resolve_from_commands(&commands);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].keycode, KeyCode::KeyD);
+        assert!(resolved[0].modifiers.meta);
+        assert_eq!(resolved[0].command, "split-window -h");
+    }
+
+    #[test]
+    fn resolve_from_commands_skips_unmappable_key() {
+        let commands: ConfigCommandOverrides =
+            [(parse_key_chord("Cmd+Plus").unwrap(), "x".to_string())]
+                .into_iter()
+                .collect();
+        assert!(resolve_from_commands(&commands).is_empty());
+    }
+
+    #[test]
+    fn match_command_requires_exact_modifiers() {
+        let commands: ConfigCommandOverrides = [(
+            parse_key_chord("Alt+I").unwrap(),
+            "split-window -h".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let r = ResolvedShortcuts {
+            actions: Vec::new(),
+            commands: resolve_from_commands(&commands),
+        };
+        assert_eq!(
+            r.match_command(KeyCode::KeyI, mods(false, false, true, false)),
+            Some("split-window -h")
+        );
+        assert_eq!(
+            r.match_command(KeyCode::KeyI, mods(true, false, true, false)),
+            None
+        );
+        assert_eq!(
+            r.match_command(KeyCode::KeyI, mods(false, false, false, false)),
+            None
         );
     }
 }

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -476,13 +476,22 @@ enum RunClass {
     Plain,
 }
 
-/// Classifies one tmux command by text: rename and confirm-before wrappers take
-/// priority (they become ozmux prompts), then copy-mode entry, then plain send.
+/// Classifies one tmux command by text.
+///
+/// A bare `rename-window` / `renamew` / `rename-session` / `rename` verb (no
+/// trailing arguments) opens the interactive ozmux rename prompt; the
+/// `command-prompt`-wrapped default-binding form is recognized via
+/// `RenameKind::parse`. A rename carrying an explicit name (e.g.
+/// `rename-window foo`) is sent verbatim so the name is not dropped.
+/// `confirm-before` wrappers become an ozmux confirm prompt; copy-mode entry is
+/// sent then marked; everything else is a plain verbatim send.
 fn classify_run_command(command: &str) -> RunClass {
-    let first = command.split_whitespace().next().unwrap_or("");
-    let rename_kind = match first {
-        "rename-window" | "renamew" => Some(RenameKind::Window),
-        "rename-session" | "rename" => Some(RenameKind::Session),
+    let mut tokens = command.split_whitespace();
+    let first = tokens.next().unwrap_or("");
+    let bare = tokens.next().is_none();
+    let rename_kind = match (first, bare) {
+        ("rename-window" | "renamew", true) => Some(RenameKind::Window),
+        ("rename-session" | "rename", true) => Some(RenameKind::Session),
         _ => RenameKind::parse(command),
     };
     if let Some(kind) = rename_kind {
@@ -1446,6 +1455,18 @@ mod tests {
         ));
         assert!(matches!(
             classify_run_command("next-window"),
+            RunClass::Plain
+        ));
+    }
+
+    #[test]
+    fn classify_rename_with_explicit_name_is_plain() {
+        assert!(matches!(
+            classify_run_command("rename-window foo"),
+            RunClass::Plain
+        ));
+        assert!(matches!(
+            classify_run_command("rename-session bar"),
             RunClass::Plain
         ));
     }

--- a/src/tmux/input.rs
+++ b/src/tmux/input.rs
@@ -258,6 +258,7 @@ fn forward_keys_to_tmux(
     // Collect forwardable tmux key names in event order. Super-modified keys are
     // matched against the configured ozmux shortcuts or swallowed; none reach tmux.
     let mut key_names: Vec<String> = Vec::new();
+    let mut opened_prompt = false;
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
@@ -307,6 +308,30 @@ fn forward_keys_to_tmux(
             }
             continue;
         }
+        if let Some(command) = resolved.match_command(ev.key_code, cfg_mods) {
+            // A command override abandons any pending tmux prefix sequence,
+            // exactly like a GUI action.
+            *prefix_pending = false;
+            if let Some(entity) = active_entity
+                && let Ok(mut handle) = handles.get_mut(entity)
+                && handle.snap_to_bottom_vt_only()
+            {
+                handle.flush_emit(&mut commands, entity);
+            }
+            if let Some(client) = client.as_deref_mut()
+                && matches!(
+                    run_control_command(&mut commands, client, &rename, active_entity, command),
+                    Flow::PromptOpened
+                )
+            {
+                // NOTE: a prompt now owns the keyboard. Break out of the event
+                // loop; the post-loop drain (events.clear) below cannot run while
+                // events.read() still borrows `events`.
+                opened_prompt = true;
+                break;
+            }
+            continue;
+        }
         // NOTE: tmux/PTY has no Super modifier, so a Cmd-modified key that
         // matched no ozmux shortcut must be swallowed here, never forwarded.
         if mods.super_ {
@@ -318,6 +343,10 @@ fn forward_keys_to_tmux(
         }
     }
 
+    if opened_prompt {
+        events.clear();
+        return;
+    }
     // NOTE: this branch must return before plan_forward — a copy-mode entry
     // binding pressed while already in copy mode is relayed here (not
     // re-intercepted), which would otherwise re-insert CopyModeState each press.
@@ -389,41 +418,25 @@ fn forward_keys_to_tmux(
         return;
     };
     for action in actions {
-        if let Forwarded::Run(command) = &action
-            && let Some(kind) = RenameKind::parse(command)
-            && let Some(subject) = resolve_rename_subject(kind, &rename)
-        {
-            commands.insert_resource(RenamePrompt::new(subject));
-            // NOTE: the prompt now owns the keyboard — stop here so no further
-            // actions from this frame are sent to tmux.
-            break;
-        }
-        if let Forwarded::Run(command) = &action
-            && let Some((message, inner)) = parse_confirm_before(command)
-        {
-            commands.insert_resource(ConfirmState {
-                message,
-                command: inner,
-            });
-            // NOTE: the prompt now owns the keyboard — stop here so any further
-            // actions decoded from this same frame are NOT sent to tmux (that
-            // would bypass the confirmation the prompt is gating).
-            break;
-        }
-        let enters_copy_mode = matches!(&action, Forwarded::Run(cmd) if is_copy_mode_entry(cmd));
-        let result = match action {
-            Forwarded::Run(command) => client.send(&command),
-            Forwarded::Keys(names) => client.send(SendPaneKeys {
-                pane: target,
-                names: &names,
-            }),
-        };
-        if let Err(e) = result {
-            tracing::warn!(?e, "tmux forward send failed");
-            break;
-        }
-        if enters_copy_mode && let Some(entity) = active_entity {
-            commands.entity(entity).insert(CopyModeState);
+        match action {
+            Forwarded::Run(command) => {
+                // NOTE: PromptOpened / SendFailed must stop here — a prompt now
+                // owns the keyboard, and a failed send aborts the frame; either
+                // way no later action from this frame may be sent.
+                match run_control_command(&mut commands, client, &rename, active_entity, &command) {
+                    Flow::Sent => {}
+                    Flow::PromptOpened | Flow::SendFailed => break,
+                }
+            }
+            Forwarded::Keys(names) => {
+                if let Err(e) = client.send(SendPaneKeys {
+                    pane: target,
+                    names: &names,
+                }) {
+                    tracing::warn!(?e, "tmux forward send failed");
+                    break;
+                }
+            }
         }
     }
 }
@@ -442,6 +455,96 @@ fn forward_keys_to_tmux(
 /// strings and the `copy-mode-vi` table name do not trip it.
 fn is_copy_mode_entry(command: &str) -> bool {
     command.split_whitespace().any(|token| token == "copy-mode")
+}
+
+/// What a bound/override tmux `Run` command does, decided from the command text
+/// alone (no world access) so it is unit-testable.
+#[derive(Debug)]
+enum RunClass {
+    /// `rename-window` / `rename-session` — ozmux opens its own rename prompt.
+    Rename(RenameKind),
+    /// `confirm-before … <inner>` — ozmux opens its own confirm prompt.
+    Confirm {
+        /// Prompt text to show.
+        message: String,
+        /// Inner command to run on confirm.
+        command: String,
+    },
+    /// A command that enters copy mode — send it, then mark `CopyModeState`.
+    CopyEntry,
+    /// Any other command — send it verbatim.
+    Plain,
+}
+
+/// Classifies one tmux command by text: rename and confirm-before wrappers take
+/// priority (they become ozmux prompts), then copy-mode entry, then plain send.
+fn classify_run_command(command: &str) -> RunClass {
+    let first = command.split_whitespace().next().unwrap_or("");
+    let rename_kind = match first {
+        "rename-window" | "renamew" => Some(RenameKind::Window),
+        "rename-session" | "rename" => Some(RenameKind::Session),
+        _ => RenameKind::parse(command),
+    };
+    if let Some(kind) = rename_kind {
+        return RunClass::Rename(kind);
+    }
+    if let Some((message, inner)) = parse_confirm_before(command) {
+        return RunClass::Confirm {
+            message,
+            command: inner,
+        };
+    }
+    if is_copy_mode_entry(command) {
+        return RunClass::CopyEntry;
+    }
+    RunClass::Plain
+}
+
+/// The control-flow outcome of running one `Run` command.
+enum Flow {
+    /// Command sent (or sent and copy-mode marked); keep processing.
+    Sent,
+    /// An ozmux prompt opened and now owns the keyboard; the caller must stop.
+    PromptOpened,
+    /// The control-connection send failed (already logged); the caller stops.
+    SendFailed,
+}
+
+/// Runs one tmux `Run` command with the same interception a tmux binding gets:
+/// rename / confirm-before open an ozmux prompt instead of sending; a copy-mode
+/// entry sends then marks `CopyModeState`; everything else sends verbatim. A
+/// rename whose subject cannot be resolved falls back to a verbatim send (as the
+/// pre-refactor loop did).
+fn run_control_command(
+    commands: &mut Commands,
+    client: &mut TmuxClient,
+    rename: &RenameParams,
+    active_entity: Option<Entity>,
+    command: &str,
+) -> Flow {
+    let enters_copy_mode = match classify_run_command(command) {
+        RunClass::Rename(kind) => {
+            if let Some(subject) = resolve_rename_subject(kind, rename) {
+                commands.insert_resource(RenamePrompt::new(subject));
+                return Flow::PromptOpened;
+            }
+            false
+        }
+        RunClass::Confirm { message, command } => {
+            commands.insert_resource(ConfirmState { message, command });
+            return Flow::PromptOpened;
+        }
+        RunClass::CopyEntry => true,
+        RunClass::Plain => false,
+    };
+    if let Err(e) = client.send(command) {
+        tracing::warn!(?e, "tmux control command send failed");
+        return Flow::SendFailed;
+    }
+    if enters_copy_mode && let Some(entity) = active_entity {
+        commands.entity(entity).insert(CopyModeState);
+    }
+    Flow::Sent
 }
 
 /// `send-keys -X -t %<id> -N <lines> scroll-up|scroll-down` — one copy-mode wheel notch.
@@ -1297,6 +1400,54 @@ mod tests {
         assert!(is_copy_mode_entry("copy-mode -eu"));
         assert!(!is_copy_mode_entry("copy-selection"));
         assert!(!is_copy_mode_entry("new-window"));
+    }
+
+    #[test]
+    fn classify_rename_commands() {
+        assert!(matches!(
+            classify_run_command("rename-window"),
+            RunClass::Rename(RenameKind::Window)
+        ));
+        assert!(matches!(
+            classify_run_command("renamew"),
+            RunClass::Rename(RenameKind::Window)
+        ));
+        assert!(matches!(
+            classify_run_command("rename-session"),
+            RunClass::Rename(RenameKind::Session)
+        ));
+    }
+
+    #[test]
+    fn classify_confirm_before_command() {
+        match classify_run_command("confirm-before kill-server") {
+            RunClass::Confirm { command, .. } => assert_eq!(command, "kill-server"),
+            other => panic!("expected Confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_copy_mode_entry() {
+        assert!(matches!(
+            classify_run_command("copy-mode"),
+            RunClass::CopyEntry
+        ));
+        assert!(matches!(
+            classify_run_command("copy-mode -u"),
+            RunClass::CopyEntry
+        ));
+    }
+
+    #[test]
+    fn classify_plain_command() {
+        assert!(matches!(
+            classify_run_command("split-window -h"),
+            RunClass::Plain
+        ));
+        assert!(matches!(
+            classify_run_command("next-window"),
+            RunClass::Plain
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

ozmux forwards keyboard input to tmux through `forward_keys_to_tmux`: for each key it matches the 5 built-in ozmux GUI actions, swallows any leftover `Cmd`-modified chord, then dispatches against tmux's own `list-keys` bindings. There is no way to make a key run a **different** tmux command from ozmux config — the only options are editing `tmux.conf` or living with tmux's defaults. In particular, every `Cmd`-based chord is simply swallowed and cannot trigger any tmux action at all.

## Solution

Add a `[shortcuts.commands]` config table mapping a single key chord to a tmux command. In tmux mode, when a pressed chord is present in the table, ozmux runs the configured command over the `tmux -CC` control connection instead of letting tmux's own binding handle the key; any chord **not** in the table falls through to tmux unchanged. Because the check sits before the Super-swallow, `Cmd`-based chords (previously dead) become usable as tmux-command triggers.

```toml
[shortcuts.commands]
"Cmd+D" = "split-window -h"
"Cmd+W" = "kill-pane"
"Alt+1" = "select-window -t 1"
```

Affected areas: the `ozmux_configs` crate (config schema + validation) and the `ozmux` binary's input layer.

- **Config (`crates/ozmux_configs`):** new `CommandOverrides` table with a custom `Deserialize` that parses chord-string keys via the existing `parse_key_chord` and rejects two strings that normalize to the same chord. A chord bound to **both** a built-in action and a command override is a **fatal** load error (`Shortcuts::validate_no_conflicts`, surfaced via the existing `DuplicateChords` error); unbind the built-in (`= ""`) to repurpose its chord.
- **Resolution (`src/input/shortcuts.rs`):** overrides resolve once at startup into the existing `ResolvedShortcuts` resource (now a named struct `{ actions, commands }`); `match_command` matches on physical `(KeyCode, Modifiers)` with exact-modifier equality. The Default-mode reserved-chord set is untouched (built-ins only).
- **Dispatch (`src/tmux/input.rs`):** matched in `forward_keys_to_tmux` after the built-in GUI-action check and before the Super-swallow. A shared `run_control_command` helper — extracted from the existing `Forwarded::Run` body — runs both override commands and tmux bindings, so an override running `rename-window` / `confirm-before …` / a copy-mode entry behaves identically to the same command reached through a tmux binding.

Scope/semantics: tmux-mode only (overrides run tmux commands); single chords only (no prefix sequences — edit `tmux.conf` for those); load-at-startup (restart to apply). A bare `rename-window` opens ozmux's interactive prompt, while `rename-window foo` (explicit name) is sent verbatim.

Developed via brainstorming + a parallel spec review (Codex + Claude Code Agent), then implemented TDD task-by-task with per-task reviews and a final whole-branch review. `cargo test` (workspace), `clippy --workspace --all-targets`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
