### PR TITLE
fix(tmux): recover from black panes after split / resize / copy-mode entry

### DIFF
--- a/crates/ozma_tty_renderer/src/lib.rs
+++ b/crates/ozma_tty_renderer/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::glyph::font::{
     CellMetrics, FontFace, FontLoadError, TerminalCellMetricsResource, TerminalFontInitSet,
     TerminalFontPlugin, TerminalFontSize, TerminalFonts,
 };
+pub use material::TerminalPaddingFallback;
 
 pub mod prelude {
     pub use crate::TerminalRendererPlugin;

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -47,7 +47,8 @@ impl Plugin for TerminalMaterialPlugin {
             "shaders/terminal_ui_material.wgsl",
             Shader::from_wgsl
         );
-        app.add_plugins(UiMaterialPlugin::<TerminalUiMaterial>::default())
+        app.init_resource::<TerminalPaddingFallback>()
+            .add_plugins(UiMaterialPlugin::<TerminalUiMaterial>::default())
             .add_plugins(state::TerminalMaterialStatePlugin)
             // NOTE: Scheduled in `PostUpdate` (not `Update`) so it runs after
             // `ui_layout_system` has written the current frame's
@@ -139,6 +140,13 @@ impl Default for PaneInactiveStyle {
         }
     }
 }
+
+/// Padding colour used for the area outside a terminal grid (and the whole
+/// quad while a grid is unpainted) when the terminal has no OSC 11 default
+/// background. Defaults to black (the prior behaviour); the binary sets it to
+/// the theme background so a momentarily-unpainted pane is not pure black.
+#[derive(Resource, Default)]
+pub struct TerminalPaddingFallback(pub [u8; 3]);
 
 /// Number of inline-overlay texture slots on `TerminalUiMaterial`.
 ///
@@ -466,6 +474,16 @@ impl GpuGlyph {
     }
 }
 
+fn padding_color(default_bg: [u8; 3], fallback: [u8; 3]) -> Vec4 {
+    let [r, g, b] = if default_bg == [0, 0, 0] {
+        fallback
+    } else {
+        default_bg
+    };
+    let c = Color::srgb_u8(r, g, b).to_linear();
+    Vec4::new(c.red, c.green, c.blue, 1.0)
+}
+
 fn update_terminal_material(
     mut atlas: ResMut<GlyphAtlas>,
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
@@ -484,6 +502,7 @@ fn update_terminal_material(
     windows: Query<&Window, With<PrimaryWindow>>,
     mut cell_metrics_res: ResMut<TerminalCellMetricsResource>,
     hover: Res<HyperlinkHoverState>,
+    fallback: Res<TerminalPaddingFallback>,
 ) {
     // NOTE: This system runs unconditionally — *not* gated by
     // `Changed<TerminalGrid>`. The `mat.params = ...` write at the end is
@@ -603,11 +622,7 @@ fn update_terminal_material(
             state.initialized = true;
         }
 
-        let bg_padding_color = {
-            let [r, g, b] = grid.default_bg;
-            let c = Color::srgb_u8(r, g, b).to_linear();
-            Vec4::new(c.red, c.green, c.blue, 1.0)
-        };
+        let bg_padding_color = padding_color(grid.default_bg, fallback.0);
 
         let (hover_hyperlink_id, hover_active) = match (hover.entity, hover.hyperlink_id) {
             (Some(e), Some(id)) if e == entity => (id.0, if hover.modifier_held { 1 } else { 0 }),
@@ -933,5 +948,19 @@ mod tests {
             196,
             "overlay_desaturate after overlay_dim"
         );
+    }
+
+    #[test]
+    fn padding_color_falls_back_when_default_bg_is_black() {
+        let got = padding_color([0, 0, 0], [30, 32, 40]);
+        let c = Color::srgb_u8(30, 32, 40).to_linear();
+        assert_eq!(got, Vec4::new(c.red, c.green, c.blue, 1.0));
+    }
+
+    #[test]
+    fn padding_color_uses_default_bg_when_set() {
+        let got = padding_color([10, 20, 30], [99, 99, 99]);
+        let c = Color::srgb_u8(10, 20, 30).to_linear();
+        assert_eq!(got, Vec4::new(c.red, c.green, c.blue, 1.0));
     }
 }

--- a/crates/ozma_tty_renderer/src/schema/grid.rs
+++ b/crates/ozma_tty_renderer/src/schema/grid.rs
@@ -44,8 +44,10 @@ pub struct TerminalGrid {
     /// interner rationale).
     pub hyperlinks: Vec<(HyperlinkId, HyperlinkUri)>,
     /// Terminal default background color from `FrameSnapshot.default_bg`
-    /// (sourced from OSC 11). Raw `[r, g, b]` bytes; black when not set.
-    /// Used by the material system to fill padding pixels outside the grid.
+    /// (sourced from OSC 11). Raw `[r, g, b]` bytes; black when not set. The
+    /// material uses it as the base background for default-bg cells and the
+    /// padding outside the grid; an unset `[0,0,0]` is mapped to
+    /// `TerminalPaddingFallback` (the theme background) by the material system.
     pub default_bg: [u8; 3],
 }
 

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -38,7 +38,7 @@ pub use input::{KeyMods, bevy_key_to_tmux_name};
 pub use keybindings::{
     CopyAction, Forwarded, KeyBindings, PromptKind, copy_mode_dispatch, plan_forward,
 };
-pub use output::PaneOutput;
+pub use output::{PaneOutput, RequestPaneReseed};
 pub use plugin::{TmuxEventBatch, TmuxProjectionSet, TmuxSessionPlugin};
 pub use tmux_control::{ClientEvent, ControlEvent, TmuxCommand, TransportEvent};
 pub use tmux_control_parser::{PaneId, SessionId, WindowId};

--- a/crates/tmux_session/src/output.rs
+++ b/crates/tmux_session/src/output.rs
@@ -22,6 +22,7 @@ pub struct PaneOutput {
 /// correlation and in-flight suppression.
 #[derive(Message)]
 pub struct RequestPaneReseed {
+    /// tmux pane (`%N`) to re-seed.
     pub pane: PaneId,
 }
 

--- a/crates/tmux_session/src/output.rs
+++ b/crates/tmux_session/src/output.rs
@@ -1,7 +1,7 @@
 //! The `%output` projection seam: the `PaneOutput` message and the pure
 //! helper that extracts pane output from a drained transport batch.
 
-use bevy::prelude::Message;
+use bevy::prelude::*;
 use tmux_control::{ClientEvent, ControlEvent, TransportEvent};
 use tmux_control_parser::PaneId;
 
@@ -14,6 +14,15 @@ pub struct PaneOutput {
     pub pane: PaneId,
     /// Raw VT bytes from `%output`.
     pub data: Vec<u8>,
+}
+
+/// Request from the renderer layer (the binary) to re-`capture-pane`-seed a
+/// pane whose grid was left structurally unpainted after a layout change. The
+/// crate handles it via `request_pane_capture`, reusing the existing reply
+/// correlation and in-flight suppression.
+#[derive(Message)]
+pub struct RequestPaneReseed {
+    pub pane: PaneId,
 }
 
 /// Extracts a [`PaneOutput`] for every `%output` or `%extended-output`

--- a/crates/tmux_session/src/output.rs
+++ b/crates/tmux_session/src/output.rs
@@ -1,7 +1,7 @@
 //! The `%output` projection seam: the `PaneOutput` message and the pure
 //! helper that extracts pane output from a drained transport batch.
 
-use bevy::prelude::*;
+use bevy::prelude::Message;
 use tmux_control::{ClientEvent, ControlEvent, TransportEvent};
 use tmux_control_parser::PaneId;
 

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -212,15 +212,24 @@ fn recapture_settled_panes(
     }
 }
 
-/// Re-seeds each requested pane via `request_pane_capture`. In-flight suppression
-/// is owned by the binary's reseed tracker (spec §3.2), so this sends one capture
-/// per request (the binary emits at most one request per pane per frame).
+/// Re-seeds each requested pane via `request_pane_capture`. Retry cadence is
+/// owned by the binary's aged reseed tracker (spec §3.2); this additionally
+/// skips a pane that already has a capture/cursor pair in flight so it cannot
+/// collide with `recapture_settled_panes`.
 fn handle_pane_reseed_requests(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     mut requests: MessageReader<RequestPaneReseed>,
 ) {
     let (client, enumeration) = &mut *client;
     for req in requests.read() {
+        // NOTE: two in-flight capture/cursor pairs for one pane desync the
+        // per-pane cursor correlation (`panes_with_cursor_pending` /
+        // `capture_awaiting_cursor` are keyed by pane, not by command), so the
+        // second capture lands without cursor info. The aged reseed tracker
+        // retries later, so suppressing here cannot wedge the pane.
+        if enumeration.panes_with_cursor_pending.contains(&req.pane) {
+            continue;
+        }
         request_pane_capture(client, enumeration, req.pane);
     }
 }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -212,18 +212,15 @@ fn recapture_settled_panes(
     }
 }
 
