### PR TITLE
feat(tty-renderer): raise inline overlay cap from 4 to 12 (array-backed material)

### DIFF
--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -300,7 +300,7 @@ pub struct TerminalPaddingFallback(pub [u8; 3]);
 ///
 /// Slot index = array index = `overlay<i>` field order (NOT the WGSL binding
 /// number). Hard upper bound per terminal surface (spec §6.1).
-pub const OVERLAY_SLOTS: usize = 4;
+pub const OVERLAY_SLOTS: usize = 12;
 
 /// Per-terminal overlay placements + textures, derived every frame by the
 /// consumer (e.g. ozmux's webview projection) and consumed by
@@ -358,9 +358,9 @@ impl Default for TerminalOverlays {
 /// at offset 76 that encase would otherwise insert before `bg_padding_color`
 /// (Vec4 needs 16-byte alignment, lands at offset 80). `inactive_tint` is also
 /// a Vec4 (16-byte alignment), so encase pads the 4 bytes after `dim` and lands
-/// it at offset 112; `overlay_rects` (`array<vec4<i32>, 4>`) follows at offset
-/// 128. The trailing `overlay_dim` / `overlay_desaturate` scalars sit at 192/196
-/// and the struct rounds up to its 16-byte alignment (total 208 bytes):
+/// it at offset 112; `overlay_rects` (`array<vec4<i32>, 12>`) follows at offset
+/// 128. The trailing `overlay_dim` / `overlay_desaturate` scalars sit at 320/324
+/// and the struct rounds up to its 16-byte alignment (total 336 bytes):
 ///
 /// | Offset | Field                       |
 /// |--------|-----------------------------|
@@ -386,8 +386,8 @@ impl Default for TerminalOverlays {
 /// | 104    | `dim`                       |
 /// | 112    | `inactive_tint`             |
 /// | 128    | `overlay_rects`             |
-/// | 192    | `overlay_dim`               |
-/// | 196    | `overlay_desaturate`        |
+/// | 320    | `overlay_dim`               |
+/// | 324    | `overlay_desaturate`        |
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -1055,7 +1055,7 @@ mod tests {
 
     #[test]
     fn terminal_params_uniform_size_includes_overlay_rects() {
-        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 208);
+        assert_eq!(<TerminalParams as ShaderType>::min_size().get(), 336);
     }
 
     #[test]
@@ -1071,7 +1071,7 @@ mod tests {
         // `dim` is at offset 104; `inactive_tint` (a Vec4, 16-byte aligned)
         // lands at 112 after encase pads the 4 bytes following `dim`;
         // `overlay_rects` follows at 128; the trailing scalars `overlay_dim` /
-        // `overlay_desaturate` sit at 192/196 (total 208 bytes). Field indices
+        // `overlay_desaturate` sit at 320/324 (total 336 bytes). Field indices
         // are 0-based in declaration order.
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(19),
@@ -1090,12 +1090,12 @@ mod tests {
         );
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(22),
-            192,
+            320,
             "overlay_dim after overlay_rects"
         );
         assert_eq!(
             <TerminalParams as ShaderType>::METADATA.offset(23),
-            196,
+            324,
             "overlay_desaturate after overlay_dim"
         );
     }

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -8,10 +8,19 @@ use crate::{
 };
 use bevy::{
     asset::{load_internal_asset, uuid_handle},
+    ecs::system::{SystemParamItem, lifetimeless::SRes},
     prelude::*,
     render::{
-        render_resource::{AsBindGroup, ShaderType},
-        storage::ShaderStorageBuffer,
+        render_asset::RenderAssets,
+        render_resource::{
+            AsBindGroup, AsBindGroupError, BindGroupLayout, BindGroupLayoutEntry, BindingResources,
+            BindingType, BufferBindingType, BufferInitDescriptor, BufferUsages,
+            OwnedBindingResource, SamplerBindingType, ShaderStages, ShaderType, TextureSampleType,
+            TextureViewDimension, UnpreparedBindGroup, encase,
+        },
+        renderer::RenderDevice,
+        storage::{GpuShaderStorageBuffer, ShaderStorageBuffer},
+        texture::{FallbackImage, GpuImage},
     },
     shader::ShaderRef,
     window::PrimaryWindow,
@@ -65,29 +74,172 @@ impl Plugin for TerminalMaterialPlugin {
 }
 
 /// Custom UI material backing the full-screen terminal node.
-#[derive(AsBindGroup, Asset, TypePath, Clone, Default)]
+#[derive(Asset, TypePath, Clone)]
 pub struct TerminalUiMaterial {
-    #[uniform(0)]
     params: TerminalParams,
-    #[storage(1, read_only)]
     cells: Handle<ShaderStorageBuffer>,
-    #[storage(2, read_only)]
     glyphs: Handle<ShaderStorageBuffer>,
-    #[texture(3)]
-    #[sampler(4)]
     atlas: Handle<Image>,
-    #[texture(5)]
-    #[sampler(6)]
-    overlay0: Option<Handle<Image>>,
-    #[texture(7)]
-    #[sampler(8)]
-    overlay1: Option<Handle<Image>>,
-    #[texture(9)]
-    #[sampler(10)]
-    overlay2: Option<Handle<Image>>,
-    #[texture(11)]
-    #[sampler(12)]
-    overlay3: Option<Handle<Image>>,
+    overlays: [Option<Handle<Image>>; OVERLAY_SLOTS],
+}
+
+/// First `@binding` index of the overlay texture array; slot `i` binds at
+/// `OVERLAY_TEX_BINDING_BASE + i`. Bindings 0..=5 are params/cells/glyphs/atlas
+/// texture/atlas sampler/shared overlay sampler.
+const OVERLAY_TEX_BINDING_BASE: u32 = 6;
+
+impl Default for TerminalUiMaterial {
+    fn default() -> Self {
+        Self {
+            params: TerminalParams::default(),
+            cells: Handle::default(),
+            glyphs: Handle::default(),
+            atlas: Handle::default(),
+            overlays: [const { None }; OVERLAY_SLOTS],
+        }
+    }
+}
+
+impl AsBindGroup for TerminalUiMaterial {
+    type Data = ();
+    type Param = (
+        SRes<RenderAssets<GpuImage>>,
+        SRes<FallbackImage>,
+        SRes<RenderAssets<GpuShaderStorageBuffer>>,
+    );
+
+    fn label() -> &'static str {
+        "terminal_ui_material"
+    }
+
+    fn bind_group_data(&self) -> Self::Data {}
+
+    fn unprepared_bind_group(
+        &self,
+        _layout: &BindGroupLayout,
+        render_device: &RenderDevice,
+        (images, fallback_image, storage_buffers): &mut SystemParamItem<'_, '_, Self::Param>,
+        _force_no_bindless: bool,
+    ) -> Result<UnpreparedBindGroup, AsBindGroupError> {
+        let mut params_buffer = encase::UniformBuffer::new(Vec::new());
+        params_buffer.write(&self.params).unwrap();
+
+        let cells = storage_buffers
+            .get(&self.cells)
+            .ok_or(AsBindGroupError::RetryNextUpdate)?;
+        let glyphs = storage_buffers
+            .get(&self.glyphs)
+            .ok_or(AsBindGroupError::RetryNextUpdate)?;
+        let atlas = images
+            .get(&self.atlas)
+            .ok_or(AsBindGroupError::RetryNextUpdate)?;
+
+        let mut bindings = vec![
+            (
+                0,
+                OwnedBindingResource::Buffer(render_device.create_buffer_with_data(
+                    &BufferInitDescriptor {
+                        label: Some("terminal_params"),
+                        usage: BufferUsages::UNIFORM,
+                        contents: params_buffer.as_ref(),
+                    },
+                )),
+            ),
+            (1, OwnedBindingResource::Buffer(cells.buffer.clone())),
+            (2, OwnedBindingResource::Buffer(glyphs.buffer.clone())),
+            (
+                3,
+                OwnedBindingResource::TextureView(
+                    TextureViewDimension::D2,
+                    atlas.texture_view.clone(),
+                ),
+            ),
+            (
+                4,
+                OwnedBindingResource::Sampler(SamplerBindingType::Filtering, atlas.sampler.clone()),
+            ),
+            (
+                5,
+                OwnedBindingResource::Sampler(
+                    SamplerBindingType::Filtering,
+                    fallback_image.d2.sampler.clone(),
+                ),
+            ),
+        ];
+
+        // NOTE: A `None` slot, OR a `Some` whose GpuImage is not yet loaded,
+        // binds the fallback view. The shader never samples it (the `rect.z==0`
+        // sentinel gates it), and this avoids stalling the whole material's bind
+        // group on a single mid-load overlay texture.
+        for (i, handle) in self.overlays.iter().enumerate() {
+            let view = handle.as_ref().and_then(|h| images.get(h)).map_or_else(
+                || fallback_image.d2.texture_view.clone(),
+                |img| img.texture_view.clone(),
+            );
+            bindings.push((
+                OVERLAY_TEX_BINDING_BASE + i as u32,
+                OwnedBindingResource::TextureView(TextureViewDimension::D2, view),
+            ));
+        }
+
+        Ok(UnpreparedBindGroup {
+            bindings: BindingResources(bindings),
+        })
+    }
+
+    fn bind_group_layout_entries(
+        _render_device: &RenderDevice,
+        _force_no_bindless: bool,
+    ) -> Vec<BindGroupLayoutEntry> {
+        let texture = |binding: u32| BindGroupLayoutEntry {
+            binding,
+            visibility: ShaderStages::FRAGMENT,
+            ty: BindingType::Texture {
+                sample_type: TextureSampleType::Float { filterable: true },
+                view_dimension: TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        };
+        let sampler = |binding: u32| BindGroupLayoutEntry {
+            binding,
+            visibility: ShaderStages::FRAGMENT,
+            ty: BindingType::Sampler(SamplerBindingType::Filtering),
+            count: None,
+        };
+        let storage = |binding: u32| BindGroupLayoutEntry {
+            binding,
+            visibility: ShaderStages::FRAGMENT,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+
+        let mut entries = vec![
+            BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: Some(<TerminalParams as ShaderType>::min_size()),
+                },
+                count: None,
+            },
+            storage(1),
+            storage(2),
+            texture(3),
+            sampler(4),
+            sampler(5),
+        ];
+        for i in 0..OVERLAY_SLOTS as u32 {
+            entries.push(texture(OVERLAY_TEX_BINDING_BASE + i));
+        }
+        entries
+    }
 }
 
 impl UiMaterial for TerminalUiMaterial {
@@ -97,13 +249,9 @@ impl UiMaterial for TerminalUiMaterial {
 }
 
 impl TerminalUiMaterial {
-    /// Copies the slot-indexed overlay handles onto the per-slot material
-    /// fields. The ONLY place that maps slot index -> `overlay<i>` field.
+    /// Overwrites the overlay texture array, slot-indexed (`None` = inactive).
     fn set_overlays(&mut self, textures: &[Option<Handle<Image>>; OVERLAY_SLOTS]) {
-        self.overlay0 = textures[0].clone();
-        self.overlay1 = textures[1].clone();
-        self.overlay2 = textures[2].clone();
-        self.overlay3 = textures[3].clone();
+        self.overlays = textures.clone();
     }
 }
 
@@ -891,16 +1039,18 @@ mod tests {
     }
 
     #[test]
-    fn set_overlays_maps_slot_index_to_field_order() {
+    fn set_overlays_copies_into_overlays_array() {
         const H_A: Handle<Image> = uuid_handle!("c0fee000-0000-4000-8000-000000000001");
         const H_B: Handle<Image> = uuid_handle!("c0fee000-0000-4000-8000-000000000002");
         let mut mat = TerminalUiMaterial::default();
-        let textures = [Some(H_A), None, Some(H_B), None];
+        let mut textures = [const { None }; OVERLAY_SLOTS];
+        textures[0] = Some(H_A);
+        textures[2] = Some(H_B);
         mat.set_overlays(&textures);
-        assert_eq!(mat.overlay0, Some(H_A));
-        assert_eq!(mat.overlay1, None);
-        assert_eq!(mat.overlay2, Some(H_B));
-        assert_eq!(mat.overlay3, None);
+        assert_eq!(mat.overlays[0], Some(H_A));
+        assert_eq!(mat.overlays[1], None);
+        assert_eq!(mat.overlays[2], Some(H_B));
+        assert_eq!(mat.overlays[3], None);
     }
 
     #[test]

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -298,8 +298,9 @@ pub struct TerminalPaddingFallback(pub [u8; 3]);
 
 /// Number of inline-overlay texture slots on `TerminalUiMaterial`.
 ///
-/// Slot index = array index = `overlay<i>` field order (NOT the WGSL binding
-/// number). Hard upper bound per terminal surface (spec §6.1).
+/// Slot index = array index into `overlays` / `overlay_rects`; the WGSL
+/// texture binding is `OVERLAY_TEX_BINDING_BASE + i`. Hard upper bound per
+/// terminal surface (spec §6.1).
 pub const OVERLAY_SLOTS: usize = 12;
 
 /// Per-terminal overlay placements + textures, derived every frame by the
@@ -1117,21 +1118,19 @@ mod tests {
     #[test]
     fn wgsl_overlay_bindings_track_overlay_slots() {
         let src = include_str!("shaders/terminal_ui_material.wgsl");
-        // 1. One `texture_2d<f32>` per overlay slot, plus the atlas texture.
         let texture_decls = src.matches("_tex: texture_2d<f32>").count();
         assert_eq!(
             texture_decls,
             OVERLAY_SLOTS + 1,
             "expected atlas + {OVERLAY_SLOTS} overlay texture declarations"
         );
-        // 2. The uniform rect array length must match (a stale size is a silent
-        //    uniform-offset bug: no binding error, garbage overlay_dim/desaturate).
+        // NOTE: a stale rect-array size is a silent uniform-offset bug — no
+        // binding error, but the shader misreads overlay_dim/overlay_desaturate
+        // at the wrong offsets (192/196 instead of 320/324).
         assert!(
             src.contains(&format!("overlay_rects: array<vec4<i32>, {OVERLAY_SLOTS}>")),
             "overlay_rects must be array<vec4<i32>, {OVERLAY_SLOTS}>"
         );
-        // 3. One sample_overlay_slot call per slot (bindings cannot be indexed
-        //    dynamically, so the unroll count must equal OVERLAY_SLOTS).
         let calls = src.matches("color = sample_overlay_slot(").count();
         assert_eq!(calls, OVERLAY_SLOTS, "sample_overlay_slot call count");
     }

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -16,7 +16,7 @@ use bevy::{
             AsBindGroup, AsBindGroupError, BindGroupLayout, BindGroupLayoutEntry, BindingResources,
             BindingType, BufferBindingType, BufferInitDescriptor, BufferUsages,
             OwnedBindingResource, SamplerBindingType, ShaderStages, ShaderType, TextureSampleType,
-            TextureViewDimension, UnpreparedBindGroup, encase,
+            TextureViewDimension, UnpreparedBindGroup, encase::UniformBuffer,
         },
         renderer::RenderDevice,
         storage::{GpuShaderStorageBuffer, ShaderStorageBuffer},
@@ -121,7 +121,7 @@ impl AsBindGroup for TerminalUiMaterial {
         (images, fallback_image, storage_buffers): &mut SystemParamItem<'_, '_, Self::Param>,
         _force_no_bindless: bool,
     ) -> Result<UnpreparedBindGroup, AsBindGroupError> {
-        let mut params_buffer = encase::UniformBuffer::new(Vec::new());
+        let mut params_buffer = UniformBuffer::new(Vec::new());
         params_buffer.write(&self.params).unwrap();
 
         let cells = storage_buffers
@@ -166,6 +166,7 @@ impl AsBindGroup for TerminalUiMaterial {
                 ),
             ),
         ];
+        bindings.reserve(OVERLAY_SLOTS);
 
         // NOTE: A `None` slot, OR a `Some` whose GpuImage is not yet loaded,
         // binds the fallback view. The shader never samples it (the `rect.z==0`
@@ -1133,5 +1134,35 @@ mod tests {
         );
         let calls = src.matches("color = sample_overlay_slot(").count();
         assert_eq!(calls, OVERLAY_SLOTS, "sample_overlay_slot call count");
+
+        // NOTE: the counts above cannot catch a binding-number drift or a
+        // copy-paste that samples the wrong texture for a slot — both produce a
+        // runtime bind-group/pipeline error, never a test failure. Pin the
+        // shared sampler binding, each slot's texture binding, and the per-call
+        // overlay_rects[i] <-> overlay{i}_tex pairing, all from the Rust
+        // constants, so a drift fails here instead.
+        assert!(
+            src.contains(&format!(
+                "@binding({}) var overlay_samp: sampler;",
+                OVERLAY_TEX_BINDING_BASE - 1
+            )),
+            "shared overlay_samp must be at binding {}",
+            OVERLAY_TEX_BINDING_BASE - 1
+        );
+        for i in 0..OVERLAY_SLOTS {
+            let binding = OVERLAY_TEX_BINDING_BASE + i as u32;
+            assert!(
+                src.contains(&format!(
+                    "@binding({binding}) var overlay{i}_tex: texture_2d<f32>;"
+                )),
+                "overlay{i}_tex must be declared at binding {binding}"
+            );
+            assert!(
+                src.contains(&format!(
+                    "sample_overlay_slot(params.overlay_rects[{i}], overlay{i}_tex, overlay_samp,"
+                )),
+                "slot {i} call must pair overlay_rects[{i}] with overlay{i}_tex"
+            );
+        }
     }
 }

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -1113,4 +1113,26 @@ mod tests {
         let c = Color::srgb_u8(10, 20, 30).to_linear();
         assert_eq!(got, Vec4::new(c.red, c.green, c.blue, 1.0));
     }
+
+    #[test]
+    fn wgsl_overlay_bindings_track_overlay_slots() {
+        let src = include_str!("shaders/terminal_ui_material.wgsl");
+        // 1. One `texture_2d<f32>` per overlay slot, plus the atlas texture.
+        let texture_decls = src.matches("_tex: texture_2d<f32>").count();
+        assert_eq!(
+            texture_decls,
+            OVERLAY_SLOTS + 1,
+            "expected atlas + {OVERLAY_SLOTS} overlay texture declarations"
+        );
+        // 2. The uniform rect array length must match (a stale size is a silent
+        //    uniform-offset bug: no binding error, garbage overlay_dim/desaturate).
+        assert!(
+            src.contains(&format!("overlay_rects: array<vec4<i32>, {OVERLAY_SLOTS}>")),
+            "overlay_rects must be array<vec4<i32>, {OVERLAY_SLOTS}>"
+        );
+        // 3. One sample_overlay_slot call per slot (bindings cannot be indexed
+        //    dynamically, so the unroll count must equal OVERLAY_SLOTS).
+        let calls = src.matches("color = sample_overlay_slot(").count();
+        assert_eq!(calls, OVERLAY_SLOTS, "sample_overlay_slot call count");
+    }
 }

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -27,7 +27,7 @@ struct TerminalParams {
     hover_active: u32,
     dim: f32,
     inactive_tint: vec4<f32>,
-    overlay_rects: array<vec4<i32>, 4>,
+    overlay_rects: array<vec4<i32>, 12>,
     overlay_dim: f32,
     overlay_desaturate: f32,
 };
