### PR TITLE
fix(tmux): propagate UTF-8 LC_CTYPE to panes so typed CJK isn't garbled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,48 @@ fn is_utf8_locale(value: &str) -> bool {
     upper.contains("UTF-8") || upper.contains("UTF8")
 }
 
+/// The UTF-8 `LC_CTYPE` ozmux advertises to tmux panes spawned after attach
+/// (see `crate::tmux::locale`), so their shells render typed wide characters
+/// correctly instead of as `<00xx>` placeholders.
+///
+/// A pane shell stuck in the C/POSIX locale makes zsh's line editor re-render
+/// every typed multibyte glyph as its per-byte C-locale notation (an orphaned
+/// lead byte plus `<0083>`-style placeholders), which ozmux then faithfully
+/// displays. This happens whenever the tmux server ozmux adopts was itself
+/// started without a UTF-8 locale (e.g. a pre-existing server, or a launchd
+/// `.app` with stripped env). Pushing this value into tmux's environment fixes
+/// newly-spawned panes.
+///
+/// Resolves to the first UTF-8 locale among `LC_ALL` / `LC_CTYPE` / `LANG`,
+/// skipping any non-UTF-8 entries, falling back to [`UTF8_CTYPE_FALLBACK`].
+///
+/// This deliberately differs from [`utf8_locale_fallback`]: that one honors
+/// tmux's first-non-empty-wins precedence to decide *whether* ozmux's own
+/// process needs the fallback, so a leading non-UTF-8 value (e.g. `LC_ALL=C`)
+/// makes it return the fallback. Here we instead want a concrete UTF-8 *value*
+/// to advertise to panes, so a non-UTF-8 entry is skipped rather than allowed to
+/// win. Because `ensure_utf8_locale_env` runs first, on macOS this always
+/// resolves to a UTF-8 value even when the inherited environment selected the
+/// C/POSIX locale.
+pub(crate) fn utf8_ctype_for_panes() -> String {
+    resolve_utf8_ctype(
+        std::env::var("LC_ALL").ok().as_deref(),
+        std::env::var("LC_CTYPE").ok().as_deref(),
+        std::env::var("LANG").ok().as_deref(),
+    )
+}
+
+/// Pure resolver behind [`utf8_ctype_for_panes`]: the first non-empty UTF-8
+/// locale among the three values, or [`UTF8_CTYPE_FALLBACK`].
+fn resolve_utf8_ctype(lc_all: Option<&str>, lc_ctype: Option<&str>, lang: Option<&str>) -> String {
+    [lc_all, lc_ctype, lang]
+        .into_iter()
+        .flatten()
+        .find(|value| !value.is_empty() && is_utf8_locale(value))
+        .map(str::to_string)
+        .unwrap_or_else(|| UTF8_CTYPE_FALLBACK.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -295,6 +337,37 @@ mod tests {
         assert_eq!(
             utf8_locale_fallback(Some("en_US.UTF-8"), None, Some("C")),
             None
+        );
+    }
+
+    #[test]
+    fn resolve_ctype_falls_back_when_no_utf8_locale() {
+        assert_eq!(resolve_utf8_ctype(None, None, None), "en_US.UTF-8");
+        assert_eq!(
+            resolve_utf8_ctype(Some("C"), Some("C"), Some("C")),
+            "en_US.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some(""), Some(""), Some("POSIX")),
+            "en_US.UTF-8"
+        );
+    }
+
+    #[test]
+    fn resolve_ctype_keeps_first_utf8_locale() {
+        // The user's own UTF-8 locale is preserved rather than overwritten with
+        // the en_US fallback, honoring tmux's LC_ALL > LC_CTYPE > LANG order.
+        assert_eq!(
+            resolve_utf8_ctype(None, Some("ja_JP.UTF-8"), None),
+            "ja_JP.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some("en_US.UTF-8"), Some("C"), None),
+            "en_US.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some("C"), None, Some("ja_JP.UTF-8")),
+            "ja_JP.UTF-8"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,9 @@ fn term_fallback(current: Option<&str>) -> Option<&'static str> {
 
 /// The UTF-8 `LC_CTYPE` ozmux installs when the inherited locale is not UTF-8.
 /// Guaranteed present on macOS, the only platform [`ensure_utf8_locale_env`]
-/// writes it on.
-const UTF8_CTYPE_FALLBACK: &str = "en_US.UTF-8";
+/// writes it on. Also the fallback advertised to tmux panes
+/// (`crate::tmux::locale`).
+pub(crate) const UTF8_CTYPE_FALLBACK: &str = "en_US.UTF-8";
 
 /// Ensures `LC_CTYPE` advertises a UTF-8 locale when the inherited environment
 /// selects none, so tmux treats ozmux's control client as UTF-8 capable.
@@ -217,51 +218,9 @@ fn utf8_locale_fallback(
 
 /// Returns whether a locale string selects the UTF-8 codeset (`…UTF-8`,
 /// `…UTF8`, or the bare macOS `UTF-8`), case-insensitively.
-fn is_utf8_locale(value: &str) -> bool {
+pub(crate) fn is_utf8_locale(value: &str) -> bool {
     let upper = value.to_ascii_uppercase();
     upper.contains("UTF-8") || upper.contains("UTF8")
-}
-
-/// The UTF-8 `LC_CTYPE` ozmux advertises to tmux panes spawned after attach
-/// (see `crate::tmux::locale`), so their shells render typed wide characters
-/// correctly instead of as `<00xx>` placeholders.
-///
-/// A pane shell stuck in the C/POSIX locale makes zsh's line editor re-render
-/// every typed multibyte glyph as its per-byte C-locale notation (an orphaned
-/// lead byte plus `<0083>`-style placeholders), which ozmux then faithfully
-/// displays. This happens whenever the tmux server ozmux adopts was itself
-/// started without a UTF-8 locale (e.g. a pre-existing server, or a launchd
-/// `.app` with stripped env). Pushing this value into tmux's environment fixes
-/// newly-spawned panes.
-///
-/// Resolves to the first UTF-8 locale among `LC_ALL` / `LC_CTYPE` / `LANG`,
-/// skipping any non-UTF-8 entries, falling back to [`UTF8_CTYPE_FALLBACK`].
-///
-/// This deliberately differs from [`utf8_locale_fallback`]: that one honors
-/// tmux's first-non-empty-wins precedence to decide *whether* ozmux's own
-/// process needs the fallback, so a leading non-UTF-8 value (e.g. `LC_ALL=C`)
-/// makes it return the fallback. Here we instead want a concrete UTF-8 *value*
-/// to advertise to panes, so a non-UTF-8 entry is skipped rather than allowed to
-/// win. Because `ensure_utf8_locale_env` runs first, on macOS this always
-/// resolves to a UTF-8 value even when the inherited environment selected the
-/// C/POSIX locale.
-pub(crate) fn utf8_ctype_for_panes() -> String {
-    resolve_utf8_ctype(
-        std::env::var("LC_ALL").ok().as_deref(),
-        std::env::var("LC_CTYPE").ok().as_deref(),
-        std::env::var("LANG").ok().as_deref(),
-    )
-}
-
-/// Pure resolver behind [`utf8_ctype_for_panes`]: the first non-empty UTF-8
-/// locale among the three values, or [`UTF8_CTYPE_FALLBACK`].
-fn resolve_utf8_ctype(lc_all: Option<&str>, lc_ctype: Option<&str>, lang: Option<&str>) -> String {
-    [lc_all, lc_ctype, lang]
-        .into_iter()
-        .flatten()
-        .find(|value| !value.is_empty() && is_utf8_locale(value))
-        .map(str::to_string)
-        .unwrap_or_else(|| UTF8_CTYPE_FALLBACK.to_string())
 }
 
 #[cfg(test)]
@@ -337,37 +296,6 @@ mod tests {
         assert_eq!(
             utf8_locale_fallback(Some("en_US.UTF-8"), None, Some("C")),
             None
-        );
-    }
-
-    #[test]
-    fn resolve_ctype_falls_back_when_no_utf8_locale() {
-        assert_eq!(resolve_utf8_ctype(None, None, None), "en_US.UTF-8");
-        assert_eq!(
-            resolve_utf8_ctype(Some("C"), Some("C"), Some("C")),
-            "en_US.UTF-8"
-        );
-        assert_eq!(
-            resolve_utf8_ctype(Some(""), Some(""), Some("POSIX")),
-            "en_US.UTF-8"
-        );
-    }
-
-    #[test]
-    fn resolve_ctype_keeps_first_utf8_locale() {
-        // The user's own UTF-8 locale is preserved rather than overwritten with
-        // the en_US fallback, honoring tmux's LC_ALL > LC_CTYPE > LANG order.
-        assert_eq!(
-            resolve_utf8_ctype(None, Some("ja_JP.UTF-8"), None),
-            "ja_JP.UTF-8"
-        );
-        assert_eq!(
-            resolve_utf8_ctype(Some("en_US.UTF-8"), Some("C"), None),
-            "en_US.UTF-8"
-        );
-        assert_eq!(
-            resolve_utf8_ctype(Some("C"), None, Some("ja_JP.UTF-8")),
-            "ja_JP.UTF-8"
         );
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -6,6 +6,7 @@ mod divider_handle;
 mod forward;
 mod gate;
 mod input;
+mod locale;
 mod mode_ui;
 mod mouse;
 mod pane_focus;
@@ -23,6 +24,7 @@ use divider_handle::DividerHandlePlugin;
 use forward::ForwardPlugin;
 use gate::GatePlugin;
 use input::InputPlugin;
+use locale::TmuxLocalePlugin;
 use mode_ui::TmuxModeUiPlugin;
 use mouse::MousePlugin;
 use ozmux_tmux::{TmuxClient, TmuxConnectionClosed, TmuxSessionPlugin};
@@ -55,6 +57,7 @@ impl Plugin for OzmuxTmuxPlugin {
                 PaneFocusPlugin,
                 GatePlugin,
                 WebviewTokensPlugin,
+                TmuxLocalePlugin,
                 TmuxModeUiPlugin,
             ));
     }

--- a/src/tmux/locale.rs
+++ b/src/tmux/locale.rs
@@ -24,7 +24,7 @@
 //! untouched (overriding it would clobber a deliberate UTF-8 `LC_ALL` and other
 //! locale categories), so that rarer case is not repaired by this.
 
-use crate::utf8_ctype_for_panes;
+use crate::{UTF8_CTYPE_FALLBACK, is_utf8_locale};
 use bevy::prelude::*;
 use ozmux_tmux::{SetEnvironmentGlobal, TmuxClient, TmuxClientMut};
 
@@ -57,9 +57,74 @@ fn propagate_utf8_ctype(mut client: TmuxClientMut<'_, '_>) {
     }
 }
 
+/// The UTF-8 `LC_CTYPE` ozmux advertises to tmux panes spawned after attach, so
+/// their shells render typed wide characters correctly instead of as `<00xx>`
+/// placeholders (see this module's docs for the full failure mode).
+///
+/// Resolves to the first UTF-8 locale among `LC_ALL` / `LC_CTYPE` / `LANG`,
+/// skipping any non-UTF-8 entries, falling back to [`UTF8_CTYPE_FALLBACK`].
+///
+/// This deliberately differs from `utf8_locale_fallback` (in `src/main.rs`):
+/// that one honors tmux's first-non-empty-wins precedence to decide *whether*
+/// ozmux's own process needs the fallback, so a leading non-UTF-8 value (e.g.
+/// `LC_ALL=C`) makes it return the fallback. Here we instead want a concrete
+/// UTF-8 *value* to advertise to panes, so a non-UTF-8 entry is skipped rather
+/// than allowed to win. Because `ensure_utf8_locale_env` runs first, on macOS
+/// this always resolves to a UTF-8 value even when the inherited environment
+/// selected the C/POSIX locale.
+fn utf8_ctype_for_panes() -> String {
+    resolve_utf8_ctype(
+        std::env::var("LC_ALL").ok().as_deref(),
+        std::env::var("LC_CTYPE").ok().as_deref(),
+        std::env::var("LANG").ok().as_deref(),
+    )
+}
+
+/// Pure resolver behind [`utf8_ctype_for_panes`]: the first non-empty UTF-8
+/// locale among the three values, or [`UTF8_CTYPE_FALLBACK`].
+fn resolve_utf8_ctype(lc_all: Option<&str>, lc_ctype: Option<&str>, lang: Option<&str>) -> String {
+    [lc_all, lc_ctype, lang]
+        .into_iter()
+        .flatten()
+        .find(|value| !value.is_empty() && is_utf8_locale(value))
+        .map(str::to_string)
+        .unwrap_or_else(|| UTF8_CTYPE_FALLBACK.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_ctype_falls_back_when_no_utf8_locale() {
+        assert_eq!(resolve_utf8_ctype(None, None, None), "en_US.UTF-8");
+        assert_eq!(
+            resolve_utf8_ctype(Some("C"), Some("C"), Some("C")),
+            "en_US.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some(""), Some(""), Some("POSIX")),
+            "en_US.UTF-8"
+        );
+    }
+
+    #[test]
+    fn resolve_ctype_keeps_first_utf8_locale() {
+        // The user's own UTF-8 locale is preserved rather than overwritten with
+        // the en_US fallback, honoring tmux's LC_ALL > LC_CTYPE > LANG order.
+        assert_eq!(
+            resolve_utf8_ctype(None, Some("ja_JP.UTF-8"), None),
+            "ja_JP.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some("en_US.UTF-8"), Some("C"), None),
+            "en_US.UTF-8"
+        );
+        assert_eq!(
+            resolve_utf8_ctype(Some("C"), None, Some("ja_JP.UTF-8")),
+            "ja_JP.UTF-8"
+        );
+    }
 
     #[test]
     fn propagate_sends_global_utf8_lc_ctype() {

--- a/src/tmux/locale.rs
+++ b/src/tmux/locale.rs
@@ -1,0 +1,115 @@
+//! Propagates a UTF-8 `LC_CTYPE` into the adopted tmux server's environment on
+//! the attach edge, so panes spawned afterward run their shells in a UTF-8
+//! locale.
+//!
+//! Without this, a tmux server that was started without a UTF-8 locale (a
+//! pre-existing server, or a launchd-launched `.app` whose env was stripped)
+//! gives every pane shell the C/POSIX locale. zsh's line editor then re-renders
+//! each typed multibyte glyph using its per-byte C-locale notation — an orphaned
+//! UTF-8 lead byte (which renders as the replacement character) followed by
+//! `<0083>`-style placeholders for the continuation bytes — which ozmux
+//! faithfully displays as garbage. ozmux's own outgoing bytes are correct UTF-8;
+//! the corruption is purely in zsh's echo of typed wide characters.
+//!
+//! The fix is a global `set-environment -g LC_CTYPE <utf8>`: tmux merges its
+//! global environment into every pane process it spawns *after* the set. It
+//! cannot retroactively fix a pane that forked earlier (including the adopted
+//! control-mode pane), so an already-running shell must be restarted (or have
+//! `LC_CTYPE` exported) to pick up the locale.
+//!
+//! Only `LC_CTYPE` is set — the one category zsh's wide-character echo depends
+//! on, and the one `ensure_utf8_locale_env` already normalizes for ozmux's own
+//! control client. A non-UTF-8 `LC_ALL` deliberately exported
+//! into the adopted server's environment outranks `LC_CTYPE` and is left
+//! untouched (overriding it would clobber a deliberate UTF-8 `LC_ALL` and other
+//! locale categories), so that rarer case is not repaired by this.
+
+use crate::utf8_ctype_for_panes;
+use bevy::prelude::*;
+use ozmux_tmux::{SetEnvironmentGlobal, TmuxClient, TmuxClientMut};
+
+/// Registers the attach-edge `LC_CTYPE` propagation system.
+pub(crate) struct TmuxLocalePlugin;
+
+impl Plugin for TmuxLocalePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, propagate_utf8_ctype.run_if(tmux_client_added));
+    }
+}
+
+/// Run condition: true on the frame a [`TmuxClient`] is newly adopted.
+fn tmux_client_added(added: Query<(), Added<TmuxClient>>) -> bool {
+    !added.is_empty()
+}
+
+/// Sends `set-environment -g LC_CTYPE <utf8>` over the adopted connection so
+/// panes spawned after attach inherit a UTF-8 locale.
+///
+/// Runs exactly once per attach (`Added<TmuxClient>`). The value is resolved by
+/// [`utf8_ctype_for_panes`], which is guaranteed UTF-8 on macOS.
+fn propagate_utf8_ctype(mut client: TmuxClientMut<'_, '_>) {
+    let ctype = utf8_ctype_for_panes();
+    if let Err(error) = client.send(SetEnvironmentGlobal {
+        key: "LC_CTYPE",
+        value: &ctype,
+    }) {
+        tracing::warn!(?error, %ctype, "failed to set tmux global LC_CTYPE for new panes");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn propagate_sends_global_utf8_lc_ctype() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let gateway = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        app.add_systems(Update, propagate_utf8_ctype.run_if(tmux_client_added));
+        app.update();
+
+        let out = app
+            .world_mut()
+            .get_mut::<TmuxClient>(gateway)
+            .unwrap()
+            .take_outgoing();
+        let command = String::from_utf8(out).expect("utf-8 command");
+        assert!(
+            command.starts_with("set-environment -g LC_CTYPE "),
+            "attach must push a global LC_CTYPE: {command:?}"
+        );
+        let upper = command.to_ascii_uppercase();
+        assert!(
+            upper.contains("UTF-8") || upper.contains("UTF8"),
+            "the advertised LC_CTYPE must be a UTF-8 locale: {command:?}"
+        );
+    }
+
+    #[test]
+    fn propagate_runs_once_per_attach_not_every_frame() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        let gateway = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        app.add_systems(Update, propagate_utf8_ctype.run_if(tmux_client_added));
+
+        app.update();
+        let _ = app
+            .world_mut()
+            .get_mut::<TmuxClient>(gateway)
+            .unwrap()
+            .take_outgoing();
+
+        // A second frame with no fresh `Added<TmuxClient>` edge must not resend.
+        app.update();
+        let out = app
+            .world_mut()
+            .get_mut::<TmuxClient>(gateway)
+            .unwrap()
+            .take_outgoing();
+        assert!(
+            out.is_empty(),
+            "LC_CTYPE is set only on the attach edge, not every frame: {out:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Typing Japanese (or any CJK) via the IME into a tmux pane and "holding"/typing continuously prints garbage like `ÔøΩ<0083><0080>` instead of the characters:

```
% dadadadaÔøΩ<0083><0086>ÔøΩ<0082>ÔøΩÔøΩ<0083><0088>ÔøΩ<0083><0080>…
```

Decoded, each `ダ` (`E3 83 80`) arrives as the codepoints **U+FFFD** (`ÔøΩ`) + `<0083>` + `<0080>` — the UTF-8 lead byte `E3` orphaned, the continuation bytes surfacing as placeholders.

Investigation (see notes below) proved ozmux is **not** the corruptor:

- A pane `xxd` capture showed ozmux **sends clean** `e3 83 80 …`.
- A unit test through the real VT parser shows the renderer only emits `�`+C1 when a wide char is split by an escape — i.e. the *echo stream itself* is malformed.
- `tmux pipe-pane` confirmed: zsh's line editor (ZLE) in the **C/POSIX locale** re-renders each typed wide char byte-by-byte (orphaned lead byte + `<0083>`-style `nicechar` placeholders). The user confirmed `LC_CTYPE="C"` in the pane.

So the root cause is that the pane's shell runs in a non-UTF-8 locale. It only affects **typed** CJK (ZLE echo) — program output of UTF-8 passes straight through.

Why the existing fix didn't cover it: ozmux **adopts the user's own `tmux -CC`** rather than spawning tmux, so `ensure_utf8_locale_env` (which only normalizes ozmux's own process env) never reaches a pre-existing / stripped-env server's panes. Same locale family as #202, different symptom.

## Solution

On the tmux attach edge, push `set-environment -g LC_CTYPE <utf8>` into the adopted server's global environment so panes spawned afterward inherit a UTF-8 locale — mirroring the `$OZMA_SOCK` global propagation in `src/tmux/webview_tokens.rs`.

Affected (engine/tmux integration only):

- `src/tmux/locale.rs` *(new)* — `TmuxLocalePlugin`: a `propagate_utf8_ctype` system gated on the `Added<TmuxClient>` attach edge sends the `set-environment -g LC_CTYPE` command.
- `src/main.rs` — `utf8_ctype_for_panes()` resolves the value (first UTF-8 of `LC_ALL` / `LC_CTYPE` / `LANG`, else `en_US.UTF-8`); `ensure_utf8_locale_env` already guarantees a UTF-8 result on macOS.
- `src/tmux.rs` — registers `TmuxLocalePlugin`.

### Scope / limitations (documented in `src/tmux/locale.rs`)

- `set-environment -g` reaches panes spawned **after** the set; an already-running shell (incl. the current one) must be restarted, or `export LC_CTYPE=en_US.UTF-8`.
- Only `LC_CTYPE` is set. A non-UTF-8 `LC_ALL` deliberately exported into the server's env outranks it and is intentionally left untouched (clearing it would clobber a deliberate UTF-8 `LC_ALL`).

### Tests

`resolve_utf8_ctype` precedence/fallback is unit-tested; the attach-edge system is tested for "sends a global UTF-8 `LC_CTYPE`" and "runs once per attach, not every frame". Full `ozmux` + `ozmux_tmux` suites pass (486 tests); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
