### PR TITLE
fix(tmux): skip unsolicited control-mode reply blocks so copy mode works in multi-pane

### DIFF
--- a/crates/tmux_control/src/protocol.rs
+++ b/crates/tmux_control/src/protocol.rs
@@ -4,7 +4,7 @@
 use crate::error::{TmuxError, TmuxResult};
 use std::collections::VecDeque;
 use tmux_control_parser::{BlockAssembler, ControlEvent, Frame};
-use tracing::warn;
+use tracing::{debug, warn};
 
 // NOTE: `tmux -CC` wraps its entire control stream in a DCS sequence —
 // `ESC P 1000 p` … `ESC \`. The introducer is glued to the first `%begin`, so
@@ -108,20 +108,8 @@ impl ProtocolClient {
         Ok(events)
     }
 
-    /// Pre-registers the single reply block that an *adopted* `tmux -CC` stream
-    /// emits on entry (its introducer is glued to the first `%begin`), so the
-    /// in-world drive correlates it instead of dropping it as unsolicited.
-    pub fn register_external_pending(&mut self) -> CommandId {
-        self.register_pending()
-    }
-
-    /// Pre-registers a pending command with no outgoing bytes.
-    ///
-    /// Backs [`register_external_pending`](Self::register_external_pending) for
-    /// the launch subcommand's (`new-session` / `attach-session`) reply block,
-    /// which arrives before any client `send`. tmux assigns it an arbitrary
-    /// command number, so correlation is by FIFO.
-    pub(crate) fn register_pending(&mut self) -> CommandId {
+    /// Assigns the next [`CommandId`] and records it as awaiting a reply.
+    fn register_pending(&mut self) -> CommandId {
         let id = CommandId(self.next_id);
         self.next_id += 1;
         self.pending.push_back(id);
@@ -159,33 +147,63 @@ impl ProtocolClient {
             }
         };
         match frame {
-            Some(Frame::Reply { number, ok, body }) => match self.pending.pop_front() {
-                Some(id) => Ok(Some(ClientEvent::CommandComplete {
-                    id,
-                    number,
-                    ok,
-                    output: body,
-                })),
-                // NOTE: a reply block with no pending command means tmux emitted a
-                // command-output block this control client did not originate.
-                // Observed when `select-pane` changes focus in a multi-pane
-                // session, likely because `focus-events on` causes tmux to run
-                // an additional internal command (focus-in/focus-out delivery)
-                // that generates its own `%begin … %end` block. Closing the
-                // transport over it would tear down the whole projection (blank
-                // screen); log at debug and skip so the connection stays alive.
-                None => {
-                    tracing::debug!(
-                        number,
-                        "skipping unsolicited tmux reply (no pending command); transport remains open"
-                    );
-                    Ok(None)
+            Some(Frame::Reply {
+                number,
+                flags,
+                ok,
+                body,
+            }) => {
+                // NOTE: only a control-client command reply (flags bit 0 set) may
+                // consume a pending slot. tmux also emits unsolicited blocks this
+                // client never sent — the adopted-stream launch reply, and a
+                // hook's `run-shell` output (e.g. `after-select-pane` in a
+                // multi-pane session). Those carry flags=0; popping `pending` for
+                // one would assign the next sent command's id to it and desync
+                // every later reply (which silently freezes the copy-mode refresh
+                // loop). Skipping without popping keeps FIFO correlation aligned.
+                if !is_client_command_reply(flags) {
+                    return Ok(None);
                 }
-            },
+                match self.pending.pop_front() {
+                    Some(id) => Ok(Some(ClientEvent::CommandComplete {
+                        id,
+                        number,
+                        ok,
+                        output: body,
+                    })),
+                    // NOTE: a flags=1 reply with no pending command means the FIFO
+                    // is already desynced (more client replies than sent commands).
+                    // Closing the transport over it would blank the whole
+                    // projection; log at debug and skip so the connection stays
+                    // alive.
+                    None => {
+                        debug!(
+                            number,
+                            "skipping client-command reply with no pending command; transport remains open"
+                        );
+                        Ok(None)
+                    }
+                }
+            }
             Some(Frame::Notification(event)) => Ok(Some(ClientEvent::Notification(event))),
             None => Ok(None),
         }
     }
+}
+
+/// Returns whether a `%begin` flags bitmask marks a reply to a command the
+/// control client sent.
+///
+/// tmux sets bit 0 only for commands read from the control client's own input
+/// (its `CMDQ_STATE_CONTROL` flag, set on the control-client read path), and
+/// clears it for the adopted-stream launch reply and for unsolicited internal
+/// output (e.g. a hook's `run-shell`, as `after-select-pane` triggers). That bit
+/// is exactly the FIFO precondition: only a client-issued command's reply may
+/// consume a pending slot. The man page labels the field "currently not used",
+/// but it is populated — the man page's own example shows `%begin … 1` for a
+/// command reply; confirmed in `-CC` mode on tmux 3.6b.
+fn is_client_command_reply(flags: u32) -> bool {
+    flags & 1 != 0
 }
 
 #[cfg(test)]
