### PR TITLE
Bundle ozbrowser/ozmd into the Homebrew cask; English README

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -35,6 +35,18 @@ jobs:
       - name: Provision CEF + release render process
         run: just setup-cef-release
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Build ozmd web assets
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
       - name: Import signing certificate
         if: env.MACOS_CERT_P12 != ''
         uses: apple-actions/import-codesign-certs@v3

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ozmux(Ozma Terminal Multiplexer)
+# ozmux (Ozma Terminal Multiplexer)
 
 > [!CAUTION]
 > This app is still in early development and may introduce breaking changes.
 
-ターミナル内にwebviewを描画することができるターミナルエミュレータ。
-tmuxの統合機能も標準搭載しています。
+ozmux is a terminal emulator that can render webviews directly inside the
+terminal, with built-in tmux integration.
 
 ## Installation
 
@@ -12,7 +12,6 @@ macOS (Apple Silicon) via Homebrew Cask:
 
 ```bash
 brew install --cask not-elm/ozmux/ozmux
-brew install ozmd ozbrowser # optional
 ```
 
 This taps `not-elm/homebrew-ozmux`, installs `ozmux.app` into `/Applications`,
@@ -22,33 +21,51 @@ and pulls in `tmux` as a dependency. Upgrade later with:
 brew upgrade --cask ozmux
 ```
 
+The companion apps `ozmd` and `ozbrowser` (built with the `ratatui-ozma` SDK)
+are installed from source with `just install-apps`.
+
 ## Features
 
 ### Webview
 
-ターミナル内にWebviewを表示することができます。これは特にTUIアプリの可能性を広げることが期待できます。例えば:
+ozmux can display webviews inside the terminal, which opens up new
+possibilities for TUI applications. For example:
 
-- チャートのような高度なグラフィックをレンダリングする
-- Wasmを使ったゲームを埋め込む
-- ローカルホストのフロントエンド
+- render rich graphics such as charts
+- embed games built with WebAssembly
+- host a local frontend (e.g. a dev server on localhost)
 
-### Tmux Intergration
+### Tmux Integration
 
-TmuxのControl Modeを使ったtmux統合機能を標準でサポートしています。キーバインドはtmux.confに設定されているものをそのまま使うことができます。
-`tmux -CC`をターミナル内で実行することでこのモードに切り替えることができます。
+ozmux supports tmux through its control mode (`tmux -CC`), so your existing
+`tmux.conf` keybindings work as-is. ozmux starts as a plain single-pane
+terminal; running `tmux -CC` inside it switches to integration mode, where
+tmux windows and panes are rendered natively.
 
 ## SDK
 
-- [ratatui_ozma](sdk/ratatui_zoma)
+- [ratatui-ozma](sdk/ratatui-ozma) — Rust SDK: a ratatui widget and RPC
+  handler for embedding ozmux webviews from a TUI app.
+- [@ozma/web](sdk/ozma-web) — TypeScript client for the in-page `window.ozma`
+  bridge.
 
 ## Ozma Webview Protocol
 
-Please see [docs/osc.md](docs/osc.md)
+A program registers webview content over ozmux's control socket to mint an
+opaque handle, then writes an `OSC 5379;mount;<handle>;<rows>;<cols>` escape
+sequence to mount it as an in-process webview at that cell geometry
+(`OSC 5379;unmount;<handle>` tears it down). The page talks back to the host
+program through the `window.ozma` bridge. Use one of the SDKs above for a
+ready-made client.
 
-## Configs
+## Configuration
 
-Please see [docs/configs.md](docs/configs.md)
+ozmux reads `~/.config/ozmux/config.toml`, resolved against built-in
+defaults. Override the file path with `$OZMUX_CONFIG`, or the config
+directory with `$XDG_CONFIG_HOME`. Configurable areas include theme colors,
+fonts, keyboard and shortcut bindings, mouse behavior, inactive-pane dimming,
+and the default shell.
 
-## Licenses
+## License
 
-MIT
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# ozmux
+# ozmux(Ozma Terminal Multiplexer)
 
-A terminal multiplexer built as a single
-[Bevy](https://bevyengine.org/) application (`ozmux`). Terminal emulation,
-GPU rendering, layout, input, and in-process CEF webview rendering all run in
-one ECS world.
+> [!CAUTION]
+> This app is still in early development and may introduce breaking changes.
+
+ターミナル内にwebviewを描画することができるターミナルエミュレータ。
+tmuxの統合機能も標準搭載しています。
 
 ## Installation
 
@@ -11,6 +12,7 @@ macOS (Apple Silicon) via Homebrew Cask:
 
 ```bash
 brew install --cask not-elm/ozmux/ozmux
+brew install ozmd ozbrowser # optional
 ```
 
 This taps `not-elm/homebrew-ozmux`, installs `ozmux.app` into `/Applications`,
@@ -20,48 +22,33 @@ and pulls in `tmux` as a dependency. Upgrade later with:
 brew upgrade --cask ozmux
 ```
 
-## Prerequisites
+## Features
 
