### PR TITLE
feat(ozmd): local-file hyperlink navigation

### DIFF
--- a/apps/ozmd/package.json
+++ b/apps/ozmd/package.json
@@ -16,6 +16,7 @@
     "katex": "catalog:",
     "mermaid": "catalog:",
     "dompurify": "catalog:",
+    "github-slugger": "catalog:",
     "highlight.js": "catalog:"
   },
   "devDependencies": {

--- a/apps/ozmd/src/app.rs
+++ b/apps/ozmd/src/app.rs
@@ -169,6 +169,15 @@ impl App {
         }
     }
 
+    /// Clears search state when the viewed document changes (matches/bar are stale).
+    pub(crate) fn clear_search_state(&mut self) {
+        self.search_active = false;
+        self.search_query.clear();
+        if self.mode == Mode::Search {
+            self.mode = Mode::Normal;
+        }
+    }
+
     fn resolve_chord(&mut self, c: char) -> Vec<Cmd> {
         match c {
             'g' => vec![Cmd::Scroll(ScrollAction::Top)],

--- a/apps/ozmd/src/app.rs
+++ b/apps/ozmd/src/app.rs
@@ -20,6 +20,8 @@ pub(crate) enum Cmd {
     ClearSearch,
     /// Re-read the file from disk and push new content.
     Reload,
+    /// Pop the navigation back stack.
+    Back,
     /// Exit the app.
     Quit,
 }
@@ -97,6 +99,7 @@ impl App {
             }
             Action::Quit => vec![Cmd::Quit],
             Action::Reload => vec![Cmd::Reload],
+            Action::Back => vec![Cmd::Back],
             Action::ScrollLineDown => vec![Cmd::Scroll(ScrollAction::Down)],
             Action::ScrollLineUp => vec![Cmd::Scroll(ScrollAction::Up)],
             Action::ScrollHalfDown => vec![Cmd::Scroll(ScrollAction::HalfDown)],
@@ -355,5 +358,11 @@ mod tests {
         app.set_current_heading_index(Some(0));
         app.on_action(Action::Prefix('['));
         assert_eq!(app.on_action(Action::Prefix('[')), vec![]);
+    }
+
+    #[test]
+    fn back_action_emits_back_cmd() {
+        let mut app = App::default();
+        assert_eq!(app.on_action(Action::Back), vec![Cmd::Back]);
     }
 }

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -42,14 +42,7 @@ impl Document {
 /// # Errors
 /// Returns an error if the path does not exist or is not a regular file.
 pub(crate) fn resolve_path(arg: &str) -> io::Result<PathBuf> {
-    let path = fs::canonicalize(arg)?;
-    if !path.is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "not a regular file",
-        ));
-    }
-    Ok(path)
+    require_regular_file(arg)
 }
 
 /// Reads and parses the Markdown file at `path` into a [`Document`].
@@ -65,7 +58,11 @@ pub(crate) fn load(path: &Path) -> io::Result<Document> {
 /// # Errors
 /// Returns an error if the path does not exist or is not a regular file.
 pub(crate) fn resolve_link(base_dir: &Path, target: &str) -> io::Result<PathBuf> {
-    let path = fs::canonicalize(base_dir.join(target))?;
+    require_regular_file(base_dir.join(target))
+}
+
+fn require_regular_file(path: impl AsRef<Path>) -> io::Result<PathBuf> {
+    let path = fs::canonicalize(path)?;
     if !path.is_file() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -153,7 +153,10 @@ mod tests {
         let from_parent = resolve_link(&sub, "../sib.md").unwrap();
         assert_eq!(from_parent, fs::canonicalize(&sibling).unwrap());
         let abs = sibling.to_str().unwrap();
-        assert_eq!(resolve_link(&sub, abs).unwrap(), fs::canonicalize(&sibling).unwrap());
+        assert_eq!(
+            resolve_link(&sub, abs).unwrap(),
+            fs::canonicalize(&sibling).unwrap()
+        );
     }
 
     #[test]

--- a/apps/ozmd/src/document.rs
+++ b/apps/ozmd/src/document.rs
@@ -59,6 +59,30 @@ pub(crate) fn load(path: &Path) -> io::Result<Document> {
     Ok(Document::from_source(text, base_dir))
 }
 
+/// Resolves a link `target` (relative or absolute) against `base_dir` to an
+/// absolute, canonical path, requiring it to be an existing regular file.
+///
+/// # Errors
+/// Returns an error if the path does not exist or is not a regular file.
+pub(crate) fn resolve_link(base_dir: &Path, target: &str) -> io::Result<PathBuf> {
+    let path = fs::canonicalize(base_dir.join(target))?;
+    if !path.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "not a regular file",
+        ));
+    }
+    Ok(path)
+}
+
+/// Whether `path` has a Markdown extension (`.md` or `.markdown`, ASCII
+/// case-insensitive).
+pub(crate) fn is_markdown(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+}
+
 /// Reads the change fingerprint (length + mtime) for `path`.
 pub(crate) fn fingerprint(path: &Path) -> io::Result<Fingerprint> {
     let meta = fs::metadata(path)?;
@@ -108,5 +132,43 @@ mod tests {
         fs::write(&path, "a much longer body than before").unwrap();
         let fp2 = fingerprint(&path).unwrap();
         assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn resolve_link_resolves_relative_against_base_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("child.md");
+        fs::write(&target, "x").unwrap();
+        let got = resolve_link(dir.path(), "child.md").unwrap();
+        assert_eq!(got, fs::canonicalize(&target).unwrap());
+    }
+
+    #[test]
+    fn resolve_link_handles_parent_and_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        let sibling = dir.path().join("sib.md");
+        fs::write(&sibling, "x").unwrap();
+        let from_parent = resolve_link(&sub, "../sib.md").unwrap();
+        assert_eq!(from_parent, fs::canonicalize(&sibling).unwrap());
+        let abs = sibling.to_str().unwrap();
+        assert_eq!(resolve_link(&sub, abs).unwrap(), fs::canonicalize(&sibling).unwrap());
+    }
+
+    #[test]
+    fn resolve_link_rejects_missing_and_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve_link(dir.path(), "nope.md").is_err());
+        assert!(resolve_link(dir.path(), ".").is_err());
+    }
+
+    #[test]
+    fn is_markdown_matches_extensions_case_insensitively() {
+        assert!(is_markdown(Path::new("a.md")));
+        assert!(is_markdown(Path::new("a.MARKDOWN")));
+        assert!(is_markdown(Path::new("/x/y.Md")));
+        assert!(!is_markdown(Path::new("a.txt")));
+        assert!(!is_markdown(Path::new("README")));
     }
 }

