### PR TITLE
fix: restore full pane terminal state on tmux -CC re-attach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ node_modules
 
 docs/discussions/
 .serena/
+
+# Local bug-repro screenshot, not for version control
+/bug.png

--- a/crates/ozma_tty_engine/src/handle.rs
+++ b/crates/ozma_tty_engine/src/handle.rs
@@ -175,6 +175,13 @@ impl TerminalHandle {
         Self::new(cols, rows, listener, reply_rx, control_rx, control_tx)
     }
 
+    /// Returns the scrollback capacity a default-configured handle is built
+    /// with, so callers sizing external history fetches (e.g. tmux
+    /// `capture-pane -S`) stay in sync with the mirror's real cap.
+    pub fn default_scroll_cap() -> usize {
+        Config::default().scrolling_history
+    }
+
     /// Drains and returns any pending alacritty `PtyWrite` reply bytes
     /// (DSR / DA answers). A detached handle has no PTY to write them to;
     /// the caller forwards them to the external program (tmux input) or
@@ -1419,6 +1426,14 @@ mod tests {
         assert!(
             !h.is_noop_emit(&dirty, &curr_cursor, mode, mode, curr_vi, curr_sel),
             "selection appeared on prev_selection==None → must NOT be a no-op"
+        );
+    }
+
+    #[test]
+    fn default_scroll_cap_matches_config_default() {
+        assert_eq!(
+            TerminalHandle::default_scroll_cap(),
+            Config::default().scrolling_history
         );
     }
 

--- a/crates/ozmux_tmux/src/command.rs
+++ b/crates/ozmux_tmux/src/command.rs
@@ -17,7 +17,8 @@ pub use ops::{
     SelectPaneTowards, SplitDirection, SplitWindow, ZoomPane,
 };
 pub(crate) use query::{
-    ActivePane, AggressiveResize, CapturePane, ClientName, CursorQuery, ListWindows,
+    ActivePane, AggressiveResize, CapturePane, CapturePanePending, CapturePaneSavedPrimary,
+    CapturePaneWithHistory, ClientName, CursorQuery, ListWindows, PaneStateQuery,
     SubscribeWindowFlags, Version,
 };
 pub use size::{RefreshClient, ResizeWindow, WindowRefreshClient};

--- a/crates/ozmux_tmux/src/command.rs
+++ b/crates/ozmux_tmux/src/command.rs
@@ -18,8 +18,7 @@ pub use ops::{
 };
 pub(crate) use query::{
     ActivePane, AggressiveResize, CapturePane, CapturePanePending, CapturePaneSavedPrimary,
-    CapturePaneWithHistory, ClientName, CursorQuery, ListWindows, PaneStateQuery,
-    SubscribeWindowFlags, Version,
+    CapturePaneWithHistory, ClientName, ListWindows, PaneStateQuery, SubscribeWindowFlags, Version,
 };
 pub use size::{RefreshClient, ResizeWindow, WindowRefreshClient};
 pub use target::{RenameSession, RenameWindow, ResizePaneX, ResizePaneY, SelectPane, SelectWindow};

--- a/crates/ozmux_tmux/src/command/query.rs
+++ b/crates/ozmux_tmux/src/command/query.rs
@@ -111,19 +111,6 @@ impl TmuxCommand for CapturePanePending {
     }
 }
 
-/// `display-message -p -t %<id> '#{cursor_x} #{cursor_y}'` — a pane's real cursor.
-pub(crate) struct CursorQuery {
-    pub id: PaneId,
-}
-impl TmuxCommand for CursorQuery {
-    fn into_raw_command(self) -> String {
-        format!(
-            "display-message -p -t %{} '#{{cursor_x}} #{{cursor_y}}'",
-            self.id.0
-        )
-    }
-}
-
 /// `show-options -wqv -t @<win> aggressive-resize` — the per-window option value.
 pub(crate) struct AggressiveResize {
     pub win: WindowId,
@@ -219,14 +206,6 @@ mod tests {
         assert_eq!(
             CapturePanePending { id: PaneId(2) }.into_raw_command(),
             "capture-pane -pPC -t %2"
-        );
-    }
-
-    #[test]
-    fn cursor_query_targets_pane() {
-        assert_eq!(
-            CursorQuery { id: PaneId(4) }.into_raw_command(),
-            "display-message -p -t %4 '#{cursor_x} #{cursor_y}'"
         );
     }
 

--- a/crates/ozmux_tmux/src/command/query.rs
+++ b/crates/ozmux_tmux/src/command/query.rs
@@ -3,6 +3,8 @@
 //! cursor, aggressive-resize.
 
 use crate::enumerate::{LIST_WINDOWS_FORMAT, WINDOW_FLAGS_SUBSCRIPTION};
+use crate::state_restore::PANE_STATE_FORMAT;
+use ozma_tty_engine::TerminalHandle;
 use tmux_control::TmuxCommand;
 use tmux_control_parser::{PaneId, WindowId};
 
@@ -46,13 +48,66 @@ impl TmuxCommand for SubscribeWindowFlags {
     }
 }
 
-/// `capture-pane -p -e -t %<id>` — a pane's current visible content (with SGR).
+/// `capture-pane -peqJ -t %<id>` — the pane's visible screen (with SGR,
+/// wrapped lines joined, trailing spaces preserved by `-J`).
 pub(crate) struct CapturePane {
     pub id: PaneId,
 }
 impl TmuxCommand for CapturePane {
     fn into_raw_command(self) -> String {
-        format!("capture-pane -p -e -t %{}", self.id.0)
+        format!("capture-pane -peqJ -t %{}", self.id.0)
+    }
+}
+
+/// `capture-pane -peqJ -S -<cap>` — the pane's base grid: primary history
+/// plus the CURRENT visible screen (the alt screen while alternate is on).
+pub(crate) struct CapturePaneWithHistory {
+    pub id: PaneId,
+}
+impl TmuxCommand for CapturePaneWithHistory {
+    fn into_raw_command(self) -> String {
+        format!(
+            "capture-pane -peqJ -t %{} -S -{}",
+            self.id.0,
+            TerminalHandle::default_scroll_cap()
+        )
+    }
+}
+
+/// `capture-pane -peqJa` — the saved primary screen tmux snapshotted on alt
+/// entry (`saved_grid`); empty via `-q` when the pane never entered alt.
+pub(crate) struct CapturePaneSavedPrimary {
+    pub id: PaneId,
+}
+impl TmuxCommand for CapturePaneSavedPrimary {
+    fn into_raw_command(self) -> String {
+        format!("capture-pane -peqJa -t %{}", self.id.0)
+    }
+}
+
+/// `display-message -p` over [`PANE_STATE_FORMAT`] (positional message, as
+/// `CopyStateQuery` does — display-message has no `-F` flag) — one pane's
+/// terminal modes, cursor, scroll region, and tab stops.
+pub(crate) struct PaneStateQuery {
+    pub id: PaneId,
+}
+impl TmuxCommand for PaneStateQuery {
+    fn into_raw_command(self) -> String {
+        format!(
+            "display-message -p -t %{} \"{PANE_STATE_FORMAT}\"",
+            self.id.0
+        )
+    }
+}
+
+/// `capture-pane -pPC` — pending (unflushed) pane output with control
+/// characters octal-escaped.
+pub(crate) struct CapturePanePending {
+    pub id: PaneId,
+}
+impl TmuxCommand for CapturePanePending {
+    fn into_raw_command(self) -> String {
+        format!("capture-pane -pPC -t %{}", self.id.0)
     }
 }
 
@@ -124,10 +179,46 @@ mod tests {
     }
 
     #[test]