@@ -71,6 +71,14 @@ struct CellColors {
 @group(1) @binding(7) var overlay1_tex: texture_2d<f32>;
 @group(1) @binding(8) var overlay2_tex: texture_2d<f32>;
 @group(1) @binding(9) var overlay3_tex: texture_2d<f32>;
+@group(1) @binding(10) var overlay4_tex: texture_2d<f32>;
+@group(1) @binding(11) var overlay5_tex: texture_2d<f32>;
+@group(1) @binding(12) var overlay6_tex: texture_2d<f32>;
+@group(1) @binding(13) var overlay7_tex: texture_2d<f32>;
+@group(1) @binding(14) var overlay8_tex: texture_2d<f32>;
+@group(1) @binding(15) var overlay9_tex: texture_2d<f32>;
+@group(1) @binding(16) var overlay10_tex: texture_2d<f32>;
+@group(1) @binding(17) var overlay11_tex: texture_2d<f32>;
 
 // NOTE: Must stay in sync with `ozmux_terminal_protocol::style::*`. The
 //       Rust-side test `style_bits_match_protocol_constants` asserts the
@@ -440,6 +448,14 @@ fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     color = sample_overlay_slot(params.overlay_rects[1], overlay1_tex, overlay_samp, p_px, hit, color);
     color = sample_overlay_slot(params.overlay_rects[2], overlay2_tex, overlay_samp, p_px, hit, color);
     color = sample_overlay_slot(params.overlay_rects[3], overlay3_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[4], overlay4_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[5], overlay5_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[6], overlay6_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[7], overlay7_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[8], overlay8_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[9], overlay9_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[10], overlay10_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[11], overlay11_tex, overlay_samp, p_px, hit, color);
     return color;
 }
 

