### PR TITLE
feat(shortcuts): tmux-style repeat (`<Leader:r>` + `repeat-time-ms`)

### DIFF
--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -296,8 +296,15 @@ pub enum Leader {
 pub enum Binding {
     /// Fires when the chord is pressed directly.
     Direct(KeyChord),
-    /// Fires when the chord is pressed after the leader (`<Leader>x`).
-    Leader(KeyChord),
+    /// Fires when the chord is pressed after the leader (`<Leader>x`), or —
+    /// with `repeat` — re-fires inside the repeat window (`<Leader:r>x`).
+    Leader {
+        /// The second-key chord pressed after the leader.
+        chord: KeyChord,
+        /// True when bound with the `<Leader:r>` token: after firing, the key
+        /// re-fires within `repeat-time-ms` without re-pressing the leader.
+        repeat: bool,
+    },
 }
 
 impl Binding {
@@ -305,7 +312,8 @@ impl Binding {
     /// leader-scoped binding.
     pub fn chord(&self) -> &KeyChord {
         match self {
-            Binding::Direct(chord) | Binding::Leader(chord) => chord,
+            Binding::Direct(chord) => chord,
+            Binding::Leader { chord, .. } => chord,
         }
     }
 }
@@ -414,13 +422,13 @@ impl Shortcuts {
             })
     }
 
-    /// Bound leader-scoped chords only: `(label, chord, action)`.
+    /// Bound leader-scoped chords only: `(label, chord, action, repeat)`.
     pub fn leader_chords(
         &self,
-    ) -> impl Iterator<Item = (&'static str, &KeyChord, ShortcutAction)> + '_ {
+    ) -> impl Iterator<Item = (&'static str, &KeyChord, ShortcutAction, bool)> + '_ {
         self.bindings_iter()
             .filter_map(|(label, bound, action)| match bound {
-                Some(Binding::Leader(chord)) => Some((label, chord, action)),
+                Some(Binding::Leader { chord, repeat }) => Some((label, chord, action, *repeat)),
                 _ => None,
             })
     }
@@ -432,7 +440,10 @@ impl Shortcuts {
 
     /// Detects chord collisions among leader-scoped bindings.
     pub(crate) fn validate_no_leader_conflicts(&self) -> Result<(), Vec<DuplicateChord>> {
-        conflicts(self.leader_chords())
+        conflicts(
+            self.leader_chords()
+                .map(|(label, chord, action, _)| (label, chord, action)),
+        )
     }
 
     /// Normalizes numeric fields: a `leader_tap_timeout_ms` of 0 is meaningless
@@ -466,11 +477,22 @@ pub enum ShortcutAction {
 /// Matched case-insensitively at the START of the value only.
 const LEADER_TOKEN: &str = "<Leader>";
 
-/// Strips a leading, case-insensitive `<Leader>` token, returning the remaining
-/// chord text. `None` when the value is not leader-scoped.
-fn strip_leader_prefix(value: &str) -> Option<&str> {
+/// The literal token marking a repeatable leader-scoped binding value
+/// (`<Leader:r>x`). Matched case-insensitively at the START of the value only.
+const LEADER_REPEAT_TOKEN: &str = "<Leader:r>";
+
+/// Strips a leading, case-insensitive `<Leader>` / `<Leader:r>` token,
+/// returning the remaining chord text and whether the repeat form was used.
+/// `None` when the value is not leader-scoped.
+fn strip_leader_prefix(value: &str) -> Option<(&str, bool)> {
+    if let Some((head, rest)) = value.split_at_checked(LEADER_REPEAT_TOKEN.len())
+        && head.eq_ignore_ascii_case(LEADER_REPEAT_TOKEN)
+    {
+        return Some((rest, true));
+    }
     let (head, rest) = value.split_at_checked(LEADER_TOKEN.len())?;
-    head.eq_ignore_ascii_case(LEADER_TOKEN).then_some(rest)
+    head.eq_ignore_ascii_case(LEADER_TOKEN)
+        .then_some((rest, false))
 }
 
 /// Parses a non-empty config value into a `Binding`: a leading `<Leader>`
@@ -478,7 +500,9 @@ fn strip_leader_prefix(value: &str) -> Option<&str> {
 /// `parse_key_chord`, so `"<Leader>"` (empty remainder) is an error.
 fn parse_binding(value: &str) -> Result<Binding, KeyChordParseError> {
     match strip_leader_prefix(value) {
-        Some(rest) => parse_key_chord(rest).map(Binding::Leader),
+        Some((rest, repeat)) => {
+            parse_key_chord(rest).map(|chord| Binding::Leader { chord, repeat })
+        }
         None => parse_key_chord(value).map(Binding::Direct),
     }
 }
@@ -505,7 +529,14 @@ where
     let text = match value {
         None => String::new(),
         Some(Binding::Direct(chord)) => chord.to_string(),
-        Some(Binding::Leader(chord)) => format!("{LEADER_TOKEN}{chord}"),
+        Some(Binding::Leader {
+            chord,
+            repeat: false,
+        }) => format!("{LEADER_TOKEN}{chord}"),
+        Some(Binding::Leader {
+            chord,
+            repeat: true,
+        }) => format!("{LEADER_REPEAT_TOKEN}{chord}"),
     };
     ser.serialize_str(&text)
 }
@@ -839,8 +870,11 @@ mod tests {
 
     #[test]
     fn strip_leader_prefix_only_at_start() {
-        assert_eq!(strip_leader_prefix("<Leader>s"), Some("s"));
-        assert_eq!(strip_leader_prefix("<Leader>Ctrl+d"), Some("Ctrl+d"));
+        assert_eq!(strip_leader_prefix("<Leader>s"), Some(("s", false)));
+        assert_eq!(
+            strip_leader_prefix("<Leader>Ctrl+d"),
+            Some(("Ctrl+d", false))
+        );
         assert_eq!(strip_leader_prefix("Cmd+<Leader>"), None);
         assert_eq!(strip_leader_prefix("s"), None);
         assert_eq!(strip_leader_prefix(""), None);
@@ -854,17 +888,26 @@ mod tests {
         );
         assert_eq!(
             parse_binding("<Leader>s").unwrap(),
-            Binding::Leader(parse_key_chord("s").unwrap())
+            Binding::Leader {
+                chord: parse_key_chord("s").unwrap(),
+                repeat: false,
+            }
         );
         assert_eq!(
             parse_binding("<Leader>Ctrl+d").unwrap(),
-            Binding::Leader(parse_key_chord("Ctrl+d").unwrap())
+            Binding::Leader {
+                chord: parse_key_chord("Ctrl+d").unwrap(),
+                repeat: false,
+            }
         );
     }
 
     #[test]
     fn parse_binding_leader_token_case_insensitive() {
-        let want = Binding::Leader(parse_key_chord("s").unwrap());
+        let want = Binding::Leader {
+            chord: parse_key_chord("s").unwrap(),
+            repeat: false,
+        };
         assert_eq!(parse_binding("<leader>s").unwrap(), want);
         assert_eq!(parse_binding("<LEADER>s").unwrap(), want);
     }
@@ -903,7 +946,10 @@ mod tests {
         let parsed: BindingWrapper = serde_json::from_str(r#"{"v":"<Leader>s"}"#).unwrap();
         assert_eq!(
             parsed.v,
-            Some(Binding::Leader(parse_key_chord("s").unwrap()))
+            Some(Binding::Leader {
+                chord: parse_key_chord("s").unwrap(),
+                repeat: false,
+            })
         );
     }
 
@@ -945,11 +991,17 @@ detach-session = "<Leader>d"
         );
         assert_eq!(
             s.enter_copy_mode,
-            Some(Binding::Leader(parse_key_chord("s").unwrap()))
+            Some(Binding::Leader {
+                chord: parse_key_chord("s").unwrap(),
+                repeat: false,
+            })
         );
         assert_eq!(
             s.detach_session,
-            Some(Binding::Leader(parse_key_chord("d").unwrap()))
+            Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            })
         );
         assert_eq!(
             s.paste,
@@ -980,8 +1032,14 @@ detach-session = "<Leader>d"
     #[test]
     fn leader_conflict_detected() {
         let s = Shortcuts {
-            enter_copy_mode: Some(Binding::Leader(parse_key_chord("d").unwrap())),
-            detach_session: Some(Binding::Leader(parse_key_chord("d").unwrap())),
+            enter_copy_mode: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            }),
+            detach_session: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            }),
             ..Default::default()
         };
         let err = s.validate_no_leader_conflicts().unwrap_err();
@@ -1001,7 +1059,10 @@ detach-session = "<Leader>d"
     fn serialize_leader_binding_emits_leader_token() {
         let s = Shortcuts {
             leader: Some(Leader::Chord(parse_key_chord("Ctrl+A").unwrap())),
-            detach_session: Some(Binding::Leader(parse_key_chord("d").unwrap())),
+            detach_session: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            }),
             ..Default::default()
         };
         let json = serde_json::to_string(&s).unwrap();
@@ -1089,5 +1150,76 @@ detach-session = "<Leader>d"
         };
         let json = serde_json::to_string(&s).unwrap();
         assert!(json.contains(r#""leader":"Cmd""#), "got {json}");
+    }
+
+    #[test]
+    fn strip_leader_prefix_detects_repeat_token() {
+        assert_eq!(strip_leader_prefix("<Leader>s"), Some(("s", false)));
+        assert_eq!(strip_leader_prefix("<Leader:r>s"), Some(("s", true)));
+        assert_eq!(
+            strip_leader_prefix("<leader:R>Ctrl+d"),
+            Some(("Ctrl+d", true))
+        );
+        assert_eq!(strip_leader_prefix("s"), None);
+        assert_eq!(strip_leader_prefix(""), None);
+    }
+
+    #[test]
+    fn parse_binding_repeat_leader() {
+        assert_eq!(
+            parse_binding("<Leader:r>h").unwrap(),
+            Binding::Leader {
+                chord: parse_key_chord("h").unwrap(),
+                repeat: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_binding_bare_repeat_token_is_err() {
+        assert!(parse_binding("<Leader:r>").is_err());
+    }
+
+    #[test]
+    fn serialize_repeat_leader_binding_emits_repeat_token() {
+        let s = Shortcuts {
+            detach_session: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: true,
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            json.contains(r#""detach-session":"<Leader:r>D""#),
+            "a repeat Leader binding serializes with the <Leader:r> token; got {json}"
+        );
+    }
+
+    #[test]
+    fn leader_chords_carries_repeat_flag() {
+        let s = Shortcuts {
+            enter_copy_mode: Some(Binding::Leader {
+                chord: parse_key_chord("s").unwrap(),
+                repeat: true,
+            }),
+            detach_session: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            }),
+            ..Default::default()
+        };
+        let entries: Vec<_> = s.leader_chords().collect();
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .any(|(l, _, _, r)| *l == "enter-copy-mode" && *r)
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|(l, _, _, r)| *l == "detach-session" && !*r)
+        );
     }
 }

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -504,8 +504,10 @@ fn strip_leader_prefix(value: &str) -> Option<(&str, bool)> {
 }
 
 /// Parses a non-empty config value into a `Binding`: a leading `<Leader>`