-- Rust 1.95 (pinned by `rust-toolchain.toml`)
-- Node + `pnpm@10.30.2` (for the `@ozma/web` TypeScript package; dev/CI use Node 24)
-- [`just`](https://just.systems/) — the task runner (`brew install just` or `cargo install just`)
-- The Chromium Embedded Framework, installed once:
-  ```bash
-  just setup-cef
-  ```
+### Webview
 
-## Run
+ターミナル内にWebviewを表示することができます。これは特にTUIアプリの可能性を広げることが期待できます。例えば:
 
-```bash
-pnpm install
-cargo run               # or: just run
-```
+- チャートのような高度なグラフィックをレンダリングする
+- Wasmを使ったゲームを埋め込む
+- ローカルホストのフロントエンド
 
-## Layout
+### Tmux Intergration
 
-- `src/` — the `ozmux` Bevy binary
-- `crates/` — `ozma_tty_engine`, `ozma_tty_renderer`, `extension_host`, `multiplexer`, `configs`
-- `sdk/ozma-web` — `@ozma/web` (in-page `window.ozma` bridge client for webview pages)
+TmuxのControl Modeを使ったtmux統合機能を標準でサポートしています。キーバインドはtmux.confに設定されているものをそのまま使うことができます。
+`tmux -CC`をターミナル内で実行することでこのモードに切り替えることができます。
 
-## Webviews
+## SDK
 
-A program in the shell can render a webview **inline in the terminal text flow**
-(a live CEF webview composited in the terminal shader, scrolling with the text).
-It registers content over the control plane to mint a handle, then writes an OSC
-5379 `mount;<handle>` sequence:
+- [ratatui_ozma](sdk/ratatui_zoma)
 
-```sh
-printf '\033]5379;mount;%s;12;48\033\\' "$handle"
-printf '\n%.0s' $(seq 12)
-```
+## Ozma Webview Protocol
 
-For a runnable end-to-end client (register → mount → `window.ozma` back-channel)
-see [`examples/dyn_webview_client.rs`](examples/dyn_webview_client.rs). Click the
-view to focus it; keys, wheel, and IME then route to the page; `Ctrl+Shift+Escape`
-returns focus to the terminal. Full protocol, focus model, and limits:
-[`docs/dyn-webview.md`](docs/dyn-webview.md) and
-[`docs/webview.md`](docs/webview.md).
+Please see [docs/osc.md](docs/osc.md)
 
-## Development
+## Configs
 
-See `CLAUDE.md` for architecture and `.claude/rules/` for coding conventions.
+Please see [docs/configs.md](docs/configs.md)
+
+## Licenses
+
+MIT

--- a/build/macos/homebrew/ozmux.rb.tmpl
+++ b/build/macos/homebrew/ozmux.rb.tmpl
@@ -12,6 +12,8 @@ cask "ozmux" do
   depends_on formula: "tmux"
 
   app "ozmux.app"
+  binary "#{appdir}/ozmux.app/Contents/Resources/ozbrowser"
+  binary "#{appdir}/ozmux.app/Contents/Resources/ozmd"
 
   caveats do
     "If macOS blocks the app (un-notarized build), clear quarantine:\n" \

--- a/justfile
+++ b/justfile
@@ -75,10 +75,10 @@ icon *args:
 
 # build and package the ozmux .app (extra args pass through, e.g. --version 1.2.3)
 [macos]
-bundle-macos *args:
+bundle-macos *args: ozmd-web
     python3 scripts/bundle_macos.py {{ args }}
 
 # setup-cef-release then bundle with notarization
 [macos]
-release-macos *args: setup-cef-release
+release-macos *args: setup-cef-release ozmd-web
     python3 scripts/bundle_macos.py --notarize {{ args }}

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -330,9 +330,14 @@ def codesign_bundle(cfg: BundleConfig) -> None:
         run(codesign_argv(cfg.sign_identity, helper_app, hardened=hardened, entitlements=entitlements))
 
     resources = cfg.app_path / "Contents" / "Resources"
+    # NOTE: companions are plain CLIs (no CEF) exposed directly on the user's
+    # PATH; sign them with the hardened runtime but WITHOUT entitlements. They
+    # must not inherit the CEF grants (JIT, unsigned-executable-memory, disabled
+    # library validation) — least privilege. Do not unify this with the helper
+    # signing above.
     for src in cfg.companion_bins:
         run(codesign_argv(cfg.sign_identity, resources / src.name,
-                          hardened=hardened, entitlements=entitlements))
+                          hardened=hardened, entitlements=None))
 
     run(codesign_argv(cfg.sign_identity, cfg.app_path, hardened=hardened, entitlements=entitlements))
     run(codesign_verify_argv(cfg.app_path))

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -329,6 +329,11 @@ def codesign_bundle(cfg: BundleConfig) -> None:
         helper_app = frameworks / f"{cfg.bin_name} Helper{suffix}.app"
         run(codesign_argv(cfg.sign_identity, helper_app, hardened=hardened, entitlements=entitlements))
 
+    resources = cfg.app_path / "Contents" / "Resources"
+    for src in cfg.companion_bins:
+        run(codesign_argv(cfg.sign_identity, resources / src.name,
+                          hardened=hardened, entitlements=entitlements))
+
     run(codesign_argv(cfg.sign_identity, cfg.app_path, hardened=hardened, entitlements=entitlements))
     run(codesign_verify_argv(cfg.app_path))
 

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -297,6 +297,16 @@ def embed_cef(cfg: BundleConfig) -> None:
         print(f"  Created {helper_name}.app")
 
 
