### PR TITLE
fix(webview): display webviews in Default mode (single-PTY, no tmux)

### DIFF
--- a/crates/ozma_webview/src/control_plane.rs
+++ b/crates/ozma_webview/src/control_plane.rs
@@ -329,6 +329,36 @@ pub struct ControlPlaneHandle {
     pub tokens: TokenRegistry,
 }
 
+impl ControlPlaneHandle {
+    /// Returns the `OZMA_SOCK` / `OZMA_TOKEN` env pairs to inject into `surface`'s
+    /// PTY so a program running in it can reach the control plane and resolve to
+    /// `surface`. Pure: derives the token but does NOT register it — call
+    /// [`bind_surface`](Self::bind_surface) after the PTY actually spawns, so a
+    /// failed spawn leaks no binding.
+    pub fn surface_env(&self, surface: Entity) -> [(String, String); 2] {
+        [
+            (
+                "OZMA_SOCK".to_string(),
+                self.sock_path.to_string_lossy().into_owned(),
+            ),
+            ("OZMA_TOKEN".to_string(), surface_token(surface)),
+        ]
+    }
+
+    /// Registers `token -> surface` so a connecting program's `$OZMA_TOKEN`
+    /// resolves to `surface`. Call only after the surface's PTY has spawned.
+    pub fn bind_surface(&self, surface: Entity) {
+        self.tokens.insert(surface_token(surface), surface);
+    }
+}
+
+/// Derives the per-surface token (`ozma:<entity-bits>`) from a surface entity.
+/// Single-sources the format so [`ControlPlaneHandle::surface_env`] and
+/// [`ControlPlaneHandle::bind_surface`] always agree.
+fn surface_token(surface: Entity) -> String {
+    format!("ozma:{}", surface.to_bits())
+}
+
 /// Wires the control-plane listener, the event-apply system, and the teardown
 /// observer. Takes the `WebviewAssetRegistry` shared with the `ozma` scheme handler.
 pub(crate) struct ControlPlanePlugin {
@@ -904,6 +934,37 @@ mod token_tests {
         assert_eq!(reg.resolve("%1"), None);
         assert_eq!(reg.resolve("tok"), None);
         assert_eq!(reg.resolve("%2"), Some(Entity::from_bits(8)));
+    }
+
+    #[test]
+    fn surface_env_is_pure_and_bind_surface_registers() {
+        let handle = ControlPlaneHandle {
+            sock_path: PathBuf::from("/tmp/ctl.sock"),
+            tokens: TokenRegistry::default(),
+        };
+        let surface = Entity::from_bits(42);
+        let token = format!("ozma:{}", surface.to_bits());
+
+        let env = handle.surface_env(surface);
+        assert_eq!(
+            env,
+            [
+                ("OZMA_SOCK".to_string(), "/tmp/ctl.sock".to_string()),
+                ("OZMA_TOKEN".to_string(), token.clone()),
+            ]
+        );
+        assert_eq!(
+            handle.tokens.resolve(&token),
+            None,
+            "surface_env must not register the token (pure read)"
+        );
+
+        handle.bind_surface(surface);
+        assert_eq!(
+            handle.tokens.resolve(&token),
+            Some(surface),
+            "bind_surface registers token -> surface"
+        );
     }
 }
 

--- a/src/app_mode.rs
+++ b/src/app_mode.rs
@@ -4,6 +4,7 @@ use crate::ui::UiRoot;
 use bevy::prelude::*;
 use ozma_terminal::{KeyboardFocused, OzmaSpawnOptions, OzmaTerminalBundle, OzmaTerminalConfig};
 use ozma_tty_engine::ControlModeWatch;
+use ozma_webview::ControlPlaneHandle;
 
 /// Application mode. `Default` is the default (single PTY, no tmux).
 /// `Tmux` activates the tmux multiplexer backend.