-/// selects `Leader`, otherwise `Direct`. The remainder is parsed by
-/// `parse_key_chord`, so `"<Leader>"` (empty remainder) is an error.
+/// or `<Leader:r>` selects `Leader`, with the `:r` form setting
+/// `repeat: true`; otherwise the value parses as `Direct`. The remainder is
+/// parsed by `parse_key_chord`, so `"<Leader>"` (empty remainder) is an
+/// error.
 fn parse_binding(value: &str) -> Result<Binding, KeyChordParseError> {
     match strip_leader_prefix(value) {
         Some((rest, repeat)) => {
@@ -529,7 +531,8 @@ where
 }
 
 /// serde field serializer for `Option<Binding>`: `None` → `""`,
-/// `Direct(c)` → `c`, `Leader(c)` → `"<Leader>" + c`.
+/// `Direct(c)` → `c`, `Leader { chord, repeat: false }` → `"<Leader>" + c`,
+/// `Leader { chord, repeat: true }` → `"<Leader:r>" + c`.
 fn ser_binding_or_unbind<S>(value: &Option<Binding>, ser: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -1043,6 +1046,25 @@ detach-session = "<Leader>d"
             enter_copy_mode: Some(Binding::Leader {
                 chord: parse_key_chord("d").unwrap(),
                 repeat: false,
+            }),
+            detach_session: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: false,
+            }),
+            ..Default::default()
+        };
+        let err = s.validate_no_leader_conflicts().unwrap_err();
+        assert_eq!(err.len(), 1);
+        assert!(err[0].actions.contains(&"enter-copy-mode"));
+        assert!(err[0].actions.contains(&"detach-session"));
+    }
+
+    #[test]
+    fn leader_conflict_detected_across_repeat_flag() {
+        let s = Shortcuts {
+            enter_copy_mode: Some(Binding::Leader {
+                chord: parse_key_chord("d").unwrap(),
+                repeat: true,
             }),
             detach_session: Some(Binding::Leader {
                 chord: parse_key_chord("d").unwrap(),

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -367,6 +367,13 @@ pub struct Shortcuts {
     /// with no intervening key/mouse press counts as a tap. Default 300; 0 is
     /// normalized to 300.
     pub leader_tap_timeout_ms: u64,
+    /// Repeat window (ms) for `<Leader:r>` bindings: after such a binding
+    /// fires, pressing a repeat-marked key again within this window re-fires
+    /// it without the leader; each fire re-arms the window. Default 500.
+    ///
+    /// 0 disables repeat entirely (tmux `repeat-time 0` parity) and is NOT
+    /// normalized away, unlike `leader_tap_timeout_ms`.
+    pub repeat_time_ms: u64,
 }
 
 impl Default for Shortcuts {
@@ -379,6 +386,7 @@ impl Default for Shortcuts {
             enter_copy_mode: Some(Binding::Direct(parse_default_chord("Cmd+S"))),
             detach_session: Some(Binding::Direct(parse_default_chord("Ctrl+Shift+D"))),
             leader_tap_timeout_ms: 300,
+            repeat_time_ms: 500,
         }
     }
 }
@@ -1051,7 +1059,7 @@ detach-session = "<Leader>d"
     #[test]
     fn default_shortcuts_json_snapshot() {
         let json = serde_json::to_string(&Shortcuts::default()).unwrap();
-        let expected = r#"{"leader":"Cmd","paste":"Cmd+V","release-webview-focus":"Ctrl+Shift+Escape","quit":"Cmd+Q","enter-copy-mode":"Cmd+S","detach-session":"Ctrl+Shift+D","leader-tap-timeout-ms":300}"#;
+        let expected = r#"{"leader":"Cmd","paste":"Cmd+V","release-webview-focus":"Ctrl+Shift+Escape","quit":"Cmd+Q","enter-copy-mode":"Cmd+S","detach-session":"Ctrl+Shift+D","leader-tap-timeout-ms":300,"repeat-time-ms":500}"#;
         assert_eq!(json, expected);
     }
 
@@ -1220,6 +1228,30 @@ detach-session = "<Leader>d"
             entries
                 .iter()
                 .any(|(l, _, _, r)| *l == "detach-session" && !*r)
+        );
+    }
+
+    #[test]
+    fn shortcuts_default_repeat_time_is_500() {
+        assert_eq!(Shortcuts::default().repeat_time_ms, 500);
+    }
+
+    #[test]
+    fn shortcuts_parses_repeat_time_ms() {
+        let s: Shortcuts = toml::from_str("repeat-time-ms = 250\n").unwrap();
+        assert_eq!(s.repeat_time_ms, 250);
+    }
+
+    #[test]
+    fn normalize_keeps_zero_repeat_time() {
+        let mut s = Shortcuts {
+            repeat_time_ms: 0,
+            ..Default::default()
+        };
+        s.normalize();
+        assert_eq!(
+            s.repeat_time_ms, 0,
+            "0 means repeat disabled; it must survive normalize()"
         );
     }
 }

--- a/crates/ozmux_configs/src/shortcuts.rs
+++ b/crates/ozmux_configs/src/shortcuts.rs
@@ -312,8 +312,7 @@ impl Binding {
     /// leader-scoped binding.
     pub fn chord(&self) -> &KeyChord {
         match self {
-            Binding::Direct(chord) => chord,
-            Binding::Leader { chord, .. } => chord,
+            Binding::Direct(chord) | Binding::Leader { chord, .. } => chord,
         }
     }
 }
@@ -540,14 +539,14 @@ where
     let text = match value {
         None => String::new(),
         Some(Binding::Direct(chord)) => chord.to_string(),
-        Some(Binding::Leader {
-            chord,
-            repeat: false,
-        }) => format!("{LEADER_TOKEN}{chord}"),
-        Some(Binding::Leader {
-            chord,
-            repeat: true,
-        }) => format!("{LEADER_REPEAT_TOKEN}{chord}"),
+        Some(Binding::Leader { chord, repeat }) => {
+            let token = if *repeat {
+                LEADER_REPEAT_TOKEN
+            } else {
+                LEADER_TOKEN
+            };
+            format!("{token}{chord}")
+        }
     };
     ser.serialize_str(&text)
 }

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -82,11 +82,18 @@ leader = "Cmd"
 # Modifier-tap window (ms): a press+release within this time, with no intervening
 # key or mouse press, counts as a tap. Default 300; 0 reverts to 300.
 leader-tap-timeout-ms = 300
+# Repeat window (ms) for "<Leader:r>..." bindings: after such a binding fires,
+# pressing a repeat-marked key again within this window re-fires the action
+# without the leader. Each fire re-arms the window. Default 500; 0 disables
+# repeat entirely.
+repeat-time-ms = 500
 
 # Each action takes ONE value: a direct chord ("Cmd+V"), a leader-scoped
-# chord ("<Leader>s" = leader then s), or "" to unbind. Rebinding to a chord
-# already used by another action is a startup validation error. A direct
-# chord and a "<Leader>"-prefixed chord with the same key never collide.
+# chord ("<Leader>s" = leader then s), a repeatable leader-scoped chord
+# ("<Leader:r>s" = same, but re-fires within repeat-time-ms), or "" to unbind.
+# Rebinding to a chord already used by another action is a startup validation
+# error. A direct chord and a "<Leader>"-prefixed chord with the same key
+# never collide.
 paste                 = "Cmd+V"
 release-webview-focus = "Ctrl+Shift+Escape"
 quit                  = "Cmd+Q"
@@ -110,6 +117,22 @@ Examples: `Cmd+Shift+Q`, `Ctrl+Alt+ArrowLeft`, `Cmd+Plus`.
 Invalid chords — an empty token (`Cmd+`), an unknown named key (`Cmd+F12`), a
 duplicated modifier (`Cmd+Meta+S`), or more than one key (`Cmd+S+T`) — fail at
 startup.
+
+## Repeatable bindings (`<Leader:r>`)
+
+Binding an action with `<Leader:r>` instead of `<Leader>` makes it repeatable,
+like tmux's `bind -r`: after the binding fires, pressing any repeat-marked key
+again within `repeat-time-ms` (default 500) re-fires its action without
+re-pressing the leader, and each fire re-arms the window. Holding the key down
+keeps firing (OS key auto-repeat participates). Any other key — including keys
+bound with plain `<Leader>` — closes the window immediately and is handled
+normally (it is never swallowed). Pressing the leader inside the window starts
+a fresh leader sequence.
+
+Caveat: with a letter key (say `<Leader:r>h`), typing that same letter into the
+shell within the window re-fires the action instead of reaching the terminal.
+If that bites, set `repeat-time-ms = 0` (disables repeat globally) or drop the
+`:r` marker from that binding.
 
 ## Shortcut actions
 

--- a/src/input/default_mode.rs
+++ b/src/input/default_mode.rs
@@ -7,7 +7,9 @@
 use crate::input::focus::MouseDisabled;
 use crate::input::focus::{KeyboardDisabled, KeyboardFocused};
 use crate::input::ime::{ImeCommit, ImeState};
-use crate::input::shortcuts::{LeaderGate, LeaderPhase, LeaderStep, Shortcuts, step_leader};
+use crate::input::shortcuts::{
+    LeaderGate, LeaderPhase, LeaderStep, Shortcuts, clear_leader_phase, step_leader,
+};
 use crate::input::{InputPhase, current_modifiers};
 use crate::mode::AppMode;
 use crate::surface_geom::phys_to_pane_local;
