### PR TITLE
fix(tmux): reset display state in the capture seed before replay

### DIFF
--- a/crates/tmux_session/src/event_pump.rs
+++ b/crates/tmux_session/src/event_pump.rs
@@ -35,12 +35,22 @@ pub(crate) fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
 }
 
 /// Joins `capture-pane -p -e` reply lines into VT bytes for seeding a pane's
-/// screen: a cursor-home + clear-screen prefix so the snapshot repaints from a
-/// clean grid (the reply can arrive after live `%output` has already moved the
-/// cursor — without the reset the rows would stack and duplicate), then the rows
-/// CRLF-joined (the reply omits line terminators).
+/// screen: a clean-state prefix (reset scroll region + origin mode + SGR, then
+/// cursor-home + clear-screen) so the snapshot repaints from a clean grid with
+/// the default background and absolute positioning, then the rows CRLF-joined
+/// (the reply omits line terminators). Home + clear also keep the rows from
+/// stacking when the reply arrives after live `%output` has moved the cursor.
 pub(crate) fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
-    let mut bytes = b"\x1b[H\x1b[2J".to_vec();
+    // NOTE: the reset prefix MUST precede the ESC[2J erase and the row replay.
+    // `capture-pane -e` output assumes a default-state terminal, but it is
+    // replayed into the long-lived pane mirror, which can still carry modes left
+    // by prior `%output` (e.g. nvim mid-redraw on a resize): a stale SGR
+    // background floods the erase and default-bg cells (the blue-pane bug), and
+    // a stale scroll region (DECSTBM) or origin mode (DECOM) scrolls the CRLF
+    // replay within the wrong margins or mis-places the cursor. Reset region
+    // (ESC[r), origin (ESC[?6l), and SGR (ESC[0m) first so the replay is
+    // faithful regardless of prior state.
+    let mut bytes = b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec();
     bytes.extend_from_slice(lines.join("\r\n").as_bytes());
     bytes
 }
@@ -310,10 +320,10 @@ mod tests {
 
     #[test]
     fn capture_to_bytes_with_cursor_appends_cursor_escape() {
-        // ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4, 1-origin)
+        // ESC[r ESC[?6l ESC[0m ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4)
         assert_eq!(
             capture_to_bytes_with_cursor(&["hello".to_string()], 3, 5),
-            b"\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec()
+            b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec()
         );
     }
 

--- a/src/tmux/copy_mode.rs
+++ b/src/tmux/copy_mode.rs
@@ -364,11 +364,17 @@ fn apply_capture_reply(
 }
 
 /// Joins `capture-pane -p -e` reply lines into VT bytes for the scratch handle:
-/// a cursor-home + clear-screen prefix so the snapshot repaints from a clean
-/// grid, then the rows CRLF-joined (the reply omits line terminators). Mirrors
+/// a clean-state prefix (reset scroll region + origin mode + SGR, then
+/// cursor-home + clear-screen) so the snapshot repaints from a clean grid, then
+/// the rows CRLF-joined (the reply omits line terminators). Mirrors
 /// `ozmux_tmux`'s `capture_to_bytes` for the live seed path.
 fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
-    let mut bytes = b"\x1b[H\x1b[2J".to_vec();
+    // NOTE: the reset prefix MUST precede the ESC[2J erase — see the matching
+    // NOTE on `ozmux_tmux`'s `capture_to_bytes`. A stale SGR background, scroll
+    // region (DECSTBM), or origin mode (DECOM) left in the reused render handle
+    // would otherwise flood or mis-scroll the scrolled copy view on copy-mode
+    // entry.
+    let mut bytes = b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec();
     bytes.extend_from_slice(lines.join("\r\n").as_bytes());
     bytes
 }
@@ -667,13 +673,16 @@ mod tests {
         let lines = vec!["row one".to_string(), "row two".to_string()];
         assert_eq!(
             capture_to_bytes(&lines),
-            b"\x1b[H\x1b[2Jrow one\r\nrow two".to_vec(),
+            b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2Jrow one\r\nrow two".to_vec(),
         );
     }
 
     #[test]
     fn capture_to_bytes_empty_is_just_the_reset() {
-        assert_eq!(capture_to_bytes(&[]), b"\x1b[H\x1b[2J".to_vec());
+        assert_eq!(
+            capture_to_bytes(&[]),
+            b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a tmux pane is focused (e.g. running nvim) and the GUI window is resized, the pane's text area floods with a solid background color — the editor content disappears under a flat blue fill. It recovers on the next interaction but recurs on resize.

On resize, ozmux re-seeds a pane's display mirror from tmux via `capture-pane -p -e`. The seed cleared the screen (`ESC[H ESC[2J`) and replayed the captured rows **without first restoring a clean display state**. `capture-pane -e` output assumes a default-state terminal, but the per-pane mirror is long-lived and can still carry modes left by the program's prior `%output` (nvim mid-redraw during a resize):

- a stale **SGR background** → `ESC[2J` erases to that color and every default-bg captured cell inherits it (the blue flood — `capture-pane -e` emits no bg code for default cells);
- a stale **scroll region** (DECSTBM) → the CRLF row replay scrolls within the wrong margins; a stale **origin mode** (DECOM) → the seeded cursor is mis-positioned.

## Solution

Prepend a clean-state reset to both capture-seed builders so the replay is faithful regardless of the mirror's prior state — reset scroll region (`ESC[r`), origin mode (`ESC[?6l`), and SGR (`ESC[0m`) **before** the home + erase.

Affected (tmux backend):
- `crates/tmux_session/src/event_pump.rs` — live pane reseed (`capture_to_bytes` / `capture_to_bytes_with_cursor`).
- `src/tmux/copy_mode.rs` — copy-mode scrolled-view seed (same latent bug on copy-mode entry).

Why this scope: tmux's `-e` capture is meant to be replayed onto a default-state terminal, so the seed must establish that state. DECSTR (`ESC[!p`) is not implemented by `alacritty_terminal` 0.26, and RIS (`ESC c`) would wrongly clear scrollback and the OSC 11 default background — so targeted soft-reset sequences are the correct depth. A program's real OSC 11 default background is intentionally preserved.

Verified with unit tests asserting the exact seed bytes in both crates (`cargo test -p ozmux_tmux`, `cargo test -p ozmux`); `cargo fmt --check` clean. Root-caused with a real-tmux `capture-pane -e` byte experiment; reviewed by Codex and a multi-agent code-review pass (which surfaced the scroll-region/origin-mode hardening beyond the initial SGR-only fix).

> Note: live GUI verification (resize a focused nvim pane → no flood) is still pending — the interactive resize can't be driven headlessly.

<details><summary>Repro (before fix)</summary>

`bug.png` (captured locally) shows the focused nvim pane's editor area flooded with a solid blue after a window resize. Pixel analysis: ~70% a single blue (RGB 101,162,227) with the text gone, distinct from the theme background (RGB 30,32,40) — a stale-state fill, not the renderer fallback. Drag `bug.png` into this description to attach the image.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
