### PR TITLE
feat(shortcuts): app-native tmux actions — drop prefix forwarding, per-command EntityEvents

### DIFF
--- a/crates/ozmux_configs/src/lib.rs
+++ b/crates/ozmux_configs/src/lib.rs
@@ -178,14 +178,14 @@ mod validate_tests {
 
     #[test]
     fn validate_detects_chord_conflict() {
-        let toml_str = "[shortcuts]\nrelease-webview-focus = \"Cmd+V\"\n";
+        let toml_str = "[shortcuts]\nrelease-webview-focus = \"Cmd+Q\"\n";
         let mut configs: OzmuxConfigs = toml::from_str(toml_str).unwrap();
         configs.normalize();
         let err = configs.validate().unwrap_err();
         match err {
             OzmuxConfigsError::DuplicateChords(dupes) => {
                 assert_eq!(dupes.len(), 1);
-                assert!(dupes[0].actions.contains(&"paste"));
+                assert!(dupes[0].actions.contains(&"quit"));
                 assert!(dupes[0].actions.contains(&"release-webview-focus"));
             }
             _ => panic!("expected DuplicateChords, got {err:?}"),
@@ -372,7 +372,7 @@ mod integration_tests {
         assert_eq!(quit.key, shortcuts::Key::Char('q'));
         assert!(quit.modifiers.meta && quit.modifiers.shift);
         assert!(
-            matches!(c.shortcuts.paste, Some(Binding::Direct(_))),
+            matches!(c.shortcuts.paste, Some(Binding::Leader(_))),
             "unspecified active bindings keep their defaults",
         );
     }

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -342,8 +342,8 @@ pub struct Shortcuts {
         serialize_with = "ser_binding_or_unbind"
     )]
     pub quit: Option<Binding>,
-    /// Enter copy mode (Alacritty vi mode) on the focused terminal in
-    /// `AppMode::Default`.
+    /// Enter copy mode: Alacritty vi mode in `AppMode::Default`, tmux
+    /// copy-mode in `AppMode::Tmux`.
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -355,6 +355,150 @@ pub struct Shortcuts {
         serialize_with = "ser_binding_or_unbind"
     )]
     pub detach_session: Option<Binding>,
+    /// Focus the pane to the left (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_left_pane: Option<Binding>,
+    /// Focus the pane below (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_down_pane: Option<Binding>,
+    /// Focus the pane above (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_up_pane: Option<Binding>,
+    /// Focus the pane to the right (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_right_pane: Option<Binding>,
+    /// Split the active pane side-by-side — vertical divider, tmux `-h` (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub split_vertical_pane: Option<Binding>,
+    /// Split the active pane stacked — horizontal divider, tmux `-v` (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub split_horizontal_pane: Option<Binding>,
+    /// Kill the active pane, after a confirm prompt (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub kill_pane: Option<Binding>,
+    /// Toggle zoom on the active pane (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub zoom_pane: Option<Binding>,
+    /// Open a new window (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub new_window: Option<Binding>,
+    /// Kill the active window, after a confirm prompt (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub kill_window: Option<Binding>,
+    /// Switch to the next window (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub next_window: Option<Binding>,
+    /// Switch to the previous window (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub previous_window: Option<Binding>,
+    /// Switch to the window at tmux index 0 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_0: Option<Binding>,
+    /// Switch to the window at tmux index 1 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_1: Option<Binding>,
+    /// Switch to the window at tmux index 2 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_2: Option<Binding>,
+    /// Switch to the window at tmux index 3 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_3: Option<Binding>,
+    /// Switch to the window at tmux index 4 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_4: Option<Binding>,
+    /// Switch to the window at tmux index 5 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_5: Option<Binding>,
+    /// Switch to the window at tmux index 6 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_6: Option<Binding>,
+    /// Switch to the window at tmux index 7 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_7: Option<Binding>,
+    /// Switch to the window at tmux index 8 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_8: Option<Binding>,
+    /// Switch to the window at tmux index 9 (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub select_window_9: Option<Binding>,
+    /// Open the rename prompt for the active window (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub rename_window: Option<Binding>,
+    /// Open the rename prompt for the session (tmux mode only).
+    #[serde(
+        deserialize_with = "deser_binding_or_unbind",
+        serialize_with = "ser_binding_or_unbind"
+    )]
+    pub rename_session: Option<Binding>,
     /// Timeout (ms) for a modifier-tap leader: press+release within this window
     /// with no intervening key/mouse press counts as a tap. Default 300; 0 is
     /// normalized to 300.
@@ -365,11 +509,35 @@ impl Default for Shortcuts {
     fn default() -> Self {
         Shortcuts {
             leader: Some(Leader::ModifierTap(TapModifier::Meta)),
-            paste: Some(Binding::Direct(parse_default_chord("Cmd+V"))),
+            paste: Some(parse_default_binding("<Leader>p")),
             release_webview_focus: Some(Binding::Direct(parse_default_chord("Ctrl+Shift+Escape"))),
             quit: Some(Binding::Direct(parse_default_chord("Cmd+Q"))),
             enter_copy_mode: Some(Binding::Direct(parse_default_chord("Cmd+S"))),
             detach_session: Some(Binding::Direct(parse_default_chord("Ctrl+Shift+D"))),
+            select_left_pane: Some(parse_default_binding("<Leader>h")),
+            select_down_pane: Some(parse_default_binding("<Leader>j")),
+            select_up_pane: Some(parse_default_binding("<Leader>k")),
+            select_right_pane: Some(parse_default_binding("<Leader>l")),
+            split_vertical_pane: Some(parse_default_binding("<Leader>i")),
+            split_horizontal_pane: Some(parse_default_binding("<Leader>o")),
+            kill_pane: Some(parse_default_binding("<Leader>x")),
+            zoom_pane: Some(parse_default_binding("<Leader>z")),
+            new_window: Some(parse_default_binding("<Leader>c")),
+            kill_window: Some(parse_default_binding("<Leader>Shift+X")),
+            next_window: Some(parse_default_binding("<Leader>n")),
+            previous_window: Some(parse_default_binding("<Leader>Shift+N")),
+            select_window_0: Some(parse_default_binding("<Leader>0")),
+            select_window_1: Some(parse_default_binding("<Leader>1")),
+            select_window_2: Some(parse_default_binding("<Leader>2")),
+            select_window_3: Some(parse_default_binding("<Leader>3")),
+            select_window_4: Some(parse_default_binding("<Leader>4")),
+            select_window_5: Some(parse_default_binding("<Leader>5")),
+            select_window_6: Some(parse_default_binding("<Leader>6")),
+            select_window_7: Some(parse_default_binding("<Leader>7")),
+            select_window_8: Some(parse_default_binding("<Leader>8")),
+            select_window_9: Some(parse_default_binding("<Leader>9")),
+            rename_window: Some(parse_default_binding("<Leader>r")),
+            rename_session: Some(parse_default_binding("<Leader>Shift+R")),
             leader_tap_timeout_ms: 300,
         }
     }
@@ -398,6 +566,106 @@ impl Shortcuts {
                 "detach-session",
                 &self.detach_session,
                 ShortcutAction::DetachSession,
+            ),
+            (
+                "select-left-pane",
+                &self.select_left_pane,
+                ShortcutAction::SelectPane(PaneDirection::Left),
+            ),
+            (
+                "select-down-pane",
+                &self.select_down_pane,
+                ShortcutAction::SelectPane(PaneDirection::Down),
+            ),
+            (
+                "select-up-pane",
+                &self.select_up_pane,
+                ShortcutAction::SelectPane(PaneDirection::Up),
+            ),
+            (
+                "select-right-pane",
+                &self.select_right_pane,
+                ShortcutAction::SelectPane(PaneDirection::Right),
+            ),
+            (
+                "split-vertical-pane",
+                &self.split_vertical_pane,
+                ShortcutAction::SplitPane(SplitOrientation::Vertical),
+            ),
+            (
+                "split-horizontal-pane",
+                &self.split_horizontal_pane,
+                ShortcutAction::SplitPane(SplitOrientation::Horizontal),
+            ),
+            ("kill-pane", &self.kill_pane, ShortcutAction::KillPane),
+            ("zoom-pane", &self.zoom_pane, ShortcutAction::ZoomPane),
+            ("new-window", &self.new_window, ShortcutAction::NewWindow),
+            ("kill-window", &self.kill_window, ShortcutAction::KillWindow),
+            ("next-window", &self.next_window, ShortcutAction::NextWindow),
+            (
+                "previous-window",
+                &self.previous_window,
+                ShortcutAction::PreviousWindow,
+            ),
+            (
+                "select-window-0",
+                &self.select_window_0,
+                ShortcutAction::SelectWindow(0),
+            ),
+            (
+                "select-window-1",
+                &self.select_window_1,
+                ShortcutAction::SelectWindow(1),
+            ),
+            (
+                "select-window-2",
+                &self.select_window_2,
+                ShortcutAction::SelectWindow(2),
+            ),
+            (
+                "select-window-3",
+                &self.select_window_3,
+                ShortcutAction::SelectWindow(3),
+            ),
+            (
+                "select-window-4",
+                &self.select_window_4,
+                ShortcutAction::SelectWindow(4),
+            ),
+            (
+                "select-window-5",
+                &self.select_window_5,
+                ShortcutAction::SelectWindow(5),
+            ),
+            (
+                "select-window-6",
+                &self.select_window_6,
+                ShortcutAction::SelectWindow(6),
+            ),
+            (
+                "select-window-7",
+                &self.select_window_7,
+                ShortcutAction::SelectWindow(7),
+            ),
+            (
+                "select-window-8",
+                &self.select_window_8,
+                ShortcutAction::SelectWindow(8),
+            ),
+            (
+                "select-window-9",
+                &self.select_window_9,
+                ShortcutAction::SelectWindow(9),
+            ),
+            (
+                "rename-window",
+                &self.rename_window,
+                ShortcutAction::RenameWindow,
+            ),
+            (
+                "rename-session",
+                &self.rename_session,
+                ShortcutAction::RenameSession,
             ),
         ]
         .into_iter()
@@ -444,10 +712,31 @@ impl Shortcuts {
     }
 }
 
-/// Shortcut actions reachable under forward-only key routing. tmux owns the
-/// pane/window operations now; these are the ozmux-local GUI actions.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "kebab-case")]
+/// A neighbor direction for the `select-pane` shortcut actions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaneDirection {
+    /// Focus the pane to the left.
+    Left,
+    /// Focus the pane below.
+    Down,
+    /// Focus the pane above.
+    Up,
+    /// Focus the pane to the right.
+    Right,
+}
+
+/// Which way a split divides the pane, named after the DIVIDER the user sees.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SplitOrientation {
+    /// A vertical divider: panes end up side by side (tmux `split-window -h`).
+    Vertical,
+    /// A horizontal divider: panes end up stacked (tmux `split-window -v`).
+    Horizontal,
+}
+
+/// Shortcut actions. GUI-local actions plus the tmux pane/window operations
+/// (the latter are inert outside `AppMode::Tmux`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShortcutAction {
     /// Paste the system clipboard into the active terminal.
     Paste,
@@ -457,9 +746,31 @@ pub enum ShortcutAction {
     Quit,
     /// Detaches from the tmux session and returns to Default single-terminal mode.
     DetachSession,
-    /// Enters copy mode (Alacritty vi mode) on the focused terminal in
-    /// `AppMode::Default`.
+    /// Enters copy mode: Alacritty vi mode in `AppMode::Default`, tmux
+    /// copy-mode in `AppMode::Tmux`.
     EnterCopyMode,
+    /// Focuses the neighbor pane in the given direction (tmux mode only).
+    SelectPane(PaneDirection),
+    /// Splits the active pane (tmux mode only).
+    SplitPane(SplitOrientation),
+    /// Kills the active pane after a confirm prompt (tmux mode only).
+    KillPane,
+    /// Toggles zoom on the active pane (tmux mode only).
+    ZoomPane,
+    /// Opens a new window in the current session (tmux mode only).
+    NewWindow,
+    /// Kills the active window after a confirm prompt (tmux mode only).
+    KillWindow,
+    /// Switches to the next window (tmux mode only).
+    NextWindow,
+    /// Switches to the previous window (tmux mode only).
+    PreviousWindow,
+    /// Switches to the window with this tmux display index (tmux mode only).
+    SelectWindow(u8),
+    /// Opens the rename prompt for the active window (tmux mode only).
+    RenameWindow,
+    /// Opens the rename prompt for the session (tmux mode only).
+    RenameSession,
 }
 
 /// The literal token marking a leader-scoped binding value (`<Leader>x`).
@@ -609,6 +920,10 @@ fn parse_modifier_to_bit(token: &str) -> Option<(Modifiers, &'static str)> {
 
 fn parse_default_chord(s: &str) -> KeyChord {
     parse_key_chord(s).unwrap_or_else(|e| panic!("invalid default chord {s:?}: {e}"))
+}
+
+fn parse_default_binding(s: &str) -> Binding {
+    parse_binding(s).unwrap_or_else(|e| panic!("invalid default binding {s:?}: {e}"))
 }
 
 /// Detects chord collisions across a table's bound entries. Returns a `Vec`
@@ -913,15 +1228,70 @@ mod tests {
         assert_eq!(s.leader, Some(Leader::ModifierTap(TapModifier::Meta)));
         assert_eq!(
             s.paste,
-            Some(Binding::Direct(parse_key_chord("Cmd+V").unwrap()))
+            Some(Binding::Leader(parse_key_chord("p").unwrap()))
         );
         assert_eq!(
             s.quit,
             Some(Binding::Direct(parse_key_chord("Cmd+Q").unwrap()))
         );
-        assert_eq!(s.bindings_iter().count(), 5);
-        assert_eq!(s.direct_chords().count(), 5);
-        assert_eq!(s.leader_chords().count(), 0);
+        assert_eq!(s.bindings_iter().count(), 29);
+        assert_eq!(s.direct_chords().count(), 4);
+        assert_eq!(s.leader_chords().count(), 25);
+    }
+
+    #[test]
+    fn bindings_iter_count_is_pinned_to_field_count() {
+        // NOTE: drift guard — adding a Shortcuts field without its
+        // bindings_iter() entry silently unbinds the action.
+        assert_eq!(Shortcuts::default().bindings_iter().count(), 29);
+    }
+
+    #[test]
+    fn default_tmux_actions_are_leader_bound() {
+        let s = Shortcuts::default();
+        assert_eq!(
+            s.select_left_pane,
+            Some(Binding::Leader(parse_key_chord("h").unwrap()))
+        );
+        assert_eq!(
+            s.split_vertical_pane,
+            Some(Binding::Leader(parse_key_chord("i").unwrap()))
+        );
+        assert_eq!(
+            s.kill_window,
+            Some(Binding::Leader(parse_key_chord("Shift+X").unwrap()))
+        );
+        assert_eq!(
+            s.select_window_0,
+            Some(Binding::Leader(parse_key_chord("0").unwrap()))
+        );
+        assert_eq!(
+            s.rename_session,
+            Some(Binding::Leader(parse_key_chord("Shift+R").unwrap()))
+        );
+        assert_eq!(
+            s.paste,
+            Some(Binding::Leader(parse_key_chord("p").unwrap()))
+        );
+    }
+
+    #[test]
+    fn tmux_actions_parse_from_flat_toml() {
+        let toml = r#"
+split-vertical-pane = "<Leader>g"
+select-window-3 = ""
+new-window = "Cmd+T"
+"#;
+        let s: Shortcuts = toml::from_str(toml).unwrap();
+        assert_eq!(
+            s.split_vertical_pane,
+            Some(Binding::Leader(parse_key_chord("g").unwrap()))
+        );
+        assert_eq!(s.select_window_3, None);
+        assert_eq!(
+            s.new_window,
+            Some(Binding::Direct(parse_key_chord("Cmd+T").unwrap()))
+        );
     }
 
     #[test]
@@ -953,9 +1323,9 @@ detach-session = "<Leader>d"
         );
         assert_eq!(
             s.paste,
-            Some(Binding::Direct(parse_key_chord("Cmd+V").unwrap()))
+            Some(Binding::Leader(parse_key_chord("p").unwrap()))
         );
-        assert_eq!(s.leader_chords().count(), 2);
+        assert_eq!(s.leader_chords().count(), 27);
     }
 
     #[test]
@@ -993,7 +1363,7 @@ detach-session = "<Leader>d"
     #[test]
     fn default_shortcuts_json_snapshot() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
-        let expected = r#"{"leader":"Cmd","paste":"Cmd+V","release-webview-focus":"Ctrl+Shift+Escape","quit":"Cmd+Q","enter-copy-mode":"Cmd+S","detach-session":"Ctrl+Shift+D","leader-tap-timeout-ms":300}"#;
+        let expected = r#"{"leader":"Cmd","paste":"<Leader>P","release-webview-focus":"Ctrl+Shift+Escape","quit":"Cmd+Q","enter-copy-mode":"Cmd+S","detach-session":"Ctrl+Shift+D","select-left-pane":"<Leader>H","select-down-pane":"<Leader>J","select-up-pane":"<Leader>K","select-right-pane":"<Leader>L","split-vertical-pane":"<Leader>I","split-horizontal-pane":"<Leader>O","kill-pane":"<Leader>X","zoom-pane":"<Leader>Z","new-window":"<Leader>C","kill-window":"<Leader>Shift+X","next-window":"<Leader>N","previous-window":"<Leader>Shift+N","select-window-0":"<Leader>0","select-window-1":"<Leader>1","select-window-2":"<Leader>2","select-window-3":"<Leader>3","select-window-4":"<Leader>4","select-window-5":"<Leader>5","select-window-6":"<Leader>6","select-window-7":"<Leader>7","select-window-8":"<Leader>8","select-window-9":"<Leader>9","rename-window":"<Leader>R","rename-session":"<Leader>Shift+R","leader-tap-timeout-ms":300}"#;
         assert_eq!(json, expected);
     }
 

--- a/crates/ozmux_configs/tests/fixtures/duplicate_leader_binding.toml
+++ b/crates/ozmux_configs/tests/fixtures/duplicate_leader_binding.toml
@@ -1,0 +1,3 @@
+[shortcuts]
+new-window = "<Leader>g"
+zoom-pane = "<Leader>g"

