### PR TITLE
fix(ime): opaque preedit background so mid-line IME composition doesn't overlap

### DIFF
--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -182,7 +182,7 @@ pub(crate) fn position_ime_overlay(
     anchors: Query<(&ComputedNode, &UiGlobalTransform, &TerminalGrid)>,
     metrics: Res<TerminalCellMetricsResource>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
-    mut overlay_root: Query<(&mut Node, &mut Text), With<ImeOverlayNode>>,
+    mut overlay_root: Query<(&mut Node, &mut Text, &mut BackgroundColor), With<ImeOverlayNode>>,
     mut caret_bar: Query<
         &mut Node,
         (
@@ -200,7 +200,7 @@ pub(crate) fn position_ime_overlay(
         ),
     >,
 ) {
-    let Ok((mut root_node, mut root_text)) = overlay_root.single_mut() else {
+    let Ok((mut root_node, mut root_text, mut root_bg)) = overlay_root.single_mut() else {
         return;
     };
     let mut bar = caret_bar.single_mut().ok();
@@ -261,6 +261,17 @@ pub(crate) fn position_ime_overlay(
     root_node.left = Val::Px(pos.x);
     root_node.top = Val::Px(pos.y);
     root_node.display = Display::Flex;
+
+    // NOTE: the shell still renders the pre-commit line under the
+    // preedit (only the block cursor is suppressed, not the cells), so a
+    // transparent preedit lets mid-line characters bleed through and
+    // collide with the composed glyphs. An opaque background matching
+    // the pane's default bg occludes them — match the VT default (what
+    // the renderer fills default-bg cells with) so the box is seamless.
+    let occluding_bg = Color::srgb_u8(grid.default_bg[0], grid.default_bg[1], grid.default_bg[2]);
+    if root_bg.0 != occluding_bg {
+        root_bg.0 = occluding_bg;
+    }
 
     // Write the full composition text to the root. With a single
     // `Text` entity (no `TextSpan` children), Bevy's text pipeline
@@ -704,6 +715,82 @@ mod tests {
         assert!(
             matched,
             "IME overlay TextFont must use TerminalFontSize (9.0), not the constant"
+        );
+    }
+
+    #[test]
+    fn overlay_background_matches_pane_default_bg_while_composing() {
+        use bevy::asset::Handle;
+        use bevy::window::WindowResolution;
+        use ozma_terminal::OzmaTerminal;
+        use ozma_tty_renderer::prelude::Cursor;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(TerminalFontSize(12.0));
+        app.insert_resource(TerminalCellMetricsResource {
+            metrics: metrics(8.0, 16.0),
+            phys_font_size: 12,
+        });
+
+        let mut state = ImeState::default();
+        apply_event(
+            &mut state,
+            &Ime::Preedit {
+                window: Entity::PLACEHOLDER,
+                value: "あ".into(),
+                cursor: Some((3, 3)),
+            },
+        );
+        app.insert_resource(state);
+
+        app.add_systems(Startup, spawn_ime_overlay_once);
+        app.world_mut().spawn((
+            Window {
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app.world_mut().spawn((
+            OzmaTerminal,
+            KeyboardFocused,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalGrid {
+                cursor: Some(Cursor::default()),
+                default_bg: [10, 20, 30],
+                ..TerminalGrid::default()
+            },
+        ));
+
+        app.update();
+        app.world_mut()
+            .run_system_once(position_ime_overlay)
+            .unwrap();
+
+        let mut overlays = app
+            .world_mut()
+            .query_filtered::<Entity, With<ImeOverlayNode>>();
+        let overlay = overlays.single(app.world()).expect("overlay entity");
+
+        let bg = app
+            .world()
+            .get::<BackgroundColor>(overlay)
+            .expect("overlay must carry an opaque BackgroundColor while composing");
+        assert_eq!(
+            bg.0,
+            Color::srgb_u8(10, 20, 30),
+            "overlay background must match the focused pane's default_bg so it occludes the underlying line",
+        );
+        assert_eq!(
+            app.world().get::<Node>(overlay).unwrap().display,
+            Display::Flex,
+            "overlay must be shown while composing",
         );
     }
 

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -262,12 +262,6 @@ pub(crate) fn position_ime_overlay(
     root_node.top = Val::Px(pos.y);
     root_node.display = Display::Flex;
 
-    // NOTE: the shell still renders the pre-commit line under the
-    // preedit (only the block cursor is suppressed, not the cells), so a
-    // transparent preedit lets mid-line characters bleed through and
-    // collide with the composed glyphs. An opaque background matching
-    // the pane's default bg occludes them — match the VT default (what
-    // the renderer fills default-bg cells with) so the box is seamless.
     let occluding_bg = Color::srgb_u8(grid.default_bg[0], grid.default_bg[1], grid.default_bg[2]);
     if root_bg.0 != occluding_bg {
         root_bg.0 = occluding_bg;


### PR DESCRIPTION
## Problem

In tmux mode, starting IME composition in the **middle** of a line made the
preedit (composition) text visually overlap the existing line content. Example:
with `TEST` on screen, moving the cursor onto the `E` and composing drew the
preedit glyphs on top of the still-rendered `EST`, garbling both.

Root cause: the IME preedit overlay's root `Text` node had a **transparent**
background (Bevy's `Node` required-component default of `Color::NONE`). The
shell owns the line buffer and keeps rendering the pre-commit line beneath the
preedit — only the block cursor is suppressed (`suppress_terminal_cursor_during_ime`),
not the cell glyphs — so the underlying characters showed through. At
end-of-line there is nothing underneath, which is why the bug only manifested
mid-line. (The overlay is shared, so this affected Default mode too.)

## Solution

`position_ime_overlay` (`src/ui/ime_overlay.rs`) now sets the overlay's
`BackgroundColor` to the focused pane's `grid.default_bg` while composing,
giving the preedit an **opaque** background that occludes the underlying cells —
the conventional terminal-IME behavior (macOS Terminal.app / iTerm2). Since the
terminal program controls the line buffer, occluding (rather than shifting the
line) is the only achievable approach until commit.

- The color is read **dynamically per-pane** (not a static `theme` constant) and
  matches exactly what the renderer fills default-background cells with
  (`bg_padding_color`), so the box blends seamlessly. A static color would render
  a mismatched box over a black/custom terminal background.
- The write is **conditional** (`if root_bg.0 != occluding_bg`), so Bevy change
  detection only fires on a real change, per the repo's change-detection rule.

Affected: `src/ui/ime_overlay.rs` only — engine/renderer untouched.

### Testing

- Added a regression test `overlay_background_matches_pane_default_bg_while_composing`
  asserting the overlay's background matches the focused pane's `default_bg` and
  the overlay is shown while composing.
- Full binary suite green (`cargo test -p ozmux`), `clippy` and `fmt` clean.

> Known minor limitation (pre-existing, out of scope): the UI-shaped preedit
> width and the terminal cell pitch are not pixel-identical, so a ~1px sliver of
> underlying text can peek at the right edge. Not the cause of the reported
> overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