+def copy_companions(cfg: BundleConfig) -> None:
+    resources = cfg.app_path / "Contents" / "Resources"
+    resources.mkdir(parents=True, exist_ok=True)
+    for src in cfg.companion_bins:
+        dest = resources / src.name
+        shutil.copy2(src, dest)
+        dest.chmod(0o755)
+        print(f"  Embedded companion {src.name}")
+
+
 def strip_xattrs(cfg: BundleConfig) -> None:
     run(xattr_strip_argv(cfg.app_path))
 
@@ -357,6 +367,7 @@ def package(cfg: BundleConfig) -> str:
 
 def cargo_build(cfg: BundleConfig) -> None:
     run(cargo_build_argv(cfg.target_triple, CARGO_PROFILE))
+    run(companion_cargo_build_argv(cfg.target_triple, CARGO_PROFILE, COMPANION_BINS))
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -369,6 +380,7 @@ def main(argv: list[str] | None = None) -> None:
     verify_prerequisites(cfg)
     assemble_app(cfg)
     embed_cef(cfg)
+    copy_companions(cfg)
     strip_xattrs(cfg)
     if not cfg.no_sign:
         codesign_bundle(cfg)

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -21,6 +21,7 @@ ARCH = "arm64"
 TARGET_TRIPLE = "aarch64-apple-darwin"
 CARGO_PROFILE = "dist"
 HELPER_SUFFIXES = ("", " (GPU)", " (Renderer)", " (Plugin)")
+COMPANION_BINS = ("ozbrowser", "ozmd")
 MIN_MACOS = "11.0"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -74,6 +75,13 @@ def build_helper_plist(name: str, bundle_id: str) -> dict:
 def cargo_build_argv(triple: str, profile: str) -> list[str]:
     return ["cargo", "build", "--profile", profile, "--target", triple,
             "--locked", "--no-default-features"]
+
+
+def companion_cargo_build_argv(triple: str, profile: str, names: tuple[str, ...]) -> list[str]:
+    argv = ["cargo", "build", "--profile", profile, "--target", triple, "--locked"]
+    for name in names:
+        argv += ["-p", name]
+    return argv
 
 
 def lipo_archs_argv(path: Path) -> list[str]:

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -11,7 +11,7 @@ import plistlib
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 APP_NAME = "ozmux"
@@ -149,6 +149,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Bundle ozmux into a CEF-embedded macOS .app")
     p.add_argument("--version")
     p.add_argument("--bin")
+    p.add_argument("--ozbrowser-bin")
+    p.add_argument("--ozmd-bin")
     p.add_argument("--skip-build", action="store_true")
     p.add_argument("--no-sign", action="store_true")
     p.add_argument("--sign-identity")
@@ -174,6 +176,13 @@ def resolve_config(args: argparse.Namespace) -> BundleConfig:
     if notarize and args.no_sign:
         print("==> WARNING: --no-sign skips signing; disabling notarization")
         notarize = False
+    companion_bins = []
+    for name in COMPANION_BINS:
+        override = getattr(args, f"{name}_bin")
+        if override:
+            companion_bins.append(Path(override))
+        else:
+            companion_bins.append(REPO_ROOT / "target" / TARGET_TRIPLE / CARGO_PROFILE / name)
     return BundleConfig(
         version=version, app_name=APP_NAME, bin_name=BIN_NAME, bundle_id_base=BUNDLE_ID_BASE,
         arch=ARCH, target_triple=TARGET_TRIPLE, bin_source=bin_source,
@@ -181,6 +190,7 @@ def resolve_config(args: argparse.Namespace) -> BundleConfig:
         helper_bin=Path(args.helper_bin).expanduser(),
         out_dir=Path(args.out_dir), sign_identity=sign_identity,
         no_sign=args.no_sign, notarize=notarize,
+        companion_bins=companion_bins,
     )
 
 
@@ -195,6 +205,11 @@ def verify_prerequisites(cfg: BundleConfig) -> None:
         raise SystemExit(
             f"render-process helper not found: {cfg.helper_bin} (run `just setup-cef-release`)"
         )
+    for src in cfg.companion_bins:
+        if not src.is_file():
+            raise SystemExit(
+                f"companion binary not found: {src} (build first or pass --{src.name}-bin)"
+            )
 
 
 def run(argv: list[str], redact: tuple[str, ...] = ()) -> None:
@@ -381,6 +396,7 @@ class BundleConfig:
     sign_identity: str
     no_sign: bool
     notarize: bool
+    companion_bins: list[Path] = field(default_factory=list)
 
     @property
     def app_path(self) -> Path:

--- a/scripts/bundle_macos.py
+++ b/scripts/bundle_macos.py
@@ -106,6 +106,10 @@ def codesign_verify_argv(path: Path) -> list[str]:
     return ["codesign", "--verify", "--deep", "--strict", str(path)]
 
 
+def codesign_verify_one_argv(path: Path) -> list[str]:
+    return ["codesign", "--verify", str(path)]
+
+
 def xattr_strip_argv(path: Path) -> list[str]:
     return ["xattr", "-cr", str(path)]
 
@@ -176,13 +180,13 @@ def resolve_config(args: argparse.Namespace) -> BundleConfig:
     if notarize and args.no_sign:
         print("==> WARNING: --no-sign skips signing; disabling notarization")
         notarize = False
-    companion_bins = []
+    companion_bins = {}
     for name in COMPANION_BINS:
