### PR TITLE
refactor(mouse): dedupe surface→context kernel; fix stale docs

### DIFF
--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -16,7 +16,7 @@ use ozma_terminal::{
     OzmaTerminal, TerminalMouseWrite, TerminalOpenUri, TerminalSelectionClear,
     TerminalSelectionCopy, TerminalSelectionStart, TerminalSelectionUpdate,
 };
-use ozma_tty_engine::{CellCoord, Point, SelectionType, Side, TerminalHandle};
+use ozma_tty_engine::{CellCoord, Point, SelectionType, Side, TermMode, TerminalHandle};
 use ozma_tty_renderer::schema::TerminalGrid;
 
 mod button;
@@ -168,6 +168,26 @@ impl CellContext<'_> {
             self.grid.rows,
         )
     }
+}
+
+/// Resolves `target` to its `(CellContext, TermMode)` at the given cell pitch,
+/// or `None` when it is no longer a live surface. Shared by the button and wheel
+/// dispatchers so both build a hit-test context the same way.
+fn cell_context_for<'a>(
+    terminals: &'a TerminalSurfaces<'_, '_>,
+    target: Entity,
+    cell_w: f32,
+    cell_h: f32,
+) -> Option<(CellContext<'a>, TermMode)> {
+    let (_, handle, node, transform, grid) = terminals.get(target).ok()?;
+    let ctx = CellContext {
+        node,
+        transform,
+        grid,
+        cell_w,
+        cell_h,
+    };
+    Some((ctx, handle.current_modes()))
 }
 
 #[cfg(test)]

--- a/src/input/mouse/button.rs
+++ b/src/input/mouse/button.rs
@@ -4,7 +4,10 @@
 //! effects out via the shared `trigger_mouse_effects`. Registered by
 //! `MouseButtonInputPlugin`; skips `MouseDisabled` surfaces.
 
-use super::{CellContext, MouseEffect, TerminalSurfaces, hit_candidates, trigger_mouse_effects};
+use super::{
+    CellContext, MouseEffect, TerminalSurfaces, cell_context_for, hit_candidates,
+    trigger_mouse_effects,
+};
 use crate::input::InputPhase;
 use crate::input::bindings::OzmaMouseConfig;
 use crate::input::current_modifiers;
@@ -102,10 +105,10 @@ fn dispatch_mouse_buttons(
 }
 
 /// Resolves the window guard and the per-frame cursor/constants for one run, or
-/// `None` after performing the same reader-drains + gesture reset the inline
-/// guards did. Window missing/unfocused drains both readers; a cursor that
-/// `effective_drag_cursor` rejects drains only `buttons` (`cursor_moved` was
-/// already drained by the read).
+/// `None` when the frame should be skipped (window missing/unfocused, empty
+/// candidate set, or a cursor `effective_drag_cursor` rejects). On `None` the
+/// caller drains the input readers and resets the gesture — this fn does not
+/// (it reads `cursor_moved` only to refresh `last_cursor_phys`).
 fn resolve_frame(
     gesture: &mut OzmaMouseGesture,
     cursor_moved: &mut MessageReader<CursorMoved>,
@@ -147,15 +150,7 @@ fn ctx_for<'a>(
     target: Entity,
     frame: &FrameContext,
 ) -> Option<(CellContext<'a>, TermMode)> {
-    let (_, handle, node, transform, grid) = terminals.get(target).ok()?;
-    let ctx = CellContext {
-        node,
-        transform,
-        grid,
-        cell_w: frame.cell_w,
-        cell_h: frame.cell_h,
-    };
-    Some((ctx, handle.current_modes()))
+    cell_context_for(terminals, target, frame.cell_w, frame.cell_h)
 }
 
 /// Processes one `MouseButtonInput`: hit-tests the target (press) or the locked

--- a/src/input/mouse/wheel.rs
+++ b/src/input/mouse/wheel.rs
@@ -5,7 +5,7 @@
 //! `apply_wheel_action`. Registered by `MouseWheelInputPlugin`; skips
 //! `MouseDisabled` surfaces.
 