--- a/crates/ozmux_configs/tests/fixtures/tmux_action_binding.toml
+++ b/crates/ozmux_configs/tests/fixtures/tmux_action_binding.toml
@@ -1,0 +1,3 @@
+[shortcuts]
+split-vertical-pane = "<Leader>g"
+select-window-5 = ""

--- a/crates/ozmux_configs/tests/load.rs
+++ b/crates/ozmux_configs/tests/load.rs
@@ -1,4 +1,4 @@
-use ozmux_configs::shortcuts::Key;
+use ozmux_configs::shortcuts::{Binding, Key, parse_key_chord};
 use ozmux_configs::test_support::load_with_overrides;
 use ozmux_configs::{OzmuxConfigs, OzmuxConfigsError};
 use std::path::PathBuf;
@@ -85,4 +85,31 @@ fn syntax_error_surfaces_parse_toml() {
 fn unknown_action_surfaces_parse_toml() {
     let err = load_with_overrides(Some(fixture("unknown_action.toml")), None, None).unwrap_err();
     assert!(matches!(err, OzmuxConfigsError::ParseToml { .. }));
+}
+
+#[test]
+fn tmux_action_rebind_and_unbind() {
+    let configs =
+        load_with_overrides(Some(fixture("tmux_action_binding.toml")), None, None).unwrap();
+    assert_eq!(
+        configs.shortcuts.split_vertical_pane,
+        Some(Binding::Leader(parse_key_chord("g").unwrap()))
+    );
+    assert_eq!(configs.shortcuts.select_window_5, None);
+}
+
+#[test]
+fn duplicate_leader_chord_rejected() {
+    let err = load_with_overrides(Some(fixture("duplicate_leader_binding.toml")), None, None)
+        .unwrap_err();
+    match err {
+        OzmuxConfigsError::DuplicatePrefixChords(dupes) => {
+            assert!(
+                dupes
+                    .iter()
+                    .any(|d| d.actions.contains(&"new-window") && d.actions.contains(&"zoom-pane"))
+            );
+        }
+        other => panic!("expected DuplicatePrefixChords, got {other:?}"),
+    }
 }

--- a/crates/tmux_session/src/command.rs
+++ b/crates/tmux_session/src/command.rs
@@ -18,7 +18,7 @@ pub use ops::{
 };
 pub(crate) use query::{
     ActivePane, AggressiveResize, CapturePane, ClientName, CursorQuery, ListKeys, ListWindows,
-    ModeKeys, PrefixOptions, SubscribeWindowFlags, Version,
+    ModeKeys, SubscribeWindowFlags, Version,
 };
 pub use size::{RefreshClient, ResizeWindow, WindowRefreshClient};
 pub use target::{RenameSession, RenameWindow, ResizePaneX, ResizePaneY, SelectPane, SelectWindow};

--- a/crates/tmux_session/src/command.rs
+++ b/crates/tmux_session/src/command.rs
@@ -4,6 +4,7 @@
 mod copymode;
 mod env;
 mod io;
+mod ops;
 mod query;
 mod size;
 mod target;
@@ -11,6 +12,10 @@ mod target;
 pub use copymode::{CopyModeCapture, CopyStateQuery, Prompt, ShowBuffer};
 pub use env::{SetEnvironmentGlobal, SetEnvironmentInSession, UnsetEnvironmentGlobal};
 pub use io::{SendBytes, SendPaneKeys};
+pub use ops::{
+    EnterCopyMode, KillPane, KillWindow, NewWindow, NextWindow, PaneDirection, PreviousWindow,
+    SelectPaneTowards, SplitDirection, SplitWindow, ZoomPane,
+};
 pub(crate) use query::{
     ActivePane, AggressiveResize, CapturePane, ClientName, CursorQuery, ListKeys, ListWindows,
     ModeKeys, PrefixOptions, SubscribeWindowFlags, Version,

--- a/crates/tmux_session/src/command/ops.rs
+++ b/crates/tmux_session/src/command/ops.rs
@@ -193,7 +193,10 @@ mod tests {
             "kill-pane -t %5"
         );
         assert_eq!(
-            KillWindow { window: WindowId(2) }.into_raw_command(),
+            KillWindow {
+                window: WindowId(2)
+            }
+            .into_raw_command(),
             "kill-window -t @2"
         );
     }
@@ -202,11 +205,17 @@ mod tests {
     fn window_cycle_commands_target_session() {
         assert_eq!(NewWindow.into_raw_command(), "new-window");
         assert_eq!(
-            NextWindow { session: SessionId(1) }.into_raw_command(),
+            NextWindow {
+                session: SessionId(1)
+            }
+            .into_raw_command(),
             "next-window -t $1"
         );
         assert_eq!(
-            PreviousWindow { session: SessionId(1) }.into_raw_command(),
+            PreviousWindow {
+                session: SessionId(1)
+            }
+            .into_raw_command(),
             "previous-window -t $1"
         );
     }

--- a/crates/tmux_session/src/command/ops.rs
+++ b/crates/tmux_session/src/command/ops.rs
@@ -1,0 +1,225 @@
+//! Pane / window operation commands driven by ozmux-native shortcuts:
+//! split, kill, zoom, copy-mode entry, directional pane selection, and
+//! window cycling.
+
+use tmux_control::TmuxCommand;
+use tmux_control_parser::{PaneId, SessionId, WindowId};
+
+/// Which way `split-window` divides a pane, in tmux flag semantics.
+///
+/// NOTE: tmux names the layout axis, not the divider: `-h` (Horizontal) puts
+/// panes side by side. The config-facing `SplitOrientation` names the divider
+/// instead; the binary maps between the two.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SplitDirection {
+    /// `-h`: panes end up side by side.
+    Horizontal,
+    /// `-v`: panes end up stacked.
+    Vertical,
+}
+
+/// A neighbor direction for `select-pane`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaneDirection {
+    /// `-L`.
+    Left,
+    /// `-D`.
+    Down,
+    /// `-U`.
+    Up,
+    /// `-R`.
+    Right,
+}
+
+/// `split-window -h|-v -t %<id>` — splits the target pane.
+pub struct SplitWindow {
+    /// Target pane id.
+    pub pane: PaneId,
+    /// Split direction (tmux flag semantics).
+    pub direction: SplitDirection,
+}
+impl TmuxCommand for SplitWindow {
+    fn into_raw_command(self) -> String {
+        let flag = match self.direction {
+            SplitDirection::Horizontal => "-h",
+            SplitDirection::Vertical => "-v",
+        };
+        format!("split-window {flag} -t %{}", self.pane.0)
+    }
+}
+
+/// `select-pane -L|-D|-U|-R -t %<id>` — focuses the target pane's neighbor.
+pub struct SelectPaneTowards {
+    /// The pane whose neighbor is selected.
+    pub pane: PaneId,
+    /// Which neighbor to select.
+    pub direction: PaneDirection,
+}
+impl TmuxCommand for SelectPaneTowards {
+    fn into_raw_command(self) -> String {
+        let flag = match self.direction {
+            PaneDirection::Left => "-L",
+            PaneDirection::Down => "-D",
+            PaneDirection::Up => "-U",
+            PaneDirection::Right => "-R",
+        };
+        format!("select-pane {flag} -t %{}", self.pane.0)
+    }
+}
+
+/// `kill-pane -t %<id>`.
+pub struct KillPane {
+    /// Target pane id.
+    pub pane: PaneId,
+}
+impl TmuxCommand for KillPane {
+    fn into_raw_command(self) -> String {
+        format!("kill-pane -t %{}", self.pane.0)
+    }
+}
+
+/// `kill-window -t @<id>`.
+pub struct KillWindow {
+    /// Target window id.
+    pub window: WindowId,
+}
+impl TmuxCommand for KillWindow {
+    fn into_raw_command(self) -> String {
+        format!("kill-window -t @{}", self.window.0)
+    }
+}
+
+/// `new-window` — opens a window in the client's current session. Bare on
+/// purpose: `-t` carries placement semantics, so the current-session default
+/// is what a shortcut wants.
+pub struct NewWindow;
+impl TmuxCommand for NewWindow {
+    fn into_raw_command(self) -> String {
+        "new-window".to_string()
+    }
+}
+
+/// `next-window -t $<id>`.
+pub struct NextWindow {
+    /// Target session id.
+    pub session: SessionId,
+}
+impl TmuxCommand for NextWindow {
+    fn into_raw_command(self) -> String {
+        format!("next-window -t ${}", self.session.0)
+    }
+}
+
+/// `previous-window -t $<id>`.
+pub struct PreviousWindow {
+    /// Target session id.
+    pub session: SessionId,
+}
+impl TmuxCommand for PreviousWindow {
+    fn into_raw_command(self) -> String {
+        format!("previous-window -t ${}", self.session.0)
+    }
+}
+
+/// `resize-pane -Z -t %<id>` — toggles zoom on the target pane.
+pub struct ZoomPane {
+    /// Target pane id.
+    pub pane: PaneId,
+}
+impl TmuxCommand for ZoomPane {
+    fn into_raw_command(self) -> String {
+        format!("resize-pane -Z -t %{}", self.pane.0)
+    }
+}
+
+/// `copy-mode -t %<id>` — puts the target pane into tmux copy mode.
+pub struct EnterCopyMode {
+    /// Target pane id.
+    pub pane: PaneId,
+}
+impl TmuxCommand for EnterCopyMode {
+    fn into_raw_command(self) -> String {
+        format!("copy-mode -t %{}", self.pane.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_window_renders_both_directions() {
+        assert_eq!(
+            SplitWindow {
+                pane: PaneId(3),
+                direction: SplitDirection::Horizontal
+            }
+            .into_raw_command(),
+            "split-window -h -t %3"
+        );
+        assert_eq!(
+            SplitWindow {
+                pane: PaneId(3),
+                direction: SplitDirection::Vertical
+            }
+            .into_raw_command(),
+            "split-window -v -t %3"
+        );
+    }
+
+    #[test]
+    fn select_pane_towards_renders_all_directions() {
+        for (direction, flag) in [
+            (PaneDirection::Left, "-L"),
+            (PaneDirection::Down, "-D"),
+            (PaneDirection::Up, "-U"),
+            (PaneDirection::Right, "-R"),
+        ] {
+            assert_eq!(
+                SelectPaneTowards {
+                    pane: PaneId(7),
+                    direction
+                }
+                .into_raw_command(),
+                format!("select-pane {flag} -t %7")
+            );
+        }
+    }
+
+    #[test]
+    fn kill_commands_target_ids() {
+        assert_eq!(
+            KillPane { pane: PaneId(5) }.into_raw_command(),
+            "kill-pane -t %5"
+        );
+        assert_eq!(
+            KillWindow { window: WindowId(2) }.into_raw_command(),
+            "kill-window -t @2"
+        );
+    }
+
+    #[test]
+    fn window_cycle_commands_target_session() {
+        assert_eq!(NewWindow.into_raw_command(), "new-window");
+        assert_eq!(
+            NextWindow { session: SessionId(1) }.into_raw_command(),
+            "next-window -t $1"
+        );
+        assert_eq!(
+            PreviousWindow { session: SessionId(1) }.into_raw_command(),
+            "previous-window -t $1"
+        );
+    }
+
+    #[test]
+    fn zoom_and_copy_mode_target_pane() {
+        assert_eq!(
+            ZoomPane { pane: PaneId(4) }.into_raw_command(),
+            "resize-pane -Z -t %4"
+        );
+        assert_eq!(
+            EnterCopyMode { pane: PaneId(4) }.into_raw_command(),
+            "copy-mode -t %4"
+        );
+    }
+}

--- a/crates/tmux_session/src/command/query.rs
+++ b/crates/tmux_session/src/command/query.rs
@@ -1,6 +1,6 @@
 //! Enumeration / introspection queries sent on attach and during projection:
 //! list windows, client name, active pane, version, subscriptions, captures,
-//! cursor, mode-keys, aggressive-resize, key tables, prefix options.
+//! cursor, mode-keys, aggressive-resize, key tables.
 
 use crate::enumerate::{LIST_WINDOWS_FORMAT, WINDOW_FLAGS_SUBSCRIPTION};
 use tmux_control::TmuxCommand;
@@ -97,14 +97,6 @@ impl TmuxCommand for ListKeys<'_> {
     }
 }
 