@@ -166,9 +168,7 @@ fn app_shortcut_handler(
 ) {
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if ime.is_composing() || !focused {
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
@@ -180,9 +180,7 @@ fn app_shortcut_handler(
             continue;
         }
         if webview_focused && shortcuts.is_release_webview_focus(ev.key_code, mods) {
-            if *leader_phase != LeaderPhase::Idle {
-                *leader_phase = LeaderPhase::Idle;
-            }
+            clear_leader_phase(&mut leader_phase);
             focused_webview.0 = None;
             continue;
         }
@@ -191,9 +189,7 @@ fn app_shortcut_handler(
         // here instead of stepping the state machine prevents a stale leader
         // from firing once keyboard focus returns to the terminal.
         let (action, via_leader) = if webview_focused {
-            if *leader_phase != LeaderPhase::Idle {
-                *leader_phase = LeaderPhase::Idle;
-            }
+            clear_leader_phase(&mut leader_phase);
             (shortcuts.match_gui_action(ev.key_code, mods), false)
         } else {
             // NOTE: OS key auto-repeat delivers extra Pressed events; feeding

--- a/src/input/default_mode.rs
+++ b/src/input/default_mode.rs
@@ -7,7 +7,7 @@
 use crate::input::focus::MouseDisabled;
 use crate::input::focus::{KeyboardDisabled, KeyboardFocused};
 use crate::input::ime::{ImeCommit, ImeState};
-use crate::input::shortcuts::{LeaderGate, LeaderPending, LeaderStep, Shortcuts, step_leader};
+use crate::input::shortcuts::{LeaderGate, LeaderPhase, LeaderStep, Shortcuts, step_leader};
 use crate::input::{InputPhase, current_modifiers};
 use crate::mode::AppMode;
 use crate::surface_geom::phys_to_pane_local;
@@ -17,6 +17,7 @@ use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::prelude::*;
+use bevy::time::Real;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
@@ -155,45 +156,53 @@ fn app_shortcut_handler(
     mut exit: MessageWriter<AppExit>,
     mut events: MessageReader<KeyboardInput>,
     mut focused_webview: ResMut<FocusedWebview>,
-    mut leader_pending: ResMut<LeaderPending>,
+    mut leader_phase: ResMut<LeaderPhase>,
     shortcuts: Res<Shortcuts>,
     ime: Res<ImeState>,
     bevy_keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     terminal: Query<Entity, (With<OzmaTerminal>, With<KeyboardFocused>)>,
+    time: Res<Time<Real>>,
 ) {
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if ime.is_composing() || !focused {
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
     let mods = current_modifiers(&bevy_keys);
     let webview_focused = focused_webview.0.is_some();
+    let now = time.elapsed();
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
         }
         if webview_focused && shortcuts.is_release_webview_focus(ev.key_code, mods) {
-            leader_pending.0 = false;
+            if *leader_phase != LeaderPhase::Idle {
+                *leader_phase = LeaderPhase::Idle;
+            }
             focused_webview.0 = None;
             continue;
         }
         // NOTE: the leader is honored only when a webview does not own the
-        // keyboard (v0 scope, mirrors tmux mode); resetting `leader_pending`
+        // keyboard (v0 scope, mirrors tmux mode); resetting the leader phase
         // here instead of stepping the state machine prevents a stale leader
         // from firing once keyboard focus returns to the terminal.
         let (action, via_leader) = if webview_focused {
-            leader_pending.0 = false;
+            if *leader_phase != LeaderPhase::Idle {
+                *leader_phase = LeaderPhase::Idle;
+            }
             (shortcuts.match_gui_action(ev.key_code, mods), false)
         } else {
             // NOTE: OS key auto-repeat delivers extra Pressed events; feeding
-            // them to step_leader would toggle `pending` by parity. Treat a
+            // them to step_leader would toggle the phase by parity. Treat a
             // repeat as Passthrough without stepping the machine.
             let step = if ev.repeat {
                 LeaderStep::Passthrough
             } else {
-                step_leader(&mut leader_pending.0, &shortcuts, ev.key_code, mods)
+                step_leader(&mut leader_phase, &shortcuts, ev.key_code, mods, now)
             };
             match step {
                 LeaderStep::RunAction(a) => (Some(a), true),

--- a/src/input/default_mode.rs
+++ b/src/input/default_mode.rs
@@ -15,7 +15,7 @@ use crate::ui::copy_mode::{CopyModeState, EnterCopyModeActionEvent};
 use crate::webview_pointer::topmost_surface_at;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
-use bevy::input::keyboard::KeyboardInput;
+use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::time::Real;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
@@ -197,9 +197,10 @@ fn app_shortcut_handler(
             (shortcuts.match_gui_action(ev.key_code, mods), false)
         } else {
             // NOTE: OS key auto-repeat delivers extra Pressed events; feeding
-            // them to step_leader would toggle the phase by parity. Treat a
-            // repeat as Passthrough without stepping the machine.
-            let step = if ev.repeat {
+            // them to step_leader outside the repeat window would toggle the
+            // pending phase by parity. Inside the window they must step the
+            // machine so held keys keep firing (tmux parity).
+            let step = if ev.repeat && !matches!(*leader_phase, LeaderPhase::Repeat { .. }) {
                 LeaderStep::Passthrough
             } else {
                 step_leader(&mut leader_phase, &shortcuts, ev.key_code, mods, now)
@@ -266,11 +267,20 @@ fn gui_action_suppressed_by_webview(webview_focused: bool, action: ShortcutActio
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::focus::KeyboardFocused;
+    use crate::input::shortcuts::{LeaderPhase, test_shortcuts_with_repeat_prefix};
     use bevy::app::App;
+    use bevy::app::AppExit;
     use bevy::ecs::resource::Resource;
+    use bevy::input::ButtonInput;
+    use bevy::input::ButtonState;
+    use bevy::input::keyboard::{Key, KeyboardInput};
     use bevy::prelude::{Entity, MinimalPlugins, On, ResMut};
+    use bevy::window::PrimaryWindow;
+    use ozma_terminal::OzmaTerminal;
     use ozma_tty_engine::TerminalKeyInput;
     use ozmux_tmux::{PaneId, TmuxPane};
+    use std::time::Duration;
     use tmux_control_parser::CellDims;
 
     #[test]
@@ -471,5 +481,86 @@ mod tests {
             "webview focus alone must NOT MouseDisable the shell — an off-rect click must fall \
              through to the terminal (and clear webview focus in the router)"
         );
+    }
+
+    #[derive(Resource, Default)]
+    struct CopyModeHits(u32);
+
+    fn repeat_dispatch_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_message::<KeyboardInput>()
+            .add_message::<AppExit>()
+            .init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<ImeState>()
+            .init_resource::<FocusedWebview>()
+            .init_resource::<LeaderPhase>()
+            .init_resource::<CopyModeHits>()
+            .insert_resource(test_shortcuts_with_repeat_prefix(
+                KeyCode::KeyH,
+                ShortcutAction::EnterCopyMode,
+                Duration::from_secs(60),
+            ))
+            .add_systems(Update, app_shortcut_handler)
+            .add_observer(
+                |_ev: On<EnterCopyModeActionEvent>, mut hits: ResMut<CopyModeHits>| {
+                    hits.0 += 1;
+                },
+            );
+        app.world_mut().spawn((
+            Window {
+                focused: true,
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        app
+    }
+
+    fn send_key_repeat(app: &mut App, key_code: KeyCode, repeat: bool) {
+        app.world_mut().write_message(KeyboardInput {
+            key_code,
+            logical_key: Key::Character("h".into()),
+            state: ButtonState::Pressed,
+            text: None,
+            repeat,
+            window: Entity::PLACEHOLDER,
+        });
+    }
+
+    #[test]
+    fn os_key_repeat_refires_inside_repeat_window() {
+        let mut app = repeat_dispatch_app();
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Repeat {
+            deadline: Duration::from_secs(60),
+        };
+        send_key_repeat(&mut app, KeyCode::KeyH, true);
+        app.update();
+        assert_eq!(
+            app.world().resource::<CopyModeHits>().0,
+            1,
+            "an OS auto-repeat of a repeat-marked key must re-fire inside the window (tmux parity)"
+        );
+        assert!(
+            matches!(
+                *app.world().resource::<LeaderPhase>(),
+                LeaderPhase::Repeat { .. }
+            ),
+            "firing must keep (re-arm) the window"
+        );
+    }
+
+    #[test]
+    fn os_key_repeat_outside_window_stays_passthrough() {
+        let mut app = repeat_dispatch_app();
+        send_key_repeat(&mut app, KeyCode::KeyH, true);
+        app.update();
+        assert_eq!(
+            app.world().resource::<CopyModeHits>().0,
+            0,
+            "auto-repeat with no window open must not step the leader machine"
+        );
+        assert_eq!(*app.world().resource::<LeaderPhase>(), LeaderPhase::Idle);
     }
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -13,7 +13,6 @@ use bevy::prelude::*;
 use bevy::time::Real;
 use ozma_terminal::{OzmaTerminal, PasteAction};
 use ozma_tty_engine::{TerminalKey, TerminalKeyInput, TerminalModifiers};
-use ozmux_configs::shortcuts::Modifiers;
 
 /// Registers `TerminalInputBindings` and the default keyboard dispatcher.
 pub(super) struct KeyboardInputPlugin;
@@ -69,12 +68,7 @@ fn dispatch_input(
         return;
     };
     let mods = current_terminal_modifiers(&keys);
-    let cfg_mods = Modifiers {
-        ctrl: mods.ctrl,
-        shift: mods.shift,
-        alt: mods.alt,
-        meta: mods.meta,
-    };
+    let cfg_mods = current_modifiers(&keys);
     let now = time.elapsed();
     let mut repeat_deadline = match *leader_phase {
         LeaderPhase::Repeat { deadline } => Some(deadline),
@@ -95,6 +89,13 @@ fn dispatch_input(
         }
         if suppress_leader_second_key && !is_modifier_key(ev.key_code) {
             suppress_leader_second_key = false;
+            // NOTE: the consumed second key opens the repeat window in Advance;
+            // the local snapshot must open with it, or a duplicate press of the
+            // same repeat-marked key later in the SAME frame would be typed to
+            // the PTY here yet also fire the action again in Advance.
+            if shortcuts.opens_repeat_window(ev.key_code, cfg_mods) {
+                repeat_deadline = Some(now);
+            }
             continue;
         }
         // NOTE: while the repeat window is open, withhold ONLY keys that match a
@@ -290,6 +291,30 @@ mod tests {
             c.keys,
             vec![TerminalKey::Text("b".into()), TerminalKey::Text("h".into())],
             "a non-matching key closes the window for the rest of the frame; the repeat key after it must be typed, not withheld"
+        );
+    }
+
+    #[test]
+    fn pending_second_key_opens_withholding_for_same_frame_duplicate() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        app.world_mut()
+            .insert_resource(test_shortcuts_with_repeat_prefix(
+                KeyCode::KeyH,
+                ShortcutAction::EnterCopyMode,
+                Duration::from_millis(500),
+            ));
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        // The second key opens the repeat window in Advance; a duplicate press
+        // in the SAME frame must be withheld here too, or it is typed to the
+        // PTY while Advance fires the action for it a second time.
+        press(&mut app, KeyCode::KeyH, Key::Character("h".into()));
+        press(&mut app, KeyCode::KeyH, Key::Character("h".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert!(
+            c.keys.is_empty(),
+            "a same-frame duplicate of the window-opening second key must be withheld, not typed"
         );
     }
 

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -4,14 +4,16 @@
 
 use crate::input::bindings::{ReservedChord, TerminalInputBindings};
 use crate::input::focus::{KeyboardDisabled, KeyboardFocused};
-use crate::input::shortcuts::{LeaderGate, LeaderPhase, is_modifier_key};
+use crate::input::shortcuts::{LeaderGate, LeaderPhase, Shortcuts, is_modifier_key};
 use crate::input::{InputPhase, current_modifiers};
 use bevy::ecs::message::MessageReader;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::prelude::*;
+use bevy::time::Real;
 use ozma_terminal::{OzmaTerminal, PasteAction};
 use ozma_tty_engine::{TerminalKey, TerminalKeyInput, TerminalModifiers};
+use ozmux_configs::shortcuts::Modifiers;
 
 /// Registers `TerminalInputBindings` and the default keyboard dispatcher.
 pub(super) struct KeyboardInputPlugin;
@@ -47,6 +49,8 @@ fn dispatch_input(
     bindings: Res<TerminalInputBindings>,
     keys: Res<ButtonInput<KeyCode>>,
     leader_phase: Res<LeaderPhase>,
+    shortcuts: Res<Shortcuts>,
+    time: Res<Time<Real>>,
     terminal: Query<
         Entity,
         (
@@ -65,6 +69,17 @@ fn dispatch_input(
         return;
     };
     let mods = current_terminal_modifiers(&keys);
+    let cfg_mods = Modifiers {
+        ctrl: mods.ctrl,
+        shift: mods.shift,
+        alt: mods.alt,
+        meta: mods.meta,
+    };
+    let now = time.elapsed();
+    let repeat_deadline = match *leader_phase {
+        LeaderPhase::Repeat { deadline } => Some(deadline),
+        _ => None,
+    };
     // NOTE: while a leader chord is pending its second key, suppress ONLY that
     // one key (the first non-modifier Pressed this frame) from the PTY — the
     // leader machine (`app_shortcut_handler`, ordered after this via
@@ -80,6 +95,18 @@ fn dispatch_input(
         }
         if suppress_leader_second_key && !is_modifier_key(ev.key_code) {
             suppress_leader_second_key = false;
+            continue;
+        }
+        // NOTE: while the repeat window is open, withhold ONLY keys that match a
+        // repeat-marked leader binding (the leader machine in
+        // LeaderGate::Advance fires them). Withholding anything else here would
+        // eat ordinary typing during the window.
+        if let Some(deadline) = repeat_deadline
+            && now <= deadline
+            && shortcuts
+                .match_repeat_prefix(ev.key_code, cfg_mods)
+                .is_some()
+        {
             continue;
         }
         if bindings
@@ -138,6 +165,9 @@ fn bevy_key_to_terminal_key(logical_key: &Key) -> Option<TerminalKey> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::shortcuts::test_shortcuts_with_repeat_prefix;
+    use ozmux_configs::shortcuts::ShortcutAction;
+    use std::time::Duration;
 
     #[derive(Resource, Default)]
     struct Captured {
@@ -152,6 +182,7 @@ mod tests {
             .init_resource::<ButtonInput<KeyCode>>()
             .init_resource::<Captured>()
             .init_resource::<LeaderPhase>()
+            .init_resource::<Shortcuts>()
             .add_plugins(KeyboardInputPlugin)
             .add_observer(|ev: On<PasteAction>, mut c: ResMut<Captured>| {
                 let _ = ev;
@@ -179,6 +210,62 @@ mod tests {
         app.world_mut()
             .resource_mut::<ButtonInput<KeyCode>>()
             .press(KeyCode::SuperLeft);
+    }
+
+    fn install_repeat_window(app: &mut App, deadline: Duration) {
+        app.world_mut()
+            .insert_resource(test_shortcuts_with_repeat_prefix(
+                KeyCode::KeyH,
+                ShortcutAction::EnterCopyMode,
+                Duration::from_millis(500),
+            ));
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Repeat { deadline };
+    }
+
+    #[test]
+    fn repeat_window_withholds_matching_key_from_pty() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        install_repeat_window(&mut app, Duration::from_secs(60));
+        press(&mut app, KeyCode::KeyH, Key::Character("h".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert!(
+            c.keys.is_empty(),
+            "a repeat-marked key inside the window is consumed by the leader machine, not typed"
+        );
+    }
+
+    #[test]
+    fn repeat_window_types_non_matching_key() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        install_repeat_window(&mut app, Duration::from_secs(60));
+        press(&mut app, KeyCode::KeyB, Key::Character("b".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert_eq!(
+            c.keys,
+            vec![TerminalKey::Text("b".into())],
+            "a non-matching key during the repeat window must reach the PTY"
+        );
+    }
+
+    #[test]
+    fn expired_repeat_window_types_matching_key() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        app.update();
+        std::thread::sleep(Duration::from_millis(2));
+        install_repeat_window(&mut app, Duration::ZERO);
+        press(&mut app, KeyCode::KeyH, Key::Character("h".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert_eq!(
+            c.keys,
+            vec![TerminalKey::Text("h".into())],
+            "an expired window must not withhold keys"
+        );
     }
 
     #[test]

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -4,7 +4,7 @@
 
 use crate::input::bindings::{ReservedChord, TerminalInputBindings};
 use crate::input::focus::{KeyboardDisabled, KeyboardFocused};
-use crate::input::shortcuts::{LeaderGate, LeaderPending, is_modifier_key};
+use crate::input::shortcuts::{LeaderGate, LeaderPhase, is_modifier_key};
 use crate::input::{InputPhase, current_modifiers};
 use bevy::ecs::message::MessageReader;
 use bevy::input::ButtonState;
@@ -46,7 +46,7 @@ fn dispatch_input(
     mut events: MessageReader<KeyboardInput>,
     bindings: Res<TerminalInputBindings>,
     keys: Res<ButtonInput<KeyCode>>,
-    leader_pending: Res<LeaderPending>,
+    leader_phase: Res<LeaderPhase>,
     terminal: Query<
         Entity,
         (
@@ -73,7 +73,7 @@ fn dispatch_input(
     // of the main key, and consuming the slot on it would leak the real second
     // key to the PTY. Clearing the whole batch would instead drop other keys
     // typed in the same frame.
-    let mut suppress_leader_second_key = leader_pending.0;
+    let mut suppress_leader_second_key = matches!(*leader_phase, LeaderPhase::Pending);
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
             continue;
@@ -151,7 +151,7 @@ mod tests {
         app.add_plugins(MinimalPlugins)
             .init_resource::<ButtonInput<KeyCode>>()
             .init_resource::<Captured>()
-            .init_resource::<LeaderPending>()
+            .init_resource::<LeaderPhase>()
             .add_plugins(KeyboardInputPlugin)
             .add_observer(|ev: On<PasteAction>, mut c: ResMut<Captured>| {
                 let _ = ev;
@@ -208,7 +208,7 @@ mod tests {
     fn leader_pending_suppresses_pty_typing() {
         let mut app = test_app();
         app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
-        app.world_mut().resource_mut::<LeaderPending>().0 = true;
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
         press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
         app.update();
         let c = app.world().resource::<Captured>();
@@ -223,7 +223,7 @@ mod tests {
     fn leader_pending_types_trailing_same_frame_keys() {
         let mut app = test_app();
         app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
-        app.world_mut().resource_mut::<LeaderPending>().0 = true;
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
         // The leader's second key (a) is suppressed; a trailing same-frame key
         // (b) must still reach the PTY.
         press(&mut app, KeyCode::KeyA, Key::Character("a".into()));
@@ -237,7 +237,7 @@ mod tests {
     fn leader_pending_suppression_skips_bare_modifier() {
         let mut app = test_app();
         app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
-        app.world_mut().resource_mut::<LeaderPending>().0 = true;
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
         // The second chord's modifier (Ctrl) emits its own Pressed event ahead
         // of the main key; it must NOT consume the suppression slot, or the real
         // second key (d) would leak to the PTY.

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -76,7 +76,7 @@ fn dispatch_input(
         meta: mods.meta,
     };
     let now = time.elapsed();
-    let repeat_deadline = match *leader_phase {
+    let mut repeat_deadline = match *leader_phase {
         LeaderPhase::Repeat { deadline } => Some(deadline),
         _ => None,
     };
@@ -100,14 +100,23 @@ fn dispatch_input(
         // NOTE: while the repeat window is open, withhold ONLY keys that match a
         // repeat-marked leader binding (the leader machine in
         // LeaderGate::Advance fires them). Withholding anything else here would
-        // eat ordinary typing during the window.
+        // eat ordinary typing during the window. `step_leader` (which runs
+        // after this system, per LeaderGate::Read.before(Advance)) closes the
+        // window on the first non-matching key of the batch, so the local
+        // snapshot must close with it: otherwise a repeat-marked key later in
+        // the SAME frame would be withheld here yet evaluate as Passthrough in
+        // Advance (window already closed) — fired nowhere, silently swallowed.
         if let Some(deadline) = repeat_deadline
             && now <= deadline
-            && shortcuts
+            && !is_modifier_key(ev.key_code)
+        {
+            if shortcuts
                 .match_repeat_prefix(ev.key_code, cfg_mods)
                 .is_some()
-        {
-            continue;
+            {
+                continue;
+            }
+            repeat_deadline = None;
         }
         if bindings
             .reserved
@@ -265,6 +274,22 @@ mod tests {
             c.keys,
             vec![TerminalKey::Text("h".into())],
             "an expired window must not withhold keys"
+        );
+    }
+
+    #[test]
+    fn window_closing_key_stops_withholding_same_frame() {
+        let mut app = test_app();
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        install_repeat_window(&mut app, Duration::from_secs(60));
+        press(&mut app, KeyCode::KeyB, Key::Character("b".into()));
+        press(&mut app, KeyCode::KeyH, Key::Character("h".into()));
+        app.update();
+        let c = app.world().resource::<Captured>();
+        assert_eq!(
+            c.keys,
+            vec![TerminalKey::Text("b".into()), TerminalKey::Text("h".into())],
+            "a non-matching key closes the window for the rest of the frame; the repeat key after it must be typed, not withheld"
         );
     }
 

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -191,27 +191,6 @@ impl Shortcuts {
         }
     }
 
-    /// True when `(keycode, mods)` is the configured leader chord.
-    fn is_leader(&self, keycode: KeyCode, mods: Modifiers) -> bool {
-        matches!(self.leader, Some(ResolvedLeader::Chord(kc, m)) if kc == keycode && m == mods)
-    }
-
-    fn tap_modifier(&self) -> Option<TapModifier> {
-        match self.leader {
-            Some(ResolvedLeader::Tap(m)) => Some(m),
-            _ => None,
-        }
-    }
-
-    /// Returns the leader-scoped action bound to `(keycode, mods)`, if any.
-    /// Excludes `ReleaseWebviewFocus` (mirrors `match_gui_action`): leader
-    /// dispatch only runs when no webview is focused, so a leader-scoped
-    /// release-webview-focus could never fire — resolving it to `Swallow`
-    /// avoids a dead `RunAction`.
-    fn match_prefix_action(&self, keycode: KeyCode, mods: Modifiers) -> Option<ShortcutAction> {
-        self.match_prefix_entry(keycode, mods).map(|s| s.action)
-    }
-
     /// Returns the leader-scoped action bound to `(keycode, mods)` when the
     /// binding is repeat-marked (`<Leader:r>`). The single predicate shared by
     /// `step_leader` (transition) and `dispatch_input` (PTY withholding) so the
@@ -226,9 +205,23 @@ impl Shortcuts {
             .map(|s| s.action)
     }
 
+    /// True when `(keycode, mods)` is the configured leader chord.
+    fn is_leader(&self, keycode: KeyCode, mods: Modifiers) -> bool {
+        matches!(self.leader, Some(ResolvedLeader::Chord(kc, m)) if kc == keycode && m == mods)
+    }
+
+    fn tap_modifier(&self) -> Option<TapModifier> {
+        match self.leader {
+            Some(ResolvedLeader::Tap(m)) => Some(m),
+            _ => None,
+        }
+    }
+
     /// Returns the prefix-table entry bound to `(keycode, mods)`, excluding
-    /// `ReleaseWebviewFocus` (mirrors `match_gui_action`; see
-    /// `match_prefix_action`'s rationale).
+    /// `ReleaseWebviewFocus` (mirrors `match_gui_action`): leader dispatch only
+    /// runs when no webview is focused, so a leader-scoped
+    /// release-webview-focus could never fire — resolving it to `Swallow`
+    /// avoids a dead `RunAction`.
     fn match_prefix_entry(&self, keycode: KeyCode, mods: Modifiers) -> Option<&OzmuxShortcut> {
         self.prefix.iter().find(|s| {
             s.action != ShortcutAction::ReleaseWebviewFocus
@@ -847,6 +840,20 @@ mod tests {
     }
 
     #[test]
+    fn test_constructor_builds_repeat_prefix() {
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyH,
+            ShortcutAction::EnterCopyMode,
+            ms(500),
+        );
+        assert_eq!(
+            sc.match_repeat_prefix(KeyCode::KeyH, mods(false, false, false, false)),
+            Some(ShortcutAction::EnterCopyMode)
+        );
+        assert!(sc.is_leader(KeyCode::KeyA, mods(true, false, false, false)));
+    }
+
+    #[test]
     fn step_tap_fires_on_quick_press_release() {
         let mut armed = None;
         assert_eq!(
@@ -979,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn match_prefix_action_excludes_release_webview_focus() {
+    fn match_prefix_entry_excludes_release_webview_focus() {
         let s = Shortcuts {
             direct: Vec::new(),
             prefix: vec![OzmuxShortcut {
@@ -996,7 +1003,8 @@ mod tests {
             repeat_time: Duration::from_millis(500),
         };
         assert_eq!(
-            s.match_prefix_action(KeyCode::KeyR, mods(false, false, false, false)),
+            s.match_prefix_entry(KeyCode::KeyR, mods(false, false, false, false))
+                .map(|s| s.action),
             None,
             "a leader-scoped release-webview-focus resolves to Swallow, not a dead RunAction",
         );
@@ -1100,7 +1108,7 @@ mod tests {
     }
 
     #[test]
-    fn match_prefix_action_resolves_and_requires_exact_mods() {
+    fn match_prefix_entry_resolves_and_requires_exact_mods() {
         let s = Shortcuts {
             direct: Vec::new(),
             prefix: vec![OzmuxShortcut {
@@ -1117,15 +1125,18 @@ mod tests {
             repeat_time: Duration::from_millis(500),
         };
         assert_eq!(
-            s.match_prefix_action(KeyCode::KeyS, mods(false, false, false, false)),
+            s.match_prefix_entry(KeyCode::KeyS, mods(false, false, false, false))
+                .map(|s| s.action),
             Some(ShortcutAction::EnterCopyMode)
         );
         assert_eq!(
-            s.match_prefix_action(KeyCode::KeyS, mods(false, true, false, false)),
+            s.match_prefix_entry(KeyCode::KeyS, mods(false, true, false, false))
+                .map(|s| s.action),
             None
         );
         assert_eq!(
-            s.match_prefix_action(KeyCode::KeyD, mods(false, false, false, false)),
+            s.match_prefix_entry(KeyCode::KeyD, mods(false, false, false, false))
+                .map(|s| s.action),
             None
         );
     }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -141,7 +141,7 @@ impl Shortcuts {
         keycode: KeyCode,
         mods: Modifiers,
     ) -> Option<ShortcutAction> {
-        Self::match_action_in(&self.direct, keycode, mods)
+        Self::find_entry(&self.direct, keycode, mods).map(|s| s.action)
     }
 
     /// True when `(keycode, mods)` matches the configured release-webview-focus
@@ -205,6 +205,14 @@ impl Shortcuts {
             .map(|s| s.action)
     }
 
+    /// True when a leader second key `(keycode, mods)` opens the repeat window:
+    /// it matches a repeat-marked prefix binding and `repeat_time` is non-zero.
+    /// Mirrors the `step_leader` Pending arm so `dispatch_input` can start
+    /// withholding in the same frame the window opens.
+    pub(crate) fn opens_repeat_window(&self, keycode: KeyCode, mods: Modifiers) -> bool {
+        !self.repeat_time.is_zero() && self.match_repeat_prefix(keycode, mods).is_some()
+    }
+
     /// True when `(keycode, mods)` is the configured leader chord.
     fn is_leader(&self, keycode: KeyCode, mods: Modifiers) -> bool {
         matches!(self.leader, Some(ResolvedLeader::Chord(kc, m)) if kc == keycode && m == mods)
@@ -223,28 +231,22 @@ impl Shortcuts {
     /// release-webview-focus could never fire — resolving it to `Swallow`
     /// avoids a dead `RunAction`.
     fn match_prefix_entry(&self, keycode: KeyCode, mods: Modifiers) -> Option<&OzmuxShortcut> {
-        self.prefix.iter().find(|s| {
+        Self::find_entry(&self.prefix, keycode, mods)
+    }
+
+    /// Returns the first entry in `table` bound to `(keycode, mods)`, excluding
+    /// `ReleaseWebviewFocus` (matched separately via `is_release_webview_focus`).
+    /// The single exclusion predicate behind both the direct and prefix lookups.
+    fn find_entry(
+        table: &[OzmuxShortcut],
+        keycode: KeyCode,
+        mods: Modifiers,
+    ) -> Option<&OzmuxShortcut> {
+        table.iter().find(|s| {
             s.action != ShortcutAction::ReleaseWebviewFocus
                 && s.keycode == keycode
                 && s.modifiers == mods
         })
-    }
-
-    /// Returns the first action in `table` bound to `(keycode, mods)`, excluding
-    /// `ReleaseWebviewFocus` (matched separately via `is_release_webview_focus`).
-    fn match_action_in(
-        table: &[OzmuxShortcut],
-        keycode: KeyCode,
-        mods: Modifiers,
-    ) -> Option<ShortcutAction> {
-        table
-            .iter()
-            .find(|s| {
-                s.action != ShortcutAction::ReleaseWebviewFocus
-                    && s.keycode == keycode
-                    && s.modifiers == mods
-            })
-            .map(|s| s.action)
     }
 }
 
@@ -316,13 +318,51 @@ pub(crate) fn step_leader(
     LeaderStep::Passthrough
 }
 
+/// Resets the shared leader phase to `Idle`, writing through the `ResMut` only
+/// on a real change so Bevy change detection fires exactly when the phase was
+/// engaged. The single reset idiom for every dispatcher drain/abort site.
+pub(crate) fn clear_leader_phase(leader_phase: &mut ResMut<LeaderPhase>) {
+    if **leader_phase != LeaderPhase::Idle {
+        **leader_phase = LeaderPhase::Idle;
+    }
+}
+
+/// Test-only constructor: a `Shortcuts` with one repeat-marked, modifier-less
+/// prefix binding and a `Ctrl+A` chord leader. Used by the keyboard and
+/// dispatcher tests, which cannot name this module's private fields.
+#[cfg(test)]
+pub(crate) fn test_shortcuts_with_repeat_prefix(
+    keycode: KeyCode,
+    action: ShortcutAction,
+    repeat_time: Duration,
+) -> Shortcuts {
+    Shortcuts {
+        direct: Vec::new(),
+        prefix: vec![OzmuxShortcut {
+            keycode,
+            modifiers: Modifiers::default(),
+            action,
+            repeat: true,
+        }],
+        leader: Some(ResolvedLeader::Chord(
+            KeyCode::KeyA,
+            Modifiers {
+                ctrl: true,
+                shift: false,
+                alt: false,
+                meta: false,
+            },
+        )),
+        tap_timeout: Duration::from_millis(300),
+        repeat_time,
+    }
+}
+
 /// Clears the leader phase (pending or repeat window) and any in-progress
 /// modifier tap on an `AppMode` transition or a webview focus change, so a
 /// leader engaged/armed in one context never fires in another.
 fn reset_leader_phase(mut leader_phase: ResMut<LeaderPhase>, mut tap: ResMut<ModifierTapState>) {
-    if *leader_phase != LeaderPhase::Idle {
-        *leader_phase = LeaderPhase::Idle;
-    }
+    clear_leader_phase(&mut leader_phase);
     if tap.armed.is_some() {
         tap.armed = None;
     }
@@ -632,37 +672,6 @@ fn key_to_keycode(key: &ConfigKey) -> Option<KeyCode> {
         ConfigKey::Plus => return None,
         ConfigKey::Other(_) => return None,
     })
-}
-
-/// Test-only constructor: a `Shortcuts` with one repeat-marked, modifier-less
-/// prefix binding and a `Ctrl+A` chord leader. Used by the keyboard and
-/// dispatcher tests, which cannot name this module's private fields.
-#[cfg(test)]
-pub(crate) fn test_shortcuts_with_repeat_prefix(
-    keycode: KeyCode,
-    action: ShortcutAction,
-    repeat_time: Duration,
-) -> Shortcuts {
-    Shortcuts {
-        direct: Vec::new(),
-        prefix: vec![OzmuxShortcut {
-            keycode,
-            modifiers: Modifiers::default(),
-            action,
-            repeat: true,
-        }],
-        leader: Some(ResolvedLeader::Chord(
-            KeyCode::KeyA,
-            Modifiers {
-                ctrl: true,
-                shift: false,
-                alt: false,
-                meta: false,
-            },
-        )),
-        tap_timeout: Duration::from_millis(300),
-        repeat_time,
-    }
 }
 
 #[cfg(test)]
@@ -1475,9 +1484,9 @@ mod tests {
         app.update();
         tap_key(&mut app, KeyCode::SuperLeft, ButtonState::Released);
         app.update();
-        assert_ne!(
+        assert_eq!(
             *app.world().resource::<LeaderPhase>(),
-            LeaderPhase::Pending,
+            LeaderPhase::Idle,
             "mouse press in a keyboard-less frame must disarm the tap and suppress the leader"
         );
     }
@@ -1497,9 +1506,9 @@ mod tests {
             .clear();
         tap_key(&mut app, KeyCode::SuperLeft, ButtonState::Released);
         app.update();
-        assert_ne!(
+        assert_eq!(
             *app.world().resource::<LeaderPhase>(),
-            LeaderPhase::Pending,
+            LeaderPhase::Idle,
             "a mouse press in the same frame as the modifier press must suppress the tap"
         );
     }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -120,6 +120,7 @@ pub(crate) struct Shortcuts {
     prefix: Vec<OzmuxShortcut>,
     leader: Option<ResolvedLeader>,
     tap_timeout: Duration,
+    repeat_time: Duration,
 }
 
 impl Shortcuts {
@@ -354,6 +355,7 @@ fn build_shortcuts(mut resolved: ResMut<Shortcuts>, configs: Res<OzmuxConfigsRes
     );
     resolved.prefix = resolve_from_chords(sc.leader_chords());
     resolved.tap_timeout = Duration::from_millis(sc.leader_tap_timeout_ms);
+    resolved.repeat_time = Duration::from_millis(sc.repeat_time_ms);
     // The leader (default Cmd tap) is only meaningful when there are
     // `<Leader>`-scoped bindings to reach; with none it stays inert, so a
     // default tap never swallows a key for users who bind no leader action.
@@ -653,6 +655,7 @@ mod tests {
             prefix: Vec::new(),
             leader: Some(ResolvedLeader::Tap(TapModifier::Meta)),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         assert_eq!(s.tap_modifier(), Some(TapModifier::Meta));
     }
@@ -664,6 +667,7 @@ mod tests {
             prefix: Vec::new(),
             leader: Some(ResolvedLeader::Tap(TapModifier::Meta)),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         assert!(!s.is_leader(KeyCode::SuperLeft, mods(false, false, false, true)));
         assert!(!s.is_leader(KeyCode::SuperLeft, mods(false, false, false, false)));
@@ -676,6 +680,7 @@ mod tests {
             prefix: Vec::new(),
             leader: Some(ResolvedLeader::Tap(TapModifier::Meta)),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         let b = s.input_bindings();
         assert!(
@@ -699,6 +704,7 @@ mod tests {
             prefix: Vec::new(),
             leader: None,
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         }
     }
 
@@ -712,6 +718,7 @@ mod tests {
                 mods(true, false, false, false),
             )),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         assert!(s.is_leader(KeyCode::KeyA, mods(true, false, false, false)));
         assert!(!s.is_leader(KeyCode::KeyA, mods(false, false, false, false)));
@@ -733,6 +740,7 @@ mod tests {
                 mods(true, false, false, false),
             )),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         assert_eq!(
             s.match_prefix_action(KeyCode::KeyR, mods(false, false, false, false)),
@@ -777,6 +785,7 @@ mod tests {
                 mods(true, false, false, false),
             )),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         let mut pending = false;
         assert!(matches!(
@@ -839,6 +848,7 @@ mod tests {
                 mods(true, false, false, false),
             )),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         };
         assert_eq!(
             s.match_prefix_action(KeyCode::KeyS, mods(false, false, false, false)),
@@ -1021,6 +1031,7 @@ mod tests {
                 mods(true, false, false, false),
             )),
             tap_timeout: Duration::from_millis(300),
+            repeat_time: Duration::from_millis(500),
         }
     }
 
@@ -1132,6 +1143,7 @@ mod tests {
                 prefix: Vec::new(),
                 leader: Some(ResolvedLeader::Tap(TapModifier::Meta)),
                 tap_timeout: Duration::from_millis(300),
+                repeat_time: Duration::from_millis(500),
             })
             .add_systems(Update, detect_modifier_tap);
         app.world_mut().spawn((
@@ -1237,5 +1249,18 @@ mod tests {
         };
         let resolved = resolved_shortcuts(config);
         assert_eq!(resolved.tap_modifier(), Some(TapModifier::Meta));
+    }
+
+    #[test]
+    fn build_shortcuts_resolves_repeat_time() {
+        let config = OzmuxConfigs {
+            shortcuts: ConfigShortcuts {
+                repeat_time_ms: 250,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let resolved = resolved_shortcuts(config);
+        assert_eq!(resolved.repeat_time, Duration::from_millis(250));
     }
 }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -108,6 +108,7 @@ struct OzmuxShortcut {
     keycode: KeyCode,
     modifiers: Modifiers,
     action: ShortcutAction,
+    repeat: bool,
 }
 
 /// The startup-resolved ozmux shortcut tables. Built once from
@@ -347,7 +348,10 @@ fn detect_modifier_tap(
 /// the empty default.
 fn build_shortcuts(mut resolved: ResMut<Shortcuts>, configs: Res<OzmuxConfigsResource>) {
     let sc = &configs.shortcuts;
-    resolved.direct = resolve_from_chords(sc.direct_chords());
+    resolved.direct = resolve_from_chords(
+        sc.direct_chords()
+            .map(|(label, chord, action)| (label, chord, action, false)),
+    );
     resolved.prefix = resolve_from_chords(sc.leader_chords());
     resolved.tap_timeout = Duration::from_millis(sc.leader_tap_timeout_ms);
     // The leader (default Cmd tap) is only meaningful when there are
@@ -415,15 +419,16 @@ fn ozma_mouse_config(mc: &MouseConfig) -> OzmaMouseConfig {
 /// Resolves each bound chord to an `OzmuxShortcut`, skipping (with a warning)
 /// any chord whose logical key has no physical `KeyCode`.
 fn resolve_from_chords<'a>(
-    chords: impl Iterator<Item = (&'static str, &'a KeyChord, ShortcutAction)>,
+    chords: impl Iterator<Item = (&'static str, &'a KeyChord, ShortcutAction, bool)>,
 ) -> Vec<OzmuxShortcut> {
     let mut out = Vec::new();
-    for (label, chord, action) in chords {
+    for (label, chord, action, repeat) in chords {
         match key_to_keycode(&chord.key) {
             Some(keycode) => out.push(OzmuxShortcut {
                 keycode,
                 modifiers: chord.modifiers,
                 action,
+                repeat,
             }),
             None => tracing::warn!(
                 label,
@@ -690,7 +695,7 @@ mod tests {
 
     fn direct_only(config: &ConfigShortcuts) -> Shortcuts {
         Shortcuts {
-            direct: resolve_from_chords(config.direct_chords()),
+            direct: resolve_from_chords(config.direct_chords().map(|(l, c, a)| (l, c, a, false))),
             prefix: Vec::new(),
             leader: None,
             tap_timeout: Duration::from_millis(300),
@@ -721,6 +726,7 @@ mod tests {
                 keycode: KeyCode::KeyR,
                 modifiers: mods(false, false, false, false),
                 action: ShortcutAction::ReleaseWebviewFocus,
+                repeat: false,
             }],
             leader: Some(ResolvedLeader::Chord(
                 KeyCode::KeyA,
@@ -764,6 +770,7 @@ mod tests {
                 keycode: KeyCode::KeyD,
                 modifiers: mods(true, false, false, false),
                 action: ShortcutAction::DetachSession,
+                repeat: false,
             }],
             leader: Some(ResolvedLeader::Chord(
                 KeyCode::KeyB,
@@ -825,6 +832,7 @@ mod tests {
                 keycode: KeyCode::KeyS,
                 modifiers: mods(false, false, false, false),
                 action: ShortcutAction::EnterCopyMode,
+                repeat: false,
             }],
             leader: Some(ResolvedLeader::Chord(
                 KeyCode::KeyA,
@@ -849,15 +857,20 @@ mod tests {
     #[test]
     fn resolve_from_chords_accepts_leader_chords() {
         let config = ConfigShortcuts {
-            detach_session: Some(Binding::Leader(
-                ozmux_configs::shortcuts::parse_key_chord("d").unwrap(),
-            )),
+            detach_session: Some(Binding::Leader {
+                chord: ozmux_configs::shortcuts::parse_key_chord("d").unwrap(),
+                repeat: true,
+            }),
             ..Default::default()
         };
         let resolved = resolve_from_chords(config.leader_chords());
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].keycode, KeyCode::KeyD);
         assert_eq!(resolved[0].action, ShortcutAction::DetachSession);
+        assert!(
+            resolved[0].repeat,
+            "the <Leader:r> flag must reach the resolved table"
+        );
     }
 
     #[test]
@@ -1001,6 +1014,7 @@ mod tests {
                 keycode: KeyCode::KeyS,
                 modifiers: mods(false, false, false, false),
                 action: ShortcutAction::EnterCopyMode,
+                repeat: false,
             }],
             leader: Some(ResolvedLeader::Chord(
                 KeyCode::KeyA,
@@ -1213,9 +1227,10 @@ mod tests {
     fn build_shortcuts_activates_default_cmd_leader_with_a_leader_binding() {
         let config = OzmuxConfigs {
             shortcuts: ConfigShortcuts {
-                detach_session: Some(Binding::Leader(
-                    ozmux_configs::shortcuts::parse_key_chord("d").unwrap(),
-                )),
+                detach_session: Some(Binding::Leader {
+                    chord: ozmux_configs::shortcuts::parse_key_chord("d").unwrap(),
+                    repeat: false,
+                }),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -25,7 +25,7 @@ pub(super) struct ShortcutsPlugin;
 impl Plugin for ShortcutsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Shortcuts>()
-            .init_resource::<LeaderPending>()
+            .init_resource::<LeaderPhase>()
             .init_resource::<ModifierTapState>()
             .configure_sets(
                 Update,
@@ -53,24 +53,34 @@ impl Plugin for ShortcutsPlugin {
                     // keyboard dispatchers never see the round-trip; without this reset a
                     // leader engaged before a mouse-only webview focus/blur would consume the
                     // next terminal keystroke as its second key.
-                    reset_leader_pending
+                    reset_leader_phase
                         .run_if(resource_exists_and_changed::<FocusedWebview>)
                         .before(LeaderGate::Detect),
                 ),
             )
-            .add_systems(OnExit(AppMode::Tmux), reset_leader_pending)
-            .add_systems(OnExit(AppMode::Default), reset_leader_pending);
+            .add_systems(OnExit(AppMode::Tmux), reset_leader_phase)
+            .add_systems(OnExit(AppMode::Default), reset_leader_phase);
     }
 }
 
-/// Shared leader-pending flag: `true` between a leader chord and its second key.
-/// Owned by `ShortcutsPlugin`; advanced by both the tmux and Default keyboard
-/// dispatchers and read by `dispatch_input` to suppress PTY typing mid-sequence.
-#[derive(Resource, Default)]
-pub(crate) struct LeaderPending(
-    /// `true` while a leader chord is pending its second key.
-    pub(crate) bool,
-);
+/// Shared leader phase: where the leader state machine is between keys.
+/// Owned by `ShortcutsPlugin`; advanced by the tmux and Default keyboard
+/// dispatchers and read by `dispatch_input` to withhold leader-consumed keys
+/// from PTY typing.
+#[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LeaderPhase {
+    /// No leader sequence in progress.
+    #[default]
+    Idle,
+    /// A leader fired; the next key resolves against the prefix table.
+    Pending,
+    /// A `<Leader:r>` binding fired; repeat-marked keys re-fire until the
+    /// deadline (extended on each fire) or a non-matching key closes it.
+    Repeat {
+        /// Absolute `Time<Real>::elapsed()` instant the window closes at.
+        deadline: Duration,
+    },
+}
 
 /// In-progress modifier-tap state: the target's down-time while armed.
 #[derive(Resource, Default)]
@@ -78,15 +88,15 @@ struct ModifierTapState {
     armed: Option<Duration>,
 }
 
-/// Orders the three `FocusedKey` systems that touch `LeaderPending` so
-/// `detect_modifier_tap` (`Detect`) sets the flag before `dispatch_input`
+/// Orders the three `FocusedKey` systems that touch `LeaderPhase` so
+/// `detect_modifier_tap` (`Detect`) sets it before `dispatch_input`
 /// (`Read`) observes it, and `app_shortcut_handler` (`Advance`) steps the
 /// leader machine and clears it last.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum LeaderGate {
-    /// `detect_modifier_tap`: sets `LeaderPending` on a modifier tap.
+    /// `detect_modifier_tap`: sets `LeaderPhase` to `Pending` on a modifier tap.
     Detect,
-    /// `dispatch_input`: reads `LeaderPending` to gate PTY typing.
+    /// `dispatch_input`: reads `LeaderPhase` to gate PTY typing.
     Read,
     /// `app_shortcut_handler` / `forward_keys_to_tmux`: advances the leader.
     Advance,
@@ -199,7 +209,32 @@ impl Shortcuts {
     /// release-webview-focus could never fire — resolving it to `Swallow`
     /// avoids a dead `RunAction`.
     fn match_prefix_action(&self, keycode: KeyCode, mods: Modifiers) -> Option<ShortcutAction> {
-        Self::match_action_in(&self.prefix, keycode, mods)
+        self.match_prefix_entry(keycode, mods).map(|s| s.action)
+    }
+
+    /// Returns the leader-scoped action bound to `(keycode, mods)` when the
+    /// binding is repeat-marked (`<Leader:r>`). The single predicate shared by
+    /// `step_leader` (transition) and `dispatch_input` (PTY withholding) so the
+    /// two can never disagree about which keys the repeat window consumes.
+    pub(crate) fn match_repeat_prefix(
+        &self,
+        keycode: KeyCode,
+        mods: Modifiers,
+    ) -> Option<ShortcutAction> {
+        self.match_prefix_entry(keycode, mods)
+            .filter(|s| s.repeat)
+            .map(|s| s.action)
+    }
+
+    /// Returns the prefix-table entry bound to `(keycode, mods)`, excluding
+    /// `ReleaseWebviewFocus` (mirrors `match_gui_action`; see
+    /// `match_prefix_action`'s rationale).
+    fn match_prefix_entry(&self, keycode: KeyCode, mods: Modifiers) -> Option<&OzmuxShortcut> {
+        self.prefix.iter().find(|s| {
+            s.action != ShortcutAction::ReleaseWebviewFocus
+                && s.keycode == keycode
+                && s.modifiers == mods
+        })
     }
 
     /// Returns the first action in `table` bound to `(keycode, mods)`, excluding
@@ -234,45 +269,66 @@ pub(crate) enum LeaderStep {
 }
 
 /// Advances the ozmux leader state machine for one pressed key, threading
-/// `pending` across frames (mirrors the tmux `plan_forward` prefix dispatch).
-/// Swallows the leader itself and any unmatched second key; returns
-/// `Passthrough` for unrelated keys.
+/// `phase` across frames. `now` is the caller's `Time<Real>::elapsed()`.
+/// Swallows the leader itself and any unmatched second key; drives the
+/// `<Leader:r>` repeat window (fire-and-extend inside the window, close and
+/// re-evaluate on any other key); returns `Passthrough` for unrelated keys.
 pub(crate) fn step_leader(
-    pending: &mut bool,
+    phase: &mut LeaderPhase,
     shortcuts: &Shortcuts,
     keycode: KeyCode,
     mods: Modifiers,
+    now: Duration,
 ) -> LeaderStep {
-    // NOTE: a bare modifier press must NOT touch `pending`. The second chord's
+    // NOTE: a bare modifier press must NOT touch the phase. The second chord's
     // modifier (e.g. Ctrl) emits its own `Pressed` event ahead of the main key;
     // stepping on it would consume the pending leader by parity and abort the
-    // sequence before the real key arrives.
+    // sequence. Closing the repeat window on it would likewise break
+    // modifier-carrying repeat chords (`<Leader:r>Ctrl+H`).
     if is_modifier_key(keycode) {
         return LeaderStep::Passthrough;
     }
-    if *pending {
-        *pending = false;
-        return match shortcuts.match_prefix_action(keycode, mods) {
-            Some(action) => LeaderStep::RunAction(action),
+    if let LeaderPhase::Repeat { deadline } = *phase {
+        if now <= deadline
+            && let Some(action) = shortcuts.match_repeat_prefix(keycode, mods)
+        {
+            *phase = LeaderPhase::Repeat {
+                deadline: now + shortcuts.repeat_time,
+            };
+            return LeaderStep::RunAction(action);
+        }
+        // NOTE: an expired window or a non-repeat key must close the window and
+        // fall through to normal evaluation below — swallowing the key here
+        // would eat ordinary typing (tmux re-dispatches the same way).
+        *phase = LeaderPhase::Idle;
+    }
+    if *phase == LeaderPhase::Pending {
+        *phase = LeaderPhase::Idle;
+        return match shortcuts.match_prefix_entry(keycode, mods) {
+            Some(entry) => {
+                if entry.repeat && !shortcuts.repeat_time.is_zero() {
+                    *phase = LeaderPhase::Repeat {
+                        deadline: now + shortcuts.repeat_time,
+                    };
+                }
+                LeaderStep::RunAction(entry.action)
+            }
             None => LeaderStep::Swallow,
         };
     }
     if shortcuts.is_leader(keycode, mods) {
-        *pending = true;
+        *phase = LeaderPhase::Pending;
         return LeaderStep::Swallow;
     }
     LeaderStep::Passthrough
 }
 
-/// Clears `LeaderPending` and any in-progress modifier tap on an `AppMode`
-/// transition or a webview focus change, so a leader engaged/armed in one
-/// context never fires in another.
-fn reset_leader_pending(
-    mut leader_pending: ResMut<LeaderPending>,
-    mut tap: ResMut<ModifierTapState>,
-) {
-    if leader_pending.0 {
-        leader_pending.0 = false;
+/// Clears the leader phase (pending or repeat window) and any in-progress
+/// modifier tap on an `AppMode` transition or a webview focus change, so a
+/// leader engaged/armed in one context never fires in another.
+fn reset_leader_phase(mut leader_phase: ResMut<LeaderPhase>, mut tap: ResMut<ModifierTapState>) {
+    if *leader_phase != LeaderPhase::Idle {
+        *leader_phase = LeaderPhase::Idle;
     }
     if tap.armed.is_some() {
         tap.armed = None;
@@ -285,15 +341,16 @@ fn tap_leader_enabled(shortcuts: Res<Shortcuts>) -> bool {
 }
 
 /// Detects a bare modifier tap (press+release within the timeout, no
-/// intervening key or mouse press) and engages `LeaderPending`. Mode-agnostic;
-/// runs in `LeaderGate::Detect` before the dispatchers read/advance the leader.
+/// intervening key or mouse press) and engages `LeaderPhase::Pending`.
+/// Mode-agnostic; runs in `LeaderGate::Detect` before the dispatchers
+/// read/advance the leader.
 ///
 /// Gated with `run_if(tap_leader_enabled)`. Reads press AND release
 /// `KeyboardInput` (the dispatchers only read `Pressed`), so it owns the tap
 /// gesture; the second key is handled by the existing `step_leader` pending arm.
 fn detect_modifier_tap(
     mut state: ResMut<ModifierTapState>,
-    mut leader_pending: ResMut<LeaderPending>,
+    mut leader_phase: ResMut<LeaderPhase>,
     mut keys: MessageReader<KeyboardInput>,
     mouse: Res<ButtonInput<MouseButton>>,
     time: Res<Time<Real>>,
@@ -330,8 +387,10 @@ fn detect_modifier_tap(
             } else {
                 continue;
             };
-            if step_tap(&mut armed, event, now, timeout) == TapOutcome::Fired && !leader_pending.0 {
-                leader_pending.0 = true;
+            if step_tap(&mut armed, event, now, timeout) == TapOutcome::Fired
+                && *leader_phase != LeaderPhase::Pending
+            {
+                *leader_phase = LeaderPhase::Pending;
             }
         }
     }
@@ -582,6 +641,37 @@ fn key_to_keycode(key: &ConfigKey) -> Option<KeyCode> {
     })
 }
 
+/// Test-only constructor: a `Shortcuts` with one repeat-marked, modifier-less
+/// prefix binding and a `Ctrl+A` chord leader. Used by the keyboard and
+/// dispatcher tests, which cannot name this module's private fields.
+#[cfg(test)]
+pub(crate) fn test_shortcuts_with_repeat_prefix(
+    keycode: KeyCode,
+    action: ShortcutAction,
+    repeat_time: Duration,
+) -> Shortcuts {
+    Shortcuts {
+        direct: Vec::new(),
+        prefix: vec![OzmuxShortcut {
+            keycode,
+            modifiers: Modifiers::default(),
+            action,
+            repeat: true,
+        }],
+        leader: Some(ResolvedLeader::Chord(
+            KeyCode::KeyA,
+            Modifiers {
+                ctrl: true,
+                shift: false,
+                alt: false,
+                meta: false,
+            },
+        )),
+        tap_timeout: Duration::from_millis(300),
+        repeat_time,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -591,6 +681,169 @@ mod tests {
 
     fn ms(n: u64) -> Duration {
         Duration::from_millis(n)
+    }
+
+    fn repeat_fixture() -> Shortcuts {
+        Shortcuts {
+            direct: Vec::new(),
+            prefix: vec![
+                OzmuxShortcut {
+                    keycode: KeyCode::KeyS,
+                    modifiers: mods(false, false, false, false),
+                    action: ShortcutAction::EnterCopyMode,
+                    repeat: true,
+                },
+                OzmuxShortcut {
+                    keycode: KeyCode::KeyD,
+                    modifiers: mods(false, false, false, false),
+                    action: ShortcutAction::DetachSession,
+                    repeat: true,
+                },
+                OzmuxShortcut {
+                    keycode: KeyCode::KeyP,
+                    modifiers: mods(false, false, false, false),
+                    action: ShortcutAction::Paste,
+                    repeat: false,
+                },
+            ],
+            leader: Some(ResolvedLeader::Chord(
+                KeyCode::KeyA,
+                mods(true, false, false, false),
+            )),
+            tap_timeout: ms(300),
+            repeat_time: ms(500),
+        }
+    }
+
+    fn no_mods() -> Modifiers {
+        mods(false, false, false, false)
+    }
+
+    #[test]
+    fn repeat_binding_opens_window_and_refires_without_leader() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Pending;
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyS, no_mods(), ms(0)),
+            LeaderStep::RunAction(ShortcutAction::EnterCopyMode)
+        ));
+        assert_eq!(phase, LeaderPhase::Repeat { deadline: ms(500) });
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyS, no_mods(), ms(100)),
+            LeaderStep::RunAction(ShortcutAction::EnterCopyMode)
+        ));
+        assert_eq!(
+            phase,
+            LeaderPhase::Repeat { deadline: ms(600) },
+            "each fire re-arms the window"
+        );
+    }
+
+    #[test]
+    fn other_repeat_binding_fires_inside_window() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyD, no_mods(), ms(100)),
+            LeaderStep::RunAction(ShortcutAction::DetachSession)
+        ));
+        assert_eq!(phase, LeaderPhase::Repeat { deadline: ms(600) });
+    }
+
+    #[test]
+    fn non_repeat_prefix_binding_does_not_fire_inside_window() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyP, no_mods(), ms(100)),
+            LeaderStep::Passthrough
+        ));
+        assert_eq!(
+            phase,
+            LeaderPhase::Idle,
+            "a non-repeat key closes the window and re-dispatches normally (tmux parity)"
+        );
+    }
+
+    #[test]
+    fn unmatched_key_inside_window_passes_through_and_closes() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyZ, no_mods(), ms(100)),
+            LeaderStep::Passthrough
+        ));
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn leader_inside_window_starts_new_pending() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(
+                &mut phase,
+                &sc,
+                KeyCode::KeyA,
+                mods(true, false, false, false),
+                ms(100)
+            ),
+            LeaderStep::Swallow
+        ));
+        assert_eq!(phase, LeaderPhase::Pending);
+    }
+
+    #[test]
+    fn expired_window_reevaluates_normally() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyS, no_mods(), ms(600)),
+            LeaderStep::Passthrough
+        ));
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn zero_repeat_time_never_opens_window() {
+        let sc = Shortcuts {
+            repeat_time: Duration::ZERO,
+            ..repeat_fixture()
+        };
+        let mut phase = LeaderPhase::Pending;
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyS, no_mods(), ms(0)),
+            LeaderStep::RunAction(ShortcutAction::EnterCopyMode)
+        ));
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn modifier_key_does_not_close_window() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Repeat { deadline: ms(500) };
+        assert!(matches!(
+            step_leader(
+                &mut phase,
+                &sc,
+                KeyCode::ControlLeft,
+                mods(true, false, false, false),
+                ms(100)
+            ),
+            LeaderStep::Passthrough
+        ));
+        assert_eq!(phase, LeaderPhase::Repeat { deadline: ms(500) });
+    }
+
+    #[test]
+    fn non_repeat_binding_from_pending_stays_idle() {
+        let sc = repeat_fixture();
+        let mut phase = LeaderPhase::Pending;
+        assert!(matches!(
+            step_leader(&mut phase, &sc, KeyCode::KeyP, no_mods(), ms(0)),
+            LeaderStep::RunAction(ShortcutAction::Paste)
+        ));
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
@@ -770,8 +1023,8 @@ mod tests {
     #[test]
     fn step_leader_ignores_bare_modifier_and_survives_to_second_chord() {
         // Reproduces [0]: the second chord's Ctrl modifier emits its own Pressed
-        // event before KeyD; it must not consume `pending`. Leader Ctrl+B,
-        // prefix detach-session = Ctrl+D.
+        // event before KeyD; it must not consume the pending phase. Leader
+        // Ctrl+B, prefix detach-session = Ctrl+D.
         let sc = Shortcuts {
             direct: Vec::new(),
             prefix: vec![OzmuxShortcut {
@@ -787,50 +1040,63 @@ mod tests {
             tap_timeout: Duration::from_millis(300),
             repeat_time: Duration::from_millis(500),
         };
-        let mut pending = false;
+        let mut phase = LeaderPhase::Idle;
         assert!(matches!(
             step_leader(
-                &mut pending,
+                &mut phase,
                 &sc,
                 KeyCode::ControlLeft,
-                mods(true, false, false, false)
+                mods(true, false, false, false),
+                ms(0)
             ),
             LeaderStep::Passthrough
         ));
-        assert!(!pending, "a bare modifier must not engage the leader");
+        assert_eq!(
+            phase,
+            LeaderPhase::Idle,
+            "a bare modifier must not engage the leader"
+        );
         assert!(matches!(
             step_leader(
-                &mut pending,
+                &mut phase,
                 &sc,
                 KeyCode::KeyB,
-                mods(true, false, false, false)
+                mods(true, false, false, false),
+                ms(0)
             ),
             LeaderStep::Swallow
         ));
-        assert!(pending, "the leader chord engages pending");
+        assert_eq!(
+            phase,
+            LeaderPhase::Pending,
+            "the leader chord engages pending"
+        );
         assert!(matches!(
             step_leader(
-                &mut pending,
+                &mut phase,
                 &sc,
                 KeyCode::ControlLeft,
-                mods(true, false, false, false)
+                mods(true, false, false, false),
+                ms(0)
             ),
             LeaderStep::Passthrough
         ));
-        assert!(
-            pending,
+        assert_eq!(
+            phase,
+            LeaderPhase::Pending,
             "a bare modifier must NOT clear pending mid-sequence"
         );
         assert!(matches!(
             step_leader(
-                &mut pending,
+                &mut phase,
                 &sc,
                 KeyCode::KeyD,
-                mods(true, false, false, false)
+                mods(true, false, false, false),
+                ms(0)
             ),
             LeaderStep::RunAction(ShortcutAction::DetachSession)
         ));
-        assert!(!pending);
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
@@ -1038,87 +1304,93 @@ mod tests {
     #[test]
     fn leader_press_sets_pending_and_swallows() {
         let sc = leader_fixture();
-        let mut pending = false;
+        let mut phase = LeaderPhase::Idle;
         let step = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyA,
             mods(true, false, false, false),
+            ms(0),
         );
         assert!(matches!(step, LeaderStep::Swallow));
-        assert!(pending);
+        assert_eq!(phase, LeaderPhase::Pending);
     }
 
     #[test]
     fn pending_plus_bound_key_runs_action_and_clears_pending() {
         let sc = leader_fixture();
-        let mut pending = true;
+        let mut phase = LeaderPhase::Pending;
         let step = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyS,
             mods(false, false, false, false),
+            ms(0),
         );
         assert!(matches!(
             step,
             LeaderStep::RunAction(ShortcutAction::EnterCopyMode)
         ));
-        assert!(!pending);
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
     fn pending_plus_unbound_key_swallows_and_clears_pending() {
         let sc = leader_fixture();
-        let mut pending = true;
+        let mut phase = LeaderPhase::Pending;
         let step = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyZ,
             mods(false, false, false, false),
+            ms(0),
         );
         assert!(matches!(step, LeaderStep::Swallow));
-        assert!(!pending);
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
     fn unrelated_key_passes_through() {
         let sc = leader_fixture();
-        let mut pending = false;
+        let mut phase = LeaderPhase::Idle;
         let step = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyB,
             mods(false, false, false, false),
+            ms(0),
         );
         assert!(matches!(step, LeaderStep::Passthrough));
-        assert!(!pending);
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
     fn sequential_leader_then_bound_key_threads_pending() {
         // NOTE: the dispatch loop calls step_leader per event with one shared
-        // `pending` local; this verifies the leader press then the bound key
+        // `phase` local; this verifies the leader press then the bound key
         // thread that state correctly across two calls.
         let sc = leader_fixture();
-        let mut pending = false;
+        let mut phase = LeaderPhase::Idle;
         let first = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyA,
             mods(true, false, false, false),
+            ms(0),
         );
         assert!(matches!(first, LeaderStep::Swallow));
         let second = step_leader(
-            &mut pending,
+            &mut phase,
             &sc,
             KeyCode::KeyS,
             mods(false, false, false, false),
+            ms(0),
         );
         assert!(matches!(
             second,
             LeaderStep::RunAction(ShortcutAction::EnterCopyMode)
         ));
-        assert!(!pending);
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]
@@ -1137,7 +1409,7 @@ mod tests {
             .add_message::<KeyboardInput>()
             .init_resource::<ButtonInput<MouseButton>>()
             .insert_resource(ModifierTapState::default())
-            .insert_resource(LeaderPending(false))
+            .init_resource::<LeaderPhase>()
             .insert_resource(Shortcuts {
                 direct: Vec::new(),
                 prefix: Vec::new(),
@@ -1174,9 +1446,10 @@ mod tests {
         app.update();
         tap_key(&mut app, KeyCode::SuperLeft, ButtonState::Released);
         app.update();
-        assert!(
-            app.world().resource::<LeaderPending>().0,
-            "a quick modifier tap must engage LeaderPending"
+        assert_eq!(
+            *app.world().resource::<LeaderPhase>(),
+            LeaderPhase::Pending,
+            "a quick modifier tap must engage LeaderPhase::Pending"
         );
     }
 
@@ -1191,8 +1464,9 @@ mod tests {
         app.update();
         tap_key(&mut app, KeyCode::SuperLeft, ButtonState::Released);
         app.update();
-        assert!(
-            !app.world().resource::<LeaderPending>().0,
+        assert_ne!(
+            *app.world().resource::<LeaderPhase>(),
+            LeaderPhase::Pending,
             "mouse press in a keyboard-less frame must disarm the tap and suppress the leader"
         );
     }
@@ -1212,8 +1486,9 @@ mod tests {
             .clear();
         tap_key(&mut app, KeyCode::SuperLeft, ButtonState::Released);
         app.update();
-        assert!(
-            !app.world().resource::<LeaderPending>().0,
+        assert_ne!(
+            *app.world().resource::<LeaderPhase>(),
+            LeaderPhase::Pending,
             "a mouse press in the same frame as the modifier press must suppress the tap"
         );
     }

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -12,7 +12,9 @@
 use super::pane_hit::tmux_pane_at_phys;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
-use crate::input::shortcuts::{LeaderGate, LeaderPhase, LeaderStep, Shortcuts, step_leader};
+use crate::input::shortcuts::{
+    LeaderGate, LeaderPhase, LeaderStep, Shortcuts, clear_leader_phase, step_leader,
+};
 use crate::mode::AppMode;
 use crate::mode::tmux::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::mode::tmux::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
@@ -140,9 +142,7 @@ fn forward_keys_to_tmux(
     // prefix state machine.
     if copy_prompt.open.is_some() {
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
@@ -150,9 +150,7 @@ fn forward_keys_to_tmux(
     // system reads the y/n answer. Drain here so no key leaks to tmux or the pane.
     if confirm_state.is_some() {
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
@@ -160,9 +158,7 @@ fn forward_keys_to_tmux(
     // reads the typed text. Drain here so no key leaks to tmux or the pane.
     if rename.prompt.is_some() {
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
@@ -170,18 +166,14 @@ fn forward_keys_to_tmux(
     // navigation keys would both garble IME composition and double-send.
     if ime.is_composing() {
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if !focused {
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
@@ -275,15 +267,22 @@ fn forward_keys_to_tmux(
         }
 
         *prefix_pending = false;
-        if *leader_phase != LeaderPhase::Idle {
-            *leader_phase = LeaderPhase::Idle;
-        }
+        clear_leader_phase(&mut leader_phase);
         events.clear();
         return;
     }
 
     // Collect forwardable tmux key names in event order. Super-modified keys are
     // matched against the configured ozmux shortcuts or swallowed; none reach tmux.
+    let in_copy_mode = active_entity.is_some_and(|e| copy_modes.get(e).is_ok());
+    // NOTE: an open repeat window must not intercept copy-mode keys — a
+    // repeat-marked key doubling as a copy-mode command (vi h/j/k/l etc.) would
+    // re-fire the bound action and re-arm the window instead of reaching
+    // copy_mode_dispatch. Close the window before stepping; Pending semantics
+    // (leader + second key inside copy mode) stay unchanged.
+    if in_copy_mode && matches!(*leader_phase, LeaderPhase::Repeat { .. }) {
+        *leader_phase = LeaderPhase::Idle;
+    }
     let mut key_names: Vec<String> = Vec::new();
     for ev in events.read() {
         if ev.state != ButtonState::Pressed {
@@ -373,11 +372,10 @@ fn forward_keys_to_tmux(
         }
     }
 
-    // NOTE: this branch must return before plan_forward — a copy-mode entry
-    // binding pressed while already in copy mode is relayed here (not
-    // re-intercepted), which would otherwise re-insert CopyModeState each press.
-    let in_copy_mode = active_entity.is_some_and(|e| copy_modes.get(e).is_ok());
-
+    // NOTE: the copy-mode branch below must return before plan_forward — a
+    // copy-mode entry binding pressed while already in copy mode is relayed
+    // there (not re-intercepted), which would otherwise re-insert
+    // CopyModeState each press.
     if !in_copy_mode
         && !key_names.is_empty()
         && let Some(entity) = active_entity

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -12,7 +12,7 @@
 use super::pane_hit::tmux_pane_at_phys;
 use crate::configs::OzmuxConfigsResource;
 use crate::input::InputPhase;
-use crate::input::shortcuts::{LeaderGate, LeaderPending, LeaderStep, Shortcuts, step_leader};
+use crate::input::shortcuts::{LeaderGate, LeaderPhase, LeaderStep, Shortcuts, step_leader};
 use crate::mode::AppMode;
 use crate::mode::tmux::confirm_prompt::{ConfirmState, parse_confirm_before};
 use crate::mode::tmux::rename_prompt::{RenameKind, RenamePrompt, RenameSubject};
@@ -25,6 +25,7 @@ use bevy::input::ButtonState;
 use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
+use bevy::time::Real;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::PrimaryWindow;
 use bevy_cef::prelude::FocusedWebview;
@@ -119,14 +120,15 @@ fn forward_keys_to_tmux(
     mut focused_webview: ResMut<FocusedWebview>,
     mut copy_queries: ResMut<CopyModeQueries>,
     mut prefix_pending: Local<bool>,
-    mut leader_pending: ResMut<LeaderPending>,
+    mut leader_phase: ResMut<LeaderPhase>,
     mut handles: Query<&mut TerminalHandle>,
     mut client: Option<Single<&mut TmuxClient>>,
-    (keys, ime, bindings, resolved): (
+    (keys, ime, bindings, resolved, time): (
         Res<ButtonInput<KeyCode>>,
         Res<crate::input::ime::ImeState>,
         Res<KeyBindings>,
         Res<Shortcuts>,
+        Res<Time<Real>>,
     ),
     active_pane: Option<Single<(Entity, &TmuxPane), With<ActivePane>>>,
     copy_modes: Query<(), With<CopyModeState>>,
@@ -138,7 +140,9 @@ fn forward_keys_to_tmux(
     // prefix state machine.
     if copy_prompt.open.is_some() {
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
@@ -146,7 +150,9 @@ fn forward_keys_to_tmux(
     // system reads the y/n answer. Drain here so no key leaks to tmux or the pane.
     if confirm_state.is_some() {
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
@@ -154,7 +160,9 @@ fn forward_keys_to_tmux(
     // reads the typed text. Drain here so no key leaks to tmux or the pane.
     if rename.prompt.is_some() {
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
@@ -162,14 +170,18 @@ fn forward_keys_to_tmux(
     // navigation keys would both garble IME composition and double-send.
     if ime.is_composing() {
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
     let focused = windows.single().map(|w| w.focused).unwrap_or(false);
     if !focused {
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
@@ -186,6 +198,7 @@ fn forward_keys_to_tmux(
         alt: mods.alt,
         meta: mods.super_,
     };
+    let now = time.elapsed();
 
     // The active pane (if any) is the forward/paste target. GUI chords below do
     // not need it (so quit and similar chords work before a pane is projected);
@@ -262,7 +275,9 @@ fn forward_keys_to_tmux(
         }
 
         *prefix_pending = false;
-        leader_pending.0 = false;
+        if *leader_phase != LeaderPhase::Idle {
+            *leader_phase = LeaderPhase::Idle;
+        }
         events.clear();
         return;
     }
@@ -279,17 +294,17 @@ fn forward_keys_to_tmux(
         // plan_forward. cfg_mods is a per-frame snapshot, so a same-frame
         // leader+second-key batch shares one modifier read.
         // NOTE: OS key auto-repeat delivers extra Pressed events; feeding them
-        // to step_leader would toggle `pending` by parity. Treat a repeat as
+        // to step_leader would toggle the phase by parity. Treat a repeat as
         // Passthrough without stepping the machine — EXCEPT while a leader is
         // pending, where a repeat (e.g. a held leader chord) must be swallowed,
         // not forwarded, or the held chord leaks to the pane on every repeat.
         let step = if ev.repeat {
-            if leader_pending.0 {
+            if matches!(*leader_phase, LeaderPhase::Pending) {
                 continue;
             }
             LeaderStep::Passthrough
         } else {
-            step_leader(&mut leader_pending.0, &resolved, ev.key_code, cfg_mods)
+            step_leader(&mut leader_phase, &resolved, ev.key_code, cfg_mods, now)
         };
         let gui_action = match step {
             LeaderStep::RunAction(action) => Some(action),

--- a/src/input/tmux/input.rs
+++ b/src/input/tmux/input.rs
@@ -293,16 +293,18 @@ fn forward_keys_to_tmux(
         // forwarding so a swallowed/resolved leader key never reaches
         // plan_forward. cfg_mods is a per-frame snapshot, so a same-frame
         // leader+second-key batch shares one modifier read.
-        // NOTE: OS key auto-repeat delivers extra Pressed events; feeding them
-        // to step_leader would toggle the phase by parity. Treat a repeat as
-        // Passthrough without stepping the machine — EXCEPT while a leader is
-        // pending, where a repeat (e.g. a held leader chord) must be swallowed,
-        // not forwarded, or the held chord leaks to the pane on every repeat.
+        // NOTE: OS key auto-repeat delivers extra Pressed events. Outside the
+        // repeat window they must not step the machine (pending would toggle by
+        // parity; a held leader chord must stay swallowed, not forwarded).
+        // Inside the window they must step it so held keys keep firing.
         let step = if ev.repeat {
-            if matches!(*leader_phase, LeaderPhase::Pending) {
-                continue;
+            match *leader_phase {
+                LeaderPhase::Pending => continue,
+                LeaderPhase::Repeat { .. } => {
+                    step_leader(&mut leader_phase, &resolved, ev.key_code, cfg_mods, now)
+                }
+                LeaderPhase::Idle => LeaderStep::Passthrough,
             }
-            LeaderStep::Passthrough
         } else {
             step_leader(&mut leader_phase, &resolved, ev.key_code, cfg_mods, now)
         };


### PR DESCRIPTION
## Problem

The `<Leader>` shortcut machinery (#229) is strictly one-shot: every leader-scoped action costs a fresh leader press. Actions that are naturally pressed in bursts — pane selection now, keyboard `resize-pane` in the upcoming tmux-native-shortcuts work — need tmux's `bind -r` behavior: fire once via the leader, then keep re-firing the key inside a repeat window without re-pressing the leader.

## Solution

Adds a tmux-parity repeat mechanism to the shortcut config (mechanism only; no default binding changes — the tmux-native-shortcuts branch will mark its `select-*-pane` defaults with it).

**Config (`crates/ozmux_configs`)**
- New `<Leader:r>` token: `enter-copy-mode = "<Leader:r>s"` marks a leader-scoped binding repeatable (`Binding::Leader { chord, repeat }`). The marker is only expressible on leader bindings, so no extra validation is needed; duplicate-chord validation is unchanged.
- New `repeat-time-ms` (default 500). `0` disables repeat and — unlike `leader-tap-timeout-ms` — is deliberately **not** normalized away (tmux `repeat-time 0` parity).

**Runtime (`src/input`)**
- `LeaderPending(bool)` becomes the 3-state resource `LeaderPhase { Idle, Pending, Repeat { deadline } }`; `step_leader` gains `now` and owns all window semantics (verified against tmux 3.6b source/man/live behavior): each fire re-arms the window, any repeat-marked binding keeps it alive, any other key closes it and re-evaluates normally in the same call — never swallowed — and the leader inside the window starts a fresh sequence. Lazy expiry; no timer system.
- PTY withholding in `dispatch_input` is key-aware via the shared `Shortcuts::match_repeat_prefix` predicate, and mirrors same-frame window transitions in both directions (open and close) so the Read phase can never disagree with the Advance phase within one frame's batch.
- OS key auto-repeat steps the machine only inside the window, so holding a key keeps firing (tmux parity); an open window is closed while the active pane is in copy mode so vi keys reach `copy_mode_dispatch`.
- Post-implementation review cleanups: single `find_entry` exclusion predicate, `clear_leader_phase` helper replacing nine hand-rolled guarded resets (change-detection semantics preserved), merged serializer arms.

**Docs**
- `docs/configs.md`: `[shortcuts]` sample, a "Repeatable bindings (`<Leader:r>`)" section, and the honest caveat that a repeat-marked letter key typed into the shell within the window re-fires instead (escape hatches: `repeat-time-ms = 0` or dropping `:r`).

Affected: config crate (`ozmux_configs`), host input (`src/input/{shortcuts,keyboard,default_mode,tmux/input}.rs`), docs. Existing configs without repeat settings behave identically; plain `<Leader>` bindings are unchanged.

Tests: 503 bin + 125 config tests green, including the full transition table, same-frame batch regressions (`[closing, matching]` and duplicate-second-key), OS-auto-repeat integration, and serde round-trip/snapshot updates. `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiY4ZVgSfBJ4VUmuktgqGJ
