### PR TITLE
fix(renderer): CJK fallback glyph sizing + wire font.size config

### DIFF
--- a/crates/ozma_tty_renderer/src/glyph/atlas.rs
+++ b/crates/ozma_tty_renderer/src/glyph/atlas.rs
@@ -323,20 +323,18 @@ mod tests {
             .get_or_insert(key, &fonts)
             .expect("'あ' must rasterize via fallback");
 
-        // Height the buggy code produced: the fallback outline at the PRIMARY
-        // scale. The fix must rasterize 'あ' strictly smaller than this.
         let fb = fonts.fallback_choice(&FontFace::Regular);
         let primary_scale = ab_glyph::PxScale::from(fonts.px_scale_value(size));
         let gid = fb.glyph_id('あ');
-        let buggy_h = fb
+        let primary_scaled_h = fb
             .outline_glyph(gid.with_scale(primary_scale))
             .expect("'あ' outline at primary scale")
             .px_bounds()
             .height();
 
         assert!(
-            (rect.h as f32) < buggy_h - 0.5,
-            "'あ' rect height {} must be smaller than primary-scaled height {buggy_h}",
+            (rect.h as f32) < primary_scaled_h - 0.5,
+            "'あ' rect height {} must be smaller than the primary-scaled height {primary_scaled_h}",
             rect.h
         );
     }

--- a/crates/ozma_tty_renderer/src/glyph/atlas.rs
+++ b/crates/ozma_tty_renderer/src/glyph/atlas.rs
@@ -1,4 +1,4 @@
-use ab_glyph::{Font, FontArc, OutlinedGlyph, ScaleFont};
+use ab_glyph::{Font, FontArc, OutlinedGlyph};
 use bevy::{platform::collections::HashMap, prelude::*};
 
 use crate::glyph::font::{FontFace, GlyphKey, TerminalFonts};
@@ -47,43 +47,37 @@ pub struct GlyphAtlas {
     shelves: Shelves,
 }
 
-/// Resolves a glyph for the requested codepoint, preferring the
-/// primary face and falling back to `fallback_choice` when the
-/// primary's `glyph_id` is 0 (notdef).
+/// Resolves a glyph for the requested codepoint, preferring the primary face
+/// and falling back to `fallback_choice` when the primary's `glyph_id` is 0
+/// (notdef).
 ///
-/// Returns `(font, glyph_id)` for the resolved face, or `None` when
-/// neither primary nor fallback contains the glyph.
+/// Returns `(font, glyph_id, used_fallback)` for the resolved face, or `None`
+/// when neither primary nor fallback contains the glyph. The `used_fallback`
+/// flag tells `get_or_insert` which em-matched `PxScale` to rasterize at: the
+/// primary's (`px_scale_value`) or the fallback's (`fallback_px_scale_value`),
+/// so each face renders its em-square at the same physical pixel size.
 ///
-/// Both faces are scaled at `scale` — the primary's `PxScale`. This
-/// is the Alacritty / WezTerm pattern: rasterize fallback at the
-/// primary's size so the grid pitch stays bound to the primary
-/// font's metrics. UDEVGothic35 is JBM-metric-compatible by design.
+/// `glyph_id` lookup is scale-independent, so this resolves before any scale is
+/// chosen.
 ///
-/// NOTE: this helper retries on `glyph_id == 0` only — NOT on
-/// degenerate outline (`w == 0 || h == 0`) which is still
-/// short-circuited in `get_or_insert`. A non-zero `glyph_id` with
-/// zero-extent raster indicates a malformed font, not missing
-/// coverage; not worth retrying.
-///
-/// NOTE: we keep PUA Nerd Font icons rendering through the primary
-/// face — UDEVGothic35 doesn't include Nerd Font glyphs, so for
-/// U+E000–U+F8FF the primary's glyph_id is non-zero and we never
-/// reach the fallback path.
+/// NOTE: retries on `glyph_id == 0` only — NOT on degenerate outline
+/// (`w == 0 || h == 0`), which `get_or_insert` still short-circuits after
+/// outlining. PUA Nerd Font icons (U+E000–U+F8FF) resolve non-zero on the
+/// primary, so they never reach the fallback.
 fn resolve_glyph<'a>(
     fonts: &'a TerminalFonts,
     face: &FontFace,
     ch: char,
-    scale: ab_glyph::PxScale,
-) -> Option<(&'a FontArc, ab_glyph::GlyphId)> {
+) -> Option<(&'a FontArc, ab_glyph::GlyphId, bool)> {
     let primary = fonts.choice(face);
-    let id = primary.as_scaled(scale).glyph_id(ch);
+    let id = primary.glyph_id(ch);
     if id.0 != 0 {
-        return Some((primary, id));
+        return Some((primary, id, false));
     }
     let fallback = fonts.fallback_choice(face);
-    let id = fallback.as_scaled(scale).glyph_id(ch);
+    let id = fallback.glyph_id(ch);
     if id.0 != 0 {
-        return Some((fallback, id));
+        return Some((fallback, id, true));
     }
     None
 }
@@ -120,8 +114,13 @@ impl GlyphAtlas {
             return Some(*r);
         }
         let ch = char::from_u32(key.codepoint)?;
-        let scale = ab_glyph::PxScale::from(fonts.px_scale_value(key.size_px));
-        let (font, glyph_id) = resolve_glyph(fonts, &key.face, ch, scale)?;
+        let (font, glyph_id, used_fallback) = resolve_glyph(fonts, &key.face, ch)?;
+        let scale_value = if used_fallback {
+            fonts.fallback_px_scale_value(key.size_px)
+        } else {
+            fonts.px_scale_value(key.size_px)
+        };
+        let scale = ab_glyph::PxScale::from(scale_value);
 
         let outlined = font.outline_glyph(glyph_id.with_scale(scale))?;
         let bounds = outlined.px_bounds();
@@ -311,6 +310,35 @@ mod tests {
             .get_or_insert(key, &fonts)
             .expect("Powerline glyph U+E0B0 must rasterize via primary");
         assert!(rect.w > 0 && rect.h > 0, "U+E0B0 rect must be non-empty");
+    }
+
+    #[test]
+    fn cjk_rasterizes_at_fallback_scale_not_primary_scale() {
+        use ab_glyph::Font as _;
+        let fonts = TerminalFonts::default();
+        let mut atlas = GlyphAtlas::default();
+        let size = 24u16;
+        let key = make_key(FontFace::Regular, 0x3042, size); // 'あ'
+        let rect = atlas
+            .get_or_insert(key, &fonts)
+            .expect("'あ' must rasterize via fallback");
+
+        // Height the buggy code produced: the fallback outline at the PRIMARY
+        // scale. The fix must rasterize 'あ' strictly smaller than this.
+        let fb = fonts.fallback_choice(&FontFace::Regular);
+        let primary_scale = ab_glyph::PxScale::from(fonts.px_scale_value(size));
+        let gid = fb.glyph_id('あ');
+        let buggy_h = fb
+            .outline_glyph(gid.with_scale(primary_scale))
+            .expect("'あ' outline at primary scale")
+            .px_bounds()
+            .height();
+
+        assert!(
+            (rect.h as f32) < buggy_h - 0.5,
+            "'あ' rect height {} must be smaller than primary-scaled height {buggy_h}",
+            rect.h
+        );
     }
 
     #[test]

--- a/crates/ozma_tty_renderer/src/glyph/font.rs
+++ b/crates/ozma_tty_renderer/src/glyph/font.rs
@@ -622,13 +622,11 @@ mod tests {
         let phys = 12u16;
         let primary = fonts.px_scale_value(phys);
         let fallback = fonts.fallback_px_scale_value(phys);
-        // UDEVGothic35 em_scale (1.161133) is ~12% smaller than JBM (1.320000);
-        // the fallback must rasterize correspondingly smaller, not at the
-        // primary's scale (which inflated CJK by +13.68%).
         let ratio = fallback / primary;
         assert!(
             (ratio - 0.879646).abs() < 0.001,
-            "fallback/primary px_scale ratio = {ratio} (expected ~0.879646)"
+            "fallback/primary px_scale ratio = {ratio} (expected ~0.879646: \
+             UDEVGothic35 em_scale 1.161133 / JBM 1.320000)"
         );
     }
 

--- a/crates/ozma_tty_renderer/src/glyph/font.rs
+++ b/crates/ozma_tty_renderer/src/glyph/font.rs
@@ -22,10 +22,7 @@ pub enum FontLoadError {
     },
 }
 
-/// Font size in CSS pixels; multiplied by the PrimaryWindow's
-/// `scale_factor` to obtain the physical pixel size fed to
-/// `cell_metrics_px`.
-pub const FONT_SIZE_PX: f32 = 12.0;
+const FONT_SIZE_PX: f32 = 12.0;
 
 /// Logical (CSS) pixel font size for the terminal grid. Multiplied by the
 /// PrimaryWindow's `scale_factor` to obtain the physical pixel size fed to

--- a/crates/ozma_tty_renderer/src/glyph/font.rs
+++ b/crates/ozma_tty_renderer/src/glyph/font.rs
@@ -183,6 +183,18 @@ fn max_ascii_overflow_for_face(face: &FontArc, px_scale: f32, cell_w_phys_floor:
     worst.max(0.0)
 }
 