-        override = getattr(args, f"{name}_bin")
+        override = getattr(args, f"{name}_bin", None)
         if override:
-            companion_bins.append(Path(override))
+            companion_bins[name] = Path(override).expanduser()
         else:
-            companion_bins.append(REPO_ROOT / "target" / TARGET_TRIPLE / CARGO_PROFILE / name)
+            companion_bins[name] = REPO_ROOT / "target" / TARGET_TRIPLE / CARGO_PROFILE / name
     return BundleConfig(
         version=version, app_name=APP_NAME, bin_name=BIN_NAME, bundle_id_base=BUNDLE_ID_BASE,
         arch=ARCH, target_triple=TARGET_TRIPLE, bin_source=bin_source,
@@ -205,10 +209,10 @@ def verify_prerequisites(cfg: BundleConfig) -> None:
         raise SystemExit(
             f"render-process helper not found: {cfg.helper_bin} (run `just setup-cef-release`)"
         )
-    for src in cfg.companion_bins:
+    for name, src in cfg.companion_bins.items():
         if not src.is_file():
             raise SystemExit(
-                f"companion binary not found: {src} (build first or pass --{src.name}-bin)"
+                f"companion binary not found: {src} (build first or pass --{name}-bin)"
             )
 
 
@@ -298,13 +302,13 @@ def embed_cef(cfg: BundleConfig) -> None:
 
 
 def copy_companions(cfg: BundleConfig) -> None:
-    resources = cfg.app_path / "Contents" / "Resources"
+    resources = cfg.resources_path
     resources.mkdir(parents=True, exist_ok=True)
-    for src in cfg.companion_bins:
-        dest = resources / src.name
+    for name, src in cfg.companion_bins.items():
+        dest = resources / name
         shutil.copy2(src, dest)
         dest.chmod(0o755)
-        print(f"  Embedded companion {src.name}")
+        print(f"  Embedded companion {name}")
 
 
 def strip_xattrs(cfg: BundleConfig) -> None:
@@ -329,15 +333,20 @@ def codesign_bundle(cfg: BundleConfig) -> None:
         helper_app = frameworks / f"{cfg.bin_name} Helper{suffix}.app"
         run(codesign_argv(cfg.sign_identity, helper_app, hardened=hardened, entitlements=entitlements))
 
-    resources = cfg.app_path / "Contents" / "Resources"
+    resources = cfg.resources_path
     # NOTE: companions are plain CLIs (no CEF) exposed directly on the user's
     # PATH; sign them with the hardened runtime but WITHOUT entitlements. They
     # must not inherit the CEF grants (JIT, unsigned-executable-memory, disabled
     # library validation) — least privilege. Do not unify this with the helper
     # signing above.
-    for src in cfg.companion_bins:
-        run(codesign_argv(cfg.sign_identity, resources / src.name,
+    # NOTE: codesign --verify --deep --strict on the outer app does NOT descend
+    # into plain executables in Contents/Resources, so verify each companion
+    # explicitly here — otherwise a broken signing loop ships unsigned binaries
+    # with no error on the local/ad-hoc path.
+    for name in cfg.companion_bins:
+        run(codesign_argv(cfg.sign_identity, resources / name,
                           hardened=hardened, entitlements=None))
+        run(codesign_verify_one_argv(resources / name))
 
     run(codesign_argv(cfg.sign_identity, cfg.app_path, hardened=hardened, entitlements=entitlements))
     run(codesign_verify_argv(cfg.app_path))
@@ -375,8 +384,23 @@ def package(cfg: BundleConfig) -> str:
     return digest
 
 
+def verify_ozmd_web_assets(assets_dir: Path | None = None) -> None:
+    assets = assets_dir if assets_dir is not None else REPO_ROOT / "apps" / "ozmd" / "assets"
+    real = (
+        [p for p in assets.glob("*") if p.name not in {".gitignore", ".gitkeep"}]
+        if assets.is_dir() else []
+    )
+    if not real:
+        raise SystemExit(
+            "ozmd web assets missing: apps/ozmd/assets/ has only placeholders. "
+            "Run `pnpm build` (or `just ozmd-web`) before bundling, "
+            "or ozmd will ship a blank viewer."
+        )
+
+
 def cargo_build(cfg: BundleConfig) -> None:
     run(cargo_build_argv(cfg.target_triple, CARGO_PROFILE))
+    verify_ozmd_web_assets()
     run(companion_cargo_build_argv(cfg.target_triple, CARGO_PROFILE, COMPANION_BINS))
 
 
@@ -418,7 +442,7 @@ class BundleConfig:
     sign_identity: str
     no_sign: bool
     notarize: bool
-    companion_bins: list[Path] = field(default_factory=list)
+    companion_bins: dict[str, Path] = field(default_factory=dict)
 
     @property
     def app_path(self) -> Path:
@@ -427,6 +451,10 @@ class BundleConfig:
     @property
     def zip_path(self) -> Path:
         return self.out_dir / zip_name(self.app_name, self.version, self.arch)
+
+    @property
+    def resources_path(self) -> Path:
+        return self.app_path / "Contents" / "Resources"
 
 
 if __name__ == "__main__":

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -314,6 +314,10 @@ class EndToEnd(unittest.TestCase):
         shutil.copy("/usr/bin/true", dest)
         dest.chmod(0o755)
 
+    def _unsigned_macho(self, dest: Path) -> None:
+        self._macho(dest)
+        subprocess.run(["codesign", "--remove-signature", str(dest)], check=True)
+
     def _fake_cef(self, root: Path) -> Path:
         fw = root / "Chromium Embedded Framework.framework"
         (fw / "Libraries").mkdir(parents=True)
@@ -326,8 +330,8 @@ class EndToEnd(unittest.TestCase):
             d = Path(d)
             self._macho(d / "ozmux")
             self._macho(d / "helper")
-            self._macho(d / "ozbrowser")
-            self._macho(d / "ozmd")
+            self._unsigned_macho(d / "ozbrowser")
+            self._unsigned_macho(d / "ozmd")
             fw = self._fake_cef(d)
             out = d / "out"
             bm.main([
@@ -347,11 +351,19 @@ class EndToEnd(unittest.TestCase):
             resources = out / "ozmux.app" / "Contents" / "Resources"
             self.assertTrue((resources / "ozbrowser").is_file())
             self.assertTrue((resources / "ozmd").is_file())
-            # ad-hoc signature must verify deep+strict — fails if a nested companion is unsigned
+            # ad-hoc signature must verify deep+strict on the outer bundle
             subprocess.run(
                 ["codesign", "--verify", "--deep", "--strict", str(out / "ozmux.app")],
                 check=True,
             )
+            # NOTE: codesign --verify --deep --strict on the outer bundle does not descend into
+            # plain executables inside Contents/Resources (only into sub-bundles). We must
+            # explicitly verify each companion so the test fails if the signing loop is removed.
+            for name in ("ozbrowser", "ozmd"):
+                subprocess.run(
+                    ["codesign", "--verify", str(resources / name)],
+                    check=True,
+                )
 
 
 class NotarizeGuards(unittest.TestCase):

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -13,6 +13,12 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import bundle_macos as bm
 
 
+def _write_fake_macho(dest: Path) -> None:
+    # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
+    shutil.copy("/usr/bin/true", dest)
+    dest.chmod(0o755)
+
+
 class PureHelpers(unittest.TestCase):
     def test_zip_name(self):
         self.assertEqual(bm.zip_name("ozmux", "0.1.0", "arm64"), "ozmux-0.1.0-arm64.zip")
@@ -46,8 +52,8 @@ class CaskTemplate(unittest.TestCase):
     def test_template_has_companion_binary_stanzas(self):
         tmpl = (bm.REPO_ROOT / "build" / "macos" / "homebrew" / "ozmux.rb.tmpl").read_text()
         self.assertIn('app "ozmux.app"', tmpl)
-        self.assertIn('binary "#{appdir}/ozmux.app/Contents/Resources/ozbrowser"', tmpl)
-        self.assertIn('binary "#{appdir}/ozmux.app/Contents/Resources/ozmd"', tmpl)
+        for name in bm.COMPANION_BINS:
+            self.assertIn(f'binary "#{{appdir}}/ozmux.app/Contents/Resources/{name}"', tmpl)
 
 
 class PlistLogic(unittest.TestCase):
@@ -197,9 +203,9 @@ class ConfigResolution(unittest.TestCase):
 
     def test_resolve_companion_defaults(self):
         cfg = bm.resolve_config(self._parse(["--version", "0.1.0", "--skip-build"]))
-        names = [p.name for p in cfg.companion_bins]
+        names = list(cfg.companion_bins.keys())
         self.assertEqual(names, ["ozbrowser", "ozmd"])
-        for p in cfg.companion_bins:
+        for p in cfg.companion_bins.values():
             self.assertIn("aarch64-apple-darwin", str(p))
             self.assertIn("dist", str(p))
 
@@ -208,7 +214,14 @@ class ConfigResolution(unittest.TestCase):
             "--version", "0.1.0", "--skip-build",
             "--ozbrowser-bin", "/tmp/ob", "--ozmd-bin", "/tmp/om",
         ]))
-        self.assertEqual(cfg.companion_bins, [Path("/tmp/ob"), Path("/tmp/om")])
+        self.assertEqual(cfg.companion_bins, {"ozbrowser": Path("/tmp/ob"), "ozmd": Path("/tmp/om")})
+
+    def test_resolve_companion_override_expands_user(self):
+        cfg = bm.resolve_config(self._parse([
+            "--version", "0.1.0", "--skip-build", "--ozbrowser-bin", "~/bins/ozbrowser",
+        ]))
+        self.assertFalse(str(cfg.companion_bins["ozbrowser"]).startswith("~"))
+        self.assertTrue(str(cfg.companion_bins["ozbrowser"]).endswith("/bins/ozbrowser"))
 
     def test_verify_prerequisites_missing_companion(self):
         with tempfile.TemporaryDirectory() as d:
@@ -229,23 +242,18 @@ class ConfigResolution(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
 class AssembleAndEmbed(unittest.TestCase):
-    def _macho(self, dest: Path) -> None:
-        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
-        shutil.copy("/usr/bin/true", dest)
-        dest.chmod(0o755)
-
     def _fake_cef(self, root: Path) -> Path:
         fw = root / "Chromium Embedded Framework.framework"
         (fw / "Libraries").mkdir(parents=True)
-        self._macho(fw / "Chromium Embedded Framework")
-        self._macho(fw / "Libraries" / "libEGL.dylib")
+        _write_fake_macho(fw / "Chromium Embedded Framework")
+        _write_fake_macho(fw / "Libraries" / "libEGL.dylib")
         (fw / "Resources").mkdir()
         (fw / "Resources" / "icudtl.dat").write_bytes(b"fake")
         return fw
 
     def _cfg(self, d: Path) -> "bm.BundleConfig":
-        self._macho(d / "ozmux")
-        self._macho(d / "helper")
+        _write_fake_macho(d / "ozmux")
+        _write_fake_macho(d / "helper")
         fw = self._fake_cef(d)
         return bm.BundleConfig(
             version="9.9.9", app_name="ozmux", bin_name="ozmux",
@@ -288,23 +296,18 @@ class AssembleAndEmbed(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
 class CopyCompanions(unittest.TestCase):
-    def _macho(self, dest: Path) -> None:
-        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
-        shutil.copy("/usr/bin/true", dest)
-        dest.chmod(0o755)
-
     def test_copy_companions_into_resources(self):
         with tempfile.TemporaryDirectory() as d:
             d = Path(d)
-            self._macho(d / "ozbrowser")
-            self._macho(d / "ozmd")
+            _write_fake_macho(d / "ozbrowser")
+            _write_fake_macho(d / "ozmd")
             cfg = bm.BundleConfig(
                 version="9.9.9", app_name="ozmux", bin_name="ozmux",
                 bundle_id_base="not.elm.ozmux", arch="arm64",
                 target_triple="aarch64-apple-darwin",
                 bin_source=d / "ozmux", cef_framework=d / "cef", helper_bin=d / "helper",
                 out_dir=d / "out", sign_identity="-", no_sign=True, notarize=False,
-                companion_bins=[d / "ozbrowser", d / "ozmd"],
+                companion_bins={"ozbrowser": d / "ozbrowser", "ozmd": d / "ozmd"},
             )
             resources = cfg.app_path / "Contents" / "Resources"
             resources.mkdir(parents=True)
@@ -314,30 +317,45 @@ class CopyCompanions(unittest.TestCase):
                 self.assertTrue(dest.is_file())
                 self.assertTrue(os.access(dest, os.X_OK))
 
+    def test_override_basename_embeds_under_canonical_name(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            _write_fake_macho(d / "ozbrowser-cli")
+            _write_fake_macho(d / "ozmd-v2")
+            cfg = bm.BundleConfig(
+                version="9.9.9", app_name="ozmux", bin_name="ozmux",
+                bundle_id_base="not.elm.ozmux", arch="arm64",
+                target_triple="aarch64-apple-darwin",
+                bin_source=d / "ozmux", cef_framework=d / "cef", helper_bin=d / "helper",
+                out_dir=d / "out", sign_identity="-", no_sign=True, notarize=False,
+                companion_bins={"ozbrowser": d / "ozbrowser-cli", "ozmd": d / "ozmd-v2"},
+            )
+            (cfg.app_path / "Contents" / "Resources").mkdir(parents=True)
+            bm.copy_companions(cfg)
+            resources = cfg.app_path / "Contents" / "Resources"
+            self.assertTrue((resources / "ozbrowser").is_file())
+            self.assertTrue((resources / "ozmd").is_file())
+            self.assertFalse((resources / "ozbrowser-cli").exists())
+
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
 class EndToEnd(unittest.TestCase):
-    def _macho(self, dest: Path) -> None:
-        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
-        shutil.copy("/usr/bin/true", dest)
-        dest.chmod(0o755)
-
     def _unsigned_macho(self, dest: Path) -> None:
-        self._macho(dest)
+        _write_fake_macho(dest)
         subprocess.run(["codesign", "--remove-signature", str(dest)], check=True)
 
     def _fake_cef(self, root: Path) -> Path:
         fw = root / "Chromium Embedded Framework.framework"
         (fw / "Libraries").mkdir(parents=True)
-        self._macho(fw / "Chromium Embedded Framework")
-        self._macho(fw / "Libraries" / "libEGL.dylib")
+        _write_fake_macho(fw / "Chromium Embedded Framework")
+        _write_fake_macho(fw / "Libraries" / "libEGL.dylib")
         return fw
 
     def test_main_adhoc_end_to_end(self):
         with tempfile.TemporaryDirectory() as d:
             d = Path(d)
-            self._macho(d / "ozmux")
-            self._macho(d / "helper")
+            _write_fake_macho(d / "ozmux")
+            _write_fake_macho(d / "helper")
             self._unsigned_macho(d / "ozbrowser")
             self._unsigned_macho(d / "ozmd")
             fw = self._fake_cef(d)
@@ -372,6 +390,70 @@ class EndToEnd(unittest.TestCase):
                     ["codesign", "--verify", str(resources / name)],
                     check=True,
                 )
+
+
+class CompanionSigning(unittest.TestCase):
+    def test_companions_signed_hardened_without_entitlements(self):
+        recorded = []
+
+        def fake_run(argv, redact=()):
+            recorded.append(argv)
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            app = d / "out" / "ozmux.app"
+            (app / "Contents" / "Resources").mkdir(parents=True)
+            cef = app / "Contents" / "Frameworks" / "Chromium Embedded Framework.framework"
+            (cef / "Libraries").mkdir(parents=True)
+            cfg = bm.BundleConfig(
+                version="9.9.9", app_name="ozmux", bin_name="ozmux",
+                bundle_id_base="not.elm.ozmux", arch="arm64",
+                target_triple="aarch64-apple-darwin",
+                bin_source=d / "ozmux", cef_framework=d / "cef", helper_bin=d / "helper",
+                out_dir=d / "out",
+                sign_identity="Developer ID Application: TEST", no_sign=False, notarize=False,
+                companion_bins={"ozbrowser": d / "ozbrowser", "ozmd": d / "ozmd"},
+            )
+            orig = bm.run
+            bm.run = fake_run
+            try:
+                bm.codesign_bundle(cfg)
+            finally:
+                bm.run = orig
+
+        resources = app / "Contents" / "Resources"
+        sign_argvs = [a for a in recorded if a[:1] == ["codesign"] and "--sign" in a]
+
+        def argv_for(path):
+            return next(a for a in sign_argvs if a[-1] == str(path))
+
+        for name in ("ozbrowser", "ozmd"):
+            a = argv_for(resources / name)
+            self.assertIn("--options", a)            # hardened runtime kept
+            self.assertNotIn("--entitlements", a)    # least privilege: no CEF grants
+        # the outer app IS signed with the CEF entitlements
+        self.assertIn("--entitlements", argv_for(app))
+
+
+class OzmdWebAssetsGuard(unittest.TestCase):
+    def test_missing_assets_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / ".gitkeep").write_text("")
+            (d / ".gitignore").write_text("*\n")
+            with self.assertRaises(SystemExit):
+                bm.verify_ozmd_web_assets(d)
+
+    def test_present_assets_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "index.html").write_text("<html></html>")
+            bm.verify_ozmd_web_assets(d)
+
+    def test_missing_dir_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit):
+                bm.verify_ozmd_web_assets(Path(d) / "does-not-exist")
 
 
 class NotarizeGuards(unittest.TestCase):

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -187,6 +187,37 @@ class ConfigResolution(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 bm.verify_prerequisites(cfg)
 
+    def test_resolve_companion_defaults(self):
+        cfg = bm.resolve_config(self._parse(["--version", "0.1.0", "--skip-build"]))
+        names = [p.name for p in cfg.companion_bins]
+        self.assertEqual(names, ["ozbrowser", "ozmd"])
+        for p in cfg.companion_bins:
+            self.assertIn("aarch64-apple-darwin", str(p))
+            self.assertIn("dist", str(p))
+
+    def test_resolve_companion_overrides(self):
+        cfg = bm.resolve_config(self._parse([
+            "--version", "0.1.0", "--skip-build",
+            "--ozbrowser-bin", "/tmp/ob", "--ozmd-bin", "/tmp/om",
+        ]))
+        self.assertEqual(cfg.companion_bins, [Path("/tmp/ob"), Path("/tmp/om")])
+
+    def test_verify_prerequisites_missing_companion(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            # main bin, cef dir, helper all present; only a companion is missing
+            (d / "ozmux").write_bytes(b"")
+            (d / "helper").write_bytes(b"")
+            cef = d / "cef"
+            cef.mkdir()
+            cfg = bm.resolve_config(bm.build_arg_parser().parse_args([
+                "--version", "0.1.0", "--bin", str(d / "ozmux"),
+                "--cef-framework", str(cef), "--helper-bin", str(d / "helper"),
+                "--ozbrowser-bin", str(d / "missing-ob"), "--ozmd-bin", str(d / "missing-om"),
+            ]))
+            with self.assertRaises(SystemExit):
+                bm.verify_prerequisites(cfg)
+
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
 class AssembleAndEmbed(unittest.TestCase):
@@ -266,6 +297,8 @@ class EndToEnd(unittest.TestCase):
             d = Path(d)
             self._macho(d / "ozmux")
             self._macho(d / "helper")
+            (d / "ozbrowser").write_bytes(b"")
+            (d / "ozmd").write_bytes(b"")
             fw = self._fake_cef(d)
             out = d / "out"
             bm.main([
@@ -273,6 +306,8 @@ class EndToEnd(unittest.TestCase):
                 "--bin", str(d / "ozmux"),
                 "--cef-framework", str(fw),
                 "--helper-bin", str(d / "helper"),
+                "--ozbrowser-bin", str(d / "ozbrowser"),
+                "--ozmd-bin", str(d / "ozmd"),
                 "--out-dir", str(out),
             ])
             zip_path = out / "ozmux-9.9.9-arm64.zip"

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -279,6 +279,35 @@ class AssembleAndEmbed(unittest.TestCase):
 
 
 @unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
+class CopyCompanions(unittest.TestCase):
+    def _macho(self, dest: Path) -> None:
+        # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true
+        shutil.copy("/usr/bin/true", dest)
+        dest.chmod(0o755)
+
+    def test_copy_companions_into_resources(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            self._macho(d / "ozbrowser")
+            self._macho(d / "ozmd")
+            cfg = bm.BundleConfig(
+                version="9.9.9", app_name="ozmux", bin_name="ozmux",
+                bundle_id_base="not.elm.ozmux", arch="arm64",
+                target_triple="aarch64-apple-darwin",
+                bin_source=d / "ozmux", cef_framework=d / "cef", helper_bin=d / "helper",
+                out_dir=d / "out", sign_identity="-", no_sign=True, notarize=False,
+                companion_bins=[d / "ozbrowser", d / "ozmd"],
+            )
+            resources = cfg.app_path / "Contents" / "Resources"
+            resources.mkdir(parents=True)
+            bm.copy_companions(cfg)
+            for name in ("ozbrowser", "ozmd"):
+                dest = resources / name
+                self.assertTrue(dest.is_file())
+                self.assertTrue(os.access(dest, os.X_OK))
+
+
+@unittest.skipUnless(sys.platform == "darwin", "macOS-only integration test")
 class EndToEnd(unittest.TestCase):
     def _macho(self, dest: Path) -> None:
         # NOTE: shutil.copy (not copy2) avoids PermissionError from SIP-restricted flags on /usr/bin/true

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -130,6 +130,16 @@ class CommandBuilders(unittest.TestCase):
     def test_stapler_argv(self):
         self.assertEqual(bm.stapler_argv(Path("/tmp/a.app")), ["xcrun", "stapler", "staple", "/tmp/a.app"])
 
+    def test_companion_cargo_build_argv(self):
+        self.assertEqual(
+            bm.companion_cargo_build_argv("aarch64-apple-darwin", "dist", ("ozbrowser", "ozmd")),
+            ["cargo", "build", "--profile", "dist", "--target", "aarch64-apple-darwin",
+             "--locked", "-p", "ozbrowser", "-p", "ozmd"],
+        )
+
+    def test_companion_bins_constant(self):
+        self.assertEqual(bm.COMPANION_BINS, ("ozbrowser", "ozmd"))
+
     def test_compute_sha256(self):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"hello")

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -326,8 +326,8 @@ class EndToEnd(unittest.TestCase):
             d = Path(d)
             self._macho(d / "ozmux")
             self._macho(d / "helper")
-            (d / "ozbrowser").write_bytes(b"")
-            (d / "ozmd").write_bytes(b"")
+            self._macho(d / "ozbrowser")
+            self._macho(d / "ozmd")
             fw = self._fake_cef(d)
             out = d / "out"
             bm.main([
@@ -344,7 +344,10 @@ class EndToEnd(unittest.TestCase):
             sha_file = out / "ozmux-9.9.9-arm64.zip.sha256"
             self.assertTrue(sha_file.is_file())
             self.assertEqual(bm.compute_sha256(zip_path), sha_file.read_text().split()[0])
-            # ad-hoc signature must verify
+            resources = out / "ozmux.app" / "Contents" / "Resources"
+            self.assertTrue((resources / "ozbrowser").is_file())
+            self.assertTrue((resources / "ozmd").is_file())
+            # ad-hoc signature must verify deep+strict — fails if a nested companion is unsigned
             subprocess.run(
                 ["codesign", "--verify", "--deep", "--strict", str(out / "ozmux.app")],
                 check=True,

--- a/scripts/test_bundle_macos.py
+++ b/scripts/test_bundle_macos.py
@@ -42,6 +42,14 @@ class PureHelpers(unittest.TestCase):
         self.assertEqual(cfg.zip_path, Path("/tmp/out/ozmux-1.2.3-arm64.zip"))
 
 
+class CaskTemplate(unittest.TestCase):
+    def test_template_has_companion_binary_stanzas(self):
+        tmpl = (bm.REPO_ROOT / "build" / "macos" / "homebrew" / "ozmux.rb.tmpl").read_text()
+        self.assertIn('app "ozmux.app"', tmpl)
+        self.assertIn('binary "#{appdir}/ozmux.app/Contents/Resources/ozbrowser"', tmpl)
+        self.assertIn('binary "#{appdir}/ozmux.app/Contents/Resources/ozmd"', tmpl)
+
+
 class PlistLogic(unittest.TestCase):
     def test_merge_cef_keys_into_empty(self):
         out = bm.merge_cef_keys({})


### PR DESCRIPTION
## Summary

Two threads of work on the `publish-sdk` branch:

### Bundle the companion apps into the Homebrew cask (main change)
`brew install --cask ozmux` now also puts `ozbrowser` and `ozmd` on the user's PATH. These are plain Rust TUI binaries (no CEF) that require a running ozmux (they dial `$OZMA_SOCK`), so they ship **inside** `ozmux.app` rather than as separate formulae.

- `scripts/bundle_macos.py` builds the companions (`-p ozbrowser -p ozmd`, `dist` profile), embeds them in `ozmux.app/Contents/Resources/`, and signs each — **hardened runtime, no entitlements** (least privilege for PATH-exposed CLIs) — **before** the outer app, so they ride the existing notarization.
- `build/macos/homebrew/ozmux.rb.tmpl` exposes them via `binary` stanzas.
- `.github/workflows/release-macos.yml` gains a pnpm/node step so `ozmd`'s `rust-embed` web assets are built before the cargo build; a `verify_ozmd_web_assets` guard + local `just` recipe deps prevent shipping a blank viewer outside CI.
- arm64-only, macOS-only, matching the existing pipeline.

### Docs
English README rewrite with inlined protocol/config summaries; removed empty doc stubs.

## Testing
`python3 scripts/test_bundle_macos.py` — 43/43 passing (incl. darwin integration tests that assemble, sign, and verify a fake bundle, and a genuine signing-order regression guard).

## Review
Built task-by-task with per-task review, a final whole-feature review, and an xhigh multi-agent `/code-review` pass. Two follow-ups deliberately deferred: a companion lipo arch-check, and a shared composite action for the duplicated pnpm/node setup across workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)