### PR TITLE
feat: horizontal mouse-wheel / trackpad scroll for mouse-mode apps

### DIFF
--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -376,25 +376,20 @@ pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f
     }
 }
 
-/// Adds `delta_cells` to the accumulator and returns whole notches to emit
-/// (positive = up/older), carrying the remainder. Resets the residual on a
-/// sign flip, then processes the new delta at full magnitude.
-pub(crate) fn accumulate_notches(
-    acc: &mut WheelAccumulator,
-    delta_cells: f32,
-    cells_per_notch: f32,
-) -> i32 {
-    if acc.residual_cells != 0.0
-        && delta_cells != 0.0
-        && acc.residual_cells.signum() != delta_cells.signum()
-    {
-        acc.residual_cells = 0.0;
+/// Adds `delta_cells` to `residual` and returns whole notches to emit
+/// (positive = up/older for the vertical axis, right for the horizontal axis),
+/// carrying the remainder. Resets `residual` on a sign flip, then processes the
+/// new delta at full magnitude. A zero / negative-zero delta has no direction
+/// and must not trip the sign-flip reset.
+pub(crate) fn accumulate_notches(residual: &mut f32, delta_cells: f32, cells_per_notch: f32) -> i32 {
+    if *residual != 0.0 && delta_cells != 0.0 && (*residual).signum() != delta_cells.signum() {
+        *residual = 0.0;
     }
     let threshold = cells_per_notch.max(f32::EPSILON);
-    acc.residual_cells += delta_cells;
-    let notches = (acc.residual_cells / threshold).trunc() as i32;
+    *residual += delta_cells;
+    let notches = (*residual / threshold).trunc() as i32;
     if notches != 0 {
-        acc.residual_cells -= notches as f32 * threshold;
+        *residual -= notches as f32 * threshold;
     }
     notches
 }
@@ -662,7 +657,7 @@ pub(crate) fn dispatch_mouse_wheel(
         .read()
         .map(|ev| wheel_delta_cells(ev.unit, ev.y, ctx.cell_h))
         .sum();
-    let raw = accumulate_notches(&mut gesture_acc, delta_cells, cfg.cells_per_notch);
+    let raw = accumulate_notches(&mut gesture_acc.residual_cells, delta_cells, cfg.cells_per_notch);
     if raw == 0 {
         return;
     }
@@ -1857,9 +1852,9 @@ mod tests {
     #[test]
     fn accumulator_emits_on_threshold_and_carries_remainder() {
         let mut acc = WheelAccumulator::default();
-        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
-        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
-        assert_eq!(accumulate_notches(&mut acc, -1.0, 0.5), -2);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 1);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, -1.0, 0.5), -2);
     }
 
     #[test]
@@ -1869,16 +1864,16 @@ mod tests {
         let b = world.spawn_empty().id();
         let mut acc = WheelAccumulator::default();
         acc.retarget(a);
-        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
         acc.retarget(a);
         assert_eq!(
-            accumulate_notches(&mut acc, 0.3, 0.5),
+            accumulate_notches(&mut acc.residual_cells, 0.3, 0.5),
             1,
             "0.3 + 0.3 = 0.6 → one notch on the same target"
         );
         acc.retarget(b);
         assert_eq!(
-            accumulate_notches(&mut acc, 0.3, 0.5),
+            accumulate_notches(&mut acc.residual_cells, 0.3, 0.5),
             0,
             "switching target clears the carried residual"
         );
@@ -1889,9 +1884,9 @@ mod tests {
         // A zero / negative-zero delta has no direction and must NOT trip the
         // sign-flip reset (signum(-0.0) == -1.0 would otherwise drop the carry).
         let mut acc = WheelAccumulator::default();
-        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 0);
-        assert_eq!(accumulate_notches(&mut acc, -0.0, 0.5), 0);
-        assert_eq!(accumulate_notches(&mut acc, 0.3, 0.5), 1);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, -0.0, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 1);
     }
 
     #[test]

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -700,10 +700,10 @@ pub(crate) fn dispatch_mouse_wheel(
         effects.extend(decide_wheel(modes, -raw_v, cell, mods, &cfg.wheel));
     }
     if raw_h != 0 {
-        // NOTE: positive ev.x → Right (cb 67); confirm against a live Neovim and
-        // flip to `-raw_h` if reversed (winit's macOS PixelDelta horizontal sign
-        // is historically opposite X11/Wayland, so the on-screen direction is
-        // runtime-verified, not assumed).
+        // TODO: verify the horizontal direction against a live Neovim and flip
+        // `raw_h` to `-raw_h` if reversed. winit's macOS PixelDelta horizontal
+        // sign is historically opposite X11/Wayland, so positive ev.x → Right
+        // (cb 67) is assumed here, not yet runtime-confirmed.
         let mods = build_wheel_modifiers_horizontal(&keys, &cfg);
         effects.extend(effects_from_wheel_action(WheelAction::route_horizontal(
             modes, raw_h, cell, mods, &cfg.wheel,
@@ -1931,6 +1931,13 @@ mod tests {
             accumulate_notches(&mut acc.residual_cells, 0.3, 0.5),
             0,
             "switching target clears the carried residual"
+        );
+        assert_eq!(accumulate_notches(&mut acc.residual_cells_h, 0.3, 0.5), 0);
+        acc.retarget(a);
+        assert_eq!(
+            accumulate_notches(&mut acc.residual_cells_h, 0.3, 0.5),
+            0,
+            "a target change must clear the carried horizontal residual too"
         );
     }
 

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -662,9 +662,13 @@ pub(crate) fn dispatch_mouse_wheel(
 
     gesture_acc.retarget(target);
     let (delta_v, delta_h) = wheel.read().fold((0.0f32, 0.0f32), |(v, h), ev| {
+        // NOTE: BOTH axes divide by cell_h (line height), not cell_w, so a given
+        // finger distance yields the same notch rate horizontally and vertically.
+        // Using the narrower cell_w (advance_phys, ~half of line_height_phys) made
+        // horizontal ~2x too sensitive — do not "correct" ev.x to ctx.cell_w.
         (
             v + wheel_delta_cells(ev.unit, ev.y, ctx.cell_h),
-            h + wheel_delta_cells(ev.unit, ev.x, ctx.cell_w),
+            h + wheel_delta_cells(ev.unit, ev.x, ctx.cell_h),
         )
     });
     let raw_v = accumulate_notches(&mut gesture_acc.residual_cells, delta_v, cfg.cells_per_notch);
@@ -2096,6 +2100,49 @@ mod tests {
             cap.0.iter().flatten().all(|e| !matches!(e, MouseEffect::Write(_))),
             "horizontal wheel outside a mouse mode must not emit a report, got {:?}",
             cap.0
+        );
+    }
+
+    #[test]
+    fn pixel_horizontal_sensitivity_matches_vertical() {
+        // Equal Pixel-unit deltas on both axes must emit equal report counts.
+        // Regression: horizontal divided ev.x by cell_w (~half of cell_h), so a
+        // given finger distance fired ~2x the notches and scrolled too far.
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseWheel>>()
+            .write(MouseWheel {
+                unit: MouseScrollUnit::Pixel,
+                x: 16.0,
+                y: 16.0,
+                window: Entity::PLACEHOLDER,
+            });
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        let count = |needle: &[u8]| -> usize {
+            cap.0
+                .iter()
+                .flatten()
+                .filter_map(|e| match e {
+                    MouseEffect::Write(b) => Some(b),
+                    _ => None,
+                })
+                .map(|b| b.windows(needle.len()).filter(|w| *w == needle).count())
+                .sum()
+        };
+        // test_metrics: cell_w = 8, cell_h = 16. y=16 → up reports (cb 64);
+        // x=16 → right reports (cb 67).
+        let vertical = count(b"\x1b[<64;");
+        let horizontal = count(b"\x1b[<67;");
+        assert!(
+            vertical > 0 && horizontal > 0,
+            "both axes must emit reports, got v={vertical} h={horizontal}"
+        );
+        assert_eq!(
+            horizontal, vertical,
+            "equal Pixel deltas must emit equal report counts (horizontal sensitivity \
+             must match vertical), got v={vertical} h={horizontal}"
         );
     }
 }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -403,7 +403,13 @@ pub(crate) fn decide_wheel(
     mods: WheelModifiers,
     cfg: &WheelConfig,
 ) -> Vec<MouseEffect> {
-    match WheelAction::route(modes, notches, cell, mods, cfg) {
+    effects_from_wheel_action(WheelAction::route(modes, notches, cell, mods, cfg))
+}
+
+/// Maps a routed `WheelAction` to host effects. Shared by the vertical
+/// (`route`) and horizontal (`route_horizontal`) wheel paths.
+fn effects_from_wheel_action(action: WheelAction) -> Vec<MouseEffect> {
+    match action {
         WheelAction::Noop => Vec::new(),
         WheelAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
         WheelAction::ScrollViewport(lines) => vec![MouseEffect::Scroll(lines)],
@@ -810,6 +816,18 @@ fn build_wheel_modifiers(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> 
         alt: m.alt,
         fine: fine_held(cfg.fine_modifier, &m),
     }
+}
+
+/// Horizontal-wheel modifiers. On macOS the OS converts Shift+wheel into a
+/// horizontal scroll while Shift stays physically held; stripping the Shift bit
+/// keeps the report a plain `<ScrollWheelLeft/Right>` rather than the shifted
+/// (and by default unmapped) variant. Other platforms pass modifiers through.
+fn build_wheel_modifiers_horizontal(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> WheelModifiers {
+    let mut mods = build_wheel_modifiers(keys, cfg);
+    if cfg!(target_os = "macos") {
+        mods.shift = false;
+    }
+    mods
 }
 
 fn fine_held(modifier: FineModifier, m: &TerminalModifiers) -> bool {
@@ -1913,5 +1931,31 @@ mod tests {
             &WheelConfig::default(),
         );
         assert!(matches!(fx.as_slice(), [MouseEffect::Write(b)] if !b.is_empty()));
+    }
+
+    #[test]
+    fn effects_from_wheel_action_maps_each_variant() {
+        assert_eq!(effects_from_wheel_action(WheelAction::Noop), vec![]);
+        assert_eq!(
+            effects_from_wheel_action(WheelAction::WriteToPty(b"x".to_vec())),
+            vec![MouseEffect::Write(b"x".to_vec())]
+        );
+        assert_eq!(
+            effects_from_wheel_action(WheelAction::ScrollViewport(3)),
+            vec![MouseEffect::Scroll(3)]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn horizontal_modifiers_strip_shift_on_macos() {
+        let mut keys = ButtonInput::<KeyCode>::default();
+        keys.press(KeyCode::ShiftLeft);
+        let cfg = OzmaMouseConfig::default();
+        let mods = build_wheel_modifiers_horizontal(&keys, &cfg);
+        assert!(
+            !mods.shift,
+            "macOS converts Shift+wheel to horizontal at the OS level; the report must not carry the Shift bit"
+        );
     }
 }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -348,20 +348,22 @@ pub(crate) fn decide_button(
     effects
 }
 
-/// Carries the sub-notch wheel remainder across frames, scoped to the last
-/// terminal the wheel targeted.
+/// Carries the sub-notch wheel remainder across frames, per axis, scoped to the
+/// last terminal the wheel targeted.
 #[derive(Resource, Default)]
 pub(crate) struct WheelAccumulator {
     residual_cells: f32,
+    residual_cells_h: f32,
     last_target: Option<Entity>,
 }
 
 impl WheelAccumulator {
-    /// Resets the residual when the wheel target changes, so a sub-notch fraction
-    /// accumulated over one terminal cannot bleed into the next.
+    /// Resets both residuals when the wheel target changes, so a sub-notch
+    /// fraction accumulated over one terminal cannot bleed into the next.
     fn retarget(&mut self, entity: Entity) {
         if self.last_target != Some(entity) {
             self.residual_cells = 0.0;
+            self.residual_cells_h = 0.0;
             self.last_target = Some(entity);
         }
     }
@@ -659,22 +661,38 @@ pub(crate) fn dispatch_mouse_wheel(
     };
 
     gesture_acc.retarget(target);
-    let delta_cells: f32 = wheel
-        .read()
-        .map(|ev| wheel_delta_cells(ev.unit, ev.y, ctx.cell_h))
-        .sum();
-    let raw = accumulate_notches(&mut gesture_acc.residual_cells, delta_cells, cfg.cells_per_notch);
-    if raw == 0 {
+    let (delta_v, delta_h) = wheel.read().fold((0.0f32, 0.0f32), |(v, h), ev| {
+        (
+            v + wheel_delta_cells(ev.unit, ev.y, ctx.cell_h),
+            h + wheel_delta_cells(ev.unit, ev.x, ctx.cell_w),
+        )
+    });
+    let raw_v = accumulate_notches(&mut gesture_acc.residual_cells, delta_v, cfg.cells_per_notch);
+    let raw_h = accumulate_notches(&mut gesture_acc.residual_cells_h, delta_h, cfg.cells_per_notch);
+    if raw_v == 0 && raw_h == 0 {
         return;
     }
-    // NOTE: Bevy +y (up/older) → engine convention (negative = up/older).
-    let notches = -raw;
     let cell = ctx
         .hit(cursor_phys)
         .map(|(cell, _)| cell)
         .unwrap_or(CellCoord { col: 1, row: 1 });
-    let mods = build_wheel_modifiers(&keys, &cfg);
-    let effects = decide_wheel(handle.current_modes(), notches, cell, mods, &cfg.wheel);
+    let modes = handle.current_modes();
+    let mut effects = Vec::new();
+    if raw_v != 0 {
+        // NOTE: Bevy +y (up/older) → engine convention (negative = up/older).
+        let mods = build_wheel_modifiers(&keys, &cfg);
+        effects.extend(decide_wheel(modes, -raw_v, cell, mods, &cfg.wheel));
+    }
+    if raw_h != 0 {
+        // NOTE: positive ev.x → Right (cb 67); confirm against a live Neovim and
+        // flip to `-raw_h` if reversed (winit's macOS PixelDelta horizontal sign
+        // is historically opposite X11/Wayland, so the on-screen direction is
+        // runtime-verified, not assumed).
+        let mods = build_wheel_modifiers_horizontal(&keys, &cfg);
+        effects.extend(effects_from_wheel_action(WheelAction::route_horizontal(
+            modes, raw_h, cell, mods, &cfg.wheel,
+        )));
+    }
     if !effects.is_empty() {
         commands.trigger(TerminalMouseEffects {
             entity: target,
@@ -1956,6 +1974,128 @@ mod tests {
         assert!(
             !mods.shift,
             "macOS converts Shift+wheel to horizontal at the OS level; the report must not carry the Shift bit"
+        );
+    }
+
+    fn make_wheel_app(enable_modes: &[u8]) -> App {
+        use bevy::window::WindowResolution;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<MouseWheel>()
+            .init_resource::<OzmaMouseConfig>()
+            .init_resource::<WheelAccumulator>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<Clipboard>()
+            .init_resource::<CapturedEffects>()
+            .insert_resource(test_metrics())
+            .add_observer(
+                |ev: On<TerminalMouseEffects>, mut cap: ResMut<CapturedEffects>| {
+                    cap.0.push(ev.effects.clone());
+                },
+            )
+            .add_systems(Update, dispatch_mouse_wheel);
+
+        let mut handle = TerminalHandle::detached(100, 37);
+        handle.advance(enable_modes);
+        app.world_mut().spawn((
+            OzmaTerminal,
+            handle,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalGrid {
+                cols: 100,
+                rows: 37,
+                ..default()
+            },
+        ));
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app
+    }
+
+    fn write_wheel(app: &mut App, x: f32, y: f32) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseWheel>>()
+            .write(MouseWheel {
+                unit: MouseScrollUnit::Line,
+                x,
+                y,
+                window: Entity::PLACEHOLDER,
+            });
+    }
+
+    #[test]
+    fn dispatch_pure_horizontal_right_emits_sgr_67() {
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().any(
+                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))
+            ),
+            "a +x wheel in mouse mode must emit an SGR wheel-right (cb 67) report, got {:?}",
+            cap.0
+        );
+    }
+
+    #[test]
+    fn dispatch_horizontal_left_emits_sgr_66() {
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, -0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().any(
+                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<66;"))
+            ),
+            "a -x wheel in mouse mode must emit an SGR wheel-left (cb 66) report, got {:?}",
+            cap.0
+        );
+    }
+
+    #[test]
+    fn dispatch_diagonal_emits_both_axes_in_one_trigger() {
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.5, -0.5);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert_eq!(cap.0.len(), 1, "both axes must arrive in ONE trigger, got {:?}", cap.0);
+        let frame = &cap.0[0];
+        assert!(
+            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<65;"))),
+            "vertical (down, cb 65) report missing: {frame:?}"
+        );
+        assert!(
+            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))),
+            "horizontal (right, cb 67) report missing: {frame:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_horizontal_without_mouse_mode_emits_no_report() {
+        let mut app = make_wheel_app(b"");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().all(|e| !matches!(e, MouseEffect::Write(_))),
+            "horizontal wheel outside a mouse mode must not emit a report, got {:?}",
+            cap.0
         );
     }
 }

--- a/crates/ozma_terminal/src/mouse.rs
+++ b/crates/ozma_terminal/src/mouse.rs
@@ -383,7 +383,11 @@ pub(crate) fn wheel_delta_cells(unit: MouseScrollUnit, y: f32, cell_h: f32) -> f
 /// carrying the remainder. Resets `residual` on a sign flip, then processes the
 /// new delta at full magnitude. A zero / negative-zero delta has no direction
 /// and must not trip the sign-flip reset.
-pub(crate) fn accumulate_notches(residual: &mut f32, delta_cells: f32, cells_per_notch: f32) -> i32 {
+pub(crate) fn accumulate_notches(
+    residual: &mut f32,
+    delta_cells: f32,
+    cells_per_notch: f32,
+) -> i32 {
     if *residual != 0.0 && delta_cells != 0.0 && (*residual).signum() != delta_cells.signum() {
         *residual = 0.0;
     }
@@ -671,8 +675,16 @@ pub(crate) fn dispatch_mouse_wheel(
             h + wheel_delta_cells(ev.unit, ev.x, ctx.cell_h),
         )
     });
-    let raw_v = accumulate_notches(&mut gesture_acc.residual_cells, delta_v, cfg.cells_per_notch);
-    let raw_h = accumulate_notches(&mut gesture_acc.residual_cells_h, delta_h, cfg.cells_per_notch);
+    let raw_v = accumulate_notches(
+        &mut gesture_acc.residual_cells,
+        delta_v,
+        cfg.cells_per_notch,
+    );
+    let raw_h = accumulate_notches(
+        &mut gesture_acc.residual_cells_h,
+        delta_h,
+        cfg.cells_per_notch,
+    );
     if raw_v == 0 && raw_h == 0 {
         return;
     }
@@ -844,7 +856,10 @@ fn build_wheel_modifiers(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> 
 /// horizontal scroll while Shift stays physically held; stripping the Shift bit
 /// keeps the report a plain `<ScrollWheelLeft/Right>` rather than the shifted
 /// (and by default unmapped) variant. Other platforms pass modifiers through.
-fn build_wheel_modifiers_horizontal(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> WheelModifiers {
+fn build_wheel_modifiers_horizontal(
+    keys: &ButtonInput<KeyCode>,
+    cfg: &OzmaMouseConfig,
+) -> WheelModifiers {
     let mut mods = build_wheel_modifiers(keys, cfg);
     if cfg!(target_os = "macos") {
         mods.shift = false;
@@ -2046,9 +2061,10 @@ mod tests {
         app.update();
         let cap = app.world().resource::<CapturedEffects>();
         assert!(
-            cap.0.iter().flatten().any(
-                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))
-            ),
+            cap.0
+                .iter()
+                .flatten()
+                .any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))),
             "a +x wheel in mouse mode must emit an SGR wheel-right (cb 67) report, got {:?}",
             cap.0
         );
@@ -2062,9 +2078,10 @@ mod tests {
         app.update();
         let cap = app.world().resource::<CapturedEffects>();
         assert!(
-            cap.0.iter().flatten().any(
-                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<66;"))
-            ),
+            cap.0
+                .iter()
+                .flatten()
+                .any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<66;"))),
             "a -x wheel in mouse mode must emit an SGR wheel-left (cb 66) report, got {:?}",
             cap.0
         );
@@ -2077,14 +2094,23 @@ mod tests {
         write_wheel(&mut app, 0.5, -0.5);
         app.update();
         let cap = app.world().resource::<CapturedEffects>();
-        assert_eq!(cap.0.len(), 1, "both axes must arrive in ONE trigger, got {:?}", cap.0);
+        assert_eq!(
+            cap.0.len(),
+            1,
+            "both axes must arrive in ONE trigger, got {:?}",
+            cap.0
+        );
         let frame = &cap.0[0];
         assert!(
-            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<65;"))),
+            frame
+                .iter()
+                .any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<65;"))),
             "vertical (down, cb 65) report missing: {frame:?}"
         );
         assert!(
-            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))),
+            frame
+                .iter()
+                .any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))),
             "horizontal (right, cb 67) report missing: {frame:?}"
         );
     }