@@ -55,6 +56,7 @@ fn ensure_default_mode_ui(
     mut exit: MessageWriter<AppExit>,
     ui_root: Query<Entity, With<UiRoot>>,
     config: Res<OzmaTerminalConfig>,
+    control: Option<Res<ControlPlaneHandle>>,
 ) {
     let Ok(ui_root) = ui_root.single() else {
         return;
@@ -76,20 +78,33 @@ fn ensure_default_mode_ui(
             ChildOf(ui_root),
         ))
         .id();
+    let shell = commands.spawn_empty().id();
+    let env = control
+        .as_deref()
+        .map(|c| c.surface_env(shell).to_vec())
+        .unwrap_or_default();
     match OzmaTerminalBundle::spawn(OzmaSpawnOptions {
         shell: config.shell.clone(),
+        env,
         ..default()
     }) {
         Ok(bundle) => {
-            commands.spawn((
+            commands.entity(shell).insert((
                 bundle,
                 KeyboardFocused,
                 ControlModeWatch::default(),
                 DefaultShell,
                 ChildOf(mode_ui),
             ));
+            // NOTE: bind the token only after a successful spawn. gc keys on
+            // RemovedComponents<OzmaTerminal> (never added on the error path),
+            // so a pre-spawn bind would leak the token if the spawn failed.
+            if let Some(c) = control.as_deref() {
+                c.bind_surface(shell);
+            }
         }
         Err(e) => {
+            commands.entity(shell).despawn();
             tracing::error!(?e, "failed to spawn ozma terminal");
             exit.write(AppExit::Success);
         }
@@ -100,6 +115,8 @@ fn ensure_default_mode_ui(
 mod tests {
     use super::*;
     use bevy::state::app::StatesPlugin;
+    use ozma_webview::TokenRegistry;
+    use std::path::PathBuf;
 
     fn build_app(initial_mode: AppMode) -> App {
         let mut app = App::new();
@@ -162,5 +179,30 @@ mod tests {
             .iter(world)
             .count();
         assert_eq!(count, 1, "exactly one DefaultShell after round-trip");
+    }
+
+    #[test]
+    fn default_shell_registers_a_resolvable_webview_token() {
+        let mut app = build_app(AppMode::Default);
+        let tokens = TokenRegistry::default();
+        app.world_mut().insert_resource(ControlPlaneHandle {
+            sock_path: PathBuf::from("/tmp/ctl.sock"),
+            tokens: tokens.clone(),
+        });
+        app.update();
+
+        let shell = {
+            let world = app.world_mut();
+            world
+                .query_filtered::<Entity, With<DefaultShell>>()
+                .single(world)
+                .expect("DefaultShell spawned")
+        };
+        let token = format!("ozma:{}", shell.to_bits());
+        assert_eq!(
+            tokens.resolve(&token),
+            Some(shell),
+            "the default shell's $OZMA_TOKEN must resolve to its own surface entity"
+        );
     }
 }


### PR DESCRIPTION
## Problem

In-process webviews displayed in **tmux mode** (`AppMode::Tmux`) but not in **Default mode** (`AppMode::Default` — a single PTY, no tmux). A program running in the Default-mode shell could never mount a webview.

The render pipeline (OSC 5379 mount → overlay projection → material) is already mode-agnostic. The real gap is the control-plane handshake: a webview mount requires a prior control-socket registration (`resolve_mount` drops unregistered views), and `$OZMA_SOCK` + `$OZMA_TOKEN` injection plus the token→surface binding were wired **only for tmux panes** — never for the default shell.

## Solution

Wire the same per-surface handshake the tmux path already performs, for the Default-mode shell. Symmetric to the tmux path; the render pipeline and the tmux path are untouched.

**Affected: the webview crate (`crates/ozma_webview`) and the binary's Default-mode spawn (`src/app_mode.rs`).**

- **`crates/ozma_webview/src/control_plane.rs`** — add `ControlPlaneHandle::surface_env` (pure; returns the `OZMA_SOCK` / `OZMA_TOKEN` env pairs) and `bind_surface` (registers `ozma:<entity-bits>` → surface). The token is single-sourced by a private `surface_token`.
- **`src/app_mode.rs`** — `ensure_default_mode_ui` now reserves the shell entity, injects the env into the PTY via `OzmaSpawnOptions.env`, and binds the token **after a successful spawn** (so a failed spawn leaks no binding). It is a graceful no-op when the control plane is absent.

The `ratatui-ozma` SDK already supports this path (it reads `$OZMA_TOKEN` for the direct-PTY backend), so only the host side was missing.

### Testing

- Unit test: `surface_env` purity + `bind_surface` registration.
- Integration test: the default shell's injected `$OZMA_TOKEN` resolves to its own surface entity (forks a real `/bin/sh`).
- `cargo test -p ozma_webview` → **136 passed**; `cargo test -p ozmux` → **377 passed**; 0 failed. No regressions.

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