-/// Re-seeds each requested pane via `request_pane_capture`, skipping panes that
-/// already have a capture/cursor pair in flight (so a repeated request while the
-/// reply is pending does not duplicate the command).
+/// Re-seeds each requested pane via `request_pane_capture`. In-flight suppression
+/// is owned by the binary's reseed tracker (spec §3.2), so this sends one capture
+/// per request (the binary emits at most one request per pane per frame).
 fn handle_pane_reseed_requests(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     mut requests: MessageReader<RequestPaneReseed>,
 ) {
     let (client, enumeration) = &mut *client;
     for req in requests.read() {
-        if enumeration.panes_with_cursor_pending.contains(&req.pane) {
-            continue;
-        }
         request_pane_capture(client, enumeration, req.pane);
     }
 }

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -17,7 +17,7 @@ use crate::event_pump::{
 use crate::events::{TmuxActivePaneChanged, TmuxWindowsRetained};
 use crate::keybindings::{KeyBindings, ModeKeys, parse_list_keys, parse_prefix};
 use crate::observers::{TmuxProjection, register_observers};
-use crate::output::{PaneOutput, collect_pane_outputs};
+use crate::output::{PaneOutput, RequestPaneReseed, collect_pane_outputs};
 use bevy::prelude::*;
 use ozma_tty_engine::{AdoptedControlMode, TerminalRawWrite};
 use tmux_control::{ClientEvent, TransportEvent};
@@ -48,6 +48,7 @@ impl Plugin for TmuxSessionPlugin {
             .init_resource::<CopyModeQueries>()
             .init_resource::<TmuxEventBatch>()
             .add_message::<PaneOutput>()
+            .add_message::<RequestPaneReseed>()
             .add_message::<CopyModeReply>()
             .add_message::<TmuxClientAttached>()
             .add_systems(
@@ -66,7 +67,11 @@ impl Plugin for TmuxSessionPlugin {
             )
             .add_systems(
                 Update,
-                (request_pane_captures, recapture_settled_panes)
+                (
+                    request_pane_captures,
+                    recapture_settled_panes,
+                    handle_pane_reseed_requests.run_if(on_message::<RequestPaneReseed>),
+                )
                     .after(TmuxProjectionSet)
                     .run_if(any_with_component::<TmuxClient>),
             );
@@ -204,6 +209,22 @@ fn recapture_settled_panes(
             state.done = true;
             request_pane_capture(client, enumeration, pane.id);
         }
+    }
+}
+
+/// Re-seeds each requested pane via `request_pane_capture`, skipping panes that
+/// already have a capture/cursor pair in flight (so a repeated request while the
+/// reply is pending does not duplicate the command).
+fn handle_pane_reseed_requests(
+    mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
+    mut requests: MessageReader<RequestPaneReseed>,
+) {
+    let (client, enumeration) = &mut *client;
+    for req in requests.read() {
+        if enumeration.panes_with_cursor_pending.contains(&req.pane) {
+            continue;
+        }
+        request_pane_capture(client, enumeration, req.pane);
     }
 }
 

--- a/docs/superpowers/plans/2026-06-26-pane-black-paint-recovery.md
+++ b/docs/superpowers/plans/2026-06-26-pane-black-paint-recovery.md
@@ -1,0 +1,925 @@
+# Pane Black-Screen Paint Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop tmux panes from rendering fully black after a layout change (split / window resize / copy-mode entry) by making the seed→route→paint pipeline self-healing.
+
+**Architecture:** Four independent fixes from the design spec. (C1) `route_tmux_output` buffers a pane's bytes when its handle/grid is not yet present and replays them once ready, instead of dropping them. (C2) a binary-side rescue system detects a structurally-unpainted grid via a pure sentinel and asks the tmux crate to re-`capture-pane` (debounced, in-flight-suppressed) until it paints. (C3) the copy-mode refresh loop gains a capture-in-flight resend and records `last_scroll` on *reply* (not send) so a lost capture is retried. (C4) the renderer paints an unpainted pane's padding with the theme background instead of pure black.
+
+**Tech Stack:** Rust (edition 2024, toolchain 1.95), Bevy 0.18 ECS, `alacritty_terminal` VT, tmux `-CC` control mode. Crates touched: `ozma_tty_renderer`, `ozmux_tmux` (crate `tmux_session`), and the root binary `ozmux` (`src/`).
+
+**Spec:** `docs/superpowers/specs/2026-06-26-pane-black-paint-recovery-design.md`
+
+## Global Constraints
+
+- Comments: only `// TODO:` / `// NOTE:` (critical caveat) / `// SAFETY:`. All comments in English. (`.claude/rules/rust.md`)
+- No `mod.rs`. Every `pub` item gets a `///` doc; every module file gets a `//!`.
+- Visibility: start private; widen only for a real out-of-module caller. New items used in one module stay private.
+- All `use` at the top of the file in one contiguous block; no inline fully-qualified paths in signatures/bodies.
+- `Plugin::build` bodies use a single method chain off `app`.
+- Register systems/observers in the `Plugin` defined in the SAME file; parents only `add_plugins`.
+- Mutable params before immutable in fn signatures (except `self` / `On<E>` first, or a documented semantic order).
+- Gate whole-system change checks with `run_if`, not in-body `is_changed()` early returns.
+- Do NOT use `set_changed()` / `bypass_change_detection()`; mutate conditionally so `DerefMut` drives change detection.
+- `Query` params: descriptive noun, never a `_q` suffix.
+- TDD: write the failing test first, watch it fail, implement minimally, watch it pass, commit. Frequent commits.
+- Every commit message ends with the trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Lint gate before each commit: `cargo clippy --workspace --all-targets` clean and `cargo fmt`.
+
+## File Structure
+
+- `crates/ozma_tty_renderer/src/material.rs` — **modify**: add a `padding_color` pure helper + `TerminalPaddingFallback` resource; consult it in `update_terminal_material`. Export the resource.
+- `crates/ozma_tty_renderer/src/lib.rs` — **modify**: `pub use` the new resource.
+- `src/tmux/render.rs` — **modify**: add `PendingPaneOutput` resource + buffering/replay in `route_tmux_output`; insert `TerminalPaddingFallback` from the theme; register the rescue plugin's ordering.
+- `src/tmux/paint_rescue.rs` — **create**: `grid_needs_full_seed` pure helper, `PaneSeedDebounce` resource, `rescue_unpainted_panes` system, `PaintRescuePlugin`.
+- `src/tmux.rs` — **modify**: declare `mod paint_rescue;` and `add_plugins(PaintRescuePlugin)`.
+- `crates/tmux_session/src/output.rs` — **modify**: add the `RequestPaneReseed` message.
+- `crates/tmux_session/src/plugin.rs` — **modify**: register the message + a `handle_pane_reseed_requests` system that calls `request_pane_capture`.
+- `crates/tmux_session/src/lib.rs` — **modify**: `pub use` `RequestPaneReseed`.
+- `src/tmux/copy_mode.rs` — **modify**: add `decide_capture` pure helper + `capture_in_flight` bookkeeping; record `last_scroll` on capture reply; age/resend lost captures.
+
+The five tasks are independent and can be reviewed separately. Task 4 depends on Task 3's helper; the rest have no ordering dependency.
+
+---
+
+### Task 1: Component 4 — non-black padding fallback (renderer)
+
+**Files:**
+- Modify: `crates/ozma_tty_renderer/src/material.rs`
+- Modify: `crates/ozma_tty_renderer/src/lib.rs`
+- Test: inline `#[cfg(test)] mod tests` in `crates/ozma_tty_renderer/src/material.rs`
+
+**Interfaces:**
+- Produces: `pub struct TerminalPaddingFallback([u8; 3])` (resource; `Default` = `[0,0,0]`), and a private `fn padding_color(default_bg: [u8; 3], fallback: [u8; 3]) -> Vec4`.
+- Consumes: nothing.
+
+**Background:** `update_terminal_material` currently computes `bg_padding_color` straight from `grid.default_bg`, which is `[0,0,0]` until a snapshot carries OSC 11 (`crates/ozma_tty_renderer/src/schema/grid.rs:46`). An unpainted grid therefore paints pure black. We map an unset `[0,0,0]` to a configurable fallback. The fallback resource defaults to `[0,0,0]` so behaviour is unchanged until the binary sets it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests { ... }` block in `crates/ozma_tty_renderer/src/material.rs` (add `use super::*;` if not already present in that block):
+
+```rust
+#[test]
+fn padding_color_falls_back_when_default_bg_is_black() {
+    let got = padding_color([0, 0, 0], [30, 32, 40]);
+    let c = Color::srgb_u8(30, 32, 40).to_linear();
+    assert_eq!(got, Vec4::new(c.red, c.green, c.blue, 1.0));
+}
+
+#[test]
+fn padding_color_uses_default_bg_when_set() {
+    let got = padding_color([10, 20, 30], [99, 99, 99]);
+    let c = Color::srgb_u8(10, 20, 30).to_linear();
+    assert_eq!(got, Vec4::new(c.red, c.green, c.blue, 1.0));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozma_tty_renderer padding_color`
+Expected: FAIL — `cannot find function `padding_color` in this scope`.
+
+- [ ] **Step 3: Add the resource and the pure helper**
+
+Add near the other resources/types in `crates/ozma_tty_renderer/src/material.rs`:
+
+```rust
+/// Padding colour used for the area outside a terminal grid (and the whole
+/// quad while a grid is unpainted) when the terminal has no OSC 11 default
+/// background. Defaults to black (the prior behaviour); the binary sets it to
+/// the theme background so a momentarily-unpainted pane is not pure black.
+#[derive(Resource)]
+pub struct TerminalPaddingFallback(pub [u8; 3]);
+
+impl Default for TerminalPaddingFallback {
+    fn default() -> Self {
+        Self([0, 0, 0])
+    }
+}
+```
+
+Add the private helper alongside the other free functions in the same file:
+
+```rust
+fn padding_color(default_bg: [u8; 3], fallback: [u8; 3]) -> Vec4 {
+    let [r, g, b] = if default_bg == [0, 0, 0] {
+        fallback
+    } else {
+        default_bg
+    };
+    let c = Color::srgb_u8(r, g, b).to_linear();
+    Vec4::new(c.red, c.green, c.blue, 1.0)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozma_tty_renderer padding_color`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire the helper + resource into the renderer**
+
+In `crates/ozma_tty_renderer/src/material.rs`, add the resource param to `update_terminal_material` (immutable params group — place after the existing `Res`/`ResMut` params, keeping mutable-first ordering):
+
+```rust
+    fallback: Res<TerminalPaddingFallback>,
+```
+
+Replace the existing `bg_padding_color` block (currently `let bg_padding_color = { let [r, g, b] = grid.default_bg; let c = Color::srgb_u8(r, g, b).to_linear(); Vec4::new(c.red, c.green, c.blue, 1.0) };`) with:
+
+```rust
+        let bg_padding_color = padding_color(grid.default_bg, fallback.0);
+```
+
+In the same file's `TerminalMaterialPlugin` `build` (the plugin that registers `update_terminal_material`), add to the method chain:
+
+```rust
+            .init_resource::<TerminalPaddingFallback>()
+```
+
+In `crates/ozma_tty_renderer/src/lib.rs`, export it next to the other material re-exports:
+
+```rust
+pub use material::TerminalPaddingFallback;
+```
+
+- [ ] **Step 6: Set the fallback from the theme in the binary**
+
+In `src/tmux/render.rs`, add to imports (in the existing top `use` block):
+
+```rust
+use ozma_tty_renderer::TerminalPaddingFallback;
+```
+
+In `RenderPlugin::build` (`src/tmux/render.rs:38`), add to the `app` method chain (after `.insert_resource(ClearColor(theme::PANE_GAP))`):
+
+```rust
+            .insert_resource(TerminalPaddingFallback(theme_background_bytes()))
+```
+
+Add this private helper to `src/tmux/render.rs` (bottom, with the other free fns):
+
+```rust
+fn theme_background_bytes() -> [u8; 3] {
+    let s = theme::BACKGROUND.to_srgba();
+    [
+        (s.red * 255.0).round() as u8,
+        (s.green * 255.0).round() as u8,
+        (s.blue * 255.0).round() as u8,
+    ]
+}
+```
+
+- [ ] **Step 7: Verify the workspace builds and lints**
+
+Run: `cargo build -p ozma_tty_renderer && cargo clippy -p ozma_tty_renderer --all-targets && cargo fmt`
+Expected: builds clean, no clippy warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/ozma_tty_renderer/src/material.rs crates/ozma_tty_renderer/src/lib.rs src/tmux/render.rs
+git commit -m "$(cat <<'EOF'
+feat(renderer): theme-background padding fallback for unpainted grids
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Component 1 — buffer & replay routed pane output (binary)
+
+**Files:**
+- Modify: `src/tmux/render.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/tmux/render.rs`
+
+**Interfaces:**
+- Produces: `struct PendingPaneOutput` (resource) with `fn push(&mut self, pane: PaneId, data: &[u8])` and `fn take(&mut self, pane: PaneId) -> Option<Vec<u8>>`, and `const PENDING_PANE_OUTPUT_CAP: usize`.
+- Consumes: `PaneOutput { pane: PaneId, data: Vec<u8> }`, `TerminalHandle`, `TmuxPane` (already imported in `render.rs`).
+
+**Background:** `route_tmux_output` (`src/tmux/render.rs:165`) drops a pane's bytes when `entity_of.get(&pane)` misses or `handles.get_mut(entity)` errors (`continue`). For a `capture-pane` reply that arrives before the pane entity/handle is flushed, the authoritative seed bytes are lost and the grid stays black until the next unrelated `%output`. We buffer the bytes (bounded) and replay them once the pane is ready.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests { ... }` block in `src/tmux/render.rs` (create the block if absent; add `use super::*;` and `use tmux_control_parser::PaneId;`):
+
+```rust
+#[test]
+fn pending_output_accumulates_then_takes() {
+    let mut p = PendingPaneOutput::default();
+    p.push(PaneId(1), b"ab");
+    p.push(PaneId(1), b"cd");
+    p.push(PaneId(2), b"xy");
+    assert_eq!(p.take(PaneId(1)).as_deref(), Some(&b"abcd"[..]));
+    assert_eq!(p.take(PaneId(1)), None);
+    assert_eq!(p.take(PaneId(2)).as_deref(), Some(&b"xy"[..]));
+}
+
+#[test]
+fn pending_output_drops_pane_buffer_over_cap() {
+    let mut p = PendingPaneOutput::default();
+    let big = vec![0u8; PENDING_PANE_OUTPUT_CAP];
+    p.push(PaneId(1), &big);
+    p.push(PaneId(1), b"z");
+    let got = p.take(PaneId(1)).unwrap_or_default();
+    assert!(
+        got.len() <= PENDING_PANE_OUTPUT_CAP,
+        "buffer must not grow past the cap"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test pending_output`
+Expected: FAIL — `cannot find type `PendingPaneOutput``.
+
+- [ ] **Step 3: Add the resource**
+
+Add to `src/tmux/render.rs` (near `LastClientSize`), and ensure `use std::collections::HashMap;` is present (it already is):
+
+```rust
+/// Total cap, across all panes, for bytes buffered while a pane's handle/grid
+/// is not yet present. One MiB is far above any real capture seed; the cap only
+/// guards a pane that never attaches.
+const PENDING_PANE_OUTPUT_CAP: usize = 1 << 20;
+
+/// Bytes routed to a pane before its `TerminalHandle` was queryable, held until
+/// the pane is ready and then replayed. Prevents losing the authoritative
+/// `capture-pane` seed (spec Component 1).
+#[derive(Resource, Default)]
+struct PendingPaneOutput {
+    buf: HashMap<PaneId, Vec<u8>>,
+    total: usize,
+}
+
+impl PendingPaneOutput {
+    fn push(&mut self, pane: PaneId, data: &[u8]) {
+        if self.total + data.len() > PENDING_PANE_OUTPUT_CAP {
+            if let Some(old) = self.buf.remove(&pane) {
+                self.total -= old.len();
+            }
+            tracing::warn!(
+                pane = pane.0,
+                "pending pane-output over cap; dropped buffered bytes"
+            );
+            if data.len() > PENDING_PANE_OUTPUT_CAP {
+                return;
+            }
+        }
+        let entry = self.buf.entry(pane).or_default();
+        entry.extend_from_slice(data);
+        self.total += data.len();
+    }
+
+    fn take(&mut self, pane: PaneId) -> Option<Vec<u8>> {
+        let v = self.buf.remove(&pane)?;
+        self.total -= v.len();
+        Some(v)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test pending_output`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Register the resource**
+
+In `RenderPlugin::build` (`src/tmux/render.rs:38`), add to the `app` chain:
+
+```rust
+            .init_resource::<PendingPaneOutput>()
+```
+
+- [ ] **Step 6: Buffer-and-replay inside `route_tmux_output`**
+
+Add the resource param to `route_tmux_output` (mutable params group, after `mut commands` / `mut reader` / `mut handles`):
+
+```rust
+    mut pending: ResMut<PendingPaneOutput>,
+```
+
+Replace the per-pane loop body (`src/tmux/render.rs:180-207`) so that unresolved panes buffer and ready panes drain. The new body of the function, from after `let entity_of = ...;`:
+
+```rust
+    let mut pane_ids: std::collections::HashSet<PaneId> = by_pane.keys().copied().collect();
+    pane_ids.extend(pending.buf.keys().copied());
+    for pane in pane_ids {
+        let fresh = by_pane.remove(&pane).unwrap_or_default();
+        let Some(&entity) = entity_of.get(&pane) else {
+            pending.push(pane, &fresh);
+            continue;
+        };
+        let Ok((mut handle, mut title)) = handles.get_mut(entity) else {
+            pending.push(pane, &fresh);
+            continue;
+        };
+        if let Some(buffered) = pending.take(pane) {
+            handle.advance(&buffered);
+        }
+        handle.advance(&fresh);
+        handle.drain_control_events(&mut commands, entity, &mut title);
+        if copy_modes.get(entity).is_err() {
+            handle.flush_emit(&mut commands, entity);
+        }
+        let _ = handle.take_replies();
+    }
+```
+
+Add `use std::collections::HashSet;` to the top `use` block (do NOT inline the path — replace the inline `std::collections::HashSet` above with `HashSet` after adding the import).
+
+- [ ] **Step 7: Verify build, lint, and the existing render tests**
+
+Run: `cargo test -p ozmux render && cargo clippy --all-targets && cargo fmt`
+Expected: builds clean; pre-existing `route_tmux_output` tests (if any) still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tmux/render.rs
+git commit -m "$(cat <<'EOF'
+fix(tmux): buffer & replay pane output instead of dropping it before attach
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `grid_needs_full_seed` pure sentinel helper (binary)
+
+**Files:**
+- Create: `src/tmux/paint_rescue.rs`
+- Modify: `src/tmux.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/tmux/paint_rescue.rs`
+
+**Interfaces:**
+- Produces: `fn grid_needs_full_seed(grid_cols: u16, grid_rows: u16, cells_len: usize, handle_cols: u16, handle_rows: u16) -> bool`.
+- Consumes: nothing (pure).
+
+**Background:** The detector for an unpainted grid is structural (spec §2.2/§3.2): the **dims-vs-handle** clause catches the common `0×0` grid; `cells.len() != rows` catches the dims-written-but-cells-empty variant (e.g. a lost resize snapshot). A genuinely blank captured pane yields `cells.len() == rows` (a snapshot builds one row vector per visible row), so it must NOT fire.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tmux/paint_rescue.rs` with only the module doc, the function stub's test, and `mod tests`:
+
+```rust
+//! Structural rescue for tmux panes whose grid was left unpainted after a
+//! layout change: detects the unpainted state and asks `ozmux_tmux` to
+//! re-`capture-pane` until the grid paints (spec Component 2).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_grid_against_sized_handle_needs_seed() {
+        assert!(grid_needs_full_seed(0, 0, 0, 80, 24));
+    }
+
+    #[test]
+    fn dims_written_but_cells_empty_needs_seed() {
+        assert!(grid_needs_full_seed(80, 24, 0, 80, 24));
+    }
+
+    #[test]
+    fn blank_captured_pane_does_not_need_seed() {
+        // A real snapshot yields one (possibly empty) row vector per row.
+        assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
+    }
+
+    #[test]
+    fn painted_matching_grid_does_not_need_seed() {
+        assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
+    }
+}
+```
+
+Declare the module in `src/tmux.rs` (add next to the other `mod` lines):
+
+```rust
+mod paint_rescue;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux grid_needs_full_seed`
+Expected: FAIL — `cannot find function `grid_needs_full_seed``.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `src/tmux/paint_rescue.rs` above the `#[cfg(test)]` block:
+
+```rust
+/// Returns whether a pane's grid is structurally unpainted and needs a full
+/// re-seed. The dims-vs-handle clause catches the common `0×0` grid; the
+/// `cells_len != rows` clause catches a grid whose dims were written but whose
+/// rows were never repopulated (e.g. a lost resize snapshot). A genuinely blank
+/// captured pane has `cells_len == rows`, so it does not fire.
+fn grid_needs_full_seed(
+    grid_cols: u16,
+    grid_rows: u16,
+    cells_len: usize,
+    handle_cols: u16,
+    handle_rows: u16,
+) -> bool {
+    (grid_cols, grid_rows) != (handle_cols, handle_rows) || cells_len != grid_rows as usize
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozmux grid_needs_full_seed`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tmux/paint_rescue.rs src/tmux.rs
+git commit -m "$(cat <<'EOF'
+feat(tmux): pure grid_needs_full_seed sentinel for paint rescue
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Component 2 — reseed request message + rescue system
+
+**Files:**
+- Modify: `crates/tmux_session/src/output.rs` (add the message)
+- Modify: `crates/tmux_session/src/plugin.rs` (register + handle it)
+- Modify: `crates/tmux_session/src/lib.rs` (export it)
+- Modify: `src/tmux/paint_rescue.rs` (debounce helper + system + plugin)
+- Modify: `src/tmux.rs` (add the plugin)
+- Test: inline `#[cfg(test)] mod tests` in `src/tmux/paint_rescue.rs`
+
+**Interfaces:**
+- Produces (crate): `pub struct RequestPaneReseed { pub pane: PaneId }` (a Bevy `Message`).
+- Produces (binary): `fn should_emit_reseed(counter: &mut u8, needs_seed: bool, threshold: u8) -> bool`; `struct PaneSeedDebounce` resource; `fn rescue_unpainted_panes(...)`; `pub(crate) struct PaintRescuePlugin`.
+- Consumes: `grid_needs_full_seed` (Task 3); `TmuxPane`, `TerminalHandle`, `TerminalGrid`, `CopyModeState`; crate `request_pane_capture` machinery (via the message).
+
+**Background:** The binary owns the renderer-component read (`TerminalGrid`); the crate owns the `capture-pane` reply correlation (renderer-free). So the binary computes the sentinel and emits `RequestPaneReseed { pane }`; the crate re-uses `request_pane_capture` (with its existing `panes_with_cursor_pending` in-flight suppression). A binary-side per-pane counter debounces, so the 1-frame resize transient (dims written before the deferred snapshot flush, spec §3.2) does not trigger a capture; only a state persisting `threshold` frames does.
+
+- [ ] **Step 1: Write the failing test (debounce helper)**
+
+Add to the `#[cfg(test)] mod tests` block in `src/tmux/paint_rescue.rs`:
+
+```rust
+#[test]
+fn debounce_emits_only_after_threshold_consecutive_true() {
+    let mut c = 0u8;
+    assert!(!should_emit_reseed(&mut c, true, 3)); // 1
+    assert!(!should_emit_reseed(&mut c, true, 3)); // 2
+    assert!(should_emit_reseed(&mut c, true, 3)); // 3 -> emit
+}
+
+#[test]
+fn debounce_resets_on_false() {
+    let mut c = 0u8;
+    should_emit_reseed(&mut c, true, 3);
+    should_emit_reseed(&mut c, true, 3);
+    assert!(!should_emit_reseed(&mut c, false, 3)); // reset
+    assert_eq!(c, 0);
+    assert!(!should_emit_reseed(&mut c, true, 3)); // counting restarts at 1
+}
+
+#[test]
+fn debounce_does_not_re_emit_every_frame_while_held() {
+    let mut c = 0u8;
+    for _ in 0..2 {
+        should_emit_reseed(&mut c, true, 3);
+    }
+    assert!(should_emit_reseed(&mut c, true, 3)); // emits at threshold
+    assert!(!should_emit_reseed(&mut c, true, 3)); // held: no re-emit until reset
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux should_emit_reseed`
+Expected: FAIL — `cannot find function `should_emit_reseed``.
+
+- [ ] **Step 3: Implement the debounce helper**
+
+Add to `src/tmux/paint_rescue.rs` (above the test block):
+
+```rust
+/// Advances a per-pane debounce counter and returns whether to emit a reseed
+/// request this frame. Emits exactly once when `needs_seed` has held for
+/// `threshold` consecutive frames; a `false` resets the counter; once emitted it
+/// will not re-emit until the counter resets (the saturated value stays above
+/// `threshold`, and only the exact `== threshold` transition emits).
+fn should_emit_reseed(counter: &mut u8, needs_seed: bool, threshold: u8) -> bool {
+    if !needs_seed {
+        *counter = 0;
+        return false;
+    }
+    *counter = counter.saturating_add(1);
+    *counter == threshold
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozmux should_emit_reseed`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add the crate message**
+
+In `crates/tmux_session/src/output.rs`, add (with the other message/types; keep imports at the top):
+
+```rust
+/// Request from the renderer layer (the binary) to re-`capture-pane`-seed a
+/// pane whose grid was left structurally unpainted after a layout change. The
+/// crate handles it via `request_pane_capture`, reusing the existing reply
+/// correlation and in-flight suppression.
+#[derive(Message)]
+pub struct RequestPaneReseed {
+    pub pane: PaneId,
+}
+```
+
+Ensure `use bevy::prelude::*;` and `use tmux_control_parser::PaneId;` are present at the top of `output.rs` (add if missing).
+
+In `crates/tmux_session/src/lib.rs`, extend the `output` re-export line to:
+
+```rust
+pub use output::{PaneOutput, RequestPaneReseed};
+```
+
+- [ ] **Step 6: Register + handle the message in the crate plugin**
+
+In `crates/tmux_session/src/plugin.rs`, import the message (top `use` block; extend the existing `crate::output` use):
+
+```rust
+use crate::output::{PaneOutput, RequestPaneReseed, collect_pane_outputs};
+```
+
+In `TmuxSessionPlugin::build` (`crates/tmux_session/src/plugin.rs:44`), add the message registration in the chain (next to `.add_message::<PaneOutput>()`):
+
+```rust
+            .add_message::<RequestPaneReseed>()
+```
+
+and add the handler to the post-projection systems tuple (`plugin.rs:67-72`), so it becomes:
+
+```rust
+            .add_systems(
+                Update,
+                (
+                    request_pane_captures,
+                    recapture_settled_panes,
+                    handle_pane_reseed_requests.run_if(on_message::<RequestPaneReseed>),
+                )
+                    .after(TmuxProjectionSet)
+                    .run_if(any_with_component::<TmuxClient>),
+            );
+```
+
+Add the handler fn to `plugin.rs` (private; near `recapture_settled_panes`):
+
+```rust
+/// Re-seeds each requested pane via `request_pane_capture`, skipping panes that
+/// already have a capture/cursor pair in flight (so a repeated request while the
+/// reply is pending does not duplicate the command).
+fn handle_pane_reseed_requests(
+    mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
+    mut requests: MessageReader<RequestPaneReseed>,
+) {
+    let (client, enumeration) = &mut *client;
+    for req in requests.read() {
+        if enumeration.panes_with_cursor_pending.contains(&req.pane) {
+            continue;
+        }
+        request_pane_capture(client, enumeration, req.pane);
+    }
+}
+```
+
+Confirm `MessageReader` and `on_message` are in scope via `use bevy::prelude::*;` (already present).
+
+- [ ] **Step 7: Verify the crate builds and lints**
+
+Run: `cargo test -p ozmux_tmux && cargo clippy -p ozmux_tmux --all-targets && cargo fmt`
+Expected: builds clean; crate tests pass.
+
+- [ ] **Step 8: Write the rescue system + plugin (binary)**
+
+Add to `src/tmux/paint_rescue.rs` (above the test block). Put the imports at the top of the file, in one block under the `//!`:
+
+```rust
+use crate::ui::copy_mode::CopyModeState;
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalHandle;
+use ozma_tty_renderer::schema::TerminalGrid;
+use ozmux_tmux::{PaneId, RequestPaneReseed, TmuxPane, TmuxProjectionSet};
+use std::collections::HashMap;
+```
+
+```rust
+/// Frames the unpainted state must persist before a reseed is requested. Filters
+/// the 1-frame resize transient (dims written before the deferred snapshot
+/// flush) while still healing a genuinely lost seed quickly.
+const RESEED_DEBOUNCE_FRAMES: u8 = 3;
+
+/// Per-pane consecutive-frames-unpainted counters for the reseed debounce.
+#[derive(Resource, Default)]
+struct PaneSeedDebounce(HashMap<PaneId, u8>);
+
+/// Wires the structural paint-rescue system after the tmux projection chain.
+pub(crate) struct PaintRescuePlugin;
+
+impl Plugin for PaintRescuePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PaneSeedDebounce>()
+            .add_systems(
+                Update,
+                rescue_unpainted_panes
+                    .after(TmuxProjectionSet)
+                    .in_set(super::TmuxActiveSet),
+            );
+    }
+}
+
+/// Requests a tmux re-seed for each non-copy-mode pane whose grid is
+/// structurally unpainted (see [`grid_needs_full_seed`]) once the state has held
+/// for [`RESEED_DEBOUNCE_FRAMES`]. Copy-mode panes are skipped — they paint via
+/// the separate `CopyRenderHandle` (Component 3).
+fn rescue_unpainted_panes(
+    mut debounce: ResMut<PaneSeedDebounce>,
+    mut reseed: MessageWriter<RequestPaneReseed>,
+    panes: Query<(&TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
+) {
+    for (pane, handle, grid) in panes.iter() {
+        let (h_cols, h_rows, _) = handle.read_geometry();
+        let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
+        let counter = debounce.0.entry(pane.id).or_default();
+        if should_emit_reseed(counter, needs, RESEED_DEBOUNCE_FRAMES) {
+            reseed.write(RequestPaneReseed { pane: pane.id });
+        }
+    }
+}
+```
+
+- [ ] **Step 9: Register the plugin**
+
+In `src/tmux.rs`, import and add the plugin to `OzmuxTmuxPlugin`'s `add_plugins` tuple (next to `RenderPlugin`):
+
+```rust
+use paint_rescue::PaintRescuePlugin;
+```
+
+```rust
+                RenderPlugin,
+                PaintRescuePlugin,
+```
+
+- [ ] **Step 10: Verify build, lint, all tests**
+
+Run: `cargo test -p ozmux paint_rescue && cargo build && cargo clippy --all-targets && cargo fmt`
+Expected: builds clean; helper tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/tmux_session/src/output.rs crates/tmux_session/src/plugin.rs crates/tmux_session/src/lib.rs src/tmux/paint_rescue.rs src/tmux.rs
+git commit -m "$(cat <<'EOF'
+fix(tmux): structurally rescue unpainted panes via debounced reseed
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Component 3 — copy-mode capture backstop + last_scroll fix
+
+**Files:**
+- Modify: `src/tmux/copy_mode.rs`
+- Test: inline `#[cfg(test)] mod tests` in `src/tmux/copy_mode.rs`
+
+**Interfaces:**
+- Produces: `enum CaptureDecision { Skip, Issue }` and `fn decide_capture(last_captured_scroll: Option<u32>, capture_in_flight: bool, scroll: u32) -> CaptureDecision`.
+- Consumes / modifies: `CopyRefreshState` (adds a `capture_in_flight: HashMap<PaneId, CapturePending>` field), `apply_state_reply`, `apply_capture_reply`, `issue_copy_state`.
+
+**Background:** Today `apply_state_reply` records `last_scroll` at **send** time (`src/tmux/copy_mode.rs:265`) and gates the capture on `last_scroll != scroll`. So a lost capture at the same scroll position permanently suppresses any retry, and there is no capture-in-flight resend (only the State query resends). We (a) record the captured scroll on the **capture reply**, (b) track an in-flight capture per pane, and (c) age it so a lost capture is retried.
+
+- [ ] **Step 1: Write the failing test (decision helper)**
+
+Add to the `#[cfg(test)] mod tests` block in `src/tmux/copy_mode.rs` (add `use super::*;`):
+
+```rust
+#[test]
+fn decide_capture_issues_for_new_scroll() {
+    assert_eq!(decide_capture(None, false, 5), CaptureDecision::Issue);
+    assert_eq!(decide_capture(Some(3), false, 5), CaptureDecision::Issue);
+}
+
+#[test]
+fn decide_capture_skips_when_already_captured_that_scroll() {
+    assert_eq!(decide_capture(Some(5), false, 5), CaptureDecision::Skip);
+}
+
+#[test]
+fn decide_capture_skips_while_in_flight() {
+    // A capture for this scroll is already pending; do not duplicate.
+    assert_eq!(decide_capture(None, true, 5), CaptureDecision::Skip);
+}
+
+#[test]
+fn decide_capture_reissues_after_lost_capture_cleared() {
+    // last_captured stayed stale (reply never landed) and the in-flight entry
+    // was aged out; the next state reply must re-issue.
+    assert_eq!(decide_capture(Some(3), false, 5), CaptureDecision::Issue);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p ozmux decide_capture`
+Expected: FAIL — `cannot find function `decide_capture``.
+
+- [ ] **Step 3: Implement the decision helper + in-flight type**
+
+Add to `src/tmux/copy_mode.rs`:
+
+```rust
+/// Whether a `State` reply should trigger a fresh `capture-pane`.
+#[derive(Debug, PartialEq, Eq)]
+enum CaptureDecision {
+    Skip,
+    Issue,
+}
+
+/// Per-pane in-flight capture bookkeeping: the scroll position the pending
+/// capture is for, and how many updates it has been outstanding (for the resend
+/// backstop).
+struct CapturePending {
+    scroll: u32,
+    age: u32,
+}
+
+/// Decides whether to issue a capture for `scroll`: issue when we have not yet
+/// captured that scroll position and no capture for it is already in flight.
+fn decide_capture(
+    last_captured_scroll: Option<u32>,
+    capture_in_flight: bool,
+    scroll: u32,
+) -> CaptureDecision {
+    if capture_in_flight || last_captured_scroll == Some(scroll) {
+        CaptureDecision::Skip
+    } else {
+        CaptureDecision::Issue
+    }
+}
+```
+
+Extend `CopyRefreshState` (`src/tmux/copy_mode.rs:61`) with the in-flight map (rename `last_scroll`'s role to "last *captured* scroll"):
+
+```rust
+#[derive(Resource, Default)]
+struct CopyRefreshState {
+    state_in_flight: HashMap<PaneId, u32>,
+    last_scroll: HashMap<PaneId, u32>,
+    capture_in_flight: HashMap<PaneId, CapturePending>,
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p ozmux decide_capture`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Record the captured scroll on the *reply*, not the send**
+
+In `apply_state_reply` (`src/tmux/copy_mode.rs:229`), replace the `changed`/send block (currently lines 251-270) with the in-flight-aware version:
+
+```rust
+    let in_flight = refresh.capture_in_flight.contains_key(&reply.pane);
+    let last = refresh.last_scroll.get(&reply.pane).copied();
+    if decide_capture(last, in_flight, state.scroll_position) == CaptureDecision::Skip {
+        return;
+    }
+    let Some(client) = client else {
+        return;
+    };
+    match client.send(CopyModeCapture {
+        pane: reply.pane,
+        scroll_position: state.scroll_position,
+        pane_height: state.pane_height,
+    }) {
+        Ok(id) => {
+            queries.register(id, reply.pane, CopyQueryKind::Capture);
+            refresh.capture_in_flight.insert(
+                reply.pane,
+                CapturePending {
+                    scroll: state.scroll_position,
+                    age: 0,
+                },
+            );
+        }
+        Err(error) => tracing::warn!(?error, pane = reply.pane.0, "copy-capture send failed"),
+    }
+```
+
+In `apply_capture_reply` (`src/tmux/copy_mode.rs:277`), add a `refresh: &mut CopyRefreshState` parameter (mutable-first, before `render_handles` is mutable too — place `refresh` first), and on a successful reply move the pending scroll into `last_scroll`. Change the signature and the success path:
+
+```rust
+fn apply_capture_reply(
+    commands: &mut Commands,
+    refresh: &mut CopyRefreshState,
+    render_handles: &mut Query<&mut CopyRenderHandle>,
+    pane_entity: Entity,
+    reply: &CopyModeReply,
+) {
+    if !reply.ok {
+        return;
+    }
+    if let Some(pending) = refresh.capture_in_flight.remove(&reply.pane) {
+        refresh.last_scroll.insert(reply.pane, pending.scroll);
+    }
+    let bytes = capture_to_bytes(&reply.output);
+    // ... unchanged from here ...
+```
+
+Update the `apply_capture_reply` call site in `consume_copy_reply` (`src/tmux/copy_mode.rs:213`) to pass `&mut refresh`:
+
+```rust
+                apply_capture_reply(&mut commands, &mut refresh, &mut render_handles, entity, reply);
+```
+
+- [ ] **Step 6: Age out a lost capture so it is retried**
+
+In `issue_copy_state` (`src/tmux/copy_mode.rs:127`), after the existing per-pane state-query loop, age the capture-in-flight entries and drop stale ones so the next `State` reply re-issues (since `last_scroll` was not advanced for a lost capture). Add at the end of the function body:
+
+```rust
+    refresh.capture_in_flight.retain(|pane, pending| {
+        pending.age += 1;
+        let keep = pending.age < STALE_STATE_RESEND_UPDATES;
+        if !keep {
+            tracing::warn!(pane = pane.0, "copy capture reply lost; will re-issue");
+        }
+        keep
+    });
+```
+
+(`issue_copy_state` already takes `mut refresh: ResMut<CopyRefreshState>`, so no signature change.)
+
+- [ ] **Step 7: Prune capture-in-flight on copy-mode exit**
+
+In `on_copy_mode_exit` (`src/tmux/copy_mode.rs:104`), where it already prunes `state_in_flight` / `last_scroll` for the pane, add:
+
+```rust
+        refresh.capture_in_flight.remove(&pane.id);
+```
+
+(inside the existing `if let Ok(pane) = panes.get(entity) { ... }` block).
+
+- [ ] **Step 8: Run the focused + full copy-mode tests**
+
+Run: `cargo test -p ozmux copy_mode && cargo test -p ozmux decide_capture`
+Expected: PASS — the pre-existing `copy_mode_exit_repaints_live_grid_and_prunes_refresh_state` test still passes, plus the new helper tests.
+
+- [ ] **Step 9: Verify build, lint**
+
+Run: `cargo build && cargo clippy --all-targets && cargo fmt`
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/tmux/copy_mode.rs
+git commit -m "$(cat <<'EOF'
+fix(tmux): resend lost copy-mode captures; record last_scroll on reply
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Whole workspace builds:** `cargo build`
+- [ ] **All tests pass:** `cargo test`
+- [ ] **Lint clean:** `cargo clippy --workspace --all-targets`
+- [ ] **Formatted:** `cargo fmt --check`
+- [ ] **Manual smoke (per `verify` skill):** run the app, split a pane / resize the window / enter copy mode repeatedly and confirm no pane goes black. Document the observation.
+
+## Self-Review (author checklist — completed at write time)
+
+1. **Spec coverage:** C1 → Task 2; C2 → Tasks 3+4 (incl. dims-vs-handle primary clause, debounce/transient handling, in-flight suppression via `panes_with_cursor_pending`, `Without<CopyModeState>` gate); C3 → Task 5 (capture resend + `last_scroll`-on-reply); C4 → Task 1 (material fallback, not creation-time init). Open-question simplifications (fold into `recapture_settled_panes`, drop C1) are deliberately NOT taken here — C2 reuses `request_pane_capture` via a message rather than mutating the `pub(crate)` `PaneRecaptureState` from the binary, which the binary cannot name.
+2. **Placeholder scan:** none — every step carries concrete code and commands.
+3. **Type consistency:** `grid_needs_full_seed` signature identical in Tasks 3 and 4; `RequestPaneReseed { pane }` produced in crate (Task 4 Step 5) and consumed in the binary system (Step 8); `CopyRefreshState.capture_in_flight: HashMap<PaneId, CapturePending>` defined (Step 3) and used (Steps 5–7); `apply_capture_reply`'s new `refresh` param added at the definition (Step 5) and the call site (Step 5).

--- a/docs/superpowers/specs/2026-06-26-pane-black-paint-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-26-pane-black-paint-recovery-design.md
@@ -1,0 +1,291 @@
+# Pane Black-Screen Paint Recovery — Design
+
+- **Date:** 2026-06-26
+- **Status:** Draft (post-spec-review)
+- **Topic:** Panes frequently render fully black after a layout change (pane
+  split, window resize, copy-mode entry) and only recover on the next
+  unrelated interaction.
+
+## 1. Problem
+
+After a layout-changing event — splitting a pane, resizing the window, or
+entering copy mode — a tmux pane frequently renders **completely black**. The
+black recovers when the user does *something* (key input, mouse move, another
+resize, window switch), but the same operations frequently re-trigger it
+("recovers on interaction, but recurs frequently", user-confirmed).
+
+This is not a one-frame flash and not a permanent wedge: the grid is left
+unpainted and stays black until the next event happens to drive a fresh paint.
+
+## 2. Root Cause
+
+### 2.1 How a tmux pane is painted
+
+tmux `-CC` does not replay a pane's existing screen on attach; it only streams
+new `%output`. So ozmux seeds each pane's display mirror from tmux's
+authoritative grid via `capture-pane`:
+
+```
+request_pane_captures (Added<TmuxPane>)            crates/tmux_session/src/plugin.rs:121
+recapture_settled_panes (size settle, one-shot)    crates/tmux_session/src/plugin.rs:181
+   → tmux capture-pane + cursor query
+   → apply_reply(Capture arm) → emits PaneOutput
+   → route_tmux_output: handle.advance + flush_emit src/tmux/render.rs:165
+   → FrameSnapshot → apply_snapshot → TerminalGrid  crates/ozma_tty_renderer/src/grid.rs:19
+```
+
+### 2.2 The colour mechanism (corrected)
+
+A pane shows fully black when its `TerminalGrid` is **structurally empty /
+unpainted** — `grid.cells` empty or shorter than `grid.rows` — combined with
+`default_bg = [0,0,0]`:
+
+- `TerminalGrid::default()` is `0×0` with `default_bg = [0,0,0]`
+  (`crates/ozma_tty_renderer/src/schema/grid.rs:7`, `:46`).
+- The material's `bg_padding_color` is derived from `grid.default_bg`
+  (`crates/ozma_tty_renderer/src/material.rs:606`).
+- `TerminalParams::new` clamps `grid_size` to at least `1×1`
+  (`crates/ozma_tty_renderer/src/material.rs:370`:
+  `grid_size: UVec2::new(cols.max(1), rows.max(1))`). **Therefore the shader's
+  `grid_size == 0 → fallback` branch
+  (`crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl:128`) is only
+  a narrow default-material / first-frame fallback, NOT the normal
+  unpainted-grid path.** The *persistent* black is a ≥1×1 grid whose cells are
+  dummy / default — each cell's background unpacks to black/transparent and is
+  painted with the black `bg_padding_color`.
+
+This corrects the earlier "grid_size==0 fallback" framing. The signal is
+**structural**, but note which clause is load-bearing: in the common cases the
+grid is left at `0×0` — a fresh handle is born at the pane dims so
+`layout_tmux_panes` never writes new dims (`src/tmux/render.rs:134`, `:461`),
+and `apply_delta` never sets `rows` (`crates/ozma_tty_renderer/src/grid.rs:44`)
+— where `cells.len() != rows` is `0 != 0` → **false**. The detector that
+actually fires for the common case is **`(grid.cols, grid.rows)` disagreeing
+with the handle geometry**; `cells.len() != rows` only catches the
+dims-already-written-but-cells-empty variant. Both clauses are required. The
+signal is neither `grid_size == 0` nor `last_seq == 0`.
+
+### 2.3 The four drop-and-no-retry holes
+
+The grid stays empty because the seed→route→paint pipeline can lose the
+authoritative `capture-pane` bytes (or the resulting snapshot) and then never
+reliably retries:
+
+| # | Hole | Evidence |
+|---|------|----------|
+| 1 | `route_tmux_output` **discards** a pane's `PaneOutput` bytes when the pane entity or its `TerminalHandle` is not yet present (`continue`, not buffered). | `src/tmux/render.rs:180`, `src/tmux/render.rs:184` |
+| 2 | `apply_snapshot` **silently drops** the `FrameSnapshot` when `TerminalGrid` is absent (early `return`). | `crates/ozma_tty_renderer/src/grid.rs:19` |
+| 3 | `recapture_settled_panes` is **one-shot per size** (`done` flag, re-armed only on a dims change). If its capture is lost, no retry until dims change again. | `crates/tmux_session/src/plugin.rs:188`, `:200`, `:204` |
+| 4 | CopyMode capture replies have **no resend backstop**. The copy-STATE query resends every `STALE_STATE_RESEND_UPDATES` frames, but the capture query has no equivalent. Worse: `last_scroll` is recorded at **send** time (`copy_mode.rs:265`), so a lost capture at the same scroll position **suppresses** any future recapture. | `src/tmux/copy_mode.rs:142`, `:145`, `:263`, `:265` |
+
+### 2.4 Aggravators surfaced by the Codex review
+
+- **A delta advances `last_seq` while leaving the grid empty.** `apply_delta`
+  does not set `cols`/`rows`/`default_bg` or allocate rows; dirty rows are
+  ignored when `cells.len()==0` (`crates/ozma_tty_renderer/src/grid.rs:61`:
+  `if row_idx < grid.cells.len()`). So a *lost snapshot followed by a delta*
+  leaves `last_seq > 0` yet the grid structurally empty. **This is why
+  `last_seq == 0` is an invalid "never painted" sentinel** — and why the rescue
+  condition must be structural (`cells.len() != rows`).
+- **`FrameDelta` carries no `default_bg`** (`crates/ozma_tty_renderer/src/schema/frame.rs`).
+  After a lost snapshot, later deltas cannot restore a non-black background.
+- The "chained systems never flush commands before `route_tmux_output`" theory
+  is **not** the primary race: this repo relies on auto-inserted `ApplyDeferred`
+  between ordered systems (see the load-bearing NOTE at
+  `src/tmux/copy_mode.rs:44`). The real race is **replies/messages arriving
+  before projection/attachment exists, or a snapshot triggered before
+  `TerminalGrid` exists** — i.e. holes 1 and 2.
+
+### 2.5 Non-causes (ruled out)
+
+- **Material / bind-group failure** is not the main cause: both storage buffers
+  are seeded with a dummy element to avoid a zero-size bind failure
+  (`crates/ozma_tty_renderer/src/material/state.rs:79`).
+- **Webview/CEF `last_seq` ordering** (`crates/ozma_webview/src/webview/mount.rs:620`)
+  explains *missing webviews*, not a fully black terminal pane. Out of scope.
+
+## 3. Design (A-iii)
+
+The earlier proposal "A-ii" — a perpetual reconciler keyed on `last_seq == 0` —
+is rejected: `last_seq == 0` is not "never painted" (§2.4) and a perpetual loop
+risks spamming tmux. The refined design pairs a **primary fix that stops losing
+the bytes** with a **narrow, structural, self-stopping rescue**, plus targeted
+copy-mode and defence-in-depth pieces.
+
+### 3.1 Component 1 (PRIMARY) — buffer & replay routed output
+
+Stop dropping the authoritative `capture-pane` bytes.
+
+- Introduce a `PendingPaneOutput` resource: `HashMap<PaneId, Vec<u8>>` (bounded).
+- In `route_tmux_output`, when the pane entity is unknown (`entity_of` miss) or
+  its `TerminalHandle` is not yet present, **append the bytes to
+  `PendingPaneOutput` instead of `continue`-dropping** them.
+- Each frame, for every pane now ready (entity + `TerminalHandle` +
+  `TerminalGrid` present), drain its pending buffer and replay through
+  `handle.advance` + `flush_emit`. Because the repo inserts `ApplyDeferred`
+  between ordered systems, "ready next frame" is reliable.
+- **Bound** the buffer (cap total bytes and/or age per pane). On overflow, drop
+  oldest and `tracing::warn!` — never a silent cap (repo rule: no silent
+  truncation).
+
+This closes holes 1 and (transitively) 2: by replaying only once both the
+handle and grid exist, the snapshot is no longer emitted into a gridless entity.
+
+### 3.2 Component 2 — structural rescue (narrow, self-stopping)
+
+A debounced system that heals a grid that ended up structurally empty despite
+the pane being attached (covers holes 2/3 and the delta-advances-last_seq
+aggravator).
+
+- **Sentinel (structural, not `last_seq`):** for a non-copy-mode tmux pane with
+  both `TerminalHandle` and `TerminalGrid`, treat the grid as unpainted when
+  **`(grid.cols, grid.rows)` disagrees with the handle geometry** (the
+  load-bearing clause — it catches the common `0×0` grid; see §2.2) **or**
+  `grid.cells.len() != grid.rows as usize` (the dims-written-but-cells-empty
+  variant). Extract this as a pure, unit-testable helper
+  `grid_needs_full_seed(grid, handle_geometry)` so the "blank captured pane does
+  not misfire" guarantee (a real snapshot yields `cells.len() == rows`) is
+  covered by a test.
+- **Authoritative rescue only — NO local-repaint-first:** when the sentinel
+  fires, request a fresh tmux `capture-pane` via the existing
+  `request_pane_capture` (`crates/tmux_session/src/plugin.rs:134`). The earlier
+  "repaint_full from the local mirror first" idea is **dropped**: in the hole-1
+  case the local mirror is itself blank, so `repaint_full`
+  (`crates/ozma_tty_engine/src/handle.rs:318`) would paint a blank grid, flip
+  the sentinel false, and **suppress the very recapture that restores the real
+  content** — actively masking the bug. tmux is the source of truth, matching
+  the existing `recapture_settled_panes` approach. Rescue is bounded by:
+  - **in-flight suppression** — use a **dedicated** capture-in-flight age map
+    keyed by `PaneId`, *not* `EnumerationState.panes_with_cursor_pending` (the
+    latter tracks only the cursor half of a paired request and misses a capture
+    whose companion `CursorQuery` send failed —
+    `crates/tmux_session/src/plugin.rs:140`);
+  - **debounce** — at most one re-request every `N` frames (model after the
+    existing `STALE_STATE_RESEND_UPDATES` copy-state cadence).
+- **Ordering — avoid the resize transient:** `layout_tmux_panes` writes
+  `grid.rows` immediately (`src/tmux/render.rs:466`) but its `emit_pending`
+  snapshot is a deferred `commands.trigger` applied only at the next sync point
+  (`crates/ozma_tty_engine/src/handle.rs:304`), so `cells.len() != rows` is
+  transiently true on **every** resize. The rescue must run **before**
+  `layout_tmux_panes` or **after the snapshot flush** (or skip a pane that
+  already has an `emit_pending`/capture in flight) so it does not misfire on
+  this transient.
+- **Self-stopping:** once a capture lands and `apply_snapshot` repopulates
+  `cells` and dims agree with the handle, the sentinel is false and the system
+  goes quiet. No perpetual loop.
+
+### 3.3 Component 3 — CopyMode capture backstop
+
+Copy mode renders the scrolled view through a separate `CopyRenderHandle`, not
+the live `TerminalHandle`, so it needs its own fix (Component 2 must **skip**
+panes with `CopyModeState`).
+
+- Add a **capture-in-flight age map** mirroring `STALE_STATE_RESEND_UPDATES` so
+  a lost copy capture is resent.
+- **Fix the `last_scroll` suppression bug:** record `last_scroll` only after the
+  capture **reply** is applied (or track an independent "captured at scroll"
+  value), so a lost same-scroll capture is no longer permanently suppressed
+  (`src/tmux/copy_mode.rs:263`–`:265`).
+- Component 2's normal-pane recapture is gated `Without<CopyModeState>` (or an
+  equivalent run condition) so the two paths never fight over the grid.
+
+### 3.4 Component 4 (B — insurance) — non-black default background
+
+Defence-in-depth so a momentarily-unpainted pane is never alarming pure black,
+and so the "delta carries no `default_bg`" gap (§2.4) is mitigated:
+
+- Map an unset / `[0,0,0]` background to the configured **theme terminal
+  background** in the material `bg_padding_color` computation
+  (`crates/ozma_tty_renderer/src/material.rs:606`) — **not** at `TerminalGrid`
+  creation time. `apply_snapshot` overwrites `grid.default_bg` from
+  `snap.default_bg` (`crates/ozma_tty_renderer/src/grid.rs:36`), which is itself
+  `[0,0,0]` whenever OSC 11 is unset
+  (`crates/ozma_tty_renderer/src/schema/frame.rs`), so a creation-time init is
+  undone by the first real snapshot. The material-fallback form is the robust
+  one and also covers the "delta carries no `default_bg`" gap (§2.4).
+- This does **not** fix the root cause; it converts a pure-black flash into a
+  neutral terminal-background colour while Components 1–3 do the real work.
+
+## 4. Data Flow (after the fix)
+
+```
+capture-pane reply ─► PaneOutput
+   └─ route_tmux_output
+        ├─ entity+handle+grid ready ─► advance + flush_emit ─► snapshot ─► grid painted
+        └─ not ready ─────────────► PendingPaneOutput[pane]  (buffered, bounded)
+                                         └─ next frame, when ready ─► replay ─► painted
+
+structural-rescue system (debounced, Without<CopyModeState>)
+   └─ grid_needs_full_seed(grid, handle_geometry)  [dims-vs-handle OR cells.len()!=rows]
+        ─► capture-pane (authoritative, in-flight suppressed, ordered to skip the
+           resize transient) ─► … ─► painted ─► sentinel false ─► quiet
+
+copy-mode capture (With<CopyModeState>)
+   └─ capture-in-flight age ≥ threshold ─► resend; last_scroll recorded on reply
+```
+
+## 5. Error Handling & Edge Cases
+
+- **Pane that never attaches / dies before ready:** `PendingPaneOutput` is
+  bounded and aged out with a warning; no unbounded growth.
+- **Legitimately empty/cleared pane:** an empty screen still produces a
+  `capture-pane` reply whose snapshot sets `cells.len() == rows` with blank
+  cells, so the sentinel `cells.len() != rows` is false — the rescue does not
+  misfire on a genuinely blank pane.
+- **Rapid resizes / window drag:** existing `RECAPTURE_SETTLE_FRAMES` debounce
+  plus Component 2's debounce + in-flight suppression bound the request rate.
+- **Copy-mode enter on an already-empty grid:** Component 3's resend plus the
+  `last_scroll`-on-reply fix guarantee eventual paint without relying on a
+  user scroll.
+- **`capture-pane` is read-only and idempotent** (the seed prepends
+  clear-screen), so re-requesting is always safe — already proven by
+  `recapture_settled_panes`.
+
+## 6. Testing Strategy
+
+Favour pure decision/helpers testable without GPU/PTY/`App` (repo idiom — see
+`.claude/rules/rust.md` "System composition"):
+
+- **Output buffer:** bytes stashed when handle absent; replayed on attach;
+  bounded + warns on overflow.
+- **Rescue sentinel:** the pure helper `grid_needs_full_seed(grid,
+  handle_geometry)` — fires on dims-vs-handle mismatch (the `0×0` case) and on
+  `cells.len() != rows`; does **not** misfire on a genuinely blank captured pane
+  (snapshot `rows_data.len() == rows` ⇒ `cells.len() == rows`); does **not**
+  misfire on the resize transient (dims written before the deferred snapshot
+  flush — covered by the §3.2 ordering constraint); debounce honoured; in-flight
+  suppression prevents duplicate requests; system goes quiet once consistent.
+- **CopyMode:** capture resend after the age threshold; `last_scroll` no longer
+  suppresses recapture after a lost same-scroll capture.
+- **Regression:** snapshot-then-delta stays painted; a dropped snapshot is
+  healed within `N` frames; `Without<CopyModeState>` gating keeps the two
+  capture paths from colliding.
+
+## 7. Out of Scope (YAGNI)
+
+- The perpetual `last_seq`-based reconciler (A-ii) — rejected.
+- Webview/CEF black panes (§2.5) — separate concern.
+- Reworking the coalescer / emit path.
+
+## 8. Open Questions
+
+- Where the theme terminal background lives (config vs `src/theme.rs`) for
+  Component 4, and whether to thread it through `FrameSnapshot.default_bg`
+  defaults or only the material fallback.
+- Concrete values for the debounce interval `N` and the `PendingPaneOutput`
+  byte/age caps (tune during implementation).
+- **Resolved (review):** Component 2's "local repaint first" is **dropped** — it
+  masks hole-1 recovery (§3.2). Rescue is authoritative-only.
+- Whether to **fold Component 2 into the existing `recapture_settled_panes` /
+  `PaneRecaptureState`** (2026-06-24 spec) by adding a re-arm condition (reset
+  `done = false` when `grid_needs_full_seed` is true), reusing its settle
+  debounce, dims tracking, and in-flight suppression. This keeps the state
+  machine in one place, but requires reading the renderer-crate `TerminalGrid`
+  from `ozmux_tmux` (which stays renderer-free) — so the structural check would
+  live in `src/tmux/` and feed the crate via a marker/event.
+- Whether **Component 1's byte buffer can be dropped** once Component 2 is
+  authoritative-only: lost bytes would be recovered by re-fetching from tmux
+  rather than buffered/replayed, collapsing Components 1+2 into one mechanism.
+  Trade-off: loses the exact-byte replay fast path and leans entirely on
+  `capture-pane` for the lost-bytes case (valid **only** with local-first also
+  removed — keeping local-first while dropping Component 1 is broken).

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -27,6 +27,7 @@ use input::InputPlugin;
 use mode_ui::TmuxModeUiPlugin;
 use mouse::MousePlugin;
 use ozmux_tmux::{TmuxClient, TmuxConnectionClosed, TmuxSessionPlugin};
+use paint_rescue::PaintRescuePlugin;
 use pane_focus::PaneFocusPlugin;
 use render::RenderPlugin;
 use webview_tokens::WebviewTokensPlugin;
@@ -47,6 +48,7 @@ impl Plugin for OzmuxTmuxPlugin {
                 TmuxSessionPlugin,
                 AdoptPlugin,
                 RenderPlugin,
+                PaintRescuePlugin,
                 InputPlugin,
                 MousePlugin,
                 ForwardPlugin,

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -8,6 +8,7 @@ mod gate;
 mod input;
 mod mode_ui;
 mod mouse;
+mod paint_rescue;
 mod pane_focus;
 pub(crate) mod pane_hit;
 mod render;

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -629,7 +629,7 @@ mod tests {
     }
 
     #[test]
-    fn decide_capture_reissues_after_lost_capture_cleared() {
+    fn decide_capture_issues_when_scroll_differs_and_not_in_flight() {
         assert_eq!(decide_capture(Some(3), false, 5), CaptureDecision::Issue);
     }
 

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -56,12 +56,15 @@ impl Plugin for CopyModePlugin {
 
 /// Bookkeeping for the copy-mode refresh loop: per-pane the number of updates a
 /// state query has been outstanding (so at most one is in flight, but a stale one
-/// is re-issued — see `issue_copy_state`), and the last captured `scroll_position`
-/// per pane (so an unchanged viewport skips re-capturing).
+/// is re-issued — see `issue_copy_state`), the last *captured* `scroll_position`
+/// per pane (recorded on the capture reply, so an unchanged viewport skips
+/// re-capturing), and an in-flight capture entry per pane (so a concurrent state
+/// reply does not trigger a duplicate capture while one is already pending).
 #[derive(Resource, Default)]
 struct CopyRefreshState {
     state_in_flight: HashMap<PaneId, u32>,
     last_scroll: HashMap<PaneId, u32>,
+    capture_in_flight: HashMap<PaneId, CapturePending>,
 }
 
 /// Updates a still-in-flight state query waits before `issue_copy_state` re-sends
@@ -72,6 +75,35 @@ struct CopyRefreshState {
 /// continuous loop, so a reply tmux has emitted is always read — this is not a
 /// flush of "stuck" traffic, just a fresh query whose reply can still land.
 const STALE_STATE_RESEND_UPDATES: u32 = 12;
+
+/// Whether a `State` reply should trigger a fresh `capture-pane`.
+#[derive(Debug, PartialEq, Eq)]
+enum CaptureDecision {
+    Skip,
+    Issue,
+}
+
+/// Per-pane in-flight capture bookkeeping: the scroll position the pending
+/// capture is for, and how many updates it has been outstanding (for the resend
+/// backstop).
+struct CapturePending {
+    scroll: u32,
+    age: u32,
+}
+
+/// Decides whether to issue a capture for `scroll`: issue when we have not yet
+/// captured that scroll position and no capture for it is already in flight.
+fn decide_capture(
+    last_captured_scroll: Option<u32>,
+    capture_in_flight: bool,
+    scroll: u32,
+) -> CaptureDecision {
+    if capture_in_flight || last_captured_scroll == Some(scroll) {
+        CaptureDecision::Skip
+    } else {
+        CaptureDecision::Issue
+    }
+}
 
 /// The latest copy-mode state snapshot for a pane. Written only when the state
 /// changes (so `Changed<CopyModeSnapshot>` is meaningful), and read back to
@@ -119,6 +151,7 @@ fn on_copy_mode_exit(
     if let Ok(pane) = panes.get(entity) {
         refresh.state_in_flight.remove(&pane.id);
         refresh.last_scroll.remove(&pane.id);
+        refresh.capture_in_flight.remove(&pane.id);
     }
 }
 
@@ -160,6 +193,14 @@ fn issue_copy_state(
             }
         }
     }
+    refresh.capture_in_flight.retain(|pane, pending| {
+        pending.age += 1;
+        let keep = pending.age < STALE_STATE_RESEND_UPDATES;
+        if !keep {
+            tracing::warn!(pane = pane.0, "copy capture reply lost; will re-issue");
+        }
+        keep
+    });
 }
 
 /// Applies each correlated [`CopyModeReply`]: a `State` reply drives exit (when
@@ -210,7 +251,13 @@ fn consume_copy_reply(
                 if copy_modes.get(entity).is_err() {
                     continue;
                 }
-                apply_capture_reply(&mut commands, &mut render_handles, entity, reply);
+                apply_capture_reply(
+                    &mut commands,
+                    &mut refresh,
+                    &mut render_handles,
+                    entity,
+                    reply,
+                );
             }
             CopyQueryKind::Buffer => {
                 if reply.ok {
@@ -248,8 +295,9 @@ fn apply_state_reply(
     if stored != Some(&state) {
         commands.entity(entity).insert(CopyModeSnapshot(state));
     }
-    let changed = refresh.last_scroll.get(&reply.pane) != Some(&state.scroll_position);
-    if !changed {
+    let in_flight = refresh.capture_in_flight.contains_key(&reply.pane);
+    let last = refresh.last_scroll.get(&reply.pane).copied();
+    if decide_capture(last, in_flight, state.scroll_position) == CaptureDecision::Skip {
         return;
     }
     let Some(client) = client else {
@@ -262,9 +310,13 @@ fn apply_state_reply(
     }) {
         Ok(id) => {
             queries.register(id, reply.pane, CopyQueryKind::Capture);
-            refresh
-                .last_scroll
-                .insert(reply.pane, state.scroll_position);
+            refresh.capture_in_flight.insert(
+                reply.pane,
+                CapturePending {
+                    scroll: state.scroll_position,
+                    age: 0,
+                },
+            );
         }
         Err(error) => tracing::warn!(?error, pane = reply.pane.0, "copy-capture send failed"),
     }
@@ -276,12 +328,16 @@ fn apply_state_reply(
 /// both the `CopyRenderHandle` and the `TerminalGrid` the emit targets.
 fn apply_capture_reply(
     commands: &mut Commands,
+    refresh: &mut CopyRefreshState,
     render_handles: &mut Query<&mut CopyRenderHandle>,
     pane_entity: Entity,
     reply: &CopyModeReply,
 ) {
     if !reply.ok {
         return;
+    }
+    if let Some(pending) = refresh.capture_in_flight.remove(&reply.pane) {
+        refresh.last_scroll.insert(reply.pane, pending.scroll);
     }
     let bytes = capture_to_bytes(&reply.output);
     let (cols, rows) = capture_dims(&reply.output);
@@ -554,6 +610,27 @@ mod tests {
             24,
         );
         assert_eq!(cell, Some((0, 0)));
+    }
+
+    #[test]
+    fn decide_capture_issues_for_new_scroll() {
+        assert_eq!(decide_capture(None, false, 5), CaptureDecision::Issue);
+        assert_eq!(decide_capture(Some(3), false, 5), CaptureDecision::Issue);
+    }
+
+    #[test]
+    fn decide_capture_skips_when_already_captured_that_scroll() {
+        assert_eq!(decide_capture(Some(5), false, 5), CaptureDecision::Skip);
+    }
+
+    #[test]
+    fn decide_capture_skips_while_in_flight() {
+        assert_eq!(decide_capture(None, true, 5), CaptureDecision::Skip);
+    }
+
+    #[test]
+    fn decide_capture_reissues_after_lost_capture_cleared() {
+        assert_eq!(decide_capture(Some(3), false, 5), CaptureDecision::Issue);
     }
 
     #[test]

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -333,10 +333,15 @@ fn apply_capture_reply(
     pane_entity: Entity,
     reply: &CopyModeReply,
 ) {
+    // NOTE: clear the in-flight entry even on failure, before the early return —
+    // otherwise a failed capture leaves the pane's `capture_in_flight` set and
+    // `decide_capture` suppresses every retry until `issue_copy_state` ages it
+    // out (≤ STALE_STATE_RESEND_UPDATES frames).
+    let pending = refresh.capture_in_flight.remove(&reply.pane);
     if !reply.ok {
         return;
     }
-    if let Some(pending) = refresh.capture_in_flight.remove(&reply.pane) {
+    if let Some(pending) = pending {
         refresh.last_scroll.insert(reply.pane, pending.scroll);
     }
     let bytes = capture_to_bytes(&reply.output);

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -1,0 +1,44 @@
+//! Structural rescue for tmux panes whose grid was left unpainted after a
+//! layout change: detects the unpainted state and asks `ozmux_tmux` to
+//! re-`capture-pane` until the grid paints (spec Component 2).
+
+/// Returns whether a pane's grid is structurally unpainted and needs a full
+/// re-seed. The dims-vs-handle clause catches the common `0×0` grid; the
+/// `cells_len != rows` clause catches a grid whose dims were written but whose
+/// rows were never repopulated (e.g. a lost resize snapshot). A genuinely blank
+/// captured pane has `cells_len == rows`, so it does not fire.
+fn grid_needs_full_seed(
+    grid_cols: u16,
+    grid_rows: u16,
+    cells_len: usize,
+    handle_cols: u16,
+    handle_rows: u16,
+) -> bool {
+    (grid_cols, grid_rows) != (handle_cols, handle_rows) || cells_len != grid_rows as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_grid_against_sized_handle_needs_seed() {
+        assert!(grid_needs_full_seed(0, 0, 0, 80, 24));
+    }
+
+    #[test]
+    fn dims_written_but_cells_empty_needs_seed() {
+        assert!(grid_needs_full_seed(80, 24, 0, 80, 24));
+    }
+
+    #[test]
+    fn blank_captured_pane_does_not_need_seed() {
+        // A real snapshot yields one (possibly empty) row vector per row.
+        assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
+    }
+
+    #[test]
+    fn painted_matching_grid_does_not_need_seed() {
+        assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
+    }
+}

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -7,6 +7,10 @@
 /// `cells_len != rows` clause catches a grid whose dims were written but whose
 /// rows were never repopulated (e.g. a lost resize snapshot). A genuinely blank
 /// captured pane has `cells_len == rows`, so it does not fire.
+// NOTE: the only caller (the rescue system) lands in the next task; this
+// allowance is removed then. #[expect] is unusable here because the fn is
+// live in the test target but dead in the lib build.
+#[allow(dead_code)]
 fn grid_needs_full_seed(
     grid_cols: u16,
     grid_rows: u16,

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -2,6 +2,7 @@
 //! layout change: detects the unpainted state and asks `ozmux_tmux` to
 //! re-`capture-pane` until the grid paints (spec Component 2).
 
+use super::render::TmuxLayoutSet;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalHandle;
@@ -39,7 +40,7 @@ impl Plugin for PaintRescuePlugin {
                 Update,
                 rescue_unpainted_panes
                     .after(TmuxProjectionSet)
-                    .before(super::render::TmuxLayoutSet)
+                    .before(TmuxLayoutSet)
                     .in_set(super::TmuxActiveSet),
             );
     }

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -2,15 +2,41 @@
 //! layout change: detects the unpainted state and asks `ozmux_tmux` to
 //! re-`capture-pane` until the grid paints (spec Component 2).
 
+use crate::ui::copy_mode::CopyModeState;
+use bevy::prelude::*;
+use ozma_tty_engine::TerminalHandle;
+use ozma_tty_renderer::schema::TerminalGrid;
+use ozmux_tmux::{PaneId, RequestPaneReseed, TmuxPane, TmuxProjectionSet};
+use std::collections::HashMap;
+
+/// Frames the unpainted state must persist before a reseed is requested. Filters
+/// the 1-frame resize transient (dims written before the deferred snapshot
+/// flush) while still healing a genuinely lost seed quickly.
+const RESEED_DEBOUNCE_FRAMES: u8 = 3;
+
+/// Per-pane consecutive-frames-unpainted counters for the reseed debounce.
+#[derive(Resource, Default)]
+struct PaneSeedDebounce(HashMap<PaneId, u8>);
+
+/// Wires the structural paint-rescue system after the tmux projection chain.
+pub(crate) struct PaintRescuePlugin;
+
+impl Plugin for PaintRescuePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PaneSeedDebounce>().add_systems(
+            Update,
+            rescue_unpainted_panes
+                .after(TmuxProjectionSet)
+                .in_set(super::TmuxActiveSet),
+        );
+    }
+}
+
 /// Returns whether a pane's grid is structurally unpainted and needs a full
 /// re-seed. The dims-vs-handle clause catches the common `0×0` grid; the
 /// `cells_len != rows` clause catches a grid whose dims were written but whose
 /// rows were never repopulated (e.g. a lost resize snapshot). A genuinely blank
 /// captured pane has `cells_len == rows`, so it does not fire.
-// NOTE: the only caller (the rescue system) lands in the next task; this
-// allowance is removed then. #[expect] is unusable here because the fn is
-// live in the test target but dead in the lib build.
-#[allow(dead_code)]
 fn grid_needs_full_seed(
     grid_cols: u16,
     grid_rows: u16,
@@ -19,6 +45,39 @@ fn grid_needs_full_seed(
     handle_rows: u16,
 ) -> bool {
     (grid_cols, grid_rows) != (handle_cols, handle_rows) || cells_len != grid_rows as usize
+}
+
+/// Advances a per-pane debounce counter and returns whether to emit a reseed
+/// request this frame. Emits exactly once when `needs_seed` has held for
+/// `threshold` consecutive frames; a `false` resets the counter; once emitted it
+/// will not re-emit until the counter resets (the saturated value stays above
+/// `threshold`, and only the exact `== threshold` transition emits).
+fn should_emit_reseed(counter: &mut u8, needs_seed: bool, threshold: u8) -> bool {
+    if !needs_seed {
+        *counter = 0;
+        return false;
+    }
+    *counter = counter.saturating_add(1);
+    *counter == threshold
+}
+
+/// Requests a tmux re-seed for each non-copy-mode pane whose grid is
+/// structurally unpainted (see [`grid_needs_full_seed`]) once the state has held
+/// for [`RESEED_DEBOUNCE_FRAMES`]. Copy-mode panes are skipped — they paint via
+/// the separate `CopyRenderHandle` (Component 3).
+fn rescue_unpainted_panes(
+    mut debounce: ResMut<PaneSeedDebounce>,
+    mut reseed: MessageWriter<RequestPaneReseed>,
+    panes: Query<(&TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
+) {
+    for (pane, handle, grid) in panes.iter() {
+        let (h_cols, h_rows, _) = handle.read_geometry();
+        let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
+        let counter = debounce.0.entry(pane.id).or_default();
+        if should_emit_reseed(counter, needs, RESEED_DEBOUNCE_FRAMES) {
+            reseed.write(RequestPaneReseed { pane: pane.id });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -37,12 +96,39 @@ mod tests {
 
     #[test]
     fn blank_captured_pane_does_not_need_seed() {
-        // A real snapshot yields one (possibly empty) row vector per row.
         assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
     }
 
     #[test]
     fn painted_matching_grid_does_not_need_seed() {
         assert!(!grid_needs_full_seed(80, 24, 24, 80, 24));
+    }
+
+    #[test]
+    fn debounce_emits_only_after_threshold_consecutive_true() {
+        let mut c = 0u8;
+        assert!(!should_emit_reseed(&mut c, true, 3)); // 1
+        assert!(!should_emit_reseed(&mut c, true, 3)); // 2
+        assert!(should_emit_reseed(&mut c, true, 3)); // 3 -> emit
+    }
+
+    #[test]
+    fn debounce_resets_on_false() {
+        let mut c = 0u8;
+        should_emit_reseed(&mut c, true, 3);
+        should_emit_reseed(&mut c, true, 3);
+        assert!(!should_emit_reseed(&mut c, false, 3)); // reset
+        assert_eq!(c, 0);
+        assert!(!should_emit_reseed(&mut c, true, 3)); // counting restarts at 1
+    }
+
+    #[test]
+    fn debounce_does_not_re_emit_every_frame_while_held() {
+        let mut c = 0u8;
+        for _ in 0..2 {
+            should_emit_reseed(&mut c, true, 3);
+        }
+        assert!(should_emit_reseed(&mut c, true, 3)); // emits at threshold
+        assert!(!should_emit_reseed(&mut c, true, 3)); // held: no re-emit until reset
     }
 }

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -107,9 +107,9 @@ mod tests {
     #[test]
     fn debounce_emits_only_after_threshold_consecutive_true() {
         let mut c = 0u8;
-        assert!(!should_emit_reseed(&mut c, true, 3)); // 1
-        assert!(!should_emit_reseed(&mut c, true, 3)); // 2
-        assert!(should_emit_reseed(&mut c, true, 3)); // 3 -> emit
+        assert!(!should_emit_reseed(&mut c, true, 3));
+        assert!(!should_emit_reseed(&mut c, true, 3));
+        assert!(should_emit_reseed(&mut c, true, 3));
     }
 
     #[test]
@@ -117,9 +117,9 @@ mod tests {
         let mut c = 0u8;
         should_emit_reseed(&mut c, true, 3);
         should_emit_reseed(&mut c, true, 3);
-        assert!(!should_emit_reseed(&mut c, false, 3)); // reset
+        assert!(!should_emit_reseed(&mut c, false, 3));
         assert_eq!(c, 0);
-        assert!(!should_emit_reseed(&mut c, true, 3)); // counting restarts at 1
+        assert!(!should_emit_reseed(&mut c, true, 3));
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
         for _ in 0..2 {
             should_emit_reseed(&mut c, true, 3);
         }
-        assert!(should_emit_reseed(&mut c, true, 3)); // emits at threshold
-        assert!(!should_emit_reseed(&mut c, true, 3)); // held: no re-emit until reset
+        assert!(should_emit_reseed(&mut c, true, 3));
+        assert!(!should_emit_reseed(&mut c, true, 3));
     }
 }

--- a/src/tmux/paint_rescue.rs
+++ b/src/tmux/paint_rescue.rs
@@ -9,26 +9,39 @@ use ozma_tty_renderer::schema::TerminalGrid;
 use ozmux_tmux::{PaneId, RequestPaneReseed, TmuxPane, TmuxProjectionSet};
 use std::collections::HashMap;
 
-/// Frames the unpainted state must persist before a reseed is requested. Filters
-/// the 1-frame resize transient (dims written before the deferred snapshot
-/// flush) while still healing a genuinely lost seed quickly.
+/// Frames the unpainted state must persist before the FIRST reseed request
+/// (filters the ≤1-frame resize transient).
 const RESEED_DEBOUNCE_FRAMES: u8 = 3;
+/// Frames to wait for a reseed's capture to land before re-requesting. This is
+/// the dedicated in-flight age (spec §3.2) so a lost reply does not wedge a pane.
+const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 
-/// Per-pane consecutive-frames-unpainted counters for the reseed debounce.
+/// Per-pane reseed state: a debounce streak before the first request, then an
+/// in-flight age that re-requests on timeout until the grid paints.
+#[derive(Default)]
+struct ReseedTracker {
+    unpainted_streak: u8,
+    inflight_age: Option<u16>,
+}
+
+/// Per-pane reseed trackers, keyed by `PaneId`.
 #[derive(Resource, Default)]
-struct PaneSeedDebounce(HashMap<PaneId, u8>);
+struct PaneSeedTrackers(HashMap<PaneId, ReseedTracker>);
 
 /// Wires the structural paint-rescue system after the tmux projection chain.
 pub(crate) struct PaintRescuePlugin;
 
 impl Plugin for PaintRescuePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PaneSeedDebounce>().add_systems(
-            Update,
-            rescue_unpainted_panes
-                .after(TmuxProjectionSet)
-                .in_set(super::TmuxActiveSet),
-        );
+        app.init_resource::<PaneSeedTrackers>()
+            .add_observer(prune_tracker_on_pane_removed)
+            .add_systems(
+                Update,
+                rescue_unpainted_panes
+                    .after(TmuxProjectionSet)
+                    .before(super::render::TmuxLayoutSet)
+                    .in_set(super::TmuxActiveSet),
+            );
     }
 }
 
@@ -47,36 +60,65 @@ fn grid_needs_full_seed(
     (grid_cols, grid_rows) != (handle_cols, handle_rows) || cells_len != grid_rows as usize
 }
 
-/// Advances a per-pane debounce counter and returns whether to emit a reseed
-/// request this frame. Emits exactly once when `needs_seed` has held for
-/// `threshold` consecutive frames; a `false` resets the counter; once emitted it
-/// will not re-emit until the counter resets (the saturated value stays above
-/// `threshold`, and only the exact `== threshold` transition emits).
-fn should_emit_reseed(counter: &mut u8, needs_seed: bool, threshold: u8) -> bool {
+/// Advances a pane's reseed tracker one frame and returns whether to emit a
+/// reseed request now. A painted grid (`!needs_seed`) resets the tracker.
+/// Otherwise it debounces `RESEED_DEBOUNCE_FRAMES` consecutive unpainted frames
+/// before the first request, then suppresses while a request is in flight,
+/// re-requesting every `RESEED_INFLIGHT_TIMEOUT` frames until the grid paints.
+fn reseed_decision(tracker: &mut ReseedTracker, needs_seed: bool) -> bool {
     if !needs_seed {
-        *counter = 0;
+        *tracker = ReseedTracker::default();
         return false;
     }
-    *counter = counter.saturating_add(1);
-    *counter == threshold
+    match &mut tracker.inflight_age {
+        Some(age) => {
+            *age = age.saturating_add(1);
+            if *age >= RESEED_INFLIGHT_TIMEOUT {
+                *age = 0;
+                true
+            } else {
+                false
+            }
+        }
+        None => {
+            tracker.unpainted_streak = tracker.unpainted_streak.saturating_add(1);
+            if tracker.unpainted_streak >= RESEED_DEBOUNCE_FRAMES {
+                tracker.inflight_age = Some(0);
+                true
+            } else {
+                false
+            }
+        }
+    }
 }
 
 /// Requests a tmux re-seed for each non-copy-mode pane whose grid is
-/// structurally unpainted (see [`grid_needs_full_seed`]) once the state has held
-/// for [`RESEED_DEBOUNCE_FRAMES`]. Copy-mode panes are skipped — they paint via
-/// the separate `CopyRenderHandle` (Component 3).
+/// structurally unpainted (see [`grid_needs_full_seed`]) once the state has
+/// held for [`RESEED_DEBOUNCE_FRAMES`], then re-requests every
+/// [`RESEED_INFLIGHT_TIMEOUT`] frames until the grid paints. Copy-mode panes
+/// are skipped — they paint via the separate `CopyRenderHandle` (Component 3).
 fn rescue_unpainted_panes(
-    mut debounce: ResMut<PaneSeedDebounce>,
+    mut trackers: ResMut<PaneSeedTrackers>,
     mut reseed: MessageWriter<RequestPaneReseed>,
     panes: Query<(&TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
 ) {
     for (pane, handle, grid) in panes.iter() {
         let (h_cols, h_rows, _) = handle.read_geometry();
         let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
-        let counter = debounce.0.entry(pane.id).or_default();
-        if should_emit_reseed(counter, needs, RESEED_DEBOUNCE_FRAMES) {
+        let tracker = trackers.0.entry(pane.id).or_default();
+        if reseed_decision(tracker, needs) {
             reseed.write(RequestPaneReseed { pane: pane.id });
         }
+    }
+}
+
+fn prune_tracker_on_pane_removed(
+    ev: On<Remove, TmuxPane>,
+    mut trackers: ResMut<PaneSeedTrackers>,
+    panes: Query<&TmuxPane>,
+) {
+    if let Ok(pane) = panes.get(ev.entity) {
+        trackers.0.remove(&pane.id);
     }
 }
 
@@ -105,30 +147,41 @@ mod tests {
     }
 
     #[test]
-    fn debounce_emits_only_after_threshold_consecutive_true() {
-        let mut c = 0u8;
-        assert!(!should_emit_reseed(&mut c, true, 3));
-        assert!(!should_emit_reseed(&mut c, true, 3));
-        assert!(should_emit_reseed(&mut c, true, 3));
+    fn reseed_emits_after_debounce_frames() {
+        let mut t = ReseedTracker::default();
+        assert!(!reseed_decision(&mut t, true));
+        assert!(!reseed_decision(&mut t, true));
+        assert!(reseed_decision(&mut t, true));
     }
 
     #[test]
-    fn debounce_resets_on_false() {
-        let mut c = 0u8;
-        should_emit_reseed(&mut c, true, 3);
-        should_emit_reseed(&mut c, true, 3);
-        assert!(!should_emit_reseed(&mut c, false, 3));
-        assert_eq!(c, 0);
-        assert!(!should_emit_reseed(&mut c, true, 3));
-    }
-
-    #[test]
-    fn debounce_does_not_re_emit_every_frame_while_held() {
-        let mut c = 0u8;
-        for _ in 0..2 {
-            should_emit_reseed(&mut c, true, 3);
+    fn reseed_suppresses_while_in_flight_then_retries_on_timeout() {
+        let mut t = ReseedTracker::default();
+        for _ in 0..RESEED_DEBOUNCE_FRAMES {
+            reseed_decision(&mut t, true);
         }
-        assert!(should_emit_reseed(&mut c, true, 3));
-        assert!(!should_emit_reseed(&mut c, true, 3));
+        for _ in 0..(RESEED_INFLIGHT_TIMEOUT - 1) {
+            assert!(!reseed_decision(&mut t, true));
+        }
+        assert!(reseed_decision(&mut t, true));
+    }
+
+    #[test]
+    fn reseed_resets_when_painted() {
+        let mut t = ReseedTracker::default();
+        for _ in 0..RESEED_DEBOUNCE_FRAMES {
+            reseed_decision(&mut t, true);
+        }
+        assert!(!reseed_decision(&mut t, false));
+        assert!(t.inflight_age.is_none());
+        assert_eq!(t.unpainted_streak, 0);
+    }
+
+    #[test]
+    fn reseed_ignores_one_frame_transient() {
+        let mut t = ReseedTracker::default();
+        assert!(!reseed_decision(&mut t, true));
+        assert!(!reseed_decision(&mut t, false));
+        assert!(!reseed_decision(&mut t, true));
     }
 }

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -67,6 +67,12 @@ impl PendingPaneOutput {
     }
 }
 
+/// Ordering handle for `layout_tmux_panes` so the paint-rescue system can run
+/// before this frame's grid-dims write (avoids the ≤1-frame resize transient
+/// where `cells.len() != rows`).
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TmuxLayoutSet;
+
 #[derive(Resource, Default)]
 struct LastClientSize {
     window: Option<WindowId>,
@@ -90,9 +96,10 @@ impl Plugin for RenderPlugin {
                 (
                     attach_tmux_window_container,
                     attach_tmux_pane_terminal,
-                    route_tmux_output.run_if(on_message::<PaneOutput>),
+                    route_tmux_output
+                        .run_if(on_message::<PaneOutput>.or(pending_pane_output_waiting)),
                     sync_active_window,
-                    layout_tmux_panes,
+                    layout_tmux_panes.in_set(TmuxLayoutSet),
                 )
                     .chain()
                     .after(TmuxProjectionSet)
@@ -191,6 +198,10 @@ fn attach_tmux_pane_terminal(
             },
         ));
     }
+}
+
+fn pending_pane_output_waiting(pending: Res<PendingPaneOutput>) -> bool {
+    !pending.buf.is_empty()
 }
 
 /// Routes tmux `%output` into each pane's handle. Groups a frame's

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -67,6 +67,19 @@ impl PendingPaneOutput {
     }
 }
 
+/// Drops a despawned pane's buffered output so its `PaneId` cannot keep
+/// `pending_pane_output_waiting` true (which would spin `route_tmux_output`
+/// every frame for the rest of the session).
+fn prune_pending_on_pane_removed(
+    ev: On<Remove, TmuxPane>,
+    mut pending: ResMut<PendingPaneOutput>,
+    panes: Query<&TmuxPane>,
+) {
+    if let Ok(pane) = panes.get(ev.entity) {
+        pending.take(pane.id);
+    }
+}
+
 /// Ordering handle for `layout_tmux_panes` so the paint-rescue system can run
 /// before this frame's grid-dims write (avoids the ≤1-frame resize transient
 /// where `cells.len() != rows`).
@@ -91,6 +104,7 @@ impl Plugin for RenderPlugin {
             .init_resource::<PendingPaneOutput>()
             .insert_resource(ClearColor(theme::PANE_GAP))
             .insert_resource(TerminalPaddingFallback(theme_background_bytes()))
+            .add_observer(prune_pending_on_pane_removed)
             .add_systems(
                 Update,
                 (
@@ -241,11 +255,18 @@ fn route_tmux_output(
     for pane in pane_ids {
         let fresh = by_pane.remove(&pane).unwrap_or_default();
         let Some(&entity) = entity_of.get(&pane) else {
-            pending.push(pane, &fresh);
+            // NOTE: only buffer real bytes — pushing an empty `fresh` would
+            // create/keep a phantom entry that keeps `pending_pane_output_waiting`
+            // true and spins this system every frame.
+            if !fresh.is_empty() {
+                pending.push(pane, &fresh);
+            }
             continue;
         };
         let Ok((mut handle, mut title)) = handles.get_mut(entity) else {
-            pending.push(pane, &fresh);
+            if !fresh.is_empty() {
+                pending.push(pane, &fresh);
+            }
             continue;
         };
         if let Some(buffered) = pending.take(pane) {

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -19,9 +19,50 @@ use ozmux_tmux::{
     TmuxProjectionSet, TmuxWindow, TmuxWindowLayout, WindowId, WindowRefreshClient,
 };
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use tmux_control_parser::{Cell, DividerAxis, PaneId, SplitDir};
+
+/// Total cap, across all panes, for bytes buffered while a pane's handle/grid
+/// is not yet present. One MiB is far above any real capture seed; the cap only
+/// guards a pane that never attaches.
+const PENDING_PANE_OUTPUT_CAP: usize = 1 << 20;
+
+/// Bytes routed to a pane before its `TerminalHandle` was queryable, held until
+/// the pane is ready and then replayed. Prevents losing the authoritative
+/// `capture-pane` seed (spec Component 1).
+#[derive(Resource, Default)]
+struct PendingPaneOutput {
+    buf: HashMap<PaneId, Vec<u8>>,
+    total: usize,
+}
+
+impl PendingPaneOutput {
+    fn push(&mut self, pane: PaneId, data: &[u8]) {
+        if self.total + data.len() > PENDING_PANE_OUTPUT_CAP {
+            if let Some(old) = self.buf.remove(&pane) {
+                self.total -= old.len();
+            }
+            tracing::warn!(
+                pane = pane.0,
+                "pending pane-output over cap; dropped buffered bytes"
+            );
+            if data.len() > PENDING_PANE_OUTPUT_CAP {
+                return;
+            }
+        }
+        let entry = self.buf.entry(pane).or_default();
+        entry.extend_from_slice(data);
+        self.total += data.len();
+    }
+
+    fn take(&mut self, pane: PaneId) -> Option<Vec<u8>> {
+        let v = self.buf.remove(&pane)?;
+        self.total -= v.len();
+        Some(v)
+    }
+}
 
 #[derive(Resource, Default)]
 struct LastClientSize {
@@ -38,6 +79,7 @@ pub(crate) struct RenderPlugin;
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LastClientSize>()
+            .init_resource::<PendingPaneOutput>()
             .insert_resource(ClearColor(theme::PANE_GAP))
             .insert_resource(TerminalPaddingFallback(theme_background_bytes()))
             .add_systems(
@@ -168,6 +210,7 @@ fn route_tmux_output(
     mut commands: Commands,
     mut reader: MessageReader<PaneOutput>,
     mut handles: Query<(&mut TerminalHandle, &mut TerminalTitle)>,
+    mut pending: ResMut<PendingPaneOutput>,
     panes: Query<(Entity, &TmuxPane)>,
     copy_modes: Query<(), With<crate::ui::copy_mode::CopyModeState>>,
 ) {
@@ -179,14 +222,22 @@ fn route_tmux_output(
             .extend_from_slice(&msg.data);
     }
     let entity_of: HashMap<_, _> = panes.iter().map(|(e, p)| (p.id, e)).collect();
-    for (pane, data) in by_pane {
+    let mut pane_ids: HashSet<PaneId> = by_pane.keys().copied().collect();
+    pane_ids.extend(pending.buf.keys().copied());
+    for pane in pane_ids {
+        let fresh = by_pane.remove(&pane).unwrap_or_default();
         let Some(&entity) = entity_of.get(&pane) else {
+            pending.push(pane, &fresh);
             continue;
         };
         let Ok((mut handle, mut title)) = handles.get_mut(entity) else {
+            pending.push(pane, &fresh);
             continue;
         };
-        handle.advance(&data);
+        if let Some(buffered) = pending.take(pane) {
+            handle.advance(&buffered);
+        }
+        handle.advance(&fresh);
         // NOTE: drain captured control frames — crucially the OSC 5379
         // mount/unmount verbs — into observer triggers. The engine's own control
         // drain runs only for PtyHandle-backed terminals; tmux panes have no
@@ -779,6 +830,7 @@ mod tests {
         app.add_plugins(OzmaTerminalPlugin { config_shell: None });
         app.init_resource::<Assets<TerminalUiMaterial>>();
         app.add_message::<PaneOutput>();
+        app.init_resource::<PendingPaneOutput>();
 
         let pane_id = PaneId(1);
         let pane_entity = app
@@ -835,6 +887,7 @@ mod tests {
         app.add_plugins(OzmaTerminalPlugin { config_shell: None });
         app.init_resource::<Assets<TerminalUiMaterial>>();
         app.add_message::<PaneOutput>();
+        app.init_resource::<PendingPaneOutput>();
 
         let pane_id = PaneId(1);
         let pane_entity = app
@@ -925,6 +978,7 @@ mod tests {
         app.add_plugins(TerminalGridPlugin);
         app.init_resource::<Assets<TerminalUiMaterial>>();
         app.add_message::<PaneOutput>();
+        app.init_resource::<PendingPaneOutput>();
         app.insert_resource(OscWebviewGate(Arc::new(AtomicBool::new(true))));
         app.init_resource::<Seen>();
         app.add_observer(|_ev: On<OscWebviewRequest>, mut seen: ResMut<Seen>| {
@@ -1509,6 +1563,30 @@ mod tests {
             "pane 3 gets its share of slack"
         );
         assert_eq!(bbox.y, 440.0, "bounding box matches workspace_h");
+    }
+
+    #[test]
+    fn pending_output_accumulates_then_takes() {
+        let mut p = PendingPaneOutput::default();
+        p.push(PaneId(1), b"ab");
+        p.push(PaneId(1), b"cd");
+        p.push(PaneId(2), b"xy");
+        assert_eq!(p.take(PaneId(1)).as_deref(), Some(&b"abcd"[..]));
+        assert_eq!(p.take(PaneId(1)), None);
+        assert_eq!(p.take(PaneId(2)).as_deref(), Some(&b"xy"[..]));
+    }
+
+    #[test]
+    fn pending_output_drops_pane_buffer_over_cap() {
+        let mut p = PendingPaneOutput::default();
+        let big = vec![0u8; PENDING_PANE_OUTPUT_CAP];
+        p.push(PaneId(1), &big);
+        p.push(PaneId(1), b"z");
+        let got = p.take(PaneId(1)).unwrap_or_default();
+        assert!(
+            got.len() <= PENDING_PANE_OUTPUT_CAP,
+            "buffer must not grow past the cap"
+        );
     }
 
     #[test]

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -48,7 +48,10 @@ impl PendingPaneOutput {
                 pane = pane.0,
                 "pending pane-output over cap; dropped buffered bytes"
             );
-            if data.len() > PENDING_PANE_OUTPUT_CAP {
+            // NOTE: the cap is global across all panes — if evicting this pane's
+            // own backlog still leaves no room (another pane holds the budget),
+            // drop the incoming bytes so `total` can never exceed the cap.
+            if self.total + data.len() > PENDING_PANE_OUTPUT_CAP {
                 return;
             }
         }
@@ -237,7 +240,9 @@ fn route_tmux_output(
         if let Some(buffered) = pending.take(pane) {
             handle.advance(&buffered);
         }
-        handle.advance(&fresh);
+        if !fresh.is_empty() {
+            handle.advance(&fresh);
+        }
         // NOTE: drain captured control frames — crucially the OSC 5379
         // mount/unmount verbs — into observer triggers. The engine's own control
         // drain runs only for PtyHandle-backed terminals; tmux panes have no
@@ -1582,11 +1587,37 @@ mod tests {
         let big = vec![0u8; PENDING_PANE_OUTPUT_CAP];
         p.push(PaneId(1), &big);
         p.push(PaneId(1), b"z");
+        assert!(
+            p.total <= PENDING_PANE_OUTPUT_CAP,
+            "total must not grow past the cap"
+        );
         let got = p.take(PaneId(1)).unwrap_or_default();
         assert!(
             got.len() <= PENDING_PANE_OUTPUT_CAP,
             "buffer must not grow past the cap"
         );
+        assert_eq!(p.total, 0, "taking the only pane drains total to zero");
+    }
+
+    #[test]
+    fn pending_output_enforces_global_cap_across_panes() {
+        let mut p = PendingPaneOutput::default();
+        let big = vec![0u8; PENDING_PANE_OUTPUT_CAP];
+        p.push(PaneId(2), &big);
+        // pane 2 already holds the whole budget; a push to pane 1 must not let
+        // `total` exceed the global cap even though pane 1 has no backlog to evict.
+        p.push(PaneId(1), b"hello");
+        assert!(
+            p.total <= PENDING_PANE_OUTPUT_CAP,
+            "global cap holds across panes, got total = {}",
+            p.total
+        );
+        // The incoming bytes were dropped (no room), so pane 1 holds nothing.
+        assert_eq!(p.take(PaneId(1)), None);
+        // Draining pane 2 returns the budget exactly.
+        let got = p.take(PaneId(2)).unwrap_or_default();
+        assert_eq!(got.len(), PENDING_PANE_OUTPUT_CAP);
+        assert_eq!(p.total, 0, "draining all panes returns total to zero");
     }
 
     #[test]

--- a/src/tmux/render.rs
+++ b/src/tmux/render.rs
@@ -11,6 +11,7 @@ use bevy::window::PrimaryWindow;
 use ozma_terminal::{OzmaTerminal, cells_for};
 use ozma_tty_engine::{TerminalHandle, TerminalTitle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
+use ozma_tty_renderer::TerminalPaddingFallback;
 use ozma_tty_renderer::schema::TerminalGrid;
 use ozma_webview::OscWebviewGate;
 use ozmux_tmux::{
@@ -38,6 +39,7 @@ impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LastClientSize>()
             .insert_resource(ClearColor(theme::PANE_GAP))
+            .insert_resource(TerminalPaddingFallback(theme_background_bytes()))
             .add_systems(
                 Update,
                 (
@@ -617,6 +619,15 @@ fn sync_client_size(
         }
         Err(e) => tracing::warn!(?e, cols, rows, "window refresh-client send failed"),
     }
+}
+
+fn theme_background_bytes() -> [u8; 3] {
+    let s = theme::BACKGROUND.to_srgba();
+    [
+        (s.red * 255.0).round() as u8,
+        (s.green * 255.0).round() as u8,
+        (s.blue * 255.0).round() as u8,
+    ]
 }
 
 fn sync_active_window(mut windows: Query<(&mut Node, Has<ActiveWindow>), With<TmuxWindow>>) {


### PR DESCRIPTION
## Problem

Terminal panes frequently render **completely black** after a layout change — splitting a pane, resizing the window, or entering copy mode — and only recover on the next unrelated interaction (a keypress, mouse move, another resize, or window switch), after which the same actions readily trigger it again.

Root cause: after a layout change a pane's `TerminalGrid` is not reliably repainted. tmux `-CC` does not replay a pane's screen on attach, so each pane is seeded from tmux's authoritative grid via `capture-pane`. That seed → route → paint pipeline had four "drop-and-no-retry" holes:

1. `route_tmux_output` **dropped** a pane's bytes when its `TerminalHandle` wasn't queryable yet (an authoritative seed arriving before attach was lost).
2. `apply_snapshot` **silently dropped** a `FrameSnapshot` when `TerminalGrid` was absent.
3. `recapture_settled_panes` was **one-shot per size** — a lost capture never retried until the next size change.
4. Copy-mode capture replies had **no resend backstop**, and `last_scroll` was recorded at *send* time, so a lost same-scroll capture permanently suppressed re-capture.

A structurally-empty grid (`cells.len() != rows`) combined with the default `[0,0,0]` background renders the whole quad black, so any of the above surfaced as a black pane.

## Solution

Four focused components make the pipeline self-healing. Affected areas: the GPU terminal renderer (`crates/ozma_tty_renderer`), the tmux multiplexer crate (`crates/tmux_session`), and the binary's tmux render/copy-mode layer (`src/tmux`).

- **C1 — buffer & replay routed output** (`src/tmux/render.rs`): a bounded `PendingPaneOutput` resource buffers a pane's bytes when its handle isn't ready and replays them once it is, instead of dropping the authoritative seed. Pruned on pane despawn.
- **C2 — structural reseed rescue** (`src/tmux/paint_rescue.rs` + `crates/tmux_session`): a binary-side system detects a structurally-unpainted grid via a pure sentinel (`grid_needs_full_seed`, debounced) and emits a `RequestPaneReseed` message; the tmux crate handles it by re-`capture-pane`-ing with in-flight suppression. An aged per-pane tracker re-requests until the grid paints (no wedge), and the system runs before `layout_tmux_panes` to avoid the resize transient. The crate stays renderer-free.
- **C3 — copy-mode capture backstop** (`src/tmux/copy_mode.rs`): records `last_scroll` on the capture *reply* (not send), tracks a per-pane in-flight capture, and ages out / resends a lost capture so copy mode can't freeze.
- **C4 — non-black padding fallback** (`crates/ozma_tty_renderer`): a `TerminalPaddingFallback` resource maps an unset (`[0,0,0]`) background to the theme terminal background in the material, so a momentarily-unpainted pane shows the terminal background rather than alarming pure black.

The design was reviewed against the codebase (spec + plan in `docs/superpowers/`), and the implementation went through per-component and whole-branch review; a follow-up review pass closed integration findings (despawn pruning, failed-capture retry, double-send suppression).

### Testing

`cargo fmt --check`, `cargo clippy --workspace --all-targets` (zero warnings), and `cargo test --workspace` (all green) pass. New unit tests cover `padding_color`, `PendingPaneOutput` (incl. the global byte cap), `grid_needs_full_seed`, the reseed debounce/aging state machine, and `decide_capture`. Manual in-app verification (split / resize / copy-mode entry no longer blacks out) is still recommended since the app is a GPU Bevy binary not runnable headless in CI.