--- a/apps/ozmd/src/keymap.rs
+++ b/apps/ozmd/src/keymap.rs
@@ -28,6 +28,8 @@ pub(crate) enum Action {
     ScrollPageDown,
     ScrollPageUp,
     GoBottom,
+    /// Pop the navigation back stack.
+    Back,
     /// First key of a two-key chord (`g`, `]`, `[`).
     Prefix(char),
     ToggleOutline,
@@ -77,9 +79,11 @@ fn map_normal(ctrl: bool, code: KeyCode) -> Action {
         KeyCode::Char('u') if ctrl => Action::ScrollHalfUp,
         KeyCode::Char('f') if ctrl => Action::ScrollPageDown,
         KeyCode::Char('b') if ctrl => Action::ScrollPageUp,
+        KeyCode::Char('o') if ctrl => Action::Back,
         _ if ctrl => Action::Ignore,
         KeyCode::Char('q') => Action::Quit,
         KeyCode::Char('r') => Action::Reload,
+        KeyCode::Backspace => Action::Back,
         KeyCode::Char('j') | KeyCode::Down => Action::ScrollLineDown,
         KeyCode::Char('k') | KeyCode::Up => Action::ScrollLineUp,
         KeyCode::Char(' ') | KeyCode::PageDown => Action::ScrollPageDown,
@@ -178,6 +182,23 @@ mod tests {
                 KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
             ),
             Action::Escape
+        );
+    }
+
+    #[test]
+    fn normal_backspace_and_ctrl_o_go_back() {
+        assert_eq!(
+            map(Mode::Normal, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            Action::Back
+        );
+        assert_eq!(map(Mode::Normal, ctrl('o')), Action::Back);
+    }
+
+    #[test]
+    fn search_backspace_still_edits_query() {
+        assert_eq!(
+            map(Mode::Search, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            Action::SearchBackspace
         );
     }
 }

--- a/apps/ozmd/src/keymap.rs
+++ b/apps/ozmd/src/keymap.rs
@@ -188,7 +188,10 @@ mod tests {
     #[test]
     fn normal_backspace_and_ctrl_o_go_back() {
         assert_eq!(
-            map(Mode::Normal, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            map(
+                Mode::Normal,
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)
+            ),
             Action::Back
         );
         assert_eq!(map(Mode::Normal, ctrl('o')), Action::Back);
@@ -197,7 +200,10 @@ mod tests {
     #[test]
     fn search_backspace_still_edits_query() {
         assert_eq!(
-            map(Mode::Search, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            map(
+                Mode::Search,
+                KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)
+            ),
             Action::SearchBackspace
         );
     }

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -149,6 +149,7 @@ fn event_loop(
                     Cmd::Reload => {
                         apply_reload(&mut state, &mut live, &mut last_fp, view, shared, path)?;
                     }
+                    Cmd::Back => {}
                     Cmd::Scroll(action) => {
                         let _ = view.emit("scroll", &Scroll { action });
                     }

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -10,6 +10,7 @@ mod ui;
 mod watcher;
 
 use crate::app::{App, Cmd};
+use crate::document::Document;
 use crate::protocol::{
     Content, NavigateRequest, OpenExternal, OpenPath, Scroll, ScrollState, ScrollTo, Search,
     SearchCount, SearchNav,
@@ -47,6 +48,7 @@ struct Session {
     live: LiveStatus,
     latest_ratio: f64,
     flash: Option<String>,
+    search_status: Option<SearchCount>,
 }
 
 impl Session {
@@ -63,6 +65,7 @@ impl Session {
             live: LiveStatus::Watching,
             latest_ratio: 0.0,
             flash: None,
+            search_status: None,
         }
     }
 
@@ -70,14 +73,18 @@ impl Session {
         (self.latest_ratio * 100.0).round() as u16
     }
 
+    fn base_dir(&self) -> &Path {
+        self.current_path.parent().unwrap_or_else(|| Path::new("."))
+    }
+
     fn navigate(
         &mut self,
         request: NavigateRequest,
-        shared: &Arc<Mutex<document::Document>>,
+        shared: &Arc<Mutex<Document>>,
         view: &WebviewHandle,
         reload_tx: &mpsc::Sender<()>,
     ) {
-        let base = self.current_path.parent().unwrap_or_else(|| Path::new("."));
+        let base = self.base_dir();
         match document::resolve_link(base, &request.path) {
             Ok(target) if document::is_markdown(&target) => {
                 let previous = HistoryEntry {
@@ -97,19 +104,21 @@ impl Session {
 
     fn back(
         &mut self,
-        shared: &Arc<Mutex<document::Document>>,
+        shared: &Arc<Mutex<Document>>,
         view: &WebviewHandle,
         reload_tx: &mpsc::Sender<()>,
     ) {
         match self.history.pop() {
             Some(entry) => {
-                let _ = self.load_and_show(
+                if !self.load_and_show(
                     &entry.path,
                     ScrollTo::Ratio { ratio: entry.ratio },
                     shared,
                     view,
                     reload_tx,
-                );
+                ) {
+                    self.history.push(entry);
+                }
             }
             None => self.flash = Some("no previous page".to_owned()),
         }
@@ -119,7 +128,7 @@ impl Session {
         &mut self,
         target: &Path,
         scroll_to: ScrollTo,
-        shared: &Arc<Mutex<document::Document>>,
+        shared: &Arc<Mutex<Document>>,
         view: &WebviewHandle,
         reload_tx: &mpsc::Sender<()>,
     ) -> bool {
@@ -142,6 +151,8 @@ impl Session {
         self.last_fp = document::fingerprint(target).ok();
         self.live = LiveStatus::Watching;
         self.flash = None;
+        self.search_status = None;
+        self.state.clear_search_state();
         self.state.set_outline(doc.outline.clone());
         let content = content_for(&doc, scroll_to);
         if let Ok(mut guard) = shared.lock() {
@@ -151,7 +162,7 @@ impl Session {
         true
     }
 
-    fn reload(&mut self, shared: &Arc<Mutex<document::Document>>, view: &WebviewHandle) {
+    fn reload(&mut self, shared: &Arc<Mutex<Document>>, view: &WebviewHandle) {
         let fp = match document::fingerprint(&self.current_path) {
             Ok(fp) => fp,
             Err(_) => {
@@ -174,6 +185,7 @@ impl Session {
         // permanently suppress a later reload with the same fingerprint.
         self.last_fp = Some(fp);
         self.live = LiveStatus::Watching;
+        self.flash = None;
         self.state.set_outline(doc.outline.clone());
         let content = content_for(&doc, ScrollTo::Preserve);
         if let Ok(mut guard) = shared.lock() {
@@ -258,7 +270,7 @@ fn run() -> anyhow::Result<()> {
 fn register_view(
     ozma: &Ozma,
     asset_dir: &tempfile::TempDir,
-    shared: Arc<Mutex<document::Document>>,
+    shared: Arc<Mutex<Document>>,
 ) -> anyhow::Result<WebviewHandle> {
     let ready_doc = Arc::clone(&shared);
     let view = ozma.register(
@@ -291,7 +303,7 @@ fn event_loop(
     current_watcher: FileWatcher,
     ozma: &Ozma,
     view: &WebviewHandle,
-    shared: &Arc<Mutex<document::Document>>,
+    shared: &Arc<Mutex<Document>>,
     start_path: PathBuf,
     reload_tx: mpsc::Sender<()>,
     reload_rx: &mpsc::Receiver<()>,
@@ -303,11 +315,9 @@ fn event_loop(
     session
         .state
         .set_outline(shared.lock().unwrap().outline.clone());
-    let mut search_status: Option<SearchCount> = None;
-
     loop {
         for c in view.read_events::<SearchCount>() {
-            search_status = Some(c);
+            session.search_status = Some(c);
         }
         for s in view.read_events::<ScrollState>() {
             session.latest_ratio = s.ratio.clamp(0.0, 1.0);
@@ -324,10 +334,7 @@ fn event_loop(
             }
         }
         for op in view.read_events::<OpenPath>() {
-            let base = session
-                .current_path
-                .parent()
-                .unwrap_or_else(|| Path::new("."));
+            let base = session.base_dir();
             match document::resolve_link(base, &op.path) {
                 Ok(target) => spawn_open(&target),
                 Err(_) => session.flash = Some(format!("cannot open {}", op.path)),
@@ -352,7 +359,7 @@ fn event_loop(
                 &session.file_name,
                 session.live,
                 percent,
-                search_status,
+                session.search_status,
                 session.flash.as_deref(),
             );
         })?;
@@ -380,7 +387,7 @@ fn event_loop(
                         let _ = view.emit("searchNav", &SearchNav { dir });
                     }
                     Cmd::ClearSearch => {
-                        search_status = None;
+                        session.search_status = None;
                         let _ = view.emit("clearSearch", &());
                     }
                 }
@@ -389,7 +396,7 @@ fn event_loop(
     }
 }
 
-fn content_for(doc: &document::Document, scroll_to: ScrollTo) -> Content {
+fn content_for(doc: &Document, scroll_to: ScrollTo) -> Content {
     Content {
         markdown: doc.text.clone(),
         base_dir: doc.base_dir.display().to_string(),

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -68,6 +68,85 @@ impl Session {
         (self.latest_ratio.clamp(0.0, 1.0) * 100.0).round() as u16
     }
 
+    fn navigate(
+        &mut self,
+        request: NavigateRequest,
+        shared: &Arc<Mutex<document::Document>>,
+        view: &WebviewHandle,
+        reload_tx: &mpsc::Sender<()>,
+    ) {
+        let base = self.current_path.parent().unwrap_or_else(|| Path::new("."));
+        match document::resolve_link(base, &request.path) {
+            Ok(target) if document::is_markdown(&target) => {
+                self.history.push(HistoryEntry {
+                    path: self.current_path.clone(),
+                    ratio: self.latest_ratio,
+                });
+                let scroll = request
+                    .fragment
+                    .map_or(ScrollTo::Top, |slug| ScrollTo::Slug { slug });
+                self.load_and_show(&target, scroll, shared, view, reload_tx);
+            }
+            _ => self.flash = Some(format!("cannot open {}", request.path)),
+        }
+    }
+
+    fn back(
+        &mut self,
+        shared: &Arc<Mutex<document::Document>>,
+        view: &WebviewHandle,
+        reload_tx: &mpsc::Sender<()>,
+    ) {
+        match self.history.pop() {
+            Some(entry) => {
+                let path = entry.path.clone();
+                self.load_and_show(
+                    &path,
+                    ScrollTo::Ratio { ratio: entry.ratio },
+                    shared,
+                    view,
+                    reload_tx,
+                );
+            }
+            None => self.flash = Some("no previous page".to_owned()),
+        }
+    }
+
+    fn load_and_show(
+        &mut self,
+        target: &Path,
+        scroll_to: ScrollTo,
+        shared: &Arc<Mutex<document::Document>>,
+        view: &WebviewHandle,
+        reload_tx: &mpsc::Sender<()>,
+    ) {
+        let doc = match document::load(target) {
+            Ok(d) => d,
+            Err(_) => {
+                self.flash = Some(format!("cannot open {}", target.display()));
+                return;
+            }
+        };
+        match watcher::watch(target, reload_tx.clone()) {
+            Ok(w) => self.current_watcher = w,
+            Err(_) => {
+                self.flash = Some("watch failed".to_owned());
+                return;
+            }
+        }
+        self.current_path = target.to_path_buf();
+        self.file_name = file_name_of(target);
+        self.last_fp = document::fingerprint(target).ok();
+        self.live = LiveStatus::Watching;
+        self.flash = None;
+        self.state.set_outline(doc.outline.clone());
+        let content = content_for(&doc, scroll_to);
+        if let Ok(mut guard) = shared.lock() {
+            *guard = doc;
+        }
+        let _ = view.emit("content", &content);
+    }
+
     fn reload(&mut self, shared: &Arc<Mutex<document::Document>>, view: &WebviewHandle) {
         let fp = match document::fingerprint(&self.current_path) {
             Ok(fp) => fp,
@@ -104,6 +183,24 @@ fn file_name_of(path: &Path) -> String {
     path.file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default()
+}
+
+/// Whether `url` carries one of the schemes safe to hand to the OS opener.
+fn allowed_external_url(url: &str) -> bool {
+    matches!(
+        url.split_once(':'),
+        Some((scheme, _))
+            if scheme.eq_ignore_ascii_case("http")
+                || scheme.eq_ignore_ascii_case("https")
+                || scheme.eq_ignore_ascii_case("mailto")
+                || scheme.eq_ignore_ascii_case("tel")
+    )
+}
+
+/// Opens `target` (a URL or absolute path) with the macOS default handler.
+/// No shell is involved, so `target` is not interpreted.
+fn spawn_open(target: &str) {
+    let _ = std::process::Command::new("open").arg(target).spawn();
 }
 
 fn main() {
@@ -198,7 +295,6 @@ fn event_loop(
         .state
         .set_outline(shared.lock().unwrap().outline.clone());
     let mut search_status: Option<SearchCount> = None;
-    let _ = &reload_tx;
 
     loop {
         for c in view.read_events::<SearchCount>() {
@@ -210,9 +306,24 @@ fn event_loop(
                 .state
                 .set_current_heading_index(s.current_heading_index);
         }
-        let _ = view.read_events::<NavigateRequest>();
-        let _ = view.read_events::<OpenExternal>();
-        let _ = view.read_events::<OpenPath>();
+        for request in view.read_events::<NavigateRequest>() {
+            session.navigate(request, shared, view, &reload_tx);
+        }
+        for ext in view.read_events::<OpenExternal>() {
+            if allowed_external_url(&ext.url) {
+                spawn_open(&ext.url);
+            }
+        }
+        for op in view.read_events::<OpenPath>() {
+            let base = session
+                .current_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."));
+            match document::resolve_link(base, &op.path) {
+                Ok(target) => spawn_open(&target.to_string_lossy()),
+                Err(_) => session.flash = Some(format!("cannot open {}", op.path)),
+            }
+        }
 
         let mut reload = false;
         while reload_rx.try_recv().is_ok() {
@@ -245,7 +356,7 @@ fn event_loop(
                 match cmd {
                     Cmd::Quit => return Ok(()),
                     Cmd::Reload => session.reload(shared, view),
-                    Cmd::Back => {}
+                    Cmd::Back => session.back(shared, view, &reload_tx),
                     Cmd::Scroll(action) => {
                         let _ = view.emit("scroll", &Scroll { action });
                     }
@@ -284,4 +395,21 @@ fn install_panic_hook() {
         let _ = execute!(stdout(), LeaveAlternateScreen);
         prev(info);
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowed_external_url_accepts_web_schemes_only() {
+        assert!(allowed_external_url("https://example.com"));
+        assert!(allowed_external_url("http://x"));
+        assert!(allowed_external_url("mailto:a@b.com"));
+        assert!(allowed_external_url("tel:+1"));
+        assert!(!allowed_external_url("javascript:alert(1)"));
+        assert!(!allowed_external_url("data:text/html,x"));
+        assert!(!allowed_external_url("file:///etc/passwd"));
+        assert!(!allowed_external_url("not a url"));
+    }
 }

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -10,7 +10,7 @@ mod ui;
 mod watcher;
 
 use crate::app::{App, Cmd};
-use crate::protocol::{Content, Scroll, ScrollState, Search, SearchCount, SearchNav};
+use crate::protocol::{Content, Scroll, ScrollState, ScrollTo, Search, SearchCount, SearchNav};
 use crate::ui::LiveStatus;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -218,6 +218,7 @@ fn content_of(doc: &document::Document) -> Content {
     Content {
         markdown: doc.text.clone(),
         base_dir: doc.base_dir.display().to_string(),
+        scroll_to: ScrollTo::Preserve,
     }
 }
 

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -10,21 +10,101 @@ mod ui;
 mod watcher;
 
 use crate::app::{App, Cmd};
-use crate::protocol::{Content, Scroll, ScrollState, ScrollTo, Search, SearchCount, SearchNav};
+use crate::protocol::{
+    Content, NavigateRequest, OpenExternal, OpenPath, Scroll, ScrollState, ScrollTo, Search,
+    SearchCount, SearchNav,
+};
 use crate::ui::LiveStatus;
+use crate::watcher::FileWatcher;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use ratatui::crossterm::event::{self, Event};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use ratatui_ozma::{Ozma, OzmaBackend, OzmaError, RpcError, Webview, WebviewHandle};
+use ratatui_ozma::{KeyChord, Ozma, OzmaBackend, OzmaError, RpcError, Webview, WebviewHandle};
 use std::io::stdout;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+struct HistoryEntry {
+    path: PathBuf,
+    ratio: f64,
+}
+
+struct Session {
+    state: App,
+    current_path: PathBuf,
+    history: Vec<HistoryEntry>,
+    current_watcher: FileWatcher,
+    file_name: String,
+    last_fp: Option<document::Fingerprint>,
+    live: LiveStatus,
+    latest_ratio: f64,
+    flash: Option<String>,
+}
+
+impl Session {
+    fn new(current_path: PathBuf, current_watcher: FileWatcher) -> Self {
+        let last_fp = document::fingerprint(&current_path).ok();
+        let file_name = file_name_of(&current_path);
+        Self {
+            state: App::default(),
+            current_path,
+            history: Vec::new(),
+            current_watcher,
+            file_name,
+            last_fp,
+            live: LiveStatus::Watching,
+            latest_ratio: 0.0,
+            flash: None,
+        }
+    }
+
+    fn scroll_percent(&self) -> u16 {
+        (self.latest_ratio.clamp(0.0, 1.0) * 100.0).round() as u16
+    }
+
+    fn reload(&mut self, shared: &Arc<Mutex<document::Document>>, view: &WebviewHandle) {
+        let fp = match document::fingerprint(&self.current_path) {
+            Ok(fp) => fp,
+            Err(_) => {
+                self.live = LiveStatus::Missing;
+                return;
+            }
+        };
+        if Some(fp) == self.last_fp {
+            return;
+        }
+        let doc = match document::load(&self.current_path) {
+            Ok(d) => d,
+            Err(_) => {
+                self.live = LiveStatus::Missing;
+                return;
+            }
+        };
+        // NOTE: record the fingerprint only after a successful load — setting it
+        // before would let a transient read failure poison the skip-check and
+        // permanently suppress a later reload with the same fingerprint.
+        self.last_fp = Some(fp);
+        self.live = LiveStatus::Watching;
+        self.state.set_outline(doc.outline.clone());
+        let content = content_for(&doc, ScrollTo::Preserve);
+        if let Ok(mut guard) = shared.lock() {
+            *guard = doc;
+        }
+        let _ = view.emit("content", &content);
+    }
+}
+
+fn file_name_of(path: &Path) -> String {
+    path.file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
 
 fn main() {
     if let Err(e) = run() {
@@ -53,7 +133,7 @@ fn run() -> anyhow::Result<()> {
     let view = register_view(&ozma, &asset_dir, Arc::clone(&shared))?;
 
     let (reload_tx, reload_rx) = mpsc::channel::<()>();
-    let _watcher = watcher::watch(&path, reload_tx)?;
+    let watcher = watcher::watch(&path, reload_tx.clone())?;
 
     enable_raw_mode()?;
     if let Err(e) = execute!(stdout(), EnterAlternateScreen) {
@@ -62,7 +142,7 @@ fn run() -> anyhow::Result<()> {
     }
     install_panic_hook();
 
-    let result = event_loop(&ozma, &view, &shared, &path, &reload_rx);
+    let result = event_loop(watcher, &ozma, &view, &shared, path, reload_tx, &reload_rx);
 
     let _ = disable_raw_mode();
     let _ = execute!(stdout(), LeaveAlternateScreen);
@@ -78,77 +158,93 @@ fn register_view(
     let view = ozma.register(
         Webview::dir(asset_dir.path(), "index.html")
             .interactive(true)
+            .forward_keys([
+                KeyChord {
+                    mods: KeyModifiers::NONE,
+                    code: KeyCode::Backspace,
+                },
+                KeyChord {
+                    mods: KeyModifiers::CONTROL,
+                    code: KeyCode::Char('o'),
+                },
+            ])
             .on("ready", move |(): ()| -> Result<Content, RpcError> {
                 let doc = ready_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
-                Ok(content_of(&doc))
+                Ok(content_for(&doc, ScrollTo::Preserve))
             })
             .add_event::<SearchCount>("searchCount")
-            .add_event::<ScrollState>("scrollState"),
+            .add_event::<ScrollState>("scrollState")
+            .add_event::<NavigateRequest>("navigate")
+            .add_event::<OpenExternal>("openExternal")
+            .add_event::<OpenPath>("openPath"),
     )?;
     Ok(view)
 }
 
 fn event_loop(
+    current_watcher: FileWatcher,
     ozma: &Ozma,
     view: &WebviewHandle,
     shared: &Arc<Mutex<document::Document>>,
-    path: &Path,
+    start_path: PathBuf,
+    reload_tx: mpsc::Sender<()>,
     reload_rx: &mpsc::Receiver<()>,
 ) -> anyhow::Result<()> {
     let backend = OzmaBackend::new(CrosstermBackend::new(stdout()), ozma);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut state = App::default();
-    state.set_outline(shared.lock().unwrap().outline.clone());
-    let mut live = LiveStatus::Watching;
-    let mut scroll_percent: u16 = 0;
-    let mut last_fp = document::fingerprint(path).ok();
+    let mut session = Session::new(start_path, current_watcher);
+    session
+        .state
+        .set_outline(shared.lock().unwrap().outline.clone());
     let mut search_status: Option<SearchCount> = None;
-    let file_name = path
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
+    let _ = &reload_tx;
 
     loop {
         for c in view.read_events::<SearchCount>() {
             search_status = Some(c);
         }
         for s in view.read_events::<ScrollState>() {
-            scroll_percent = (s.ratio.clamp(0.0, 1.0) * 100.0).round() as u16;
-            state.set_current_heading_index(s.current_heading_index);
+            session.latest_ratio = s.ratio.clamp(0.0, 1.0);
+            session
+                .state
+                .set_current_heading_index(s.current_heading_index);
         }
+        let _ = view.read_events::<NavigateRequest>();
+        let _ = view.read_events::<OpenExternal>();
+        let _ = view.read_events::<OpenPath>();
 
         let mut reload = false;
         while reload_rx.try_recv().is_ok() {
             reload = true;
         }
         if reload {
-            apply_reload(&mut state, &mut live, &mut last_fp, view, shared, path)?;
+            session.reload(shared, view);
         }
 
+        let percent = session.scroll_percent();
         terminal.draw(|f| {
             ui::draw(
                 f,
                 &mut ozma.frame(),
-                &state,
+                &session.state,
                 &view.id(),
-                &file_name,
-                live,
-                scroll_percent,
+                &session.file_name,
+                session.live,
+                percent,
                 search_status,
+                session.flash.as_deref(),
             );
         })?;
 
         if event::poll(Duration::from_millis(33))?
             && let Event::Key(key) = event::read()?
         {
-            let action = keymap::map(state.mode(), key);
-            for cmd in state.on_action(action) {
+            let action = keymap::map(session.state.mode(), key);
+            for cmd in session.state.on_action(action) {
                 match cmd {
                     Cmd::Quit => return Ok(()),
-                    Cmd::Reload => {
-                        apply_reload(&mut state, &mut live, &mut last_fp, view, shared, path)?;
-                    }
+                    Cmd::Reload => session.reload(shared, view),
                     Cmd::Back => {}
                     Cmd::Scroll(action) => {
                         let _ = view.emit("scroll", &Scroll { action });
@@ -173,53 +269,11 @@ fn event_loop(
     }
 }
 
-fn apply_reload(
-    state: &mut App,
-    live: &mut LiveStatus,
-    last_fp: &mut Option<document::Fingerprint>,
-    view: &WebviewHandle,
-    shared: &Arc<Mutex<document::Document>>,
-    path: &Path,
-) -> anyhow::Result<()> {
-    let fp = match document::fingerprint(path) {
-        Ok(fp) => fp,
-        Err(_) => {
-            *live = LiveStatus::Missing;
-            return Ok(());
-        }
-    };
-    if Some(fp) == *last_fp {
-        return Ok(());
-    }
-    let doc = match document::load(path) {
-        Ok(d) => d,
-        Err(_) => {
-            *live = LiveStatus::Missing;
-            return Ok(());
-        }
-    };
-    // NOTE: record the fingerprint only after a successful load — setting it
-    // before would let a transient read failure poison the skip-check and
-    // permanently suppress a later reload with the same fingerprint.
-    *last_fp = Some(fp);
-    *live = LiveStatus::Watching;
-    state.set_outline(doc.outline.clone());
-    let content = content_of(&doc);
-    {
-        let mut guard = shared
-            .lock()
-            .map_err(|_| anyhow::anyhow!("state poisoned"))?;
-        *guard = doc;
-    }
-    let _ = view.emit("content", &content);
-    Ok(())
-}
-
-fn content_of(doc: &document::Document) -> Content {
+fn content_for(doc: &document::Document, scroll_to: ScrollTo) -> Content {
     Content {
         markdown: doc.text.clone(),
         base_dir: doc.base_dir.display().to_string(),
-        scroll_to: ScrollTo::Preserve,
+        scroll_to,
     }
 }
 

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -24,8 +24,10 @@ use ratatui::crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ratatui_ozma::{KeyChord, Ozma, OzmaBackend, OzmaError, RpcError, Webview, WebviewHandle};
+use std::ffi::OsStr;
 use std::io::stdout;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -65,7 +67,7 @@ impl Session {
     }
 
     fn scroll_percent(&self) -> u16 {
-        (self.latest_ratio.clamp(0.0, 1.0) * 100.0).round() as u16
+        (self.latest_ratio * 100.0).round() as u16
     }
 
     fn navigate(
@@ -78,14 +80,16 @@ impl Session {
         let base = self.current_path.parent().unwrap_or_else(|| Path::new("."));
         match document::resolve_link(base, &request.path) {
             Ok(target) if document::is_markdown(&target) => {
-                self.history.push(HistoryEntry {
+                let previous = HistoryEntry {
                     path: self.current_path.clone(),
                     ratio: self.latest_ratio,
-                });
+                };
                 let scroll = request
                     .fragment
                     .map_or(ScrollTo::Top, |slug| ScrollTo::Slug { slug });
-                self.load_and_show(&target, scroll, shared, view, reload_tx);
+                if self.load_and_show(&target, scroll, shared, view, reload_tx) {
+                    self.history.push(previous);
+                }
             }
             _ => self.flash = Some(format!("cannot open {}", request.path)),
         }
@@ -99,9 +103,8 @@ impl Session {
     ) {
         match self.history.pop() {
             Some(entry) => {
-                let path = entry.path.clone();
-                self.load_and_show(
-                    &path,
+                let _ = self.load_and_show(
+                    &entry.path,
                     ScrollTo::Ratio { ratio: entry.ratio },
                     shared,
                     view,
@@ -119,19 +122,19 @@ impl Session {
         shared: &Arc<Mutex<document::Document>>,
         view: &WebviewHandle,
         reload_tx: &mpsc::Sender<()>,
-    ) {
+    ) -> bool {
         let doc = match document::load(target) {
             Ok(d) => d,
             Err(_) => {
                 self.flash = Some(format!("cannot open {}", target.display()));
-                return;
+                return false;
             }
         };
         match watcher::watch(target, reload_tx.clone()) {
             Ok(w) => self.current_watcher = w,
             Err(_) => {
                 self.flash = Some("watch failed".to_owned());
-                return;
+                return false;
             }
         }
         self.current_path = target.to_path_buf();
@@ -145,6 +148,7 @@ impl Session {
             *guard = doc;
         }
         let _ = view.emit("content", &content);
+        true
     }
 
     fn reload(&mut self, shared: &Arc<Mutex<document::Document>>, view: &WebviewHandle) {
@@ -197,10 +201,15 @@ fn allowed_external_url(url: &str) -> bool {
     )
 }
 
+// NOTE: `open` launches each target with the user's own authority — the same as
+// double-clicking it in Finder. Some regular-file types auto-execute or redirect
+// (.command/.terminal/.tool run scripts; .webloc/.fileloc open an embedded URL),
+// so ozmd is for viewing TRUSTED local documents and does not sandbox link
+// targets (see the design's non-goals).
 /// Opens `target` (a URL or absolute path) with the macOS default handler.
 /// No shell is involved, so `target` is not interpreted.
-fn spawn_open(target: &str) {
-    let _ = std::process::Command::new("open").arg(target).spawn();
+fn spawn_open(target: impl AsRef<OsStr>) {
+    let _ = Command::new("open").arg(target).spawn();
 }
 
 fn main() {
@@ -320,7 +329,7 @@ fn event_loop(
                 .parent()
                 .unwrap_or_else(|| Path::new("."));
             match document::resolve_link(base, &op.path) {
-                Ok(target) => spawn_open(&target.to_string_lossy()),
+                Ok(target) => spawn_open(&target),
                 Err(_) => session.flash = Some(format!("cannot open {}", op.path)),
             }
         }

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -25,6 +25,45 @@ pub(crate) enum SearchDir {
     Prev,
 }
 
+/// A page request to navigate to a local Markdown file (`navigate` event).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NavigateRequest {
+    /// The link's raw path (relative or absolute), percent-decoded by the page.
+    pub(crate) path: String,
+    /// The link's `#fragment`, if any, to scroll to after the document loads.
+    pub(crate) fragment: Option<String>,
+}
+
+/// A page request to open an external URL in the system browser (`openExternal`).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OpenExternal {
+    /// The external URL (`http`/`https`/`mailto`/`tel`).
+    pub(crate) url: String,
+}
+
+/// A page request to open a local non-Markdown file with the OS default app
+/// (`openPath` event).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct OpenPath {
+    /// The link's raw path (relative or absolute), percent-decoded by the page.
+    pub(crate) path: String,
+}
+
+/// Where the page should scroll after applying a `content` push.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub(crate) enum ScrollTo {
+    /// Keep the current scroll anchor (initial load / file-change reload).
+    Preserve,
+    /// Jump to the top (forward navigation with no fragment).
+    Top,
+    /// Restore a 0.0..=1.0 ratio (back navigation).
+    Ratio { ratio: f64 },
+    /// Scroll to the slug-id element (forward navigation to `file.md#frag`).
+    Slug { slug: String },
+}
+
 /// The full document content pushed to the page (and returned from `ready`).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +72,8 @@ pub(crate) struct Content {
     pub(crate) markdown: String,
     /// Absolute parent directory (string form) of the source file.
     pub(crate) base_dir: String,
+    /// Where the page should scroll after rendering this content.
+    pub(crate) scroll_to: ScrollTo,
 }
 
 /// Search-result counts the page reports back (`searchCount` event).
@@ -98,10 +139,11 @@ mod tests {
         let c = Content {
             markdown: "# x".into(),
             base_dir: "/tmp".into(),
+            scroll_to: ScrollTo::Preserve,
         };
         assert_eq!(
             serde_json::to_value(&c).unwrap(),
-            json!({"markdown": "# x", "baseDir": "/tmp"})
+            json!({"markdown": "# x", "baseDir": "/tmp", "scrollTo": {"kind": "preserve"}})
         );
     }
 
@@ -123,5 +165,41 @@ mod tests {
                 current: 3
             }
         );
+    }
+
+    #[test]
+    fn scroll_to_serializes_tagged_camel_case() {
+        assert_eq!(serde_json::to_value(ScrollTo::Preserve).unwrap(), json!({"kind": "preserve"}));
+        assert_eq!(serde_json::to_value(ScrollTo::Top).unwrap(), json!({"kind": "top"}));
+        assert_eq!(
+            serde_json::to_value(ScrollTo::Ratio { ratio: 0.5 }).unwrap(),
+            json!({"kind": "ratio", "ratio": 0.5})
+        );
+        assert_eq!(
+            serde_json::to_value(ScrollTo::Slug { slug: "mounting".into() }).unwrap(),
+            json!({"kind": "slug", "slug": "mounting"})
+        );
+    }
+
+    #[test]
+    fn content_includes_scroll_to() {
+        let c = Content {
+            markdown: "# x".into(),
+            base_dir: "/tmp".into(),
+            scroll_to: ScrollTo::Top,
+        };
+        assert_eq!(
+            serde_json::to_value(&c).unwrap(),
+            json!({"markdown": "# x", "baseDir": "/tmp", "scrollTo": {"kind": "top"}})
+        );
+    }
+
+    #[test]
+    fn navigate_request_reads_path_and_optional_fragment() {
+        let a: NavigateRequest = serde_json::from_value(json!({"path": "a.md", "fragment": "sec"})).unwrap();
+        assert_eq!(a.path, "a.md");
+        assert_eq!(a.fragment.as_deref(), Some("sec"));
+        let b: NavigateRequest = serde_json::from_value(json!({"path": "a.md", "fragment": null})).unwrap();
+        assert_eq!(b.fragment, None);
     }
 }

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -169,14 +169,23 @@ mod tests {
 
     #[test]
     fn scroll_to_serializes_tagged_camel_case() {
-        assert_eq!(serde_json::to_value(ScrollTo::Preserve).unwrap(), json!({"kind": "preserve"}));
-        assert_eq!(serde_json::to_value(ScrollTo::Top).unwrap(), json!({"kind": "top"}));
+        assert_eq!(
+            serde_json::to_value(ScrollTo::Preserve).unwrap(),
+            json!({"kind": "preserve"})
+        );
+        assert_eq!(
+            serde_json::to_value(ScrollTo::Top).unwrap(),
+            json!({"kind": "top"})
+        );
         assert_eq!(
             serde_json::to_value(ScrollTo::Ratio { ratio: 0.5 }).unwrap(),
             json!({"kind": "ratio", "ratio": 0.5})
         );
         assert_eq!(
-            serde_json::to_value(ScrollTo::Slug { slug: "mounting".into() }).unwrap(),
+            serde_json::to_value(ScrollTo::Slug {
+                slug: "mounting".into()
+            })
+            .unwrap(),
             json!({"kind": "slug", "slug": "mounting"})
         );
     }
@@ -196,10 +205,12 @@ mod tests {
 
     #[test]
     fn navigate_request_reads_path_and_optional_fragment() {
-        let a: NavigateRequest = serde_json::from_value(json!({"path": "a.md", "fragment": "sec"})).unwrap();
+        let a: NavigateRequest =
+            serde_json::from_value(json!({"path": "a.md", "fragment": "sec"})).unwrap();
         assert_eq!(a.path, "a.md");
         assert_eq!(a.fragment.as_deref(), Some("sec"));
-        let b: NavigateRequest = serde_json::from_value(json!({"path": "a.md", "fragment": null})).unwrap();
+        let b: NavigateRequest =
+            serde_json::from_value(json!({"path": "a.md", "fragment": null})).unwrap();
         assert_eq!(b.fragment, None);
     }
 }

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -32,6 +32,7 @@ pub(crate) struct NavigateRequest {
     /// The link's raw path (relative or absolute), percent-decoded by the page.
     pub(crate) path: String,
     /// The link's `#fragment`, if any, to scroll to after the document loads.
+    #[serde(default)]
     pub(crate) fragment: Option<String>,
 }
 

--- a/apps/ozmd/src/ui.rs
+++ b/apps/ozmd/src/ui.rs
@@ -30,6 +30,7 @@ pub(crate) fn draw(
     live: LiveStatus,
     scroll_percent: u16,
     search: Option<SearchCount>,
+    flash: Option<&str>,
 ) {
     let search_open = app.mode() == Mode::Search || app.search_active();
     let vchunks = Layout::default()
@@ -41,7 +42,7 @@ pub(crate) fn draw(
         ])
         .split(frame.area());
 
-    draw_status(frame, vchunks[0], file_name, live, scroll_percent);
+    draw_status(frame, vchunks[0], file_name, live, scroll_percent, flash);
     draw_body(frame, placements, vchunks[1], app, handle_id);
     if search_open {
         draw_search(frame, vchunks[2], app, search);
@@ -54,12 +55,17 @@ fn draw_status(
     file_name: &str,
     live: LiveStatus,
     scroll_percent: u16,
+    flash: Option<&str>,
 ) {
     let dot = match live {
         LiveStatus::Watching => "● live",
         LiveStatus::Missing => "○ missing",
     };
-    let line = Line::from(format!("ozmd · {file_name}    {dot}    {scroll_percent}%"));
+    let base = format!("ozmd · {file_name}    {dot}    {scroll_percent}%");
+    let line = match flash {
+        Some(msg) => Line::from(format!("{base}    {msg}")),
+        None => Line::from(base),
+    };
     frame.render_widget(
         Paragraph::new(line).style(Style::default().add_modifier(Modifier::REVERSED)),
         area,

--- a/apps/ozmd/web/anchors.test.ts
+++ b/apps/ozmd/web/anchors.test.ts
@@ -25,4 +25,10 @@ describe('installHeadingAnchors', () => {
     const ids = Array.from(div.querySelectorAll('span.ozmd-anchor')).map((s) => s.id);
     expect(ids).toEqual(['repeat', 'repeat-1']);
   });
+
+  it('skips injecting a slug that collides with an existing positional id (Fix 2)', () => {
+    const div = build('<h2 id="h0">Intro</h2><h2 id="h1">H0</h2>');
+    expect(div.querySelector('h2:nth-of-type(2) > span.ozmd-anchor')).toBeNull();
+    expect(div.querySelectorAll('[id="h0"]').length).toBe(1);
+  });
 });

--- a/apps/ozmd/web/anchors.test.ts
+++ b/apps/ozmd/web/anchors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { installHeadingAnchors } from './anchors';
+
+function build(html: string): HTMLElement {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  installHeadingAnchors(div);
+  return div;
+}
+
+describe('installHeadingAnchors', () => {
+  it('injects a slug-id span into each heading', () => {
+    const div = build('<h1 id="h0">Mounting</h1><h2 id="h1">Foo Bar</h2>');
+    expect(div.querySelector('h1 > span.ozmd-anchor')?.id).toBe('mounting');
+    expect(div.querySelector('h2 > span.ozmd-anchor')?.id).toBe('foo-bar');
+  });
+
+  it('preserves the existing h{n} heading ids', () => {
+    const div = build('<h1 id="h0">Title</h1>');
+    expect(div.querySelector('h1')?.id).toBe('h0');
+  });
+
+  it('dedupes colliding slugs', () => {
+    const div = build('<h2>Repeat</h2><h2>Repeat</h2>');
+    const ids = Array.from(div.querySelectorAll('span.ozmd-anchor')).map((s) => s.id);
+    expect(ids).toEqual(['repeat', 'repeat-1']);
+  });
+});

--- a/apps/ozmd/web/anchors.ts
+++ b/apps/ozmd/web/anchors.ts
@@ -1,0 +1,21 @@
+import GithubSlugger from 'github-slugger';
+
+/**
+ * Prepends a zero-width `<span class="ozmd-anchor" id="{slug}">` to every heading
+ * under `root`, so `#section` links resolve. Slugs use GitHub's exact algorithm
+ * (deduped). The heading's own `id="h{n}"` is left intact — those ids are what
+ * the scroll-state reporting and outline jump depend on.
+ */
+export function installHeadingAnchors(root: HTMLElement): void {
+  const slugger = new GithubSlugger();
+  for (const heading of root.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6')) {
+    const slug = slugger.slug(heading.textContent ?? '');
+    if (slug.length === 0) {
+      continue;
+    }
+    const anchor = document.createElement('span');
+    anchor.className = 'ozmd-anchor';
+    anchor.id = slug;
+    heading.prepend(anchor);
+  }
+}

--- a/apps/ozmd/web/anchors.ts
+++ b/apps/ozmd/web/anchors.ts
@@ -13,6 +13,12 @@ export function installHeadingAnchors(root: HTMLElement): void {
     if (slug.length === 0) {
       continue;
     }
+    // NOTE: skip a slug that collides with an existing id (e.g. the renderer's
+    // positional `h{n}` heading ids) so getElementById keeps resolving to the real
+    // heading rather than this injected anchor.
+    if (root.querySelector(`[id="${slug}"]`) !== null) {
+      continue;
+    }
     const anchor = document.createElement('span');
     anchor.className = 'ozmd-anchor';
     anchor.id = slug;

--- a/apps/ozmd/web/index.html
+++ b/apps/ozmd/web/index.html
@@ -12,6 +12,7 @@
       code { font-family: ui-monospace, monospace; }
       mark.ozmd-match { background: #ffd33d55; color: inherit; }
       mark.ozmd-current { background: #ffd33d; color: #000; }
+      .ozmd-anchor { display: inline; scroll-margin-top: 8px; }
       table { border-collapse: collapse; }
       th, td { border: 1px solid #30363d; padding: 6px 12px; }
     </style>

--- a/apps/ozmd/web/links.test.ts
+++ b/apps/ozmd/web/links.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { classifyLink } from './links';
+
+describe('classifyLink', () => {
+  it('treats empty and unsupported schemes as ignore', () => {
+    expect(classifyLink('')).toEqual({ kind: 'ignore' });
+    expect(classifyLink('javascript:alert(1)')).toEqual({ kind: 'ignore' });
+    expect(classifyLink('data:text/html,x')).toEqual({ kind: 'ignore' });
+    expect(classifyLink('file:///etc/passwd')).toEqual({ kind: 'ignore' });
+  });
+
+  it('classifies in-page anchors', () => {
+    expect(classifyLink('#mounting')).toEqual({ kind: 'anchor', fragment: 'mounting' });
+  });
+
+  it('classifies external schemes', () => {
+    expect(classifyLink('https://example.com')).toEqual({
+      kind: 'external',
+      url: 'https://example.com',
+    });
+    expect(classifyLink('mailto:a@b.com')).toEqual({ kind: 'external', url: 'mailto:a@b.com' });
+    expect(classifyLink('tel:+1')).toEqual({ kind: 'external', url: 'tel:+1' });
+  });
+
+  it('classifies markdown links with optional fragment', () => {
+    expect(classifyLink('docs/osc.md')).toEqual({
+      kind: 'markdown',
+      path: 'docs/osc.md',
+      fragment: null,
+    });
+    expect(classifyLink('../a.md#sec')).toEqual({
+      kind: 'markdown',
+      path: '../a.md',
+      fragment: 'sec',
+    });
+    expect(classifyLink('/abs/x.MARKDOWN')).toEqual({
+      kind: 'markdown',
+      path: '/abs/x.MARKDOWN',
+      fragment: null,
+    });
+  });
+
+  it('classifies other local files', () => {
+    expect(classifyLink('img.png')).toEqual({ kind: 'file', path: 'img.png' });
+    expect(classifyLink('examples/foo.rs')).toEqual({ kind: 'file', path: 'examples/foo.rs' });
+  });
+
+  it('percent-decodes local paths', () => {
+    expect(classifyLink('docs/a%20b.md')).toEqual({
+      kind: 'markdown',
+      path: 'docs/a b.md',
+      fragment: null,
+    });
+  });
+});

--- a/apps/ozmd/web/links.test.ts
+++ b/apps/ozmd/web/links.test.ts
@@ -18,6 +18,10 @@ describe('classifyLink', () => {
       kind: 'external',
       url: 'https://example.com',
     });
+    expect(classifyLink('http://example.com')).toEqual({
+      kind: 'external',
+      url: 'http://example.com',
+    });
     expect(classifyLink('mailto:a@b.com')).toEqual({ kind: 'external', url: 'mailto:a@b.com' });
     expect(classifyLink('tel:+1')).toEqual({ kind: 'external', url: 'tel:+1' });
   });
@@ -49,6 +53,14 @@ describe('classifyLink', () => {
     expect(classifyLink('docs/a%20b.md')).toEqual({
       kind: 'markdown',
       path: 'docs/a b.md',
+      fragment: null,
+    });
+  });
+
+  it('falls back to the raw path on malformed percent-encoding', () => {
+    expect(classifyLink('docs/a%ZZb.md')).toEqual({
+      kind: 'markdown',
+      path: 'docs/a%ZZb.md',
       fragment: null,
     });
   });

--- a/apps/ozmd/web/links.test.ts
+++ b/apps/ozmd/web/links.test.ts
@@ -64,4 +64,12 @@ describe('classifyLink', () => {
       fragment: null,
     });
   });
+
+  it('classifies percent-encoded extension correctly (Fix 3)', () => {
+    expect(classifyLink('docs/notes%2Emd')).toEqual({
+      kind: 'markdown',
+      path: 'docs/notes.md',
+      fragment: null,
+    });
+  });
 });

--- a/apps/ozmd/web/links.ts
+++ b/apps/ozmd/web/links.ts
@@ -1,0 +1,49 @@
+/** A classified `<a href>` target: where a click should be routed. */
+export type LinkTarget =
+  | { kind: 'anchor'; fragment: string }
+  | { kind: 'markdown'; path: string; fragment: string | null }
+  | { kind: 'file'; path: string }
+  | { kind: 'external'; url: string }
+  | { kind: 'ignore' };
+
+const EXTERNAL_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
+
+/**
+ * Classifies a raw `href` (the attribute string, not the browser-resolved URL)
+ * into the action the click handler should take. Local paths are percent-decoded
+ * so the controller receives real filesystem paths.
+ */
+export function classifyLink(href: string): LinkTarget {
+  const raw = href.trim();
+  if (raw.length === 0) {
+    return { kind: 'ignore' };
+  }
+  if (raw.startsWith('#')) {
+    return { kind: 'anchor', fragment: decode(raw.slice(1)) };
+  }
+  const scheme = schemeOf(raw);
+  if (scheme !== null) {
+    return EXTERNAL_SCHEMES.has(scheme) ? { kind: 'external', url: raw } : { kind: 'ignore' };
+  }
+  const hash = raw.indexOf('#');
+  const pathPart = hash === -1 ? raw : raw.slice(0, hash);
+  const fragment = hash === -1 ? null : decode(raw.slice(hash + 1));
+  const path = decode(pathPart);
+  if (/\.(md|markdown)$/i.test(pathPart)) {
+    return { kind: 'markdown', path, fragment };
+  }
+  return { kind: 'file', path };
+}
+
+function schemeOf(raw: string): string | null {
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(raw);
+  return m === null ? null : m[1].toLowerCase();
+}
+
+function decode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}

--- a/apps/ozmd/web/links.ts
+++ b/apps/ozmd/web/links.ts
@@ -29,7 +29,7 @@ export function classifyLink(href: string): LinkTarget {
   const pathPart = hash === -1 ? raw : raw.slice(0, hash);
   const fragment = hash === -1 ? null : decode(raw.slice(hash + 1));
   const path = decode(pathPart);
-  if (/\.(md|markdown)$/i.test(pathPart)) {
+  if (/\.(md|markdown)$/i.test(path)) {
     return { kind: 'markdown', path, fragment };
   }
   return { kind: 'file', path };

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -3,6 +3,8 @@ import 'highlight.js/styles/github-dark.css';
 import { ozma } from '@ozma/web';
 import DOMPurify from 'dompurify';
 import mermaid from 'mermaid';
+import { installHeadingAnchors } from './anchors';
+import { classifyLink } from './links';
 import { renderMarkdown } from './render';
 import { Search } from './search';
 
@@ -14,9 +16,16 @@ const search = new Search();
 let mermaidSeq = 0;
 let renderGeneration = 0;
 
+type ScrollTo =
+  | { kind: 'preserve' }
+  | { kind: 'top' }
+  | { kind: 'ratio'; ratio: number }
+  | { kind: 'slug'; slug: string };
+
 interface ContentPayload {
   markdown: string;
   baseDir: string;
+  scrollTo: ScrollTo;
 }
 
 function headingEls(): HTMLElement[] {
@@ -65,6 +74,37 @@ function restoreScrollAnchor(anchor: ScrollAnchor): void {
   window.scrollTo({ top: max > 0 ? anchor.ratio * max : 0 });
 }
 
+function scrollToAnchor(fragment: string): boolean {
+  const el = document.getElementById(fragment);
+  if (el === null) {
+    return false;
+  }
+  el.scrollIntoView({ block: 'start' });
+  reportScrollState();
+  return true;
+}
+
+function applyScrollTarget(scrollTo: ScrollTo, anchor: ScrollAnchor): void {
+  switch (scrollTo.kind) {
+    case 'preserve':
+      restoreScrollAnchor(anchor);
+      break;
+    case 'top':
+      window.scrollTo({ top: 0 });
+      break;
+    case 'ratio': {
+      const max = scrollMax();
+      window.scrollTo({ top: max > 0 ? scrollTo.ratio * max : 0 });
+      break;
+    }
+    case 'slug':
+      if (!scrollToAnchor(scrollTo.slug)) {
+        window.scrollTo({ top: 0 });
+      }
+      break;
+  }
+}
+
 function reportScrollState(): void {
   const max = scrollMax();
   const ratio = max > 0 ? window.scrollY / max : 0;
@@ -107,14 +147,14 @@ async function setContent(payload: ContentPayload): Promise<void> {
   const generation = ++renderGeneration;
   const anchor = captureScrollAnchor();
   content.innerHTML = renderMarkdown(payload.markdown);
+  installHeadingAnchors(content);
   await renderMermaid();
   // NOTE: a newer setContent superseded this one during the await (rapid reloads
-  // race) — skip the stale scroll restore so only the latest render positions the
-  // viewport.
+  // race) — skip the stale scroll so only the latest render positions the viewport.
   if (generation !== renderGeneration) {
     return;
   }
-  restoreScrollAnchor(anchor);
+  applyScrollTarget(payload.scrollTo, anchor);
   reportScrollState();
 }
 
@@ -168,6 +208,40 @@ ozma.on('searchNav', (p: { dir: 'next' | 'prev' }) => {
 });
 ozma.on('clearSearch', () => {
   search.clear(content);
+});
+
+content.addEventListener('click', (e) => {
+  const target = e.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+  const a = target.closest('a');
+  if (a === null) {
+    return;
+  }
+  const raw = a.getAttribute('href');
+  if (raw === null) {
+    return;
+  }
+  const link = classifyLink(raw);
+  e.preventDefault();
+  switch (link.kind) {
+    case 'anchor':
+      scrollToAnchor(link.fragment);
+      break;
+    case 'markdown':
+      reportScrollState();
+      ozma.emit('navigate', { path: link.path, fragment: link.fragment });
+      break;
+    case 'file':
+      ozma.emit('openPath', { path: link.path });
+      break;
+    case 'external':
+      ozma.emit('openExternal', { url: link.url });
+      break;
+    case 'ignore':
+      break;
+  }
 });
 
 window.addEventListener('scroll', reportScrollState, { passive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     esbuild:
       specifier: ^0.27.0
       version: 0.27.7
+    github-slugger:
+      specifier: ^2.0.0
+      version: 2.0.0
     highlight.js:
       specifier: ^11.0.0
       version: 11.11.1
@@ -62,6 +65,9 @@ importers:
       dompurify:
         specifier: 'catalog:'
         version: 3.4.10
+      github-slugger:
+        specifier: 'catalog:'
+        version: 2.0.0
       highlight.js:
         specifier: 'catalog:'
         version: 11.11.1
@@ -1040,6 +1046,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2468,6 +2477,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  github-slugger@2.0.0: {}
 
   gopd@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ catalog:
   katex: ^0.16.11
   mermaid: ^11.0.0
   dompurify: ^3.1.6
+  github-slugger: ^2.0.0
   jsdom: ^25.0.0
 
 catalogMode: strict


### PR DESCRIPTION
## Summary

Local-file hyperlinks in `ozmd` previously **404'd** — clicking `[docs/osc.md](docs/osc.md)` performed a top-level navigation against the `ozma://` asset origin, tearing down the SPA. This PR makes links work:

- **Local `.md` links** navigate in place, with a **back stack** (Backspace / Ctrl-o) that restores the previous document's scroll position.
- **External URLs** (`http`/`https`/`mailto`/`tel`) open in the system browser; **non-Markdown local files** open with the OS default app.
- **Intra-document anchors** (`#section`) and **file + fragment** links (`docs/osc.md#mounting`) scroll to the target heading.
- Every `<a>` click is intercepted (`preventDefault`), so a click can never replace/break the ozmd view.

## How it works

The page classifies each raw `href` (pure `classifyLink` in `web/links.ts`) and routes the intent to the Rust controller — the only side with filesystem access — over the existing `read_events` + `emit('content')` channel:

```
page click → classifyLink → anchor: scroll locally
                           → markdown: emit navigate{path,fragment}
                           → file:     emit openPath{path}
                           → external: emit openExternal{url}
controller drains → resolve against the current doc's dir → load → re-point watcher → push content (ScrollTo)
```

Notable design points:
- **`forward_keys` is load-bearing**: clicking the webview transfers keyboard ownership to CEF, so the back keys are declared via `Webview::forward_keys([Backspace, Ctrl-o])` to stay reachable after a click. (Verified for the tmux backend; see "Not yet verified".)
- `Content.scrollTo` is an explicit tagged enum (`preserve`/`top`/`ratio`/`slug`) — removes a JSON null/undefined trap and carries the fragment target on the navigation's own content push (no page-side race).
- Heading anchors use **`github-slugger`** (byte-exact GitHub slugs) injected as a child `<span id>`, leaving the renderer's positional `h{n}` ids — and the outline/scroll machinery that depends on them — untouched.

## Security / trust boundary

- `open` is invoked as `Command::new("open").arg(target)` — **no shell**, so no argument injection.
- External URLs are restricted to an `http`/`https`/`mailto`/`tel` allowlist (enforced on both sides); `javascript:`/`data:` classify as `ignore` (and DOMPurify already strips them).
- Resolved paths are `canonicalize`d and required to be regular files.
- **Decision (documented):** `open` launches each target with the user's own authority (same as double-clicking in Finder); a few regular-file types (`.command`/`.webloc`) auto-execute or redirect. ozmd is for viewing **trusted** local documents and deliberately does not sandbox link targets — captured as a `// NOTE:` at the open site.

## Testing

- Rust: `cargo test -p ozmd` — 41 passing; clippy + rustfmt clean.
- TypeScript: 27 (ozmd) + 8 (ozma-web) passing; `check-types` + biome clean; web bundle builds.
- Unit coverage for the pure seams: `classifyLink` (all branches incl. percent-encoded paths), `installHeadingAnchors` (slug dedupe + id-collision skip), `resolve_link`/`is_markdown`, the Back keymap, the external-scheme allowlist, and the `ScrollTo`/`Content` wire shapes.

## Review trail

Brainstorm → spec → spec-review (Codex + Claude) → plan → subagent-driven implementation (8 tasks, each spec+quality reviewed) → whole-branch review → `/code-review max --fix` (4 finder angles → 9 additional fixes: back-stack restore-on-failure, anchor id-collision, decoded-extension match, search/flash reset, dedup).

## Not yet verified (needs a live ozmux pane)

The **GUI end-to-end click-through** (real link click, Back, external/file open, `#anchor`) and **`forward_keys` reachability on the Default single-PTY backend** have not been exercised at runtime — only the automated gates and the tmux-backend focus path are confirmed. Worth a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
