### PR TITLE
fix(tmux): auto-recover blank panes from the live mirror

### DIFF
--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -408,6 +408,33 @@ impl TerminalHandle {
         self.term.mode().contains(TermMode::ALT_SCREEN)
     }
 
+    /// Returns `true` when the visible viewport holds any non-whitespace glyph.
+    ///
+    /// The host paint-rescue uses this to tell a rendered grid that went blank
+    /// from a transient (recoverable: the live mirror still has content) from a
+    /// genuinely empty pane (nothing to restore). Scans only the visible rows.
+    ///
+    /// NOTE: glyph-only — a cell visible solely through a non-default background
+    /// or reverse video reads as blank. This intentionally matches the host's
+    /// equally glyph-only grid-blank test so the two agree (a mismatch would let
+    /// the recovery repaint-loop); the cost is that a purely color-block pane is
+    /// not auto-recovered. The `'\0'` exclusion mirrors `frame_builder`'s
+    /// unallocated-cell normalization (`'\0'` → `' '` in the emitted grid): an
+    /// unallocated viewport renders blank, so it must read blank here too, or the
+    /// recovery would repaint-loop on the `'\0'`-vs-space divergence.
+    pub fn has_visible_content(&self) -> bool {
+        let rows = self.term.screen_lines() as u16;
+        for viewport_y in 0..rows {
+            let line = viewport_row_to_line(&self.term, viewport_y as i32);
+            for cell in &self.term.grid()[line] {
+                if cell.c != '\0' && !cell.c.is_whitespace() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Enters vi (copy) mode. Idempotent — a second call while already
     /// in vi mode is a no-op rather than a toggle-off. Schedules a Full
     /// damage emit so the renderer observes the new mode (`Term::toggle_vi_mode`
@@ -2946,6 +2973,21 @@ mod tests {
         h.resize_grid_only(40, 10);
         let (cols, rows, _) = h.read_geometry();
         assert_eq!((cols, rows), (40, 10));
+    }
+
+    #[test]
+    fn has_visible_content_distinguishes_blank_from_painted() {
+        let blank = TerminalHandle::detached(20, 5);
+        assert!(
+            !blank.has_visible_content(),
+            "a fresh detached handle has no glyphs"
+        );
+        let mut painted = TerminalHandle::detached(20, 5);
+        painted.advance(b"hi");
+        assert!(
+            painted.has_visible_content(),
+            "a handle with advanced text reports visible content"
+        );
     }
 
     #[test]

--- a/crates/ozma_tty_renderer/src/material.rs
+++ b/crates/ozma_tty_renderer/src/material.rs
@@ -930,7 +930,7 @@ fn resolve_glyph_index(
     atlas: &mut GlyphAtlas,
     phys_font_size: u16,
 ) -> u32 {
-    if cell.width == 0 || cell.text.is_empty() || cell.text.trim().is_empty() {
+    if cell.is_blank() {
         return u32::MAX;
     }
     let codepoint = cell.text.chars().next().map(|c| c as u32).unwrap_or(0);

--- a/crates/ozma_tty_renderer/src/schema/grid.rs
+++ b/crates/ozma_tty_renderer/src/schema/grid.rs
@@ -135,6 +135,17 @@ pub struct Cell {
     pub hyperlink_id: Option<HyperlinkId>,
 }
 
+impl Cell {
+    /// Whether this cell paints no glyph: a zero-width cell (combining mark /
+    /// wide-char spacer) or one whose text is empty or all whitespace.
+    ///
+    /// Shared by the renderer's glyph resolution and the host paint-rescue's
+    /// blank-grid test so the two notions of "renders nothing" cannot drift.
+    pub fn is_blank(&self) -> bool {
+        self.width == 0 || self.text.trim().is_empty()
+    }
+}
+
 /// A row of runs ordered left-to-right.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Row {

--- a/crates/ozma_tty_renderer/src/schema/grid.rs
+++ b/crates/ozma_tty_renderer/src/schema/grid.rs
@@ -141,6 +141,7 @@ impl Cell {
     ///
     /// Shared by the renderer's glyph resolution and the host paint-rescue's
     /// blank-grid test so the two notions of "renders nothing" cannot drift.
+    #[inline]
     pub fn is_blank(&self) -> bool {
         self.width == 0 || self.text.trim().is_empty()
     }

--- a/docs/plans/2026-06-30-paint-rescue-component-split.md
+++ b/docs/plans/2026-06-30-paint-rescue-component-split.md
@@ -1,0 +1,380 @@
+# paint_rescue Component Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the two per-pane state machines in `src/mode/tmux/paint_rescue.rs` out of one combined `ReseedTracker` struct (held in a `HashMap<PaneId, _>` resource) into two independent Bevy Components on the pane entity.
+
+**Architecture:** Define `StructuralReseedState` and `BlankRecoveryState` as `#[derive(Component, Default)]`, attach them once per pane via a dedicated `attach_rescue_state` system (the binary cannot `#[require]` the out-of-crate `TmuxPane`), then rewrite the decision functions and `rescue_unpainted_panes` to read the components by `&mut` directly. Drop the `PaneSeedTrackers` resource and the `prune_tracker_on_pane_removed` observer (Components despawn with the entity).
+
+**Tech Stack:** Rust (edition 2024), Bevy 0.18 ECS.
+
+## Global Constraints
+
+- Pure internal refactor — externally observable behavior MUST NOT change (coverage, debounce timing, copy-mode freeze). Reference: `docs/specs/2026-06-30-paint-rescue-component-split-design.md`.
+- Debounce constants unchanged: `RESEED_DEBOUNCE_FRAMES = 3`, `RESEED_INFLIGHT_TIMEOUT = 30`.
+- Rust conventions (`.claude/rules/rust.md`): no `mod.rs`; non-doc comments only `// TODO:` / `// NOTE:` / `// SAFETY:`; all `use` at top in one contiguous block, no inline fully-qualified paths; minimize visibility (these items are module-private — no `pub`); `Plugin::build` is a single method chain; mutable params before immutable; private items declared after exported ones.
+- Lint gate after each task: `cargo build`, `cargo clippy --workspace` (0 warnings), `cargo fmt --check`.
+- Test gate after each task: `cargo test --bin ozmux paint_rescue -- --test-threads=1` (plus `cargo test -p ozma_tty_engine has_visible_content` stays green — unchanged but a smoke check).
+
+---
+
+### Task 1: Add the two state Components and the attach system
+
+Introduce the new components and the system that attaches them, registered in the plugin. The old `ReseedTracker` / `PaneSeedTrackers` and `rescue_unpainted_panes` stay in place and unchanged this task, so the crate compiles and all existing tests stay green; the new components are attached but not yet read.
+
+**Files:**
+- Modify: `src/mode/tmux/paint_rescue.rs`
+
+**Interfaces:**
+- Produces:
+  - `struct StructuralReseedState { unpainted_streak: u8, inflight_age: Option<u16> }` — `#[derive(Component, Default)]`
+  - `struct BlankRecoveryState { streak: u8, recovery_seq: Option<u32>, settled: bool }` — `#[derive(Component, Default)]`
+  - `fn attach_rescue_state(commands: Commands, panes: Query<Entity, (With<TmuxPane>, Without<StructuralReseedState>)>)` — inserts both components once per pane.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `src/mode/tmux/paint_rescue.rs`:
+
+```rust
+#[test]
+fn attach_inserts_both_state_components_once() {
+    use tmux_control_parser::CellDims;
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_systems(Update, attach_rescue_state);
+
+    let pane = app
+        .world_mut()
+        .spawn(TmuxPane {
+            id: PaneId(1),
+            dims: CellDims {
+                width: 4,
+                height: 2,
+                xoff: 0,
+                yoff: 0,
+            },
+        })
+        .id();
+
+    app.update();
+
+    assert!(
+        app.world().get::<StructuralReseedState>(pane).is_some(),
+        "attach inserts StructuralReseedState",
+    );
+    assert!(
+        app.world().get::<BlankRecoveryState>(pane).is_some(),
+        "attach inserts BlankRecoveryState",
+    );
+
+    // A second pass must not re-insert (Without<StructuralReseedState> filter).
+    app.update();
+    assert!(app.world().get::<StructuralReseedState>(pane).is_some());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --bin ozmux attach_inserts_both_state_components_once -- --test-threads=1`
+Expected: FAIL — `cannot find type StructuralReseedState` / `cannot find function attach_rescue_state` (compile error).
+
+- [ ] **Step 3: Add the two components**
+
+Insert after the existing `RESEED_INFLIGHT_TIMEOUT` const (and before `ReseedTracker`) in `src/mode/tmux/paint_rescue.rs`:
+
+```rust
+/// Per-pane structural-reseed debounce: a streak before the first capture
+/// request, then an in-flight age that re-requests on timeout until painted.
+#[derive(Component, Default)]
+struct StructuralReseedState {
+    unpainted_streak: u8,
+    inflight_age: Option<u16>,
+}
+
+/// Per-pane blank-recovery debounce: a blank-grid-vs-live-mirror episode keyed
+/// on the grid seq, repainting from the mirror once the divergence persists.
+#[derive(Component, Default)]
+struct BlankRecoveryState {
+    streak: u8,
+    recovery_seq: Option<u32>,
+    settled: bool,
+}
+```
+
+- [ ] **Step 4: Add the attach system**
+
+Add this system (place it near the other systems, after `rescue_unpainted_panes`):
+
+```rust
+/// Attaches the per-pane rescue state components once per pane. `TmuxPane` is
+/// defined in `ozmux_tmux`, so the binary cannot `#[require]` these onto it; the
+/// `Without<StructuralReseedState>` filter makes this run exactly once per pane
+/// (both components are always inserted together).
+fn attach_rescue_state(
+    mut commands: Commands,
+    panes: Query<Entity, (With<TmuxPane>, Without<StructuralReseedState>)>,
+) {
+    for entity in panes.iter() {
+        commands
+            .entity(entity)
+            .insert((StructuralReseedState::default(), BlankRecoveryState::default()));
+    }
+}
+```
+
+- [ ] **Step 5: Register the attach system in the plugin**
+
+In `PaintRescuePlugin::build`, add `attach_rescue_state` to the `Update` systems, chained before `rescue_unpainted_panes`. Replace the current single-system registration:
+
+```rust
+impl Plugin for PaintRescuePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PaneSeedTrackers>()
+            .add_observer(prune_tracker_on_pane_removed)
+            .add_observer(repaint_pane_from_mirror)
+            .add_systems(
+                Update,
+                (attach_rescue_state, rescue_unpainted_panes)
+                    .chain()
+                    .after(TmuxProjectionSet)
+                    .before(TmuxLayoutSet)
+                    .in_set(super::TmuxActiveSet),
+            );
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test --bin ozmux attach_inserts_both_state_components_once -- --test-threads=1`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + full paint_rescue suite**
+
+Run: `cargo clippy --workspace 2>&1 | tail -2` (expect 0 warnings) and `cargo fmt` then `cargo test --bin ozmux paint_rescue -- --test-threads=1`
+Expected: clippy clean, all paint_rescue tests PASS (the new components are unused-by-system this task, but attached — no behavior change).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/mode/tmux/paint_rescue.rs
+git commit -m "refactor(tmux): add per-pane rescue state components + attach system"
+```
+
+---
+
+### Task 2: Migrate the rescue path to the components and delete the resource
+
+Rewrite the decision functions and `rescue_unpainted_panes` to read the new components, delete `ReseedTracker` / `PaneSeedTrackers` / `prune_tracker_on_pane_removed`, and update the tests. The crate compiles and all tests pass at the end.
+
+**Files:**
+- Modify: `src/mode/tmux/paint_rescue.rs`
+
+**Interfaces:**
+- Consumes (from Task 1): `StructuralReseedState`, `BlankRecoveryState`, `attach_rescue_state`.
+- Produces:
+  - `fn reseed_decision(state: &mut StructuralReseedState, needs_seed: bool) -> bool`
+  - `fn evaluate_blank_recovery(state: &mut BlankRecoveryState, grid: &TerminalGrid, handle: &TerminalHandle) -> bool`
+  - `fn rescue_unpainted_panes(commands: Commands, reseed: MessageWriter<RequestPaneReseed>, panes: Query<(Entity, &TmuxPane, &TerminalHandle, &TerminalGrid, &mut StructuralReseedState, &mut BlankRecoveryState), Without<CopyModeState>>)`
+
+- [ ] **Step 1: Rewrite `reseed_decision` to take `&mut StructuralReseedState`**
+
+Replace the existing `reseed_decision` fn body's signature and the `!needs_seed` branch (the per-field reset becomes a full reset; delete the `// NOTE:` footgun comment):
+
+```rust
+/// Advances a pane's structural-reseed debounce one frame and returns whether to
+/// emit a reseed request now. A painted grid (`!needs_seed`) resets the state.
+/// Otherwise it debounces `RESEED_DEBOUNCE_FRAMES` consecutive unpainted frames
+/// before the first request, then suppresses while a request is in flight,
+/// re-requesting every `RESEED_INFLIGHT_TIMEOUT` frames until the grid paints.
+fn reseed_decision(state: &mut StructuralReseedState, needs_seed: bool) -> bool {
+    if !needs_seed {
+        *state = StructuralReseedState::default();
+        return false;
+    }
+    match &mut state.inflight_age {
+        Some(age) => {
+            *age = age.saturating_add(1);
+            if *age >= RESEED_INFLIGHT_TIMEOUT {
+                *age = 0;
+                true
+            } else {
+                false
+            }
+        }
+        None => {
+            state.unpainted_streak = state.unpainted_streak.saturating_add(1);
+            if state.unpainted_streak >= RESEED_DEBOUNCE_FRAMES {
+                state.inflight_age = Some(0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `evaluate_blank_recovery` to take `&mut BlankRecoveryState`**
+
+Replace its signature and field names (`blank_recovery_seq` → `recovery_seq`, `blank_streak` → `streak`, `blank_recovery_settled` → `settled`):
+
+```rust
+/// Advances a pane's blank-recovery state machine one frame and returns whether
+/// to repaint it from the live mirror now.
+///
+/// Fires once the grid has been blank while the mirror still holds content for
+/// [`RESEED_DEBOUNCE_FRAMES`] consecutive frames. The episode is keyed on the
+/// grid `last_seq`: a seq change reopens evaluation, and once an episode is
+/// `settled` (repainted, mirror also blank, or grid painted) the per-frame
+/// mirror scan is skipped until the grid changes again.
+fn evaluate_blank_recovery(
+    state: &mut BlankRecoveryState,
+    grid: &TerminalGrid,
+    handle: &TerminalHandle,
+) -> bool {
+    if state.recovery_seq != Some(grid.last_seq) {
+        state.recovery_seq = Some(grid.last_seq);
+        state.streak = 0;
+        state.settled = false;
+    }
+    if state.settled {
+        return false;
+    }
+    if !grid_visibly_blank(grid) {
+        state.streak = 0;
+        state.settled = true;
+        return false;
+    }
+    if !handle.has_visible_content() {
+        // NOTE: grid and mirror both blank — a genuinely empty pane with nothing
+        // to restore. Settling here (not just returning) is load-bearing: it
+        // stops the per-frame mirror scan until the grid's seq changes.
+        state.settled = true;
+        return false;
+    }
+    state.streak = state.streak.saturating_add(1);
+    if state.streak >= RESEED_DEBOUNCE_FRAMES {
+        state.settled = true;
+        true
+    } else {
+        false
+    }
+}
+```
+
+- [ ] **Step 3: Rewrite `rescue_unpainted_panes` to query the components**
+
+Replace the whole function:
+
+```rust
+/// Requests a tmux re-seed for each non-copy-mode pane whose grid is
+/// structurally unpainted (see [`grid_needs_full_seed`]) once the state has
+/// held for [`RESEED_DEBOUNCE_FRAMES`], then re-requests every
+/// [`RESEED_INFLIGHT_TIMEOUT`] frames until the grid paints. Copy-mode panes
+/// are skipped — they paint via the separate `CopyRenderHandle`.
+///
+/// Separately, recovers a grid that went *blank* (structurally fine) while its
+/// live mirror still holds content: it triggers [`RepaintLiveMirror`], whose
+/// observer repaints from the authoritative mirror. The gather query stays
+/// read-only on the handle; the `&mut TerminalHandle` write lives in the observer.
+fn rescue_unpainted_panes(
+    mut commands: Commands,
+    mut reseed: MessageWriter<RequestPaneReseed>,
+    mut panes: Query<
+        (
+            Entity,
+            &TmuxPane,
+            &TerminalHandle,
+            &TerminalGrid,
+            &mut StructuralReseedState,
+            &mut BlankRecoveryState,
+        ),
+        Without<CopyModeState>,
+    >,
+) {
+    for (entity, pane, handle, grid, mut reseed_state, mut blank_state) in panes.iter_mut() {
+        let (h_cols, h_rows, _) = handle.read_geometry();
+        let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
+        if reseed_decision(&mut reseed_state, needs) {
+            reseed.write(RequestPaneReseed { pane: pane.id });
+        }
+        if needs {
+            // NOTE: structural reseed owns this pane; reopen blank-recovery so it
+            // re-evaluates once the grid is structurally repainted.
+            *blank_state = BlankRecoveryState::default();
+            continue;
+        }
+        if evaluate_blank_recovery(&mut blank_state, grid, handle) {
+            commands.trigger(RepaintLiveMirror { entity });
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Delete `ReseedTracker`, `PaneSeedTrackers`, the prune observer, and the resource init**
+
+In `src/mode/tmux/paint_rescue.rs`:
+- Delete the `ReseedTracker` struct definition.
+- Delete the `PaneSeedTrackers` struct definition.
+- Delete the `prune_tracker_on_pane_removed` function.
+- In `PaintRescuePlugin::build`, remove `.init_resource::<PaneSeedTrackers>()` and `.add_observer(prune_tracker_on_pane_removed)`. Resulting body:
+
+```rust
+impl Plugin for PaintRescuePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(repaint_pane_from_mirror).add_systems(
+            Update,
+            (attach_rescue_state, rescue_unpainted_panes)
+                .chain()
+                .after(TmuxProjectionSet)
+                .before(TmuxLayoutSet)
+                .in_set(super::TmuxActiveSet),
+        );
+    }
+}
+```
+
+- [ ] **Step 5: Remove the now-unused `HashMap` import**
+
+In the top `use` block, delete `use std::collections::HashMap;`. (Leave `PaneId` in the `ozmux_tmux` import — it is still used by `RequestPaneReseed { pane: pane.id }` only via `pane.id`; if `cargo build` reports `PaneId` unused, remove it too.)
+
+- [ ] **Step 6: Update the unit tests for the new types**
+
+In the `tests` module, replace every `ReseedTracker::default()` with the matching component, and rename field accesses. Concretely:
+- Tests calling `reseed_decision(&mut t, ...)`: change `let mut t = ReseedTracker::default();` → `let mut t = StructuralReseedState::default();`. Field assertions `t.inflight_age` / `t.unpainted_streak` are unchanged (same field names).
+- Tests calling `evaluate_blank_recovery(&mut t, ...)`: change `let mut t = ReseedTracker::default();` → `let mut t = BlankRecoveryState::default();`, and rename `t.blank_streak` → `t.streak`, `t.blank_recovery_settled` → `t.settled`.
+
+- [ ] **Step 7: Update the two integration tests to provide the components**
+
+The integration tests `blank_grid_with_live_content_repaints_from_mirror` and `blank_grid_with_blank_mirror_is_not_repainted` currently `app.init_resource::<PaneSeedTrackers>();` and spawn a pane without the state components. For each:
+- Delete the `app.init_resource::<PaneSeedTrackers>();` line.
+- Register the attach system ahead of the rescue system: change `app.add_systems(Update, rescue_unpainted_panes);` → `app.add_systems(Update, (attach_rescue_state, rescue_unpainted_panes).chain());`
+
+This attaches the components on the first `app.update()`, exactly as in production. (The existing loops already run ≥ `RESEED_DEBOUNCE_FRAMES + 1` updates, so the one-frame attach does not eat the debounce budget.)
+
+- [ ] **Step 8: Run the full paint_rescue suite**
+
+Run: `cargo test --bin ozmux paint_rescue -- --test-threads=1`
+Expected: PASS — all structural-reseed unit tests, blank-recovery unit tests, `attach_inserts_both_state_components_once`, and both integration tests green.
+
+- [ ] **Step 9: Lint gate**
+
+Run: `cargo build` then `cargo clippy --workspace 2>&1 | tail -2` (expect 0 warnings) then `cargo fmt --check` (expect clean; run `cargo fmt` if not).
+Expected: build clean, 0 clippy warnings, fmt clean. (No `ReseedTracker` / `PaneSeedTrackers` / `prune_tracker_on_pane_removed` / `HashMap` references remain — confirm with `grep -n 'ReseedTracker\|PaneSeedTrackers\|prune_tracker\|HashMap' src/mode/tmux/paint_rescue.rs` → no output.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/mode/tmux/paint_rescue.rs
+git commit -m "refactor(tmux): split ReseedTracker into per-pane components; drop HashMap resource + prune observer"
+```
+
+---
+
+## Notes for the implementer
+
+- The two integration tests spawn the pane with `TmuxPane` + `TerminalHandle` + `TerminalGrid`. After Step 7 they also rely on `attach_rescue_state` to add the state components — the `.chain()` is what guarantees the components exist before `rescue_unpainted_panes` reads them in the same `app.update()`.
+- Do not change `grid_needs_full_seed`, `grid_visibly_blank`, `RepaintLiveMirror`, or `repaint_pane_from_mirror` — they are untouched by this refactor.
+- The `On<Remove, TmuxPane>` cleanup is intentionally gone: components are dropped when the pane entity despawns (panes are despawn-only; a reused `PaneId` on reconnect spawns a fresh entity with default components).

--- a/docs/specs/2026-06-30-paint-rescue-component-split-design.md
+++ b/docs/specs/2026-06-30-paint-rescue-component-split-design.md
@@ -1,0 +1,245 @@
+# paint_rescue: split the two state machines into separate Components
+
+## Problem
+
+`src/mode/tmux/paint_rescue.rs` holds two unrelated per-pane debounce state
+machines inside a single `ReseedTracker` struct, stored in a
+`PaneSeedTrackers(HashMap<PaneId, ReseedTracker>)` resource:
+
+1. **Structural reseed** — `unpainted_streak` + `inflight_age`, driven by
+   `reseed_decision`. Requests a tmux `capture-pane` re-seed when a pane's grid
+   is structurally unpainted (`grid_needs_full_seed`).
+2. **Blank recovery** — `blank_streak` + `blank_recovery_seq` +
+   `blank_recovery_settled`, driven by `evaluate_blank_recovery`. Repaints from
+   the live mirror when the grid went blank but the mirror still holds content.
+
+Cramming both into one struct serviced by one function created a footgun: the
+`!needs_seed` branch of `reseed_decision` must reset *only* its own fields, with
+a `// NOTE:` warning that resetting the whole tracker (`*tracker = Default`)
+would silently wipe the blank-recovery debounce every frame. The two machines
+are logically independent but structurally coupled.
+
+This is also the outlier in the codebase: peer per-pane state
+(`PaneRecaptureState`, `crates/tmux_session/src/components.rs:93`) lives as a
+**Component on the pane entity**, auto-attached via `#[require(PaneRecaptureState)]`
+on `TmuxPane`, not as a side `HashMap` keyed by `PaneId`.
+
+## Goal
+
+Split the two state machines into two independent Bevy Components on the pane
+entity and delete the `HashMap` resource. Pure internal refactor — externally
+observable behavior (coverage, debounce timing, copy-mode freeze) is unchanged.
+
+## Solution
+
+### Components (defined in `paint_rescue.rs`)
+
+Replace `ReseedTracker` with two components. The component name carries the
+context, so the `blank_` field prefixes are dropped.
+
+```rust
+/// Per-pane structural-reseed debounce: a streak before the first capture
+/// request, then an in-flight age that re-requests on timeout until painted.
+#[derive(Component, Default)]
+struct StructuralReseedState {
+    unpainted_streak: u8,
+    inflight_age: Option<u16>,
+}
+
+/// Per-pane blank-recovery debounce: a blank-grid-vs-live-mirror episode keyed
+/// on the grid seq, repainting from the mirror once the divergence persists.
+#[derive(Component, Default)]
+struct BlankRecoveryState {
+    streak: u8,
+    recovery_seq: Option<u32>,
+    settled: bool,
+}
+```
+
+### Attaching the components
+
+`TmuxPane` is defined in the `ozmux_tmux` crate, so the binary cannot add
+`#[require(...)]` to it. Instead, a dedicated attach system inserts both
+components once per pane, mirroring the existing `augment_tmux_pane`
+(`src/mode/tmux/pane_focus.rs`) and `attach_tmux_pane_terminal`
+(`src/mode/tmux/render.rs`) patterns:
+
+```rust
+fn attach_rescue_state(
+    mut commands: Commands,
+    panes: Query<Entity, (With<TmuxPane>, Without<StructuralReseedState>)>,
+) {
+    for entity in panes.iter() {
+        commands
+            .entity(entity)
+            .insert((StructuralReseedState::default(), BlankRecoveryState::default()));
+    }
+}
+```
+
+A single `Without<StructuralReseedState>` filter suffices because both
+components are always inserted together.
+
+### Plugin wiring
+
+```rust
+fn build(&self, app: &mut App) {
+    app.add_observer(repaint_pane_from_mirror)
+        .add_systems(
+            Update,
+            (attach_rescue_state, rescue_unpainted_panes)
+                .chain()
+                .after(TmuxProjectionSet)
+                .before(TmuxLayoutSet)
+                .in_set(super::TmuxActiveSet),
+        );
+}
+```
+
+`.chain()` orders attach before rescue; Bevy's auto-inserted sync point (the
+same mechanism `attach_tmux_pane_terminal` → `layout_tmux_panes` relies on)
+makes the freshly-inserted components visible to `rescue_unpainted_panes` in the
+same frame. Bevy 0.18's `ScheduleBuildSettings::auto_insert_apply_deferred`
+defaults to `true`, and the `.chain()` ordering edge combined with the earlier
+system's `Commands` param is what triggers the inserted `ApplyDeferred`.
+
+Correctness does not *depend* on that same-frame guarantee, though: a 1-frame
+attach lag would only defer a pane's first evaluation by one tick, well within
+`RESEED_DEBOUNCE_FRAMES` (3), and `rescue_unpainted_panes` only matches panes
+that also carry `TerminalHandle` + `TerminalGrid` (attached by a separate chain
+in `render.rs`). The design therefore tolerates lag rather than relying on the
+sync point.
+
+### Decision functions and the rescue system
+
+`reseed_decision` and `evaluate_blank_recovery` take their own component
+instead of the shared `&mut ReseedTracker`:
+
+```rust
+fn reseed_decision(state: &mut StructuralReseedState, needs_seed: bool) -> bool;
+fn evaluate_blank_recovery(
+    state: &mut BlankRecoveryState,
+    grid: &TerminalGrid,
+    handle: &TerminalHandle,
+) -> bool;
+```
+
+Because the blank-recovery state is now a separate component, the
+`!needs_seed` branch of `reseed_decision` can reset its whole component
+(`*state = StructuralReseedState::default()`) with no cross-machine footgun —
+the `// NOTE:` warning is deleted.
+
+The rescue system reads both components by `&mut` directly, dropping the
+`trackers.0.entry(pane.id).or_default()` lookup:
+
+```rust
+fn rescue_unpainted_panes(
+    mut commands: Commands,
+    mut reseed: MessageWriter<RequestPaneReseed>,
+    mut panes: Query<
+        (
+            Entity,
+            &TmuxPane,
+            &TerminalHandle,
+            &TerminalGrid,
+            &mut StructuralReseedState,
+            &mut BlankRecoveryState,
+        ),
+        Without<CopyModeState>,
+    >,
+) {
+    for (entity, pane, handle, grid, mut reseed_state, mut blank_state) in panes.iter_mut() {
+        let (h_cols, h_rows, _) = handle.read_geometry();
+        let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
+        if reseed_decision(&mut reseed_state, needs) {
+            reseed.write(RequestPaneReseed { pane: pane.id });
+        }
+        if needs {
+            // Structural reseed owns this pane; reopen blank-recovery so it
+            // re-evaluates once the grid is structurally repainted.
+            *blank_state = BlankRecoveryState::default();
+            continue;
+        }
+        if evaluate_blank_recovery(&mut blank_state, grid, handle) {
+            commands.trigger(RepaintLiveMirror { entity });
+        }
+    }
+}
+```
+
+### Removed
+
+- `ReseedTracker` struct.
+- `PaneSeedTrackers(HashMap<PaneId, ReseedTracker>)` resource and its
+  `init_resource`.
+- `prune_tracker_on_pane_removed` observer (`On<Remove, TmuxPane>`) and its
+  `add_observer` — Components are dropped automatically when the entity
+  despawns, so the manual prune is no longer needed. This is a strict
+  improvement: panes are despawn-only (no `remove::<TmuxPane>` anywhere — stale
+  panes and window-close cascades despawn the whole entity), and a `PaneId`
+  reused across a reconnect spawns a *fresh* entity, so it starts from default
+  component state. This matches the guarantee the in-crate `PaneRecaptureState`
+  already documents and removes the class of "`HashMap` entry outlives or
+  precedes the pane" bugs the prune observer existed to cover.
+- `use std::collections::HashMap;`.
+
+### Tests
+
+- Unit tests: replace `ReseedTracker::default()` with the relevant component
+  (`StructuralReseedState::default()` / `BlankRecoveryState::default()`); update
+  field references (`t.blank_streak` → `t.streak`,
+  `t.blank_recovery_settled` → `t.settled`).
+- Integration tests (`blank_grid_with_live_content_repaints_from_mirror`,
+  `blank_grid_with_blank_mirror_is_not_repainted`): spawn the pane entity with
+  the two state components (or register `attach_rescue_state` chained ahead of
+  `rescue_unpainted_panes`); drop the `PaneSeedTrackers` resource init.
+
+## Behavior invariance
+
+- **Coverage**: every `TmuxPane` gets both components via the attach system,
+  matching the previous `or_default()` lazy creation for every queried pane.
+- **Debounce timing**: `RESEED_DEBOUNCE_FRAMES` / `RESEED_INFLIGHT_TIMEOUT` and
+  both decision functions' logic are unchanged.
+- **Copy-mode freeze**: the rescue query keeps `Without<CopyModeState>`, so a
+  copy-mode pane's component state is left untouched (frozen) and resumes on
+  exit — identical to the previous behavior where the `HashMap` entry persisted
+  untouched.
+
+## Considered alternatives
+
+These were evaluated during spec review and deliberately not chosen; recorded so
+the reasoning is not relitigated.
+
+- **One component with two sub-struct fields** (`PaneRescueState { structural,
+  blank }`) instead of two top-level components. Achieves the same decoupling and
+  kills the same footgun, with marginally fewer moving parts (one query param,
+  one `insert`). Rejected in favor of "one concept = one component"; the two
+  decision functions still take `&mut StructuralReseedState` /
+  `&mut BlankRecoveryState` either way. A taste call, not a defect.
+- **`Option<&mut StructuralReseedState>` lazy-insert** inside the rescue system
+  instead of a dedicated attach system. Rejected as strictly worse: a query
+  cannot materialize a missing component, so it forces a `commands.insert` whose
+  effect is invisible until the next flush plus a local-default-then-write-back
+  dance. The dedicated attach system matches the `augment_tmux_pane` /
+  `attach_tmux_pane_terminal` idiom.
+- **`On<Add, TmuxPane>` observer** to insert the components once per spawn,
+  rather than a per-frame `Without<…>` polling system. Viable and idiomatic
+  (mirrors `On<Add, OzmaTerminal>`); roughly a wash. Not chosen because the
+  polling system stays gated inside `TmuxActiveSet` (`in_state(AppMode::Tmux)`),
+  whereas an observer fires regardless of `AppMode` (harmless but a minor
+  widening), and the insert is command-deferred either way.
+- **Runtime `register_required_components::<TmuxPane, StructuralReseedState>()`**
+  in `PaintRescuePlugin::build` (the runtime equivalent of `#[require]`, which
+  the binary cannot put on the out-of-crate `TmuxPane`). Rejected due to upstream
+  bug [bevyengine/bevy#16406]: runtime requirements interact incorrectly with
+  components already added via `#[require(...)]`, and `TmuxPane` carries
+  `#[require(PaneRecaptureState)]` — exactly the case that triggers the bug. The
+  repo also uses `register_required_components` nowhere.
+
+## Out of scope
+
+- No change to `reseed_decision` / `evaluate_blank_recovery` logic beyond the
+  parameter type and the now-safe full reset.
+- No change to the `RepaintLiveMirror` event or `repaint_pane_from_mirror`
+  observer.
+- No change to the structural-reseed or blank-recovery *semantics*.

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -10,13 +10,16 @@ use crate::input::bindings::OzmaMouseConfig;
 use crate::input::focus::MouseDisabled;
 use crate::input::mouse::button::MouseButtonInputPlugin;
 use crate::input::mouse::wheel::MouseWheelInputPlugin;
+use bevy::input::mouse::{MouseButtonInput, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::window::CursorMoved;
 use ozma_terminal::{
     OzmaTerminal, TerminalMouseWrite, TerminalOpenUri, TerminalSelectionClear,
     TerminalSelectionCopy, TerminalSelectionStart, TerminalSelectionUpdate,
 };
 use ozma_tty_engine::{CellCoord, Point, SelectionType, Side, TerminalHandle};
+use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::schema::TerminalGrid;
 
 mod button;
@@ -32,6 +35,16 @@ impl Plugin for MouseInputPlugin {
         app.add_plugins((MouseButtonInputPlugin, MouseWheelInputPlugin))
             .init_resource::<OzmaMouseConfig>();
     }
+}
+
+/// Run condition shared by the button and wheel dispatchers: true on any frame
+/// carrying a mouse message (button, cursor move, or wheel). A cursor-only frame
+/// must still run so the dispatchers retarget / reset; defining it once keeps the
+/// two per-file plugins' gating in lockstep.
+pub(super) fn on_any_mouse_message() -> impl SystemCondition<()> {
+    on_message::<MouseButtonInput>
+        .or(on_message::<CursorMoved>)
+        .or(on_message::<MouseWheel>)
 }
 
 /// Host-private decision IR for the button path: `decide_button` returns an
@@ -143,6 +156,16 @@ fn hit_candidates<'a>(
     terminals
         .iter()
         .map(|(e, _, node, transform, _)| (e, node, transform))
+}
+
+/// The `(cell_w, cell_h)` pitch in physical px, floored and clamped to `>= 1` so
+/// a degenerate metric cannot divide by zero. Shared by both dispatchers' cursor
+/// → cell projection.
+fn cell_pitch(metrics: &TerminalCellMetricsResource) -> (f32, f32) {
+    (
+        metrics.metrics.advance_phys.floor().max(1.0),
+        metrics.metrics.line_height_phys.floor().max(1.0),
+    )
 }
 
 /// Read-only hit-test context for one gather run: the terminal node geometry,

--- a/src/input/mouse/button.rs
+++ b/src/input/mouse/button.rs
@@ -4,7 +4,10 @@
 //! effects out via the shared `trigger_mouse_effects`. Registered by
 //! `MouseButtonInputPlugin`; skips `MouseDisabled` surfaces.
 
-use super::{CellContext, MouseEffect, TerminalSurfaces, hit_candidates, trigger_mouse_effects};
+use super::{
+    CellContext, MouseEffect, TerminalSurfaces, cell_pitch, hit_candidates, on_any_mouse_message,
+    trigger_mouse_effects,
+};
 use crate::input::InputPhase;
 use crate::input::bindings::OzmaMouseConfig;
 use crate::input::current_modifiers;
@@ -13,7 +16,7 @@ use crate::input::hyperlink::link_modifier_held;
 use crate::input::keyboard::current_terminal_modifiers;
 use crate::webview_pointer::topmost_surface_at;
 use bevy::input::ButtonState;
-use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseWheel};
+use bevy::input::mouse::{MouseButton, MouseButtonInput};
 use bevy::prelude::*;
 use bevy::time::{Real, Time};
 use bevy::window::{CursorMoved, PrimaryWindow};
@@ -34,11 +37,9 @@ impl Plugin for MouseButtonInputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<OzmaMouseGesture>().add_systems(
             Update,
-            dispatch_mouse_buttons.in_set(InputPhase::Dispatch).run_if(
-                on_message::<MouseButtonInput>
-                    .or(on_message::<CursorMoved>)
-                    .or(on_message::<MouseWheel>),
-            ),
+            dispatch_mouse_buttons
+                .in_set(InputPhase::Dispatch)
+                .run_if(on_any_mouse_message()),
         );
     }
 }
@@ -130,11 +131,12 @@ fn resolve_frame(
     }
     let active = gesture.held.is_some() || gesture.drag.is_some();
     let cursor_phys = effective_drag_cursor(live, active, gesture.last_cursor_phys)?;
+    let (cell_w, cell_h) = cell_pitch(metrics);
     Some(FrameContext {
         cursor_phys,
         scale,
-        cell_w: metrics.metrics.advance_phys.floor().max(1.0),
-        cell_h: metrics.metrics.line_height_phys.floor().max(1.0),
+        cell_w,
+        cell_h,
         mods: protocol_mods(keys),
         modifier_held: link_modifier_held(&current_modifiers(keys)),
     })
@@ -170,10 +172,7 @@ fn process_button_event(
     ev: &MouseButtonInput,
     now: Duration,
 ) {
-    let kind = match ev.state {
-        ButtonState::Pressed => ButtonEventKind::Press,
-        ButtonState::Released => ButtonEventKind::Release,
-    };
+    let kind = button_kind(ev.state);
     let target = if kind == ButtonEventKind::Press {
         topmost_surface_at(frame.cursor_phys, hit_candidates(terminals))
     } else {
@@ -370,10 +369,7 @@ fn resolve_button_event(
     cfg: &OzmaMouseConfig,
 ) -> Option<(ButtonEvent, Option<String>)> {
     let button = map_button(ev.button)?;
-    let kind = match ev.state {
-        ButtonState::Pressed => ButtonEventKind::Press,
-        ButtonState::Released => ButtonEventKind::Release,
-    };
+    let kind = button_kind(ev.state);
     // NOTE: a release with the cursor off the terminal node must still be
     // processed (via the last tracked cell) — otherwise `held`/`drag` stick and
     // later cursor motion replays stale selection / forward reports.
@@ -482,6 +478,13 @@ fn map_button(b: MouseButton) -> Option<MouseButtonKind> {
         MouseButton::Middle => Some(MouseButtonKind::Middle),
         MouseButton::Right => Some(MouseButtonKind::Right),
         _ => None,
+    }
+}
+
+fn button_kind(state: ButtonState) -> ButtonEventKind {
+    match state {
+        ButtonState::Pressed => ButtonEventKind::Press,
+        ButtonState::Released => ButtonEventKind::Release,
     }
 }
 

--- a/src/input/mouse/wheel.rs
+++ b/src/input/mouse/wheel.rs
@@ -5,7 +5,7 @@
 //! `apply_wheel_action`. Registered by `MouseWheelInputPlugin`; skips
 //! `MouseDisabled` surfaces.
 
-use super::{CellContext, TerminalSurfaces, hit_candidates};
+use super::{CellContext, TerminalSurfaces, cell_pitch, hit_candidates, on_any_mouse_message};
 use crate::input::InputPhase;
 use crate::input::bindings::{FineModifier, OzmaMouseConfig};
 use crate::input::gesture::{
@@ -13,9 +13,9 @@ use crate::input::gesture::{
 };
 use crate::input::keyboard::current_terminal_modifiers;
 use crate::webview_pointer::topmost_surface_at;
-use bevy::input::mouse::{MouseButtonInput, MouseWheel};
+use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
-use bevy::window::{CursorMoved, PrimaryWindow};
+use bevy::window::PrimaryWindow;
 use ozma_terminal::{TerminalMouseWrite, TerminalViewportScroll};
 use ozma_tty_engine::{CellCoord, TermMode, TerminalModifiers, WheelAction, WheelModifiers};
 use ozma_tty_renderer::TerminalCellMetricsResource;
@@ -30,24 +30,22 @@ impl Plugin for MouseWheelInputPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WheelAccumulator>().add_systems(
             Update,
-            dispatch_mouse_wheel.in_set(InputPhase::Dispatch).run_if(
-                on_message::<MouseButtonInput>
-                    .or(on_message::<CursorMoved>)
-                    .or(on_message::<MouseWheel>),
-            ),
+            dispatch_mouse_wheel
+                .in_set(InputPhase::Dispatch)
+                .run_if(on_any_mouse_message()),
         );
     }
 }
 
-/// A resolved wheel target for one frame: the surface entity, the cell under the
-/// cursor, the cell height (for delta scaling), and the terminal modes. A plain
-/// `Copy` value — the cell is resolved during `resolve_wheel_target`, so nothing
-/// downstream needs the borrowed `CellContext`.
+/// A resolved wheel target for one frame: the surface entity, the cell height
+/// (for delta scaling), and the physical cursor position. The cursor → cell
+/// projection and `current_modes()` read are deferred to [`resolve_wheel_cell`]
+/// so a cursor-only / sub-notch frame (the common case during pointer motion)
+/// pays only the cheap retarget, not a matrix-inverse projection it discards.
 struct WheelTarget {
     target: Entity,
-    cell: CellCoord,
     cell_h: f32,
-    modes: TermMode,
+    cursor_phys: Vec2,
 }
 
 /// The shared wheel dispatcher: resolves the topmost terminal under the cursor
@@ -74,11 +72,16 @@ fn dispatch_mouse_wheel(
     if raw_v == 0 && raw_h == 0 {
         return;
     }
+    // A whole notch fired: only now project the cursor to a cell and read modes.
+    let Some((cell, modes)) = resolve_wheel_cell(&terminals, wt.target, wt.cursor_phys, &metrics)
+    else {
+        return;
+    };
     apply_wheel(
         &mut commands,
         wt.target,
-        wt.cell,
-        wt.modes,
+        cell,
+        modes,
         raw_v,
         raw_h,
         &keys,
@@ -88,9 +91,9 @@ fn dispatch_mouse_wheel(
 
 /// Resolves the window/focus/empty-set guard + cursor → topmost surface for this
 /// frame to a `WheelTarget`, or `None` on any miss (the caller drains the wheel
-/// reader). The cell is resolved eagerly via a local `CellContext` (one cheap
-/// projection even on a frame that accumulates no notch) so the result is a
-/// lifetime-free value.
+/// reader). Deliberately does NOT project the cursor to a cell or read the
+/// terminal modes — those are deferred to [`resolve_wheel_cell`] so a frame that
+/// accumulates no whole notch pays only the cheap retarget.
 fn resolve_wheel_target(
     terminals: &TerminalSurfaces<'_, '_>,
     windows: &Query<&Window, With<PrimaryWindow>>,
@@ -100,12 +103,30 @@ fn resolve_wheel_target(
     if !window.focused || terminals.is_empty() {
         return None;
     }
-    let cell_w = metrics.metrics.advance_phys.floor().max(1.0);
-    let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
+    let (_, cell_h) = cell_pitch(metrics);
     let cursor_phys = window
         .cursor_position()
         .map(|c| c * window.scale_factor())?;
     let target = topmost_surface_at(cursor_phys, hit_candidates(terminals))?;
+    Some(WheelTarget {
+        target,
+        cell_h,
+        cursor_phys,
+    })
+}
+
+/// Projects `cursor_phys` to the cell under it and reads the target's terminal
+/// modes — the per-notch work deferred out of [`resolve_wheel_target`]. `None`
+/// when the entity is no longer a live surface. A cursor off the node falls back
+/// to cell `(1, 1)` (the same default the eager path used) so a wheel just past
+/// the edge still scrolls.
+fn resolve_wheel_cell(
+    terminals: &TerminalSurfaces<'_, '_>,
+    target: Entity,
+    cursor_phys: Vec2,
+    metrics: &TerminalCellMetricsResource,
+) -> Option<(CellCoord, TermMode)> {
+    let (cell_w, cell_h) = cell_pitch(metrics);
     let (_, handle, node, transform, grid) = terminals.get(target).ok()?;
     let ctx = CellContext {
         node,
@@ -118,12 +139,7 @@ fn resolve_wheel_target(
         .hit(cursor_phys)
         .map(|(cell, _)| cell)
         .unwrap_or(CellCoord { col: 1, row: 1 });
-    Some(WheelTarget {
-        target,
-        cell,
-        cell_h,
-        modes: handle.current_modes(),
-    })
+    Some((cell, handle.current_modes()))
 }
 
 /// Folds this frame's wheel deltas, applies the dominant-axis lock, and
@@ -438,6 +454,80 @@ mod tests {
             cap.0.iter().all(|e| !matches!(e, MouseEffect::Write(_))),
             "horizontal wheel outside a mouse mode must not emit a report, got {:?}",
             cap.0
+        );
+    }
+
+    #[derive(Resource, Default)]
+    struct CapturedScrolls(Vec<i32>);
+
+    fn capture_viewport_scrolls(app: &mut App) {
+        app.init_resource::<CapturedScrolls>();
+        app.add_observer(
+            |ev: On<TerminalViewportScroll>, mut cap: ResMut<CapturedScrolls>| {
+                cap.0.push(ev.lines);
+            },
+        );
+    }
+
+    #[test]
+    fn dispatch_vertical_without_mouse_mode_scrolls_viewport() {
+        // No app mouse mode: a vertical wheel must route to the scrollback path
+        // (WheelAction::ScrollViewport -> TerminalViewportScroll), not a report.
+        let mut app = make_wheel_app(b"");
+        capture_viewport_scrolls(&mut app);
+        set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+        write_wheel(&mut app, 0.0, 1.0);
+        app.update();
+        let scrolls = app.world().resource::<CapturedScrolls>();
+        let total: i32 = scrolls.0.iter().sum();
+        // Magnitude passthrough: the host must forward the engine's
+        // `notches * lines_per_notch` count unscaled. lines_per_notch defaults to
+        // 3, so the scroll is a non-zero multiple of 3 — guards against
+        // apply_wheel_action clamping (e.g. to +/-1) or rescaling the count.
+        assert!(
+            total != 0 && total.rem_euclid(3) == 0,
+            "viewport scroll must pass the engine's lines_per_notch (3) multiple through unscaled, got {total} from {:?}",
+            scrolls.0
+        );
+        let cap = app.world().resource::<CapturedEffects>();
+        assert!(
+            cap.0.iter().all(|e| !matches!(e, MouseEffect::Write(_))),
+            "scrollback scroll must not also emit an app report, got {:?}",
+            cap.0
+        );
+    }
+
+    #[test]
+    fn dispatch_vertical_scrollback_direction_flips_with_wheel() {
+        // Guard the -raw_v sign: opposite wheel directions must produce
+        // opposite-signed viewport scrolls.
+        let up = {
+            let mut app = make_wheel_app(b"");
+            capture_viewport_scrolls(&mut app);
+            set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+            write_wheel(&mut app, 0.0, 1.0);
+            app.update();
+            app.world()
+                .resource::<CapturedScrolls>()
+                .0
+                .iter()
+                .sum::<i32>()
+        };
+        let down = {
+            let mut app = make_wheel_app(b"");
+            capture_viewport_scrolls(&mut app);
+            set_phys_cursor(&mut app, Vec2::new(40.0, 48.0));
+            write_wheel(&mut app, 0.0, -1.0);
+            app.update();
+            app.world()
+                .resource::<CapturedScrolls>()
+                .0
+                .iter()
+                .sum::<i32>()
+        };
+        assert!(
+            up != 0 && down != 0 && up.signum() != down.signum(),
+            "wheel up and down must scroll the viewport in opposite directions, got up={up} down={down}"
         );
     }
 

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -1,7 +1,7 @@
 //! Forwards focused keyboard and mouse-wheel input to the active tmux pane.
 //! Keyboard forwarding intercepts a fixed set of ozmux GUI chords and copy-mode
 //! entry commands. Mouse-wheel forwarding handles only the cases
-//! `crate::input::mouse::dispatch_mouse_wheel` does not own (it now runs on every tmux
+//! `crate::input::mouse::wheel::dispatch_mouse_wheel` does not own (it now runs on every tmux
 //! pane, gated off solely by `MouseDisabled`): an inline webview under the
 //! pointer (forwarded to CEF), a copy-mode pane (a targeted `send-keys -X
 //! scroll-up|scroll-down`), and the alt-screen residual where ozma's viewport
@@ -595,7 +595,7 @@ fn resolve_tmux_webview_wheel_target(
 /// Which layer owns a wheel gesture over a tmux pane.
 ///
 /// `forward_wheel_to_tmux` handles only `CopyMode` and `AltScreenResidual`;
-/// every other case is `CededToOzma` — `crate::input::mouse::dispatch_mouse_wheel`
+/// every other case is `CededToOzma` — `crate::input::mouse::wheel::dispatch_mouse_wheel`
 /// runs on the same pane (gated off only by `MouseDisabled`) and owns it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum WheelOwner {
@@ -634,7 +634,7 @@ fn decide_wheel_owner(in_copy_mode: bool, in_alt_screen: bool, modes: TermMode) 
 }
 
 /// Forwards mouse-wheel events to the tmux pane UNDER THE POINTER for the cases
-/// `crate::input::mouse::dispatch_mouse_wheel` does NOT usefully own.
+/// `crate::input::mouse::wheel::dispatch_mouse_wheel` does NOT usefully own.
 ///
 /// A focused webview under the pointer claims the wheel first
 /// (`resolve_tmux_webview_wheel_target`): each event is forwarded RAW to that
@@ -653,7 +653,7 @@ fn decide_wheel_owner(in_copy_mode: bool, in_alt_screen: bool, modes: TermMode) 
 /// # Invariants
 ///
 /// The target pane MUST be the pane under the cursor, not `ActivePane`:
-/// `crate::input::mouse::dispatch_mouse_wheel` and `crate::input::tmux::gate` both key off the
+/// `crate::input::mouse::wheel::dispatch_mouse_wheel` and `crate::input::tmux::gate` both key off the
 /// cursor pane, so keying this system off the active pane would let both fire on
 /// different panes (cursor pane ≠ active pane) and double-act. The
 /// "complement gated solely by `MouseDisabled`" invariant holds only when both

--- a/src/mode/default/webview.rs
+++ b/src/mode/default/webview.rs
@@ -185,7 +185,7 @@ fn forward_default_webview_mouse_moves(
 /// Forwards the mouse wheel to the FOCUSED inline webview under the cursor on the
 /// Default shell (raw CEF wheel, focus-gated). When no focused webview is under
 /// the pointer the reader is drained and the wheel cedes to
-/// `crate::input::mouse::dispatch_mouse_wheel` (terminal scrollback) through its own
+/// `crate::input::mouse::wheel::dispatch_mouse_wheel` (terminal scrollback) through its own
 /// reader; over the rect the shell is `MouseDisabled` (rect-claim gate), so that
 /// dispatcher yields and only the page scrolls. Gated to wheel frames.
 fn forward_default_webview_wheel(

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -25,7 +25,15 @@ const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 /// request, then an in-flight age that re-requests on timeout until painted.
 #[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
 struct StructuralReseedState {
+    /// Consecutive unpainted frames counted before the first reseed request.
+    /// Once it reaches [`RESEED_DEBOUNCE_FRAMES`] the first `capture-pane`
+    /// request fires and `inflight_age` takes over; this debounce filters the
+    /// ≤1-frame resize transient so a momentary unpaint is not re-seeded.
     unpainted_streak: u8,
+    /// Whether a reseed request is in flight. `None` while still debouncing (no
+    /// request sent yet); `Some(age)` after a request, where `age` counts frames
+    /// since the last request and re-requests every [`RESEED_INFLIGHT_TIMEOUT`]
+    /// frames until the grid paints — so a lost capture reply cannot wedge a pane.
     inflight_age: Option<u16>,
 }
 
@@ -33,8 +41,20 @@ struct StructuralReseedState {
 /// on the grid seq, repainting from the mirror once the divergence persists.
 #[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
 struct BlankRecoveryState {
+    /// Consecutive frames the grid has been blank while the live mirror still
+    /// holds content, within the current `recovery_seq` episode. The repaint
+    /// fires once it reaches [`RESEED_DEBOUNCE_FRAMES`], filtering the resize
+    /// transient where the grid is briefly blank before the resize snapshot lands.
     streak: u8,
+    /// The grid `last_seq` the current episode is evaluating. A different seq
+    /// (the grid changed) reopens evaluation — resetting `streak` and `settled`;
+    /// `None` forces a fresh evaluation. Keying on the seq is what lets a settled
+    /// episode stop re-scanning until the grid actually changes again.
     recovery_seq: Option<u32>,
+    /// Whether the current episode is resolved: the repaint fired, the mirror was
+    /// also blank (genuinely empty pane, nothing to restore), or the grid is no
+    /// longer blank. Suppresses the per-frame grid/mirror scan until
+    /// `recovery_seq` changes.
     settled: bool,
 }
 

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -23,7 +23,7 @@ const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 
 /// Per-pane structural-reseed debounce: a streak before the first capture
 /// request, then an in-flight age that re-requests on timeout until painted.
-#[derive(Component, Default)]
+#[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
 struct StructuralReseedState {
     unpainted_streak: u8,
     inflight_age: Option<u16>,
@@ -31,7 +31,7 @@ struct StructuralReseedState {
 
 /// Per-pane blank-recovery debounce: a blank-grid-vs-live-mirror episode keyed
 /// on the grid seq, repainting from the mirror once the divergence persists.
-#[derive(Component, Default)]
+#[derive(Component, Default, Clone, Copy, PartialEq, Eq)]
 struct BlankRecoveryState {
     streak: u8,
     recovery_seq: Option<u32>,
@@ -187,17 +187,33 @@ fn rescue_unpainted_panes(
     for (entity, pane, handle, grid, mut reseed_state, mut blank_state) in panes.iter_mut() {
         let (h_cols, h_rows, _) = handle.read_geometry();
         let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
-        if reseed_decision(&mut reseed_state, needs) {
+        // NOTE: run the deciders on a local copy and write back through the
+        // `Mut` only on a real change. A bare `&mut`/`*state = ...` every frame
+        // would mark these components `Changed` for every pane every frame
+        // (steady state included), defeating any future `Changed`/`run_if`
+        // consumer — the repo change-detection rule. `*state` reads via `Deref`
+        // (no change tick); the guarded assignment is the only `DerefMut`.
+        let mut next_reseed = *reseed_state;
+        if reseed_decision(&mut next_reseed, needs) {
             reseed.write(RequestPaneReseed { pane: pane.id });
         }
+        if *reseed_state != next_reseed {
+            *reseed_state = next_reseed;
+        }
         if needs {
-            // NOTE: structural reseed owns this pane; reopen blank-recovery so it
+            // Structural reseed owns this pane; reopen blank-recovery so it
             // re-evaluates once the grid is structurally repainted.
-            *blank_state = BlankRecoveryState::default();
+            if *blank_state != BlankRecoveryState::default() {
+                *blank_state = BlankRecoveryState::default();
+            }
             continue;
         }
-        if evaluate_blank_recovery(&mut blank_state, grid, handle) {
+        let mut next_blank = *blank_state;
+        if evaluate_blank_recovery(&mut next_blank, grid, handle) {
             commands.trigger(RepaintLiveMirror { entity });
+        }
+        if *blank_state != next_blank {
+            *blank_state = next_blank;
         }
     }
 }
@@ -588,6 +604,87 @@ mod tests {
             app.world().resource::<SnapHits>().0,
             0,
             "a genuinely blank pane (blank mirror) must not be repainted — no repaint loop",
+        );
+    }
+
+    #[test]
+    fn steady_pane_does_not_re_mark_state_changed_each_frame() {
+        use bevy::ecs::message::Messages;
+        use ozma_tty_renderer::prelude::TerminalGridPlugin;
+        use tmux_control_parser::CellDims;
+
+        #[derive(Resource, Default)]
+        struct ChangedHits {
+            reseed: u32,
+            blank: u32,
+        }
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(TerminalGridPlugin);
+        app.init_resource::<Messages<RequestPaneReseed>>();
+        app.init_resource::<ChangedHits>();
+        app.add_observer(repaint_pane_from_mirror);
+        app.add_systems(
+            Update,
+            (
+                attach_rescue_state,
+                rescue_unpainted_panes,
+                |reseed: Query<(), Changed<StructuralReseedState>>,
+                 blank: Query<(), Changed<BlankRecoveryState>>,
+                 mut hits: ResMut<ChangedHits>| {
+                    hits.reseed += reseed.iter().count() as u32;
+                    hits.blank += blank.iter().count() as u32;
+                },
+            )
+                .chain(),
+        );
+
+        // A painted, non-copy-mode pane in steady state: grid has a glyph and the
+        // handle geometry matches the grid dims, so neither the structural reseed
+        // nor the blank-recovery path mutates after it first settles.
+        let mut handle = TerminalHandle::detached(4, 2);
+        handle.advance(b"hi");
+        app.world_mut().spawn((
+            TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 4,
+                    height: 2,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            },
+            handle,
+            TerminalGrid {
+                cols: 4,
+                rows: 2,
+                cells: vec![vec![cell("h"), cell("i")], vec![cell(" ")]],
+                ..Default::default()
+            },
+        ));
+
+        // Let the attach "added" tick and the first settling write clear.
+        for _ in 0..4 {
+            app.update();
+        }
+        {
+            let mut hits = app.world_mut().resource_mut::<ChangedHits>();
+            hits.reseed = 0;
+            hits.blank = 0;
+        }
+        // Now steady: further frames must not re-mark either component Changed.
+        for _ in 0..3 {
+            app.update();
+        }
+        let hits = app.world().resource::<ChangedHits>();
+        assert_eq!(
+            (hits.reseed, hits.blank),
+            (0, 0),
+            "a steady pane must not re-mark its rescue components Changed each frame \
+             (conditional write-back), got reseed={} blank={}",
+            hits.reseed,
+            hits.blank,
         );
     }
 }

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -12,8 +12,7 @@ use crate::ui::copy_mode::CopyModeState;
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalHandle;
 use ozma_tty_renderer::schema::{Cell, TerminalGrid};
-use ozmux_tmux::{PaneId, RequestPaneReseed, TmuxPane, TmuxProjectionSet};
-use std::collections::HashMap;
+use ozmux_tmux::{RequestPaneReseed, TmuxPane, TmuxProjectionSet};
 
 /// Frames the unpainted state must persist before the FIRST reseed request
 /// (filters the ≤1-frame resize transient).
@@ -25,10 +24,6 @@ const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 /// Per-pane structural-reseed debounce: a streak before the first capture
 /// request, then an in-flight age that re-requests on timeout until painted.
 #[derive(Component, Default)]
-#[expect(
-    dead_code,
-    reason = "fields consumed by the follow-on task migrating ReseedTracker onto this component"
-)]
 struct StructuralReseedState {
     unpainted_streak: u8,
     inflight_age: Option<u16>,
@@ -37,55 +32,25 @@ struct StructuralReseedState {
 /// Per-pane blank-recovery debounce: a blank-grid-vs-live-mirror episode keyed
 /// on the grid seq, repainting from the mirror once the divergence persists.
 #[derive(Component, Default)]
-#[expect(
-    dead_code,
-    reason = "fields consumed by the follow-on task migrating ReseedTracker onto this component"
-)]
 struct BlankRecoveryState {
     streak: u8,
     recovery_seq: Option<u32>,
     settled: bool,
 }
 
-/// Per-pane reseed state: a debounce streak before the first request, then an
-/// in-flight age that re-requests on timeout until the grid paints. The
-/// `blank_*` fields drive the independent blank-grid-vs-live-mirror recovery
-/// (see [`evaluate_blank_recovery`]).
-#[derive(Default)]
-struct ReseedTracker {
-    unpainted_streak: u8,
-    inflight_age: Option<u16>,
-    /// Consecutive frames the grid has been blank while the mirror holds
-    /// content, within the current `blank_recovery_seq` episode.
-    blank_streak: u8,
-    /// The grid `last_seq` the current blank-recovery episode is evaluating. A
-    /// new seq reopens evaluation; `None` forces a fresh evaluation.
-    blank_recovery_seq: Option<u32>,
-    /// Set once a blank episode is resolved (repainted, or the mirror is also
-    /// blank). Stops the per-frame mirror scan until the grid's seq changes.
-    blank_recovery_settled: bool,
-}
-
-/// Per-pane reseed trackers, keyed by `PaneId`.
-#[derive(Resource, Default)]
-struct PaneSeedTrackers(HashMap<PaneId, ReseedTracker>);
-
 /// Wires the structural paint-rescue system after the tmux projection chain.
 pub(crate) struct PaintRescuePlugin;
 
 impl Plugin for PaintRescuePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<PaneSeedTrackers>()
-            .add_observer(prune_tracker_on_pane_removed)
-            .add_observer(repaint_pane_from_mirror)
-            .add_systems(
-                Update,
-                (attach_rescue_state, rescue_unpainted_panes)
-                    .chain()
-                    .after(TmuxProjectionSet)
-                    .before(TmuxLayoutSet)
-                    .in_set(super::TmuxActiveSet),
-            );
+        app.add_observer(repaint_pane_from_mirror).add_systems(
+            Update,
+            (attach_rescue_state, rescue_unpainted_panes)
+                .chain()
+                .after(TmuxProjectionSet)
+                .before(TmuxLayoutSet)
+                .in_set(super::TmuxActiveSet),
+        );
     }
 }
 
@@ -104,22 +69,17 @@ fn grid_needs_full_seed(
     (grid_cols, grid_rows) != (handle_cols, handle_rows) || cells_len != grid_rows as usize
 }
 
-/// Advances a pane's reseed tracker one frame and returns whether to emit a
-/// reseed request now. A painted grid (`!needs_seed`) resets the tracker.
+/// Advances a pane's structural-reseed debounce one frame and returns whether to
+/// emit a reseed request now. A painted grid (`!needs_seed`) resets the state.
 /// Otherwise it debounces `RESEED_DEBOUNCE_FRAMES` consecutive unpainted frames
 /// before the first request, then suppresses while a request is in flight,
 /// re-requesting every `RESEED_INFLIGHT_TIMEOUT` frames until the grid paints.
-fn reseed_decision(tracker: &mut ReseedTracker, needs_seed: bool) -> bool {
+fn reseed_decision(state: &mut StructuralReseedState, needs_seed: bool) -> bool {
     if !needs_seed {
-        // NOTE: reset only the structural-reseed fields, NOT the whole tracker —
-        // the `blank_*` fields belong to the independent blank-recovery state
-        // machine (`evaluate_blank_recovery`), which runs on the common `!needs`
-        // path; clobbering them here would wipe its debounce every frame.
-        tracker.unpainted_streak = 0;
-        tracker.inflight_age = None;
+        *state = StructuralReseedState::default();
         return false;
     }
-    match &mut tracker.inflight_age {
+    match &mut state.inflight_age {
         Some(age) => {
             *age = age.saturating_add(1);
             if *age >= RESEED_INFLIGHT_TIMEOUT {
@@ -130,9 +90,9 @@ fn reseed_decision(tracker: &mut ReseedTracker, needs_seed: bool) -> bool {
             }
         }
         None => {
-            tracker.unpainted_streak = tracker.unpainted_streak.saturating_add(1);
-            if tracker.unpainted_streak >= RESEED_DEBOUNCE_FRAMES {
-                tracker.inflight_age = Some(0);
+            state.unpainted_streak = state.unpainted_streak.saturating_add(1);
+            if state.unpainted_streak >= RESEED_DEBOUNCE_FRAMES {
+                state.inflight_age = Some(0);
                 true
             } else {
                 false
@@ -161,40 +121,38 @@ fn grid_visibly_blank(grid: &TerminalGrid) -> bool {
 /// to repaint it from the live mirror now.
 ///
 /// Fires once the grid has been blank while the mirror still holds content for
-/// [`RESEED_DEBOUNCE_FRAMES`] consecutive frames (filtering the resize transient
-/// where the grid is briefly blank before the resize snapshot lands). The
-/// episode is keyed on the grid `last_seq`: a seq change reopens evaluation, and
-/// once an episode is `settled` (repainted, mirror also blank, or grid painted)
-/// the per-frame mirror scan is skipped until the grid changes again — a
-/// content-gaining mirror always bumps the seq, so this cannot wedge.
+/// [`RESEED_DEBOUNCE_FRAMES`] consecutive frames. The episode is keyed on the
+/// grid `last_seq`: a seq change reopens evaluation, and once an episode is
+/// `settled` (repainted, mirror also blank, or grid painted) the per-frame
+/// mirror scan is skipped until the grid changes again.
 fn evaluate_blank_recovery(
-    tracker: &mut ReseedTracker,
+    state: &mut BlankRecoveryState,
     grid: &TerminalGrid,
     handle: &TerminalHandle,
 ) -> bool {
-    if tracker.blank_recovery_seq != Some(grid.last_seq) {
-        tracker.blank_recovery_seq = Some(grid.last_seq);
-        tracker.blank_streak = 0;
-        tracker.blank_recovery_settled = false;
+    if state.recovery_seq != Some(grid.last_seq) {
+        state.recovery_seq = Some(grid.last_seq);
+        state.streak = 0;
+        state.settled = false;
     }
-    if tracker.blank_recovery_settled {
+    if state.settled {
         return false;
     }
     if !grid_visibly_blank(grid) {
-        tracker.blank_streak = 0;
-        tracker.blank_recovery_settled = true;
+        state.streak = 0;
+        state.settled = true;
         return false;
     }
     if !handle.has_visible_content() {
         // NOTE: grid and mirror both blank — a genuinely empty pane with nothing
         // to restore. Settling here (not just returning) is load-bearing: it
         // stops the per-frame mirror scan until the grid's seq changes.
-        tracker.blank_recovery_settled = true;
+        state.settled = true;
         return false;
     }
-    tracker.blank_streak = tracker.blank_streak.saturating_add(1);
-    if tracker.blank_streak >= RESEED_DEBOUNCE_FRAMES {
-        tracker.blank_recovery_settled = true;
+    state.streak = state.streak.saturating_add(1);
+    if state.streak >= RESEED_DEBOUNCE_FRAMES {
+        state.settled = true;
         true
     } else {
         false
@@ -205,39 +163,40 @@ fn evaluate_blank_recovery(
 /// structurally unpainted (see [`grid_needs_full_seed`]) once the state has
 /// held for [`RESEED_DEBOUNCE_FRAMES`], then re-requests every
 /// [`RESEED_INFLIGHT_TIMEOUT`] frames until the grid paints. Copy-mode panes
-/// are skipped — they paint via the separate `CopyRenderHandle` (Component 3).
+/// are skipped — they paint via the separate `CopyRenderHandle`.
 ///
-/// Separately, recovers a grid that went *blank* (structurally fine, so the
-/// reseed path above ignores it) while its live mirror still holds content: it
-/// triggers [`RepaintLiveMirror`], whose observer repaints from the
-/// authoritative mirror. This automates the manual-scroll workaround for the
-/// persistent-blank-pane bug — the only path that previously re-synced an idle
-/// pane out of a blank-but-sized grid. The gather query stays read-only; the
-/// `&mut TerminalHandle` write lives in the observer (apply-via-observer idiom).
+/// Separately, recovers a grid that went *blank* (structurally fine) while its
+/// live mirror still holds content: it triggers [`RepaintLiveMirror`], whose
+/// observer repaints from the authoritative mirror. The gather query stays
+/// read-only on the handle; the `&mut TerminalHandle` write lives in the observer.
 fn rescue_unpainted_panes(
     mut commands: Commands,
-    mut trackers: ResMut<PaneSeedTrackers>,
     mut reseed: MessageWriter<RequestPaneReseed>,
-    panes: Query<(Entity, &TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
+    mut panes: Query<
+        (
+            Entity,
+            &TmuxPane,
+            &TerminalHandle,
+            &TerminalGrid,
+            &mut StructuralReseedState,
+            &mut BlankRecoveryState,
+        ),
+        Without<CopyModeState>,
+    >,
 ) {
-    for (entity, pane, handle, grid) in panes.iter() {
+    for (entity, pane, handle, grid, mut reseed_state, mut blank_state) in panes.iter_mut() {
         let (h_cols, h_rows, _) = handle.read_geometry();
         let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
-        let tracker = trackers.0.entry(pane.id).or_default();
-        if reseed_decision(tracker, needs) {
+        if reseed_decision(&mut reseed_state, needs) {
             reseed.write(RequestPaneReseed { pane: pane.id });
         }
         if needs {
-            // NOTE: structural reseed owns this pane; reopening blank-recovery
-            // (clearing `blank_recovery_seq`) is required so it re-evaluates once
-            // the grid is structurally repainted — otherwise a settled episode
-            // would suppress recovery after the reseed lands.
-            tracker.blank_streak = 0;
-            tracker.blank_recovery_seq = None;
-            tracker.blank_recovery_settled = false;
+            // NOTE: structural reseed owns this pane; reopen blank-recovery so it
+            // re-evaluates once the grid is structurally repainted.
+            *blank_state = BlankRecoveryState::default();
             continue;
         }
-        if evaluate_blank_recovery(tracker, grid, handle) {
+        if evaluate_blank_recovery(&mut blank_state, grid, handle) {
             commands.trigger(RepaintLiveMirror { entity });
         }
     }
@@ -280,19 +239,10 @@ fn repaint_pane_from_mirror(
     }
 }
 
-fn prune_tracker_on_pane_removed(
-    ev: On<Remove, TmuxPane>,
-    mut trackers: ResMut<PaneSeedTrackers>,
-    panes: Query<&TmuxPane>,
-) {
-    if let Ok(pane) = panes.get(ev.entity) {
-        trackers.0.remove(&pane.id);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ozmux_tmux::PaneId;
 
     #[test]
     fn zero_grid_against_sized_handle_needs_seed() {
@@ -316,7 +266,7 @@ mod tests {
 
     #[test]
     fn reseed_emits_after_debounce_frames() {
-        let mut t = ReseedTracker::default();
+        let mut t = StructuralReseedState::default();
         assert!(!reseed_decision(&mut t, true));
         assert!(!reseed_decision(&mut t, true));
         assert!(reseed_decision(&mut t, true));
@@ -324,7 +274,7 @@ mod tests {
 
     #[test]
     fn reseed_suppresses_while_in_flight_then_retries_on_timeout() {
-        let mut t = ReseedTracker::default();
+        let mut t = StructuralReseedState::default();
         for _ in 0..RESEED_DEBOUNCE_FRAMES {
             reseed_decision(&mut t, true);
         }
@@ -336,7 +286,7 @@ mod tests {
 
     #[test]
     fn reseed_resets_when_painted() {
-        let mut t = ReseedTracker::default();
+        let mut t = StructuralReseedState::default();
         for _ in 0..RESEED_DEBOUNCE_FRAMES {
             reseed_decision(&mut t, true);
         }
@@ -347,7 +297,7 @@ mod tests {
 
     #[test]
     fn reseed_ignores_one_frame_transient() {
-        let mut t = ReseedTracker::default();
+        let mut t = StructuralReseedState::default();
         assert!(!reseed_decision(&mut t, true));
         assert!(!reseed_decision(&mut t, false));
         assert!(!reseed_decision(&mut t, true));
@@ -427,7 +377,7 @@ mod tests {
 
     #[test]
     fn blank_recovery_fires_after_debounce_then_settles() {
-        let mut t = ReseedTracker::default();
+        let mut t = BlankRecoveryState::default();
         let grid = blank_grid(5);
         let mut painted = TerminalHandle::detached(4, 2);
         painted.advance(b"hi");
@@ -441,20 +391,20 @@ mod tests {
 
     #[test]
     fn blank_recovery_skips_when_mirror_is_also_blank() {
-        let mut t = ReseedTracker::default();
+        let mut t = BlankRecoveryState::default();
         let grid = blank_grid(5);
         let blank = TerminalHandle::detached(4, 2);
         for _ in 0..(RESEED_DEBOUNCE_FRAMES + 2) {
             assert!(!evaluate_blank_recovery(&mut t, &grid, &blank));
         }
         // Settled on the first blank-mirror frame: no streak accumulates.
-        assert!(t.blank_recovery_settled);
-        assert_eq!(t.blank_streak, 0);
+        assert!(t.settled);
+        assert_eq!(t.streak, 0);
     }
 
     #[test]
     fn blank_recovery_resets_on_seq_change() {
-        let mut t = ReseedTracker::default();
+        let mut t = BlankRecoveryState::default();
         let mut painted = TerminalHandle::detached(4, 2);
         painted.advance(b"hi");
         // Two blank frames at seq 5, then a new seq reopens the episode, so the
@@ -462,12 +412,12 @@ mod tests {
         evaluate_blank_recovery(&mut t, &blank_grid(5), &painted);
         evaluate_blank_recovery(&mut t, &blank_grid(5), &painted);
         assert!(!evaluate_blank_recovery(&mut t, &blank_grid(6), &painted));
-        assert_eq!(t.blank_streak, 1);
+        assert_eq!(t.streak, 1);
     }
 
     #[test]
     fn blank_recovery_ignores_painted_grid() {
-        let mut t = ReseedTracker::default();
+        let mut t = BlankRecoveryState::default();
         let grid = TerminalGrid {
             cols: 4,
             rows: 2,
@@ -478,7 +428,7 @@ mod tests {
         let mut painted = TerminalHandle::detached(4, 2);
         painted.advance(b"hi");
         assert!(!evaluate_blank_recovery(&mut t, &grid, &painted));
-        assert_eq!(t.blank_streak, 0);
+        assert_eq!(t.streak, 0);
     }
 
     #[test]
@@ -490,10 +440,12 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_plugins(TerminalGridPlugin);
-        app.init_resource::<PaneSeedTrackers>();
         app.init_resource::<Messages<RequestPaneReseed>>();
         app.add_observer(repaint_pane_from_mirror);
-        app.add_systems(Update, rescue_unpainted_panes);
+        app.add_systems(
+            Update,
+            (attach_rescue_state, rescue_unpainted_panes).chain(),
+        );
 
         let dims = CellDims {
             width: 4,
@@ -584,14 +536,16 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_plugins(TerminalGridPlugin);
-        app.init_resource::<PaneSeedTrackers>();
         app.init_resource::<Messages<RequestPaneReseed>>();
         app.init_resource::<SnapHits>();
         app.add_observer(|_snap: On<FrameSnapshot>, mut hits: ResMut<SnapHits>| {
             hits.0 += 1;
         });
         app.add_observer(repaint_pane_from_mirror);
-        app.add_systems(Update, rescue_unpainted_panes);
+        app.add_systems(
+            Update,
+            (attach_rescue_state, rescue_unpainted_panes).chain(),
+        );
 
         let dims = CellDims {
             width: 4,

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -1,12 +1,17 @@
 //! Structural rescue for tmux panes whose grid was left unpainted after a
 //! layout change: detects the unpainted state and asks `ozmux_tmux` to
 //! re-`capture-pane` until the grid paints (spec Component 2).
+//!
+//! It also recovers a pane whose grid went *blank* (structurally fine, so the
+//! reseed path ignores it) while its live mirror still holds content, by
+//! repainting from the mirror — automating the manual-scroll workaround for the
+//! persistent-blank-pane bug.
 
 use super::render::TmuxLayoutSet;
 use crate::ui::copy_mode::CopyModeState;
 use bevy::prelude::*;
 use ozma_tty_engine::TerminalHandle;
-use ozma_tty_renderer::schema::TerminalGrid;
+use ozma_tty_renderer::schema::{Cell, TerminalGrid};
 use ozmux_tmux::{PaneId, RequestPaneReseed, TmuxPane, TmuxProjectionSet};
 use std::collections::HashMap;
 
@@ -18,11 +23,22 @@ const RESEED_DEBOUNCE_FRAMES: u8 = 3;
 const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 
 /// Per-pane reseed state: a debounce streak before the first request, then an
-/// in-flight age that re-requests on timeout until the grid paints.
+/// in-flight age that re-requests on timeout until the grid paints. The
+/// `blank_*` fields drive the independent blank-grid-vs-live-mirror recovery
+/// (see [`evaluate_blank_recovery`]).
 #[derive(Default)]
 struct ReseedTracker {
     unpainted_streak: u8,
     inflight_age: Option<u16>,
+    /// Consecutive frames the grid has been blank while the mirror holds
+    /// content, within the current `blank_recovery_seq` episode.
+    blank_streak: u8,
+    /// The grid `last_seq` the current blank-recovery episode is evaluating. A
+    /// new seq reopens evaluation; `None` forces a fresh evaluation.
+    blank_recovery_seq: Option<u32>,
+    /// Set once a blank episode is resolved (repainted, or the mirror is also
+    /// blank). Stops the per-frame mirror scan until the grid's seq changes.
+    blank_recovery_settled: bool,
 }
 
 /// Per-pane reseed trackers, keyed by `PaneId`.
@@ -36,6 +52,7 @@ impl Plugin for PaintRescuePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PaneSeedTrackers>()
             .add_observer(prune_tracker_on_pane_removed)
+            .add_observer(repaint_pane_from_mirror)
             .add_systems(
                 Update,
                 rescue_unpainted_panes
@@ -68,7 +85,12 @@ fn grid_needs_full_seed(
 /// re-requesting every `RESEED_INFLIGHT_TIMEOUT` frames until the grid paints.
 fn reseed_decision(tracker: &mut ReseedTracker, needs_seed: bool) -> bool {
     if !needs_seed {
-        *tracker = ReseedTracker::default();
+        // NOTE: reset only the structural-reseed fields, NOT the whole tracker —
+        // the `blank_*` fields belong to the independent blank-recovery state
+        // machine (`evaluate_blank_recovery`), which runs on the common `!needs`
+        // path; clobbering them here would wipe its debounce every frame.
+        tracker.unpainted_streak = 0;
+        tracker.inflight_age = None;
         return false;
     }
     match &mut tracker.inflight_age {
@@ -93,23 +115,126 @@ fn reseed_decision(tracker: &mut ReseedTracker, needs_seed: bool) -> bool {
     }
 }
 
+/// Whether the rendered grid paints no glyph in any cell (via [`Cell::is_blank`],
+/// the same predicate the renderer's glyph resolution uses). A pane that lost its
+/// painted content to a transient blank frame reads as blank here while its live
+/// mirror still reports `has_visible_content`. An empty `cells` vec also reads as
+/// blank, but that is the structural case [`grid_needs_full_seed`] already owns
+/// (guarded by `!needs` at the call site).
+///
+/// NOTE: glyph-only — a cell visible solely through a non-default background or
+/// reverse video (a colored status bar with no text) reads as blank. This pairs
+/// with the equally glyph-only `TerminalHandle::has_visible_content`, so the two
+/// agree and the recovery never loops; the cost is that a purely color-block
+/// pane is not auto-recovered (it still has the manual-scroll fallback).
+fn grid_visibly_blank(grid: &TerminalGrid) -> bool {
+    grid.cells.iter().flatten().all(Cell::is_blank)
+}
+
+/// Advances a pane's blank-recovery state machine one frame and returns whether
+/// to repaint it from the live mirror now.
+///
+/// Fires once the grid has been blank while the mirror still holds content for
+/// [`RESEED_DEBOUNCE_FRAMES`] consecutive frames (filtering the resize transient
+/// where the grid is briefly blank before the resize snapshot lands). The
+/// episode is keyed on the grid `last_seq`: a seq change reopens evaluation, and
+/// once an episode is `settled` (repainted, mirror also blank, or grid painted)
+/// the per-frame mirror scan is skipped until the grid changes again — a
+/// content-gaining mirror always bumps the seq, so this cannot wedge.
+fn evaluate_blank_recovery(
+    tracker: &mut ReseedTracker,
+    grid: &TerminalGrid,
+    handle: &TerminalHandle,
+) -> bool {
+    if tracker.blank_recovery_seq != Some(grid.last_seq) {
+        tracker.blank_recovery_seq = Some(grid.last_seq);
+        tracker.blank_streak = 0;
+        tracker.blank_recovery_settled = false;
+    }
+    if tracker.blank_recovery_settled {
+        return false;
+    }
+    if !grid_visibly_blank(grid) {
+        tracker.blank_streak = 0;
+        tracker.blank_recovery_settled = true;
+        return false;
+    }
+    if !handle.has_visible_content() {
+        // NOTE: grid and mirror both blank — a genuinely empty pane with nothing
+        // to restore. Settling here (not just returning) is load-bearing: it
+        // stops the per-frame mirror scan until the grid's seq changes.
+        tracker.blank_recovery_settled = true;
+        return false;
+    }
+    tracker.blank_streak = tracker.blank_streak.saturating_add(1);
+    if tracker.blank_streak >= RESEED_DEBOUNCE_FRAMES {
+        tracker.blank_recovery_settled = true;
+        true
+    } else {
+        false
+    }
+}
+
 /// Requests a tmux re-seed for each non-copy-mode pane whose grid is
 /// structurally unpainted (see [`grid_needs_full_seed`]) once the state has
 /// held for [`RESEED_DEBOUNCE_FRAMES`], then re-requests every
 /// [`RESEED_INFLIGHT_TIMEOUT`] frames until the grid paints. Copy-mode panes
 /// are skipped — they paint via the separate `CopyRenderHandle` (Component 3).
+///
+/// Separately, recovers a grid that went *blank* (structurally fine, so the
+/// reseed path above ignores it) while its live mirror still holds content: it
+/// triggers [`RepaintLiveMirror`], whose observer repaints from the
+/// authoritative mirror. This automates the manual-scroll workaround for the
+/// persistent-blank-pane bug — the only path that previously re-synced an idle
+/// pane out of a blank-but-sized grid. The gather query stays read-only; the
+/// `&mut TerminalHandle` write lives in the observer (apply-via-observer idiom).
 fn rescue_unpainted_panes(
+    mut commands: Commands,
     mut trackers: ResMut<PaneSeedTrackers>,
     mut reseed: MessageWriter<RequestPaneReseed>,
-    panes: Query<(&TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
+    panes: Query<(Entity, &TmuxPane, &TerminalHandle, &TerminalGrid), Without<CopyModeState>>,
 ) {
-    for (pane, handle, grid) in panes.iter() {
+    for (entity, pane, handle, grid) in panes.iter() {
         let (h_cols, h_rows, _) = handle.read_geometry();
         let needs = grid_needs_full_seed(grid.cols, grid.rows, grid.cells.len(), h_cols, h_rows);
         let tracker = trackers.0.entry(pane.id).or_default();
         if reseed_decision(tracker, needs) {
             reseed.write(RequestPaneReseed { pane: pane.id });
         }
+        if needs {
+            // NOTE: structural reseed owns this pane; reopening blank-recovery
+            // (clearing `blank_recovery_seq`) is required so it re-evaluates once
+            // the grid is structurally repainted — otherwise a settled episode
+            // would suppress recovery after the reseed lands.
+            tracker.blank_streak = 0;
+            tracker.blank_recovery_seq = None;
+            tracker.blank_recovery_settled = false;
+            continue;
+        }
+        if evaluate_blank_recovery(tracker, grid, handle) {
+            commands.trigger(RepaintLiveMirror { entity });
+        }
+    }
+}
+
+/// Asks the blank-recovery observer to repaint a pane's grid from its live
+/// `TerminalHandle` mirror. Triggered by [`rescue_unpainted_panes`].
+#[derive(EntityEvent)]
+struct RepaintLiveMirror {
+    #[event_target]
+    entity: Entity,
+}
+
+/// Repaints the target pane's grid from its live mirror. Holds the `&mut
+/// TerminalHandle` here so [`rescue_unpainted_panes`] can keep a read-only,
+/// parallelizable gather query.
+fn repaint_pane_from_mirror(
+    repaint: On<RepaintLiveMirror>,
+    mut commands: Commands,
+    mut handles: Query<&mut TerminalHandle>,
+) {
+    if let Ok(mut handle) = handles.get_mut(repaint.entity) {
+        handle.repaint_full(&mut commands, repaint.entity);
     }
 }
 
@@ -184,5 +309,239 @@ mod tests {
         assert!(!reseed_decision(&mut t, true));
         assert!(!reseed_decision(&mut t, false));
         assert!(!reseed_decision(&mut t, true));
+    }
+
+    fn cell(text: &str) -> ozma_tty_renderer::schema::Cell {
+        ozma_tty_renderer::schema::Cell {
+            text: text.to_string(),
+            width: 1,
+            fg: Default::default(),
+            bg: Default::default(),
+            style: 0,
+            hyperlink_id: None,
+        }
+    }
+
+    #[test]
+    fn grid_with_only_whitespace_is_blank() {
+        let grid = TerminalGrid {
+            cols: 3,
+            rows: 2,
+            cells: vec![vec![cell(" "), cell(" ")], vec![cell(""), cell(" ")]],
+            ..Default::default()
+        };
+        assert!(grid_visibly_blank(&grid));
+    }
+
+    #[test]
+    fn grid_with_any_glyph_is_not_blank() {
+        let grid = TerminalGrid {
+            cols: 3,
+            rows: 2,
+            cells: vec![vec![cell(" "), cell("x")], vec![cell(" "), cell(" ")]],
+            ..Default::default()
+        };
+        assert!(!grid_visibly_blank(&grid));
+    }
+
+    #[test]
+    fn empty_cells_reads_as_blank() {
+        let grid = TerminalGrid {
+            cols: 0,
+            rows: 0,
+            cells: vec![],
+            ..Default::default()
+        };
+        assert!(grid_visibly_blank(&grid));
+    }
+
+    #[test]
+    fn width_zero_cells_read_as_blank() {
+        // A width-0 cell (combining mark / wide-char spacer) paints no glyph, so
+        // it must read blank here too — matching the renderer's `Cell::is_blank`.
+        let zero_width = Cell {
+            text: "x".to_string(),
+            width: 0,
+            ..cell("x")
+        };
+        let grid = TerminalGrid {
+            cols: 1,
+            rows: 1,
+            cells: vec![vec![zero_width]],
+            ..Default::default()
+        };
+        assert!(grid_visibly_blank(&grid));
+    }
+
+    fn blank_grid(seq: u32) -> TerminalGrid {
+        TerminalGrid {
+            cols: 4,
+            rows: 2,
+            cells: vec![vec![cell(" ")], vec![cell(" ")]],
+            last_seq: seq,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn blank_recovery_fires_after_debounce_then_settles() {
+        let mut t = ReseedTracker::default();
+        let grid = blank_grid(5);
+        let mut painted = TerminalHandle::detached(4, 2);
+        painted.advance(b"hi");
+        // Same seq across frames: the streak accumulates to the debounce.
+        assert!(!evaluate_blank_recovery(&mut t, &grid, &painted));
+        assert!(!evaluate_blank_recovery(&mut t, &grid, &painted));
+        assert!(evaluate_blank_recovery(&mut t, &grid, &painted));
+        // Settled: the same seq does not re-fire (the repaint bumps the seq).
+        assert!(!evaluate_blank_recovery(&mut t, &grid, &painted));
+    }
+
+    #[test]
+    fn blank_recovery_skips_when_mirror_is_also_blank() {
+        let mut t = ReseedTracker::default();
+        let grid = blank_grid(5);
+        let blank = TerminalHandle::detached(4, 2);
+        for _ in 0..(RESEED_DEBOUNCE_FRAMES + 2) {
+            assert!(!evaluate_blank_recovery(&mut t, &grid, &blank));
+        }
+        // Settled on the first blank-mirror frame: no streak accumulates.
+        assert!(t.blank_recovery_settled);
+        assert_eq!(t.blank_streak, 0);
+    }
+
+    #[test]
+    fn blank_recovery_resets_on_seq_change() {
+        let mut t = ReseedTracker::default();
+        let mut painted = TerminalHandle::detached(4, 2);
+        painted.advance(b"hi");
+        // Two blank frames at seq 5, then a new seq reopens the episode, so the
+        // streak restarts and a single later frame does not fire.
+        evaluate_blank_recovery(&mut t, &blank_grid(5), &painted);
+        evaluate_blank_recovery(&mut t, &blank_grid(5), &painted);
+        assert!(!evaluate_blank_recovery(&mut t, &blank_grid(6), &painted));
+        assert_eq!(t.blank_streak, 1);
+    }
+
+    #[test]
+    fn blank_recovery_ignores_painted_grid() {
+        let mut t = ReseedTracker::default();
+        let grid = TerminalGrid {
+            cols: 4,
+            rows: 2,
+            cells: vec![vec![cell("x")], vec![cell(" ")]],
+            last_seq: 5,
+            ..Default::default()
+        };
+        let mut painted = TerminalHandle::detached(4, 2);
+        painted.advance(b"hi");
+        assert!(!evaluate_blank_recovery(&mut t, &grid, &painted));
+        assert_eq!(t.blank_streak, 0);
+    }
+
+    #[test]
+    fn blank_grid_with_live_content_repaints_from_mirror() {
+        use bevy::ecs::message::Messages;
+        use ozma_tty_renderer::prelude::TerminalGridPlugin;
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(TerminalGridPlugin);
+        app.init_resource::<PaneSeedTrackers>();
+        app.init_resource::<Messages<RequestPaneReseed>>();
+        app.add_observer(repaint_pane_from_mirror);
+        app.add_systems(Update, rescue_unpainted_panes);
+
+        let dims = CellDims {
+            width: 4,
+            height: 2,
+            xoff: 0,
+            yoff: 0,
+        };
+        let mut handle = TerminalHandle::detached(4, 2);
+        handle.advance(b"hi");
+        let pane = app
+            .world_mut()
+            .spawn((
+                TmuxPane {
+                    id: PaneId(1),
+                    dims,
+                },
+                handle,
+                TerminalGrid {
+                    cols: 4,
+                    rows: 2,
+                    cells: vec![vec![cell(" ")], vec![cell(" ")]],
+                    ..Default::default()
+                },
+            ))
+            .id();
+
+        // The mirror holds "hi" but the rendered grid is blank: after the
+        // debounce the rescue must repaint the grid from the live mirror.
+        for _ in 0..(RESEED_DEBOUNCE_FRAMES as usize + 1) {
+            app.update();
+        }
+
+        let grid = app.world().get::<TerminalGrid>(pane).unwrap();
+        let row0: String = grid.cells[0].iter().map(|c| c.text.as_str()).collect();
+        assert!(
+            row0.starts_with("hi"),
+            "blank grid with a content-bearing mirror repaints to live content, got {row0:?}",
+        );
+    }
+
+    #[test]
+    fn blank_grid_with_blank_mirror_is_not_repainted() {
+        use bevy::ecs::message::Messages;
+        use ozma_tty_renderer::prelude::TerminalGridPlugin;
+        use ozma_tty_renderer::schema::FrameSnapshot;
+        use tmux_control_parser::CellDims;
+
+        #[derive(Resource, Default)]
+        struct SnapHits(u32);
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_plugins(TerminalGridPlugin);
+        app.init_resource::<PaneSeedTrackers>();
+        app.init_resource::<Messages<RequestPaneReseed>>();
+        app.init_resource::<SnapHits>();
+        app.add_observer(|_snap: On<FrameSnapshot>, mut hits: ResMut<SnapHits>| {
+            hits.0 += 1;
+        });
+        app.add_observer(repaint_pane_from_mirror);
+        app.add_systems(Update, rescue_unpainted_panes);
+
+        let dims = CellDims {
+            width: 4,
+            height: 2,
+            xoff: 0,
+            yoff: 0,
+        };
+        app.world_mut().spawn((
+            TmuxPane {
+                id: PaneId(1),
+                dims,
+            },
+            TerminalHandle::detached(4, 2),
+            TerminalGrid {
+                cols: 4,
+                rows: 2,
+                cells: vec![vec![cell(" ")], vec![cell(" ")]],
+                ..Default::default()
+            },
+        ));
+
+        for _ in 0..(RESEED_DEBOUNCE_FRAMES as usize + 2) {
+            app.update();
+        }
+
+        assert_eq!(
+            app.world().resource::<SnapHits>().0,
+            0,
+            "a genuinely blank pane (blank mirror) must not be repainted — no repaint loop",
+        );
     }
 }

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -518,9 +518,22 @@ mod tests {
             "attach inserts BlankRecoveryState",
         );
 
-        // A second pass must not re-insert (Without<StructuralReseedState> filter).
+        // NOTE: prove idempotency — mutate the state, then a second pass must NOT
+        // re-insert (which would reset it); the Without<StructuralReseedState> filter
+        // must exclude the already-attached pane.
+        app.world_mut()
+            .get_mut::<StructuralReseedState>(pane)
+            .unwrap()
+            .unpainted_streak = 7;
         app.update();
-        assert!(app.world().get::<StructuralReseedState>(pane).is_some());
+        assert_eq!(
+            app.world()
+                .get::<StructuralReseedState>(pane)
+                .unwrap()
+                .unpainted_streak,
+            7,
+            "second pass must not re-insert (a re-insert would reset the streak to 0)",
+        );
     }
 
     #[test]

--- a/src/mode/tmux/paint_rescue.rs
+++ b/src/mode/tmux/paint_rescue.rs
@@ -22,6 +22,31 @@ const RESEED_DEBOUNCE_FRAMES: u8 = 3;
 /// the dedicated in-flight age (spec §3.2) so a lost reply does not wedge a pane.
 const RESEED_INFLIGHT_TIMEOUT: u16 = 30;
 
+/// Per-pane structural-reseed debounce: a streak before the first capture
+/// request, then an in-flight age that re-requests on timeout until painted.
+#[derive(Component, Default)]
+#[expect(
+    dead_code,
+    reason = "fields consumed by the follow-on task migrating ReseedTracker onto this component"
+)]
+struct StructuralReseedState {
+    unpainted_streak: u8,
+    inflight_age: Option<u16>,
+}
+
+/// Per-pane blank-recovery debounce: a blank-grid-vs-live-mirror episode keyed
+/// on the grid seq, repainting from the mirror once the divergence persists.
+#[derive(Component, Default)]
+#[expect(
+    dead_code,
+    reason = "fields consumed by the follow-on task migrating ReseedTracker onto this component"
+)]
+struct BlankRecoveryState {
+    streak: u8,
+    recovery_seq: Option<u32>,
+    settled: bool,
+}
+
 /// Per-pane reseed state: a debounce streak before the first request, then an
 /// in-flight age that re-requests on timeout until the grid paints. The
 /// `blank_*` fields drive the independent blank-grid-vs-live-mirror recovery
@@ -55,7 +80,8 @@ impl Plugin for PaintRescuePlugin {
             .add_observer(repaint_pane_from_mirror)
             .add_systems(
                 Update,
-                rescue_unpainted_panes
+                (attach_rescue_state, rescue_unpainted_panes)
+                    .chain()
                     .after(TmuxProjectionSet)
                     .before(TmuxLayoutSet)
                     .in_set(super::TmuxActiveSet),
@@ -214,6 +240,22 @@ fn rescue_unpainted_panes(
         if evaluate_blank_recovery(tracker, grid, handle) {
             commands.trigger(RepaintLiveMirror { entity });
         }
+    }
+}
+
+/// Attaches the per-pane rescue state components once per pane. `TmuxPane` is
+/// defined in `ozmux_tmux`, so the binary cannot `#[require]` these onto it; the
+/// `Without<StructuralReseedState>` filter makes this run exactly once per pane
+/// (both components are always inserted together).
+fn attach_rescue_state(
+    mut commands: Commands,
+    panes: Query<Entity, (With<TmuxPane>, Without<StructuralReseedState>)>,
+) {
+    for entity in panes.iter() {
+        commands.entity(entity).insert((
+            StructuralReseedState::default(),
+            BlankRecoveryState::default(),
+        ));
     }
 }
 
@@ -490,6 +532,43 @@ mod tests {
             row0.starts_with("hi"),
             "blank grid with a content-bearing mirror repaints to live content, got {row0:?}",
         );
+    }
+
+    #[test]
+    fn attach_inserts_both_state_components_once() {
+        use tmux_control_parser::CellDims;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(Update, attach_rescue_state);
+
+        let pane = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 4,
+                    height: 2,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+
+        app.update();
+
+        assert!(
+            app.world().get::<StructuralReseedState>(pane).is_some(),
+            "attach inserts StructuralReseedState",
+        );
+        assert!(
+            app.world().get::<BlankRecoveryState>(pane).is_some(),
+            "attach inserts BlankRecoveryState",
+        );
+
+        // A second pass must not re-insert (Without<StructuralReseedState> filter).
+        app.update();
+        assert!(app.world().get::<StructuralReseedState>(pane).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In tmux mode a pane could be left **painted blank** (only the background/pane-gap color showing, terminal content gone) after creating a split and then transitioning to copy mode, resizing, or clicking a pane. Scrolling temporarily restored it, but repeating the same action re-triggered the blank.

Root cause: the rendered grid had diverged from its authoritative live `TerminalHandle` mirror, and **nothing automatically re-synced an idle pane** out of that state — the structural paint-rescue only covers a structurally-unpainted grid (wrong dims / `cells_len != rows`), not a blank-but-sized one, and `recapture_settled_panes` is a one-shot. A manual scroll was the only path that repainted from the live mirror.

<details><summary>Symptom (bug.png)</summary>

Two freshly-split top panes render as solid background; the others are fine. Scrolling restores them, then the action re-blanks them.
</details>

## Solution

**Blank-pane recovery (engine + renderer + `src/mode/tmux/paint_rescue.rs`).** Automate the manual-scroll workaround: when a non-copy-mode pane's grid is visibly blank while its live mirror still holds content, trigger a `RepaintLiveMirror` `EntityEvent` whose observer repaints from the authoritative mirror (apply-via-observer idiom — the gather query stays read-only and parallelizable). The episode is keyed on the grid `last_seq` and settles once resolved, so a persistently-blank pane stops re-scanning every frame.

Consistency guards so the two-sided blank test can't repaint-loop:
- `TerminalHandle::has_visible_content` (engine) excludes `'\0'`, mirroring `frame_builder`'s unallocated-cell normalization (`'\0'` → space) — an unallocated viewport reads blank on both sides.
- A shared `Cell::is_blank()` on the renderer schema backs both the renderer's glyph resolution and the host's grid-blank test, so "renders nothing" cannot drift.

Known limitation (documented in code): recovery is glyph-only, so a pane visible solely through background color / reverse video is not auto-recovered (it keeps the manual-scroll fallback).

**Mouse-dispatch review cleanups (`src/input/mouse/*`, follow-ups to #224).** Surfaced while reviewing this branch: defer the wheel cursor→cell projection + `current_modes()` until a whole notch fires (cursor-only frames no longer pay a per-frame matrix inverse); share `cell_pitch` and an `on_any_mouse_message` run condition; add a `button_kind` helper; restore wheel-scrollback test coverage (fires / sign / line-count passthrough); fix stale `dispatch_mouse_wheel` doc paths after the module move.

Affected: `ozma_tty_engine`, `ozma_tty_renderer`, the tmux render layer, and the mouse input dispatchers.

### Verification

`cargo build`, `clippy --workspace` (0 warnings), and `cargo fmt --check` clean. Tests pass: engine 244, renderer 47, tmux_session 142, binary `input::` 200 + `mode::tmux` 135, including new `\0` / width-0 / scroll-magnitude / blank-recovery tests. Not yet exercised on the real GUI — worth a manual confirm (split → copy-mode / resize / click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)