+/// Returns a face's em-scale `(ascender − descender) / units_per_em` — the
+/// factor that maps a physical font size in pixels to the `ab_glyph::PxScale`
+/// whose em-square renders at exactly that pixel size.
+fn em_scale_of(font: &FontArc) -> f32 {
+    let face = TtfFace::parse(font.font_data(), 0)
+        .expect("ttf-parser parse failed for a face ab_glyph already accepted");
+    let asc = i32::from(face.ascender());
+    let desc = i32::from(face.descender());
+    let upem = f32::from(face.units_per_em());
+    (asc - desc) as f32 / upem
+}
+
 impl TerminalFonts {
     /// Constructs a `TerminalFonts` from eight owned TTF byte buffers, one
     /// per face (four primary + four fallback). `Vec<u8>` is required by
@@ -347,28 +359,18 @@ impl TerminalFonts {
         }
     }
 
-    /// Returns the actual `PxScale` value fed to `ab_glyph` for the given
-    /// CSS-pixel font size. Multiplies by `em_scale = (ascender − descender)
-    /// / units_per_em` (derived from the Regular face's hhea/head tables)
-    /// so the input size is interpreted as the em-square in physical pixels
-    /// (CSS / Terminal.app convention), not as `ab_glyph::PxScale`'s
-    /// native "ascent + |descent|" interpretation.
-    ///
-    /// Used by both `cell_metrics_px` (for advance / ascent / descent
-    /// derivation) and `glyph/atlas.rs` (for glyph rasterization), so both
-    /// agree on the actual rendering scale.
+    /// Returns the `ab_glyph::PxScale` value for the primary regular face at the
+    /// given physical pixel size. Used by `cell_metrics_px` and `glyph/atlas.rs`.
     pub(crate) fn px_scale_value(&self, phys_size_px: u16) -> f32 {
-        let face = TtfFace::parse(self.regular.font_data(), 0)
-            .expect(
-                "regular face: ttf-parser parse failed (bundled or user-supplied via FontBridgePlugin); \
-                 if a user override is in effect this means the override file passed ab_glyph but \
-                 ttf-parser rejected it — check the most recent FontBridgePlugin warning",
-            );
-        let asc = i32::from(face.ascender());
-        let desc = i32::from(face.descender());
-        let upem = f32::from(face.units_per_em());
-        let em_scale = (asc - desc) as f32 / upem;
-        f32::from(phys_size_px) * em_scale
+        f32::from(phys_size_px) * em_scale_of(&self.regular)
+    }
+
+    /// Returns the `PxScale` value for the CJK fallback face so its em-square
+    /// renders at the same physical pixel size as the primary's, preventing the
+    /// fallback from rasterizing larger than the grid expects. Mirrors
+    /// [`Self::px_scale_value`] but reads `self.fallback_regular`'s metrics.
+    pub(crate) fn fallback_px_scale_value(&self, phys_size_px: u16) -> f32 {
+        f32::from(phys_size_px) * em_scale_of(&self.fallback_regular)
     }
 }
 
@@ -598,6 +600,22 @@ mod tests {
             pre_inserted_bytes_ptr,
             "TerminalFonts was overwritten by Plugin::build, but the resource was \
              already present at add_plugins time — the pre-insert should have been preserved"
+        );
+    }
+
+    #[test]
+    fn fallback_px_scale_value_is_em_matched_and_smaller_than_primary() {
+        let fonts = TerminalFonts::default();
+        let phys = 12u16;
+        let primary = fonts.px_scale_value(phys);
+        let fallback = fonts.fallback_px_scale_value(phys);
+        // UDEVGothic35 em_scale (1.161133) is ~12% smaller than JBM (1.320000);
+        // the fallback must rasterize correspondingly smaller, not at the
+        // primary's scale (which inflated CJK by +13.68%).
+        let ratio = fallback / primary;
+        assert!(
+            (ratio - 0.879646).abs() < 0.001,
+            "fallback/primary px_scale ratio = {ratio} (expected ~0.879646)"
         );
     }
 

--- a/crates/ozma_tty_renderer/src/glyph/font.rs
+++ b/crates/ozma_tty_renderer/src/glyph/font.rs
@@ -28,7 +28,7 @@ const FONT_SIZE_PX: f32 = 12.0;
 /// PrimaryWindow's `scale_factor` to obtain the physical pixel size fed to
 /// `cell_metrics_px` and the glyph atlas.
 ///
-/// Defaults to [`FONT_SIZE_PX`]; the app's `FontBridgePlugin` overwrites it
+/// Defaults to 12.0 (`FONT_SIZE_PX`); the app's `FontBridgePlugin` overwrites it
 /// from `config.font.size` at Startup, before cell metrics are computed.
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct TerminalFontSize(pub f32);
@@ -643,7 +643,6 @@ mod tests {
         };
         window.resolution.set_scale_factor(1.0);
         app.world_mut().spawn((window, PrimaryWindow));
-        // Pre-insert so the plugin's init_resource keeps this value.
         app.insert_resource(TerminalFontSize(10.0));
         app.add_plugins(TerminalFontPlugin);
         app.update();