-/// `display-message -p '#{prefix} #{prefix2}'` — the session prefix options.
-pub(crate) struct PrefixOptions;
-impl TmuxCommand for PrefixOptions {
-    fn into_raw_command(self) -> String {
-        "display-message -p '#{prefix} #{prefix2}'".to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,14 +178,6 @@ mod tests {
         assert_eq!(
             ListKeys { table: "root" }.into_raw_command(),
             "list-keys -T root"
-        );
-    }
-
-    #[test]
-    fn prefix_options_reads_both_prefixes() {
-        assert_eq!(
-            PrefixOptions.into_raw_command(),
-            "display-message -p '#{prefix} #{prefix2}'"
         );
     }
 }

--- a/crates/tmux_session/src/enumerate.rs
+++ b/crates/tmux_session/src/enumerate.rs
@@ -230,8 +230,6 @@ pub(crate) enum PendingReply {
     ActivePane,
     /// Any `list-keys -T <table>` reply → `KeyBindings::install`.
     KeyBindings,
-    /// Prefix-options query → `set_prefix_keys`.
-    PrefixKeys,
     /// `#{mode-keys}` → `set_mode_keys`.
     ModeKeys,
     /// `aggressive-resize` option query → warn if `on`.
@@ -262,7 +260,7 @@ impl EnumerationState {
                 // same kind, or BOTH ids stay in `pending` and dispatch twice (a
                 // re-sent list-windows on %window-add while the attach enumeration
                 // is still in flight would fire trigger_seed twice, and a re-queried
-                // active-pane would fire TmuxActivePaneChanged twice). The four
+                // active-pane would fire TmuxActivePaneChanged twice). The two
                 // concurrent KeyBindings tables and the per-pane Capture/Cursor kinds
                 // are legitimately multi and exempt.
                 if !matches!(
@@ -553,7 +551,7 @@ mod tests {
         assert_eq!(
             state.pending.get(&CommandId(5)),
             Some(&PendingReply::KeyBindings),
-            "the four list-keys tables are concurrent — earlier KeyBindings entries are kept"
+            "the two list-keys tables are concurrent — earlier KeyBindings entries are kept"
         );
         assert_eq!(
             state.pending.get(&CommandId(6)),

--- a/crates/tmux_session/src/input.rs
+++ b/crates/tmux_session/src/input.rs
@@ -1,6 +1,6 @@
 //! Pure translation of Bevy keyboard input to tmux `send-keys` commands.
 //!
-//! Forwarded keys go straight to the active pane (`send-keys -t <pane> --`),
+//! Translated keys go straight to the active pane (`send-keys -t <pane> --`),
 //! which tmux's pane-input encoder translates (respecting the pane's
 //! application-cursor mode). `-K` is deliberately NOT used: under `tmux -CC` it
 //! mis-encodes named keys (e.g. `Up` arrives as a literal `n`), and routing

--- a/crates/tmux_session/src/keybindings.rs
+++ b/crates/tmux_session/src/keybindings.rs
@@ -1,20 +1,17 @@
-//! Reads tmux key bindings (`list-keys`) and dispatches keypresses against them:
-//! a bound key issues its tmux command verbatim, an unbound key is forwarded to
-//! the pane. Pure translation + lookup; the binary's input plugin is a thin
-//! adapter. `-K` is deliberately NOT used — it mis-encodes named keys under
-//! `tmux -CC` — and tmux.conf is the single source of truth for bindings.
+//! Reads tmux copy-mode key bindings (`list-keys -T copy-mode` /
+//! `copy-mode-vi`) and classifies a keypress made while a pane is in copy
+//! mode against them. Pure translation + lookup; the binary's input plugin is
+//! a thin adapter. `-K` is deliberately NOT used — it mis-encodes named keys
+//! under `tmux -CC` — and tmux.conf is the single source of truth for
+//! bindings.
 
 use bevy::prelude::Resource;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
-/// tmux key bindings read from `list-keys`, plus the prefix-key set. Built once
-/// on attach; empty until then, so every key forwards pane-direct (the
-/// pre-binding behavior).
+/// tmux copy-mode key bindings read from `list-keys`. Built once on attach;
+/// empty until then.
 #[derive(Resource, Default, Debug)]
 pub struct KeyBindings {
-    root: HashMap<String, String>,
-    prefix: HashMap<String, String>,
-    prefix_keys: HashSet<String>,
     copy_mode: HashMap<String, String>,
     copy_mode_vi: HashMap<String, String>,
     mode_keys: ModeKeys,
@@ -25,12 +22,6 @@ impl KeyBindings {
     pub(crate) fn install(&mut self, bindings: Vec<KeyBinding>) {
         for binding in bindings {
             match binding.table {
-                Table::Root => {
-                    self.root.insert(binding.key, binding.command);
-                }
-                Table::Prefix => {
-                    self.prefix.insert(binding.key, binding.command);
-                }
                 Table::CopyMode => {
                     self.copy_mode.insert(binding.key, binding.command);
                 }
@@ -39,11 +30,6 @@ impl KeyBindings {
                 }
             }
         }
-    }
-
-    /// Replaces the prefix-key set.
-    pub(crate) fn set_prefix_keys(&mut self, keys: HashSet<String>) {
-        self.prefix_keys = keys;
     }
 
     /// Sets which copy-mode table is active (from the `mode-keys` option).
@@ -63,45 +49,10 @@ impl KeyBindings {
 
     /// Clears all tables (on disconnect, so a reconnect re-reads).
     pub(crate) fn clear(&mut self) {
-        self.root.clear();
-        self.prefix.clear();
-        self.prefix_keys.clear();
         self.copy_mode.clear();
         self.copy_mode_vi.clear();
         self.mode_keys = ModeKeys::default();
     }
-}
-
-/// One ordered forwarding action for a frame of key input.
-#[derive(Debug)]
-pub enum Forwarded {
-    /// Run a bound tmux command verbatim over the control connection.
-    Run(String),
-    /// Forward these key names to the active pane (one batched `send-keys`).
-    Keys(Vec<String>),
-}
-
-/// Plans the ordered forwarding actions for a frame's tmux key names, threading
-/// `prefix_pending` across frames. Consecutive forwarded keys coalesce into one
-/// `Keys` batch; a bound key emits a `Run`; the prefix key and unmatched
-/// prefix-table keys are swallowed.
-pub fn plan_forward(
-    prefix_pending: &mut bool,
-    bindings: &KeyBindings,
-    key_names: impl IntoIterator<Item = String>,
-) -> Vec<Forwarded> {
-    let mut actions: Vec<Forwarded> = Vec::new();
-    for name in key_names {
-        match dispatch(prefix_pending, bindings, &name) {
-            Dispatch::Run(command) => actions.push(Forwarded::Run(command)),
-            Dispatch::Forward => match actions.last_mut() {
-                Some(Forwarded::Keys(batch)) => batch.push(name),
-                _ => actions.push(Forwarded::Keys(vec![name])),
-            },
-            Dispatch::Swallow => {}
-        }
-    }
-    actions
 }
 
 /// What ozmux does with one key while a pane is in copy mode. The bound tmux
@@ -202,8 +153,6 @@ pub fn copy_mode_dispatch(bindings: &KeyBindings, key_name: &str) -> CopyAction 
 /// Which tmux key table a binding belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Table {
-    Root,
-    Prefix,
     CopyMode,
     CopyModeVi,
 }
@@ -248,15 +197,6 @@ pub(crate) fn parse_list_keys(lines: &[String]) -> Vec<KeyBinding> {
         .collect()
 }
 
-/// Parses a `#{prefix} #{prefix2}` reply line into the set of prefix keys,
-/// skipping the literal `none` / `None` (tmux's unset `prefix2`).
-pub(crate) fn parse_prefix(line: &str) -> HashSet<String> {
-    line.split_whitespace()
-        .filter(|t| !t.eq_ignore_ascii_case("none"))
-        .map(str::to_owned)
-        .collect()
-}
-
 /// Parses one `bind-key [flags…] -T <table> <key> <command…>` line. Tokenizes
 /// the leading flags (order-independent: `-r`, `-N <n>`, `-a`, `-T <table>`),
 /// takes the next token as the backslash-escaped key, and keeps the remainder
@@ -275,8 +215,6 @@ fn parse_binding_line(line: &str) -> Option<KeyBinding> {
             "-T" => {
                 let (name, after) = split_first_token(tail);
                 table = match name {
-                    "root" => Some(Table::Root),
-                    "prefix" => Some(Table::Prefix),
                     "copy-mode" => Some(Table::CopyMode),
                     "copy-mode-vi" => Some(Table::CopyModeVi),
                     _ => return None,
@@ -333,26 +271,6 @@ fn unescape_key(s: &str) -> String {
     out
 }
 
-/// What to do with one keypress.
-enum Dispatch {
-    Run(String),
-    Forward,
-    Swallow,
-}
-
-/// Routes one key name against the bindings, threading prefix state.
-fn dispatch(prefix_pending: &mut bool, bindings: &KeyBindings, key_name: &str) -> Dispatch {
-    if *prefix_pending {
-        *prefix_pending = false;
-        return lookup(&bindings.prefix, key_name).map_or(Dispatch::Swallow, Dispatch::Run);
-    }
-    if bindings.prefix_keys.contains(key_name) {
-        *prefix_pending = true;
-        return Dispatch::Swallow;
-    }
-    lookup(&bindings.root, key_name).map_or(Dispatch::Forward, Dispatch::Run)
-}
-
 /// Looks up a key in a table, falling back to the table's `Any` binding (tmux
 /// runs `Any` when no more-specific key matches).
 fn lookup(table: &HashMap<String, String>, key_name: &str) -> Option<String> {
@@ -391,16 +309,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_root_binding() {
-        let lines =
-            vec!["bind-key    -T root         M-i               split-window -h".to_string()];
+    fn parses_copy_mode_binding_with_generous_whitespace() {
+        let lines = vec![
+            "bind-key    -T copy-mode         M-i               send-keys -X cursor-up".to_string(),
+        ];
         let got = parse_list_keys(&lines);
         assert_eq!(
             got,
             vec![KeyBinding {
-                table: Table::Root,
+                table: Table::CopyMode,
                 key: "M-i".to_string(),
-                command: "split-window -h".to_string(),
+                command: "send-keys -X cursor-up".to_string(),
                 repeat: false,
             }]
         );
@@ -408,27 +327,28 @@ mod tests {
 
     #[test]
     fn parses_repeat_flag_before_table() {
-        let lines = vec!["bind-key -r -T prefix Up   resize-pane -U".to_string()];
+        let lines = vec!["bind-key -r -T copy-mode-vi Up   send-keys -X cursor-up".to_string()];
         let got = parse_list_keys(&lines);
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].table, Table::Prefix);
+        assert_eq!(got[0].table, Table::CopyModeVi);
         assert_eq!(got[0].key, "Up");
-        assert_eq!(got[0].command, "resize-pane -U");
+        assert_eq!(got[0].command, "send-keys -X cursor-up");
         assert!(got[0].repeat);
     }
 
     #[test]
     fn unescapes_backslash_escaped_key() {
-        let lines = vec![r#"bind-key -T prefix \;   last-pane"#.to_string()];
+        let lines = vec![r#"bind-key -T copy-mode-vi \;   send-keys -X cancel"#.to_string()];
         let got = parse_list_keys(&lines);
         assert_eq!(got[0].key, ";");
-        assert_eq!(got[0].command, "last-pane");
+        assert_eq!(got[0].command, "send-keys -X cancel");
     }
 
     #[test]
     fn preserves_command_internal_spacing_and_semicolons() {
-        let lines =
-            vec![r#"bind-key -T root C-x   display-message "a  b" \; refresh-client"#.to_string()];
+        let lines = vec![
+            r#"bind-key -T copy-mode C-x   display-message "a  b" \; refresh-client"#.to_string(),
+        ];
         let got = parse_list_keys(&lines);
         assert_eq!(
             got[0].command,
@@ -440,122 +360,11 @@ mod tests {
     fn skips_unparseable_lines_keeping_others() {
         let lines = vec![
             "garbage line".to_string(),
-            "bind-key -T root a   new-window".to_string(),
+            "bind-key -T copy-mode a   send-keys -X cursor-left".to_string(),
         ];
         let got = parse_list_keys(&lines);
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].key, "a");
-    }
-
-    #[test]
-    fn parse_prefix_skips_none_case_insensitive() {
-        assert_eq!(parse_prefix("C-b None"), HashSet::from(["C-b".to_string()]));
-        assert_eq!(
-            parse_prefix("C-a C-b"),
-            HashSet::from(["C-a".to_string(), "C-b".to_string()])
-        );
-        assert!(parse_prefix("none None").is_empty());
-    }
-
-    fn bindings(
-        root: &[(&str, &str)],
-        prefix: &[(&str, &str)],
-        prefix_keys: &[&str],
-    ) -> KeyBindings {
-        let mut kb = KeyBindings::default();
-        kb.install(
-            root.iter()
-                .map(|(k, c)| KeyBinding {
-                    table: Table::Root,
-                    key: (*k).to_string(),
-                    command: (*c).to_string(),
-                    repeat: false,
-                })
-                .chain(prefix.iter().map(|(k, c)| KeyBinding {
-                    table: Table::Prefix,
-                    key: (*k).to_string(),
-                    command: (*c).to_string(),
-                    repeat: false,
-                }))
-                .collect(),
-        );
-        kb.set_prefix_keys(prefix_keys.iter().map(|k| (*k).to_string()).collect());
-        kb
-    }
-
-    #[test]
-    fn root_bound_key_runs_its_command() {
-        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
-        let actions = plan_forward(&mut false, &kb, vec!["M-i".to_string()]);
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(&actions[0], Forwarded::Run(c) if c == "split-window -h"));
-    }
-
-    #[test]
-    fn unbound_key_is_forwarded() {
-        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
-        let actions = plan_forward(&mut false, &kb, vec!["Up".to_string()]);
-        assert_eq!(actions.len(), 1);
-        assert!(matches!(&actions[0], Forwarded::Keys(v) if v == &vec!["Up".to_string()]));
-    }
-
-    #[test]
-    fn prefix_then_bound_key_runs_prefix_command() {
-        let kb = bindings(&[], &[("c", "new-window")], &["C-b"]);
-        let mut pending = false;
-        let first = plan_forward(&mut pending, &kb, vec!["C-b".to_string()]);
-        assert!(first.is_empty(), "prefix key is swallowed");
-        assert!(pending, "prefix is now pending");
-        let second = plan_forward(&mut pending, &kb, vec!["c".to_string()]);
-        assert!(matches!(&second[0], Forwarded::Run(c) if c == "new-window"));
-        assert!(!pending, "pending cleared after the prefix key");
-    }
-
-    #[test]
-    fn prefix_then_unbound_key_is_swallowed() {
-        let kb = bindings(&[], &[("c", "new-window")], &["C-b"]);
-        let mut pending = false;
-        plan_forward(&mut pending, &kb, vec!["C-b".to_string()]);
-        let actions = plan_forward(&mut pending, &kb, vec!["z".to_string()]);
-        assert!(
-            actions.is_empty(),
-            "unbound prefix key is dropped, not forwarded"
-        );
-        assert!(!pending);
-    }
-
-    #[test]
-    fn any_binding_is_the_fallback() {
-        let kb = bindings(
-            &[("M-i", "split-window -h"), ("Any", "display-message hi")],
-            &[],
-            &["C-b"],
-        );
-        let specific = plan_forward(&mut false, &kb, vec!["M-i".to_string()]);
-        assert!(matches!(&specific[0], Forwarded::Run(c) if c == "split-window -h"));
-        let fallback = plan_forward(&mut false, &kb, vec!["X".to_string()]);
-        assert!(matches!(&fallback[0], Forwarded::Run(c) if c == "display-message hi"));
-    }
-
-    #[test]
-    fn consecutive_forwards_coalesce_then_split_on_run() {
-        let kb = bindings(&[("M-i", "split-window -h")], &[], &["C-b"]);
-        let actions = plan_forward(
-            &mut false,
-            &kb,
-            vec![
-                "a".to_string(),
-                "b".to_string(),
-                "M-i".to_string(),
-                "c".to_string(),
-            ],
-        );
-        assert_eq!(actions.len(), 3);
-        assert!(
-            matches!(&actions[0], Forwarded::Keys(v) if v == &vec!["a".to_string(), "b".to_string()])
-        );
-        assert!(matches!(&actions[1], Forwarded::Run(c) if c == "split-window -h"));
-        assert!(matches!(&actions[2], Forwarded::Keys(v) if v == &vec!["c".to_string()]));
     }
 
     #[test]

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -36,9 +36,7 @@ pub use enumerate::{
 };
 pub use events::{TmuxConnectionClosed, TmuxConnectionReset};
 pub use input::{KeyMods, bevy_key_to_tmux_name};
-pub use keybindings::{
-    CopyAction, Forwarded, KeyBindings, PromptKind, copy_mode_dispatch, plan_forward,
-};
+pub use keybindings::{CopyAction, KeyBindings, PromptKind, copy_mode_dispatch};
 pub use output::{PaneOutput, RequestPaneReseed};
 pub use plugin::{TmuxEventBatch, TmuxProjectionSet, TmuxSessionPlugin};
 pub use tmux_control::{ClientEvent, ControlEvent, TmuxCommand, TransportEvent};

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -19,10 +19,11 @@ mod output;
 mod plugin;
 
 pub use command::{
-    CopyModeCapture, CopyStateQuery, Prompt, RefreshClient, RenameSession, RenameWindow,
-    ResizePaneX, ResizePaneY, ResizeWindow, SelectPane, SelectWindow, SendBytes, SendPaneKeys,
-    SetEnvironmentGlobal, SetEnvironmentInSession, ShowBuffer, UnsetEnvironmentGlobal,
-    WindowRefreshClient,
+    CopyModeCapture, CopyStateQuery, EnterCopyMode, KillPane, KillWindow, NewWindow, NextWindow,
+    PaneDirection, Prompt, PreviousWindow, RefreshClient, RenameSession, RenameWindow,
+    ResizePaneX, ResizePaneY, ResizeWindow, SelectPane, SelectPaneTowards, SelectWindow,
+    SendBytes, SendPaneKeys, SetEnvironmentGlobal, SetEnvironmentInSession, ShowBuffer,
+    SplitDirection, SplitWindow, UnsetEnvironmentGlobal, WindowRefreshClient, ZoomPane,
 };
 pub use components::{
     ActivePane, ActiveWindow, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout, WindowFlags,

--- a/crates/tmux_session/src/lib.rs
+++ b/crates/tmux_session/src/lib.rs
@@ -20,10 +20,10 @@ mod plugin;
 
 pub use command::{
     CopyModeCapture, CopyStateQuery, EnterCopyMode, KillPane, KillWindow, NewWindow, NextWindow,
-    PaneDirection, Prompt, PreviousWindow, RefreshClient, RenameSession, RenameWindow,
-    ResizePaneX, ResizePaneY, ResizeWindow, SelectPane, SelectPaneTowards, SelectWindow,
-    SendBytes, SendPaneKeys, SetEnvironmentGlobal, SetEnvironmentInSession, ShowBuffer,
-    SplitDirection, SplitWindow, UnsetEnvironmentGlobal, WindowRefreshClient, ZoomPane,
+    PaneDirection, PreviousWindow, Prompt, RefreshClient, RenameSession, RenameWindow, ResizePaneX,
+    ResizePaneY, ResizeWindow, SelectPane, SelectPaneTowards, SelectWindow, SendBytes,
+    SendPaneKeys, SetEnvironmentGlobal, SetEnvironmentInSession, ShowBuffer, SplitDirection,
+    SplitWindow, UnsetEnvironmentGlobal, WindowRefreshClient, ZoomPane,
 };
 pub use components::{
     ActivePane, ActiveWindow, TmuxPane, TmuxSession, TmuxWindow, TmuxWindowLayout, WindowFlags,

--- a/crates/tmux_session/src/plugin.rs
+++ b/crates/tmux_session/src/plugin.rs
@@ -3,7 +3,7 @@
 
 use crate::command::{
     ActivePane, AggressiveResize, CapturePane, ClientName, CursorQuery, ListKeys, ListWindows,
-    ModeKeys as ModeKeysCmd, PrefixOptions, SubscribeWindowFlags, Version,
+    ModeKeys as ModeKeysCmd, SubscribeWindowFlags, Version,
 };
 use crate::components::{PaneRecaptureState, TmuxPane, TmuxSession};
 use crate::connection::{TmuxAttached, TmuxClient};
@@ -15,7 +15,7 @@ use crate::event_pump::{
     parse_cursor_pos, trigger_notification, trigger_seed,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxWindowsRetained};
-use crate::keybindings::{KeyBindings, ModeKeys, parse_list_keys, parse_prefix};
+use crate::keybindings::{KeyBindings, ModeKeys, parse_list_keys};
 use crate::observers::{TmuxProjection, register_observers};
 use crate::output::{PaneOutput, RequestPaneReseed, collect_pane_outputs};
 use bevy::prelude::*;
@@ -262,22 +262,13 @@ fn mark_attached_on_first_protocol(
 }
 
 /// Sends the one-time initial query suite when the client attaches:
-/// `list-windows`, active-pane, window-flags subscription, client name, the four
-/// `list-keys` tables, prefix options, mode-keys, and version. Gated by
+/// `list-windows`, active-pane, window-flags subscription, client name, the two
+/// copy-mode `list-keys` tables, mode-keys, and version. Gated by
 /// `on_message::<TmuxClientAttached>` so it runs exactly once per attach edge.
 fn send_attach_enumeration(mut client: Single<(&mut TmuxClient, &mut EnumerationState)>) {
     let (client, enumeration) = &mut *client;
     send_session_enumeration(client, enumeration);
     enumeration.register(client.send(ClientName), PendingReply::ClientName);
-    enumeration.register(
-        client.send(ListKeys { table: "root" }),
-        PendingReply::KeyBindings,
-    );
-    enumeration.register(
-        client.send(ListKeys { table: "prefix" }),
-        PendingReply::KeyBindings,
-    );
-    enumeration.register(client.send(PrefixOptions), PendingReply::PrefixKeys);
     enumeration.register(
         client.send(ListKeys { table: "copy-mode" }),
         PendingReply::KeyBindings,
@@ -492,15 +483,6 @@ fn apply_reply(
         PendingReply::ActivePane => tracing::warn!("active-pane query command failed"),
         PendingReply::KeyBindings if ok => keybindings.install(parse_list_keys(output)),
         PendingReply::KeyBindings => tracing::warn!("list-keys command failed"),
-        PendingReply::PrefixKeys if ok => {
-            keybindings.set_prefix_keys(
-                output
-                    .first()
-                    .map(|line| parse_prefix(line))
-                    .unwrap_or_default(),
-            );
-        }
-        PendingReply::PrefixKeys => tracing::warn!("prefix query command failed"),
         PendingReply::ModeKeys if ok => {
             keybindings.set_mode_keys(
                 output

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -193,8 +193,9 @@ ozmux, root-table and prefix-table bindings from your `tmux.conf` do not fire
 inside ozmux — the tmux prefix key passes straight through to the pane like
 any other keystroke. Use the `[shortcuts]` actions above instead. Keys pressed
 **inside tmux copy-mode** are unaffected by this and still follow tmux's own
-copy-mode key tables (`vi-copy-mode-keys` / `emacs-copy-mode-keys`), since
-ozmux forwards them to tmux once copy-mode is active.
+copy-mode key tables (`copy-mode` / `copy-mode-vi`, selected by the tmux
+`mode-keys` option), since ozmux forwards them to tmux once copy-mode is
+active.
 
 Note on the leader: because the stock defaults above bind two dozen actions to
 `<Leader>...`, the `Cmd` tap leader is armed by default — tapping and
@@ -203,3 +204,15 @@ and the very next keystroke either fires a bound `<Leader>` action or is
 swallowed if nothing matches. `LeaderPending` has no expiry: after an
 accidental tap, the next keystroke is consumed one way or the other, it does
 not time out on its own.
+
+Two consequences of the stock `<Leader>` defaults worth knowing:
+
+- **Rebinding a `<Leader>` chord that a stock default already uses** (e.g.
+  `enter-copy-mode = "<Leader>c"`, which collides with the default
+  `new-window = "<Leader>c"`) is a startup validation error naming both
+  actions. Unbind the stock default explicitly (`new-window = ""`) or pick a
+  free chord.
+- **`leader = ""` disables every `<Leader>`-bound action at once** — with the
+  stock defaults that includes `paste` and all 24 tmux actions, silently
+  (a warning is logged, but startup succeeds). If you disable the leader,
+  rebind the actions you need to direct chords, e.g. `paste = "Cmd+V"`.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -74,9 +74,9 @@ webview_desaturate = 0.6  # f32 0..=1. Desaturation for inactive webviews (0 = f
 # The leader for "<Leader>..." bindings. Either a full chord ("Ctrl+A": press
 # the chord, then the next key) OR a bare modifier to TAP ("Cmd"/"Ctrl"/"Alt":
 # tap the modifier with no other key, then the next key). Defaults to "Cmd", and
-# is active only when at least one action is bound to "<Leader>..." — so you can
-# use "<Leader>p" without setting this, and a stray tap never eats a key when you
-# bind no leader action. Set "" to disable it. "Shift" is not allowed as a tap.
+# is active only when at least one action is bound to "<Leader>..." — the stock
+# defaults below already bind two dozen actions to "<Leader>...", so the Cmd tap
+# is armed out of the box. Set "" to disable it. "Shift" is not allowed as a tap.
 # Choose a leader distinct from your tmux prefix.
 leader = "Cmd"
 # Modifier-tap window (ms): a press+release within this time, with no intervening
@@ -87,11 +87,43 @@ leader-tap-timeout-ms = 300
 # chord ("<Leader>s" = leader then s), or "" to unbind. Rebinding to a chord
 # already used by another action is a startup validation error. A direct
 # chord and a "<Leader>"-prefixed chord with the same key never collide.
-paste                 = "Cmd+V"
+
+# --- existing actions ---
+paste                 = "<Leader>p"    # Was "Cmd+V" pre-tmux-native-shortcuts; set paste = "Cmd+V" to restore.
 release-webview-focus = "Ctrl+Shift+Escape"
 quit                  = "Cmd+Q"
-enter-copy-mode       = "Cmd+S"
-detach-session        = "Ctrl+Shift+D"
+enter-copy-mode       = "Cmd+S"        # Both modes: Alacritty vi mode in Default, tmux copy-mode under tmux.
+detach-session        = "Ctrl+Shift+D" # tmux mode only.
+
+# --- pane actions (tmux mode only) ---
+select-left-pane      = "<Leader>h"    # select-pane -L
+select-down-pane      = "<Leader>j"    # select-pane -D
+select-up-pane        = "<Leader>k"    # select-pane -U
+select-right-pane     = "<Leader>l"    # select-pane -R
+split-vertical-pane   = "<Leader>i"    # split-window -h (side-by-side)
+split-horizontal-pane = "<Leader>o"    # split-window -v (stacked)
+kill-pane             = "<Leader>x"    # kill-pane, after a confirm prompt
+zoom-pane             = "<Leader>z"    # resize-pane -Z
+
+# --- window actions (tmux mode only) ---
+new-window            = "<Leader>c"        # new-window
+kill-window           = "<Leader>Shift+X"  # kill-window, after a confirm prompt
+next-window           = "<Leader>n"        # next-window
+previous-window       = "<Leader>Shift+N"  # previous-window (p is taken by paste)
+select-window-0       = "<Leader>0"        # select-window -t @<id at tmux index 0>
+select-window-1       = "<Leader>1"
+select-window-2       = "<Leader>2"
+select-window-3       = "<Leader>3"
+select-window-4       = "<Leader>4"
+select-window-5       = "<Leader>5"
+select-window-6       = "<Leader>6"
+select-window-7       = "<Leader>7"
+select-window-8       = "<Leader>8"
+select-window-9       = "<Leader>9"
+
+# --- rename actions (tmux mode only) ---
+rename-window         = "<Leader>r"        # opens the rename prompt for the active window
+rename-session        = "<Leader>Shift+R"  # opens the rename prompt for the session
 ```
 
 ## Chord syntax
@@ -115,14 +147,59 @@ startup.
 
 | Action | Default | What it does |
 | --- | --- | --- |
-| `paste` | `Cmd+V` | Paste from the system clipboard. |
+| `paste` | `<Leader>p` | Paste from the system clipboard. |
 | `release-webview-focus` | `Ctrl+Shift+Escape` | Return keyboard focus from a focused webview to the terminal. |
 | `quit` | `Cmd+Q` | Quit ozmux. |
 | `enter-copy-mode` | `Cmd+S` | Enter copy mode. |
-| `detach-session` | `Ctrl+Shift+D` | Detach the current tmux session. |
+| `detach-session` | `Ctrl+Shift+D` | Detach the current tmux session (tmux mode only). |
+| `select-left-pane` | `<Leader>h` | Focus the pane to the left (tmux mode only). |
+| `select-down-pane` | `<Leader>j` | Focus the pane below (tmux mode only). |
+| `select-up-pane` | `<Leader>k` | Focus the pane above (tmux mode only). |
+| `select-right-pane` | `<Leader>l` | Focus the pane to the right (tmux mode only). |
+| `split-vertical-pane` | `<Leader>i` | Split the active pane side-by-side (tmux `split-window -h`) (tmux mode only). |
+| `split-horizontal-pane` | `<Leader>o` | Split the active pane stacked (tmux `split-window -v`) (tmux mode only). |
+| `kill-pane` | `<Leader>x` | Kill the active pane, after a confirm prompt (tmux mode only). |
+| `zoom-pane` | `<Leader>z` | Toggle zoom on the active pane (tmux mode only). |
+| `new-window` | `<Leader>c` | Open a new window (tmux mode only). |
+| `kill-window` | `<Leader>Shift+X` | Kill the active window, after a confirm prompt (tmux mode only). |
+| `next-window` | `<Leader>n` | Switch to the next window (tmux mode only). |
+| `previous-window` | `<Leader>Shift+N` | Switch to the previous window (tmux mode only). |
+| `select-window-0` | `<Leader>0` | Switch to the window at tmux index 0 (tmux mode only). |
+| `select-window-1` | `<Leader>1` | Switch to the window at tmux index 1 (tmux mode only). |
+| `select-window-2` | `<Leader>2` | Switch to the window at tmux index 2 (tmux mode only). |
+| `select-window-3` | `<Leader>3` | Switch to the window at tmux index 3 (tmux mode only). |
+| `select-window-4` | `<Leader>4` | Switch to the window at tmux index 4 (tmux mode only). |
+| `select-window-5` | `<Leader>5` | Switch to the window at tmux index 5 (tmux mode only). |
+| `select-window-6` | `<Leader>6` | Switch to the window at tmux index 6 (tmux mode only). |
+| `select-window-7` | `<Leader>7` | Switch to the window at tmux index 7 (tmux mode only). |
+| `select-window-8` | `<Leader>8` | Switch to the window at tmux index 8 (tmux mode only). |
+| `select-window-9` | `<Leader>9` | Switch to the window at tmux index 9 (tmux mode only). |
+| `rename-window` | `<Leader>r` | Open the rename prompt for the active window (tmux mode only). |
+| `rename-session` | `<Leader>Shift+R` | Open the rename prompt for the session (tmux mode only). |
 
-Note: some actions only take effect in one mode. `enter-copy-mode` is active in
-Default (single-terminal) mode only — under tmux, copy mode is entered through
-tmux's own key bindings. `detach-session` is active under tmux only. This applies
-whether the action is bound directly or as a leader-scoped key (e.g. `<Leader>s`),
-and regardless of whether the leader is a chord or a modifier tap.
+Note: some actions only take effect in one mode. `enter-copy-mode` now works in
+**both** modes: Alacritty vi mode in Default (single-terminal) mode, tmux
+copy-mode under tmux. `detach-session` and all 24 pane/window/rename actions
+above (`select-*-pane`, `split-*-pane`, `kill-pane`, `zoom-pane`, `new-window`,
+`kill-window`, `next-window`, `previous-window`, `select-window-0`…`9`,
+`rename-window`, `rename-session`) are active under tmux mode only — they are
+inert in Default mode. `paste`, `quit`, and `release-webview-focus` work in
+both modes. This applies whether an action is bound directly or as a
+leader-scoped key (e.g. `<Leader>s`), and regardless of whether the leader is
+a chord or a modifier tap.
+
+Note on tmux.conf bindings: with the tmux prefix key no longer intercepted by
+ozmux, root-table and prefix-table bindings from your `tmux.conf` do not fire
+inside ozmux — the tmux prefix key passes straight through to the pane like
+any other keystroke. Use the `[shortcuts]` actions above instead. Keys pressed
+**inside tmux copy-mode** are unaffected by this and still follow tmux's own
+copy-mode key tables (`vi-copy-mode-keys` / `emacs-copy-mode-keys`), since
+ozmux forwards them to tmux once copy-mode is active.
+
+Note on the leader: because the stock defaults above bind two dozen actions to
+`<Leader>...`, the `Cmd` tap leader is armed by default — tapping and
+releasing `Cmd` (with no other key/mouse press in between) arms the leader,
+and the very next keystroke either fires a bound `<Leader>` action or is
+swallowed if nothing matches. `LeaderPending` has no expiry: after an
+accidental tap, the next keystroke is consumed one way or the other, it does
+not time out on its own.

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -33,8 +33,10 @@ pub(crate) struct ReservedChord {
 /// still gets working paste and forwards everything else.
 #[derive(Resource)]
 pub(crate) struct TerminalInputBindings {
-    /// The chord that triggers `PasteAction`.
-    pub paste: ReservedChord,
+    /// The chord that triggers `PasteAction`, when paste is direct-bound.
+    /// `None` when paste is leader-scoped or unbound (the leader path in
+    /// `app_shortcut_handler` owns paste then).
+    pub paste: Option<ReservedChord>,
     /// Chords the dispatcher skips for the host to handle.
     pub reserved: Vec<ReservedChord>,
 }
@@ -42,13 +44,13 @@ pub(crate) struct TerminalInputBindings {
 impl Default for TerminalInputBindings {
     fn default() -> Self {
         Self {
-            paste: ReservedChord {
+            paste: Some(ReservedChord {
                 key_code: KeyCode::KeyV,
                 ctrl: false,
                 shift: false,
                 alt: false,
                 meta: true,
-            },
+            }),
             reserved: Vec::new(),
         }
     }

--- a/src/input/default_mode.rs
+++ b/src/input/default_mode.rs
@@ -227,6 +227,17 @@ fn app_shortcut_handler(
                 }
             }
             ShortcutAction::ReleaseWebviewFocus => {}
+            ShortcutAction::SelectPane(_)
+            | ShortcutAction::SplitPane(_)
+            | ShortcutAction::KillPane
+            | ShortcutAction::ZoomPane
+            | ShortcutAction::NewWindow
+            | ShortcutAction::KillWindow
+            | ShortcutAction::NextWindow
+            | ShortcutAction::PreviousWindow
+            | ShortcutAction::SelectWindow(_)
+            | ShortcutAction::RenameWindow
+            | ShortcutAction::RenameSession => {}
         }
     }
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -89,7 +89,9 @@ fn dispatch_input(
         {
             continue;
         }
-        if chord_matches(&bindings.paste, ev.key_code, &mods) {
+        if let Some(paste) = bindings.paste.as_ref()
+            && chord_matches(paste, ev.key_code, &mods)
+        {
             commands.trigger(PasteAction { entity });
             continue;
         }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -146,7 +146,8 @@ impl Shortcuts {
     /// Paste chord becomes `paste`; every other direct chord — plus the leader
     /// chord — becomes a `reserved` entry the crate dispatcher skips for the
     /// host to handle. Reserving the leader keeps `dispatch_input` from typing
-    /// it into the PTY while the leader engages.
+    /// it into the PTY while the leader engages. Leader-scoped or unbound
+    /// paste yields `None` — no direct-chord fallback.
     pub(crate) fn input_bindings(&self) -> TerminalInputBindings {
         let mut paste = None;
         let mut reserved = Vec::new();
@@ -173,10 +174,7 @@ impl Shortcuts {
                 meta: modifiers.meta,
             });
         }
-        TerminalInputBindings {
-            paste: paste.unwrap_or_else(|| TerminalInputBindings::default().paste),
-            reserved,
-        }
+        TerminalInputBindings { paste, reserved }
     }
 
     /// True when `(keycode, mods)` is the configured leader chord.
@@ -980,21 +978,30 @@ mod tests {
 
     #[test]
     fn input_bindings_excludes_paste_from_reserved() {
-        let r = direct_only(&ConfigShortcuts::default());
+        use ozmux_configs::shortcuts::parse_key_chord;
+
+        let mut config = OzmuxConfigs::default();
+        config.shortcuts.paste = Some(Binding::Direct(parse_key_chord("Cmd+V").unwrap()));
+        let r = resolved_shortcuts(config);
         let b = r.input_bindings();
-        assert_eq!(b.paste.key_code, KeyCode::KeyV);
-        assert!(b.paste.meta && !b.paste.ctrl && !b.paste.shift && !b.paste.alt);
-        assert_eq!(
-            b.reserved.len(),
-            4,
-            "Quit, ReleaseWebviewFocus, DetachSession, EnterCopyMode"
-        );
+        let paste = b.paste.expect("direct-bound paste must resolve to a chord");
+        assert_eq!(paste.key_code, KeyCode::KeyV);
+        assert!(paste.meta && !paste.ctrl && !paste.shift && !paste.alt);
         assert!(
             !b.reserved
                 .iter()
                 .any(|c| c.key_code == KeyCode::KeyV && c.meta),
             "the paste chord must not appear in reserved",
         );
+    }
+
+    #[test]
+    fn input_bindings_leader_paste_has_no_direct_chord() {
+        // Default config now binds paste to <Leader>p: the crate dispatcher
+        // must NOT keep a stale Cmd+V direct-paste fallback.
+        let resolved = resolved_shortcuts(OzmuxConfigs::default());
+        let b = resolved.input_bindings();
+        assert!(b.paste.is_none());
     }
 
     fn leader_fixture() -> Shortcuts {

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -855,9 +855,11 @@ mod tests {
             ..Default::default()
         };
         let resolved = resolve_from_chords(config.leader_chords());
-        assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].keycode, KeyCode::KeyD);
-        assert_eq!(resolved[0].action, ShortcutAction::DetachSession);
+        let detach = resolved
+            .iter()
+            .find(|s| s.action == ShortcutAction::DetachSession)
+            .expect("detach-session must resolve as a leader chord");
+        assert_eq!(detach.keycode, KeyCode::KeyD);
     }
 
     #[test]
@@ -884,18 +886,14 @@ mod tests {
     }
 
     #[test]
-    fn default_bindings_resolve_to_five() {
+    fn default_bindings_resolve_to_four() {
         let r = direct_only(&ConfigShortcuts::default());
-        assert_eq!(r.direct.len(), 5);
+        assert_eq!(r.direct.len(), 4);
     }
 
     #[test]
     fn match_gui_action_resolves_defaults() {
         let r = direct_only(&ConfigShortcuts::default());
-        assert_eq!(
-            r.match_gui_action(KeyCode::KeyV, mods(false, false, false, true)),
-            Some(ShortcutAction::Paste)
-        );
         assert_eq!(
             r.match_gui_action(KeyCode::KeyQ, mods(false, false, false, true)),
             Some(ShortcutAction::Quit)
@@ -903,6 +901,11 @@ mod tests {
         assert_eq!(
             r.match_gui_action(KeyCode::KeyS, mods(false, false, false, true)),
             Some(ShortcutAction::EnterCopyMode)
+        );
+        assert_eq!(
+            r.match_gui_action(KeyCode::KeyV, mods(false, false, false, true)),
+            None,
+            "paste is leader-scoped by default (<Leader>p), not direct"
         );
     }
 
@@ -1204,7 +1207,42 @@ mod tests {
 
     #[test]
     fn build_shortcuts_leaves_default_cmd_leader_inert_without_leader_bindings() {
-        let resolved = resolved_shortcuts(OzmuxConfigs::default());
+        // NOTE: `ConfigShortcuts::default()` now ships 25 leader-scoped tmux
+        // actions, so `OzmuxConfigs::default()` alone no longer exercises the
+        // inert-leader path; every default `<Leader>`-bound field is explicitly
+        // unbound here to reproduce a config with no leader bindings at all.
+        let config = OzmuxConfigs {
+            shortcuts: ConfigShortcuts {
+                paste: None,
+                select_left_pane: None,
+                select_down_pane: None,
+                select_up_pane: None,
+                select_right_pane: None,
+                split_vertical_pane: None,
+                split_horizontal_pane: None,
+                kill_pane: None,
+                zoom_pane: None,
+                new_window: None,
+                kill_window: None,
+                next_window: None,
+                previous_window: None,
+                select_window_0: None,
+                select_window_1: None,
+                select_window_2: None,
+                select_window_3: None,
+                select_window_4: None,
+                select_window_5: None,
+                select_window_6: None,
+                select_window_7: None,
+                select_window_8: None,
+                select_window_9: None,
+                rename_window: None,
+                rename_session: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let resolved = resolved_shortcuts(config);
         assert!(resolved.tap_modifier().is_none());
         assert!(resolved.leader.is_none());
     }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -230,9 +230,8 @@ pub(crate) enum LeaderStep {
 }
 
 /// Advances the ozmux leader state machine for one pressed key, threading
-/// `pending` across frames (mirrors the tmux `plan_forward` prefix dispatch).
-/// Swallows the leader itself and any unmatched second key; returns
-/// `Passthrough` for unrelated keys.
+/// `pending` across frames. Swallows the leader itself and any unmatched
+/// second key; returns `Passthrough` for unrelated keys.
 pub(crate) fn step_leader(
     pending: &mut bool,
     shortcuts: &Shortcuts,

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -1,21 +1,29 @@
 //! Forwards focused keyboard and mouse-wheel input to the active tmux pane.
-//! Keyboard forwarding intercepts a fixed set of ozmux GUI chords and copy-mode
-//! entry commands. Mouse-wheel forwarding handles only the cases
-//! `crate::input::mouse::wheel::dispatch_mouse_wheel` does not own (it now runs on every tmux
-//! pane, gated off solely by `MouseDisabled`): an inline webview under the
-//! pointer (forwarded to CEF), a copy-mode pane (a targeted `send-keys -X
-//! scroll-up|scroll-down`), and the alt-screen residual where ozma's viewport
-//! scroll would no-op (cursor-key `send-keys`). Events accumulate into
-//! cell-deltas (so trackpad / high-resolution `Pixel` scrolling quantizes the
-//! same way the native terminal path does); every other case is ceded to ozma.
+//! Keyboard forwarding dispatches a fixed set of ozmux GUI chords as
+//! per-command action events (`crate::mode::tmux::action`) and copy-mode
+//! entry commands; unmatched keys forward straight to the pane in one
+//! `SendPaneKeys` batch per frame. Mouse-wheel forwarding handles only the
+//! cases `crate::input::mouse::wheel::dispatch_mouse_wheel` does not own (it
+//! now runs on every tmux pane, gated off solely by `MouseDisabled`): an
+//! inline webview under the pointer (forwarded to CEF), a copy-mode pane (a
+//! targeted `send-keys -X scroll-up|scroll-down`), and the alt-screen
+//! residual where ozma's viewport scroll would no-op (cursor-key
+//! `send-keys`). Events accumulate into cell-deltas (so trackpad /
+//! high-resolution `Pixel` scrolling quantizes the same way the native
+//! terminal path does); every other case is ceded to ozma.
 
 use super::pane_hit::tmux_pane_at_phys;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
 use crate::input::shortcuts::{LeaderGate, LeaderPending, LeaderStep, Shortcuts, step_leader};
 use crate::mode::AppMode;
-use crate::mode::tmux::confirm_prompt::{ConfirmState, parse_confirm_before};
-use crate::mode::tmux::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
+use crate::mode::tmux::action::{
+    EnterCopyModeRequest, KillPaneRequest, KillWindowRequest, NewWindowRequest, NextWindowRequest,
+    PreviousWindowRequest, RenameSessionRequest, RenameWindowRequest, SelectPaneRequest,
+    SelectWindowRequest, SplitPaneRequest, ZoomPaneRequest,
+};
+use crate::mode::tmux::confirm_prompt::ConfirmState;
+use crate::mode::tmux::rename_prompt::RenamePrompt;
 use crate::mode::tmux::{TmuxActiveSet, request_detach};
 use crate::ui::copy_mode::CopyModeState;
 use crate::ui::copy_search::{CopyPrompt, CopyPromptState};
@@ -34,11 +42,14 @@ use ozma_tty_engine::{TermMode, TerminalHandle};
 use ozma_tty_renderer::TerminalCellMetricsResource;
 use ozma_tty_renderer::prelude::TerminalOverlays;
 use ozma_webview::{ForwardKeys, NonInteractive, Webview};
-use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
+use ozmux_configs::shortcuts::{
+    Modifiers, PaneDirection as CfgPaneDirection, ShortcutAction,
+    SplitOrientation as CfgSplitOrientation,
+};
 use ozmux_tmux::{
-    ActivePane, ActiveWindow, CopyAction, CopyModeQueries, CopyQueryKind, Forwarded, KeyBindings,
-    KeyMods, PromptKind, SendBytes, SendPaneKeys, ShowBuffer, TmuxClient, TmuxCommand, TmuxPane,
-    TmuxSession, TmuxWindow, bevy_key_to_tmux_name, copy_mode_dispatch, plan_forward,
+    ActivePane, ActiveWindow, CopyAction, CopyModeQueries, CopyQueryKind, KeyBindings, KeyMods,
+    PaneDirection, PromptKind, SendBytes, SendPaneKeys, ShowBuffer, SplitDirection, TmuxClient,
+    TmuxCommand, TmuxPane, TmuxSession, TmuxWindow, bevy_key_to_tmux_name, copy_mode_dispatch,
 };
 
 /// Registers the tmux keyboard-forwarding and mouse-wheel systems.
@@ -113,20 +124,20 @@ fn outcome_of(action: CopyAction) -> CopyOutcome {
 fn forward_keys_to_tmux(
     mut commands: Commands,
     (mut copy_prompt, mut exit): (ResMut<CopyPrompt>, MessageWriter<AppExit>),
-    (confirm_state, rename): (Option<Res<ConfirmState>>, RenameParams),
+    (confirm_state, rename_prompt): (Option<Res<ConfirmState>>, Option<Res<RenamePrompt>>),
     mut events: MessageReader<KeyboardInput>,
     mut clipboard: ResMut<Clipboard>,
     mut focused_webview: ResMut<FocusedWebview>,
     mut copy_queries: ResMut<CopyModeQueries>,
-    mut prefix_pending: Local<bool>,
     mut leader_pending: ResMut<LeaderPending>,
     mut handles: Query<&mut TerminalHandle>,
     mut client: Option<Single<&mut TmuxClient>>,
-    (keys, ime, bindings, resolved): (
+    (keys, ime, bindings, resolved, targets): (
         Res<ButtonInput<KeyCode>>,
         Res<crate::input::ime::ImeState>,
         Res<KeyBindings>,
         Res<Shortcuts>,
+        ActionTargets,
     ),
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     copy_modes: Query<(), With<CopyModeState>>,
@@ -137,7 +148,6 @@ fn forward_keys_to_tmux(
     // own system handles raw keys. Drain here so no key leaks to tmux or the
     // prefix state machine.
     if copy_prompt.open.is_some() {
-        *prefix_pending = false;
         leader_pending.0 = false;
         events.clear();
         return;
@@ -145,15 +155,13 @@ fn forward_keys_to_tmux(
     // NOTE: while the confirm-before prompt is open it owns the keyboard; its own
     // system reads the y/n answer. Drain here so no key leaks to tmux or the pane.
     if confirm_state.is_some() {
-        *prefix_pending = false;
         leader_pending.0 = false;
         events.clear();
         return;
     }
     // NOTE: while the rename prompt is open it owns the keyboard; its own system
     // reads the typed text. Drain here so no key leaks to tmux or the pane.
-    if rename.prompt.is_some() {
-        *prefix_pending = false;
+    if rename_prompt.is_some() {
         leader_pending.0 = false;
         events.clear();
         return;
@@ -161,14 +169,12 @@ fn forward_keys_to_tmux(
     // NOTE: drain (don't replay) while composing — forwarding preedit
     // navigation keys would both garble IME composition and double-send.
     if ime.is_composing() {
-        *prefix_pending = false;
         leader_pending.0 = false;
         events.clear();
         return;
     }
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if !focused {
-        *prefix_pending = false;
         leader_pending.0 = false;
         events.clear();
         return;
@@ -235,23 +241,13 @@ fn forward_keys_to_tmux(
         }
 
         if !forward_names.is_empty() {
-            let actions = plan_forward(&mut prefix_pending, &bindings, forward_names);
-            if let (Some(target), Some(client)) = (target.as_deref(), client.as_deref_mut()) {
-                for action in actions {
-                    let result = match action {
-                        Forwarded::Run(cmd) => client.send_effect(&cmd),
-                        Forwarded::Keys(names) => client
-                            .send(SendPaneKeys {
-                                pane: target,
-                                names: &names,
-                            })
-                            .map(|_| ()),
-                    };
-                    if let Err(e) = result {
-                        tracing::warn!(?e, "forward-key send failed");
-                        break;
-                    }
-                }
+            if let (Some(target), Some(client)) = (target.as_deref(), client.as_deref_mut())
+                && let Err(e) = client.send(SendPaneKeys {
+                    pane: target,
+                    names: &forward_names,
+                })
+            {
+                tracing::warn!(?e, "forward-key send failed");
             }
             if let Some(entity) = active_entity
                 && let Ok(mut handle) = handles.get_mut(entity)
@@ -261,7 +257,6 @@ fn forward_keys_to_tmux(
             }
         }
 
-        *prefix_pending = false;
         leader_pending.0 = false;
         events.clear();
         return;
@@ -275,9 +270,9 @@ fn forward_keys_to_tmux(
             continue;
         }
         // NOTE: leader dispatch must run before direct matching and tmux
-        // forwarding so a swallowed/resolved leader key never reaches
-        // plan_forward. cfg_mods is a per-frame snapshot, so a same-frame
-        // leader+second-key batch shares one modifier read.
+        // forwarding so a swallowed/resolved leader key never reaches the
+        // plain key-forward batch below. cfg_mods is a per-frame snapshot, so
+        // a same-frame leader+second-key batch shares one modifier read.
         // NOTE: OS key auto-repeat delivers extra Pressed events; feeding them
         // to step_leader would toggle `pending` by parity. Treat a repeat as
         // Passthrough without stepping the machine — EXCEPT while a leader is
@@ -294,15 +289,11 @@ fn forward_keys_to_tmux(
         let gui_action = match step {
             LeaderStep::RunAction(action) => Some(action),
             LeaderStep::Swallow => {
-                *prefix_pending = false;
                 continue;
             }
             LeaderStep::Passthrough => resolved.match_gui_action(ev.key_code, cfg_mods),
         };
         if let Some(action) = gui_action {
-            // A GUI action (direct or via the leader) abandons any pending tmux
-            // prefix sequence.
-            *prefix_pending = false;
             match action {
                 ShortcutAction::Quit => {
                     exit.write(AppExit::Success);
@@ -341,26 +332,88 @@ fn forward_keys_to_tmux(
                         request_detach(client);
                     }
                 }
-                ShortcutAction::EnterCopyMode => {}
-                // TODO: wire real dispatch in Task 7.
-                ShortcutAction::SelectPane(_)
-                | ShortcutAction::SplitPane(_)
-                | ShortcutAction::KillPane
-                | ShortcutAction::ZoomPane
-                | ShortcutAction::NewWindow
-                | ShortcutAction::KillWindow
-                | ShortcutAction::NextWindow
-                | ShortcutAction::PreviousWindow
-                | ShortcutAction::SelectWindow(_)
-                | ShortcutAction::RenameWindow
-                | ShortcutAction::RenameSession => {}
+                ShortcutAction::EnterCopyMode => {
+                    // NOTE: re-entry guard — re-triggering while the pane is
+                    // already in copy mode would double-insert CopyModeState
+                    // and re-run `copy-mode` on a pane that is already in it.
+                    if let Some(entity) = active_entity
+                        && copy_modes.get(entity).is_err()
+                    {
+                        commands.trigger(EnterCopyModeRequest { entity });
+                    }
+                }
+                ShortcutAction::SelectPane(direction) => {
+                    if let Some(entity) = active_entity {
+                        commands.trigger(SelectPaneRequest {
+                            entity,
+                            direction: tmux_pane_direction(direction),
+                        });
+                    }
+                }
+                ShortcutAction::SplitPane(orientation) => {
+                    if let Some(entity) = active_entity {
+                        commands.trigger(SplitPaneRequest {
+                            entity,
+                            direction: tmux_split_direction(orientation),
+                        });
+                    }
+                }
+                ShortcutAction::KillPane => {
+                    if let Some(entity) = active_entity {
+                        commands.trigger(KillPaneRequest { entity });
+                    }
+                }
+                ShortcutAction::ZoomPane => {
+                    if let Some(entity) = active_entity {
+                        commands.trigger(ZoomPaneRequest { entity });
+                    }
+                }
+                ShortcutAction::NewWindow => {
+                    if let Ok(entity) = targets.session.single() {
+                        commands.trigger(NewWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::NextWindow => {
+                    if let Ok(entity) = targets.session.single() {
+                        commands.trigger(NextWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::PreviousWindow => {
+                    if let Ok(entity) = targets.session.single() {
+                        commands.trigger(PreviousWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::SelectWindow(index) => {
+                    if let Some(entity) = targets
+                        .windows
+                        .iter()
+                        .find(|(_, window)| window.index == u32::from(index))
+                        .map(|(entity, _)| entity)
+                    {
+                        commands.trigger(SelectWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::KillWindow => {
+                    if let Ok(entity) = targets.active_window.single() {
+                        commands.trigger(KillWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::RenameWindow => {
+                    if let Ok(entity) = targets.active_window.single() {
+                        commands.trigger(RenameWindowRequest { entity });
+                    }
+                }
+                ShortcutAction::RenameSession => {
+                    if let Ok(entity) = targets.session.single() {
+                        commands.trigger(RenameSessionRequest { entity });
+                    }
+                }
             }
             continue;
         }
         // NOTE: tmux/PTY has no Super modifier, so a Cmd-modified key that
         // matched no ozmux shortcut must be swallowed here, never forwarded.
         if mods.super_ {
-            *prefix_pending = false;
             continue;
         }
         if let Some(name) = bevy_key_to_tmux_name(&ev.logical_key, ev.key_code, mods) {
@@ -368,9 +421,10 @@ fn forward_keys_to_tmux(
         }
     }
 
-    // NOTE: this branch must return before plan_forward — a copy-mode entry
-    // binding pressed while already in copy mode is relayed here (not
-    // re-intercepted), which would otherwise re-insert CopyModeState each press.
+    // NOTE: this branch must return before the plain key-forward dispatch below
+    // — a copy-mode entry binding pressed while already in copy mode is relayed
+    // here (not re-intercepted), which would otherwise re-insert CopyModeState
+    // each press.
     let in_copy_mode = active_entity.is_some_and(|e| copy_modes.get(e).is_ok());
 
     if !in_copy_mode
@@ -427,73 +481,38 @@ fn forward_keys_to_tmux(
         return;
     }
 
-    // Dispatch the keys against the tmux bindings: bound keys run their command
-    // verbatim, unbound keys forward to the active pane. NOTE: the bound command
-    // acts on tmux's current pane; ozmux keeps that synced to the focused pane
-    // via select-pane, and both travel this FIFO control connection in order.
-    let actions = plan_forward(&mut prefix_pending, &bindings, key_names);
-    if actions.is_empty() {
+    if key_names.is_empty() {
         return;
     }
     let (Some(target), Some(client)) = (target.as_deref(), client.as_deref_mut()) else {
         return;
     };
-    for action in actions {
-        if let Forwarded::Run(command) = &action
-            && let Some(kind) = RenameKind::parse(command)
-            && let Some(subject) = resolve_rename_subject(kind, &rename)
-        {
-            commands.insert_resource(RenamePrompt::new(subject));
-            // NOTE: the prompt now owns the keyboard — stop here so no further
-            // actions from this frame are sent to tmux.
-            break;
-        }
-        if let Forwarded::Run(command) = &action
-            && let Some((message, inner)) = parse_confirm_before(command)
-        {
-            commands.insert_resource(ConfirmState {
-                message,
-                command: inner,
-            });
-            // NOTE: the prompt now owns the keyboard — stop here so any further
-            // actions decoded from this same frame are NOT sent to tmux (that
-            // would bypass the confirmation the prompt is gating).
-            break;
-        }
-        let enters_copy_mode = matches!(&action, Forwarded::Run(cmd) if is_copy_mode_entry(cmd));
-        let result = match action {
-            Forwarded::Run(command) => client.send_effect(&command),
-            Forwarded::Keys(names) => client
-                .send(SendPaneKeys {
-                    pane: target,
-                    names: &names,
-                })
-                .map(|_| ()),
-        };
-        if let Err(e) = result {
-            tracing::warn!(?e, "tmux forward send failed");
-            break;
-        }
-        if enters_copy_mode && let Some(entity) = active_entity {
-            commands.entity(entity).insert(CopyModeState);
-        }
+    if let Err(e) = client.send(SendPaneKeys {
+        pane: target,
+        names: &key_names,
+    }) {
+        tracing::warn!(?e, "tmux key forward failed");
     }
 }
 
-/// True when a resolved tmux command can enter copy mode, so ozmux inserts
-/// `CopyModeState` alongside running it on tmux.
-///
-/// Matches a bare `copy-mode` token anywhere in the command, not just at the
-/// front: tmux's default mouse-wheel bindings enter copy mode through a
-/// conditional (e.g. `WheelUpPane` is
-/// `if-shell -F "…" { send-keys -M } { copy-mode -e }`), so a first-token check
-/// would miss them. A false positive — the conditional taking the non-copy-mode
-/// branch on an alt-screen / mouse-reporting pane — is harmless: the copy-mode
-/// refresh loop removes `CopyModeState` again on the first `#{pane_in_mode} == 0`
-/// state reply. The `copy-mode` token is matched whole-word, so quoted format
-/// strings and the `copy-mode-vi` table name do not trip it.
-fn is_copy_mode_entry(command: &str) -> bool {
-    command.split_whitespace().any(|token| token == "copy-mode")
+/// Maps the config-facing pane direction (named after the neighbor) to the
+/// tmux command enum.
+fn tmux_pane_direction(direction: CfgPaneDirection) -> PaneDirection {
+    match direction {
+        CfgPaneDirection::Left => PaneDirection::Left,
+        CfgPaneDirection::Down => PaneDirection::Down,
+        CfgPaneDirection::Up => PaneDirection::Up,
+        CfgPaneDirection::Right => PaneDirection::Right,
+    }
+}
+
+/// Maps the config-facing split orientation (named after the DIVIDER) to the
+/// tmux flag enum (named after the layout axis) — the two cross on purpose.
+fn tmux_split_direction(orientation: CfgSplitOrientation) -> SplitDirection {
+    match orientation {
+        CfgSplitOrientation::Vertical => SplitDirection::Horizontal,
+        CfgSplitOrientation::Horizontal => SplitDirection::Vertical,
+    }
 }
 
 /// `send-keys -X -t %<id> -N <lines> scroll-up|scroll-down` — one copy-mode wheel notch.
@@ -577,37 +596,13 @@ struct TmuxWebviewWheelParams<'w, 's> {
     browsers: Option<NonSend<'w, Browsers>>,
 }
 
-/// Rename-interception params bundled to stay within Bevy's system-parameter
-/// limit (`forward_keys_to_tmux` is already at 16 top-level params). `prompt`
-/// gates the keyboard while a rename is open; the queries resolve the target
-/// captured at prompt-open.
+/// Target-entity lookups for the tmux shortcut actions, bundled to stay
+/// within Bevy's system-parameter limit.
 #[derive(SystemParam)]
-struct RenameParams<'w, 's> {
-    prompt: Option<Res<'w, RenamePrompt>>,
-    active_window: Query<'w, 's, &'static TmuxWindow, With<ActiveWindow>>,
-    session: Query<'w, 's, &'static TmuxSession>,
-}
-
-/// Resolves the rename target (id + current name) from ECS for `kind`, or `None`
-/// when no active window / attached session exists (the binding then forwards
-/// verbatim, as before).
-fn resolve_rename_subject(kind: RenameKind, rename: &RenameParams) -> Option<RenameSubject> {
-    match kind {
-        RenameKind::Window => {
-            let w = rename.active_window.single().ok()?;
-            Some(RenameSubject::Window {
-                id: w.id,
-                current_name: w.name.clone(),
-            })
-        }
-        RenameKind::Session => {
-            let s = rename.session.single().ok()?;
-            Some(RenameSubject::Session {
-                id: s.id,
-                current_name: s.name.clone(),
-            })
-        }
-    }
+struct ActionTargets<'w, 's> {
+    active_window: Query<'w, 's, Entity, With<ActiveWindow>>,
+    session: Query<'w, 's, Entity, With<TmuxSession>>,
+    windows: Query<'w, 's, (Entity, &'static TmuxWindow)>,
 }
 
 /// Resolves the focused webview under the pointer, or `None` (the tmux
@@ -1333,25 +1328,26 @@ mod tests {
     }
 
     #[test]
-    fn detects_copy_mode_entry_command() {
-        assert!(is_copy_mode_entry("copy-mode"));
-        assert!(is_copy_mode_entry("copy-mode -u"));
-        assert!(is_copy_mode_entry("copy-mode -eu"));
-        assert!(!is_copy_mode_entry("copy-selection"));
-        assert!(!is_copy_mode_entry("new-window"));
+    fn split_orientation_crosses_to_tmux_flag() {
+        assert_eq!(
+            tmux_split_direction(CfgSplitOrientation::Vertical),
+            SplitDirection::Horizontal
+        );
+        assert_eq!(
+            tmux_split_direction(CfgSplitOrientation::Horizontal),
+            SplitDirection::Vertical
+        );
     }
 
     #[test]
-    fn detects_copy_mode_entry_inside_wheel_conditional() {
-        // tmux's default `WheelUpPane` root binding enters copy mode through an
-        // if-shell conditional, not a leading `copy-mode` token. ozmux must still
-        // recognize the entry so it inserts `CopyModeState` (the refresh loop
-        // removes it again if the conditional took the send-keys branch).
-        assert!(is_copy_mode_entry(
-            "if-shell -F \"#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}\" { send-keys -M } { copy-mode -e }"
-        ));
-        // A wheel that only forwards a mouse event to the app is not an entry.
-        assert!(!is_copy_mode_entry("send-keys -M"));
-        assert!(!is_copy_mode_entry("send-keys -X scroll-up"));
+    fn pane_direction_maps_one_to_one() {
+        assert_eq!(
+            tmux_pane_direction(CfgPaneDirection::Left),
+            PaneDirection::Left
+        );
+        assert_eq!(
+            tmux_pane_direction(CfgPaneDirection::Right),
+            PaneDirection::Right
+        );
     }
 }

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -342,6 +342,18 @@ fn forward_keys_to_tmux(
                     }
                 }
                 ShortcutAction::EnterCopyMode => {}
+                // TODO: wire real dispatch in Task 7.
+                ShortcutAction::SelectPane(_)
+                | ShortcutAction::SplitPane(_)
+                | ShortcutAction::KillPane
+                | ShortcutAction::ZoomPane
+                | ShortcutAction::NewWindow
+                | ShortcutAction::KillWindow
+                | ShortcutAction::NextWindow
+                | ShortcutAction::PreviousWindow
+                | ShortcutAction::SelectWindow(_)
+                | ShortcutAction::RenameWindow
+                | ShortcutAction::RenameSession => {}
             }
             continue;
         }

--- a/src/mode/tmux.rs
+++ b/src/mode/tmux.rs
@@ -1,5 +1,6 @@
 //! tmux feature plugin: aggregates all tmux runtime sub-plugins.
 
+pub(crate) mod action;
 mod adopt;
 pub(crate) mod confirm_prompt;
 pub(crate) mod copy_mode;
@@ -19,6 +20,7 @@ use crate::input::tmux::input::InputPlugin;
 use crate::input::tmux::mouse::MousePlugin;
 use crate::input::tmux::window_bar_input::WindowBarInputPlugin;
 use crate::mode::AppMode;
+use action::TmuxActionPlugin;
 use adopt::AdoptPlugin;
 use bevy::prelude::*;
 use confirm_prompt::ConfirmPromptPlugin;
@@ -58,6 +60,7 @@ impl Plugin for OzmuxTmuxPlugin {
                 WebviewTokensPlugin,
             ))
             .add_plugins((
+                TmuxActionPlugin,
                 TmuxLocalePlugin,
                 TmuxModeUiPlugin,
                 ConfirmPromptPlugin,

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -8,11 +8,20 @@ mod zoom_pane;
 
 use bevy::prelude::*;
 
-#[allow(unused_imports)]
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
 pub(crate) use select_pane::SelectPaneRequest;
-#[allow(unused_imports)]
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
 pub(crate) use split_pane::SplitPaneRequest;
-#[allow(unused_imports)]
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
 pub(crate) use zoom_pane::ZoomPaneRequest;
 
 /// Aggregates the per-command tmux action plugins.

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -2,11 +2,14 @@
 //! command has one `EntityEvent` + apply observer module under
 //! `src/mode/tmux/action/`. This root aggregates their per-file plugins.
 
+mod enter_copy_mode;
 mod kill_pane;
 mod kill_window;
 mod new_window;
 mod next_window;
 mod previous_window;
+mod rename_session;
+mod rename_window;
 mod select_pane;
 mod select_window;
 mod split_pane;
@@ -14,6 +17,11 @@ mod zoom_pane;
 
 use bevy::prelude::*;
 
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use enter_copy_mode::EnterCopyModeRequest;
 #[expect(
     unused_imports,
     reason = "consumed by Task 7's shortcut dispatch wiring"
@@ -43,6 +51,16 @@ pub(crate) use previous_window::PreviousWindowRequest;
     unused_imports,
     reason = "consumed by Task 7's shortcut dispatch wiring"
 )]
+pub(crate) use rename_session::RenameSessionRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use rename_window::RenameWindowRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
 pub(crate) use select_pane::SelectPaneRequest;
 #[expect(
     unused_imports,
@@ -66,11 +84,14 @@ pub(crate) struct TmuxActionPlugin;
 impl Plugin for TmuxActionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            enter_copy_mode::EnterCopyModePlugin,
             kill_pane::KillPanePlugin,
             kill_window::KillWindowPlugin,
             new_window::NewWindowPlugin,
             next_window::NextWindowPlugin,
             previous_window::PreviousWindowPlugin,
+            rename_session::RenameSessionPlugin,
+            rename_window::RenameWindowPlugin,
             select_pane::SelectPanePlugin,
             select_window::SelectWindowPlugin,
             split_pane::SplitPanePlugin,

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -17,65 +17,17 @@ mod zoom_pane;
 
 use bevy::prelude::*;
 
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use enter_copy_mode::EnterCopyModeRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use kill_pane::KillPaneRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use kill_window::KillWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use new_window::NewWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use next_window::NextWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use previous_window::PreviousWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use rename_session::RenameSessionRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use rename_window::RenameWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use select_pane::SelectPaneRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use select_window::SelectWindowRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use split_pane::SplitPaneRequest;
-#[expect(
-    unused_imports,
-    reason = "consumed by Task 7's shortcut dispatch wiring"
-)]
 pub(crate) use zoom_pane::ZoomPaneRequest;
 
 /// Aggregates the per-command tmux action plugins.

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -2,6 +2,8 @@
 //! command has one `EntityEvent` + apply observer module under
 //! `src/mode/tmux/action/`. This root aggregates their per-file plugins.
 
+mod kill_pane;
+mod kill_window;
 mod new_window;
 mod next_window;
 mod previous_window;
@@ -12,6 +14,16 @@ mod zoom_pane;
 
 use bevy::prelude::*;
 
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use kill_pane::KillPaneRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use kill_window::KillWindowRequest;
 #[expect(
     unused_imports,
     reason = "consumed by Task 7's shortcut dispatch wiring"
@@ -54,6 +66,8 @@ pub(crate) struct TmuxActionPlugin;
 impl Plugin for TmuxActionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            kill_pane::KillPanePlugin,
+            kill_window::KillWindowPlugin,
             new_window::NewWindowPlugin,
             next_window::NextWindowPlugin,
             previous_window::PreviousWindowPlugin,

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -2,7 +2,11 @@
 //! command has one `EntityEvent` + apply observer module under
 //! `src/mode/tmux/action/`. This root aggregates their per-file plugins.
 
+mod new_window;
+mod next_window;
+mod previous_window;
 mod select_pane;
+mod select_window;
 mod split_pane;
 mod zoom_pane;
 
@@ -12,7 +16,27 @@ use bevy::prelude::*;
     unused_imports,
     reason = "consumed by Task 7's shortcut dispatch wiring"
 )]
+pub(crate) use new_window::NewWindowRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use next_window::NextWindowRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use previous_window::PreviousWindowRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
 pub(crate) use select_pane::SelectPaneRequest;
+#[expect(
+    unused_imports,
+    reason = "consumed by Task 7's shortcut dispatch wiring"
+)]
+pub(crate) use select_window::SelectWindowRequest;
 #[expect(
     unused_imports,
     reason = "consumed by Task 7's shortcut dispatch wiring"
@@ -30,8 +54,12 @@ pub(crate) struct TmuxActionPlugin;
 impl Plugin for TmuxActionPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
-            split_pane::SplitPanePlugin,
+            new_window::NewWindowPlugin,
+            next_window::NextWindowPlugin,
+            previous_window::PreviousWindowPlugin,
             select_pane::SelectPanePlugin,
+            select_window::SelectWindowPlugin,
+            split_pane::SplitPanePlugin,
             zoom_pane::ZoomPanePlugin,
         ));
     }

--- a/src/mode/tmux/action.rs
+++ b/src/mode/tmux/action.rs
@@ -1,0 +1,29 @@
+//! Per-command tmux action events: each ozmux shortcut that drives a tmux
+//! command has one `EntityEvent` + apply observer module under
+//! `src/mode/tmux/action/`. This root aggregates their per-file plugins.
+
+mod select_pane;
+mod split_pane;
+mod zoom_pane;
+
+use bevy::prelude::*;
+
+#[allow(unused_imports)]
+pub(crate) use select_pane::SelectPaneRequest;
+#[allow(unused_imports)]
+pub(crate) use split_pane::SplitPaneRequest;
+#[allow(unused_imports)]
+pub(crate) use zoom_pane::ZoomPaneRequest;
+
+/// Aggregates the per-command tmux action plugins.
+pub(crate) struct TmuxActionPlugin;
+
+impl Plugin for TmuxActionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((
+            split_pane::SplitPanePlugin,
+            select_pane::SelectPanePlugin,
+            zoom_pane::ZoomPanePlugin,
+        ));
+    }
+}

--- a/src/mode/tmux/action/enter_copy_mode.rs
+++ b/src/mode/tmux/action/enter_copy_mode.rs
@@ -1,0 +1,102 @@
+//! `EnterCopyModeRequest` — puts the target tmux pane into copy mode and
+//! marks it with `CopyModeState` (the marker the copy-mode refresh loop and
+//! wheel routing key off).
+
+use crate::ui::copy_mode::CopyModeState;
+use bevy::prelude::*;
+use ozmux_tmux::{EnterCopyMode, TmuxClient, TmuxPane};
+
+/// Enters tmux copy mode on the pane owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct EnterCopyModeRequest {
+    /// The pane entity to put into copy mode.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `EnterCopyModeRequest` apply observer.
+pub(super) struct EnterCopyModePlugin;
+
+impl Plugin for EnterCopyModePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_enter_copy_mode);
+    }
+}
+
+fn on_enter_copy_mode(
+    ev: On<EnterCopyModeRequest>,
+    mut commands: Commands,
+    mut client: Option<Single<&mut TmuxClient>>,
+    panes: Query<&TmuxPane>,
+) {
+    let Ok(pane) = panes.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    match client.send(EnterCopyMode { pane: pane.id }) {
+        Ok(_) => {
+            commands.entity(ev.entity).insert(CopyModeState);
+        }
+        Err(e) => tracing::warn!(?e, "copy-mode send failed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::{CellDims, PaneId};
+
+    #[test]
+    fn enter_copy_mode_sends_and_marks() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_enter_copy_mode);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(8),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut()
+            .trigger(EnterCopyModeRequest { entity: target });
+        app.update();
+        let out = {
+            let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+            String::from_utf8(client.take_outgoing()).unwrap()
+        };
+        assert!(out.contains("copy-mode -t %8"), "got {out:?}");
+        assert!(app.world().entity(target).contains::<CopyModeState>());
+    }
+
+    #[test]
+    fn enter_copy_mode_without_client_does_not_mark() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_enter_copy_mode);
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut()
+            .trigger(EnterCopyModeRequest { entity: target });
+        app.update();
+        assert!(!app.world().entity(target).contains::<CopyModeState>());
+    }
+}

--- a/src/mode/tmux/action/kill_pane.rs
+++ b/src/mode/tmux/action/kill_pane.rs
@@ -3,7 +3,7 @@
 
 use crate::mode::tmux::confirm_prompt::ConfirmState;
 use bevy::prelude::*;
-use ozmux_tmux::{KillPane, TmuxCommand, TmuxPane};
+use ozmux_tmux::{KillPane, TmuxClient, TmuxCommand, TmuxPane};
 
 /// Asks for confirmation, then kills the tmux pane owning `entity`.
 #[derive(EntityEvent, Debug, Clone)]
@@ -22,10 +22,21 @@ impl Plugin for KillPanePlugin {
     }
 }
 
-fn on_kill_pane(ev: On<KillPaneRequest>, mut commands: Commands, panes: Query<&TmuxPane>) {
+fn on_kill_pane(
+    ev: On<KillPaneRequest>,
+    mut commands: Commands,
+    panes: Query<&TmuxPane>,
+    clients: Query<(), With<TmuxClient>>,
+) {
     let Ok(pane) = panes.get(ev.entity) else {
         return;
     };
+    // NOTE: without a live client the confirmed kill would be silently
+    // dropped by the prompt's send path — opening the modal would capture
+    // the keyboard for a no-op, so bail before prompting.
+    if clients.is_empty() {
+        return;
+    }
     commands.insert_resource(ConfirmState {
         message: format!("kill-pane %{}? (y/n)", pane.id.0),
         command: KillPane { pane: pane.id }.into_raw_command(),
@@ -42,6 +53,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_observer(on_kill_pane);
+        app.world_mut().spawn(TmuxClient::new_adopted());
         let target = app
             .world_mut()
             .spawn(TmuxPane {
@@ -59,5 +71,27 @@ mod tests {
         let state = app.world().resource::<ConfirmState>();
         assert_eq!(state.message, "kill-pane %5? (y/n)");
         assert_eq!(state.command, "kill-pane -t %5");
+    }
+
+    #[test]
+    fn kill_pane_without_client_does_not_prompt() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_kill_pane);
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(1),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut().trigger(KillPaneRequest { entity: target });
+        app.update();
+        assert!(!app.world().contains_resource::<ConfirmState>());
     }
 }

--- a/src/mode/tmux/action/kill_pane.rs
+++ b/src/mode/tmux/action/kill_pane.rs
@@ -1,0 +1,63 @@
+//! `KillPaneRequest` — opens a confirm prompt that kills the target pane on
+//! `y` (mirrors tmux's default confirm-wrapped `kill-pane` binding).
+
+use crate::mode::tmux::confirm_prompt::ConfirmState;
+use bevy::prelude::*;
+use ozmux_tmux::{KillPane, TmuxCommand, TmuxPane};
+
+/// Asks for confirmation, then kills the tmux pane owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct KillPaneRequest {
+    /// The pane entity to kill.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `KillPaneRequest` apply observer.
+pub(super) struct KillPanePlugin;
+
+impl Plugin for KillPanePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_kill_pane);
+    }
+}
+
+fn on_kill_pane(ev: On<KillPaneRequest>, mut commands: Commands, panes: Query<&TmuxPane>) {
+    let Ok(pane) = panes.get(ev.entity) else {
+        return;
+    };
+    commands.insert_resource(ConfirmState {
+        message: format!("kill-pane %{}? (y/n)", pane.id.0),
+        command: KillPane { pane: pane.id }.into_raw_command(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::{CellDims, PaneId};
+
+    #[test]
+    fn kill_pane_opens_confirm_with_kill_command() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_kill_pane);
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(5),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut().trigger(KillPaneRequest { entity: target });
+        app.update();
+        let state = app.world().resource::<ConfirmState>();
+        assert_eq!(state.message, "kill-pane %5? (y/n)");
+        assert_eq!(state.command, "kill-pane -t %5");
+    }
+}

--- a/src/mode/tmux/action/kill_window.rs
+++ b/src/mode/tmux/action/kill_window.rs
@@ -1,0 +1,60 @@
+//! `KillWindowRequest` — opens a confirm prompt that kills the target window
+//! on `y` (mirrors tmux's default confirm-wrapped `kill-window` binding).
+
+use crate::mode::tmux::confirm_prompt::ConfirmState;
+use bevy::prelude::*;
+use ozmux_tmux::{KillWindow, TmuxCommand, TmuxWindow};
+
+/// Asks for confirmation, then kills the tmux window owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct KillWindowRequest {
+    /// The window entity to kill.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `KillWindowRequest` apply observer.
+pub(super) struct KillWindowPlugin;
+
+impl Plugin for KillWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_kill_window);
+    }
+}
+
+fn on_kill_window(ev: On<KillWindowRequest>, mut commands: Commands, windows: Query<&TmuxWindow>) {
+    let Ok(window) = windows.get(ev.entity) else {
+        return;
+    };
+    commands.insert_resource(ConfirmState {
+        message: format!("kill-window {}? (y/n)", window.name),
+        command: KillWindow { window: window.id }.into_raw_command(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::WindowId;
+
+    #[test]
+    fn kill_window_opens_confirm_with_window_name() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_kill_window);
+        let target = app
+            .world_mut()
+            .spawn(TmuxWindow {
+                id: WindowId(2),
+                index: 1,
+                name: "editor".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(KillWindowRequest { entity: target });
+        app.update();
+        let state = app.world().resource::<ConfirmState>();
+        assert_eq!(state.message, "kill-window editor? (y/n)");
+        assert_eq!(state.command, "kill-window -t @2");
+    }
+}

--- a/src/mode/tmux/action/kill_window.rs
+++ b/src/mode/tmux/action/kill_window.rs
@@ -3,7 +3,7 @@
 
 use crate::mode::tmux::confirm_prompt::ConfirmState;
 use bevy::prelude::*;
-use ozmux_tmux::{KillWindow, TmuxCommand, TmuxWindow};
+use ozmux_tmux::{KillWindow, TmuxClient, TmuxCommand, TmuxWindow};
 
 /// Asks for confirmation, then kills the tmux window owning `entity`.
 #[derive(EntityEvent, Debug, Clone)]
@@ -22,10 +22,21 @@ impl Plugin for KillWindowPlugin {
     }
 }
 
-fn on_kill_window(ev: On<KillWindowRequest>, mut commands: Commands, windows: Query<&TmuxWindow>) {
+fn on_kill_window(
+    ev: On<KillWindowRequest>,
+    mut commands: Commands,
+    windows: Query<&TmuxWindow>,
+    clients: Query<(), With<TmuxClient>>,
+) {
     let Ok(window) = windows.get(ev.entity) else {
         return;
     };
+    // NOTE: without a live client the confirmed kill would be silently
+    // dropped by the prompt's send path — opening the modal would capture
+    // the keyboard for a no-op, so bail before prompting.
+    if clients.is_empty() {
+        return;
+    }
     commands.insert_resource(ConfirmState {
         message: format!("kill-window {}? (y/n)", window.name),
         command: KillWindow { window: window.id }.into_raw_command(),
@@ -42,6 +53,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_observer(on_kill_window);
+        app.world_mut().spawn(TmuxClient::new_adopted());
         let target = app
             .world_mut()
             .spawn(TmuxWindow {
@@ -56,5 +68,24 @@ mod tests {
         let state = app.world().resource::<ConfirmState>();
         assert_eq!(state.message, "kill-window editor? (y/n)");
         assert_eq!(state.command, "kill-window -t @2");
+    }
+
+    #[test]
+    fn kill_window_without_client_does_not_prompt() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_kill_window);
+        let target = app
+            .world_mut()
+            .spawn(TmuxWindow {
+                id: WindowId(1),
+                index: 0,
+                name: "shell".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(KillWindowRequest { entity: target });
+        app.update();
+        assert!(!app.world().contains_resource::<ConfirmState>());
     }
 }

--- a/src/mode/tmux/action/new_window.rs
+++ b/src/mode/tmux/action/new_window.rs
@@ -1,12 +1,16 @@
-//! `NewWindowRequest` — opens a new tmux window in the target session.
+//! `NewWindowRequest` — opens a new tmux window in the client's current
+//! session.
 
 use bevy::prelude::*;
 use ozmux_tmux::{NewWindow, TmuxClient, TmuxSession};
 
-/// Opens a new window in the tmux session owning `entity`.
+/// Opens a new window in the client's current session. The bare `new-window`
+/// deliberately carries no `-t` (its `-t` selects an insertion position, not
+/// just a session); `entity` only gates the request on a projected session
+/// still existing.
 #[derive(EntityEvent, Debug, Clone)]
 pub(crate) struct NewWindowRequest {
-    /// The session entity to open the window in.
+    /// The projected session entity used as an existence guard.
     #[event_target]
     pub entity: Entity,
 }

--- a/src/mode/tmux/action/new_window.rs
+++ b/src/mode/tmux/action/new_window.rs
@@ -1,0 +1,64 @@
+//! `NewWindowRequest` — opens a new tmux window in the target session.
+
+use bevy::prelude::*;
+use ozmux_tmux::{NewWindow, TmuxClient, TmuxSession};
+
+/// Opens a new window in the tmux session owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct NewWindowRequest {
+    /// The session entity to open the window in.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `NewWindowRequest` apply observer.
+pub(super) struct NewWindowPlugin;
+
+impl Plugin for NewWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_new_window);
+    }
+}
+
+fn on_new_window(
+    ev: On<NewWindowRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    sessions: Query<&TmuxSession>,
+) {
+    if sessions.get(ev.entity).is_err() {
+        return;
+    }
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(NewWindow) {
+        tracing::warn!(?e, "new-window send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::SessionId;
+
+    #[test]
+    fn new_window_sends_bare_new_window() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_new_window);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let session = app
+            .world_mut()
+            .spawn(TmuxSession {
+                id: SessionId(0),
+                name: "main".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(NewWindowRequest { entity: session });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("new-window"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/action/next_window.rs
+++ b/src/mode/tmux/action/next_window.rs
@@ -1,0 +1,66 @@
+//! `NextWindowRequest` — switches the target session to its next window.
+
+use bevy::prelude::*;
+use ozmux_tmux::{NextWindow, TmuxClient, TmuxSession};
+
+/// Switches the tmux session owning `entity` to its next window.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct NextWindowRequest {
+    /// The session entity to cycle.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `NextWindowRequest` apply observer.
+pub(super) struct NextWindowPlugin;
+
+impl Plugin for NextWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_next_window);
+    }
+}
+
+fn on_next_window(
+    ev: On<NextWindowRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    sessions: Query<&TmuxSession>,
+) {
+    let Ok(session) = sessions.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(NextWindow {
+        session: session.id,
+    }) {
+        tracing::warn!(?e, "next-window send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::SessionId;
+
+    #[test]
+    fn next_window_targets_session_id() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_next_window);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let session = app
+            .world_mut()
+            .spawn(TmuxSession {
+                id: SessionId(4),
+                name: "main".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(NextWindowRequest { entity: session });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("next-window -t $4"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/action/previous_window.rs
+++ b/src/mode/tmux/action/previous_window.rs
@@ -1,0 +1,66 @@
+//! `PreviousWindowRequest` — switches the target session to its previous window.
+
+use bevy::prelude::*;
+use ozmux_tmux::{PreviousWindow, TmuxClient, TmuxSession};
+
+/// Switches the tmux session owning `entity` to its previous window.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct PreviousWindowRequest {
+    /// The session entity to cycle.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `PreviousWindowRequest` apply observer.
+pub(super) struct PreviousWindowPlugin;
+
+impl Plugin for PreviousWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_previous_window);
+    }
+}
+
+fn on_previous_window(
+    ev: On<PreviousWindowRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    sessions: Query<&TmuxSession>,
+) {
+    let Ok(session) = sessions.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(PreviousWindow {
+        session: session.id,
+    }) {
+        tracing::warn!(?e, "previous-window send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::SessionId;
+
+    #[test]
+    fn previous_window_targets_session_id() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_previous_window);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let session = app
+            .world_mut()
+            .spawn(TmuxSession {
+                id: SessionId(4),
+                name: "main".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(PreviousWindowRequest { entity: session });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("previous-window -t $4"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/action/rename_session.rs
+++ b/src/mode/tmux/action/rename_session.rs
@@ -1,0 +1,61 @@
+//! `RenameSessionRequest` — opens the ozmux rename prompt pre-filled with the
+//! target session's current name.
+
+use crate::mode::tmux::rename_prompt::{RenamePrompt, RenameSubject};
+use bevy::prelude::*;
+use ozmux_tmux::TmuxSession;
+
+/// Opens the rename prompt for the tmux session owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct RenameSessionRequest {
+    /// The session entity to rename.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `RenameSessionRequest` apply observer.
+pub(super) struct RenameSessionPlugin;
+
+impl Plugin for RenameSessionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_rename_session);
+    }
+}
+
+fn on_rename_session(
+    ev: On<RenameSessionRequest>,
+    mut commands: Commands,
+    sessions: Query<&TmuxSession>,
+) {
+    let Ok(session) = sessions.get(ev.entity) else {
+        return;
+    };
+    commands.insert_resource(RenamePrompt::new(RenameSubject::Session {
+        id: session.id,
+        current_name: session.name.clone(),
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::SessionId;
+
+    #[test]
+    fn rename_session_opens_prompt() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_rename_session);
+        let target = app
+            .world_mut()
+            .spawn(TmuxSession {
+                id: SessionId(0),
+                name: "main".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(RenameSessionRequest { entity: target });
+        app.update();
+        assert!(app.world().contains_resource::<RenamePrompt>());
+    }
+}

--- a/src/mode/tmux/action/rename_window.rs
+++ b/src/mode/tmux/action/rename_window.rs
@@ -1,0 +1,62 @@
+//! `RenameWindowRequest` — opens the ozmux rename prompt pre-filled with the
+//! target window's current name.
+
+use crate::mode::tmux::rename_prompt::{RenamePrompt, RenameSubject};
+use bevy::prelude::*;
+use ozmux_tmux::TmuxWindow;
+
+/// Opens the rename prompt for the tmux window owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct RenameWindowRequest {
+    /// The window entity to rename.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `RenameWindowRequest` apply observer.
+pub(super) struct RenameWindowPlugin;
+
+impl Plugin for RenameWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_rename_window);
+    }
+}
+
+fn on_rename_window(
+    ev: On<RenameWindowRequest>,
+    mut commands: Commands,
+    windows: Query<&TmuxWindow>,
+) {
+    let Ok(window) = windows.get(ev.entity) else {
+        return;
+    };
+    commands.insert_resource(RenamePrompt::new(RenameSubject::Window {
+        id: window.id,
+        current_name: window.name.clone(),
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::WindowId;
+
+    #[test]
+    fn rename_window_opens_prompt() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_rename_window);
+        let target = app
+            .world_mut()
+            .spawn(TmuxWindow {
+                id: WindowId(2),
+                index: 0,
+                name: "editor".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(RenameWindowRequest { entity: target });
+        app.update();
+        assert!(app.world().contains_resource::<RenamePrompt>());
+    }
+}

--- a/src/mode/tmux/action/select_pane.rs
+++ b/src/mode/tmux/action/select_pane.rs
@@ -1,0 +1,77 @@
+//! `SelectPaneRequest` — focuses a neighbor of the target tmux pane via
+//! `select-pane -L|-D|-U|-R`.
+
+use bevy::prelude::*;
+use ozmux_tmux::{PaneDirection, SelectPaneTowards, TmuxClient, TmuxPane};
+
+/// Focuses the `direction` neighbor of the tmux pane owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct SelectPaneRequest {
+    /// The pane whose neighbor is selected.
+    #[event_target]
+    pub entity: Entity,
+    /// Which neighbor to select.
+    pub direction: PaneDirection,
+}
+
+/// Registers the `SelectPaneRequest` apply observer.
+pub(super) struct SelectPanePlugin;
+
+impl Plugin for SelectPanePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_select_pane);
+    }
+}
+
+fn on_select_pane(
+    ev: On<SelectPaneRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    panes: Query<&TmuxPane>,
+) {
+    let Ok(pane) = panes.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(SelectPaneTowards {
+        pane: pane.id,
+        direction: ev.direction,
+    }) {
+        tracing::warn!(?e, "select-pane send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::{CellDims, PaneId};
+
+    #[test]
+    fn select_pane_sends_directional_select() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_select_pane);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(9),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut().trigger(SelectPaneRequest {
+            entity: target,
+            direction: PaneDirection::Left,
+        });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("select-pane -L -t %9"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/action/select_window.rs
+++ b/src/mode/tmux/action/select_window.rs
@@ -1,0 +1,67 @@
+//! `SelectWindowRequest` — switches to the target tmux window. The window
+//! entity is resolved from the shortcut's index by the dispatcher, so this
+//! observer only needs the projected `TmuxWindow` id.
+
+use bevy::prelude::*;
+use ozmux_tmux::{SelectWindow, TmuxClient, TmuxWindow};
+
+/// Switches to the tmux window owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct SelectWindowRequest {
+    /// The window entity to select.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `SelectWindowRequest` apply observer.
+pub(super) struct SelectWindowPlugin;
+
+impl Plugin for SelectWindowPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_select_window);
+    }
+}
+
+fn on_select_window(
+    ev: On<SelectWindowRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    windows: Query<&TmuxWindow>,
+) {
+    let Ok(window) = windows.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(SelectWindow { id: window.id }) {
+        tracing::warn!(?e, "select-window send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::WindowId;
+
+    #[test]
+    fn select_window_targets_window_id() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_select_window);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let window = app
+            .world_mut()
+            .spawn(TmuxWindow {
+                id: WindowId(6),
+                index: 2,
+                name: "editor".into(),
+            })
+            .id();
+        app.world_mut()
+            .trigger(SelectWindowRequest { entity: window });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("select-window -t @6"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/action/split_pane.rs
+++ b/src/mode/tmux/action/split_pane.rs
@@ -1,0 +1,92 @@
+//! `SplitPaneRequest` — splits the target tmux pane via `split-window`.
+
+use bevy::prelude::*;
+use ozmux_tmux::{SplitDirection, SplitWindow, TmuxClient, TmuxPane};
+
+/// Splits the tmux pane owning `entity` in `direction`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct SplitPaneRequest {
+    /// The pane entity to split.
+    #[event_target]
+    pub entity: Entity,
+    /// tmux split direction (`-h` / `-v`).
+    pub direction: SplitDirection,
+}
+
+/// Registers the `SplitPaneRequest` apply observer.
+pub(super) struct SplitPanePlugin;
+
+impl Plugin for SplitPanePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_split_pane);
+    }
+}
+
+fn on_split_pane(
+    ev: On<SplitPaneRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    panes: Query<&TmuxPane>,
+) {
+    let Ok(pane) = panes.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(SplitWindow {
+        pane: pane.id,
+        direction: ev.direction,
+    }) {
+        tracing::warn!(?e, "split-window send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::{CellDims, PaneId};
+
+    fn pane(app: &mut App, id: u32) -> Entity {
+        app.world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(id),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id()
+    }
+
+    #[test]
+    fn split_pane_sends_split_window() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_split_pane);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let target = pane(&mut app, 3);
+        app.world_mut().trigger(SplitPaneRequest {
+            entity: target,
+            direction: SplitDirection::Horizontal,
+        });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("split-window -h -t %3"), "got {out:?}");
+    }
+
+    #[test]
+    fn split_pane_no_panic_without_client() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_split_pane);
+        let target = pane(&mut app, 1);
+        app.world_mut().trigger(SplitPaneRequest {
+            entity: target,
+            direction: SplitDirection::Vertical,
+        });
+        app.update();
+    }
+}

--- a/src/mode/tmux/action/zoom_pane.rs
+++ b/src/mode/tmux/action/zoom_pane.rs
@@ -1,0 +1,69 @@
+//! `ZoomPaneRequest` — toggles zoom on the target tmux pane via
+//! `resize-pane -Z`.
+
+use bevy::prelude::*;
+use ozmux_tmux::{TmuxClient, TmuxPane, ZoomPane};
+
+/// Toggles zoom on the tmux pane owning `entity`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct ZoomPaneRequest {
+    /// The pane entity to zoom.
+    #[event_target]
+    pub entity: Entity,
+}
+
+/// Registers the `ZoomPaneRequest` apply observer.
+pub(super) struct ZoomPanePlugin;
+
+impl Plugin for ZoomPanePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_zoom_pane);
+    }
+}
+
+fn on_zoom_pane(
+    ev: On<ZoomPaneRequest>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    panes: Query<&TmuxPane>,
+) {
+    let Ok(pane) = panes.get(ev.entity) else {
+        return;
+    };
+    let Some(client) = client.as_deref_mut() else {
+        return;
+    };
+    if let Err(e) = client.send(ZoomPane { pane: pane.id }) {
+        tracing::warn!(?e, "resize-pane -Z send failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tmux_control_parser::{CellDims, PaneId};
+
+    #[test]
+    fn zoom_pane_sends_resize_z() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_observer(on_zoom_pane);
+        let client = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        let target = app
+            .world_mut()
+            .spawn(TmuxPane {
+                id: PaneId(2),
+                dims: CellDims {
+                    width: 10,
+                    height: 5,
+                    xoff: 0,
+                    yoff: 0,
+                },
+            })
+            .id();
+        app.world_mut().trigger(ZoomPaneRequest { entity: target });
+        app.update();
+        let mut client = app.world_mut().get_mut::<TmuxClient>(client).unwrap();
+        let out = String::from_utf8(client.take_outgoing()).unwrap();
+        assert!(out.contains("resize-pane -Z -t %2"), "got {out:?}");
+    }
+}

--- a/src/mode/tmux/confirm_prompt.rs
+++ b/src/mode/tmux/confirm_prompt.rs
@@ -1,7 +1,6 @@
-//! ozmux-owned `confirm-before` prompt. tmux's `confirm-before <cmd>` opens a
-//! client-side modal y/n prompt that a `-CC` control client cannot render or
-//! answer, so `forward_keys_to_tmux` detects such a binding, opens this prompt
-//! instead of forwarding it, and runs the inner command only on confirm.
+//! ozmux-owned confirm prompt: the kill-pane / kill-window shortcut actions
+//! open this prompt. It renders a client-side modal y/n prompt and runs the
+//! inner command only on confirm.
 
 use crate::font::TerminalUiFont;
 use crate::input::InputPhase;
@@ -51,43 +50,6 @@ pub(crate) struct ConfirmState {
     pub(crate) command: String,
 }
 
-/// Parses a `confirm-before [-by] [-c key] [-p prompt] [-t client] <command>`
-/// binding into `(message, inner command)`. Returns `None` if the command is
-/// not a `confirm-before` or has no inner command. The message defaults to
-/// `"<command>? (y/n)"` when `-p` is absent.
-pub(crate) fn parse_confirm_before(command: &str) -> Option<(String, String)> {
-    let tokens = tokenize(command);
-    let mut it = tokens.into_iter();
-    if it.next().as_deref() != Some("confirm-before") {
-        return None;
-    }
-    let mut message: Option<String> = None;
-    let mut inner: Vec<String> = Vec::new();
-    while let Some(tok) = it.next() {
-        match tok.as_str() {
-            "-p" => message = it.next(),
-            "-c" | "-t" => {
-                it.next();
-            }
-            "-b" => {}
-            // NOTE: `-y` means tmux auto-confirms (no modal), so returning None
-            // lets the command forward verbatim and tmux runs the inner command
-            // without a prompt — treating `-y` as a no-op would wrongly prompt.
-            "-y" => return None,
-            _ => {
-                inner.push(tok);
-                inner.extend(it.by_ref());
-            }
-        }
-    }
-    if inner.is_empty() {
-        return None;
-    }
-    let command = inner.join(" ");
-    let message = message.unwrap_or_else(|| format!("{command}? (y/n)"));
-    Some((message, command))
-}
-
 /// The effect of one key on an open confirm prompt.
 #[derive(Debug, PartialEq, Eq)]
 enum ConfirmStep {
@@ -108,43 +70,6 @@ fn confirm_step(key: &Key) -> Option<ConfirmStep> {
         },
         _ => None,
     }
-}
-
-/// Splits a tmux command line into tokens, honoring single and double quotes
-/// (quotes are stripped; whitespace inside quotes is preserved). Empty quoted
-/// tokens (`''`) yield an empty token.
-fn tokenize(line: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut cur = String::new();
-    let mut started = false;
-    let mut in_single = false;
-    let mut in_double = false;
-    for c in line.chars() {
-        match c {
-            '\'' if !in_double => {
-                in_single = !in_single;
-                started = true;
-            }
-            '"' if !in_single => {
-                in_double = !in_double;
-                started = true;
-            }
-            c if c.is_whitespace() && !in_single && !in_double => {
-                if started {
-                    tokens.push(std::mem::take(&mut cur));
-                    started = false;
-                }
-            }
-            c => {
-                cur.push(c);
-                started = true;
-            }
-        }
-    }
-    if started {
-        tokens.push(cur);
-    }
-    tokens
 }
 
 #[derive(Component)]
@@ -250,41 +175,6 @@ fn handle_confirm_input(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_bare_inner_command_with_default_message() {
-        let (msg, cmd) = parse_confirm_before("confirm-before 'kill-window'").unwrap();
-        assert_eq!(cmd, "kill-window");
-        assert_eq!(msg, "kill-window? (y/n)");
-    }
-
-    #[test]
-    fn parses_p_message_and_inner_command() {
-        let (msg, cmd) =
-            parse_confirm_before(r#"confirm-before -p "kill-window #W? (y/n)" kill-window"#)
-                .unwrap();
-        assert_eq!(cmd, "kill-window");
-        assert_eq!(msg, "kill-window #W? (y/n)");
-    }
-
-    #[test]
-    fn skips_boolean_and_arg_flags() {
-        let (_, cmd) = parse_confirm_before(r#"confirm-before -b -c y -t main kill-pane"#).unwrap();
-        assert_eq!(cmd, "kill-pane");
-    }
-
-    #[test]
-    fn joins_multi_token_inner_command() {
-        let (_, cmd) = parse_confirm_before("confirm-before kill-window -t @1").unwrap();
-        assert_eq!(cmd, "kill-window -t @1");
-    }
-
-    #[test]
-    fn rejects_non_confirm_before() {
-        assert!(parse_confirm_before("kill-window").is_none());
-        assert!(parse_confirm_before("confirm-before").is_none());
-        assert!(parse_confirm_before("confirm-before -p \"msg\"").is_none());
-    }
 
     #[test]
     fn confirm_step_maps_keys() {

--- a/src/mode/tmux/rename_prompt.rs
+++ b/src/mode/tmux/rename_prompt.rs
@@ -1,9 +1,6 @@
-//! ozmux-owned rename prompt for tmux's `command-prompt`-wrapped `rename-window`
-//! / `rename-session` bindings, which a `-CC` control client cannot render.
-//! `forward_keys_to_tmux` detects such a binding and inserts `RenamePrompt`
-//! instead of forwarding it; this prompt owns the keyboard, pre-fills the
-//! current name, and on submit sends a freshly-rebuilt, safely-quoted rename
-//! command. The recognizer is `RenameKind::parse`.
+//! ozmux-owned rename prompt: the rename-window / rename-session shortcut
+//! actions open this prompt. It owns the keyboard, pre-fills the current
+//! name, and on submit sends a freshly-rebuilt, safely-quoted rename command.
 
 use crate::font::TerminalUiFont;
 use crate::input::InputPhase;
@@ -131,42 +128,6 @@ impl RenamePrompt {
     }
 }
 
-/// The kind of rename a recognized binding performs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RenameKind {
-    /// `rename-window` / `renamew`.
-    Window,
-    /// `rename-session` / `rename`.
-    Session,
-}
-
-impl RenameKind {
-    /// Recognizes a default-compatible single-input `command-prompt` rename
-    /// binding, returning its [`RenameKind`], or `None` for anything ozmux
-    /// should forward verbatim (other command-prompts, multi-input prompts,
-    /// decorated templates, and non-`command-prompt` commands).
-    ///
-    /// Recognition is by command shape, not substring: the first token must be
-    /// `command-prompt`; the inner template (a `{ ... }` brace body or a quoted
-    /// template argument) must be exactly `<rename-verb> [--] <placeholder>`
-    /// where the verb is `rename-window`/`renamew`/`rename-session`/`rename`
-    /// and the placeholder is `%%` or `%1`. Multi-input prompts are rejected by
-    /// arity (any `%2`..`%9` reference), which is robust against the `-l`
-    /// literal flag and commas embedded in a single quoted prompt.
-    pub(crate) fn parse(command: &str) -> Option<Self> {
-        let tokens = tokenize(command);
-        if tokens.first().map(String::as_str) != Some("command-prompt") {
-            return None;
-        }
-        let inner = command_prompt_inner(&tokens)?;
-        let inner_tokens = tokenize(&inner);
-        if inner_tokens.iter().any(|t| has_high_arity_placeholder(t)) {
-            return None;
-        }
-        rename_kind_of(&inner_tokens)
-    }
-}
-
 /// The effect of one key on an open rename prompt.
 #[derive(Debug, PartialEq, Eq)]
 enum RenameStep {
@@ -275,105 +236,6 @@ fn handle_rename_input(
     }
 }
 
-/// Extracts the inner command template from a `command-prompt` invocation: the
-/// content of the trailing `{ ... }` brace group, else the last quoted/bare
-/// token after the flags. Returns `None` if no template is present.
-fn command_prompt_inner(tokens: &[String]) -> Option<String> {
-    if let Some(open) = tokens.iter().position(|t| t == "{") {
-        let close = tokens.iter().rposition(|t| t == "}")?;
-        if close <= open + 1 {
-            return None;
-        }
-        return Some(tokens[open + 1..close].join(" "));
-    }
-    let last = tokens.last()?;
-    if last.starts_with('-') {
-        return None;
-    }
-    Some(last.clone())
-}
-
-/// True when a token references `%2`..`%9` (a multi-prompt response slot).
-fn has_high_arity_placeholder(token: &str) -> bool {
-    let bytes = token.as_bytes();
-    for i in 0..bytes.len() {
-        if bytes[i] == b'%'
-            && let Some(&next) = bytes.get(i + 1)
-            && (b'2'..=b'9').contains(&next)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-/// Classifies an inner template's argv as a canonical rename, or `None`.
-/// Accepts `<verb> [--] <placeholder>` where placeholder is exactly `%%` or
-/// `%1` (after stripping surrounding quotes the tokenizer already removed).
-fn rename_kind_of(inner: &[String]) -> Option<RenameKind> {
-    let mut it = inner.iter();
-    let kind = match it.next().map(String::as_str)? {
-        "rename-window" | "renamew" => RenameKind::Window,
-        "rename-session" | "rename" => RenameKind::Session,
-        _ => return None,
-    };
-    let mut next = it.next().map(String::as_str)?;
-    if next == "--" {
-        next = it.next().map(String::as_str)?;
-    }
-    if next != "%%" && next != "%1" {
-        return None;
-    }
-    if it.next().is_some() {
-        return None;
-    }
-    Some(kind)
-}
-
-/// Splits a tmux command line into tokens, honoring single/double quotes (quotes
-/// stripped, whitespace inside preserved) and treating `{` / `}` as standalone
-/// tokens. Empty quoted tokens (`''`) yield an empty token.
-fn tokenize(line: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut cur = String::new();
-    let mut started = false;
-    let mut in_single = false;
-    let mut in_double = false;
-    for c in line.chars() {
-        match c {
-            '\'' if !in_double => {
-                in_single = !in_single;
-                started = true;
-            }
-            '"' if !in_single => {
-                in_double = !in_double;
-                started = true;
-            }
-            '{' | '}' if !in_single && !in_double => {
-                if started {
-                    tokens.push(std::mem::take(&mut cur));
-                    started = false;
-                }
-                tokens.push(c.to_string());
-            }
-            c if c.is_whitespace() && !in_single && !in_double => {
-                if started {
-                    tokens.push(std::mem::take(&mut cur));
-                    started = false;
-                }
-            }
-            c => {
-                cur.push(c);
-                started = true;
-            }
-        }
-    }
-    if started {
-        tokens.push(cur);
-    }
-    tokens
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,102 +329,6 @@ mod tests {
             .label(),
             "Rename session: "
         );
-    }
-
-    #[test]
-    fn recognizes_default_window_binding() {
-        assert_eq!(
-            RenameKind::parse(r##"command-prompt -I "#W" { rename-window -- "%%" }"##),
-            Some(RenameKind::Window)
-        );
-    }
-
-    #[test]
-    fn recognizes_default_session_binding() {
-        assert_eq!(
-            RenameKind::parse(r##"command-prompt -I "#S" { rename-session -- "%%" }"##),
-            Some(RenameKind::Session)
-        );
-    }
-
-    #[test]
-    fn recognizes_aliases() {
-        assert_eq!(
-            RenameKind::parse(r##"command-prompt -I "#W" { renamew -- "%%" }"##),
-            Some(RenameKind::Window)
-        );
-        assert_eq!(
-            RenameKind::parse(r##"command-prompt -I "#S" { rename -- "%%" }"##),
-            Some(RenameKind::Session)
-        );
-    }
-
-    #[test]
-    fn recognizes_quoted_template_form() {
-        assert_eq!(
-            RenameKind::parse(r##"command-prompt -I "#W" "rename-window -- '%%'""##),
-            Some(RenameKind::Window)
-        );
-    }
-
-    #[test]
-    fn recognizes_percent_one_placeholder() {
-        assert_eq!(
-            RenameKind::parse(r#"command-prompt { rename-window -- "%1" }"#),
-            Some(RenameKind::Window)
-        );
-    }
-
-    #[test]
-    fn rejects_multi_input_by_arity() {
-        assert_eq!(
-            RenameKind::parse(r#"command-prompt -p a,b { rename-window -- "%1-%2" }"#),
-            None
-        );
-    }
-
-    #[test]
-    fn accepts_literal_flag_with_comma_prompt() {
-        assert_eq!(
-            RenameKind::parse(r#"command-prompt -l -p "a,b" { rename-window -- "%%" }"#),
-            Some(RenameKind::Window)
-        );
-    }
-
-    #[test]
-    fn accepts_comma_inside_single_quoted_prompt() {
-        assert_eq!(
-            RenameKind::parse(r#"command-prompt -p "new (was a, b)" { rename-window -- "%%" }"#),
-            Some(RenameKind::Window)
-        );
-    }
-
-    #[test]
-    fn rejects_decorated_template() {
-        assert_eq!(
-            RenameKind::parse(r#"command-prompt { rename-window -- "[%%]" }"#),
-            None
-        );
-    }
-
-    #[test]
-    fn rejects_copy_mode_search_prompt() {
-        assert_eq!(
-            RenameKind::parse(
-                r#"command-prompt -T search -p "(search down)" { send-keys -X search-forward "%%%" }"#
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn rejects_confirm_before() {
-        assert_eq!(RenameKind::parse("confirm-before kill-window"), None);
-    }
-
-    #[test]
-    fn rejects_run_shell_containing_rename_window() {
-        assert_eq!(RenameKind::parse(r#"run-shell "rename-window x""#), None);
     }
 
     fn key_event(logical: Key, code: KeyCode) -> KeyboardInput {


### PR DESCRIPTION
## Problem

In tmux mode, ozmux forwarded keystrokes against a mirror of tmux's own root/prefix key tables (`plan_forward`), emulating the tmux prefix key (e.g. `C-b`) as a two-stage state machine inside the app. This duplicated the `<Leader>` machinery introduced in #229 (two parallel two-stage key state machines threaded through `forward_keys_to_tmux`), and pane/window operations depended on parsing tmux binding strings (`confirm-before`, `command-prompt` rename, `copy-mode` detection) to intercept behavior a `-CC` control client cannot render.

## Solution

Replace tmux keybinding forwarding with app-native shortcuts: each tmux command gets a `[shortcuts]` action and a per-command `EntityEvent` + apply observer (the idiom from #223).

**configs (`crates/ozmux_configs`)**
- 24 new actions in `[shortcuts]`: `select-{left,down,up,right}-pane` (`<Leader>h/j/k/l`), `split-{vertical,horizontal}-pane` (`<Leader>i/o`), `kill-pane`/`zoom-pane` (`<Leader>x/z`), `new-window`/`kill-window` (`<Leader>c`/`<Leader>Shift+X`), `next/previous-window` (`<Leader>n`/`<Leader>Shift+N`), `select-window-0…9` (`<Leader>0-9`), `rename-window/-session` (`<Leader>r`/`<Leader>Shift+R`)
- `ShortcutAction` gains 11 payload-carrying variants (`SelectPane(PaneDirection)`, `SplitPane(SplitOrientation)`, `SelectWindow(u8)`, …)
- `paste` default changes `Cmd+V` → `<Leader>p` (restore with `paste = "Cmd+V"`)

**engine (`crates/tmux_session`)**
- New typed commands in `command/ops.rs`: `SplitWindow`, `SelectPaneTowards`, `KillPane`, `KillWindow`, `NewWindow`, `NextWindow`, `PreviousWindow`, `ZoomPane`, `EnterCopyMode` — all with fixed-string tests
- Removed: `plan_forward` / `Forwarded`, the root/prefix table mirror in `KeyBindings`, prefix-key queries (`PrefixOptions`, `PendingReply::PrefixKeys`), and the attach-time `list-keys -T root|prefix` fetches. Copy-mode tables (`copy-mode` / `copy-mode-vi`) are untouched.

**binary (`src/`)**
- `src/mode/tmux/action/` — 12 per-command modules (EntityEvent + observer + per-file plugin): send-only ops go straight to `TmuxClient::send`; `kill-pane`/`kill-window` open the confirm prompt (gated on a live client); `rename-*` open the rename prompt; `enter-copy-mode` sends `copy-mode` and marks `CopyModeState` on success
- `forward_keys_to_tmux` now dispatches shortcut actions as events and batch-forwards every unmatched key pane-direct (one `send-keys` per frame); `prefix_pending` and the `RenameKind::parse` / `parse_confirm_before` / `is_copy_mode_entry` string interceptors are deleted
- `enter-copy-mode` (default `Cmd+S`) now works in tmux mode too, with a re-entry guard
- Default mode: `TerminalInputBindings.paste` is `Option`-ized so the leader-scoped paste has no stale `Cmd+V` fallback

**docs**
- `docs/configs.md` `[shortcuts]` reference rewritten: all 31 keys with defaults, migration notes (tmux.conf root/prefix bindings no longer fire inside ozmux — the prefix passes through to the pane), leader-armed-by-default caveats, `<Leader>`-collision and `leader = ""` consequences

### Breaking Changes

- **tmux.conf root/prefix bindings no longer fire inside ozmux.** The tmux prefix key (e.g. `C-b`) passes through to the pane like any other keystroke. Pane/window operations are driven by `[shortcuts]` actions instead. Copy-mode keys still follow tmux's `copy-mode` / `copy-mode-vi` tables.
- **`paste` default is now `<Leader>p`** (was `Cmd+V`). Restore the old binding with `paste = "Cmd+V"`.
- **The `Cmd` tap leader is armed by default** (stock `<Leader>` bindings now exist). A config that binds its own `<Leader>` chord on a key a stock default uses is a startup validation error — unbind the stock default (`new-window = ""`) or pick a free chord. `leader = ""` now disables all `<Leader>`-bound actions including paste.

## Testing

- `cargo test --workspace` 0 failures; `cargo clippy --workspace --all-targets` 0 warnings; `cargo fmt --all --check` clean
- New coverage: 29-entry `bindings_iter()` drift guard + defaults snapshot, fixed-string tests for all 9 new tmux commands, observer tests (sent-command strings, no-client/no-prompt paths, `CopyModeState` gating), split-orientation cross-mapping (`Vertical` → `-h`) pinned at both the config and dispatch layers, config fixtures for rebind/unbind and `<Leader>` duplicate rejection
- Reviewed: per-task spec+quality reviews, a whole-branch final review, and a multi-agent verified review (10 confirmed findings: 4 fixed in `bddcfbd3`, 6 triaged/deferred with reasons)

### Manual smoke (GUI, before merge)

- [ ] Cmd tap → `h/j/k/l` moves pane focus; `i` splits side-by-side, `o` splits stacked
- [ ] `c` / `n` / `Shift+N` / `0-9` / `z` window ops; `x` / `Shift+X` confirm (y/n/Esc); `r` / `Shift+R` rename prompt
- [ ] `C-b` passes through to the pane (`cat -v` shows `^B`); no two-stage prefix firing
- [ ] `Cmd+S` enters tmux copy-mode; copy-mode keys + wheel scroll unchanged
- [ ] Declared webview `ForwardKeys` chords still reach the pane after focusing a CEF webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)