@@ -2097,7 +2123,10 @@ mod tests {
         app.update();
         let cap = app.world().resource::<CapturedEffects>();
         assert!(
-            cap.0.iter().flatten().all(|e| !matches!(e, MouseEffect::Write(_))),
+            cap.0
+                .iter()
+                .flatten()
+                .all(|e| !matches!(e, MouseEffect::Write(_))),
             "horizontal wheel outside a mouse mode must not emit a report, got {:?}",
             cap.0
         );

--- a/crates/ozma_tty_engine/src/wheel.rs
+++ b/crates/ozma_tty_engine/src/wheel.rs
@@ -48,11 +48,13 @@ impl Default for WheelConfig {
 
 pub use crate::mouse_encode::CellCoord;
 
-/// Wheel direction. Horizontal wheels are out of scope.
+/// Wheel direction (vertical and horizontal).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WheelDir {
     Up,
     Down,
+    Left,
+    Right,
 }
 
 /// Modifier state captured at the moment the wheel event fires.
@@ -110,8 +112,32 @@ fn encode_wheel_report(
     let cb_base: u8 = match direction {
         WheelDir::Up => 64,
         WheelDir::Down => 65,
+        WheelDir::Left => 66,
+        WheelDir::Right => 67,
     };
     encode_protocol_event(modes, cb_base, cell, protocol_mods_from(mods), false, false)
+}
+
+/// Emits `min(|notches|, cap)` concatenated wheel reports for a mouse-mode
+/// pane, or `Noop` when the cap rounds the count to zero. Shared by the
+/// vertical (`route`) and horizontal (`route_horizontal`) mouse-protocol paths.
+fn emit_protocol_reports(
+    modes: TermMode,
+    direction: WheelDir,
+    notches: i32,
+    mouse_cell: CellCoord,
+    mods: WheelModifiers,
+    cfg: &WheelConfig,
+) -> WheelAction {
+    let count = notches.unsigned_abs().min(cfg.max_protocol_events_per_frame);
+    if count == 0 {
+        return WheelAction::Noop;
+    }
+    let mut buf = Vec::new();
+    for _ in 0..count {
+        buf.extend_from_slice(&encode_wheel_report(modes, direction, mods, mouse_cell));
+    }
+    WheelAction::WriteToPty(buf)
 }
 
 impl WheelAction {
@@ -151,16 +177,7 @@ impl WheelAction {
             TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION,
         );
         if any_mouse {
-            let count = (notches.unsigned_abs()).min(cfg.max_protocol_events_per_frame);
-            if count == 0 {
-                return WheelAction::Noop;
-            }
-            let mut buf = Vec::new();
-            for _ in 0..count {
-                let one = encode_wheel_report(modes, direction, mods, mouse_cell);
-                buf.extend_from_slice(&one);
-            }
-            return WheelAction::WriteToPty(buf);
+            return emit_protocol_reports(modes, direction, notches, mouse_cell, mods, cfg);
         }
 
         // NOTE: no Shift bypass to host scrollback here. `scroll_display`
@@ -191,6 +208,37 @@ impl WheelAction {
         let viewport_delta = -notches * lines_per;
         WheelAction::ScrollViewport(viewport_delta)
     }
+
+    /// Decides what to do with a horizontal wheel input.
+    ///
+    /// `notches` is sign-significant (negative = left, positive = right).
+    /// Horizontal wheel only has meaning for mouse-mode applications: when any of
+    /// `MOUSE_REPORT_CLICK`, `MOUSE_DRAG`, `MOUSE_MOTION` is set, it emits
+    /// `min(|notches|, max_protocol_events_per_frame)` SGR/X10 reports with `cb`
+    /// 66 (left) / 67 (right). Outside a mouse mode there is no horizontal
+    /// scrollback or alt-screen translation, so it returns `Noop`.
+    pub fn route_horizontal(
+        modes: TermMode,
+        notches: i32,
+        mouse_cell: CellCoord,
+        mods: WheelModifiers,
+        cfg: &WheelConfig,
+    ) -> Self {
+        if notches == 0 {
+            return WheelAction::Noop;
+        }
+        let direction = if notches < 0 {
+            WheelDir::Left
+        } else {
+            WheelDir::Right
+        };
+        if modes.intersects(
+            TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION,
+        ) {
+            return emit_protocol_reports(modes, direction, notches, mouse_cell, mods, cfg);
+        }
+        WheelAction::Noop
+    }
 }
 
 /// Emits `n` SS3-form arrow-key sequences for the alt-screen
@@ -203,6 +251,7 @@ fn alt_screen_arrow_bytes(direction: WheelDir, n: u32) -> Vec<u8> {
     let suffix = match direction {
         WheelDir::Up => b'A',
         WheelDir::Down => b'B',
+        WheelDir::Left | WheelDir::Right => unreachable!(),
     };
     let mut out = Vec::with_capacity(n as usize * 3);
     for _ in 0..n {
@@ -560,5 +609,78 @@ mod route_tests {
             &cfg_default(),
         );
         assert_eq!(action, WheelAction::WriteToPty(b"\x1b[<65;1;1M".to_vec()));
+    }
+
+    #[test]
+    fn horizontal_mouse_mode_emits_left_and_right() {
+        let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        let at = CellCoord { col: 43, row: 11 };
+        let left = WheelAction::route_horizontal(modes, -1, at, WheelModifiers::default(), &cfg_default());
+        assert_eq!(left, WheelAction::WriteToPty(b"\x1b[<66;43;11M".to_vec()));
+        let right = WheelAction::route_horizontal(modes, 1, at, WheelModifiers::default(), &cfg_default());
+        assert_eq!(right, WheelAction::WriteToPty(b"\x1b[<67;43;11M".to_vec()));
+    }
+
+    #[test]
+    fn horizontal_without_mouse_mode_is_noop() {
+        // No horizontal scrollback or alt-screen translation: normal AND alt-screen are Noop.
+        assert_eq!(
+            WheelAction::route_horizontal(TermMode::empty(), -2, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+        let alt = TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL;
+        assert_eq!(
+            WheelAction::route_horizontal(alt, 2, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_zero_notches_is_noop() {
+        let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        assert_eq!(
+            WheelAction::route_horizontal(modes, 0, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_x10_fallback_right() {
+        let modes = TermMode::MOUSE_DRAG; // no SGR_MOUSE → X10
+        let action = WheelAction::route_horizontal(modes, 1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &cfg_default());
+        // cb 67 + 32 = 99; col/row 1 + 32 = 33
+        assert_eq!(action, WheelAction::WriteToPty(vec![0x1b, b'[', b'M', 99, 33, 33]));
+    }
+
+    #[test]
+    fn horizontal_concats_and_caps() {
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let cfg = WheelConfig { max_protocol_events_per_frame: 4, ..WheelConfig::default() };
+        let action = WheelAction::route_horizontal(modes, 20, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &cfg);
+        let one = b"\x1b[<67;1;1M";
+        let mut expected = Vec::new();
+        for _ in 0..4 {
+            expected.extend_from_slice(one);
+        }
+        assert_eq!(action, WheelAction::WriteToPty(expected));
+    }
+
+    #[test]
+    fn horizontal_zero_cap_is_noop() {
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let cfg = WheelConfig { max_protocol_events_per_frame: 0, ..WheelConfig::default() };
+        assert_eq!(
+            WheelAction::route_horizontal(modes, 5, cell(), WheelModifiers::default(), &cfg),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_ctrl_modifier_bit() {
+        let modes = TermMode::SGR_MOUSE | TermMode::MOUSE_REPORT_CLICK;
+        let mods = WheelModifiers { ctrl: true, ..Default::default() };
+        let action = WheelAction::route_horizontal(modes, -1, CellCoord { col: 1, row: 1 }, mods, &cfg_default());
+        // 66 + 16 (ctrl) = 82
+        assert_eq!(action, WheelAction::WriteToPty(b"\x1b[<82;1;1M".to_vec()));
     }
 }

--- a/docs/plans/2026-06-28-mouse-wheel-horizontal-scroll.md
+++ b/docs/plans/2026-06-28-mouse-wheel-horizontal-scroll.md
@@ -1,0 +1,717 @@
+# Horizontal mouse-wheel / trackpad scroll — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Translate horizontal wheel/trackpad input (`ev.x`) into SGR/X10 horizontal wheel reports (`cb=66` left / `cb=67` right) for mouse-mode applications (e.g. Neovim with `set mouse=a` + `nowrap`), in both Default and tmux modes.
+
+**Architecture:** Add a dedicated horizontal route function to the pure engine wheel router (`WheelAction::route_horizontal`), leaving the vertical `route` untouched. In the host wheel dispatcher, accumulate the horizontal axis on its own residual and emit reports through the existing `MouseEffect::Write` → `TerminalMouseEffects` → tmux `send-keys -H` / PTY path. No new effect/event types, no new config keys.
+
+**Tech Stack:** Rust (edition 2024, toolchain 1.95), Bevy 0.18 ECS, `alacritty_terminal::TermMode`. Crates: `ozma_tty_engine` (pure wheel routing + SGR/X10 encoder), `ozma_terminal` (Bevy wheel dispatcher).
+
+## Global Constraints
+
+- Edition 2024, toolchain pinned to 1.95. Workspace builds with `cargo build`.
+- **Comments:** only `// TODO:` / `// NOTE:` / `// SAFETY:`; `// NOTE:` is for critical caveats only (concrete harm if overlooked). All comments in English. No block comments, no commented-out code, no narrative comments.
+- **Doc comments:** every externally-`pub` item gets a `///` one-line summary. (`route_horizontal` is `pub`; the private helpers are not required to have docs but a one-line `///` is welcome.)
+- **Visibility:** narrowest that compiles. `route_horizontal` is `pub` (called cross-crate from `ozma_terminal`). `emit_protocol_reports`, `effects_from_wheel_action`, `build_wheel_modifiers_horizontal` are private (used only in their defining file). New struct fields stay private.
+- **Parameter ordering:** mutable params before immutable (`accumulate_notches(residual: &mut f32, …)` keeps the `&mut` first).
+- **Item ordering:** `pub` before private within an `impl`/module.
+- No `mod.rs`. Imports at top of file, single contiguous block, no inline fully-qualified paths.
+- `cargo clippy --workspace` and `cargo fmt` must be clean (run `just fix-lint` or the per-crate equivalents).
+- **Feature scope:** mouse-mode applications only (`MOUSE_REPORT_CLICK | MOUSE_DRAG | MOUSE_MOTION`). Outside a mouse mode, horizontal wheel is a `Noop` (no scrollback, no alt-screen arrow translation). No new `[mouse]` config keys.
+
+Reference spec: `docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md`.
+
+---
+
+### Task 1: Engine — horizontal wheel routing + encoding
+
+**Files:**
+- Modify: `crates/ozma_tty_engine/src/wheel.rs`
+- Test: `crates/ozma_tty_engine/src/wheel.rs` (inline `#[cfg(test)] mod route_tests`)
+
+**Interfaces:**
+- Consumes: existing `encode_wheel_report(modes, direction, mods, cell)`, `WheelConfig`, `WheelModifiers`, `CellCoord`, `alacritty_terminal::term::TermMode`.
+- Produces (used by Task 3):
+  - `WheelDir::Left`, `WheelDir::Right` enum variants.
+  - `pub fn WheelAction::route_horizontal(modes: TermMode, notches: i32, mouse_cell: CellCoord, mods: WheelModifiers, cfg: &WheelConfig) -> WheelAction` — returns `WriteToPty(bytes)` of `min(|notches|, cap)` SGR/X10 reports (`cb 66` for `notches<0`, `cb 67` for `notches>0`) when any `MOUSE_MODE` bit is set; `Noop` otherwise or when `notches==0`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests inside the existing `#[cfg(test)] mod route_tests { … }` block in `crates/ozma_tty_engine/src/wheel.rs` (it already defines `cfg_default()` and `cell()` helpers):
+
+```rust
+    #[test]
+    fn horizontal_mouse_mode_emits_left_and_right() {
+        let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        let at = CellCoord { col: 43, row: 11 };
+        let left = WheelAction::route_horizontal(modes, -1, at, WheelModifiers::default(), &cfg_default());
+        assert_eq!(left, WheelAction::WriteToPty(b"\x1b[<66;43;11M".to_vec()));
+        let right = WheelAction::route_horizontal(modes, 1, at, WheelModifiers::default(), &cfg_default());
+        assert_eq!(right, WheelAction::WriteToPty(b"\x1b[<67;43;11M".to_vec()));
+    }
+
+    #[test]
+    fn horizontal_without_mouse_mode_is_noop() {
+        // No horizontal scrollback or alt-screen translation: normal AND alt-screen are Noop.
+        assert_eq!(
+            WheelAction::route_horizontal(TermMode::empty(), -2, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+        let alt = TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL;
+        assert_eq!(
+            WheelAction::route_horizontal(alt, 2, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_zero_notches_is_noop() {
+        let modes = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        assert_eq!(
+            WheelAction::route_horizontal(modes, 0, cell(), WheelModifiers::default(), &cfg_default()),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_x10_fallback_right() {
+        let modes = TermMode::MOUSE_DRAG; // no SGR_MOUSE → X10
+        let action = WheelAction::route_horizontal(modes, 1, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &cfg_default());
+        // cb 67 + 32 = 99; col/row 1 + 32 = 33
+        assert_eq!(action, WheelAction::WriteToPty(vec![0x1b, b'[', b'M', 99, 33, 33]));
+    }
+
+    #[test]
+    fn horizontal_concats_and_caps() {
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let cfg = WheelConfig { max_protocol_events_per_frame: 4, ..WheelConfig::default() };
+        let action = WheelAction::route_horizontal(modes, 20, CellCoord { col: 1, row: 1 }, WheelModifiers::default(), &cfg);
+        let one = b"\x1b[<67;1;1M";
+        let mut expected = Vec::new();
+        for _ in 0..4 {
+            expected.extend_from_slice(one);
+        }
+        assert_eq!(action, WheelAction::WriteToPty(expected));
+    }
+
+    #[test]
+    fn horizontal_zero_cap_is_noop() {
+        let modes = TermMode::MOUSE_DRAG | TermMode::SGR_MOUSE;
+        let cfg = WheelConfig { max_protocol_events_per_frame: 0, ..WheelConfig::default() };
+        assert_eq!(
+            WheelAction::route_horizontal(modes, 5, cell(), WheelModifiers::default(), &cfg),
+            WheelAction::Noop
+        );
+    }
+
+    #[test]
+    fn horizontal_ctrl_modifier_bit() {
+        let modes = TermMode::SGR_MOUSE | TermMode::MOUSE_REPORT_CLICK;
+        let mods = WheelModifiers { ctrl: true, ..Default::default() };
+        let action = WheelAction::route_horizontal(modes, -1, CellCoord { col: 1, row: 1 }, mods, &cfg_default());
+        // 66 + 16 (ctrl) = 82
+        assert_eq!(action, WheelAction::WriteToPty(b"\x1b[<82;1;1M".to_vec()));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p ozma_tty_engine route_tests::horizontal`
+Expected: FAIL — compile error `no variant or associated item named route_horizontal` / `no variant named Left` for `WheelDir`.
+
+- [ ] **Step 3: Implement the engine changes**
+
+In `crates/ozma_tty_engine/src/wheel.rs`:
+
+**(a)** Extend `WheelDir` (replace the existing enum, dropping the "out of scope" doc):
+
+```rust
+/// Wheel direction (vertical and horizontal).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WheelDir {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+```
+
+**(b)** Add the `cb_base` arms in `encode_wheel_report` (the `match direction` block):
+
+```rust
+    let cb_base: u8 = match direction {
+        WheelDir::Up => 64,
+        WheelDir::Down => 65,
+        WheelDir::Left => 66,
+        WheelDir::Right => 67,
+    };
+```
+
+**(c)** Replace the mouse-protocol block inside `WheelAction::route` (the `if any_mouse { … }` body) with a call to a shared helper:
+
+```rust
+        if any_mouse {
+            return emit_protocol_reports(modes, direction, notches, mouse_cell, mods, cfg);
+        }
+```
+
+**(d)** Add the shared private helper (place it next to `encode_wheel_report`, above `impl WheelAction`):
+
+```rust
+/// Emits `min(|notches|, cap)` concatenated wheel reports for a mouse-mode
+/// pane, or `Noop` when the cap rounds the count to zero. Shared by the
+/// vertical (`route`) and horizontal (`route_horizontal`) mouse-protocol paths.
+fn emit_protocol_reports(
+    modes: TermMode,
+    direction: WheelDir,
+    notches: i32,
+    mouse_cell: CellCoord,
+    mods: WheelModifiers,
+    cfg: &WheelConfig,
+) -> WheelAction {
+    let count = notches.unsigned_abs().min(cfg.max_protocol_events_per_frame);
+    if count == 0 {
+        return WheelAction::Noop;
+    }
+    let mut buf = Vec::new();
+    for _ in 0..count {
+        buf.extend_from_slice(&encode_wheel_report(modes, direction, mods, mouse_cell));
+    }
+    WheelAction::WriteToPty(buf)
+}
+```
+
+**(e)** Add `route_horizontal` inside `impl WheelAction`, immediately after `route` (both `pub`, surface-first ordering preserved):
+
+```rust
+    /// Decides what to do with a horizontal wheel input.
+    ///
+    /// `notches` is sign-significant (negative = left, positive = right).
+    /// Horizontal wheel only has meaning for mouse-mode applications: when any of
+    /// `MOUSE_REPORT_CLICK`, `MOUSE_DRAG`, `MOUSE_MOTION` is set, it emits
+    /// `min(|notches|, max_protocol_events_per_frame)` SGR/X10 reports with `cb`
+    /// 66 (left) / 67 (right). Outside a mouse mode there is no horizontal
+    /// scrollback or alt-screen translation, so it returns `Noop`.
+    pub fn route_horizontal(
+        modes: TermMode,
+        notches: i32,
+        mouse_cell: CellCoord,
+        mods: WheelModifiers,
+        cfg: &WheelConfig,
+    ) -> Self {
+        if notches == 0 {
+            return WheelAction::Noop;
+        }
+        let direction = if notches < 0 {
+            WheelDir::Left
+        } else {
+            WheelDir::Right
+        };
+        if modes.intersects(
+            TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION,
+        ) {
+            return emit_protocol_reports(modes, direction, notches, mouse_cell, mods, cfg);
+        }
+        WheelAction::Noop
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p ozma_tty_engine`
+Expected: PASS — all new `horizontal_*` tests pass AND every pre-existing `route_tests` / `sgr_tests` / `x10_tests` / `alt_screen_tests` test still passes (the `route` refactor is behavior-preserving).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ozma_tty_engine/src/wheel.rs
+git commit -m "feat(tty-engine): horizontal wheel routing (SGR/X10 cb 66/67)"
+```
+
+---
+
+### Task 2: Host — per-axis accumulator refactor (no behavior change)
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/mouse.rs`
+- Test: `crates/ozma_terminal/src/mouse.rs` (existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces (used by Task 3):
+  - `accumulate_notches(residual: &mut f32, delta_cells: f32, cells_per_notch: f32) -> i32` — now takes the residual by `&mut f32` so either axis can drive it. (`WheelAccumulator` itself is unchanged this task; the horizontal field is added in Task 3, where it is first used.)
+- Consumes: nothing new. This is a pure refactor: `cargo test -p ozma_terminal` must stay green with identical behavior.
+
+- [ ] **Step 1: Change `accumulate_notches` to take `&mut f32`**
+
+In `crates/ozma_terminal/src/mouse.rs`, replace `accumulate_notches` to take the residual by `&mut f32`. The `WheelAccumulator` struct is **unchanged** this task — the horizontal field is added in Task 3, where it is first used:
+
+```rust
+/// Adds `delta_cells` to `residual` and returns whole notches to emit
+/// (positive = up/older for the vertical axis, right for the horizontal axis),
+/// carrying the remainder. Resets `residual` on a sign flip, then processes the
+/// new delta at full magnitude. A zero / negative-zero delta has no direction
+/// and must not trip the sign-flip reset.
+pub(crate) fn accumulate_notches(residual: &mut f32, delta_cells: f32, cells_per_notch: f32) -> i32 {
+    if *residual != 0.0 && delta_cells != 0.0 && (*residual).signum() != delta_cells.signum() {
+        *residual = 0.0;
+    }
+    let threshold = cells_per_notch.max(f32::EPSILON);
+    *residual += delta_cells;
+    let notches = (*residual / threshold).trunc() as i32;
+    if notches != 0 {
+        *residual -= notches as f32 * threshold;
+    }
+    notches
+}
+```
+
+Update the **one** existing call site in `dispatch_mouse_wheel` (vertical path) to pass the field — minimal change to keep compiling, no behavior change:
+
+```rust
+    let raw = accumulate_notches(&mut gesture_acc.residual_cells, delta_cells, cfg.cells_per_notch);
+```
+
+- [ ] **Step 2: Update the three existing accumulator tests to the new signature**
+
+In the `#[cfg(test)] mod tests` block, update these three tests to pass `&mut acc.residual_cells`:
+
+```rust
+    #[test]
+    fn accumulator_emits_on_threshold_and_carries_remainder() {
+        let mut acc = WheelAccumulator::default();
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 1);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, -1.0, 0.5), -2);
+    }
+
+    #[test]
+    fn wheel_accumulator_resets_residual_on_target_change() {
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        let mut acc = WheelAccumulator::default();
+        acc.retarget(a);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
+        acc.retarget(a);
+        assert_eq!(
+            accumulate_notches(&mut acc.residual_cells, 0.3, 0.5),
+            1,
+            "0.3 + 0.3 = 0.6 → one notch on the same target"
+        );
+        acc.retarget(b);
+        assert_eq!(
+            accumulate_notches(&mut acc.residual_cells, 0.3, 0.5),
+            0,
+            "switching target clears the carried residual"
+        );
+    }
+
+    #[test]
+    fn accumulator_zero_delta_does_not_reset_residual() {
+        // A zero / negative-zero delta has no direction and must NOT trip the
+        // sign-flip reset (signum(-0.0) == -1.0 would otherwise drop the carry).
+        let mut acc = WheelAccumulator::default();
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, -0.0, 0.5), 0);
+        assert_eq!(accumulate_notches(&mut acc.residual_cells, 0.3, 0.5), 1);
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `cargo test -p ozma_terminal`
+Expected: PASS — all tests green, behavior unchanged (the new `residual_cells_h` field is unused this task).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "refactor(terminal): per-axis wheel accumulator (accumulate_notches takes &mut f32)"
+```
+
+---
+
+### Task 3: Host — horizontal wheel dispatch
+
+**Files:**
+- Modify: `crates/ozma_terminal/src/mouse.rs`
+- Test: `crates/ozma_terminal/src/mouse.rs` (existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes:
+  - `WheelAction::route_horizontal(modes, notches, mouse_cell, mods, cfg)` (Task 1).
+  - `accumulate_notches(&mut f32, …)` (Task 2). This task adds the `WheelAccumulator.residual_cells_h` field it consumes.
+  - Existing `decide_wheel`, `build_wheel_modifiers`, `wheel_delta_cells`, `CellContext { cell_w, cell_h, … }`, `TerminalMouseEffects`.
+- Produces:
+  - `fn effects_from_wheel_action(action: WheelAction) -> Vec<MouseEffect>` (private) — the shared `WheelAction → effects` mapping.
+  - `fn build_wheel_modifiers_horizontal(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> WheelModifiers` (private) — strips Shift on macOS.
+  - Updated `dispatch_mouse_wheel` emitting both axes in one merged `TerminalMouseEffects` trigger.
+
+- [ ] **Step 1: Write the helper tests**
+
+In the `#[cfg(test)] mod tests` block, add:
+
+```rust
+    #[test]
+    fn effects_from_wheel_action_maps_each_variant() {
+        assert_eq!(effects_from_wheel_action(WheelAction::Noop), vec![]);
+        assert_eq!(
+            effects_from_wheel_action(WheelAction::WriteToPty(b"x".to_vec())),
+            vec![MouseEffect::Write(b"x".to_vec())]
+        );
+        assert_eq!(
+            effects_from_wheel_action(WheelAction::ScrollViewport(3)),
+            vec![MouseEffect::Scroll(3)]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn horizontal_modifiers_strip_shift_on_macos() {
+        let mut keys = ButtonInput::<KeyCode>::default();
+        keys.press(KeyCode::ShiftLeft);
+        let cfg = OzmaMouseConfig::default();
+        let mods = build_wheel_modifiers_horizontal(&keys, &cfg);
+        assert!(
+            !mods.shift,
+            "macOS converts Shift+wheel to horizontal at the OS level; the report must not carry the Shift bit"
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p ozma_terminal effects_from_wheel_action_maps_each_variant`
+Expected: FAIL — compile error: `effects_from_wheel_action` / `build_wheel_modifiers_horizontal` not found.
+
+- [ ] **Step 3: Implement the two helpers and route `decide_wheel` through the mapper**
+
+In `crates/ozma_terminal/src/mouse.rs`:
+
+Replace `decide_wheel` so the `WheelAction → effects` mapping lives in one shared helper:
+
+```rust
+/// Pure wheel decision. `notches` is in the engine convention (negative =
+/// up/older); callers negate the Bevy-derived up-positive value before calling.
+pub(crate) fn decide_wheel(
+    modes: TermMode,
+    notches: i32,
+    cell: CellCoord,
+    mods: WheelModifiers,
+    cfg: &WheelConfig,
+) -> Vec<MouseEffect> {
+    effects_from_wheel_action(WheelAction::route(modes, notches, cell, mods, cfg))
+}
+
+/// Maps a routed `WheelAction` to host effects. Shared by the vertical
+/// (`route`) and horizontal (`route_horizontal`) wheel paths.
+fn effects_from_wheel_action(action: WheelAction) -> Vec<MouseEffect> {
+    match action {
+        WheelAction::Noop => Vec::new(),
+        WheelAction::WriteToPty(b) => vec![MouseEffect::Write(b)],
+        WheelAction::ScrollViewport(lines) => vec![MouseEffect::Scroll(lines)],
+    }
+}
+```
+
+Add `build_wheel_modifiers_horizontal` next to the existing `build_wheel_modifiers`:
+
+```rust
+/// Horizontal-wheel modifiers. On macOS the OS converts Shift+wheel into a
+/// horizontal scroll while Shift stays physically held; stripping the Shift bit
+/// keeps the report a plain `<ScrollWheelLeft/Right>` rather than the shifted
+/// (and by default unmapped) variant. Other platforms pass modifiers through.
+fn build_wheel_modifiers_horizontal(keys: &ButtonInput<KeyCode>, cfg: &OzmaMouseConfig) -> WheelModifiers {
+    let mut mods = build_wheel_modifiers(keys, cfg);
+    if cfg!(target_os = "macos") {
+        mods.shift = false;
+    }
+    mods
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `cargo test -p ozma_terminal effects_from_wheel_action_maps_each_variant horizontal_modifiers_strip_shift_on_macos`
+Expected: PASS.
+
+- [ ] **Step 5: Commit the helpers**
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(terminal): wheel effect mapper + macOS horizontal modifier strip"
+```
+
+- [ ] **Step 6: Write the dispatch integration tests + harness**
+
+Add a wheel test harness and the dispatch tests to the `#[cfg(test)] mod tests` block. (`CapturedEffects`, `test_metrics`, `set_phys_cursor` already exist in this module.)
+
+```rust
+    fn make_wheel_app(enable_modes: &[u8]) -> App {
+        use bevy::window::WindowResolution;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<MouseWheel>()
+            .init_resource::<OzmaMouseConfig>()
+            .init_resource::<WheelAccumulator>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<Clipboard>()
+            .init_resource::<CapturedEffects>()
+            .insert_resource(test_metrics())
+            .add_observer(
+                |ev: On<TerminalMouseEffects>, mut cap: ResMut<CapturedEffects>| {
+                    cap.0.push(ev.effects.clone());
+                },
+            )
+            .add_systems(Update, dispatch_mouse_wheel);
+
+        let mut handle = TerminalHandle::detached(100, 37);
+        // `\x1b[?1000;1006h` = enable X10 mouse reporting (?1000) + SGR ext (?1006).
+        handle.advance(enable_modes);
+        app.world_mut().spawn((
+            OzmaTerminal,
+            handle,
+            ComputedNode {
+                size: Vec2::new(800.0, 600.0),
+                ..ComputedNode::DEFAULT
+            },
+            UiGlobalTransform::from_xy(400.0, 300.0),
+            TerminalGrid {
+                cols: 100,
+                rows: 37,
+                ..default()
+            },
+        ));
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app
+    }
+
+    fn write_wheel(app: &mut App, x: f32, y: f32) {
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<MouseWheel>>()
+            .write(MouseWheel {
+                unit: MouseScrollUnit::Line,
+                x,
+                y,
+                window: Entity::PLACEHOLDER,
+            });
+    }
+
+    #[test]
+    fn dispatch_pure_horizontal_right_emits_sgr_67() {
+        // Pure horizontal (y = 0): also guards the regression where the vertical
+        // `raw == 0` early-return would drop horizontal-only frames.
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().any(
+                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))
+            ),
+            "a +x wheel in mouse mode must emit an SGR wheel-right (cb 67) report, got {:?}",
+            cap.0
+        );
+    }
+
+    #[test]
+    fn dispatch_horizontal_left_emits_sgr_66() {
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, -0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().any(
+                |e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<66;"))
+            ),
+            "a -x wheel in mouse mode must emit an SGR wheel-left (cb 66) report, got {:?}",
+            cap.0
+        );
+    }
+
+    #[test]
+    fn dispatch_diagonal_emits_both_axes_in_one_trigger() {
+        let mut app = make_wheel_app(b"\x1b[?1000;1006h");
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        // +x → right (67); -y is Bevy "up/older" → negated → engine down (cb 65).
+        write_wheel(&mut app, 0.5, -0.5);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert_eq!(cap.0.len(), 1, "both axes must arrive in ONE trigger, got {:?}", cap.0);
+        let frame = &cap.0[0];
+        assert!(
+            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<65;"))),
+            "vertical (down, cb 65) report missing: {frame:?}"
+        );
+        assert!(
+            frame.iter().any(|e| matches!(e, MouseEffect::Write(b) if b.starts_with(b"\x1b[<67;"))),
+            "horizontal (right, cb 67) report missing: {frame:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_horizontal_without_mouse_mode_emits_no_report() {
+        let mut app = make_wheel_app(b""); // no mouse mode enabled
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.5, 0.0);
+        app.update();
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().flatten().all(|e| !matches!(e, MouseEffect::Write(_))),
+            "horizontal wheel outside a mouse mode must not emit a report, got {:?}",
+            cap.0
+        );
+    }
+```
+
+- [ ] **Step 7: Run to verify the dispatch tests fail**
+
+Run: `cargo test -p ozma_terminal dispatch_pure_horizontal_right_emits_sgr_67 dispatch_horizontal_left_emits_sgr_66 dispatch_diagonal_emits_both_axes_in_one_trigger`
+Expected: FAIL — `dispatch_mouse_wheel` still reads only `ev.y`, so no `cb 66/67` report is produced (the right/left/diagonal asserts fail). `dispatch_horizontal_without_mouse_mode_emits_no_report` may already pass.
+
+- [ ] **Step 8: Add the horizontal residual field, then rewrite `dispatch_mouse_wheel`**
+
+First add the horizontal residual to `WheelAccumulator` and zero it on retarget. Replace the struct + its `retarget` impl:
+
+```rust
+/// Carries the sub-notch wheel remainder across frames, per axis, scoped to the
+/// last terminal the wheel targeted.
+#[derive(Resource, Default)]
+pub(crate) struct WheelAccumulator {
+    residual_cells: f32,
+    residual_cells_h: f32,
+    last_target: Option<Entity>,
+}
+
+impl WheelAccumulator {
+    /// Resets both residuals when the wheel target changes, so a sub-notch
+    /// fraction accumulated over one terminal cannot bleed into the next.
+    fn retarget(&mut self, entity: Entity) {
+        if self.last_target != Some(entity) {
+            self.residual_cells = 0.0;
+            self.residual_cells_h = 0.0;
+            self.last_target = Some(entity);
+        }
+    }
+}
+```
+
+Then replace the tail of `dispatch_mouse_wheel` — from `gesture_acc.retarget(target);` through the final `if !effects.is_empty() { … }` block — with:
+
+```rust
+    gesture_acc.retarget(target);
+    let (delta_v, delta_h) = wheel.read().fold((0.0f32, 0.0f32), |(v, h), ev| {
+        (
+            v + wheel_delta_cells(ev.unit, ev.y, ctx.cell_h),
+            h + wheel_delta_cells(ev.unit, ev.x, ctx.cell_w),
+        )
+    });
+    let raw_v = accumulate_notches(&mut gesture_acc.residual_cells, delta_v, cfg.cells_per_notch);
+    let raw_h = accumulate_notches(&mut gesture_acc.residual_cells_h, delta_h, cfg.cells_per_notch);
+    if raw_v == 0 && raw_h == 0 {
+        return;
+    }
+    let cell = ctx
+        .hit(cursor_phys)
+        .map(|(cell, _)| cell)
+        .unwrap_or(CellCoord { col: 1, row: 1 });
+    let modes = handle.current_modes();
+    let mut effects = Vec::new();
+    if raw_v != 0 {
+        // NOTE: Bevy +y (up/older) → engine convention (negative = up/older).
+        let mods = build_wheel_modifiers(&keys, &cfg);
+        effects.extend(decide_wheel(modes, -raw_v, cell, mods, &cfg.wheel));
+    }
+    if raw_h != 0 {
+        // NOTE: positive ev.x → Right (cb 67); confirm against a live Neovim and
+        // flip to `-raw_h` if reversed (winit's macOS PixelDelta horizontal sign
+        // is historically opposite X11/Wayland, so the on-screen direction is
+        // runtime-verified, not assumed).
+        let mods = build_wheel_modifiers_horizontal(&keys, &cfg);
+        effects.extend(effects_from_wheel_action(WheelAction::route_horizontal(
+            modes, raw_h, cell, mods, &cfg.wheel,
+        )));
+    }
+    if !effects.is_empty() {
+        commands.trigger(TerminalMouseEffects {
+            entity: target,
+            effects,
+        });
+    }
+```
+
+- [ ] **Step 9: Run the full crate test suite to verify everything passes**
+
+Run: `cargo test -p ozma_terminal`
+Expected: PASS — the four `dispatch_*` tests pass and every pre-existing test still passes.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/ozma_terminal/src/mouse.rs
+git commit -m "feat(terminal): forward horizontal wheel to mouse-mode apps (SGR 66/67)"
+```
+
+---
+
+### Task 4: Workspace verification + manual direction check
+
+**Files:**
+- None (verification only).
+
+**Interfaces:**
+- Consumes: the completed Tasks 1–3.
+
+- [ ] **Step 1: Run both crates' tests**
+
+Run: `cargo test -p ozma_tty_engine -p ozma_terminal`
+Expected: PASS — no failures.
+
+- [ ] **Step 2: Lint and format**
+
+Run: `cargo clippy -p ozma_tty_engine -p ozma_terminal --all-targets && cargo fmt`
+Expected: no clippy warnings; `cargo fmt` leaves no diff (or run `git diff --exit-code` after to confirm).
+
+- [ ] **Step 3: Confirm the workspace still builds**
+
+Run: `cargo build -p ozma_tty_engine -p ozma_terminal`
+Expected: clean build.
+
+- [ ] **Step 4: Manual direction verification (human-in-the-loop)**
+
+The on-screen direction is the one thing unit tests cannot confirm (`ev.x` sign + `cb` assignment compose into a perceived direction; winit's macOS horizontal sign is historically flipped). Hand this checklist to the user:
+
+1. `cargo run` (or `just run`).
+2. In a pane, run Neovim with `:set mouse=a` and `:set nowrap`, open a file with long lines.
+3. **Trackpad two-finger swipe right** → the view should scroll right (reveal text to the right). Swipe left → scroll left.
+4. If the direction is **reversed**, flip the horizontal sign: change `route_horizontal(modes, raw_h, …)` to `route_horizontal(modes, -raw_h, …)` in `dispatch_mouse_wheel` (and update the `// NOTE:` accordingly), then re-run.
+5. **macOS only:** with a traditional mouse, **Shift+scroll-wheel** should also scroll horizontally (plain `<ScrollWheelLeft/Right>`, not `<S-…>`).
+6. Confirm a **pure vertical** scroll still behaves exactly as before (no regression).
+
+- [ ] **Step 5: Final commit (if the sign was flipped or any doc tweak was needed)**
+
+```bash
+git add -A
+git commit -m "fix(terminal): correct horizontal wheel direction after live verification"
+```
+
+(If no change was needed in Step 4, skip this commit.)
+
+---
+
+## Notes for the implementer
+
+- **Bevy `MouseWheel` fields:** the test harness writes `MouseWheel { unit, x, y, window }`. If the installed Bevy version's struct differs (e.g. no `window`), match the actual definition — the compiler will tell you.
+- **Why no change to `src/mode/tmux/input.rs`:** horizontal is mouse-mode-only, and mouse-mode tmux panes are `WheelOwner::CededToOzma`, owned by `dispatch_mouse_wheel`. `forward_wheel_to_tmux` only handles copy-mode and alt-screen-residual (no horizontal meaning), and holds an independent `MessageReader<MouseWheel>` cursor, so it needs no change.
+- **Why no change to `src/mode/default/*`:** Default-mode terminal wheel is already owned by the always-on `dispatch_mouse_wheel`; the only Default wheel system is webview-only.

--- a/docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md
+++ b/docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md
@@ -1,0 +1,262 @@
+# Horizontal mouse-wheel / trackpad scroll
+
+## Problem
+
+The terminal wheel path drops the horizontal axis. Trackpad two-finger
+horizontal swipes and Shift+wheel (which macOS converts to a horizontal scroll
+at the OS level) arrive as `MouseWheel` events with a non-zero `ev.x`, but every
+terminal-side consumer reads only `ev.y`:
+
+- `ozma_tty_engine::wheel::WheelDir` is `Up` / `Down` only; its doc comment
+  states *"Horizontal wheels are out of scope."*
+- `ozma_terminal::mouse::dispatch_mouse_wheel` aggregates only
+  `wheel_delta_cells(ev.unit, ev.y, cell_h)`; `WheelAccumulator` carries a single
+  residual axis.
+
+As a result an application that understands horizontal wheel reports — e.g.
+Neovim with `set mouse=a` and `nowrap` (`ScrollWheelLeft` / `ScrollWheelRight`) —
+never receives them.
+
+Webviews are already correct: `webview_wheel_delta(unit, x, y)` plumbs both axes
+to CEF. Only the terminal path is missing horizontal support.
+
+**Goal:** when the pane under the pointer has mouse reporting enabled, translate
+horizontal wheel/trackpad input into SGR (or X10 fallback) horizontal wheel
+reports (`cb = 66` left, `cb = 67` right) and deliver them to the application,
+in both Default mode and tmux mode.
+
+## Scope
+
+In scope:
+
+- Horizontal wheel reporting to **mouse-mode applications only** (any of
+  `MOUSE_REPORT_CLICK` / `MOUSE_DRAG` / `MOUSE_MOTION` set), via SGR/X10
+  encoding, mirroring the existing vertical mouse-protocol path.
+
+Out of scope (decided during brainstorming — a terminal has no horizontal
+scrollback, so non-mouse-mode horizontal input has no meaningful target):
+
+- Horizontal scrollback / viewport scrolling in the normal screen.
+- Alt-screen `←` / `→` arrow translation (the horizontal analog of the vertical
+  `ALTERNATE_SCROLL → ↑/↓` path). Non-mouse-mode horizontal input is a no-op.
+- New configuration keys (see "Configuration").
+- Any change to copy-mode or the tmux `forward_wheel_to_tmux` path.
+
+## Approach
+
+Chosen: **a dedicated horizontal route function in the engine** (Approach A of
+three considered).
+
+- **B — generalize `WheelAction::route` with an axis parameter:** rejected.
+  It changes the signature of the well-tested vertical router and all its call
+  sites/tests for no behavioral gain; vertical and horizontal have genuinely
+  different routing rules (vertical has scrollback + alt-screen branches;
+  horizontal has neither), so merging them only adds branching.
+- **C — encode SGR 66/67 in the host dispatcher, no engine change:** rejected.
+  It duplicates the mouse-mode detection and SGR/X10 encoding that already live
+  in `ozma_tty_engine`, splitting protocol encoding across two crates.
+
+Approach A keeps the vertical `route` untouched (zero regression risk on the
+existing path) and matches the repo's "pure decider returning effect values"
+idiom.
+
+## Design
+
+### 1. Engine layer — `crates/ozma_tty_engine/`
+
+**`wheel.rs`**
+
+- Extend `WheelDir` with `Left` and `Right`. Update the enum doc comment (drop
+  "Horizontal wheels are out of scope").
+- `encode_wheel_report`: add `WheelDir::Left => 66`, `WheelDir::Right => 67` to
+  the `cb_base` match. The rest of the function (modifier bits, motion bit
+  handling, SGR-vs-X10 selection) is unchanged and shared with the vertical
+  directions. `motion = false` is passed through, as for vertical wheels.
+- Add `WheelAction::route_horizontal(modes, notches, mouse_cell, mods, cfg)`:
+  - `notches == 0` → `Noop`.
+  - Direction: `notches < 0 → Left`, `notches > 0 → Right` (the host owns the
+    mapping from `ev.x` sign to this convention — see "Direction").
+  - If any of `MOUSE_REPORT_CLICK | MOUSE_DRAG | MOUSE_MOTION` is set: emit
+    `min(|notches|, cfg.max_protocol_events_per_frame)` concatenated reports via
+    `encode_wheel_report`; return `WheelAction::WriteToPty(buf)` (or `Noop` if
+    the cap is 0). This is the only branch.
+  - Otherwise (no mouse mode): `Noop`. No scrollback, no alt-screen translation.
+
+  Reuses the existing `WheelAction` enum (`WriteToPty` / `Noop`); horizontal
+  never returns `ScrollViewport`.
+- Factor the mouse-protocol emission shared by `route` and `route_horizontal`
+  (`count = min(|notches|, cap)`, loop `encode_wheel_report`, return
+  `WriteToPty`/`Noop`) into one private helper, so horizontal does not duplicate
+  that block and `route`'s public signature + scrollback/alt-screen branches stay
+  untouched.
+
+The shared encoder `mouse_encode::encode_protocol_event` needs **no change** —
+`cb_base` 66/67 already flow through its `+32` (X10) / SGR formatting unchanged.
+
+### 2. Host layer — `crates/ozma_terminal/src/mouse.rs`
+
+- `WheelAccumulator`: hold two **named** per-axis residuals — the existing
+  `residual_cells` (vertical) plus a new horizontal residual — sharing one
+  `last_target`. Refactor `accumulate_notches` to take the residual by
+  `&mut f32` (not the whole accumulator) so both axes reuse the identical carry +
+  sign-flip logic; the `delta_cells != 0.0` guard (no reset on `0.0`/`-0.0`) is
+  preserved per axis. Retarget-on-entity-change zeroes both. Named fields, not a
+  `Vec2`, to keep accumulation axis-semantic and tests readable.
+- Reuse the `WheelAction → Vec<MouseEffect>` mapping for both axes instead of a
+  separate `decide_wheel_horizontal`: `route_horizontal` returns the same
+  `WheelAction` enum `decide_wheel` already maps, so factor that mapping into one
+  shared helper (e.g. `effects_from_wheel_action`); the horizontal path simply
+  never produces `ScrollViewport`.
+- `dispatch_mouse_wheel` (single read pass, both axes):
+  - Sum BOTH axes in ONE `wheel.read()` pass — the `MessageReader` drains once
+    per frame, so a second `read()` would see nothing. `Line` units contribute
+    `ev.x` / `ev.y` directly; `Pixel` units contribute `ev.x / cell_w` (advance)
+    and `ev.y / cell_h` (line height).
+  - Accumulate each axis on its own residual → independent notch counts.
+  - **Restructure the early return:** the current `if raw == 0 { return; }`
+    guards only the vertical count; a pure-horizontal swipe (the common case)
+    has vertical `raw == 0` and would be dropped. Return early only when BOTH
+    axes yield zero notches.
+  - Emit the vertical + horizontal effects in ONE merged `TerminalMouseEffects`
+    trigger per frame (one observer pass; report order is app-irrelevant).
+  - Axes accumulate/emit **independently** (a diagonal swipe produces both); see
+    "Axis handling".
+
+`MouseEffect::Write` already routes correctly for both backends via
+`on_terminal_mouse_effects`: a PTY-backed Default terminal writes to the PTY; a
+PTY-less tmux pane emits `TerminalForwardInput`, which the host delivers to tmux
+via `send-keys -H`.
+
+### Modifier handling (Shift+wheel on macOS)
+
+`build_wheel_modifiers` reads physical Shift from `ButtonInput<KeyCode>`. On
+macOS the OS converts Shift+vertical-wheel into horizontal scroll (`ev.x`) while
+Shift stays physically held, so a naive encoding sets the SGR Shift bit (+4):
+`cb` becomes 70/71, which Neovim parses as `<S-ScrollWheelLeft/Right>` — an
+unmapped-by-default event that defeats the "mouse wheel horizontal scroll" half
+of the goal. The two-finger trackpad path (no Shift) is already clean.
+
+Decision: on macOS (`cfg!(target_os = "macos")`), strip the Shift modifier from
+horizontal wheel reports so an OS-converted Shift+wheel yields a plain
+`<ScrollWheelLeft/Right>`. Other platforms pass modifiers through unchanged;
+Ctrl/Alt are unaffected.
+
+### 3. Data flow (all reused; no new effect/event types)
+
+```
+MouseWheel{ev.x} → dispatch_mouse_wheel
+  → aggregate horizontal cells (ev.x; Pixel ÷ cell_w)
+  → accumulate_notches (horizontal residual, &mut f32)
+  → WheelAction::route_horizontal → effects_from_wheel_action
+  → MouseEffect::Write(SGR/X10 66|67)
+  → TerminalMouseEffects → on_terminal_mouse_effects
+     ├ Default (PtyHandle): handle.write(pty, …)
+     └ tmux pane (no PtyHandle): TerminalForwardInput → tmux `send-keys -H` (raw
+       hex bytes injected into the pane, bypassing tmux's own mouse translation)
+  → application reads ScrollWheelLeft/Right
+```
+
+### 4. What does NOT change
+
+- `WheelAction::route` (vertical) — untouched.
+- `src/mode/tmux/input.rs` `forward_wheel_to_tmux` / `aggregate_tmux_wheel_cells`
+  — untouched. Horizontal is mouse-mode-only, and mouse-mode panes are
+  `WheelOwner::CededToOzma`, owned by `dispatch_mouse_wheel`. The tmux forward
+  path only handles copy-mode and alt-screen-residual, neither of which has a
+  horizontal meaning. The two systems hold independent `MessageReader<MouseWheel>`
+  cursors, so both observe every event regardless of which drains first.
+- `src/mode/default/*` — terminal wheel in Default mode is already handled by
+  `dispatch_mouse_wheel` (the always-on `OzmaMousePlugin`); Default's only wheel
+  system, `forward_default_webview_wheel`, is webview-only.
+- Webview wheel — already handles both axes.
+- Bevy's frame-summed `AccumulatedMouseScroll` is intentionally NOT adopted over
+  `MessageReader<MouseWheel>`: it collapses a frame to a single `unit`, losing the
+  per-event `Line`/`Pixel` handling both wheel consumers rely on and the
+  `clear()`-on-suppression semantics.
+
+## Direction (sign convention)
+
+Two independent mappings set the on-screen direction; BOTH are confirmed
+end-to-end against a real Neovim trace during implementation:
+
+1. **`cb` ↔ left/right.** Horizontal wheel = xterm buttons 6/7 = `cb 66/67`.
+   Neovim's SGR parser maps `cb66 → ScrollWheelLeft`, `cb67 → ScrollWheelRight`
+   (`neovim` `src/nvim/tui/input.c`), so the spec uses `Left=66`, `Right=67`.
+   Older xterm prose has been read as assigning 6/7 the opposite way, so this is
+   treated as verify-against-the-target-app, not assumed-from-prose.
+2. **`ev.x` sign ↔ left/right.** The host maps the accumulated delta at a single
+   call site. winit/Bevy horizontal sign is platform-dependent (macOS
+   `PixelDelta` horizontal sign is historically opposite X11/Wayland), so the
+   sign is confirmed empirically; the one-line mapping makes flipping trivial.
+
+The implementation verifies the *composed* result — finger/wheel direction → the
+Neovim view (`nowrap`) moving the intended way — not either mapping alone. Per
+the scope decision, no invert / enable config key is added this iteration.
+
+## Axis handling
+
+Horizontal and vertical residuals are accumulated **independently** and each
+emits notches when it crosses `cells_per_notch`. Rationale: it matches the
+existing vertical behavior, keeps the accumulator simple, and the default
+`cells_per_notch = 0.5` plus the per-axis sign-flip reset means small
+perpendicular trackpad jitter does not cross the threshold. Axis-locking
+(dominant-axis-wins per gesture) is a possible future refinement, not part of
+this iteration.
+
+Sensitivity caveat: a horizontal cell (`advance_phys`, ~8px) is ~half a vertical
+cell (`line_height_phys`, ~16px), so a shared `cells_per_notch` makes horizontal
+~2× more sensitive per pixel of travel, each notch a full app-side column jump.
+Ship v1 with the shared threshold but felt-test on a trackpad; a horizontal-only
+threshold is a possible future knob (not added now).
+
+## Configuration
+
+No new keys. In a mouse mode the protocol path emits one report per notch and
+intentionally does **not** multiply by `lines_per_notch` (the application
+decides line counts; this matches the vertical mouse-mode path and alacritty).
+The existing `cells_per_notch` accumulation threshold is reused for the
+horizontal axis. `max_protocol_events_per_frame` caps horizontal bursts, as for
+vertical.
+
+## Testing
+
+Engine (`crates/ozma_tty_engine/src/wheel.rs`, pure unit tests):
+
+- `route_horizontal` in a mouse mode emits SGR `\x1b[<66;…M` (left) and
+  `\x1b[<67;…M` (right) at the cursor cell.
+- `route_horizontal` with no mouse mode → `Noop` (normal screen AND alt-screen,
+  confirming no horizontal scrollback / arrow translation).
+- X10 fallback bytes for 66/67 (`cb+32` = 98/99).
+- Modifier bits (shift/ctrl/alt → meta) on horizontal reports.
+- Multi-notch concatenation and the `max_protocol_events_per_frame` cap
+  (including the 0-cap `Noop`).
+- `encode_wheel_report` Left/Right encoding.
+
+Host (`crates/ozma_terminal/src/mouse.rs`):
+
+- The shared `effects_from_wheel_action` maps `route_horizontal`'s `WriteToPty`
+  → `Write` (mouse mode) and `Noop` → `[]` (no mouse mode).
+- Horizontal-axis accumulation: sub-notch carry, sign-flip reset, retarget
+  reset — independent of the vertical residual.
+- A `dispatch_mouse_wheel` integration test (existing app-harness style) feeding
+  an `ev.x` event over a mouse-mode terminal and asserting a
+  `MouseEffect::Write` carrying the 66/67 bytes; and a diagonal event asserting
+  both axes emit.
+- A pure-horizontal frame (vertical delta ≈ 0) still emits a horizontal `Write`
+  — guards the `raw == 0` vertical early-return regression.
+- On macOS, a Shift-held horizontal report carries NO SGR Shift bit (plain
+  `cb 66/67`, not 70/71).
+- A diagonal frame emits both axes via a single `TerminalMouseEffects` trigger.
+
+No `ozmux_configs` test changes (no config surface change).
+
+## Assumptions to validate in review
+
+1. Horizontal axis pitch is the cell advance width (`advance_phys`), the
+   horizontal analog of `line_height_phys` used for vertical.
+2. Independent x/y accumulation (no axis-lock) is acceptable for v1.
+3. No new configuration key is desired for enabling/inverting horizontal scroll.
+4. SGR `cb = 66/67` (xterm buttons 6/7) is the correct wire encoding for
+   horizontal wheel, and `send-keys -H` injects the raw bytes into the pane
+   verbatim (not tmux's own wheel translation) — the same delivery the existing
+   vertical mouse-mode reports already use.

--- a/docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md
+++ b/docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md
@@ -204,10 +204,15 @@ perpendicular trackpad jitter does not cross the threshold. Axis-locking
 this iteration.
 
 Sensitivity caveat: a horizontal cell (`advance_phys`, ~8px) is ~half a vertical
-cell (`line_height_phys`, ~16px), so a shared `cells_per_notch` makes horizontal
-~2× more sensitive per pixel of travel, each notch a full app-side column jump.
-Ship v1 with the shared threshold but felt-test on a trackpad; a horizontal-only
-threshold is a possible future knob (not added now).
+cell (`line_height_phys`, ~16px). Dividing `ev.x` by the cell WIDTH under a
+shared `cells_per_notch` therefore made horizontal ~2× more sensitive per pixel
+of finger travel. **RESOLVED** after trackpad testing: both axes divide by
+`line_height_phys` (cell height), so the per-pixel notch rate is uniform across
+axes. In a mouse-mode report the pitch is a pure sensitivity threshold (each
+notch = one report; the application decides columns), so a common pitch is
+correct — the horizontal "cell" need not be a literal column. (NVim's default
+`mousescroll=hor:6` vs `ver:3` further scales the per-report effect, but that is
+NVim's config, not ours.)
 
 ## Configuration
 
@@ -252,8 +257,11 @@ No `ozmux_configs` test changes (no config surface change).
 
 ## Assumptions to validate in review
 
-1. Horizontal axis pitch is the cell advance width (`advance_phys`), the
-   horizontal analog of `line_height_phys` used for vertical.
+1. Horizontal sensitivity is matched to vertical by dividing `ev.x` by the cell
+   HEIGHT (`line_height_phys`) — the same pitch the vertical axis uses — NOT the
+   cell width. Trackpad testing confirmed the cell-width pitch (`advance_phys`,
+   ~½ of `line_height_phys`) made horizontal ~2× too sensitive; see "Axis
+   handling".
 2. Independent x/y accumulation (no axis-lock) is acceptable for v1.
 3. No new configuration key is desired for enabling/inverting horizontal scroll.
 4. SGR `cb = 66/67` (xterm buttons 6/7) is the correct wire encoding for

--- a/src/mode/tmux/input.rs
+++ b/src/mode/tmux/input.rs
@@ -834,6 +834,7 @@ fn consume_wheel_notches(
         accumulator.residual_cells = 0.0;
         accumulator.last_pane = Some(pane);
     } else if accumulator.residual_cells != 0.0
+        && delta_cells != 0.0
         && accumulator.residual_cells.signum() != delta_cells.signum()
     {
         accumulator.residual_cells = 0.0;


### PR DESCRIPTION
## Problem

The terminal wheel path dropped the horizontal axis. Trackpad two-finger horizontal swipes and macOS Shift+wheel (which the OS converts to a horizontal scroll) arrive as `MouseWheel` events with a non-zero `ev.x`, but every terminal-side consumer read only `ev.y`. As a result, applications that understand horizontal wheel reports — e.g. Neovim with `:set mouse=a` and `:set nowrap` (`ScrollWheelLeft` / `ScrollWheelRight`) — never received them. (Webviews already forwarded both axes to CEF; only the terminal path was missing.)

## Solution

Forward horizontal wheel / trackpad input to **mouse-mode applications** as SGR (or X10 fallback) horizontal wheel reports (`cb 66` left / `cb 67` right), in both Default and tmux modes.

- **Engine (`ozma_tty_engine`)** — add `WheelDir::Left/Right` + `cb 66/67` encoding and a dedicated `WheelAction::route_horizontal` that emits reports only when a mouse-reporting mode is set, and `Noop` otherwise (a terminal has no horizontal scrollback). The vertical `route` is untouched; the shared emit loop is factored into one private helper.
- **Host terminal (`ozma_terminal`)** — `dispatch_mouse_wheel` now sums both axes in a single `wheel.read()` pass, accumulates each on its own per-axis residual, returns early only when *both* are zero, and emits one merged `TerminalMouseEffects` trigger. Delivery rides the existing path: PTY write in Default mode, `send-keys -H` for tmux panes. On macOS the Shift bit is stripped from horizontal reports (Shift+wheel→horizontal is an OS artifact) so it stays a plain `<ScrollWheelLeft/Right>`.
- **Sensitivity** — horizontal divides `ev.x` by the cell *height* (the same pitch as vertical) so the per-pixel notch rate matches the vertical axis; dividing by the narrower cell *width* made horizontal ~2× too sensitive on a trackpad.
- **Unchanged** — the tmux `forward_wheel_to_tmux` / copy-mode and Default-mode wheel paths: mouse-mode panes are already ceded to the host dispatcher, and the two systems hold independent `MessageReader` cursors. (A small correctness guard was added to tmux `consume_wheel_notches` to match the host's zero-delta handling.)

**Scope:** mouse-mode apps only — no horizontal scrollback, no alt-screen arrow translation, no new config keys.

Affected areas: engine, host terminal, a one-line tmux guard, docs. Design notes in `docs/specs/2026-06-28-mouse-wheel-horizontal-scroll-design.md`; implementation plan in `docs/plans/2026-06-28-mouse-wheel-horizontal-scroll.md`. Not a breaking change (purely additive).

### Please confirm before relying on it
- **On-screen direction** is assumed `positive ev.x → Right (cb 67)`. winit's macOS `PixelDelta` horizontal sign is historically platform-dependent, so this is runtime-verified rather than asserted by tests (there is a `// TODO:` at the mapping). Confirm a right-swipe scrolls the Neovim view right (`:set nowrap`); if reversed, flip `raw_h` → `-raw_h`.
- Neovim's default `mousescroll=hor:6` (vs `ver:3`) scales the per-report column count — tune via `:set mousescroll` if it feels fast.

Tests: engine 247/247, `ozma_terminal` 73/73 (incl. a Pixel-unit sensitivity regression test), tmux wheel 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