@@ -279,7 +297,7 @@ mod tests {
 
     #[test]
     fn feed_arbitrary_byte_boundaries_match_whole() {
-        let whole = b"%begin 1 1 0\nbody-line\n%end 1 1 0\n";
+        let whole = b"%begin 1 1 1\nbody-line\n%end 1 1 1\n";
         let mut a = ProtocolClient::new();
         a.register_pending();
         let whole_events = a.feed(whole).unwrap();
@@ -348,7 +366,7 @@ mod tests {
         let id = c.send("capture").unwrap();
         let _ = c.take_outgoing();
         let events = c
-            .feed(b"%begin 1 1 0\nline1\n\nline3\n%end 1 1 0\n")
+            .feed(b"%begin 1 1 1\nline1\n\nline3\n%end 1 1 1\n")
             .unwrap();
         assert_eq!(
             events,
@@ -364,25 +382,18 @@ mod tests {
     #[test]
     fn feed_strips_dcs_wrapper() {
         // Mirrors a real `tmux -CC` startup: the DCS introducer is glued to the
-        // first %begin, and the terminator arrives as a bare line. CRLF endings.
+        // first %begin (the launch reply, flags=0), the terminator arrives as a
+        // bare line, CRLF endings. The launch block is unsolicited (flags=0) and
+        // skipped; only the notification passes through.
         let mut c = ProtocolClient::new();
-        let id = c.register_pending();
         let events = c
             .feed(b"\x1bP1000p%begin 1 318 0\r\n%end 1 318 0\r\n%window-add @0\r\n\x1b\\\r\n")
             .unwrap();
         assert_eq!(
             events,
-            vec![
-                ClientEvent::CommandComplete {
-                    id,
-                    number: 318,
-                    ok: true,
-                    output: vec![]
-                },
-                ClientEvent::Notification(ControlEvent::WindowAdd {
-                    window: WindowId(0)
-                }),
-            ]
+            vec![ClientEvent::Notification(ControlEvent::WindowAdd {
+                window: WindowId(0)
+            })]
         );
     }
 
@@ -391,7 +402,7 @@ mod tests {
         let mut c = ProtocolClient::new();
         let id = c.send("list-panes").unwrap();
         let _ = c.take_outgoing();
-        let events = c.feed(b"%begin 100 5 0\n0: ksh\n%end 100 5 0\n").unwrap();
+        let events = c.feed(b"%begin 100 5 1\n0: ksh\n%end 100 5 1\n").unwrap();
         assert_eq!(
             events,
             vec![ClientEvent::CommandComplete {
@@ -405,12 +416,42 @@ mod tests {
     }
 
     #[test]
+    fn unsolicited_hook_block_does_not_steal_pending_slot() {
+        // A tmux hook's `run-shell` (e.g. `after-select-pane`) emits an
+        // unsolicited %begin/%end block with flags=0; control-client command
+        // replies carry flags=1. The unsolicited block must NOT consume a pending
+        // command's slot, or every later reply mis-correlates (the copy-mode
+        // refresh loop dies when this happens in a multi-pane session).
+        let mut c = ProtocolClient::new();
+        let id = c.send("display-message -p x").unwrap();
+        let _ = c.take_outgoing();
+        let events = c
+            .feed(b"%begin 1 900 0\nHOOK\n%end 1 900 0\n%begin 1 901 1\nx\n%end 1 901 1\n")
+            .unwrap();
+        assert_eq!(
+            events,
+            vec![ClientEvent::CommandComplete {
+                id,
+                number: 901,
+                ok: true,
+                output: vec!["x".to_string()],
+            }],
+            "the flags=1 reply correlates to the sent command; the flags=0 hook block is skipped"
+        );
+        assert_eq!(
+            c.pending_len(),
+            0,
+            "the command's pending slot is consumed exactly once"
+        );
+    }
+
+    #[test]
     fn error_reply_is_not_ok() {
         let mut c = ProtocolClient::new();
         let id = c.send("bogus").unwrap();
         let _ = c.take_outgoing();
         let events = c
-            .feed(b"%begin 1 9 0\nunknown command\n%error 1 9 0\n")
+            .feed(b"%begin 1 9 1\nunknown command\n%error 1 9 1\n")
             .unwrap();
         assert_eq!(
             events,
@@ -428,7 +469,7 @@ mod tests {
         let mut c = ProtocolClient::new();
         let id = c.send("new-window").unwrap();
         let _ = c.take_outgoing();
-        let events = c.feed(b"%begin 1 2 0\n%end 1 2 0\n").unwrap();
+        let events = c.feed(b"%begin 1 2 1\n%end 1 2 1\n").unwrap();
         assert_eq!(
             events,
             vec![ClientEvent::CommandComplete {
@@ -447,7 +488,7 @@ mod tests {
         let b = c.send("b").unwrap();
         let _ = c.take_outgoing();
         let events = c
-            .feed(b"%begin 1 1 0\nA\n%end 1 1 0\n%begin 1 2 0\nB\n%end 1 2 0\n")
+            .feed(b"%begin 1 1 1\nA\n%end 1 1 1\n%begin 1 2 1\nB\n%end 1 2 1\n")
             .unwrap();
         assert_eq!(
             events,
@@ -475,7 +516,7 @@ mod tests {
         let b = c.send("b").unwrap();
         let _ = c.take_outgoing();
         let events = c
-            .feed(b"%begin 1 1 0\nA\n%end 1 1 0\n%window-add @9\n%begin 1 2 0\nB\n%end 1 2 0\n")
+            .feed(b"%begin 1 1 1\nA\n%end 1 1 1\n%window-add @9\n%begin 1 2 1\nB\n%end 1 2 1\n")
             .unwrap();
         assert_eq!(
             events,
@@ -500,11 +541,21 @@ mod tests {
     }
 
     #[test]
-    fn unsolicited_reply_is_skipped_not_fatal() {
+    fn unsolicited_flags0_reply_is_skipped_not_fatal() {
         let mut c = ProtocolClient::new();
-        // A reply block with no pending command must be skipped, not close the
-        // transport (tmux can emit blocks this control client did not originate).
+        // A flags=0 block (a hook's run-shell, or the adopted launch reply) is
+        // unsolicited and must be skipped without consuming a pending slot, not
+        // close the transport — tmux emits blocks this client did not originate.
         let events = c.feed(b"%begin 1 4 0\n%end 1 4 0\n").unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn client_reply_with_no_pending_is_skipped_not_fatal() {
+        let mut c = ProtocolClient::new();
+        // A flags=1 reply with nothing pending means the FIFO is already desynced;
+        // skip it as a safety net rather than closing the transport.
+        let events = c.feed(b"%begin 1 5 1\n%end 1 5 1\n").unwrap();
         assert!(events.is_empty());
     }
 
@@ -513,7 +564,7 @@ mod tests {
         let mut c = ProtocolClient::new();
         let id = c.send("x").unwrap();
         let _ = c.take_outgoing();
-        let events = c.feed(b"%begin 1 42 0\n%end 1 42 0\n").unwrap();
+        let events = c.feed(b"%begin 1 42 1\n%end 1 42 1\n").unwrap();
         assert_eq!(
             events,
             vec![ClientEvent::CommandComplete {
@@ -614,7 +665,7 @@ mod tests {
         let mut c = ProtocolClient::new();
         let id = c.send("x").unwrap();
         let _ = c.take_outgoing();
-        let events = c.feed(b"%begin 1 1 0\nhello world\n%end 1 1 0\n").unwrap();
+        let events = c.feed(b"%begin 1 1 1\nhello world\n%end 1 1 1\n").unwrap();
         assert_eq!(
             events,
             vec![ClientEvent::CommandComplete {
@@ -627,17 +678,29 @@ mod tests {
     }
 
     #[test]
-    fn external_pending_correlates_initial_reply_block() {
+    fn adopted_launch_block_skipped_then_first_command_correlates() {
+        // A freshly adopted tmux -CC stream emits its launch reply (flags=0, DCS
+        // introducer glued to the first %begin) before any client send. It must
+        // be skipped, not consume the first real command's pending slot.
         let mut c = ProtocolClient::new();
-        let id = c.register_external_pending();
-        // Introducer glued to the first %begin (as tmux -CC emits on entry).
-        let events = c
-            .feed(b"\x1bP1000p%begin 1 1 1\r\n0:work\r\n%end 1 1 1\r\n")
+        let launch = c
+            .feed(b"\x1bP1000p%begin 1 1 0\r\n0:work\r\n%end 1 1 0\r\n")
             .expect("feed ok");
-        assert!(matches!(
-            events.as_slice(),
-            [ClientEvent::CommandComplete { id: got, ok: true, .. }] if *got == id
-        ));
+        assert!(launch.is_empty(), "the flags=0 launch reply is skipped");
+
+        let id = c.send("list-windows").unwrap();
+        let _ = c.take_outgoing();
+        let events = c.feed(b"%begin 1 2 1\n0: win\n%end 1 2 1\n").unwrap();
+        assert_eq!(
+            events,
+            vec![ClientEvent::CommandComplete {
+                id,
+                number: 2,
+                ok: true,
+                output: vec!["0: win".to_string()],
+            }],
+            "the first client command correlates after the skipped launch block"
+        );
     }
 
     #[test]
@@ -648,7 +711,7 @@ mod tests {
         let mut c = ProtocolClient::new();
         c.send("capture").unwrap();
         let _ = c.take_outgoing();
-        let events = c.feed(b"%begin 1 1 0\nlast-line%end 1 1 0\n").unwrap();
+        let events = c.feed(b"%begin 1 1 1\nlast-line%end 1 1 1\n").unwrap();
         assert!(events.is_empty());
         assert_eq!(c.pending_len(), 1);
     }

--- a/crates/tmux_control_parser/src/assembler.rs
+++ b/crates/tmux_control_parser/src/assembler.rs
@@ -11,6 +11,11 @@ pub enum Frame {
     Reply {
         /// The command number shared by the matching `%begin`/`%end`/`%error`.
         number: u32,
+        /// The `%begin` flags bitmask, verbatim (taken from the opening
+        /// `%begin`). tmux populates bit 0 for control-client command replies;
+        /// the protocol layer owns that interpretation (see the consumer's
+        /// `is_client_command_reply`).
+        flags: u32,
         /// `true` if closed by `%end`, `false` if closed by `%error`.
         ok: bool,
         /// Reply body lines, verbatim, in order.
@@ -49,6 +54,7 @@ impl BlockAssembler {
                 match closed_ok {
                     Some(ok) => Ok(Some(Frame::Reply {
                         number: block.number,
+                        flags: block.flags,
                         ok,
                         body: block.body,
                     })),
@@ -60,9 +66,10 @@ impl BlockAssembler {
                 }
             }
             None => match ControlEvent::parse(line)? {
-                ControlEvent::Begin { number, .. } => {
+                ControlEvent::Begin { number, flags, .. } => {
                     self.open = Some(OpenBlock {
                         number,
+                        flags,
                         body: Vec::new(),
                     });
                     Ok(None)
@@ -79,6 +86,7 @@ impl BlockAssembler {
 #[derive(Debug, Clone)]
 struct OpenBlock {
     number: u32,
+    flags: u32,
     body: Vec<String>,
 }
 
@@ -106,6 +114,23 @@ mod tests {
             frames,
             vec![Frame::Reply {
                 number: 7,
+                flags: 1,
+                ok: true,
+                body: Vec::new()
+            }]
+        );
+    }
+
+    #[test]
+    fn reply_carries_begin_flags() {
+        // flags=0 marks the adopted-stream launch reply or unsolicited internal
+        // output (a hook's run-shell); flags=1 a control-client command reply.
+        let zero = feed_all(&[b"%begin 1 42 0", b"%end 1 42 0"]);
+        assert_eq!(
+            zero,
+            vec![Frame::Reply {
+                number: 42,
+                flags: 0,
                 ok: true,
                 body: Vec::new()
             }]
@@ -124,6 +149,7 @@ mod tests {
             frames,
             vec![Frame::Reply {
                 number: 8,
+                flags: 1,
                 ok: true,
                 body: vec![
                     "0: ksh* (1 panes) [80x24]".to_string(),
@@ -140,6 +166,7 @@ mod tests {
             frames,
             vec![Frame::Reply {
                 number: 9,
+                flags: 1,
                 ok: false,
                 body: vec!["unknown command: bogus".to_string()],
             }]
@@ -157,6 +184,7 @@ mod tests {
             frames,
             vec![Frame::Reply {
                 number: 10,
+                flags: 1,
                 ok: true,
                 body: vec!["%not-a-notification literally text".to_string()],
             }]
@@ -170,6 +198,7 @@ mod tests {
             frames,
             vec![Frame::Reply {
                 number: 11,
+                flags: 1,
                 ok: true,
                 body: vec!["%end 1 999 1".to_string()],
             }]
@@ -205,6 +234,7 @@ mod tests {
                 }),
                 Frame::Reply {
                     number: 12,
+                    flags: 1,
                     ok: true,
                     body: vec!["reply".to_string()]
                 },
@@ -224,6 +254,7 @@ mod tests {
             asm.feed(b"%end 1 13 1"),
             Ok(Some(Frame::Reply {
                 number: 13,
+                flags: 1,
                 ok: true,
                 body: vec!["line".to_string()]
             }))
@@ -257,6 +288,7 @@ mod tests {
             vec![
                 Frame::Reply {
                     number: 1,
+                    flags: 1,
                     ok: true,
                     body: Vec::new()
                 },

--- a/crates/tmux_session/src/connection.rs
+++ b/crates/tmux_session/src/connection.rs
@@ -23,14 +23,13 @@ pub struct TmuxClient {
 impl TmuxClient {
     /// Returns a client for a freshly adopted `tmux -CC` stream.
     ///
-    /// Pre-registers the single reply block the adopted stream emits on entry
-    /// (its DCS introducer is glued to the first `%begin`) so the in-world drive
-    /// correlates it instead of dropping it as unsolicited.
+    /// The adopted stream's first block — the launch (`new-session` /
+    /// `attach-session`) reply, whose DCS introducer is glued to the first
+    /// `%begin` — carries flags=0, so the protocol client skips it as an
+    /// unsolicited block; no pre-registration is needed.
     pub fn new_adopted() -> Self {
-        let mut protocol = ProtocolClient::new();
-        let _entry = protocol.register_external_pending();
         Self {
-            protocol,
+            protocol: ProtocolClient::new(),
             client_name: None,
             per_window_refresh: None,
         }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -213,8 +213,13 @@ fn tmux_batch_pending(batch: Res<TmuxEventBatch>) -> bool {
 
 /// Inserts [`TmuxAttached`] and emits [`TmuxClientAttached`] on the attach edge:
 /// the first frame the connected gateway has a pending batch while it is not yet
-/// attached. Gated on a pending batch; the drain only ever produces protocol
-/// events, so a pending batch is exactly "a protocol event arrived".
+/// attached. Gated on a pending batch.
+///
+/// The adopted stream's launch reply (flags=0) is skipped by the protocol client
+/// and yields no event, so the attach edge is the first notification or
+/// correlated reply — on a real `tmux -CC` attach, the session/window state tmux
+/// streams immediately after the launch block. A launch-block-only frame (its
+/// trailing notifications not yet read) merely defers attach to the next frame.
 fn mark_attached_on_first_protocol(
     mut commands: Commands,
     mut attached: MessageWriter<TmuxClientAttached>,
@@ -549,7 +554,7 @@ mod tests {
         let gateway = app
             .world_mut()
             .spawn(AdoptedControlMode::from_captured(
-                b"\x1bP1000p%begin 1 1 1\r\n%end 1 1 1\r\n".to_vec(),
+                b"\x1bP1000p%begin 1 1 0\r\n%end 1 1 0\r\n%session-changed $0 0\r\n".to_vec(),
             ))
             .id();
         app.world_mut()
@@ -682,7 +687,9 @@ mod tests {
         app.init_resource::<TmuxEventBatch>()
             .add_message::<PaneOutput>();
         app.world_mut().spawn((
-            AdoptedControlMode::from_captured(b"\x1bP1000p%begin 1 1 1\r\n%end 1 1 1\r\n".to_vec()),
+            AdoptedControlMode::from_captured(
+                b"\x1bP1000p%begin 1 1 0\r\n%end 1 1 0\r\n%session-changed $0 0\r\n".to_vec(),
+            ),
             TmuxClient::new_adopted(),
         ));
         app.add_systems(Update, drain_tmux_transport);
@@ -864,23 +871,23 @@ mod tests {
     /// -> `MessageWriter<PaneOutput>` for `%output`) -> `apply_tmux_replies`
     /// (`trigger_notification` for `%window-add` / `%layout-change`) -> the
     /// projection observers -> `TmuxWindow` / `TmuxPane` entities in the
-    /// `TmuxProjection` index. The leading DCS introducer plus a `%begin`/`%end`
-    /// block correlate with the external pending reply that `adopt` pre-registers
-    /// (mirroring the `tmux -CC` entry block); the three notification lines that
-    /// follow are the projected transcript.
+    /// `TmuxProjection` index. The leading DCS introducer plus the `%begin`/`%end`
+    /// launch block (flags=0) are skipped as unsolicited (mirroring the `tmux -CC`
+    /// entry block); the three notification lines that follow are the projected
+    /// transcript.
     #[test]
     fn transcript_drives_ecs_projection_and_pane_output() {
         use tmux_control_parser::{PaneId, WindowId};
 
         // Canned transcript fed verbatim through the drain chain:
-        //   * DCS introducer + initial %begin/%end block — the adopted tmux -CC
-        //     entry block, correlated by adopt()'s pre-registered external reply.
+        //   * DCS introducer + initial %begin/%end launch block (flags=0) — the
+        //     adopted tmux -CC entry block, skipped as an unsolicited block.
         //   * %window-add @1, %layout-change @1 (single 80x24 pane %1) — project a
         //     window and its pane. "b25f" is a real tmux layout checksum; the
         //     visible_layout field repeats the layout string (>= tmux 3.2 format).
         //   * %output %1 hello — routes to a PaneOutput message.
         let transcript: Vec<u8> = concat!(
-            "\x1bP1000p%begin 1 1 1\r\n%end 1 1 1\r\n",
+            "\x1bP1000p%begin 1 1 0\r\n%end 1 1 0\r\n",
             "%window-add @1\r\n",
             "%layout-change @1 b25f,80x24,0,0,1 b25f,80x24,0,0,1\r\n",
             "%output %1 hello\r\n",
@@ -973,11 +980,12 @@ mod tests {
     fn second_adoption_after_reset_reattaches_and_reenumerates() {
         use crate::events::TmuxConnectionReset;
 
-        // The DCS introducer + a %begin/%end block: the adopted tmux -CC entry
-        // block, which correlates with adopt()'s pre-registered external reply and
-        // produces one Protocol event that marks the gateway TmuxAttached.
+        // The DCS introducer + a %begin/%end launch block (flags=0, skipped as
+        // unsolicited) followed by a %session-changed notification: the adopted
+        // tmux -CC entry stream, whose first protocol event marks the gateway
+        // TmuxAttached.
         fn entry_block() -> Vec<u8> {
-            b"\x1bP1000p%begin 1 1 1\r\n%end 1 1 1\r\n".to_vec()
+            b"\x1bP1000p%begin 1 1 0\r\n%end 1 1 0\r\n%session-changed $0 0\r\n".to_vec()
         }
 
         fn attached_count(app: &App) -> usize {


### PR DESCRIPTION
## Problem

In `tmux -CC` (control mode), tmux **copy-mode cursor movement and scrolling are dead in multi-pane windows**: `h/j/k/l`, arrow keys, and wheel/PageUp produce no visible change, while `q` still exits copy mode. Single-pane windows work. It reproduces on setups with `run-shell` hooks (e.g. `after-select-pane` / `client-session-changed` → `run-shell`).

Root cause: control-mode reply correlation was FIFO-only. tmux emits `%begin <time> <number> <flags>` reply blocks, and `ProtocolClient` popped a pending command id for **every** reply via `pending.pop_front()`, trusting that replies arrive in send order. But a hook's `run-shell` emits an **unsolicited** `%begin/%end` block (flags=0) that this client never sent. That block stole the next sent command's pending slot and **permanently desynced** correlation, so `CopyModeReply` (the copy-state poll / capture) was never matched back — the copy-mode capture/overlay refresh loop froze, leaving the cursor overlay and scrolled view unchanged. `q` still worked because it removes `CopyModeState` **locally**, independent of that loop. It's multi-pane-only because selecting panes is what fires the hooks; single-pane never selects, so the FIFO stays aligned.

## Solution

Make `tmux -CC` reply correlation **flags-aware** so unsolicited blocks no longer desync it:

- **`crates/tmux_control_parser`** — thread the `%begin` flags through `Frame::Reply` (the value was already parsed into `ControlEvent::Begin`, just discarded by the assembler).
- **`crates/tmux_control`** — in `ProtocolClient::feed_line`, only consume a pending FIFO slot for **control-client command replies** (flags bit 0 set — tmux's `CMDQ_STATE_CONTROL`, set only on the control-client input path). **Unsolicited blocks** (the adopted-stream launch reply and hook `run-shell` output, flags=0) are skipped without popping, keeping correlation aligned.
- **`crates/tmux_control` + `crates/tmux_session`** — remove the `register_external_pending` phantom from `TmuxClient::new_adopted`; the launch block (flags=0) is now skipped naturally rather than absorbed by a fake pending slot.

### Verification

- New `unsolicited_hook_block_does_not_steal_pending_slot` reproduces the desync (written test-first: RED → GREEN).
- Existing protocol/assembler/adoption tests updated to realistic flags (real `-CC` client replies are flags=1, verified by pty capture against tmux 3.6b; the prior fixtures used flags=0 as placeholder).
- Full workspace `cargo test`, `cargo clippy --workspace --all-targets`, and `cargo fmt --all --check` all pass.

No breaking changes — `ClientEvent` shapes are unchanged; only when a reply is correlated changed.