-    fn capture_pane_targets_at_id_with_escapes() {
+    fn capture_pane_visible_uses_escape_flags() {
         assert_eq!(
             CapturePane { id: PaneId(5) }.into_raw_command(),
-            "capture-pane -p -e -t %5"
+            "capture-pane -peqJ -t %5"
+        );
+    }
+
+    #[test]
+    fn capture_with_history_reaches_mirror_scroll_cap() {
+        let cmd = CapturePaneWithHistory { id: PaneId(5) }.into_raw_command();
+        assert_eq!(
+            cmd,
+            format!(
+                "capture-pane -peqJ -t %5 -S -{}",
+                TerminalHandle::default_scroll_cap()
+            )
+        );
+    }
+
+    #[test]
+    fn capture_saved_primary_uses_alternate_flag() {
+        assert_eq!(
+            CapturePaneSavedPrimary { id: PaneId(7) }.into_raw_command(),
+            "capture-pane -peqJa -t %7"
+        );
+    }
+
+    #[test]
+    fn pane_state_query_embeds_the_state_format() {
+        let cmd = PaneStateQuery { id: PaneId(3) }.into_raw_command();
+        assert!(cmd.starts_with("display-message -p -t %3 \""));
+        assert!(cmd.contains("alternate_on=#{alternate_on}"));
+        assert!(cmd.ends_with('"'));
+    }
+
+    #[test]
+    fn capture_pending_uses_pc_flags() {
+        assert_eq!(
+            CapturePanePending { id: PaneId(2) }.into_raw_command(),
+            "capture-pane -pPC -t %2"
         );
     }
 

--- a/crates/ozmux_tmux/src/enumerate.rs
+++ b/crates/ozmux_tmux/src/enumerate.rs
@@ -4,7 +4,7 @@ use crate::components::WindowFlags;
 use crate::input::quote;
 use crate::state_restore::{GridCapture, PaneState, restore_to_bytes};
 use bevy::ecs::component::Component;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tmux_control::{CommandId, TmuxResult};
 use tmux_control_parser::{PaneId, WindowId, WindowLayout};
 
@@ -231,10 +231,6 @@ pub(crate) enum PendingReply {
     ActivePane,
     /// `aggressive-resize` option query → warn if `on`.
     AggressiveResize,
-    /// `capture-pane` of a pane's screen.
-    Capture { pane: PaneId },
-    /// Cursor-position query paired with a [`PendingReply::Capture`].
-    Cursor { pane: PaneId },
     /// The default (base) capture of a pane restore.
     RestoreBase { pane: PaneId },
     /// The `-a` saved-primary capture of a pane restore.
@@ -328,13 +324,11 @@ impl PaneRestore {
 }
 
 /// Correlates in-flight enumeration/query commands by [`CommandId`] and the
-/// capture/cursor pairing buffers, so each drained reply routes to its handler.
+/// per-pane restore buffers, so each drained reply routes to its handler.
 #[derive(Component, Default)]
 pub(crate) struct EnumerationState {
     pub(crate) pending: HashMap<CommandId, PendingReply>,
     pub(crate) aggressive_resize_checked: bool,
-    pub(crate) capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
-    pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
     pub(crate) restores: HashMap<PaneId, PaneRestore>,
 }
 
@@ -349,12 +343,10 @@ impl EnumerationState {
                 // re-sent list-windows on %window-add while the attach enumeration
                 // is still in flight would fire trigger_seed twice, and a re-queried
                 // active-pane would fire TmuxActivePaneChanged twice). The per-pane
-                // Capture/Cursor kinds are legitimately multi and exempt.
+                // Restore kinds are legitimately multi and exempt.
                 if !matches!(
                     reply,
-                    PendingReply::Capture { .. }
-                        | PendingReply::Cursor { .. }
-                        | PendingReply::RestoreBase { .. }
+                    PendingReply::RestoreBase { .. }
                         | PendingReply::RestoreSavedPrimary { .. }
                         | PendingReply::RestoreState { .. }
                         | PendingReply::RestorePending { .. }
@@ -373,19 +365,16 @@ impl EnumerationState {
         self.pending.values().any(|r| *r == reply)
     }
 
-    /// Drops the in-flight entries a session switch invalidates: the
-    /// capture/cursor pairs, the pane-restore buffers, and the enumeration ids
-    /// `send_session_enumeration` re-issues. A `HashMap` keyed by `CommandId`
-    /// does not get the old `Option` fields' free last-write-wins overwrite,
-    /// so a stale pre-switch `list-windows`/active-pane reply would otherwise
-    /// mis-seed the new session.
+    /// Drops the in-flight entries a session switch invalidates: the pane-restore
+    /// buffers and the enumeration ids `send_session_enumeration` re-issues. A
+    /// `HashMap` keyed by `CommandId` does not get the old `Option` fields' free
+    /// last-write-wins overwrite, so a stale pre-switch `list-windows`/active-pane
+    /// reply would otherwise mis-seed the new session.
     pub(crate) fn clear_for_session_switch(&mut self) {
         self.pending.retain(|_, r| {
             !matches!(
                 r,
-                PendingReply::Capture { .. }
-                    | PendingReply::Cursor { .. }
-                    | PendingReply::ListWindows
+                PendingReply::ListWindows
                     | PendingReply::ActivePane
                     | PendingReply::AggressiveResize
                     | PendingReply::RestoreBase { .. }
@@ -394,8 +383,6 @@ impl EnumerationState {
                     | PendingReply::RestorePending { .. }
             )
         });
-        self.capture_awaiting_cursor.clear();
-        self.panes_with_cursor_pending.clear();
         self.aggressive_resize_checked = false;
         self.restores.clear();
     }
@@ -585,7 +572,7 @@ mod tests {
         state.pending.insert(CommandId(3), PendingReply::ClientName);
         state
             .pending
-            .insert(CommandId(4), PendingReply::Capture { pane: PaneId(7) });
+            .insert(CommandId(4), PendingReply::RestoreBase { pane: PaneId(7) });
         state
             .pending
             .insert(CommandId(5), PendingReply::AggressiveResize);
@@ -606,7 +593,7 @@ mod tests {
         );
         assert!(
             !state.pending.contains_key(&CommandId(4)),
-            "capture dropped"
+            "restore dropped"
         );
         assert!(
             !state.pending.contains_key(&CommandId(5)),
@@ -685,28 +672,40 @@ mod tests {
             Some(&PendingReply::ActivePane)
         );
 
-        state.register(Ok(CommandId(5)), PendingReply::Capture { pane: PaneId(3) });
-        state.register(Ok(CommandId(6)), PendingReply::Capture { pane: PaneId(3) });
+        state.register(
+            Ok(CommandId(5)),
+            PendingReply::RestoreBase { pane: PaneId(3) },
+        );
+        state.register(
+            Ok(CommandId(6)),
+            PendingReply::RestoreBase { pane: PaneId(3) },
+        );
         assert_eq!(
             state.pending.get(&CommandId(5)),
-            Some(&PendingReply::Capture { pane: PaneId(3) }),
-            "two concurrent identical-value captures for the same pane are both kept, not superseded"
+            Some(&PendingReply::RestoreBase { pane: PaneId(3) }),
+            "two concurrent identical-value restores for the same pane are both kept, not superseded"
         );
         assert_eq!(
             state.pending.get(&CommandId(6)),
-            Some(&PendingReply::Capture { pane: PaneId(3) })
+            Some(&PendingReply::RestoreBase { pane: PaneId(3) })
         );
 
-        state.register(Ok(CommandId(7)), PendingReply::Capture { pane: PaneId(1) });
-        state.register(Ok(CommandId(8)), PendingReply::Capture { pane: PaneId(2) });
+        state.register(
+            Ok(CommandId(7)),
+            PendingReply::RestoreBase { pane: PaneId(1) },
+        );
+        state.register(
+            Ok(CommandId(8)),
+            PendingReply::RestoreBase { pane: PaneId(2) },
+        );
         assert_eq!(
             state.pending.get(&CommandId(7)),
-            Some(&PendingReply::Capture { pane: PaneId(1) }),
-            "per-pane captures are independent — both kept"
+            Some(&PendingReply::RestoreBase { pane: PaneId(1) }),
+            "per-pane restores are independent — both kept"
         );
         assert_eq!(
             state.pending.get(&CommandId(8)),
-            Some(&PendingReply::Capture { pane: PaneId(2) })
+            Some(&PendingReply::RestoreBase { pane: PaneId(2) })
         );
     }
 }

--- a/crates/ozmux_tmux/src/enumerate.rs
+++ b/crates/ozmux_tmux/src/enumerate.rs
@@ -266,7 +266,10 @@ impl<T> Slot<T> {
 /// resolves, then synthesizes the seed bytes exactly once.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PaneRestore {
-    pub(crate) pane_height: u16,
+    // NOTE: private — only read inside this module's own `into_bytes`; the
+    // `base`/`saved_primary`/`state`/`pending` slots below stay `pub(crate)`
+    // because plugin.rs's `fill_restore_slot` writes them from outside.
+    pane_height: u16,
     pub(crate) base: Slot<Vec<String>>,
     pub(crate) saved_primary: Slot<Vec<String>>,
     pub(crate) state: Slot<PaneState>,

--- a/crates/ozmux_tmux/src/enumerate.rs
+++ b/crates/ozmux_tmux/src/enumerate.rs
@@ -2,6 +2,7 @@
 
 use crate::components::WindowFlags;
 use crate::input::quote;
+use crate::state_restore::{GridCapture, PaneState, restore_to_bytes};
 use bevy::ecs::component::Component;
 use std::collections::{HashMap, HashSet};
 use tmux_control::{CommandId, TmuxResult};
@@ -234,6 +235,96 @@ pub(crate) enum PendingReply {
     Capture { pane: PaneId },
     /// Cursor-position query paired with a [`PendingReply::Capture`].
     Cursor { pane: PaneId },
+    /// The default (base) capture of a pane restore.
+    RestoreBase { pane: PaneId },
+    /// The `-a` saved-primary capture of a pane restore.
+    RestoreSavedPrimary { pane: PaneId },
+    /// The terminal-state (`PANE_STATE_FORMAT`) query of a pane restore.
+    RestoreState { pane: PaneId },
+    /// The pending-output capture of a pane restore.
+    RestorePending { pane: PaneId },
+}
+
+/// One in-flight reply slot of a pane restore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Slot<T> {
+    NotRequested,
+    Pending,
+    Ok(T),
+    Failed,
+}
+
+impl<T> Slot<T> {
+    fn is_pending(&self) -> bool {
+        matches!(self, Slot::Pending)
+    }
+    fn ok(self) -> Option<T> {
+        match self {
+            Slot::Ok(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+/// Accumulates the restore replies for one pane until every requested slot
+/// resolves, then synthesizes the seed bytes exactly once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PaneRestore {
+    pub(crate) pane_height: u16,
+    pub(crate) base: Slot<Vec<String>>,
+    pub(crate) saved_primary: Slot<Vec<String>>,
+    pub(crate) state: Slot<PaneState>,
+    pub(crate) pending: Slot<Vec<String>>,
+}
+
+impl PaneRestore {
+    /// Buffer for the adopt-time full restore (all four commands issued).
+    pub(crate) fn new_full(pane_height: u16) -> Self {
+        Self {
+            pane_height,
+            base: Slot::Pending,
+            saved_primary: Slot::Pending,
+            state: Slot::Pending,
+            pending: Slot::Pending,
+        }
+    }
+
+    /// Buffer for the light re-seed (visible capture + state only).
+    pub(crate) fn new_light(pane_height: u16) -> Self {
+        Self {
+            pane_height,
+            base: Slot::Pending,
+            saved_primary: Slot::NotRequested,
+            state: Slot::Pending,
+            pending: Slot::NotRequested,
+        }
+    }
+
+    /// Whether every requested slot has resolved (`Ok` or `Failed`).
+    pub(crate) fn complete(&self) -> bool {
+        !self.base.is_pending()
+            && !self.saved_primary.is_pending()
+            && !self.state.is_pending()
+            && !self.pending.is_pending()
+    }
+
+    /// Synthesizes the seed bytes from whatever slots succeeded.
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        let full = !matches!(&self.saved_primary, Slot::NotRequested);
+        let state = self.state.ok();
+        let pending = self.pending.ok().unwrap_or_default();
+        let base = self.base.ok().unwrap_or_default();
+        let grid = if full {
+            GridCapture::Full {
+                base,
+                saved_primary: self.saved_primary.ok().unwrap_or_default(),
+                pane_height: self.pane_height,
+            }
+        } else {
+            GridCapture::VisibleOnly { rows: base }
+        };
+        restore_to_bytes(&grid, state.as_ref(), &pending)
+    }
 }
 
 /// Correlates in-flight enumeration/query commands by [`CommandId`] and the
@@ -244,6 +335,7 @@ pub(crate) struct EnumerationState {
     pub(crate) aggressive_resize_checked: bool,
     pub(crate) capture_awaiting_cursor: HashMap<PaneId, Vec<String>>,
     pub(crate) panes_with_cursor_pending: HashSet<PaneId>,
+    pub(crate) restores: HashMap<PaneId, PaneRestore>,
 }
 
 impl EnumerationState {
@@ -260,7 +352,12 @@ impl EnumerationState {
                 // Capture/Cursor kinds are legitimately multi and exempt.
                 if !matches!(
                     reply,
-                    PendingReply::Capture { .. } | PendingReply::Cursor { .. }
+                    PendingReply::Capture { .. }
+                        | PendingReply::Cursor { .. }
+                        | PendingReply::RestoreBase { .. }
+                        | PendingReply::RestoreSavedPrimary { .. }
+                        | PendingReply::RestoreState { .. }
+                        | PendingReply::RestorePending { .. }
                 ) {
                     self.pending.retain(|_, r| *r != reply);
                 }
@@ -277,10 +374,11 @@ impl EnumerationState {
     }
 
     /// Drops the in-flight entries a session switch invalidates: the
-    /// capture/cursor pairs and the enumeration ids `send_session_enumeration`
-    /// re-issues. A `HashMap` keyed by `CommandId` does not get the old
-    /// `Option` fields' free last-write-wins overwrite, so a stale pre-switch
-    /// `list-windows`/active-pane reply would otherwise mis-seed the new session.
+    /// capture/cursor pairs, the pane-restore buffers, and the enumeration ids
+    /// `send_session_enumeration` re-issues. A `HashMap` keyed by `CommandId`
+    /// does not get the old `Option` fields' free last-write-wins overwrite,
+    /// so a stale pre-switch `list-windows`/active-pane reply would otherwise
+    /// mis-seed the new session.
     pub(crate) fn clear_for_session_switch(&mut self) {
         self.pending.retain(|_, r| {
             !matches!(
@@ -290,17 +388,23 @@ impl EnumerationState {
                     | PendingReply::ListWindows
                     | PendingReply::ActivePane
                     | PendingReply::AggressiveResize
+                    | PendingReply::RestoreBase { .. }
+                    | PendingReply::RestoreSavedPrimary { .. }
+                    | PendingReply::RestoreState { .. }
+                    | PendingReply::RestorePending { .. }
             )
         });
         self.capture_awaiting_cursor.clear();
         self.panes_with_cursor_pending.clear();
         self.aggressive_resize_checked = false;
+        self.restores.clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state_restore::parse_pane_state;
 
     #[test]
     fn format_is_tab_separated_with_name_last() {
@@ -509,6 +613,50 @@ mod tests {
             "stale aggressive-resize dropped so new session is re-checked"
         );
         assert!(!state.aggressive_resize_checked, "aggressive guard reset");
+    }
+
+    #[test]
+    fn full_restore_completes_only_when_all_four_slots_resolve() {
+        let mut r = PaneRestore::new_full(4);
+        assert!(!r.complete());
+        r.base = Slot::Ok(vec!["a".into()]);
+        r.saved_primary = Slot::Ok(vec![]);
+        r.state = Slot::Ok(parse_pane_state(""));
+        assert!(!r.complete());
+        r.pending = Slot::Failed;
+        assert!(r.complete());
+    }
+
+    #[test]
+    fn light_restore_needs_only_base_and_state() {
+        let mut r = PaneRestore::new_light(4);
+        r.base = Slot::Ok(vec!["a".into()]);
+        assert!(!r.complete());
+        r.state = Slot::Ok(parse_pane_state(""));
+        assert!(r.complete());
+    }
+
+    #[test]
+    fn into_bytes_survives_partial_failure() {
+        let mut r = PaneRestore::new_full(2);
+        r.base = Slot::Ok(vec!["row".into()]);
+        r.saved_primary = Slot::Failed;
+        r.state = Slot::Failed;
+        r.pending = Slot::Failed;
+        let bytes = r.into_bytes();
+        assert!(String::from_utf8_lossy(&bytes).contains("row"));
+    }
+
+    #[test]
+    fn clear_for_session_switch_drops_restore_buffers_and_pending_kinds() {
+        let mut state = EnumerationState::default();
+        state.restores.insert(PaneId(1), PaneRestore::new_full(4));
+        state
+            .pending
+            .insert(CommandId(9), PendingReply::RestoreBase { pane: PaneId(1) });
+        state.clear_for_session_switch();
+        assert!(state.restores.is_empty());
+        assert!(state.pending.is_empty());
     }
 
     #[test]

--- a/crates/ozmux_tmux/src/event_pump.rs
+++ b/crates/ozmux_tmux/src/event_pump.rs
@@ -27,43 +27,6 @@ pub(crate) fn first_reply_line(ok: bool, output: &[String], what: &str) -> Optio
         .map(str::to_owned)
 }
 
-/// Parses a `'#{cursor_x} #{cursor_y}'` reply line into `(col, row)`.
-pub(crate) fn parse_cursor_pos(output: &[String]) -> Option<(u16, u16)> {
-    let line = output.first()?;
-    let (x, y) = line.trim().split_once(' ')?;
-    Some((x.parse().ok()?, y.parse().ok()?))
-}
-
-/// Joins `capture-pane -p -e` reply lines into VT bytes for seeding a pane's
-/// screen: a clean-state prefix (reset scroll region + origin mode + SGR, then
-/// cursor-home + clear-screen) so the snapshot repaints from a clean grid with
-/// the default background and absolute positioning, then the rows CRLF-joined
-/// (the reply omits line terminators). Home + clear also keep the rows from
-/// stacking when the reply arrives after live `%output` has moved the cursor.
-pub(crate) fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
-    // NOTE: the reset prefix MUST precede the ESC[2J erase and the row replay.
-    // `capture-pane -e` output assumes a default-state terminal, but it is
-    // replayed into the long-lived pane mirror, which can still carry modes left
-    // by prior `%output` (e.g. nvim mid-redraw on a resize): a stale SGR
-    // background floods the erase and default-bg cells (the blue-pane bug), and
-    // a stale scroll region (DECSTBM) or origin mode (DECOM) scrolls the CRLF
-    // replay within the wrong margins or mis-places the cursor. Reset region
-    // (ESC[r), origin (ESC[?6l), and SGR (ESC[0m) first so the replay is
-    // faithful regardless of prior state.
-    let mut bytes = b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec();
-    bytes.extend_from_slice(lines.join("\r\n").as_bytes());
-    bytes
-}
-
-/// Like [`capture_to_bytes`] but appends a CSI cursor-position escape (`ESC[row;colH`,
-/// 1-origin) so the rendered cursor matches the real tmux pane cursor after the
-/// snapshot is painted.
-pub(crate) fn capture_to_bytes_with_cursor(lines: &[String], cx: u16, cy: u16) -> Vec<u8> {
-    let mut bytes = capture_to_bytes(lines);
-    bytes.extend_from_slice(format!("\x1b[{};{}H", cy + 1, cx + 1).as_bytes());
-    bytes
-}
-
 /// Returns the new session id if `events` contains a session-change to an id
 /// different from `current`, i.e. a real `switch-client`. Returns `None` on the
 /// first attach (`current == None`) or when the id is unchanged, so the initial
@@ -316,21 +279,6 @@ mod tests {
     fn parse_active_pane_parses_window_and_pane() {
         assert_eq!(parse_active_pane("@7 %88"), Some((WindowId(7), PaneId(88))));
         assert_eq!(parse_active_pane("garbage"), None);
-    }
-
-    #[test]
-    fn capture_to_bytes_with_cursor_appends_cursor_escape() {
-        // ESC[r ESC[?6l ESC[0m ESC[H ESC[2J + "hello" + ESC[6;4H  (cy=5→row 6, cx=3→col 4)
-        assert_eq!(
-            capture_to_bytes_with_cursor(&["hello".to_string()], 3, 5),
-            b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2Jhello\x1b[6;4H".to_vec()
-        );
-    }
-
-    #[test]
-    fn parse_cursor_pos_reads_col_row() {
-        assert_eq!(parse_cursor_pos(&["3 5".to_string()]), Some((3, 5)));
-        assert_eq!(parse_cursor_pos(&["nope".to_string()]), None);
     }
 
     #[test]

--- a/crates/ozmux_tmux/src/lib.rs
+++ b/crates/ozmux_tmux/src/lib.rs
@@ -16,6 +16,7 @@ mod input;
 mod observers;
 mod output;
 mod plugin;
+mod state_restore;
 
 pub use command::{
     CopyModeCapture, CopyStateQuery, EnterCopyMode, KillPane, KillWindow, NewWindow, NextWindow,

--- a/crates/ozmux_tmux/src/output.rs
+++ b/crates/ozmux_tmux/src/output.rs
@@ -18,7 +18,7 @@ pub struct PaneOutput {
 
 /// Request from the renderer layer (the binary) to re-`capture-pane`-seed a
 /// pane whose grid was left structurally unpainted after a layout change. The
-/// crate handles it via `request_pane_capture`, reusing the existing reply
+/// crate handles it via `request_pane_restore`, reusing the existing reply
 /// correlation and in-flight suppression.
 #[derive(Message)]
 pub struct RequestPaneReseed {

--- a/crates/ozmux_tmux/src/plugin.rs
+++ b/crates/ozmux_tmux/src/plugin.rs
@@ -301,6 +301,7 @@ fn recapture_settled_panes(
 fn handle_pane_reseed_requests(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     mut requests: MessageReader<RequestPaneReseed>,
+    index: Res<TmuxProjection>,
     panes: Query<&TmuxPane>,
 ) {
     let (client, enumeration) = &mut *client;
@@ -311,9 +312,10 @@ fn handle_pane_reseed_requests(
         if enumeration.restores.contains_key(&req.pane) {
             continue;
         }
-        let Some(pane_height) = panes
-            .iter()
-            .find(|p| p.id == req.pane)
+        let Some(pane_height) = index
+            .panes
+            .get(&req.pane)
+            .and_then(|(entity, _)| panes.get(*entity).ok())
             .map(|p| p.dims.height as u16)
         else {
             continue;
@@ -604,6 +606,12 @@ fn apply_reply(
 
 /// Resolves one slot of `pane`'s restore buffer and, once every requested
 /// slot has resolved, synthesizes and emits the seed exactly once.
+///
+/// NOTE: a failed base-capture slot leaves no real content to replay;
+/// emitting the seed anyway would clear an already-rendered pane's mirror to
+/// blank for no reason, so a failed `base` drops the buffer without emitting
+/// — matching the prior behavior of leaving the mirror untouched when
+/// `capture-pane` fails.
 fn fill_restore_slot<T>(
     enumeration: &mut EnumerationState,
     pane_output: &mut MessageWriter<PaneOutput>,
@@ -615,14 +623,20 @@ fn fill_restore_slot<T>(
         return;
     };
     assign(restore, slot);
-    if restore.complete()
-        && let Some(restore) = enumeration.restores.remove(&pane)
-    {
-        pane_output.write(PaneOutput {
-            pane,
-            data: restore.into_bytes(),
-        });
+    if !restore.complete() {
+        return;
     }
+    let Some(restore) = enumeration.restores.remove(&pane) else {
+        return;
+    };
+    if matches!(restore.base, Slot::Failed) {
+        tracing::warn!(pane = pane.0, "base capture failed, skipping restore seed");
+        return;
+    }
+    pane_output.write(PaneOutput {
+        pane,
+        data: restore.into_bytes(),
+    });
 }
 
 /// Sends the per-session enumeration queries (`list-windows` + active-pane) that
@@ -928,9 +942,9 @@ mod tests {
             MessageWriter<PaneOutput>,
         )> = SystemState::new(app.world_mut());
         {
-            let (mut commands, mut client_q, mut pane_output) =
+            let (mut commands, mut client_query, mut pane_output) =
                 system_state.get_mut(app.world_mut());
-            let (mut client, mut enumeration) = client_q
+            let (mut client, mut enumeration) = client_query
                 .single_mut()
                 .expect("gateway entity must carry TmuxClient + EnumerationState");
             apply_reply(
@@ -1003,9 +1017,9 @@ mod tests {
             MessageWriter<PaneOutput>,
         )> = SystemState::new(app.world_mut());
         {
-            let (mut commands, mut client_q, mut pane_output) =
+            let (mut commands, mut client_query, mut pane_output) =
                 system_state.get_mut(app.world_mut());
-            let (mut client, mut enumeration) = client_q
+            let (mut client, mut enumeration) = client_query
                 .single_mut()
                 .expect("gateway entity must carry TmuxClient + EnumerationState");
             // Apply the four replies in a shuffled order to prove ordering does

--- a/crates/ozmux_tmux/src/plugin.rs
+++ b/crates/ozmux_tmux/src/plugin.rs
@@ -2,24 +2,26 @@
 //! per-frame transport-drain system that triggers the projection events.
 
 use crate::command::{
-    ActivePane, AggressiveResize, CapturePane, ClientName, CursorQuery, ListWindows,
-    SubscribeWindowFlags, Version,
+    ActivePane, AggressiveResize, CapturePane, CapturePanePending, CapturePaneSavedPrimary,
+    CapturePaneWithHistory, ClientName, ListWindows, PaneStateQuery, SubscribeWindowFlags, Version,
 };
 use crate::components::{PaneRecaptureState, TmuxPane, TmuxSession};
 use crate::connection::{TmuxAttached, TmuxClient};
 use crate::copy_queries::{CopyModeQueries, CopyModeReply, drain_copy_replies};
-use crate::enumerate::{EnumerationState, PendingReply, version_supports_per_window_refresh};
+use crate::enumerate::{
+    EnumerationState, PaneRestore, PendingReply, Slot, version_supports_per_window_refresh,
+};
 use crate::event_pump::{
-    capture_to_bytes, capture_to_bytes_with_cursor, detect_session_switch, detect_window_added,
-    detect_window_switch, first_reply_line, log_transport_event, parse_active_pane,
-    parse_cursor_pos, trigger_notification, trigger_seed,
+    detect_session_switch, detect_window_added, detect_window_switch, first_reply_line,
+    log_transport_event, parse_active_pane, trigger_notification, trigger_seed,
 };
 use crate::events::{TmuxActivePaneChanged, TmuxWindowsRetained};
 use crate::observers::{TmuxProjection, register_observers};
 use crate::output::{PaneOutput, RequestPaneReseed, collect_pane_outputs};
+use crate::state_restore::parse_pane_state;
 use bevy::prelude::*;
 use ozma_tty_engine::{AdoptedControlMode, ControlModeReleased, TerminalRawWrite};
-use tmux_control::{ClientEvent, TransportEvent};
+use tmux_control::{ClientEvent, TmuxCommand, TransportEvent};
 use tmux_control_parser::PaneId;
 
 /// Soft per-frame event-count expectation. A single frame's feed produces the
@@ -114,48 +116,123 @@ impl TmuxEventBatch {
     }
 }
 
-/// Sends `capture-pane` and a companion cursor-position `display-message` once
-/// for each newly-projected pane so its current screen seeds the first paint
-/// with the cursor at the correct position. tmux `-CC` does not replay existing
-/// content on attach (it only streams new `%output`), so without this a
-/// quiescent pane stays blank until its program writes again. Gated on
-/// `Added<TmuxPane>` — runs once per pane. The capture/cursor replies are
-/// consumed by [`apply_reply`]'s `Capture`/`Cursor` arms and routed as
-/// `PaneOutput`.
+/// Sends the full restore command set once for each newly-projected pane so its
+/// tmux-side state (history+screen, saved primary, terminal modes, pending
+/// output) seeds the first paint. tmux `-CC` does not replay existing content on
+/// attach (it only streams new `%output`), so without this a quiescent pane
+/// stays blank until its program writes again. Gated on `Added<TmuxPane>` — runs
+/// once per pane. The replies are consumed by [`apply_reply`]'s `Restore*` arms,
+/// which synthesize and route the seed as `PaneOutput`.
 fn request_pane_captures(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     new_panes: Query<&TmuxPane, Added<TmuxPane>>,
 ) {
     let (client, enumeration) = &mut *client;
     for pane in new_panes.iter() {
-        request_pane_capture(client, enumeration, pane.id);
+        request_pane_restore(
+            client,
+            enumeration,
+            pane.id,
+            pane.dims.height as u16,
+            RestoreDepth::Full,
+        );
     }
 }
 
-/// Sends a `capture-pane` + cursor-position query for `pane` and registers the
-/// pending replies so [`apply_reply`] seeds the mirror from tmux's authoritative
-/// grid (clear-screen + rows + the real cursor position).
-fn request_pane_capture(client: &mut TmuxClient, enumeration: &mut EnumerationState, pane: PaneId) {
-    match client.send(CapturePane { id: pane }) {
-        Ok(cap_id) => {
-            enumeration
-                .pending
-                .insert(cap_id, PendingReply::Capture { pane });
-            match client.send(CursorQuery { id: pane }) {
-                Ok(cur_id) => {
-                    enumeration
-                        .pending
-                        .insert(cur_id, PendingReply::Cursor { pane });
-                    enumeration.panes_with_cursor_pending.insert(pane);
-                }
-                Err(error) => {
-                    tracing::warn!(?error, pane = pane.0, "failed to send cursor query");
-                }
-            }
+/// How much of a pane's tmux-side state one restore pass fetches.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RestoreDepth {
+    /// Adopt-time: history+screen, saved primary, state, pending output.
+    Full,
+    /// Re-seed: visible screen + state (history accumulates via %output).
+    Light,
+}
+
+/// Sends one restore command, registering its reply id. Returns false on a
+/// send failure so the caller resolves that slot as Failed immediately —
+/// a partially-sent restore still completes instead of wedging the pane.
+fn send_restore_command(
+    client: &mut TmuxClient,
+    enumeration: &mut EnumerationState,
+    command: impl TmuxCommand,
+    reply: PendingReply,
+) -> bool {
+    match client.send(command) {
+        Ok(id) => {
+            enumeration.pending.insert(id, reply);
+            true
         }
         Err(error) => {
-            tracing::warn!(?error, pane = pane.0, "failed to send capture-pane")
+            tracing::warn!(?error, ?reply, "failed to send restore command");
+            false
         }
+    }
+}
+
+/// Sends the restore command set for `pane` and registers a [`PaneRestore`]
+/// buffer; [`apply_reply`] fills the slots and emits the synthesized seed
+/// once every requested reply resolves.
+fn request_pane_restore(
+    client: &mut TmuxClient,
+    enumeration: &mut EnumerationState,
+    pane: PaneId,
+    pane_height: u16,
+    depth: RestoreDepth,
+) {
+    let mut buffer = match depth {
+        RestoreDepth::Full => PaneRestore::new_full(pane_height),
+        RestoreDepth::Light => PaneRestore::new_light(pane_height),
+    };
+    let base_sent = match depth {
+        RestoreDepth::Full => send_restore_command(
+            client,
+            enumeration,
+            CapturePaneWithHistory { id: pane },
+            PendingReply::RestoreBase { pane },
+        ),
+        RestoreDepth::Light => send_restore_command(
+            client,
+            enumeration,
+            CapturePane { id: pane },
+            PendingReply::RestoreBase { pane },
+        ),
+    };
+    if !base_sent {
+        buffer.base = Slot::Failed;
+    }
+    if !send_restore_command(
+        client,
+        enumeration,
+        PaneStateQuery { id: pane },
+        PendingReply::RestoreState { pane },
+    ) {
+        buffer.state = Slot::Failed;
+    }
+    if depth == RestoreDepth::Full {
+        if !send_restore_command(
+            client,
+            enumeration,
+            CapturePaneSavedPrimary { id: pane },
+            PendingReply::RestoreSavedPrimary { pane },
+        ) {
+            buffer.saved_primary = Slot::Failed;
+        }
+        if !send_restore_command(
+            client,
+            enumeration,
+            CapturePanePending { id: pane },
+            PendingReply::RestorePending { pane },
+        ) {
+            buffer.pending = Slot::Failed;
+        }
+    }
+    // NOTE: when every send failed the buffer is already complete and no
+    // reply will ever flush it; drop it (no seed) so the in-flight guard
+    // clears and the aged reseed tracker can retry later.
+    if !buffer.complete() {
+        enumeration.restores.insert(pane, buffer);
+    } else {
+        tracing::warn!(pane = pane.0, "all restore commands failed to send");
     }
 }
 
@@ -174,14 +251,14 @@ const RECAPTURE_SETTLE_FRAMES: u8 = 3;
 /// grown to the control client's size (the common case when an adopted
 /// `tmux -CC` session starts at tmux's default-size and the client then enlarges
 /// it), alacritty's grow pulls local scrollback onto the screen and pushes the
-/// prompt to mid-screen. A capture-pane + cursor seed (clear + tmux's rows + the
-/// real cursor) overwrites both. The seed re-arms whenever the pane's dims change
+/// prompt to mid-screen. A light restore (clear + tmux's visible rows + terminal
+/// state) overwrites both. The seed re-arms whenever the pane's dims change
 /// (`done` is reset on a size change in the loop below), so the post-grow size is
 /// re-seeded too; the settle delay debounces a window-drag to one re-seed per
 /// settle. Re-seeding from tmux's authoritative grid is correct for a
 /// display-only mirror — it resyncs and never loses real state (tmux owns the
-/// content). Skipped while an earlier capture for the pane is still in flight so
-/// the two capture/cursor pairs never collide.
+/// content). Skipped while an earlier restore for the pane is still in flight so
+/// the two restore passes never collide.
 fn recapture_settled_panes(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     mut panes: Query<(&TmuxPane, &mut PaneRecaptureState)>,
@@ -203,33 +280,51 @@ fn recapture_settled_panes(
         }
         if !state.done
             && state.stable >= RECAPTURE_SETTLE_FRAMES
-            && !enumeration.panes_with_cursor_pending.contains(&pane.id)
+            && !enumeration.restores.contains_key(&pane.id)
         {
             state.done = true;
-            request_pane_capture(client, enumeration, pane.id);
+            request_pane_restore(
+                client,
+                enumeration,
+                pane.id,
+                pane.dims.height as u16,
+                RestoreDepth::Light,
+            );
         }
     }
 }
 
-/// Re-seeds each requested pane via `request_pane_capture`. Retry cadence is
-/// owned by the binary's aged reseed tracker (spec §3.2); this additionally
-/// skips a pane that already has a capture/cursor pair in flight so it cannot
+/// Re-seeds each requested pane via a light `request_pane_restore`. Retry
+/// cadence is owned by the binary's aged reseed tracker (spec §3.2); this
+/// additionally skips a pane that already has a restore in flight so it cannot
 /// collide with `recapture_settled_panes`.
 fn handle_pane_reseed_requests(
     mut client: Single<(&mut TmuxClient, &mut EnumerationState)>,
     mut requests: MessageReader<RequestPaneReseed>,
+    panes: Query<&TmuxPane>,
 ) {
     let (client, enumeration) = &mut *client;
     for req in requests.read() {
-        // NOTE: two in-flight capture/cursor pairs for one pane desync the
-        // per-pane cursor correlation (`panes_with_cursor_pending` /
-        // `capture_awaiting_cursor` are keyed by pane, not by command), so the
-        // second capture lands without cursor info. The aged reseed tracker
-        // retries later, so suppressing here cannot wedge the pane.
-        if enumeration.panes_with_cursor_pending.contains(&req.pane) {
+        // NOTE: a second restore for a pane whose buffer is still in flight
+        // would land a duplicate seed; the aged reseed tracker retries later, so
+        // suppressing here cannot wedge the pane.
+        if enumeration.restores.contains_key(&req.pane) {
             continue;
         }
-        request_pane_capture(client, enumeration, req.pane);
+        let Some(pane_height) = panes
+            .iter()
+            .find(|p| p.id == req.pane)
+            .map(|p| p.dims.height as u16)
+        else {
+            continue;
+        };
+        request_pane_restore(
+            client,
+            enumeration,
+            req.pane,
+            pane_height,
+            RestoreDepth::Light,
+        );
     }
 }
 
@@ -386,11 +481,6 @@ fn apply_tmux_replies(
 ) {
     let (client, enumeration) = &mut *client;
     let events = &batch.0;
-    // NOTE: this MUST stay a single in-order pass. tmux CC-mode replies are
-    // FIFO, and capture is sent before its paired cursor query, so the Capture
-    // arm fills capture_awaiting_cursor before the Cursor arm drains it.
-    // Splitting into two passes silently drops cursor fixes on same-batch
-    // arrivals.
     for event in events {
         match event {
             TransportEvent::Protocol(ClientEvent::CommandComplete { id, ok, output, .. }) => {
@@ -476,43 +566,62 @@ fn apply_reply(
                 }
             }
         }
-        PendingReply::Capture { pane } if ok => {
-            if enumeration.panes_with_cursor_pending.contains(&pane) {
-                enumeration
-                    .capture_awaiting_cursor
-                    .insert(pane, output.to_vec());
+        PendingReply::RestoreBase { pane } => {
+            let slot = if ok {
+                Slot::Ok(output.to_vec())
             } else {
-                pane_output.write(PaneOutput {
-                    pane,
-                    data: capture_to_bytes(output),
-                });
-            }
-        }
-        PendingReply::Capture { pane } => {
-            tracing::warn!(pane = pane.0, "capture-pane command failed");
-        }
-        PendingReply::Cursor { pane } => {
-            enumeration.panes_with_cursor_pending.remove(&pane);
-            let Some(lines) = enumeration.capture_awaiting_cursor.remove(&pane) else {
-                return;
+                Slot::Failed
             };
-            let (cx, cy) = if ok {
-                parse_cursor_pos(output).unwrap_or((0, 0))
+            fill_restore_slot(enumeration, pane_output, pane, slot, |r, s| r.base = s);
+        }
+        PendingReply::RestoreSavedPrimary { pane } => {
+            let slot = if ok {
+                Slot::Ok(output.to_vec())
             } else {
-                tracing::warn!(pane = pane.0, "cursor-position query failed");
-                (0, 0)
+                Slot::Failed
             };
-            pane_output.write(PaneOutput {
-                pane,
-                data: capture_to_bytes_with_cursor(&lines, cx, cy),
+            fill_restore_slot(enumeration, pane_output, pane, slot, |r, s| {
+                r.saved_primary = s
             });
         }
-        // TODO: wired by the restore-buffer dispatch (pane-restore reply
-        // correlation lands the actual handling here).
-        PendingReply::RestoreBase { .. }
-        | PendingReply::RestoreSavedPrimary { .. }
-        | PendingReply::RestoreState { .. }
-        | PendingReply::RestorePending { .. } => {}
+        PendingReply::RestorePending { pane } => {
+            let slot = if ok {
+                Slot::Ok(output.to_vec())
+            } else {
+                Slot::Failed
+            };
+            fill_restore_slot(enumeration, pane_output, pane, slot, |r, s| r.pending = s);
+        }
+        PendingReply::RestoreState { pane } => {
+            let slot = match first_reply_line(ok, output, "pane-state") {
+                Some(line) => Slot::Ok(parse_pane_state(&line)),
+                None => Slot::Failed,
+            };
+            fill_restore_slot(enumeration, pane_output, pane, slot, |r, s| r.state = s);
+        }
+    }
+}
+
+/// Resolves one slot of `pane`'s restore buffer and, once every requested
+/// slot has resolved, synthesizes and emits the seed exactly once.
+fn fill_restore_slot<T>(
+    enumeration: &mut EnumerationState,
+    pane_output: &mut MessageWriter<PaneOutput>,
+    pane: PaneId,
+    slot: Slot<T>,
+    assign: impl FnOnce(&mut PaneRestore, Slot<T>),
+) {
+    let Some(restore) = enumeration.restores.get_mut(&pane) else {
+        return;
+    };
+    assign(restore, slot);
+    if restore.complete()
+        && let Some(restore) = enumeration.restores.remove(&pane)
+    {
+        pane_output.write(PaneOutput {
+            pane,
+            data: restore.into_bytes(),
+        });
     }
 }
 
@@ -730,7 +839,7 @@ mod tests {
                 .expect("gateway must carry EnumerationState")
                 .pending
                 .values()
-                .any(|r| matches!(r, PendingReply::Capture { pane } if *pane == PaneId(1)))
+                .any(|r| matches!(r, PendingReply::RestoreBase { pane } if *pane == PaneId(1)))
         };
 
         // Settle at the born size -> the re-seed fires once.
@@ -739,16 +848,16 @@ mod tests {
         }
         assert!(captured(&mut app), "first settle must seed the pane");
 
-        // Simulate the capture/cursor replies landing: clear the in-flight
-        // markers (so the next re-seed isn't blocked) and pending (so the second
-        // capture is detectable).
+        // Simulate the restore replies landing: clear the in-flight buffer (so
+        // the next re-seed isn't blocked) and pending (so the second restore is
+        // detectable).
         {
             let mut enumeration = app
                 .world_mut()
                 .query::<&mut EnumerationState>()
                 .single_mut(app.world_mut())
                 .expect("gateway must carry EnumerationState");
-            enumeration.panes_with_cursor_pending.clear();
+            enumeration.restores.clear();
             enumeration.pending.clear();
         }
 
@@ -855,6 +964,104 @@ mod tests {
         assert_eq!(
             *app.world().resource::<Added>().0.lock().unwrap(),
             vec![WindowId(1)]
+        );
+    }
+
+    #[test]
+    fn full_restore_emits_seed_once_after_all_replies_in_any_order() {
+        use crate::enumerate::{PaneRestore, Slot};
+        use bevy::ecs::system::SystemState;
+
+        let base = vec!["line one".to_string(), "line two".to_string()];
+        let saved_primary: Vec<String> = vec![];
+        let pending = vec!["pending-tail".to_string()];
+        let state_line = "cursor_x=3\tcursor_y=1\twrap_flag=1".to_string();
+
+        // Independently synthesize the bytes the buffer must emit once complete.
+        let expected = {
+            let mut r = PaneRestore::new_full(2);
+            r.base = Slot::Ok(base.clone());
+            r.saved_primary = Slot::Ok(saved_primary.clone());
+            r.pending = Slot::Ok(pending.clone());
+            r.state = Slot::Ok(parse_pane_state(&state_line));
+            r.into_bytes()
+        };
+
+        let mut app = App::new();
+        app.add_message::<PaneOutput>();
+        let gateway = app.world_mut().spawn(TmuxClient::new_adopted()).id();
+        // Seed the in-flight full restore buffer request_pane_restore would have.
+        app.world_mut()
+            .get_mut::<EnumerationState>(gateway)
+            .expect("TmuxClient auto-requires EnumerationState")
+            .restores
+            .insert(PaneId(1), PaneRestore::new_full(2));
+
+        let mut system_state: SystemState<(
+            Commands,
+            Query<(&mut TmuxClient, &mut EnumerationState)>,
+            MessageWriter<PaneOutput>,
+        )> = SystemState::new(app.world_mut());
+        {
+            let (mut commands, mut client_q, mut pane_output) =
+                system_state.get_mut(app.world_mut());
+            let (mut client, mut enumeration) = client_q
+                .single_mut()
+                .expect("gateway entity must carry TmuxClient + EnumerationState");
+            // Apply the four replies in a shuffled order to prove ordering does
+            // not matter: state, pending, saved-primary, base.
+            let replies = [
+                (
+                    PendingReply::RestoreState { pane: PaneId(1) },
+                    vec![state_line.clone()],
+                ),
+                (
+                    PendingReply::RestorePending { pane: PaneId(1) },
+                    pending.clone(),
+                ),
+                (
+                    PendingReply::RestoreSavedPrimary { pane: PaneId(1) },
+                    saved_primary.clone(),
+                ),
+                (PendingReply::RestoreBase { pane: PaneId(1) }, base.clone()),
+            ];
+            for (reply, output) in replies {
+                apply_reply(
+                    &mut commands,
+                    &mut enumeration,
+                    &mut pane_output,
+                    &mut client,
+                    reply,
+                    true,
+                    &output,
+                );
+            }
+        }
+        system_state.apply(app.world_mut());
+
+        let outputs: Vec<PaneOutput> = app
+            .world()
+            .resource::<Messages<PaneOutput>>()
+            .iter_current_update_messages()
+            .cloned()
+            .collect();
+        assert_eq!(
+            outputs.len(),
+            1,
+            "the seed must be emitted exactly once, after the final reply resolves"
+        );
+        assert_eq!(outputs[0].pane, PaneId(1));
+        assert_eq!(
+            outputs[0].data, expected,
+            "the emitted seed must match the synthesized restore bytes"
+        );
+        assert!(
+            !app.world()
+                .get::<EnumerationState>(gateway)
+                .unwrap()
+                .restores
+                .contains_key(&PaneId(1)),
+            "the restore buffer must be removed once the seed is emitted"
         );
     }
 
@@ -1247,7 +1454,7 @@ mod tests {
                 .expect("gateway must carry EnumerationState")
                 .pending
                 .values()
-                .any(|r| matches!(r, PendingReply::Capture { pane } if *pane == PaneId(1)))
+                .any(|r| matches!(r, PendingReply::RestoreBase { pane } if *pane == PaneId(1)))
         };
 
         // Settle pane %1 on gateway1 so the re-seed fires and done=true.
@@ -1263,7 +1470,7 @@ mod tests {
                 .query::<&mut EnumerationState>()
                 .single_mut(app.world_mut())
                 .expect("gateway must carry EnumerationState");
-            enumeration.panes_with_cursor_pending.clear();
+            enumeration.restores.clear();
             enumeration.pending.clear();
         }
         app.world_mut().entity_mut(pane1).despawn();

--- a/crates/ozmux_tmux/src/plugin.rs
+++ b/crates/ozmux_tmux/src/plugin.rs
@@ -507,6 +507,12 @@ fn apply_reply(
                 data: capture_to_bytes_with_cursor(&lines, cx, cy),
             });
         }
+        // TODO: wired by the restore-buffer dispatch (pane-restore reply
+        // correlation lands the actual handling here).
+        PendingReply::RestoreBase { .. }
+        | PendingReply::RestoreSavedPrimary { .. }
+        | PendingReply::RestoreState { .. }
+        | PendingReply::RestorePending { .. } => {}
     }
 }
 

--- a/crates/ozmux_tmux/src/state_restore.rs
+++ b/crates/ozmux_tmux/src/state_restore.rs
@@ -87,6 +87,56 @@ fn split_state_fields(line: &str) -> HashMap<&str, &str> {
     parts.iter().filter_map(|p| p.split_once('=')).collect()
 }
 
+/// Appends the DECSET/DECSTBM/tabstop/cursor tail restoring `state` onto a
+/// content-replay byte stream. Every mode is emitted in BOTH directions
+/// (`h` when set, `l` when clear) so the light re-seed path — where the
+/// mirror still carries the previous seed's modes — converges without
+/// assuming a reset baseline. Ends with the cursor CUP.
+///
+/// NOTE: DECSTBM and DECOM home the cursor, so the cursor CUP MUST stay
+/// after both; under DECOM the CUP row is region-relative and is converted
+/// from tmux's absolute `cursor_y` here.
+fn append_state_bytes(bytes: &mut Vec<u8>, state: &PaneState) {
+    let mode = |bytes: &mut Vec<u8>, seq: &str, on: bool| {
+        bytes.extend_from_slice(seq.as_bytes());
+        bytes.push(if on { b'h' } else { b'l' });
+    };
+    mode(bytes, "\x1b[?1000", state.mouse_standard);
+    mode(bytes, "\x1b[?1002", state.mouse_button);
+    mode(bytes, "\x1b[?1003", state.mouse_all);
+    mode(bytes, "\x1b[?1005", state.mouse_utf8);
+    mode(bytes, "\x1b[?1006", state.mouse_sgr);
+    mode(bytes, "\x1b[?1", state.app_cursor_keys);
+    bytes.extend_from_slice(if state.app_keypad { b"\x1b=" } else { b"\x1b>" });
+    mode(bytes, "\x1b[4", state.insert);
+    mode(bytes, "\x1b[?2004", state.bracketed_paste);
+    mode(bytes, "\x1b[?25", state.cursor_visible);
+    mode(bytes, "\x1b[?7", state.wrap);
+    mode(bytes, "\x1b[?6", state.origin);
+    if state.scroll_region_lower > state.scroll_region_upper {
+        bytes.extend_from_slice(
+            format!(
+                "\x1b[{};{}r",
+                state.scroll_region_upper + 1,
+                state.scroll_region_lower + 1
+            )
+            .as_bytes(),
+        );
+    }
+    if !state.tabs.is_empty() {
+        bytes.extend_from_slice(b"\x1b[3g");
+        for col in &state.tabs {
+            bytes.extend_from_slice(format!("\x1b[{}G\x1bH", col + 1).as_bytes());
+        }
+    }
+    let row = if state.origin {
+        state.cursor_y.saturating_sub(state.scroll_region_upper) + 1
+    } else {
+        state.cursor_y + 1
+    };
+    bytes.extend_from_slice(format!("\x1b[{};{}H", row, state.cursor_x + 1).as_bytes());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,5 +245,106 @@ mod tests {
         let s = parse_pane_state("");
         assert!(s.cursor_visible && s.wrap);
         assert!(!s.alternate_on);
+    }
+
+    fn state_bytes(state: &PaneState) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        append_state_bytes(&mut bytes, state);
+        bytes
+    }
+
+    fn default_state() -> PaneState {
+        parse_pane_state("")
+    }
+
+    #[test]
+    fn mouse_flags_emit_exclusive_tracking_and_encoding() {
+        let mut s = default_state();
+        s.mouse_button = true;
+        s.mouse_sgr = true;
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        assert!(text.contains("\x1b[?1000l") && text.contains("\x1b[?1003l"));
+        assert!(text.contains("\x1b[?1002h") && text.contains("\x1b[?1006h"));
+        assert!(text.contains("\x1b[?1005l"));
+    }
+
+    #[test]
+    fn all_off_state_emits_explicit_resets() {
+        let b = state_bytes(&default_state());
+        let text = String::from_utf8_lossy(&b);
+        for seq in [
+            "\x1b[?1000l",
+            "\x1b[?1002l",
+            "\x1b[?1003l",
+            "\x1b[?1006l",
+            "\x1b[?1l",
+            "\x1b[4l",
+            "\x1b[?2004l",
+            "\x1b>",
+        ] {
+            assert!(text.contains(seq), "missing {seq:?}");
+        }
+        assert!(text.contains("\x1b[?25h") && text.contains("\x1b[?7h"));
+    }
+
+    #[test]
+    fn hidden_cursor_and_no_wrap_emit_low() {
+        let mut s = default_state();
+        s.cursor_visible = false;
+        s.wrap = false;
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        assert!(text.contains("\x1b[?25l") && text.contains("\x1b[?7l"));
+    }
+
+    #[test]
+    fn cursor_cup_is_absolute_without_origin() {
+        let mut s = default_state();
+        s.cursor_x = 4;
+        s.cursor_y = 9;
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        assert!(text.ends_with("\x1b[10;5H"), "got {text:?}");
+    }
+
+    #[test]
+    fn cursor_cup_converts_to_region_relative_under_origin() {
+        let mut s = default_state();
+        s.origin = true;
+        s.scroll_region_upper = 3;
+        s.scroll_region_lower = 20;
+        s.cursor_x = 0;
+        s.cursor_y = 5;
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        // DECOM makes CUP region-relative: row = cursor_y - upper + 1 = 3.
+        assert!(text.contains("\x1b[?6h"));
+        assert!(text.contains("\x1b[4;21r"));
+        assert!(text.ends_with("\x1b[3;1H"), "got {text:?}");
+    }
+
+    #[test]
+    fn tabstops_clear_then_set_each_column() {
+        let mut s = default_state();
+        s.tabs = vec![8, 16];
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        let clear = text.find("\x1b[3g").expect("clear-all tabs");
+        assert!(text[clear..].contains("\x1b[9G\x1bH"));
+        assert!(text[clear..].contains("\x1b[17G\x1bH"));
+    }
+
+    #[test]
+    fn scroll_region_precedes_cursor_and_follows_modes() {
+        let mut s = default_state();
+        s.scroll_region_upper = 2;
+        s.scroll_region_lower = 30;
+        s.cursor_y = 4;
+        let b = state_bytes(&s);
+        let text = String::from_utf8_lossy(&b);
+        let region = text.find("\x1b[3;31r").expect("DECSTBM");
+        let cup = text.rfind("\x1b[").expect("cursor CUP");
+        assert!(region < cup);
     }
 }

--- a/crates/ozmux_tmux/src/state_restore.rs
+++ b/crates/ozmux_tmux/src/state_restore.rs
@@ -13,28 +13,31 @@ use tmux_control_parser::unescape_capture;
 pub(crate) const PANE_STATE_FORMAT: &str = "pane_id=#{pane_id}\talternate_on=#{alternate_on}\talternate_saved_x=#{alternate_saved_x}\talternate_saved_y=#{alternate_saved_y}\tcursor_x=#{cursor_x}\tcursor_y=#{cursor_y}\tscroll_region_upper=#{scroll_region_upper}\tscroll_region_lower=#{scroll_region_lower}\tpane_tabs=#{pane_tabs}\tcursor_flag=#{cursor_flag}\tinsert_flag=#{insert_flag}\tkeypad_cursor_flag=#{keypad_cursor_flag}\tkeypad_flag=#{keypad_flag}\twrap_flag=#{wrap_flag}\torigin_flag=#{origin_flag}\tmouse_standard_flag=#{mouse_standard_flag}\tmouse_button_flag=#{mouse_button_flag}\tmouse_all_flag=#{mouse_all_flag}\tmouse_utf8_flag=#{mouse_utf8_flag}\tmouse_sgr_flag=#{mouse_sgr_flag}\tbracket_paste_flag=#{bracket_paste_flag}";
 
 /// One pane's terminal state parsed from a [`PANE_STATE_FORMAT`] reply line.
+///
+/// NOTE: fields are private — every read lives in this module (`restore_to_bytes`
+/// / `append_state_bytes`); external code only holds this behind `Slot<PaneState>`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PaneState {
-    pub(crate) alternate_on: bool,
-    pub(crate) alternate_saved_x: u16,
-    pub(crate) alternate_saved_y: u16,
-    pub(crate) cursor_x: u16,
-    pub(crate) cursor_y: u16,
-    pub(crate) scroll_region_upper: u16,
-    pub(crate) scroll_region_lower: u16,
-    pub(crate) tabs: Vec<u16>,
-    pub(crate) cursor_visible: bool,
-    pub(crate) insert: bool,
-    pub(crate) app_cursor_keys: bool,
-    pub(crate) app_keypad: bool,
-    pub(crate) wrap: bool,
-    pub(crate) origin: bool,
-    pub(crate) mouse_standard: bool,
-    pub(crate) mouse_button: bool,
-    pub(crate) mouse_all: bool,
-    pub(crate) mouse_utf8: bool,
-    pub(crate) mouse_sgr: bool,
-    pub(crate) bracketed_paste: bool,
+    alternate_on: bool,
+    alternate_saved_x: u16,
+    alternate_saved_y: u16,
+    cursor_x: u16,
+    cursor_y: u16,
+    scroll_region_upper: u16,
+    scroll_region_lower: u16,
+    tabs: Vec<u16>,
+    cursor_visible: bool,
+    insert: bool,
+    app_cursor_keys: bool,
+    app_keypad: bool,
+    wrap: bool,
+    origin: bool,
+    mouse_standard: bool,
+    mouse_button: bool,
+    mouse_all: bool,
+    mouse_utf8: bool,
+    mouse_sgr: bool,
+    bracketed_paste: bool,
 }
 
 /// Parses one [`PANE_STATE_FORMAT`] reply line. Missing, empty, or
@@ -101,13 +104,17 @@ pub(crate) enum GridCapture {
 /// NOTE: the reset prefix MUST precede the ESC[2J erase and the row replay —
 /// stale SGR floods the erase (the blue-pane bug) and a stale DECSTBM/DECOM
 /// scrolls the CRLF replay within wrong margins. Content is replayed before
-/// modes so `-J`-joined long lines re-wrap under the default wrap=on.
+/// modes so `-J`-joined long lines re-wrap under the forced wrap=on the reset
+/// prefix now includes (a light re-seed reuses a long-lived mirror that can
+/// still carry a PRIOR restore's wrap=off, which would otherwise stop the
+/// replayed long line from re-wrapping before the real `wrap` flag is
+/// reapplied afterward).
 pub(crate) fn restore_to_bytes(
     grid: &GridCapture,
     state: Option<&PaneState>,
     pending: &[String],
 ) -> Vec<u8> {
-    let mut bytes = b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec();
+    let mut bytes = b"\x1b[r\x1b[?6l\x1b[?7h\x1b[0m\x1b[H\x1b[2J".to_vec();
     match grid {
         GridCapture::Full {
             base,
@@ -127,8 +134,8 @@ pub(crate) fn restore_to_bytes(
                 bytes.extend_from_slice(
                     format!(
                         "\x1b[{};{}H",
-                        s.alternate_saved_y + 1,
-                        s.alternate_saved_x + 1
+                        s.alternate_saved_y.saturating_add(1),
+                        s.alternate_saved_x.saturating_add(1)
                     )
                     .as_bytes(),
                 );
@@ -203,8 +210,8 @@ fn append_state_bytes(bytes: &mut Vec<u8>, state: &PaneState) {
         bytes.extend_from_slice(
             format!(
                 "\x1b[{};{}r",
-                state.scroll_region_upper + 1,
-                state.scroll_region_lower + 1
+                state.scroll_region_upper.saturating_add(1),
+                state.scroll_region_lower.saturating_add(1)
             )
             .as_bytes(),
         );
@@ -212,15 +219,20 @@ fn append_state_bytes(bytes: &mut Vec<u8>, state: &PaneState) {
     if !state.tabs.is_empty() {
         bytes.extend_from_slice(b"\x1b[3g");
         for col in &state.tabs {
-            bytes.extend_from_slice(format!("\x1b[{}G\x1bH", col + 1).as_bytes());
+            bytes.extend_from_slice(format!("\x1b[{}G\x1bH", col.saturating_add(1)).as_bytes());
         }
     }
     let row = if state.origin {
-        state.cursor_y.saturating_sub(state.scroll_region_upper) + 1
+        state
+            .cursor_y
+            .saturating_sub(state.scroll_region_upper)
+            .saturating_add(1)
     } else {
-        state.cursor_y + 1
+        state.cursor_y.saturating_add(1)
     };
-    bytes.extend_from_slice(format!("\x1b[{};{}H", row, state.cursor_x + 1).as_bytes());
+    bytes.extend_from_slice(
+        format!("\x1b[{};{}H", row, state.cursor_x.saturating_add(1)).as_bytes(),
+    );
 }
 
 fn append_rows(bytes: &mut Vec<u8>, rows: &[String]) {
@@ -452,7 +464,7 @@ mod tests {
             rows: vec!["hello".into(), "world".into()],
         };
         let b = restore_to_bytes(&grid, None, &[]);
-        assert!(b.starts_with(b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J"));
+        assert!(b.starts_with(b"\x1b[r\x1b[?6l\x1b[?7h\x1b[0m\x1b[H\x1b[2J"));
         assert!(String::from_utf8_lossy(&b).contains("hello\r\nworld"));
     }
 

--- a/crates/ozmux_tmux/src/state_restore.rs
+++ b/crates/ozmux_tmux/src/state_restore.rs
@@ -3,6 +3,7 @@
 //! replays captured content + modes into the display mirror.
 
 use std::collections::HashMap;
+use tmux_control_parser::unescape_capture;
 
 /// Tab-separated `key=#{key}` format dumping one pane's terminal state.
 ///
@@ -76,6 +77,91 @@ pub(crate) fn parse_pane_state(line: &str) -> PaneState {
     }
 }
 
+/// Captured grid content for one restore pass.
+///
+/// `Full` carries the adopt-time pair: `base` is the default capture
+/// (primary history + the CURRENT visible screen — which is the alt screen
+/// while alternate is active) and `saved_primary` is the `-a` capture (the
+/// primary screen snapshot tmux saved on alt entry). `VisibleOnly` is the
+/// light re-seed's single visible capture.
+pub(crate) enum GridCapture {
+    Full {
+        base: Vec<String>,
+        saved_primary: Vec<String>,
+        pane_height: u16,
+    },
+    VisibleOnly {
+        rows: Vec<String>,
+    },
+}
+
+/// Synthesizes one VT byte stream restoring content, terminal state, and
+/// pending output, in that order, for replay through the pane mirror.
+///
+/// NOTE: the reset prefix MUST precede the ESC[2J erase and the row replay —
+/// stale SGR floods the erase (the blue-pane bug) and a stale DECSTBM/DECOM
+/// scrolls the CRLF replay within wrong margins. Content is replayed before
+/// modes so `-J`-joined long lines re-wrap under the default wrap=on.
+pub(crate) fn restore_to_bytes(
+    grid: &GridCapture,
+    state: Option<&PaneState>,
+    pending: &[String],
+) -> Vec<u8> {
+    let mut bytes = b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J".to_vec();
+    match grid {
+        GridCapture::Full {
+            base,
+            saved_primary,
+            pane_height,
+        } => {
+            let alt = state.is_some_and(|s| s.alternate_on);
+            let height = *pane_height as usize;
+            if alt && base.len() >= height {
+                let (history, alt_rows) = base.split_at(base.len() - height);
+                append_rows(&mut bytes, history);
+                if !history.is_empty() && !saved_primary.is_empty() {
+                    bytes.extend_from_slice(b"\r\n");
+                }
+                append_rows(&mut bytes, saved_primary);
+                let s = state.expect("alt implies state");
+                bytes.extend_from_slice(
+                    format!(
+                        "\x1b[{};{}H",
+                        s.alternate_saved_y + 1,
+                        s.alternate_saved_x + 1
+                    )
+                    .as_bytes(),
+                );
+                bytes.extend_from_slice(b"\x1b[?1049h\x1b[H\x1b[2J");
+                append_rows(&mut bytes, alt_rows);
+            } else {
+                append_rows(&mut bytes, base);
+            }
+        }
+        GridCapture::VisibleOnly { rows } => {
+            // NOTE: alacritty guards 1049 (set no-ops while already in alt,
+            // unset no-ops outside alt), so re-asserting membership is
+            // idempotent in the synced case and converges a desynced mirror.
+            if let Some(state) = state {
+                bytes.extend_from_slice(if state.alternate_on {
+                    b"\x1b[?1049h"
+                } else {
+                    b"\x1b[?1049l"
+                });
+                bytes.extend_from_slice(b"\x1b[H\x1b[2J");
+            }
+            append_rows(&mut bytes, rows);
+        }
+    }
+    if let Some(state) = state {
+        append_state_bytes(&mut bytes, state);
+    }
+    if !pending.is_empty() {
+        bytes.extend_from_slice(&unescape_capture(pending.join("\n").as_bytes()));
+    }
+    bytes
+}
+
 /// Splits a state reply into `key -> value`, re-splitting on a literal
 /// `\t` sequence when the transport escaped the tab separator (a known
 /// tmux transport quirk iTerm2 also works around).
@@ -135,6 +221,10 @@ fn append_state_bytes(bytes: &mut Vec<u8>, state: &PaneState) {
         state.cursor_y + 1
     };
     bytes.extend_from_slice(format!("\x1b[{};{}H", row, state.cursor_x + 1).as_bytes());
+}
+
+fn append_rows(bytes: &mut Vec<u8>, rows: &[String]) {
+    bytes.extend_from_slice(rows.join("\r\n").as_bytes());
 }
 
 #[cfg(test)]
@@ -346,5 +436,108 @@ mod tests {
         let region = text.find("\x1b[3;31r").expect("DECSTBM");
         let cup = text.rfind("\x1b[").expect("cursor CUP");
         assert!(region < cup);
+    }
+
+    fn rows(prefix: &str, n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("{prefix}{i}")).collect()
+    }
+
+    #[test]
+    fn visible_only_matches_reset_prefix_plus_rows() {
+        let grid = GridCapture::VisibleOnly {
+            rows: vec!["hello".into(), "world".into()],
+        };
+        let b = restore_to_bytes(&grid, None, &[]);
+        assert!(b.starts_with(b"\x1b[r\x1b[?6l\x1b[0m\x1b[H\x1b[2J"));
+        assert!(String::from_utf8_lossy(&b).contains("hello\r\nworld"));
+    }
+
+    #[test]
+    fn visible_only_reasserts_alt_membership_from_state() {
+        let mut state = parse_pane_state("");
+        state.alternate_on = true;
+        let grid = GridCapture::VisibleOnly {
+            rows: vec!["v".into()],
+        };
+        let text =
+            String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
+        assert!(text.find("\x1b[?1049h").expect("alt reasserted") < text.find('v').unwrap());
+    }
+
+    #[test]
+    fn full_without_alt_replays_base_wholesale() {
+        let grid = GridCapture::Full {
+            base: rows("h", 5),
+            saved_primary: vec![],
+            pane_height: 3,
+        };
+        let state = parse_pane_state("");
+        let text =
+            String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
+        assert!(text.contains("h0\r\nh1\r\nh2\r\nh3\r\nh4"));
+        assert!(!text.contains("\x1b[?1049h"));
+    }
+
+    #[test]
+    fn full_with_alt_splits_base_tail_into_alt_screen() {
+        // base = 5 rows of history + 3 rows of CURRENT (alt) screen;
+        // saved_primary = the primary screen snapshot taken at alt entry.
+        let grid = GridCapture::Full {
+            base: [rows("hist", 5), rows("alt", 3)].concat(),
+            saved_primary: rows("prim", 3),
+            pane_height: 3,
+        };
+        let mut state = parse_pane_state("");
+        state.alternate_on = true;
+        state.alternate_saved_x = 2;
+        state.alternate_saved_y = 1;
+        let text =
+            String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
+        let hist = text.find("hist4").expect("history replayed");
+        let prim = text.find("prim0").expect("saved primary replayed");
+        let saved_cup = text.find("\x1b[2;3H").expect("saved cursor placed");
+        let alt_on = text.find("\x1b[?1049h").expect("alt entered");
+        let alt = text.find("alt0").expect("alt screen replayed");
+        assert!(
+            hist < prim && prim < saved_cup && saved_cup < alt_on && alt_on < alt,
+            "wrong order in {text:?}"
+        );
+    }
+
+    #[test]
+    fn full_with_alt_but_short_base_degrades_to_primary_only() {
+        let grid = GridCapture::Full {
+            base: rows("h", 2),
+            saved_primary: rows("prim", 3),
+            pane_height: 3,
+        };
+        let mut state = parse_pane_state("");
+        state.alternate_on = true;
+        let text =
+            String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
+        assert!(!text.contains("\x1b[?1049h"));
+        assert!(text.contains("h0\r\nh1"));
+    }
+
+    #[test]
+    fn pending_output_is_decoded_and_last() {
+        let grid = GridCapture::VisibleOnly {
+            rows: vec!["x".into()],
+        };
+        let state = parse_pane_state("");
+        let b = restore_to_bytes(&grid, Some(&state), &["tail\\033[".to_string()]);
+        assert!(b.ends_with(b"tail\x1b["));
+    }
+
+    #[test]
+    fn state_section_comes_after_content() {
+        let grid = GridCapture::VisibleOnly {
+            rows: vec!["content".into()],
+        };
+        let mut state = parse_pane_state("");
+        state.mouse_sgr = true;
+        let text =
+            String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
+        assert!(text.find("content").unwrap() < text.find("\x1b[?1006h").unwrap());
     }
 }

--- a/crates/ozmux_tmux/src/state_restore.rs
+++ b/crates/ozmux_tmux/src/state_restore.rs
@@ -1,0 +1,199 @@
+//! Pane terminal-state restoration for adopt-time seeding: the tmux format
+//! that dumps a pane's modes, its parser, and the VT byte synthesis that
+//! replays captured content + modes into the display mirror.
+
+use std::collections::HashMap;
+
+/// Tab-separated `key=#{key}` format dumping one pane's terminal state.
+///
+/// NOTE: unknown variables expand to the empty string on older tmux (e.g.
+/// `bracket_paste_flag` before 3.7), and the parser degrades empty to off —
+/// this is what makes the query version-gate-free.
+pub(crate) const PANE_STATE_FORMAT: &str = "pane_id=#{pane_id}\talternate_on=#{alternate_on}\talternate_saved_x=#{alternate_saved_x}\talternate_saved_y=#{alternate_saved_y}\tcursor_x=#{cursor_x}\tcursor_y=#{cursor_y}\tscroll_region_upper=#{scroll_region_upper}\tscroll_region_lower=#{scroll_region_lower}\tpane_tabs=#{pane_tabs}\tcursor_flag=#{cursor_flag}\tinsert_flag=#{insert_flag}\tkeypad_cursor_flag=#{keypad_cursor_flag}\tkeypad_flag=#{keypad_flag}\twrap_flag=#{wrap_flag}\torigin_flag=#{origin_flag}\tmouse_standard_flag=#{mouse_standard_flag}\tmouse_button_flag=#{mouse_button_flag}\tmouse_all_flag=#{mouse_all_flag}\tmouse_utf8_flag=#{mouse_utf8_flag}\tmouse_sgr_flag=#{mouse_sgr_flag}\tbracket_paste_flag=#{bracket_paste_flag}";
+
+/// One pane's terminal state parsed from a [`PANE_STATE_FORMAT`] reply line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PaneState {
+    pub(crate) alternate_on: bool,
+    pub(crate) alternate_saved_x: u16,
+    pub(crate) alternate_saved_y: u16,
+    pub(crate) cursor_x: u16,
+    pub(crate) cursor_y: u16,
+    pub(crate) scroll_region_upper: u16,
+    pub(crate) scroll_region_lower: u16,
+    pub(crate) tabs: Vec<u16>,
+    pub(crate) cursor_visible: bool,
+    pub(crate) insert: bool,
+    pub(crate) app_cursor_keys: bool,
+    pub(crate) app_keypad: bool,
+    pub(crate) wrap: bool,
+    pub(crate) origin: bool,
+    pub(crate) mouse_standard: bool,
+    pub(crate) mouse_button: bool,
+    pub(crate) mouse_all: bool,
+    pub(crate) mouse_utf8: bool,
+    pub(crate) mouse_sgr: bool,
+    pub(crate) bracketed_paste: bool,
+}
+
+/// Parses one [`PANE_STATE_FORMAT`] reply line. Missing, empty, or
+/// non-numeric fields degrade to zero/off; `cursor_flag` and `wrap_flag`
+/// degrade to ON (the terminal defaults). Never fails.
+pub(crate) fn parse_pane_state(line: &str) -> PaneState {
+    let fields = split_state_fields(line);
+    let flag = |key: &str| fields.get(key).is_some_and(|v| *v == "1");
+    let flag_default_on = |key: &str| fields.get(key).is_none_or(|v| v.is_empty() || *v == "1");
+    let num = |key: &str| -> u16 {
+        fields
+            .get(key)
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_default()
+    };
+    PaneState {
+        alternate_on: flag("alternate_on"),
+        alternate_saved_x: num("alternate_saved_x"),
+        alternate_saved_y: num("alternate_saved_y"),
+        cursor_x: num("cursor_x"),
+        cursor_y: num("cursor_y"),
+        scroll_region_upper: num("scroll_region_upper"),
+        scroll_region_lower: num("scroll_region_lower"),
+        tabs: fields
+            .get("pane_tabs")
+            .map(|v| v.split(',').filter_map(|t| t.parse().ok()).collect())
+            .unwrap_or_default(),
+        cursor_visible: flag_default_on("cursor_flag"),
+        insert: flag("insert_flag"),
+        app_cursor_keys: flag("keypad_cursor_flag"),
+        app_keypad: flag("keypad_flag"),
+        wrap: flag_default_on("wrap_flag"),
+        origin: flag("origin_flag"),
+        mouse_standard: flag("mouse_standard_flag"),
+        mouse_button: flag("mouse_button_flag"),
+        mouse_all: flag("mouse_all_flag"),
+        mouse_utf8: flag("mouse_utf8_flag"),
+        mouse_sgr: flag("mouse_sgr_flag"),
+        bracketed_paste: flag("bracket_paste_flag"),
+    }
+}
+
+/// Splits a state reply into `key -> value`, re-splitting on a literal
+/// `\t` sequence when the transport escaped the tab separator (a known
+/// tmux transport quirk iTerm2 also works around).
+fn split_state_fields(line: &str) -> HashMap<&str, &str> {
+    let mut parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() == 1 && line.contains("\\t") {
+        parts = line.split("\\t").collect();
+    }
+    parts.iter().filter_map(|p| p.split_once('=')).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv(pairs: &[(&str, &str)]) -> String {
+        pairs
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("\t")
+    }
+
+    #[test]
+    fn format_lists_every_key_tab_separated() {
+        for key in [
+            "pane_id",
+            "alternate_on",
+            "alternate_saved_x",
+            "alternate_saved_y",
+            "cursor_x",
+            "cursor_y",
+            "scroll_region_upper",
+            "scroll_region_lower",
+            "pane_tabs",
+            "cursor_flag",
+            "insert_flag",
+            "keypad_cursor_flag",
+            "keypad_flag",
+            "wrap_flag",
+            "origin_flag",
+            "mouse_standard_flag",
+            "mouse_button_flag",
+            "mouse_all_flag",
+            "mouse_utf8_flag",
+            "mouse_sgr_flag",
+            "bracket_paste_flag",
+        ] {
+            assert!(
+                PANE_STATE_FORMAT.contains(&format!("{key}=#{{{key}}}")),
+                "missing {key}"
+            );
+        }
+        assert!(PANE_STATE_FORMAT.contains('\t'));
+    }
+
+    #[test]
+    fn parses_nvim_like_state() {
+        let line = kv(&[
+            ("pane_id", "%3"),
+            ("alternate_on", "1"),
+            ("alternate_saved_x", "12"),
+            ("alternate_saved_y", "40"),
+            ("cursor_x", "5"),
+            ("cursor_y", "2"),
+            ("scroll_region_upper", "0"),
+            ("scroll_region_lower", "48"),
+            ("pane_tabs", "8,16,24"),
+            ("cursor_flag", "1"),
+            ("insert_flag", "0"),
+            ("keypad_cursor_flag", "1"),
+            ("keypad_flag", "1"),
+            ("wrap_flag", "0"),
+            ("origin_flag", "0"),
+            ("mouse_standard_flag", "0"),
+            ("mouse_button_flag", "1"),
+            ("mouse_all_flag", "0"),
+            ("mouse_utf8_flag", "0"),
+            ("mouse_sgr_flag", "1"),
+            ("bracket_paste_flag", "1"),
+        ]);
+        let s = parse_pane_state(&line);
+        assert!(s.alternate_on && s.mouse_button && s.mouse_sgr && s.bracketed_paste);
+        assert!(s.app_cursor_keys && s.app_keypad && !s.wrap && !s.mouse_standard);
+        assert_eq!((s.alternate_saved_x, s.alternate_saved_y), (12, 40));
+        assert_eq!((s.cursor_x, s.cursor_y), (5, 2));
+        assert_eq!((s.scroll_region_upper, s.scroll_region_lower), (0, 48));
+        assert_eq!(s.tabs, vec![8, 16, 24]);
+    }
+
+    #[test]
+    fn missing_empty_and_garbage_fields_degrade_to_off() {
+        // bracket_paste_flag missing entirely (old tmux expands unknown to ""),
+        // mouse_sgr_flag empty, cursor_x garbage.
+        let line = kv(&[
+            ("alternate_on", "0"),
+            ("mouse_sgr_flag", ""),
+            ("cursor_x", "abc"),
+        ]);
+        let s = parse_pane_state(&line);
+        assert!(!s.bracketed_paste && !s.mouse_sgr && !s.alternate_on);
+        assert_eq!(s.cursor_x, 0);
+        assert!(s.tabs.is_empty());
+    }
+
+    #[test]
+    fn resplits_on_escaped_tab_transport_bug() {
+        // Some tmux/transport combinations escape the tab separator as \\t.
+        let line = kv(&[("alternate_on", "1"), ("cursor_y", "7")]).replace('\t', "\\t");
+        let s = parse_pane_state(&line);
+        assert!(s.alternate_on);
+        assert_eq!(s.cursor_y, 7);
+    }
+
+    #[test]
+    fn cursor_visible_and_wrap_default_on_when_missing() {
+        let s = parse_pane_state("");
+        assert!(s.cursor_visible && s.wrap);
+        assert!(!s.alternate_on);
+    }
+}

--- a/crates/ozmux_tmux/src/state_restore.rs
+++ b/crates/ozmux_tmux/src/state_restore.rs
@@ -230,6 +230,10 @@ fn append_rows(bytes: &mut Vec<u8>, rows: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ozma_tty_engine::{
+        CellCoord, Column, Line, Point, SelectionType, Side, TermMode, TerminalHandle, WheelAction,
+        WheelConfig, WheelModifiers,
+    };
 
     fn kv(pairs: &[(&str, &str)]) -> String {
         pairs
@@ -539,5 +543,90 @@ mod tests {
         let text =
             String::from_utf8_lossy(&restore_to_bytes(&grid, Some(&state), &[])).into_owned();
         assert!(text.find("content").unwrap() < text.find("\x1b[?1006h").unwrap());
+    }
+
+    fn nvim_like_restore() -> Vec<u8> {
+        let grid = GridCapture::Full {
+            base: [rows("hist", 10), rows("alt", 4)].concat(),
+            saved_primary: rows("prim", 4),
+            pane_height: 4,
+        };
+        let mut state = parse_pane_state("");
+        state.alternate_on = true;
+        state.mouse_button = true;
+        state.mouse_sgr = true;
+        state.app_cursor_keys = true;
+        restore_to_bytes(&grid, Some(&state), &[])
+    }
+
+    #[test]
+    fn adopted_nvim_pane_routes_wheel_to_pty_not_scrollback() {
+        let mut handle = TerminalHandle::detached(80, 4);
+        handle.advance(&nvim_like_restore());
+        let modes = handle.current_modes();
+        assert!(modes.contains(TermMode::MOUSE_DRAG), "1002 must be set");
+        assert!(modes.contains(TermMode::SGR_MOUSE), "1006 must be set");
+        assert!(modes.contains(TermMode::ALT_SCREEN), "1049 must be set");
+        assert!(modes.contains(TermMode::APP_CURSOR), "DECCKM must be set");
+        let action = WheelAction::route(
+            modes,
+            -1,
+            CellCoord { col: 1, row: 1 },
+            WheelModifiers::default(),
+            &WheelConfig::default(),
+        );
+        assert!(
+            matches!(action, WheelAction::WriteToPty(ref b) if b.starts_with(b"\x1b[<64;")),
+            "wheel must be forwarded as an SGR report, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn adopted_shell_pane_restores_history_into_scrollback() {
+        let grid = GridCapture::Full {
+            base: rows("line", 20),
+            saved_primary: vec![],
+            pane_height: 4,
+        };
+        let state = parse_pane_state("");
+        let mut handle = TerminalHandle::detached(80, 4);
+        handle.advance(&restore_to_bytes(&grid, Some(&state), &[]));
+        assert!(!handle.current_modes().contains(TermMode::ALT_SCREEN));
+        let snapshot = handle.vi_indicator_snapshot();
+        assert!(
+            snapshot.history_size >= 10,
+            "history must land in scrollback"
+        );
+    }
+
+    fn visible_line(handle: &mut TerminalHandle, row: i32) -> String {
+        handle.selection_start_at_vt_only(
+            Point::new(Line(row), Column(0)),
+            Side::Left,
+            SelectionType::Lines,
+        );
+        let text = handle.selection_to_string().unwrap_or_default();
+        handle.selection_clear_vt_only();
+        text.trim_end().to_string()
+    }
+
+    #[test]
+    fn adopted_nvim_pane_places_alt_and_primary_grids_correctly() {
+        // Regression guard for the capture-semantics inversion (spec §2/§7):
+        // cmd1's tail must land in the ALT grid, cmd2 in the PRIMARY grid.
+        let mut handle = TerminalHandle::detached(80, 4);
+        handle.advance(&nvim_like_restore());
+        assert!(handle.is_in_alt_screen());
+        assert_eq!(
+            visible_line(&mut handle, 0),
+            "alt0",
+            "alt grid must show cmd1 tail"
+        );
+        handle.advance(b"\x1b[?1049l");
+        assert_eq!(
+            visible_line(&mut handle, 0),
+            "prim0",
+            "primary grid must show cmd2 rows"
+        );
     }
 }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -497,6 +497,43 @@ fn unescape_output(bytes: &[u8]) -> TmuxResult<Vec<u8>> {
     Ok(out)
 }
 
+/// Decodes `capture-pane -C` octal escapes (`\xxx`) back to bytes, passing
+/// any non-octal backslash sequence through verbatim.
+///
+/// Unlike [`unescape_output`] this never fails: tmux's `-C` escaping is
+/// known not to escape backslash itself, so a literal `\` in pane output
+/// arrives bare and must not be treated as a protocol error.
+pub fn unescape_capture(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        match bytes.get(i + 1..i + 4) {
+            Some(triple) if triple.iter().all(|&d| matches!(d, b'0'..=b'7')) => {
+                let value = u16::from(triple[0] - b'0') * 64
+                    + u16::from(triple[1] - b'0') * 8
+                    + u16::from(triple[2] - b'0');
+                if value <= u16::from(u8::MAX) {
+                    out.push(value as u8);
+                    i += 4;
+                    continue;
+                }
+                out.push(bytes[i]);
+                i += 1;
+            }
+            _ => {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -981,5 +1018,23 @@ mod tests {
                 rest: "some args".to_string(),
             })
         );
+    }
+
+    #[test]
+    fn unescape_capture_decodes_octal_triples() {
+        assert_eq!(unescape_capture(b"abc\\015\\012def"), b"abc\r\ndef".to_vec());
+    }
+
+    #[test]
+    fn unescape_capture_passes_lone_backslash_verbatim() {
+        // NOTE: capture-pane -C escapes control chars but NOT backslash itself,
+        // so a literal backslash followed by non-octal must survive unchanged.
+        assert_eq!(unescape_capture(b"a\\x9"), b"a\\x9".to_vec());
+        assert_eq!(unescape_capture(b"tail\\"), b"tail\\".to_vec());
+    }
+
+    #[test]
+    fn unescape_capture_passes_out_of_range_octal_verbatim() {
+        assert_eq!(unescape_capture(b"\\400"), b"\\400".to_vec());
     }
 }

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -1017,7 +1017,10 @@ mod tests {
 
     #[test]
     fn unescape_capture_decodes_octal_triples() {
-        assert_eq!(unescape_capture(b"abc\\015\\012def"), b"abc\r\ndef".to_vec());
+        assert_eq!(
+            unescape_capture(b"abc\\015\\012def"),
+            b"abc\r\ndef".to_vec()
+        );
     }
 
     #[test]

--- a/crates/tmux_control_parser/src/event.rs
+++ b/crates/tmux_control_parser/src/event.rs
@@ -480,18 +480,12 @@ fn unescape_output(bytes: &[u8]) -> TmuxResult<Vec<u8>> {
             i += 1;
             continue;
         }
-        match bytes.get(i + 1..i + 4) {
-            Some(triple) if triple.iter().all(|&d| matches!(d, b'0'..=b'7')) => {
-                let value = u16::from(triple[0] - b'0') * 64
-                    + u16::from(triple[1] - b'0') * 8
-                    + u16::from(triple[2] - b'0');
-                if value > u16::from(u8::MAX) {
-                    return Err(invalid(&bytes[i..i + 4]));
-                }
-                out.push(value as u8);
+        match bytes.get(i + 1..i + 4).and_then(decode_octal_triple) {
+            Some(byte) => {
+                out.push(byte);
                 i += 4;
             }
-            _ => return Err(invalid(&bytes[i..bytes.len().min(i + 4)])),
+            None => return Err(invalid(&bytes[i..bytes.len().min(i + 4)])),
         }
     }
     Ok(out)
@@ -500,7 +494,7 @@ fn unescape_output(bytes: &[u8]) -> TmuxResult<Vec<u8>> {
 /// Decodes `capture-pane -C` octal escapes (`\xxx`) back to bytes, passing
 /// any non-octal backslash sequence through verbatim.
 ///
-/// Unlike [`unescape_output`] this never fails: tmux's `-C` escaping is
+/// Unlike `unescape_output` this never fails: tmux's `-C` escaping is
 /// known not to escape backslash itself, so a literal `\` in pane output
 /// arrives bare and must not be treated as a protocol error.
 pub fn unescape_capture(bytes: &[u8]) -> Vec<u8> {
@@ -512,26 +506,27 @@ pub fn unescape_capture(bytes: &[u8]) -> Vec<u8> {
             i += 1;
             continue;
         }
-        match bytes.get(i + 1..i + 4) {
-            Some(triple) if triple.iter().all(|&d| matches!(d, b'0'..=b'7')) => {
-                let value = u16::from(triple[0] - b'0') * 64
-                    + u16::from(triple[1] - b'0') * 8
-                    + u16::from(triple[2] - b'0');
-                if value <= u16::from(u8::MAX) {
-                    out.push(value as u8);
-                    i += 4;
-                    continue;
-                }
-                out.push(bytes[i]);
-                i += 1;
+        match bytes.get(i + 1..i + 4).and_then(decode_octal_triple) {
+            Some(byte) => {
+                out.push(byte);
+                i += 4;
             }
-            _ => {
+            None => {
                 out.push(bytes[i]);
                 i += 1;
             }
         }
     }
     out
+}
+
+fn decode_octal_triple(triple: &[u8]) -> Option<u8> {
+    let [a, b, c] = triple else { return None };
+    if ![a, b, c].iter().all(|&&d| matches!(d, b'0'..=b'7')) {
+        return None;
+    }
+    let value = u16::from(a - b'0') * 64 + u16::from(b - b'0') * 8 + u16::from(c - b'0');
+    u8::try_from(value).ok()
 }
 
 #[cfg(test)]

--- a/crates/tmux_control_parser/src/lib.rs
+++ b/crates/tmux_control_parser/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use crate::assembler::{BlockAssembler, Frame};
 pub use crate::error::{LayoutError, TmuxError, TmuxResult};
-pub use crate::event::{ControlEvent, PaneId, SessionId, WindowId};
+pub use crate::event::{ControlEvent, PaneId, SessionId, WindowId, unescape_capture};
 pub use crate::layout::{Cell, CellDims, Divider, DividerAxis, SplitDir, WindowLayout, dividers};
 
 pub mod assembler;

--- a/src/render/tmux/copy_mode.rs
+++ b/src/render/tmux/copy_mode.rs
@@ -368,10 +368,10 @@ fn apply_capture_reply(
 /// a clean-state prefix (reset scroll region + origin mode + SGR, then
 /// cursor-home + clear-screen) so the snapshot repaints from a clean grid, then
 /// the rows CRLF-joined (the reply omits line terminators). Mirrors
-/// `ozmux_tmux`'s `capture_to_bytes` for the live seed path.
+/// `ozmux_tmux`'s `restore_to_bytes` reset-prefix for the live seed path.
 fn capture_to_bytes(lines: &[String]) -> Vec<u8> {
     // NOTE: the reset prefix MUST precede the ESC[2J erase — see the matching
-    // NOTE on `ozmux_tmux`'s `capture_to_bytes`. A stale SGR background, scroll
+    // NOTE on `ozmux_tmux`'s `restore_to_bytes`. A stale SGR background, scroll
     // region (DECSTBM), or origin mode (DECOM) left in the reused render handle
     // would otherwise flood or mis-scroll the scrolled copy view on copy-mode
     // entry.


### PR DESCRIPTION
## Summary

- Fixes a bug where, after re-attaching (adopt) to a tmux `-CC` session where nvim was already running in the alternate screen, mouse-wheel scroll over the nvim pane scrolled the local mirror's scrollback instead of being forwarded to nvim as a mouse report.
- Root cause: adopt-time seeding only restored visible content + cursor position, never the pane's terminal modes (mouse reporting, alt-screen, DECCKM). The display-only alacritty mirror's `TermMode` stayed empty, so `WheelAction::route` fell back to the scrollback path instead of forwarding the wheel event.
- Restores full pane state on adopt, iTerm2-style: fetch 4 tmux replies per pane (base capture with history, saved-primary capture, a state dump of all modes/cursor/scroll-region/tabstops, and pending output), correlate them in a `PaneRestore` buffer, and synthesize one VT byte stream (`restore_to_bytes`) replayed through the existing `PaneOutput` → `TerminalHandle.advance` path. Resize/rescue re-seeds use a lighter 2-command variant, and the old capture+cursor machinery is removed.
- Includes a follow-up hardening pass (found by a max-effort code review) fixing: silently blanking an already-rendered pane on a failed base capture, stale `wrap` mode corrupting `-J`-joined long-line replay on light re-seeds, an O(n) pane scan that should use the existing O(1) index, unchecked `u16` arithmetic on tmux-reported cursor/scroll-region values, and a few `rust.md` visibility/naming violations.

Design docs: `docs/superpowers/specs/2026-07-04-tmux-pane-state-restore-design.md` and `docs/superpowers/plans/2026-07-04-tmux-pane-state-restore.md` (gitignored, not included in this PR — available locally for reviewers who want the full design rationale, tmux capture-pane semantics research, and task-by-task implementation trail).

## Known follow-ups (not fixed in this PR — flagged during review, need a design decision)

- If the `PaneStateQuery` reply fails independently while base/saved-primary succeed, alt-screen membership and mode restoration are both silently skipped for that pane (no self-healing retry within the same restore pass).
- The alt/primary split boundary (`base.split_at(base.len() - height)`) can be thrown off by `capture-pane -J` line-joining on wrapped content, or by a pane resizing between when the restore is requested and when its replies land (no settle-delay on the adopt path, unlike the light re-seed path).
- `EnumerationState.restores`/`.pending` aren't cleaned up if a pane/window despawns mid-restore (only a session switch clears them) — a potential leak over long sessions with frequent pane churn.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all green (ozmux_tmux 150 tests, binary 248 tests, no regressions)
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --check` — clean
- [ ] Real-device GUI verification: adopt a tmux session with nvim left in alt-screen, confirm mouse-wheel scrolls the nvim buffer (not the mirror scrollback), primary/alt grids aren't swapped, arrow keys work, and post-`:q` scrollback still shows pre-adopt history — **pending, requires a human at the GUI**

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>