-use super::{CellContext, TerminalSurfaces, hit_candidates};
+use super::{TerminalSurfaces, cell_context_for, hit_candidates};
 use crate::input::InputPhase;
 use crate::input::bindings::{FineModifier, OzmaMouseConfig};
 use crate::input::gesture::{
@@ -43,6 +43,7 @@ impl Plugin for MouseWheelInputPlugin {
 /// cursor, the cell height (for delta scaling), and the terminal modes. A plain
 /// `Copy` value — the cell is resolved during `resolve_wheel_target`, so nothing
 /// downstream needs the borrowed `CellContext`.
+#[derive(Clone, Copy)]
 struct WheelTarget {
     target: Entity,
     cell: CellCoord,
@@ -106,14 +107,7 @@ fn resolve_wheel_target(
         .cursor_position()
         .map(|c| c * window.scale_factor())?;
     let target = topmost_surface_at(cursor_phys, hit_candidates(terminals))?;
-    let (_, handle, node, transform, grid) = terminals.get(target).ok()?;
-    let ctx = CellContext {
-        node,
-        transform,
-        grid,
-        cell_w,
-        cell_h,
-    };
+    let (ctx, modes) = cell_context_for(terminals, target, cell_w, cell_h)?;
     let cell = ctx
         .hit(cursor_phys)
         .map(|(cell, _)| cell)
@@ -122,7 +116,7 @@ fn resolve_wheel_target(
         target,
         cell,
         cell_h,
-        modes: handle.current_modes(),
+        modes,
     })
 }
 


### PR DESCRIPTION
## Problem

Follow-up to the mouse button/wheel refactor (#224). A max-effort code review of that branch surfaced three issues that landed via the squash merge:

- The "`terminals.get(target)` → build `CellContext` → `handle.current_modes()`" kernel was duplicated between `button.rs`'s `ctx_for` and `wheel.rs`'s `resolve_wheel_target`. A future change to how a surface becomes a hit-test context (or how its terminal modes are read) would have to be applied in both, and updating only one would silently make the two dispatchers disagree about the same surface.
- `resolve_frame`'s doc still claimed it "performs the same reader-drains + gesture reset" on a `None` return, but that cleanup was hoisted to the caller. A maintainer trusting the stale doc could delete the caller's `buttons.clear(); cursor_moved.clear(); gesture.reset();` and reintroduce a stuck-gesture / replayed-input bug.
- `WheelTarget`'s doc described it as "a plain `Copy` value" while the struct had no `#[derive(Copy)]`.

Affects the host input layer only (`src/input/mouse/`).

## Solution

- **Dedupe the surface→context kernel.** Lift it into a shared `cell_context_for(terminals, target, cell_w, cell_h) -> Option<(CellContext, TermMode)>` in `mouse.rs`. `ctx_for` (button) and `resolve_wheel_target` (wheel) now both delegate to it, so the per-target resolution lives in one place.
- **Fix `resolve_frame`'s doc** to state that on `None` the *caller* drains the readers and resets the gesture (this fn only reads `cursor_moved` to refresh `last_cursor_phys`).
- **Derive `Clone, Copy` on `WheelTarget`** so the "Copy value" doc is accurate.

Pure refactor / docs — no behavior change. Verified: `cargo test -p ozmux input::mouse` (27 passed), `cargo clippy -p ozmux --all-targets` (clean), `cargo fmt --check` (clean).

### Note on scope

Two review findings were deliberately **not** applied: (1) the host-side scrollback (`ScrollViewport → TerminalViewportScroll`) path lost its only host test when the redundant pure-decider tests were deleted — re-adding coverage reverses an explicit earlier design decision and is left for a follow-up; (2) the eager cell hit-test in `resolve_wheel_target` is the accepted value-only-`WheelTarget` trade-off (one negligible projection per cursor-move frame; the lazy alternative re-introduces the lifetime the design removed).