--- a/crates/ozma_tty_renderer/src/glyph/font.rs
+++ b/crates/ozma_tty_renderer/src/glyph/font.rs
@@ -27,6 +27,21 @@ pub enum FontLoadError {
 /// `cell_metrics_px`.
 pub const FONT_SIZE_PX: f32 = 12.0;
 
+/// Logical (CSS) pixel font size for the terminal grid. Multiplied by the
+/// PrimaryWindow's `scale_factor` to obtain the physical pixel size fed to
+/// `cell_metrics_px` and the glyph atlas.
+///
+/// Defaults to [`FONT_SIZE_PX`]; the app's `FontBridgePlugin` overwrites it
+/// from `config.font.size` at Startup, before cell metrics are computed.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct TerminalFontSize(pub f32);
+
+impl Default for TerminalFontSize {
+    fn default() -> Self {
+        Self(FONT_SIZE_PX)
+    }
+}
+
 /// Public `SystemSet` label used to order systems against the renderer's
 /// cell-metrics initialization. App-level plugins that need to mutate
 /// `TerminalFonts` before metrics are computed should run their Startup
@@ -47,7 +62,7 @@ impl Plugin for TerminalFontPlugin {
         if !app.world().contains_resource::<TerminalFonts>() {
             app.insert_resource(TerminalFonts::default());
         }
-        app.add_systems(
+        app.init_resource::<TerminalFontSize>().add_systems(
             Startup,
             init_cell_metrics_from_primary_window.in_set(TerminalFontInitSet::InitCellMetrics),
         );
@@ -69,10 +84,11 @@ impl Plugin for TerminalFontPlugin {
 fn init_cell_metrics_from_primary_window(
     mut commands: Commands,
     fonts: Res<TerminalFonts>,
+    font_size: Res<TerminalFontSize>,
     window: Single<&Window, With<PrimaryWindow>>,
 ) {
     let dpr = window.scale_factor();
-    let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
+    let phys_font_size = (font_size.0 * dpr).round() as u16;
     let metrics = fonts.cell_metrics_px(phys_font_size);
     commands.insert_resource(TerminalCellMetricsResource {
         metrics,
@@ -616,6 +632,32 @@ mod tests {
         assert!(
             (ratio - 0.879646).abs() < 0.001,
             "fallback/primary px_scale ratio = {ratio} (expected ~0.879646)"
+        );
+    }
+
+    #[test]
+    fn init_cell_metrics_honors_terminal_font_size_resource() {
+        use bevy::window::{PrimaryWindow, Window, WindowResolution};
+
+        let mut app = App::new();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        // Pre-insert so the plugin's init_resource keeps this value.
+        app.insert_resource(TerminalFontSize(10.0));
+        app.add_plugins(TerminalFontPlugin);
+        app.update();
+
+        let res = app
+            .world()
+            .get_resource::<TerminalCellMetricsResource>()
+            .expect("Startup system should insert TerminalCellMetricsResource");
+        assert_eq!(
+            res.phys_font_size, 10,
+            "phys_font_size must follow TerminalFontSize (10.0) at DPR 1.0"
         );
     }
 

--- a/crates/ozma_tty_renderer/src/lib.rs
+++ b/crates/ozma_tty_renderer/src/lib.rs
@@ -13,7 +13,7 @@ pub mod schema;
 
 pub use crate::glyph::font::{
     CellMetrics, FONT_SIZE_PX, FontFace, FontLoadError, TerminalCellMetricsResource,
-    TerminalFontInitSet, TerminalFontPlugin, TerminalFonts,
+    TerminalFontInitSet, TerminalFontPlugin, TerminalFontSize, TerminalFonts,
 };
 
 pub mod prelude {

--- a/crates/ozma_tty_renderer/src/lib.rs
+++ b/crates/ozma_tty_renderer/src/lib.rs
@@ -12,8 +12,8 @@ pub mod material;
 pub mod schema;
 
 pub use crate::glyph::font::{
-    CellMetrics, FONT_SIZE_PX, FontFace, FontLoadError, TerminalCellMetricsResource,
-    TerminalFontInitSet, TerminalFontPlugin, TerminalFontSize, TerminalFonts,
+    CellMetrics, FontFace, FontLoadError, TerminalCellMetricsResource, TerminalFontInitSet,
+    TerminalFontPlugin, TerminalFontSize, TerminalFonts,
 };
 
 pub mod prelude {

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -1,7 +1,7 @@
 use crate::{
     glyph::{
         atlas::{GlyphAtlas, GlyphRect},
-        font::{FONT_SIZE_PX, FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFonts},
+        font::{FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFontSize, TerminalFonts},
     },
     material::state::TerminalMaterialState,
     schema::{Cell, HyperlinkHoverState, SelectionKind, TerminalGrid},
@@ -479,13 +479,12 @@ fn update_terminal_material(
         Option<&TerminalOverlays>,
     )>,
     fonts: Res<TerminalFonts>,
+    font_size: Res<TerminalFontSize>,
     palette_time: Res<Time>,
     windows: Query<&Window, With<PrimaryWindow>>,
     mut cell_metrics_res: ResMut<TerminalCellMetricsResource>,
     hover: Res<HyperlinkHoverState>,
 ) {
-    // TODO: load font size from config.
-
     // NOTE: This system runs unconditionally — *not* gated by
     // `Changed<TerminalGrid>`. The `mat.params = ...` write at the end is
     // load-bearing for rendering correctness: it forces `AssetEvent::Modified`
@@ -512,7 +511,7 @@ fn update_terminal_material(
         return;
     };
     let dpr = window.scale_factor();
-    let phys_font_size = (FONT_SIZE_PX * dpr).round() as u16;
+    let phys_font_size = (font_size.0 * dpr).round() as u16;
 
     for (entity, handle, mut state, grid, pane_style, overlays) in terminals.iter_mut() {
         let atlas_invalidated = atlas.generation != state.last_atlas_generation;

--- a/crates/ozmux_configs/src/font.rs
+++ b/crates/ozmux_configs/src/font.rs
@@ -9,7 +9,9 @@ const DEFAULT_SIZE: f32 = 11.25;
 #[derive(Deserialize, Clone, Debug, PartialEq)]
 #[serde(default)]
 pub struct FontConfig {
-    /// Terminal font size in points, matching Alacritty.
+    /// Terminal font size in logical (CSS) pixels, scaled by the display's
+    /// `scale_factor` to device pixels — Alacritty's model (not literal
+    /// typographic points; no 96/72 conversion is applied).
     pub size: f32,
     /// Absolute or `~`-prefixed path to the regular-face TTF (Bevy GUI only).
     pub normal: Option<PathBuf>,

--- a/docs/superpowers/plans/2026-06-24-cjk-font-and-font-size.md
+++ b/docs/superpowers/plans/2026-06-24-cjk-font-and-font-size.md
@@ -1,0 +1,703 @@
+# CJK Fallback Sizing + `font.size` Config Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop CJK fallback glyphs from rendering ~13.7% too large/bold by rasterizing the fallback face at its own em-matched scale, and wire the ignored `font.size` config value into the renderer.
+
+**Architecture:** Two independent fixes in `crates/ozma_tty_renderer` plus binary wiring in `src/`. Part 1 makes the glyph atlas pick the rasterization `PxScale` from the *resolved* face (primary keeps the primary-regular scale; fallback uses the fallback-regular scale). Part 2 introduces a `TerminalFontSize` resource that `FontBridgePlugin` fills from `config.font.size` and the renderer reads instead of the hardcoded `FONT_SIZE_PX`. The parts are separate commits so either can be reverted alone.
+
+**Tech Stack:** Rust 2024, Bevy 0.18 ECS, `ab_glyph` 0.2 (glyph rasterization), `ttf_parser` (OpenType metrics).
+
+**Spec:** `docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md`
+
+## Global Constraints
+
+- Rust edition 2024, toolchain 1.95; Bevy 0.18 (copied from `CLAUDE.md` / `rust-toolchain.toml`).
+- All in-code comments in English. Only `// TODO:` / `// NOTE:` / `// SAFETY:` line-comment forms (`.claude/rules/rust.md`).
+- Every externally `pub` item gets a `///` doc comment; module files keep their `//!`.
+- Visibility minimization: any item used only inside its defining module MUST be private.
+- Mutable function/system params declared before immutable ones (`self`/`On<E>` excepted).
+- `Plugin::build` bodies are a single `app.` method chain (an `if` guard may precede it).
+- Systems/observers are registered by the `Plugin` defined in the same file.
+- No `mod.rs`. No manual `set_changed()` / `bypass_change_detection()`.
+- TDD: failing test first, minimal impl, green, commit. Conventional-commit messages ending with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Verified font metrics (do not re-derive): JBM-Regular `em_scale = (1020 − −300)/1000 = 1.320000`; UDEVGothic35-Regular `em_scale = (1962 − −416)/2048 = 1.161133`; fallback/primary ratio `= 0.879646`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+| --- | --- | --- |
+| `crates/ozma_tty_renderer/src/glyph/font.rs` | `em_scale_of`, `px_scale_value`, new `fallback_px_scale_value`, new `TerminalFontSize` resource, `TerminalFontPlugin`, `init_cell_metrics_from_primary_window` | 2, 3, 5 |
+| `crates/ozma_tty_renderer/src/glyph/atlas.rs` | `resolve_glyph` + `get_or_insert` pick per-face scale | 2 |
+| `crates/ozma_tty_renderer/src/material.rs` | `update_terminal_material` reads `TerminalFontSize` | 3 |
+| `crates/ozma_tty_renderer/src/lib.rs` | export `TerminalFontSize`; drop `FONT_SIZE_PX` export | 3, 5 |
+| `src/font.rs` | `bridge_font_config` sets `TerminalFontSize` from config | 4 |
+| `src/ui/ime_overlay.rs` | IME overlay reads `TerminalFontSize` | 5 |
+
+---
+
+## Task 1: Commit design artifacts
+
+Put the approved spec and this plan under version control before touching code, so the design is recoverable independently of the implementation.
+
+**Files:**
+- Add: `docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md`
+- Add: `docs/superpowers/plans/2026-06-24-cjk-font-and-font-size.md`
+
+- [ ] **Step 1: Confirm on the feature branch**
+
+Run: `git rev-parse --abbrev-ref HEAD`
+Expected: `cjk-font`
+
+- [ ] **Step 2: Commit the docs**
+
+`docs/` is gitignored, but ~101 design docs are tracked here via force-add (repo convention; see `CLAUDE.md` "docs/ — tracked in git"). Use `-f`:
+
+```bash
+git add -f docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md \
+           docs/superpowers/plans/2026-06-24-cjk-font-and-font-size.md
+git commit -m "docs: CJK fallback sizing + font.size wiring design and plan
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Part 1 — CJK fallback em-match fix
+
+Rasterize fallback (CJK) glyphs at the fallback-regular face's own em-matched scale instead of the primary's, removing the +13.68% inflation. The primary path and all cell metrics are unchanged.
+
+**Files:**
+- Modify: `crates/ozma_tty_renderer/src/glyph/font.rs` (add `em_scale_of`, refactor `px_scale_value`, add `fallback_px_scale_value`)
+- Modify: `crates/ozma_tty_renderer/src/glyph/atlas.rs` (`resolve_glyph` signature + `get_or_insert` scale selection + imports + doc)
+- Test: same two files (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `TerminalFonts::fallback_px_scale_value(&self, phys_size_px: u16) -> f32` (`pub(crate)`); free fn `em_scale_of(font: &FontArc) -> f32` (module-private); `resolve_glyph(...) -> Option<(&FontArc, ab_glyph::GlyphId, bool)>` where the `bool` is `used_fallback`.
+
+- [ ] **Step 1: Write the failing unit test for `fallback_px_scale_value`**
+
+Add to `crates/ozma_tty_renderer/src/glyph/font.rs` inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn fallback_px_scale_value_is_em_matched_and_smaller_than_primary() {
+        let fonts = TerminalFonts::default();
+        let phys = 12u16;
+        let primary = fonts.px_scale_value(phys);
+        let fallback = fonts.fallback_px_scale_value(phys);
+        // UDEVGothic35 em_scale (1.161133) is ~12% smaller than JBM (1.320000);
+        // the fallback must rasterize correspondingly smaller, not at the
+        // primary's scale (which inflated CJK by +13.68%).
+        let ratio = fallback / primary;
+        assert!(
+            (ratio - 0.879646).abs() < 0.001,
+            "fallback/primary px_scale ratio = {ratio} (expected ~0.879646)"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile**
+
+Run: `cargo test -p ozma_tty_renderer fallback_px_scale_value_is_em_matched -- --nocapture`
+Expected: FAIL — `no method named fallback_px_scale_value`.
+
+- [ ] **Step 3: Extract `em_scale_of` and add `fallback_px_scale_value`**
+
+In `crates/ozma_tty_renderer/src/glyph/font.rs`, add this module-private free function next to `max_ascii_overflow_for_face` (above the `impl TerminalFonts` block):
+
+```rust
+/// Returns a face's em-scale `(ascender − descender) / units_per_em` — the
+/// factor that maps a physical font size in pixels to the `ab_glyph::PxScale`
+/// whose em-square renders at exactly that pixel size.
+fn em_scale_of(font: &FontArc) -> f32 {
+    let face = TtfFace::parse(font.font_data(), 0)
+        .expect("ttf-parser parse failed for a face ab_glyph already accepted");
+    let asc = i32::from(face.ascender());
+    let desc = i32::from(face.descender());
+    let upem = f32::from(face.units_per_em());
+    (asc - desc) as f32 / upem
+}
+```
+
+Replace the body of `px_scale_value` (currently parses `self.regular` inline) with the extracted helper, and add `fallback_px_scale_value` directly after it:
+
+```rust
+    pub(crate) fn px_scale_value(&self, phys_size_px: u16) -> f32 {
+        f32::from(phys_size_px) * em_scale_of(&self.regular)
+    }
+
+    /// Returns the `PxScale` value for the CJK fallback face so its em-square
+    /// renders at the same physical pixel size as the primary's, preventing the
+    /// fallback from rasterizing larger than the grid expects. Mirrors
+    /// [`Self::px_scale_value`] but reads `self.fallback_regular`'s metrics.
+    pub(crate) fn fallback_px_scale_value(&self, phys_size_px: u16) -> f32 {
+        f32::from(phys_size_px) * em_scale_of(&self.fallback_regular)
+    }
+```
+
+Delete the old doc comment block above `px_scale_value` that describes the inline parse, replacing it with a one-line summary (the detailed em-scale explanation now lives on `em_scale_of`):
+
+```rust
+    /// Returns the `ab_glyph::PxScale` value for the primary regular face at the
+    /// given physical pixel size. Used by `cell_metrics_px` and `glyph/atlas.rs`.
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozma_tty_renderer fallback_px_scale_value_is_em_matched`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing atlas regression test**
+
+Add to `crates/ozma_tty_renderer/src/glyph/atlas.rs` inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn cjk_rasterizes_at_fallback_scale_not_primary_scale() {
+        use ab_glyph::Font as _;
+        let fonts = TerminalFonts::default();
+        let mut atlas = GlyphAtlas::default();
+        let size = 24u16;
+        let key = make_key(FontFace::Regular, 0x3042, size); // 'あ'
+        let rect = atlas
+            .get_or_insert(key, &fonts)
+            .expect("'あ' must rasterize via fallback");
+
+        // Height the buggy code produced: the fallback outline at the PRIMARY
+        // scale. The fix must rasterize 'あ' strictly smaller than this.
+        let fb = fonts.fallback_choice(&FontFace::Regular);
+        let primary_scale = ab_glyph::PxScale::from(fonts.px_scale_value(size));
+        let gid = fb.glyph_id('あ');
+        let buggy_h = fb
+            .outline_glyph(gid.with_scale(primary_scale))
+            .expect("'あ' outline at primary scale")
+            .px_bounds()
+            .height();
+
+        assert!(
+            (rect.h as f32) < buggy_h - 0.5,
+            "'あ' rect height {} must be smaller than primary-scaled height {buggy_h}",
+            rect.h
+        );
+    }
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `cargo test -p ozma_tty_renderer cjk_rasterizes_at_fallback_scale_not_primary_scale`
+Expected: FAIL — at HEAD the atlas still scales the fallback at the primary scale, so `rect.h == buggy_h` (assertion fails). (It will also fail to compile if Step 7's signature change is partially applied — run after Step 5 only.)
+
+- [ ] **Step 7: Rewire `resolve_glyph` and `get_or_insert`**
+
+In `crates/ozma_tty_renderer/src/glyph/atlas.rs`, change the import line 1 (drop now-unused `ScaleFont`):
+
+```rust
+use ab_glyph::{Font, FontArc, OutlinedGlyph};
+```
+
+Replace `resolve_glyph` (drop the `scale` param, return the `used_fallback` flag, look up glyph ids unscaled), and rewrite its doc comment:
+
+```rust
+/// Resolves a glyph for the requested codepoint, preferring the primary face
+/// and falling back to `fallback_choice` when the primary's `glyph_id` is 0
+/// (notdef).
+///
+/// Returns `(font, glyph_id, used_fallback)` for the resolved face, or `None`
+/// when neither primary nor fallback contains the glyph. The `used_fallback`
+/// flag tells `get_or_insert` which em-matched `PxScale` to rasterize at: the
+/// primary's (`px_scale_value`) or the fallback's (`fallback_px_scale_value`),
+/// so each face renders its em-square at the same physical pixel size.
+///
+/// `glyph_id` lookup is scale-independent, so this resolves before any scale is
+/// chosen.
+///
+/// NOTE: retries on `glyph_id == 0` only — NOT on degenerate outline
+/// (`w == 0 || h == 0`), which `get_or_insert` still short-circuits after
+/// outlining. PUA Nerd Font icons (U+E000–U+F8FF) resolve non-zero on the
+/// primary, so they never reach the fallback.
+fn resolve_glyph<'a>(
+    fonts: &'a TerminalFonts,
+    face: &FontFace,
+    ch: char,
+) -> Option<(&'a FontArc, ab_glyph::GlyphId, bool)> {
+    let primary = fonts.choice(face);
+    let id = primary.glyph_id(ch);
+    if id.0 != 0 {
+        return Some((primary, id, false));
+    }
+    let fallback = fonts.fallback_choice(face);
+    let id = fallback.glyph_id(ch);
+    if id.0 != 0 {
+        return Some((fallback, id, true));
+    }
+    None
+}
+```
+
+In `get_or_insert`, replace the three lines that compute `scale` then resolve:
+
+```rust
+        let ch = char::from_u32(key.codepoint)?;
+        let (font, glyph_id, used_fallback) = resolve_glyph(fonts, &key.face, ch)?;
+        let scale_value = if used_fallback {
+            fonts.fallback_px_scale_value(key.size_px)
+        } else {
+            fonts.px_scale_value(key.size_px)
+        };
+        let scale = ab_glyph::PxScale::from(scale_value);
+
+        let outlined = font.outline_glyph(glyph_id.with_scale(scale))?;
+```
+
+- [ ] **Step 8: Run the full renderer test suite**
+
+Run: `cargo test -p ozma_tty_renderer`
+Expected: PASS — including `cjk_rasterizes_at_fallback_scale_not_primary_scale`, `fallback_px_scale_value_is_em_matched_and_smaller_than_primary`, and the existing `cjk_renders_through_fallback`, `latin_renders_through_primary`, `nerd_font_pua_stays_on_primary`, `unknown_codepoint_returns_none`, and the `cell_metrics_px` tests (cell metrics are untouched).
+
+- [ ] **Step 9: Lint**
+
+Run: `cargo clippy -p ozma_tty_renderer`
+Expected: no warnings (confirms `ScaleFont` is no longer imported unused).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/ozma_tty_renderer/src/glyph/font.rs \
+        crates/ozma_tty_renderer/src/glyph/atlas.rs
+git commit -m "fix(renderer): rasterize CJK fallback glyphs at the fallback's em-matched scale
+
+CJK glyphs rendered ~13.7% too large/bold because the fallback face was
+rasterized with the primary font's PxScale. ab_glyph normalizes PxScale by
+each font's own (ascent - descent), so reuse inflated UDEVGothic35's em.
+resolve_glyph now reports whether it fell back, and get_or_insert picks
+fallback_px_scale_value vs px_scale_value accordingly.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Part 2a — `TerminalFontSize` resource; renderer reads it
+
+Introduce a `TerminalFontSize` resource (default `12.0`) that the renderer reads instead of the `FONT_SIZE_PX` constant. `FONT_SIZE_PX` stays `pub` for now (the binary's IME overlay still references it until Task 5).
+
+**Files:**
+- Modify: `crates/ozma_tty_renderer/src/glyph/font.rs` (resource + `Default` + plugin `init_resource` + `init_cell_metrics_from_primary_window`)
+- Modify: `crates/ozma_tty_renderer/src/material.rs` (`update_terminal_material` param + usage + import)
+- Modify: `crates/ozma_tty_renderer/src/lib.rs` (export `TerminalFontSize`)
+- Test: `crates/ozma_tty_renderer/src/glyph/font.rs`
+
+**Interfaces:**
+- Produces: `pub struct TerminalFontSize(pub f32)` with `Default` = `Self(FONT_SIZE_PX)`; init by `TerminalFontPlugin`; read by `init_cell_metrics_from_primary_window` and `update_terminal_material`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/ozma_tty_renderer/src/glyph/font.rs` inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn init_cell_metrics_honors_terminal_font_size_resource() {
+        use bevy::window::{PrimaryWindow, Window, WindowResolution};
+
+        let mut app = App::new();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        // Pre-insert so the plugin's init_resource keeps this value.
+        app.insert_resource(TerminalFontSize(10.0));
+        app.add_plugins(TerminalFontPlugin);
+        app.update();
+
+        let res = app
+            .world()
+            .get_resource::<TerminalCellMetricsResource>()
+            .expect("Startup system should insert TerminalCellMetricsResource");
+        assert_eq!(
+            res.phys_font_size, 10,
+            "phys_font_size must follow TerminalFontSize (10.0) at DPR 1.0"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p ozma_tty_renderer init_cell_metrics_honors_terminal_font_size_resource`
+Expected: FAIL — `cannot find ... TerminalFontSize`.
+
+- [ ] **Step 3: Add the `TerminalFontSize` resource**
+
+In `crates/ozma_tty_renderer/src/glyph/font.rs`, immediately after the `FONT_SIZE_PX` constant (line 28):
+
+```rust
+/// Logical (CSS) pixel font size for the terminal grid. Multiplied by the
+/// PrimaryWindow's `scale_factor` to obtain the physical pixel size fed to
+/// `cell_metrics_px` and the glyph atlas.
+///
+/// Defaults to [`FONT_SIZE_PX`]; the app's `FontBridgePlugin` overwrites it
+/// from `config.font.size` at Startup, before cell metrics are computed.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct TerminalFontSize(pub f32);
+
+impl Default for TerminalFontSize {
+    fn default() -> Self {
+        Self(FONT_SIZE_PX)
+    }
+}
+```
+
+- [ ] **Step 4: Init the resource in `TerminalFontPlugin::build` and read it in `init_cell_metrics_from_primary_window`**
+
+Change `TerminalFontPlugin::build` so the `add_systems` call chains off `init_resource`:
+
+```rust
+        app.init_resource::<TerminalFontSize>().add_systems(
+            Startup,
+            init_cell_metrics_from_primary_window.in_set(TerminalFontInitSet::InitCellMetrics),
+        );
+```
+
+Update `init_cell_metrics_from_primary_window`'s signature and `phys_font_size`:
+
+```rust
+fn init_cell_metrics_from_primary_window(
+    mut commands: Commands,
+    fonts: Res<TerminalFonts>,
+    font_size: Res<TerminalFontSize>,
+    window: Single<&Window, With<PrimaryWindow>>,
+) {
+    let dpr = window.scale_factor();
+    let phys_font_size = (font_size.0 * dpr).round() as u16;
+    let metrics = fonts.cell_metrics_px(phys_font_size);
+    commands.insert_resource(TerminalCellMetricsResource {
+        metrics,
+        phys_font_size,
+    });
+}
+```
+
+- [ ] **Step 5: Run the new test and the existing metrics test**
+
+Run: `cargo test -p ozma_tty_renderer init_cell_metrics`
+Expected: PASS — both `init_cell_metrics_honors_terminal_font_size_resource` and the existing `init_cell_metrics_from_primary_window_uses_window_scale_factor` (default `TerminalFontSize` = 12.0 → phys 24 at DPR 2.0).
+
+- [ ] **Step 6: Read `TerminalFontSize` in `update_terminal_material`**
+
+In `crates/ozma_tty_renderer/src/material.rs`, update the import (line 4) to drop `FONT_SIZE_PX` and add `TerminalFontSize`:
+
+```rust
+        font::{FontFace, GlyphKey, TerminalCellMetricsResource, TerminalFontSize, TerminalFonts},
+```
+
+Add the `font_size` param to `update_terminal_material` directly after `fonts`:
+
+```rust
+    fonts: Res<TerminalFonts>,
+    font_size: Res<TerminalFontSize>,
+```
+
+Delete the `// TODO: load font size from config.` line, and change the `phys_font_size` computation (line 515):
+
+```rust
+    let phys_font_size = (font_size.0 * dpr).round() as u16;
+```
+
+- [ ] **Step 7: Export `TerminalFontSize`**
+
+In `crates/ozma_tty_renderer/src/lib.rs`, add `TerminalFontSize` to the re-export (keep `FONT_SIZE_PX` for now):
+
+```rust
+pub use crate::glyph::font::{
+    CellMetrics, FONT_SIZE_PX, FontFace, FontLoadError, TerminalCellMetricsResource,
+    TerminalFontInitSet, TerminalFontPlugin, TerminalFontSize, TerminalFonts,
+};
+```
+
+- [ ] **Step 8: Build, test, lint the crate**
+
+Run: `cargo test -p ozma_tty_renderer && cargo clippy -p ozma_tty_renderer`
+Expected: PASS, no warnings (confirms `material.rs` no longer imports `FONT_SIZE_PX` unused).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ozma_tty_renderer/src/glyph/font.rs \
+        crates/ozma_tty_renderer/src/material.rs \
+        crates/ozma_tty_renderer/src/lib.rs
+git commit -m "feat(renderer): add TerminalFontSize resource read in place of FONT_SIZE_PX
+
+The renderer reads a TerminalFontSize resource (default 12.0) for the logical
+font size instead of the hardcoded constant, so the app can drive it from
+config. No behavior change yet — nothing overwrites the default.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Part 2b — `bridge_font_config` fills `TerminalFontSize` from config
+
+Set `TerminalFontSize` from `config.font.size` at Startup, before the no-override early-return so size is honored even when no font face is overridden. Default config (`11.25`) now reaches the renderer.
+
+**Files:**
+- Modify: `src/font.rs` (`bridge_font_config` import, signature, body)
+- Modify: `crates/ozmux_configs/src/font.rs` (clarify the `size` doc comment)
+- Test: `src/font.rs`
+
+**Interfaces:**
+- Consumes: `TerminalFontSize` (from Task 3, re-exported by `ozma_tty_renderer`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/font.rs` inside `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn bridge_sets_terminal_font_size_from_default_config() {
+        let (mut app, _guard, _env) = make_test_app();
+        app.update();
+        let size = app.world().resource::<TerminalFontSize>();
+        assert_eq!(
+            size.0, 11.25,
+            "default config font.size (11.25) must reach TerminalFontSize"
+        );
+    }
+
+    #[test]
+    fn bridge_sets_terminal_font_size_from_config_override_without_font_paths() {
+        let tmp = std::env::temp_dir().join("ozmux_font_size_override.toml");
+        std::fs::write(&tmp, "[font]\nsize = 16.0\n").expect("write toml");
+
+        let _guard = crate::configs::env_guard();
+        let _env = EnvVarGuard::set("OZMUX_CONFIG", &tmp);
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(AssetPlugin::default())
+            .add_plugins(TextPlugin)
+            .init_asset::<Font>();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        app.add_plugins(TerminalFontPlugin);
+        app.add_plugins(OzmuxConfigsPlugin);
+        app.add_plugins(FontBridgePlugin);
+        app.update();
+
+        let size = app.world().resource::<TerminalFontSize>();
+        assert_eq!(
+            size.0, 16.0,
+            "config size=16 must reach TerminalFontSize even with no font override (cold path)"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test -p ozmux --bin ozmux bridge_sets_terminal_font_size`
+Expected: FAIL — `cannot find ... TerminalFontSize` / resource not present.
+
+- [ ] **Step 3: Import `TerminalFontSize` in `src/font.rs`**
+
+Change the renderer import line (currently `use ozma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFonts, bundled};`):
+
+```rust
+use ozma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
+```
+
+- [ ] **Step 4: Add the `ResMut` param (mutable-first) and set the size**
+
+Change `bridge_font_config`'s signature so all mutable params precede the immutable `configs`:
+
+```rust
+fn bridge_font_config(
+    mut commands: Commands,
+    mut fonts_assets: ResMut<Assets<Font>>,
+    mut terminal_fonts: ResMut<TerminalFonts>,
+    mut font_size: ResMut<TerminalFontSize>,
+    configs: Res<OzmuxConfigsResource>,
+) {
+    font_size.0 = configs.font.size;
+    let font: &FontConfig = &configs.font;
+```
+
+(The `font_size.0 = configs.font.size;` line is the first statement, ahead of the `no_override` early-return, so the cold path still applies it.)
+
+- [ ] **Step 5: Clarify the `FontConfig.size` doc comment**
+
+In `crates/ozmux_configs/src/font.rs`, replace the `size` field doc (line 12, currently `/// Terminal font size in points, matching Alacritty.`):
+
+```rust
+    /// Terminal font size in logical (CSS) pixels, scaled by the display's
+    /// `scale_factor` to device pixels — Alacritty's model (not literal
+    /// typographic points; no 96/72 conversion is applied).
+```
+
+The `DEFAULT_SIZE = 11.25` constant and the `default_size_matches_alacritty` test are unchanged.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cargo test -p ozmux --bin ozmux bridge_sets_terminal_font_size && cargo test -p ozmux_configs font`
+Expected: PASS (both new bridge tests, and `ozmux_configs` font tests including `default_size_matches_alacritty`).
+
+- [ ] **Step 7: Run the existing font-bridge suite**
+
+Run: `cargo test -p ozmux --bin ozmux font::`
+Expected: PASS — existing bridge tests (`default_config_keeps_bundled_jbm_in_terminal_fonts`, the override/corrupt-face tests, `cjk_fallback_registered_in_cosmic_fontdb`) still green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/font.rs crates/ozmux_configs/src/font.rs
+git commit -m "feat: drive terminal font size from config.font.size
+
+bridge_font_config writes config.font.size into TerminalFontSize before the
+no-override early return, so the default 11.25 (and any user size) reaches the
+renderer. Default rendered text is now 11.25 logical px (was a hardcoded 12.0).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Part 2c — IME overlay reads `TerminalFontSize`; demote `FONT_SIZE_PX`
+
+Migrate the last `FONT_SIZE_PX` reader (the IME preedit overlay) to the resource so it matches terminal text size, then demote `FONT_SIZE_PX` to a module-private constant.
+
+**Files:**
+- Modify: `src/ui/ime_overlay.rs` (import, `spawn_ime_overlay_once` param + `font_size` field)
+- Modify: `crates/ozma_tty_renderer/src/glyph/font.rs` (`pub const FONT_SIZE_PX` → private `const`)
+- Modify: `crates/ozma_tty_renderer/src/lib.rs` (drop `FONT_SIZE_PX` from the re-export)
+- Test: `src/ui/ime_overlay.rs`
+
+**Interfaces:**
+- Consumes: `TerminalFontSize`; `TerminalUiFont` (existing, `crate::font::TerminalUiFont`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/ui/ime_overlay.rs` inside its existing `#[cfg(test)] mod tests` (line 426 — it already has `use super::*;` and `use bevy::prelude::MinimalPlugins;`):
+
+```rust
+    #[test]
+    fn ime_overlay_uses_terminal_font_size() {
+        use bevy::asset::Handle;
+        use bevy::text::TextFont;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(TerminalFontSize(9.0));
+        app.add_systems(Startup, spawn_ime_overlay_once);
+        app.update();
+
+        let mut query = app.world_mut().query::<&TextFont>();
+        let matched = query
+            .iter(app.world())
+            .any(|tf| (tf.font_size - 9.0).abs() < f32::EPSILON);
+        assert!(
+            matched,
+            "IME overlay TextFont must use TerminalFontSize (9.0), not the constant"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p ozmux --bin ozmux ime_overlay_uses_terminal_font_size`
+Expected: FAIL — the overlay still uses `ozma_tty_renderer::FONT_SIZE_PX` (12.0), so no `TextFont` has `font_size == 9.0`; or `TerminalFontSize` is unresolved in the test until Step 3's import.
+
+- [ ] **Step 3: Migrate `spawn_ime_overlay_once`**
+
+In `src/ui/ime_overlay.rs`, add to the import block (next to the other `use ozma_tty_renderer::...` lines):
+
+```rust
+use ozma_tty_renderer::TerminalFontSize;
+```
+
+Change `spawn_ime_overlay_once` to take the resource and use it:
+
+```rust
+fn spawn_ime_overlay_once(
+    mut commands: Commands,
+    ui_font: Res<TerminalUiFont>,
+    font_size: Res<TerminalFontSize>,
+) {
+    let text_font = TextFont {
+        font: ui_font.0.clone(),
+        font_size: font_size.0,
+        ..default()
+    };
+```
+
+- [ ] **Step 4: Run the IME overlay test**
+
+Run: `cargo test -p ozmux --bin ozmux ime_overlay_uses_terminal_font_size`
+Expected: PASS.
+
+- [ ] **Step 5: Demote `FONT_SIZE_PX` to module-private**
+
+In `crates/ozma_tty_renderer/src/glyph/font.rs`, change line 28:
+
+```rust
+const FONT_SIZE_PX: f32 = 12.0;
+```
+
+(It is now referenced only by `TerminalFontSize::default()` in this same file, so the visibility-minimization rule requires it be private.)
+
+In `crates/ozma_tty_renderer/src/lib.rs`, remove `FONT_SIZE_PX` from the re-export:
+
+```rust
+pub use crate::glyph::font::{
+    CellMetrics, FontFace, FontLoadError, TerminalCellMetricsResource, TerminalFontInitSet,
+    TerminalFontPlugin, TerminalFontSize, TerminalFonts,
+};
+```
+
+- [ ] **Step 6: Build the whole workspace and run all tests**
+
+Run: `cargo build && cargo test`
+Expected: PASS — no unresolved `FONT_SIZE_PX` references anywhere (the only remaining mentions are the doc-comment / assertion-message strings in `font.rs` tests, which are plain text, not symbols).
+
+- [ ] **Step 7: Lint the workspace**
+
+Run: `cargo clippy --workspace`
+Expected: no warnings (no unused imports; `FONT_SIZE_PX` private and used by `Default`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/ime_overlay.rs \
+        crates/ozma_tty_renderer/src/glyph/font.rs \
+        crates/ozma_tty_renderer/src/lib.rs
+git commit -m "refactor: IME overlay reads TerminalFontSize; make FONT_SIZE_PX private
+
+The IME preedit overlay now sizes to TerminalFontSize so it matches the
+terminal grid. With its last external reader migrated, FONT_SIZE_PX is demoted
+to a module-private backing constant for TerminalFontSize::default().
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Whole-workspace gate**
+
+Run: `cargo test && cargo clippy --workspace && cargo fmt --check`
+Expected: all green. (If `cargo fmt --check` reports diffs, run `cargo fmt` and amend the most recent commit.)
+
+- [ ] **Manual visual check (optional, recommended)**
+
+Run: `cargo run`
+Expected: Japanese text in the grid is no longer noticeably larger/bolder than Latin; overall text is at the configured `font.size` (default 11.25 logical px).

--- a/docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md
+++ b/docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md
@@ -1,0 +1,257 @@
+# CJK Fallback Glyph Sizing + `font.size` Config Wiring — Design
+
+- **Date:** 2026-06-24
+- **Branch:** `cjk-font`
+- **Status:** Approved (brainstorming) — pending spec review → implementation plan
+- **Scope:** Two independent fixes in `crates/ozma_tty_renderer` (+ binary wiring in `src/`):
+  1. **Part 1** — CJK fallback glyphs render ~13.7% too large/bold; fix the rasterization scale.
+  2. **Part 2** — `font.size` config value is ignored; the renderer hardcodes `12.0`. Wire it through.
+
+The two parts share this spec but are implemented as separate, individually-revertable steps.
+
+---
+
+## Part 1 — CJK fallback em-match fix
+
+### Problem
+
+Japanese (CJK) text renders slightly **bolder** and **larger** than the Latin
+alphabet in the same grid (reported visually; `bug.png`). The "bold" appearance
+is a side effect of the oversize, not a separate weight problem.
+
+### Root cause
+
+The glyph atlas rasterizes **every** glyph — primary and fallback — at a single
+`ab_glyph::PxScale` derived **only** from the primary regular face (JetBrains
+Mono):
+
+- `GlyphAtlas::get_or_insert` computes `scale = PxScale::from(fonts.px_scale_value(key.size_px))`
+  (`crates/ozma_tty_renderer/src/glyph/atlas.rs:123`).
+- `px_scale_value` = `phys_size_px × (ascender − descender) / units_per_em` of
+  `self.regular` only (`crates/ozma_tty_renderer/src/glyph/font.rs:360-372`).
+- `resolve_glyph` hands that **same** primary-derived `scale` to the fallback
+  face (UDEVGothic35) when the primary lacks the glyph
+  (`crates/ozma_tty_renderer/src/glyph/atlas.rs:72-89`), under the now-false
+  assertion "UDEVGothic35 is JBM-metric-compatible by design"
+  (`atlas.rs:58-66`).
+
+`ab_glyph::PxScale` is interpreted as the **text height**, which ab_glyph
+normalizes by each font's *own* `height_unscaled = (ascent − descent)` in font
+units. Handing the primary's `PxScale` to a fallback face whose
+`(ascent−descent)/units_per_em` ratio differs therefore resizes the fallback's
+em-square.
+
+**Verified font metrics** (parsed directly from the bundled TTF `head`/`hhea`
+tables, 2026-06-24):
+
+| Font | upem | ascender | descender | `em_scale = (asc−desc)/upem` |
+| --- | --- | --- | --- | --- |
+| JetBrainsMonoNerdFontMono-Regular | 1000 | 1020 | −300 | **1.320000** |
+| UDEVGothic35-Regular | 2048 | 1962 | −416 | **1.161133** |
+
+- At 12 px, the atlas uses `PxScale = 12 × 1.320000 = 15.84`.
+- ab_glyph renders the JBM em-square at exactly `12.0 px` (self-consistent).
+- ab_glyph renders the UDEVGothic35 em-square at
+  `2048 × 15.84 / 2378 = 13.6419 px` — an inflation of **+13.68%**
+  (`1.320000 / 1.161133 = 1.136821`).
+
+The renderer draws atlas bitmaps 1:1 (the shader samples each glyph at its native
+rasterized size; there is no fit-to-cell rescale), so the oversized bitmap
+reaches the screen at full size. Wide (width = 2) CJK cells get a two-cell budget,
+so the oversize manifests as apparent size/weight rather than clipping.
+
+### Decision
+
+**Em-match (standard).** Rasterize the fallback face at its **own** em-matched
+scale so its em-square equals the same physical pixel size as the primary's. This
+is the Alacritty / WezTerm / Ghostty default. CJK ideographs will remain
+naturally somewhat larger than Latin *lowercase* (ideographs fill the em-square;
+Latin x-height is ~half the em) — that is correct and expected. The fix removes
+only the spurious +13.68%.
+
+Rejected alternatives:
+- **Tunable per-fallback scale knob** (WezTerm-style) — YAGNI for now; em-match
+  is expected to be sufficient. Can be added later if the eye disagrees.
+- **Shrink CJK to Latin cap-height** — non-standard; risks CJK looking too small.
+
+### Approach (chosen: derive scale from the resolved face)
+
+The rasterization scale must come from the face being rasterized. Refinement:
+all four *fallback* faces share **`fallback_regular`'s** `em_scale` (not each its
+own), mirroring how all four *primary* faces already share `regular`'s scale.
+This keeps CJK regular/bold the same size and is robust if UDEV's bold metrics
+differ slightly. Only **two** scale values are needed, not eight.
+
+Rejected alternatives:
+- **Single precomputed correction factor** (`fallback_em / primary_em ≈ 0.8796`)
+  — smallest diff, but assumes all four fallback faces share `fallback_regular`'s
+  metrics and must be recomputed when the primary is overridden; it is just the
+  chosen approach hard-coded to two faces.
+- **Per-glyph TTF parse of the resolved face** — re-parses on every glyph
+  cache-miss; the chosen approach reuses the cheap on-demand parse pattern that
+  already exists for the primary.
+
+### Implementation
+
+**`crates/ozma_tty_renderer/src/glyph/font.rs`**
+- Extract a private `em_scale_of(font: &FontArc) -> f32` (the `(asc−desc)/upem`
+  computation currently inlined in both `px_scale_value` and `cell_metrics_px`)
+  and use it for both `px_scale_value` and the new `fallback_px_scale_value`,
+  removing the duplicated formula and its drift risk. Keep the existing
+  `ttf_parser` source so the primary path stays numerically identical.
+  *Optional refinement (evaluate at implementation time):* compute `em_scale_of`
+  from ab_glyph's own `font.height_unscaled() / font.units_per_em()` instead —
+  `height_unscaled()` is exactly `ascent − descent` in font units and is the
+  value ab_glyph's `v_scale_factor` itself uses, so it is tautologically
+  consistent with the rasterizer and needs no second parse. Adopt it only behind
+  a unit test asserting `em_scale_of(face)` equals the `ttf_parser`
+  `(asc−desc)/upem` the primary metrics path uses (guards against any
+  ab_glyph/ttf-parser metric-source divergence, e.g. OS/2 typo vs hhea, and the
+  `Option` from `units_per_em()`).
+- Add `pub(crate) fn fallback_px_scale_value(&self, phys_size_px: u16) -> f32`
+  → `phys × em_scale_of(&self.fallback_regular)`, mirroring `px_scale_value`
+  (which keeps reading `self.regular`). No struct-field caching: `em_scale_of`
+  is cheap (`ttf_parser::Face::parse` reads the table directory lazily — not a
+  full 13 MB parse), and these helpers run on glyph **cache-misses** *and*
+  during cell-metrics recomputation — note `px_scale_value` is **also** called
+  by `cell_metrics_px` (Startup metrics init and DPR-change material rebuilds),
+  so it is **not** invoked only on glyph cache-misses. Caching would force
+  touching `cell_metrics_px`, which is out of scope.
+
+**`crates/ozma_tty_renderer/src/glyph/atlas.rs`**
+- `resolve_glyph`: drop the `scale` parameter (glyph-id lookup is
+  scale-independent — use `ab_glyph::Font::glyph_id` directly, already in
+  scope), and return `(&FontArc, ab_glyph::GlyphId, bool /* used_fallback */)`.
+- `get_or_insert`: resolve first, then pick the scale —
+  `fonts.fallback_px_scale_value(key.size_px)` when `used_fallback`, else
+  `fonts.px_scale_value(key.size_px)` — build the `PxScale`, and outline as
+  before.
+- Rewrite the now-false doc comment on `resolve_glyph` (`atlas.rs:58-66`): the
+  "UDEVGothic35 is JBM-metric-compatible by design / both faces scaled at the
+  primary's PxScale" claim becomes "each face is scaled at its own em-matched
+  PxScale; the fallback uses `fallback_px_scale_value` so its em-square matches
+  the primary's physical size."
+
+### What stays byte-identical
+
+Cell metrics (pitch, ascent/descent, line-height, underline), `max_overflow_phys`
+(ASCII / primary only), and the entire primary glyph path. Baseline alignment is
+preserved automatically: `offset_y` comes from the same outline, now at the
+correct smaller scale, so CJK sits on the same baseline at its true size.
+
+### Tests (Part 1)
+
+- `fallback_px_scale_value(N)` ≈ `N × 1.161133`, and is ~12% **smaller** than
+  `px_scale_value(N)` (≈ `N × 1.320000`) — the direct proof the inflation is
+  gone. (Assert the ratio `≈ 0.8796`, not absolute pixels, so a font re-vendor
+  updates one tolerance.)
+- Regression: 'あ' (U+3042) rasterizes at the fallback scale — assert its rect
+  height matches the fallback-scaled outline and is strictly smaller than the
+  old primary-scaled height.
+- Guard: a primary Latin glyph still rasterizes via `px_scale_value` (unchanged
+  rect), and U+E0B0 (Nerd Font PUA) stays on the primary path
+  (`used_fallback == false`).
+- Existing `cjk_renders_through_fallback`, `latin_renders_through_primary`,
+  `nerd_font_pua_stays_on_primary`, and `unknown_codepoint_returns_none` all
+  keep passing (the CJK rect is simply smaller).
+
+---
+
+## Part 2 — Wire `font.size` into the renderer
+
+### Problem
+
+The config exposes `font.size` (default `11.25`,
+`crates/ozmux_configs/src/font.rs:6,11-13`) but the renderer ignores it and
+hardcodes `FONT_SIZE_PX = 12.0` (`crates/ozma_tty_renderer/src/glyph/font.rs:28`),
+with an explicit `// TODO: load font size from config`
+(`crates/ozma_tty_renderer/src/material.rs:487`). Changing `font.size` in config
+has no effect today.
+
+### Decision
+
+- **Honor the config default (11.25).** Because the renderer currently hardcodes
+  `12.0`, the moment config drives size the default rendered text becomes ~6%
+  smaller. This is accepted — it is the config working as documented; users set
+  their own size to taste.
+- **Treat `size` as logical px (Alacritty model).** In this codebase
+  `size × scale_factor = device px`, which *is* Alacritty's logical-px model. No
+  `×96/72` point→px conversion (that would double-count DPI and inflate text to
+  ~15 px). The `FontConfig.size` doc comment is clarified accordingly; the
+  default `11.25` and its test are unchanged.
+
+### Implementation
+
+- **New resource `TerminalFontSize(pub f32)`** (logical px), defined in
+  `crates/ozma_tty_renderer/src/glyph/font.rs` next to `FONT_SIZE_PX`,
+  `TerminalFonts`, and `TerminalFontPlugin` (registration locality). It needs a
+  `///` doc comment (it is externally `pub`). Its `Default` returns
+  `Self(FONT_SIZE_PX)` = **12.0**, so the renderer standalone and all of its
+  existing tests are unaffected. `TerminalFontPlugin` `init_resource`s it.
+- **`bridge_font_config`** (`src/font.rs:112-175`) takes
+  `ResMut<TerminalFontSize>` and sets `font_size.0 = configs.font.size`. Placed
+  **before** the `no_override` early-return (`src/font.rs:127-134`) so size is
+  honored even with no font-path override. Direct `ResMut` mutation (like the
+  existing `*terminal_fonts = …`) makes it immediately visible to
+  `init_cell_metrics_from_primary_window`, which already runs `.after` via the
+  `TerminalFontInitSet::InitCellMetrics` ordering (`bridge_font_config` is
+  registered `.before(InitCellMetrics)`). Keep mutable params first:
+  `ResMut<TerminalFontSize>` joins the existing `ResMut` group
+  (`commands`/`fonts_assets`/`terminal_fonts`) ahead of the immutable
+  `configs: Res<…>` (`.claude/rules/rust.md` mutable-params-first).
+- **`init_cell_metrics_from_primary_window`** (`font.rs:69-81`) and
+  **`update_terminal_material`** (`material.rs:515`) read
+  `Res<TerminalFontSize>` instead of the constant; remove the
+  `// TODO: load font size from config` (`material.rs:487`).
+- **`src/ui/ime_overlay.rs:368`** reads `TerminalFontSize` instead of
+  `FONT_SIZE_PX`, so the IME preedit overlay matches terminal text size (the
+  only other live reader of the constant). `COPY_MODE_INDICATOR_FONT_SIZE_PX`
+  (`src/theme.rs:55`) is independent UI chrome and is left alone.
+- **`crates/ozmux_configs/src/font.rs`**: clarify the `size` doc comment (logical
+  px scaled by DPR — Alacritty's model — not literal typographic points).
+  Default stays `11.25`; its test stays.
+- Export `TerminalFontSize` from `crates/ozma_tty_renderer/src/lib.rs`, and
+  **demote `FONT_SIZE_PX`** from the crate's public re-export to a `pub(crate)`
+  backing constant once its three readers migrate to the resource — after
+  migration nothing outside the crate reads it, so the visibility-minimization
+  rule applies. `TerminalFontSize` becomes the public size API.
+
+### Why no hot-reload concern
+
+Font size is set once at Startup, exactly like font *face* overrides today (the
+`FontBridgePlugin` module doc already states font changes require a restart).
+`update_terminal_material`'s existing `phys_size_changed` path still correctly
+handles DPR changes (window moved between displays). "Startup-only" refers to
+*writes*: `update_terminal_material` **reads** `Res<TerminalFontSize>` every
+frame to recompute `phys_font_size`, so the resource must live for the whole app
+lifetime — it is `init_resource`-d by `TerminalFontPlugin` and never removed.
+
+### Tests (Part 2)
+
+- `TerminalFontSize` default is `12.0` (renderer crate, no bridge).
+- Bridge honors `size`: config `size = 14.0` → `TerminalFontSize.0 == 14.0` and
+  `phys_font_size == 14` at DPR 1.
+- The early-return (no font override) path **still** sets size: config with only
+  `size = 16.0` and no font paths → `TerminalFontSize.0 == 16.0`.
+- Default config → `TerminalFontSize.0 == 11.25`.
+
+---
+
+## Out of scope
+
+- A user-configurable per-fallback scale knob (WezTerm-style).
+- Changing `cell_metrics_px` to cache em-scales (would touch the primary metrics
+  path for no behavior change).
+- Caching em-scales as struct fields (the on-demand parse is cheap enough).
+- Any change to wide-cell layout, baseline policy, or the shader.
+
+## Risks
+
+- **Default text size shifts ~6% smaller** (12.0 → 11.25) once Part 2 lands —
+  intended, documented here so it is not mistaken for a regression.
+- **Font re-vendor changes the metrics.** Part 1 tests assert the
+  fallback/primary scale *ratio* (≈ 0.8796) rather than absolute pixels, so a
+  re-vendor updates one tolerance, not a hardcoded constant.
+- The two parts are independent (separate files, separate failure modes); the
+  implementation plan keeps them as separate steps so either can be reverted
+  alone.

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,7 +12,7 @@
 use crate::configs::OzmuxConfigsResource;
 use bevy::prelude::*;
 use bevy::text::{CosmicFontSystem, Font};
-use ozma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFonts, bundled};
+use ozma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use ozmux_configs::font::FontConfig;
 use ozmux_configs::path::{SystemEnv, expand_user_path};
 use std::path::Path;
@@ -111,10 +111,12 @@ fn register_cjk_fallback_with_cosmic(mut font_system: ResMut<CosmicFontSystem>) 
 
 fn bridge_font_config(
     mut commands: Commands,
-    configs: Res<OzmuxConfigsResource>,
     mut fonts_assets: ResMut<Assets<Font>>,
     mut terminal_fonts: ResMut<TerminalFonts>,
+    mut font_size: ResMut<TerminalFontSize>,
+    configs: Res<OzmuxConfigsResource>,
 ) {
+    font_size.0 = configs.font.size;
     let font: &FontConfig = &configs.font;
 
     let powerline = make_ui_font_handle(bundled::REGULAR.to_vec(), &mut fonts_assets);
@@ -448,6 +450,49 @@ mod tests {
             has_udev_face,
             "UDEVGothic35 must be registered in cosmic-text fontdb after Startup",
         );
+    }
+
+    #[test]
+    fn bridge_sets_terminal_font_size_from_default_config() {
+        let (mut app, _guard, _env) = make_test_app();
+        app.update();
+        let size = app.world().resource::<TerminalFontSize>();
+        assert_eq!(
+            size.0, 11.25,
+            "default config font.size (11.25) must reach TerminalFontSize"
+        );
+    }
+
+    #[test]
+    fn bridge_sets_terminal_font_size_from_config_override_without_font_paths() {
+        let tmp = std::env::temp_dir().join("ozmux_font_size_override.toml");
+        std::fs::write(&tmp, "[font]\nsize = 16.0\n").expect("write toml");
+
+        let _guard = crate::configs::env_guard();
+        let _env = EnvVarGuard::set("OZMUX_CONFIG", &tmp);
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(AssetPlugin::default())
+            .add_plugins(TextPlugin)
+            .init_asset::<Font>();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        app.add_plugins(TerminalFontPlugin);
+        app.add_plugins(OzmuxConfigsPlugin);
+        app.add_plugins(FontBridgePlugin);
+        app.update();
+
+        let size = app.world().resource::<TerminalFontSize>();
+        assert_eq!(
+            size.0, 16.0,
+            "config size=16 must reach TerminalFontSize even with no font override (cold path)"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
     }
 
     #[test]

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -29,6 +29,7 @@ use ozma_terminal::KeyboardFocused;
 use ozma_tty_renderer::CellMetrics;
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::TerminalFontInitSet;
+use ozma_tty_renderer::TerminalFontSize;
 use ozma_tty_renderer::material::TerminalMaterialSystems;
 use ozma_tty_renderer::prelude::TerminalGrid;
 use unicode_width::UnicodeWidthStr;
@@ -362,10 +363,14 @@ const IME_OVERLAY_Z: i32 = 200;
 /// TODO: bind TextColor / UnderlineColor / BackgroundColor to theme
 /// tokens (`text-foreground` / `bg-background`) once the theme-token
 /// helper is integrated. Placeholder white for now.
-fn spawn_ime_overlay_once(mut commands: Commands, ui_font: Res<TerminalUiFont>) {
+fn spawn_ime_overlay_once(
+    mut commands: Commands,
+    ui_font: Res<TerminalUiFont>,
+    font_size: Res<TerminalFontSize>,
+) {
     let text_font = TextFont {
         font: ui_font.0.clone(),
-        font_size: ozma_tty_renderer::FONT_SIZE_PX,
+        font_size: font_size.0,
         ..default()
     };
     let color = Color::WHITE;
@@ -678,6 +683,28 @@ mod tests {
         // begin=0, end=4 → (0.0, 3.0). begin=1 (after "a"), end=4 → (1.0, 3.0).
         assert_eq!(caret_cell_offsets("aあ", (0, 4)), (0.0, 3.0));
         assert_eq!(caret_cell_offsets("aあ", (1, 4)), (1.0, 3.0));
+    }
+
+    #[test]
+    fn ime_overlay_uses_terminal_font_size() {
+        use bevy::asset::Handle;
+        use bevy::text::TextFont;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(TerminalFontSize(9.0));
+        app.add_systems(Startup, spawn_ime_overlay_once);
+        app.update();
+
+        let mut query = app.world_mut().query::<&TextFont>();
+        let matched = query
+            .iter(app.world())
+            .any(|tf| (tf.font_size - 9.0).abs() < f32::EPSILON);
+        assert!(
+            matched,
+            "IME overlay TextFont must use TerminalFontSize (9.0), not the constant"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two independent fixes (separate commits, each revertable):

### Part 1 — CJK fallback glyphs render ~13.7% too large/bold
Japanese/CJK text rendered noticeably larger and heavier than Latin in the same grid. Root cause: the glyph atlas rasterized **every** glyph — primary and fallback — at a single `ab_glyph::PxScale` derived from the primary font (JetBrains Mono). `ab_glyph::PxScale` is normalized per-font by `(ascent − descent)`, so handing the primary's scale to the fallback face (UDEVGothic35) inflated its em-square by `1.320000 / 1.161133 = +13.68%`. The "bold" look was a side effect of the oversize — there is no synthetic-bold path.

**Fix:** `resolve_glyph` now reports whether it fell back; `get_or_insert` picks `fallback_px_scale_value` (from `self.fallback_regular`) vs `px_scale_value` (from `self.regular`) accordingly, so each face rasterizes its em-square at the same physical pixel size. The primary glyph path and all cell metrics are byte-identical; baseline alignment is preserved automatically (`offset_y` comes from the same outline at the now-correct scale).

### Part 2 — `font.size` config was ignored
The renderer hardcoded `FONT_SIZE_PX = 12.0` and never read `config.font.size` (default 11.25). A new `TerminalFontSize` resource (renderer default 12.0) is filled from config by `bridge_font_config` at Startup and read by the renderer + IME overlay. `FONT_SIZE_PX` is demoted to a private backing constant.

> ⚠️ **Intended behavior change:** default rendered text is now **11.25 logical px** (was a hardcoded 12.0) — the documented config default now actually applies. Size is treated as logical px (Alacritty's `size × scale_factor` model; no 96/72 conversion).

## Testing
- `cargo test` — 331 passed / 0 failed
- `cargo clippy --workspace` — clean
- `cargo fmt --check` — clean

## Design / review
Spec and plan are tracked under `docs/superpowers/specs/2026-06-24-cjk-font-and-font-size-design.md` and `docs/superpowers/plans/2026-06-24-cjk-font-and-font-size.md`. The branch went through per-task reviews, a whole-branch review, and a max-effort `/code-review` pass (no correctness findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