--- a/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/ozma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -66,14 +66,11 @@ struct CellColors {
 @group(1) @binding(2) var<storage, read> glyphs: array<Glyph>;
 @group(1) @binding(3) var atlas_tex: texture_2d<f32>;
 @group(1) @binding(4) var atlas_sampler: sampler;
-@group(1) @binding(5) var overlay0_tex: texture_2d<f32>;
-@group(1) @binding(6) var overlay0_samp: sampler;
+@group(1) @binding(5) var overlay_samp: sampler;
+@group(1) @binding(6) var overlay0_tex: texture_2d<f32>;
 @group(1) @binding(7) var overlay1_tex: texture_2d<f32>;
-@group(1) @binding(8) var overlay1_samp: sampler;
-@group(1) @binding(9) var overlay2_tex: texture_2d<f32>;
-@group(1) @binding(10) var overlay2_samp: sampler;
-@group(1) @binding(11) var overlay3_tex: texture_2d<f32>;
-@group(1) @binding(12) var overlay3_samp: sampler;
+@group(1) @binding(8) var overlay2_tex: texture_2d<f32>;
+@group(1) @binding(9) var overlay3_tex: texture_2d<f32>;
 
 // NOTE: Must stay in sync with `ozmux_terminal_protocol::style::*`. The
 //       Rust-side test `style_bits_match_protocol_constants` asserts the
@@ -420,40 +417,29 @@ fn treat_overlay(s: vec4<f32>) -> vec4<f32> {
 // distorts the image; grid-edge clipping is inherent because only in-grid
 // fragments reach paint_grid_cell.
 
+fn sample_overlay_slot(
+    rect: vec4<i32>,
+    tex: texture_2d<f32>,
+    samp: sampler,
+    p_px: vec2<f32>,
+    hit: CellHit,
+    color: vec4<f32>,
+) -> vec4<f32> {
+    let uv = overlay_uv(rect, p_px, hit);
+    if uv.x >= 0.0 {
+        let s = treat_overlay(textureSampleLevel(tex, samp, uv, 0.0));
+        return blend_premultiplied_over(color, s);
+    }
+    return color;
+}
+
 fn paint_inline_overlays(hit: CellHit, base: vec4<f32>) -> vec4<f32> {
     var color = base;
     let p_px = vec2<f32>(f32(hit.col), f32(hit.row)) * params.cell_size_px + hit.in_cell_px;
-    // NOTE: bindings cannot be dynamically indexed in core WGSL — the four
-    // slots are unrolled by hand; keep slot order identical to the Rust
-    // `set_overlays` field order or textures swap silently.
-    {
-        let uv = overlay_uv(params.overlay_rects[0], p_px, hit);
-        if uv.x >= 0.0 {
-            let s = treat_overlay(textureSampleLevel(overlay0_tex, overlay0_samp, uv, 0.0));
-            color = blend_premultiplied_over(color, s);
-        }
-    }
-    {
-        let uv = overlay_uv(params.overlay_rects[1], p_px, hit);
-        if uv.x >= 0.0 {
-            let s = treat_overlay(textureSampleLevel(overlay1_tex, overlay1_samp, uv, 0.0));
-            color = blend_premultiplied_over(color, s);
-        }
-    }
-    {
-        let uv = overlay_uv(params.overlay_rects[2], p_px, hit);
-        if uv.x >= 0.0 {
-            let s = treat_overlay(textureSampleLevel(overlay2_tex, overlay2_samp, uv, 0.0));
-            color = blend_premultiplied_over(color, s);
-        }
-    }
-    {
-        let uv = overlay_uv(params.overlay_rects[3], p_px, hit);
-        if uv.x >= 0.0 {
-            let s = treat_overlay(textureSampleLevel(overlay3_tex, overlay3_samp, uv, 0.0));
-            color = blend_premultiplied_over(color, s);
-        }
-    }
+    color = sample_overlay_slot(params.overlay_rects[0], overlay0_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[1], overlay1_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[2], overlay2_tex, overlay_samp, p_px, hit, color);
+    color = sample_overlay_slot(params.overlay_rects[3], overlay3_tex, overlay_samp, p_px, hit, color);
     return color;
 }
 

--- a/crates/ozma_webview/src/webview/mount.rs
+++ b/crates/ozma_webview/src/webview/mount.rs
@@ -982,28 +982,27 @@ mod tests {
     }
 
     #[test]
-    fn slots_fill_in_order_and_a_fifth_mount_is_rejected() {
+    fn slots_fill_in_order_and_an_over_cap_mount_is_rejected() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        for id in ["a", "b", "c", "d", "e"] {
+        let ids: Vec<String> = (0..=OVERLAY_SLOTS).map(|i| format!("v{i}")).collect();
+        for id in &ids {
             register_ozma(&mut app, id, terminal, true);
         }
 
-        for id in ["a", "b", "c", "d"] {
+        for (i, id) in ids.iter().take(OVERLAY_SLOTS).enumerate() {
             mount(&mut app, terminal, id, Some(test_anchor()));
+            assert_eq!(slot_of(&app, terminal, id), Some(i as u8));
         }
-        assert_eq!(slot_of(&app, terminal, "a"), Some(0));
-        assert_eq!(slot_of(&app, terminal, "b"), Some(1));
-        assert_eq!(slot_of(&app, terminal, "c"), Some(2));
-        assert_eq!(slot_of(&app, terminal, "d"), Some(3));
 
-        mount(&mut app, terminal, "e", Some(test_anchor()));
+        let overflow = &ids[OVERLAY_SLOTS];
+        mount(&mut app, terminal, overflow, Some(test_anchor()));
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
-            "a fifth mount must be rejected once all slots are taken"
+            "an over-cap mount must be rejected once all slots are taken"
         );
-        assert_eq!(slot_of(&app, terminal, "e"), None);
+        assert_eq!(slot_of(&app, terminal, overflow), None);
     }
 
     #[test]
@@ -1200,18 +1199,23 @@ mod tests {
         let terminal = spawn_terminal(&mut app);
         register_ozma(&mut app, "memo", terminal, true);
 
-        for inst in ["a", "b", "c", "d"] {
+        let insts: Vec<String> = (0..=OVERLAY_SLOTS).map(|i| format!("i{i}")).collect();
+        for inst in insts.iter().take(OVERLAY_SLOTS) {
             mount_instance(&mut app, terminal, "memo", inst, Some(test_anchor()));
         }
         assert_eq!(webview_children_of(&app, terminal).len(), OVERLAY_SLOTS);
 
-        mount_instance(&mut app, terminal, "memo", "e", Some(test_anchor()));
+        let overflow = &insts[OVERLAY_SLOTS];
+        mount_instance(&mut app, terminal, "memo", overflow, Some(test_anchor()));
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
-            "the 4-slot cap is per-terminal across all instances; a 5th is rejected"
+            "the per-terminal slot cap counts all instances together; an over-cap mount is rejected"
         );
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("e")), None);
+        assert_eq!(
+            slot_of_instance(&app, terminal, "memo", Some(overflow.as_str())),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Raises the per-pane inline-webview overlay cap from **4 → 12** by holding overlay textures as an array instead of four numbered fields.

`TerminalUiMaterial` previously held `overlay0..3` as individual `#[texture]` fields (a hard cap of 4). This replaces `#[derive(AsBindGroup)]` with a hand-written `impl AsBindGroup` that holds `overlays: [Option<Handle<Image>>; OVERLAY_SLOTS]` and binds N individual textures (bindings `6..6+N`) under one shared sampler (binding 5). `OVERLAY_SLOTS` is the single knob.

## Why not `binding_array` / bindless

Investigated and ruled out: Bevy's `binding_array` is its bindless *slab* system, which the `UiMaterial` pipeline does not thread (no `BINDLESS` shader-def, no per-draw index table — `bevy_ui_render` `ui_material_pipeline.rs` emits zero shader-defs and a `[view, ui]` layout), and the high-level `OwnedBindingResource` has no `TextureViewArray` variant. Using it would require forking `bevy_ui_render` or moving the terminal quad off `UiMaterial` (losing `ComputedNode`/`MaterialNode` UI-layout integration). A fixed-capacity per-slot array stays inside `UiMaterial`.

## Verification

- Workspace `cargo build` clean (no warnings); `cargo test` green.
- GPU limits fine: 13 sampled textures + 2 samplers (within the 16/16 floor; the app runs on adapter limits via Bevy's default `Functionality` priority, so 12 is safe with headroom).
- Shared-sampler safety confirmed: bevy_cef's overlay `GpuImage` uses `DefaultImageSampler`, identical to `FallbackImage.d2.sampler` — no filtering change vs the old per-overlay samplers.
- Reviewed via 4 per-task reviews + a whole-branch review + a max-effort `/code-review` pass (0 correctness findings; 3 cleanups applied: per-frame Vec capacity, import hygiene, drift-test hardening).

## Still TODO (manual — needs a display)

- [ ] GUI smoke test: mount **>4 simultaneous webviews** in one pane; confirm they render in their rects, the inactive-pane dim/desaturate applies to overlays, and the compositing order (pane bg → overlay → cell bg → glyph) holds. A runtime bind-group/WGSL mismatch only surfaces on the GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
