### PR TITLE
feat(input): fire <Leader> shortcuts regardless of webview keyboard focus

### DIFF
--- a/docs/plans/2026-07-05-leader-shortcuts-ignore-webview-focus.md
+++ b/docs/plans/2026-07-05-leader-shortcuts-ignore-webview-focus.md
@@ -1,0 +1,699 @@
+# Leader shortcuts fire regardless of webview keyboard focus — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `<Leader>`-scoped shortcuts fire while a CEF webview owns the keyboard, and withhold the leader-claimed keys from the web page via bevy_cef's `CefKeyboardFilter`.
+
+**Architecture:** The pure decider `classify_key_batch` (`src/input/resolve.rs`) gains a `ctx.webview_focused` path that steps the leader state machine instead of resetting it, returning a new `ClassifiedKeys { effects, webview_suppressed }`. The single ECS system `resolve_shortcuts` (`src/input/dispatch.rs`) forwards `webview_suppressed` to `CefKeyboardFilter`, ordered `.before(KeyboardDeliverSet)` so bevy_cef's delivery skips those keys the same frame.
+
+**Tech Stack:** Rust (edition 2024, toolchain 1.95), Bevy 0.18 ECS, bevy_cef 0.11 (crates.io) `CefKeyboardFilter` / `KeyboardDeliverSet` / `ModifiersState`.
+
+## Global Constraints
+
+- Rust edition 2024, toolchain pinned to 1.95.
+- No `mod.rs`; comments only `// TODO:` / `// NOTE:` / `// SAFETY:`; all `use` at top of file, one contiguous block, no inline fully-qualified paths.
+- Externally-`pub` items need `///` docs; `pub(crate)`/private do not (but keep names meaningful).
+- Visibility minimization: default private; widen only for a real cross-module caller.
+- Bevy: gate whole-system change checks with `run_if`; let mutation drive change detection (no manual `set_changed`); `Plugin::build` as one method chain; register systems in the defining file's plugin.
+- Parameter ordering: mutable params before immutable (exception: a fixed leading `self` / `On<E>` slot).
+- All in-code comments in English.
+- Lint/format gate before every commit: `cargo clippy --workspace --all-targets` clean and `cargo fmt`.
+
+---
+
+## File Structure
+
+- `src/input/resolve.rs` (modify) — pure decider. Add `ClassifiedKeys`; change `classify_key_batch`'s return type; rewrite the `ctx.webview_focused` branch to run the leader machine and record claimed keys. Owns all pure-layer unit tests.
+- `src/input/dispatch.rs` (modify) — the `resolve_shortcuts` ECS system. Consume `ClassifiedKeys`, populate/clear `CefKeyboardFilter`, order `.before(KeyboardDeliverSet)`. Owns the ECS-layer tests.
+
+No other files change. The appliers (`src/input/default_mode.rs`, `src/input/tmux/input.rs`) already handle `KeyEffect::Action { via_leader: true }` and are not gated on webview focus; `src/input/shortcuts.rs` (`step_leader`, `LeaderPhase`, `detect_modifier_tap`, `reset_leader_phase`) and `src/input/focus.rs` are unchanged.
+
+---
+
+## Task 1: Leader fires during webview focus + CEF key-leak suppression
+
+**Files:**
+- Modify: `src/input/resolve.rs` (the `KeyEffect`/`BatchContext` region ~15-65, `classify_key_batch` ~75-143, the `#[cfg(test)]` `run` helper ~230-238 and webview tests ~760-805)
+- Modify: `src/input/dispatch.rs` (imports ~26-28, `resolve_shortcuts` ~110-185, `resolve_app` test helper ~222-250)
+
+**Interfaces:**
+- Produces (consumed by later tasks and by `resolve_shortcuts`):
+  - `pub(crate) struct ClassifiedKeys { pub(crate) effects: Vec<KeyEffect>, pub(crate) webview_suppressed: Vec<KeyCode> }`
+  - `fn classify_key_batch(leader_phase: &mut LeaderPhase, shortcuts: &Shortcuts, resolved_copy: &ResolvedCopyModeKeys, events: impl Iterator<Item = &KeyboardInput>, ctx: BatchContext) -> ClassifiedKeys` (return type changed from `Vec<KeyEffect>`)
+- Consumes: bevy_cef `CefKeyboardFilter` (`fn set(impl IntoIterator<Item=(Entity, KeyCode, ModifiersState)>)`, `fn contains(Entity, KeyCode, ModifiersState) -> bool`) and `ModifiersState { alt, ctrl, shift, logo }` — both from `bevy_cef::prelude`.
+
+---
+
+- [ ] **Step 1: Add `ClassifiedKeys`, change the return type, and rewrite the webview branch in `src/input/resolve.rs`**
+
+Add the struct just above `classify_key_batch` (after the `BatchContext` struct, before the `classify_key_batch` doc comment):
+
+```rust
+/// The decided output of `classify_key_batch`: the per-key `KeyEffect`s, plus the
+/// physical keys the leader claimed while a webview owned the keyboard. The caller
+/// applies the frame's modifier snapshot when withholding `webview_suppressed`
+/// from CEF via `CefKeyboardFilter`; it is empty on the non-webview path.
+pub(crate) struct ClassifiedKeys {
+    pub(crate) effects: Vec<KeyEffect>,
+    pub(crate) webview_suppressed: Vec<KeyCode>,
+}
+```
+
+Change the `classify_key_batch` signature return type from `-> Vec<KeyEffect>` to `-> ClassifiedKeys`.
+
+Immediately after `let mut effects = Vec::new();` add:
+
+```rust
+    let mut webview_suppressed = Vec::new();
+```
+
+Replace the existing `ctx.webview_focused` block (currently):
+
+```rust
+        if ctx.webview_focused {
+            // NOTE: the leader is honored only when a webview does not own
+            // the keyboard; resetting the phase here (instead of stepping
+            // the state machine) prevents a stale leader from firing once
+            // keyboard focus returns to the terminal.
+            *leader_phase = LeaderPhase::Idle;
+            if shortcuts.is_release_webview_focus(ev.key_code, ctx.mods) {
+                effects.push(KeyEffect::ReleaseWebviewFocus);
+            } else if ctx
+                .forward_chords
+                .iter()
+                .any(|chord| chord_matches(chord, ev.key_code, ctx.mods))
+            {
+                effects.push(KeyEffect::WebviewForward {
+                    logical: ev.logical_key.clone(),
+                    key_code: ev.key_code,
+                });
+            }
+            continue;
+        }
+```
+
+with:
+
+```rust
+        if ctx.webview_focused {
+            // NOTE: the leader runs even while a webview owns the keyboard, so
+            // `<Leader>` shortcuts work regardless of focus. Keys the leader
+            // claims (the leader chord itself, an abandoned second key, or a
+            // fired binding) are recorded in `webview_suppressed` so the caller
+            // withholds them from CEF; a key the leader does not claim
+            // (`Passthrough`) still resolves to release / forward as before.
+            match step_with_repeat(leader_phase, shortcuts, ev, ctx.mods, ctx.now) {
+                LeaderStep::Swallow => {
+                    webview_suppressed.push(ev.key_code);
+                }
+                LeaderStep::RunAction(action) => {
+                    webview_suppressed.push(ev.key_code);
+                    effects.push(KeyEffect::Action {
+                        action,
+                        via_leader: true,
+                    });
+                }
+                LeaderStep::Passthrough => {
+                    if shortcuts.is_release_webview_focus(ev.key_code, ctx.mods) {
+                        effects.push(KeyEffect::ReleaseWebviewFocus);
+                    } else if ctx
+                        .forward_chords
+                        .iter()
+                        .any(|chord| chord_matches(chord, ev.key_code, ctx.mods))
+                    {
+                        effects.push(KeyEffect::WebviewForward {
+                            logical: ev.logical_key.clone(),
+                            key_code: ev.key_code,
+                        });
+                    }
+                }
+            }
+            continue;
+        }
+```
+
+Change the function's final expression from `effects` to:
+
+```rust
+    ClassifiedKeys {
+        effects,
+        webview_suppressed,
+    }
+```
+
+(`step_with_repeat`, `LeaderStep`, and `chord_matches` are already in scope in this file — no new `use`.)
+
+- [ ] **Step 2: Update the `run` test helper and add `run_full` in `src/input/resolve.rs`**
+
+In the `#[cfg(test)] mod tests`, change the `run` helper's body to unwrap `.effects` so every existing effects-only test keeps compiling, and add a full-struct helper below it:
+
+```rust
+    fn run<'a>(
+        leader_phase: &mut LeaderPhase,
+        shortcuts: &Shortcuts,
+        resolved_copy: &ResolvedCopyModeKeys,
+        events: &'a [KeyboardInput],
+        ctx: BatchContext<'a>,
+    ) -> Vec<KeyEffect> {
+        classify_key_batch(leader_phase, shortcuts, resolved_copy, events.iter(), ctx).effects
+    }
+
+    fn run_full<'a>(
+        leader_phase: &mut LeaderPhase,
+        shortcuts: &Shortcuts,
+        resolved_copy: &ResolvedCopyModeKeys,
+        events: &'a [KeyboardInput],
+        ctx: BatchContext<'a>,
+    ) -> ClassifiedKeys {
+        classify_key_batch(leader_phase, shortcuts, resolved_copy, events.iter(), ctx)
+    }
+```
+
+- [ ] **Step 3: Replace the obsolete webview test and add the new webview-leader tests in `src/input/resolve.rs`**
+
+Delete the existing `webview_focus_clears_leader_and_forwards` test (it asserted the old reset-and-forward behavior, which is now replaced by leader precedence). Add these tests in the same `mod tests` (they use `test_shortcuts_with_repeat_prefix`, already imported at the top of the test module):
+
+```rust
+    #[test]
+    fn webview_pending_leader_fires_action_and_suppresses() {
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Pending;
+        let events = [press(KeyCode::KeyS, Key::Character("s".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(
+            out.effects,
+            vec![KeyEffect::Action {
+                action: ShortcutAction::EnterCopyMode,
+                via_leader: true,
+            }],
+            "a bound second key fires its leader action even while a webview is focused"
+        );
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyS],
+            "the fired key is withheld from CEF"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_leader_chord_engages_and_suppresses() {
+        // The fixture's leader is the Ctrl+A chord.
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
+        let events = [press(KeyCode::KeyA, Key::Character("a".into()))];
+        let mut c = ctx(mods(true, false, false, false), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(out.effects, vec![], "the leader chord itself emits no effect");
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyA],
+            "the leader chord is withheld from CEF"
+        );
+        assert_eq!(
+            phase,
+            LeaderPhase::Pending,
+            "pressing the leader chord under webview focus engages Pending"
+        );
+    }
+
+    #[test]
+    fn webview_pending_unbound_key_swallowed_and_suppressed() {
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Pending;
+        let events = [press(KeyCode::KeyZ, Key::Character("z".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(out.effects, vec![], "an unbound second key emits nothing");
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyZ],
+            "the swallowed second key is still withheld from CEF"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_plain_key_not_suppressed() {
+        let sc = Shortcuts::default();
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
+        let events = [press(KeyCode::KeyB, Key::Character("b".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(out.effects, vec![], "a plain key under webview focus emits nothing");
+        assert!(
+            out.webview_suppressed.is_empty(),
+            "a non-leader key is NOT withheld — the webview must still receive it"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_forward_chord_forwards_and_not_suppressed() {
+        let sc = Shortcuts::default();
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
+        let chords = [NormalizedChord {
+            code: KeyCode::KeyK,
+            alt: false,
+            ctrl: false,
+            shift: false,
+            logo: false,
+        }];
+        let events = [press(KeyCode::KeyK, Key::Character("k".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        c.forward_chords = &chords;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(
+            out.effects,
+            vec![KeyEffect::WebviewForward {
+                logical: Key::Character("k".into()),
+                key_code: KeyCode::KeyK,
+            }],
+            "with no leader engaged a declared forward chord still forwards"
+        );
+        assert!(
+            out.webview_suppressed.is_empty(),
+            "a forward chord is not a leader claim — not withheld from CEF"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+```
+
+(The existing `webview_release_chord_emits_release` test is unchanged and still passes: `Idle` + the release chord returns `Passthrough` → `ReleaseWebviewFocus`.)
+
+- [ ] **Step 4: Run the resolve.rs tests to verify Steps 1-3**
+
+Run: `cargo test -p ozmux input::resolve::tests -- --nocapture`
+Expected: PASS, including the five new `webview_*` tests. (`src/input/dispatch.rs` will NOT compile yet — that is Step 5. If cargo reports a build error in `dispatch.rs` before running resolve tests, that is expected; proceed to Step 5, then re-run.)
+
+- [ ] **Step 5: Consume `ClassifiedKeys` and populate `CefKeyboardFilter` in `src/input/dispatch.rs`**
+
+Change the bevy_cef import line from:
+
+```rust
+use bevy_cef::prelude::FocusedWebview;
+```
+
+to:
+
+```rust
+use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, ModifiersState};
+```
+
+Change the `classify_key_batch` import to also bring the new type:
+
+```rust
+use crate::input::resolve::{BatchContext, ClassifiedKeys, KeyEffect, classify_key_batch};
+```
+
+Add a `CefKeyboardFilter` parameter to `resolve_shortcuts` (mutable params come first; place it next to the other `ResMut`s, after `focused_webview`):
+
+```rust
+    mut focused_webview: ResMut<FocusedWebview>,
+    mut cef_filter: ResMut<CefKeyboardFilter>,
+    mut leader_phase: ResMut<LeaderPhase>,
+```
+
+In the coarse-guard early-return block, clear the filter before returning. Change:
+
+```rust
+    if prompt_open || guards.ime.is_composing() || !focused_window {
+        clear_leader_phase(&mut leader_phase);
+        events.clear();
+        return;
+    }
+```
+
+to:
+
+```rust
+    if prompt_open || guards.ime.is_composing() || !focused_window {
+        clear_leader_phase(&mut leader_phase);
+        clear_cef_filter(&mut cef_filter);
+        events.clear();
+        return;
+    }
+```
+
+Snapshot the focused webview entity BEFORE the effects loop that nulls it. The line `let focused = resolve_focused_surface(&focused_surface);` already sits before `classify_key_batch`; right after the `classify_key_batch` call, capture the entity and rename the result binding. Change:
+
+```rust
+    let all = classify_key_batch(
+        &mut leader_phase,
+        &inputs.shortcuts,
+        &inputs.resolved_copy,
+        events.read(),
+        ctx,
+    );
+
+    let mut effects = Vec::with_capacity(all.len());
+    for effect in all {
+```
+
+to:
+
+```rust
+    // Snapshot the webview entity BEFORE the effects loop below runs
+    // `ReleaseWebviewFocus`, which sets `focused_webview.0 = None`. Building the
+    // filter from `focused_webview.0` afterwards would drop the suppression on a
+    // frame carrying both a leader claim and a release chord.
+    let suppress_target = focused_webview.0;
+    let ClassifiedKeys {
+        effects: all,
+        webview_suppressed,
+    } = classify_key_batch(
+        &mut leader_phase,
+        &inputs.shortcuts,
+        &inputs.resolved_copy,
+        events.read(),
+        ctx,
+    );
+
+    let mut effects = Vec::with_capacity(all.len());
+    for effect in all {
+```
+
+After the effects loop and the `batch.write(...)` call, add the filter population. Insert this immediately after the `batch.write(ShortcutBatch { ... });` statement (at the end of the function body):
+
+```rust
+    let ms = ModifiersState {
+        alt: mods.alt,
+        ctrl: mods.ctrl,
+        shift: mods.shift,
+        logo: mods.meta,
+    };
+    match suppress_target {
+        Some(webview) => cef_filter.set(
+            webview_suppressed
+                .into_iter()
+                .map(|code| (webview, code, ms)),
+        ),
+        None => clear_cef_filter(&mut cef_filter),
+    }
+```
+
+Add the private clear helper at the bottom of the file's non-test items (below `resolve_shortcuts`, above the `#[cfg(test)]` module):
+
+```rust
+/// Empties `CefKeyboardFilter`. Used on the coarse-guard early return and when no
+/// webview owns the keyboard, so a stale leader claim never withholds a later key.
+fn clear_cef_filter(cef_filter: &mut CefKeyboardFilter) {
+    cef_filter.set(Vec::<(Entity, KeyCode, ModifiersState)>::new());
+}
+```
+
+- [ ] **Step 6: Add `CefKeyboardFilter` to the test app and add the filter tests in `src/input/dispatch.rs`**
+
+In the `resolve_app` test helper, add the resource init to the plugin/resource chain (next to the other `init_resource` calls):
+
+```rust
+            .init_resource::<CefKeyboardFilter>()
+```
+
+Add these tests to the `#[cfg(test)] mod tests` (they reuse the existing `resolve_app`, `press_key`, and `test_shortcuts_with_repeat_prefix` helpers):
+
+```rust
+    #[test]
+    fn filter_holds_leader_claim_under_webview_focus() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            std::time::Duration::ZERO,
+        ));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            app.world().resource::<CefKeyboardFilter>().contains(
+                webview,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "the leader-claimed second key is withheld from CEF for the focused webview"
+        );
+    }
+
+    #[test]
+    fn filter_cleared_on_guarded_frame() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            std::time::Duration::ZERO,
+        ));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        app.world_mut()
+            .resource_mut::<CefKeyboardFilter>()
+            .set([(webview, KeyCode::KeyS, ModifiersState::default())]);
+        // Window unfocused → coarse guard fires.
+        {
+            let mut windows = app
+                .world_mut()
+                .query_filtered::<&mut Window, With<PrimaryWindow>>();
+            windows.single_mut(app.world_mut()).unwrap().focused = false;
+        }
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            !app.world().resource::<CefKeyboardFilter>().contains(
+                webview,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "a guarded frame clears the filter so a stale claim never lingers"
+        );
+    }
+
+    #[test]
+    fn filter_cleared_when_nothing_claimed() {
+        let mut app = resolve_app(Shortcuts::default());
+        let term = app.world_mut().spawn((OzmaTerminal, KeyboardFocused)).id();
+        let stale = app.world_mut().spawn_empty().id();
+        app.world_mut()
+            .resource_mut::<CefKeyboardFilter>()
+            .set([(stale, KeyCode::KeyS, ModifiersState::default())]);
+        // No webview focused; a plain key claims nothing.
+        press_key(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(
+            !app.world().resource::<CefKeyboardFilter>().contains(
+                stale,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "a frame that claims nothing clears the filter"
+        );
+        let _ = term;
+    }
+```
+
+- [ ] **Step 7: Run the full affected test set**
+
+Run: `cargo test -p ozmux input::`
+Expected: PASS — the resolve.rs decider tests (including the five new `webview_*`) and the dispatch.rs tests (including the three new `filter_*`).
+
+- [ ] **Step 8: Verify a clean build (no dead-code / unused warnings) and lint/format**
+
+Run: `cargo build -p ozmux 2>&1 | grep -iE "warning|error" || echo "clean"`
+Expected: `clean` (in particular, `webview_suppressed` is read in production by `resolve_shortcuts`, so no `dead_code`).
+
+Run: `cargo clippy --workspace --all-targets && cargo fmt`
+Expected: no clippy warnings; fmt applies no further changes on re-run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/input/resolve.rs src/input/dispatch.rs
+git commit -m "$(cat <<'EOF'
+feat(input): fire <Leader> shortcuts while a webview owns the keyboard
+
+classify_key_batch now steps the leader machine on the webview-focused path
+(returning ClassifiedKeys{effects, webview_suppressed}); resolve_shortcuts
+withholds the leader-claimed keys from CEF via CefKeyboardFilter and clears it
+on guarded / unclaimed frames.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Order filter population before CEF delivery
+
+**Files:**
+- Modify: `src/input/dispatch.rs` (imports ~26-28, `DispatchPlugin::build` ~60-77, tests)
+
+**Interfaces:**
+- Consumes: bevy_cef `KeyboardDeliverSet` (the `SystemSet` covering bevy_cef's keyboard-delivery systems, from `bevy_cef::prelude`).
+- Produces: nothing new — adds a scheduling edge so `resolve_shortcuts` writes `CefKeyboardFilter` before `send_key_event` reads it.
+
+- [ ] **Step 1: Add the `.before(KeyboardDeliverSet)` ordering edge in `src/input/dispatch.rs`**
+
+Extend the bevy_cef import to include the set:
+
+```rust
+use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, KeyboardDeliverSet, ModifiersState};
+```
+
+In `DispatchPlugin::build`, add `.before(KeyboardDeliverSet)` to the `resolve_shortcuts` registration. Change:
+
+```rust
+            .add_systems(
+                Update,
+                resolve_shortcuts
+                    .in_set(ShortcutSet::Resolve)
+                    .in_set(LeaderGate::Advance)
+                    .run_if(on_message::<KeyboardInput>),
+            );
+```
+
+to:
+
+```rust
+            .add_systems(
+                Update,
+                resolve_shortcuts
+                    .in_set(ShortcutSet::Resolve)
+                    .in_set(LeaderGate::Advance)
+                    .before(KeyboardDeliverSet)
+                    .run_if(on_message::<KeyboardInput>),
+            );
+```
+
+- [ ] **Step 2: Add the ordering test in `src/input/dispatch.rs`**
+
+This proves the guarantee's purpose: a probe registered in `KeyboardDeliverSet` observes the filter already populated, i.e. `resolve_shortcuts` ran first. Add to `mod tests`:
+
+```rust
+    #[derive(Resource, Default)]
+    struct DeliverProbe {
+        saw_claim: bool,
+    }
+
+    fn deliver_probe(
+        mut probe: ResMut<DeliverProbe>,
+        filter: Res<CefKeyboardFilter>,
+        webview: Res<ProbeWebview>,
+    ) {
+        if let Some(webview) = webview.0 {
+            probe.saw_claim = filter.contains(webview, KeyCode::KeyS, ModifiersState::default());
+        }
+    }
+
+    #[derive(Resource, Default)]
+    struct ProbeWebview(Option<Entity>);
+
+    #[test]
+    fn filter_is_populated_before_keyboard_deliver_set() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            std::time::Duration::ZERO,
+        ));
+        app.init_resource::<DeliverProbe>()
+            .init_resource::<ProbeWebview>()
+            .add_systems(Update, deliver_probe.in_set(KeyboardDeliverSet));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        app.world_mut().resource_mut::<ProbeWebview>().0 = Some(webview);
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            app.world().resource::<DeliverProbe>().saw_claim,
+            "resolve_shortcuts must populate CefKeyboardFilter before KeyboardDeliverSet runs"
+        );
+    }
+```
+
+- [ ] **Step 3: Run the ordering test**
+
+Run: `cargo test -p ozmux input::dispatch::tests::filter_is_populated_before_keyboard_deliver_set`
+Expected: PASS (no schedule-cycle panic; the probe observed the claim).
+
+- [ ] **Step 4: Lint/format and full build**
+
+Run: `cargo clippy --workspace --all-targets && cargo fmt && cargo build -p ozmux`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/input/dispatch.rs
+git commit -m "$(cat <<'EOF'
+feat(input): order resolve_shortcuts before bevy_cef KeyboardDeliverSet
+
+Guarantees CefKeyboardFilter is populated in the same frame before
+send_key_event reads it, so leader-claimed keys never leak into the page.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: End-to-end verification (human checkpoint)
+
+**Files:** none (manual run).
+
+- [ ] **Step 1: Confirm the `CefKeyboardFilter` resource exists at runtime**
+
+Run: `cargo run -p ozmux` (requires `just setup-cef` provisioned). Confirm the app boots without a "resource does not exist: CefKeyboardFilter" panic — bevy_cef's `KeyboardPlugin` `init_resource`s it. If it panics because the resource is absent (e.g. a feature-gated build), defensively `init_resource::<CefKeyboardFilter>()` in `DispatchPlugin::build` and re-run; note this in the commit.
+
+- [ ] **Step 2: Manually confirm the behavior**
+
+With a mounted, focused inline webview (click into it so keyboard focus transfers to CEF):
+1. Trigger a `<Leader>` shortcut (default: tap Cmd, then the bound key — e.g. `<Leader>` + copy-mode / new-window binding). Confirm the ozmux action fires.
+2. Confirm the leader's second key does NOT appear typed into a focused web input on the page.
+3. Confirm plain typing into the webview still reaches the page (no regression), and the release chord still blurs it.
+
+Expected: leader shortcuts act on the pane/session behind the webview; no stray characters leak into the web content on the keydown.
+
+(Optional: invoke the repo's `/verify` skill to drive the affected flow if a project verify harness exists.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part 1 (decider runs the leader during webview focus) → Task 1 Steps 1-3.
+- Part 2 (populate/clear `CefKeyboardFilter`, `Vec<KeyCode>` shape, `Modifiers`→`ModifiersState` map, snapshot entity before the `ReleaseWebviewFocus` loop, clear on guard) → Task 1 Steps 5-6.
+- Ordering `.before(KeyboardDeliverSet)` + no-cycle/ordering test → Task 2.
+- Testing section (pure decider tests, applier/filter tests, schedule build) → Task 1 Steps 3/6, Task 2 Step 2.
+- Non-goals (direct chords, forward_keys/release semantics, no blur) → preserved: the `Passthrough` arm keeps the exact release/forward handling and never calls `match_gui_action`, so direct chords stay webview-owned; no applier or focus change.
+- Risks (batch.focused drift, key-release limitation, chord-leader modifiers reach CEF) → behavioral, no code required; end-to-end checks in Task 3.
+
+**Placeholder scan:** none — every code step shows complete code and exact commands.
+
+**Type consistency:** `ClassifiedKeys { effects: Vec<KeyEffect>, webview_suppressed: Vec<KeyCode> }` is defined in Task 1 Step 1 and destructured identically in Task 1 Step 5; `clear_cef_filter(&mut CefKeyboardFilter)` is defined and called (guard path + `None` arm) in Task 1 Step 5; `CefKeyboardFilter::set`/`contains` and `ModifiersState { alt, ctrl, shift, logo }` match the bevy_cef 0.11 API; `run`/`run_full` helper names are used consistently in Tasks 1-2.

--- a/docs/specs/2026-07-05-leader-shortcuts-ignore-webview-focus-design.md
+++ b/docs/specs/2026-07-05-leader-shortcuts-ignore-webview-focus-design.md
@@ -1,0 +1,343 @@
+# Leader shortcuts fire regardless of webview keyboard focus
+
+Date: 2026-07-05
+Status: design approved, pending spec review
+
+## Goal
+
+Make `<Leader>`-scoped shortcuts (the prefix table) reachable while a CEF
+webview owns the keyboard, exactly as they are when a terminal owns it. Today,
+once a webview is focused, the keyboard decider short-circuits and the leader is
+dead: `<Leader>n` (new window), `<Leader>c` (copy-mode), etc. never fire. After
+this change the leader behaves like tmux's prefix — a global escape hatch that
+works no matter what currently holds keyboard focus.
+
+The leader's claimed keystrokes must NOT also leak into the focused web page.
+`bevy_cef` delivers every keystroke to the focused webview, so firing a leader
+action without suppression would both run the action and type its key into the
+web content (`<Leader>n` → new window AND a stray `n` in a web input). The design
+therefore has two coupled parts: **(1)** let the leader run during webview focus,
+and **(2)** withhold the leader-claimed keys from CEF via `CefKeyboardFilter`.
+
+## Background
+
+### Where the leader dies today
+
+Keyboard dispatch is a single mode-agnostic pipeline (PR #239):
+`resolve_shortcuts` (`src/input/dispatch.rs`) reads `KeyboardInput`, calls the
+pure decider `classify_key_batch` (`src/input/resolve.rs`), and emits a
+`ShortcutBatch` the per-mode appliers (`apply_default_shortcuts`,
+`apply_tmux_shortcuts`) consume. The leader state machine (`LeaderPhase`,
+`step_leader`) lives in `src/input/shortcuts.rs`; the default leader is a Cmd
+tap detected by `detect_modifier_tap`, focus-independently, in `LeaderGate::Detect`.
+
+`classify_key_batch` has a `ctx.webview_focused` branch that short-circuits every
+pressed key (`src/input/resolve.rs:92`):
+
+```rust
+if ctx.webview_focused {
+    *leader_phase = LeaderPhase::Idle;            // reset the leader every key
+    if shortcuts.is_release_webview_focus(..) { ReleaseWebviewFocus }
+    else if forward_chord_matches(..)         { WebviewForward }
+    continue;                                     // everything else swallowed
+}
+```
+
+So while a webview is focused the leader is forced to `Idle` on every keystroke;
+only the release chord and the webview's declared `forward_keys` chords are
+handled. The prefix table is never consulted.
+
+`KeyboardInput` events DO reach the decider during webview focus — that is how
+the release and forward branches above match at all. So making the leader fire is
+purely a decider question; no new event plumbing is needed.
+
+### Why suppression is required (`bevy_cef` delivers to the focused webview)
+
+`bevy_cef` 0.11's `send_key_event` (in its `KeyboardDeliverSet`) delivers every
+`KeyboardInput` to the entity in `FocusedWebview`, and ozmux does not currently
+populate `bevy_cef`'s opt-out filter. bevy_cef exposes exactly the hook we need:
+
+```rust
+// bevy_cef::prelude
+pub struct CefKeyboardFilter { /* (Entity, KeyCode, ModifiersState) triples */ }
+impl CefKeyboardFilter {
+    pub fn set(&mut self, entries: impl IntoIterator<Item=(Entity, KeyCode, ModifiersState)>);
+    pub fn contains(&self, webview: Entity, code: KeyCode, mods: ModifiersState) -> bool;
+}
+pub struct KeyboardDeliverSet;   // order filter population `.before(KeyboardDeliverSet)`
+pub struct ModifiersState { pub alt: bool, pub ctrl: bool, pub shift: bool, pub logo: bool }
+```
+
+`send_key_event` skips any key whose `(webview, code, mods)` triple is in the
+filter. An embedder fills the filter each frame `.before(KeyboardDeliverSet)`;
+`set()` replaces the whole set, so it self-clears when nothing is claimed.
+
+## Non-goals
+
+- **Direct GUI chords are out of scope.** Only the leader/prefix table gains the
+  focus-independent behavior. Cmd+Q (Quit), Cmd+S (copy-mode), Cmd+V (paste) and
+  every other direct chord keep their current webview-focus behavior (they remain
+  webview-owned while a webview is focused).
+- **No change to `ReleaseWebviewFocus` or `forward_keys` semantics**, nor to the
+  tmux `WebviewForward` → `send-keys` behavior. Those keys keep reaching CEF as
+  they do today; only leader-claimed keys are newly suppressed. One narrow
+  overlap: if a chord is BOTH the configured leader and a webview `forward_keys`
+  chord, the leader wins (its `Swallow` arm precedes the forward arm) and that
+  chord is suppressed from CEF rather than forwarded.
+- **The webview is never blurred by the leader.** The leader borrows keystrokes
+  transiently; keyboard focus stays on the webview. Only the explicit
+  `ReleaseWebviewFocus` chord blurs it.
+- No config surface changes. The existing leader (Cmd tap by default, or a
+  configured chord/tap) is what activates during webview focus.
+
+## Design
+
+Approach: extend the pure decider to compute both the effects and the
+leader-claimed keys in one pass, and let `resolve_shortcuts` forward the claims
+to `CefKeyboardFilter`. Single source of truth (the decider), no logic
+duplication, and guard-consistency is structural (claims are computed in the same
+body, after the same coarse guards, as the effects). Alternatives that keep the
+decider signature unchanged were considered and rejected (see below).
+
+### Part 1 — let the leader run during webview focus (`src/input/resolve.rs`)
+
+Rewrite the `ctx.webview_focused` branch of `classify_key_batch` to step the
+leader machine instead of resetting it, then fall back to webview handling only
+for keys the leader does not claim:
+
+```rust
+if ctx.webview_focused {
+    match step_with_repeat(leader_phase, shortcuts, ev, ctx.mods, ctx.now) {
+        LeaderStep::Swallow => {
+            // the leader itself, or an abandoned second key — claimed, no effect
+            webview_suppressed.push(ev.key_code);
+            continue;
+        }
+        LeaderStep::RunAction(action) => {
+            webview_suppressed.push(ev.key_code);
+            effects.push(KeyEffect::Action { action, via_leader: true });
+            continue;
+        }
+        LeaderStep::Passthrough => {
+            // not leader-related — webview owns this key (unchanged behavior)
+            if shortcuts.is_release_webview_focus(ev.key_code, ctx.mods) {
+                effects.push(KeyEffect::ReleaseWebviewFocus);
+            } else if ctx.forward_chords.iter()
+                .any(|chord| chord_matches(chord, ev.key_code, ctx.mods))
+            {
+                effects.push(KeyEffect::WebviewForward {
+                    logical: ev.logical_key.clone(),
+                    key_code: ev.key_code,
+                });
+            }
+            continue;
+        }
+    }
+}
+```
+
+Consequences of using `step_with_repeat` (the same function the terminal path
+uses) instead of the unconditional `Idle` reset:
+
+- The Cmd-tap leader already engages via `detect_modifier_tap` during webview
+  focus (it is focus-independent). On the tap-release frame `LeaderPhase` becomes
+  `Pending`; the second-key frame resolves it here against the prefix table.
+- A configured **chord leader** (e.g. `Ctrl+B`) now engages here too: pressing it
+  during webview focus returns `Swallow` and sets `Pending` (and is suppressed
+  from CEF — Part 2), rather than reaching the web page.
+- Normal typing into a webview is unchanged: `Idle` + a non-leader key returns
+  `Passthrough`, is not suppressed, and (as today) is swallowed by ozmux while
+  bevy_cef delivers it to the page.
+- The old NOTE about resetting to prevent a "stale leader firing when focus
+  returns" is obsolete: the machine is now stepped, and the existing
+  `reset_leader_phase` (gated on `FocusedWebview` change, `src/input/shortcuts.rs`)
+  still clears any pending leader on click-in / click-out focus transitions.
+
+Return type: `classify_key_batch` currently returns `Vec<KeyEffect>`. It returns
+a small struct carrying both outputs:
+
+```rust
+pub(crate) struct ClassifiedKeys {
+    pub effects: Vec<KeyEffect>,
+    /// Physical keys the leader claimed while a webview was focused, to withhold
+    /// from CEF. The frame's modifier snapshot (`ctx.mods`, constant across the
+    /// batch) is applied by `resolve_shortcuts`. Empty on the non-webview path.
+    pub webview_suppressed: Vec<KeyCode>,
+}
+```
+
+`webview_suppressed` is populated only inside the `ctx.webview_focused` branch
+(the `Swallow` / `RunAction` arms). `KeyEffect` itself is unchanged. The sole
+production caller is `resolve_shortcuts`; the resolve.rs test helper `run` and
+the tmux/default appliers are unaffected (they consume `ShortcutBatch`, not the
+decider's return).
+
+### Part 2 — withhold the claimed keys from CEF (`src/input/dispatch.rs`)
+
+`resolve_shortcuts` maps `webview_suppressed` onto `CefKeyboardFilter`:
+
+- Add `mut cef_filter: ResMut<CefKeyboardFilter>` to the system.
+- Snapshot the focused webview entity into a local **before** the effect loop
+  that handles `ReleaseWebviewFocus` (which sets `focused_webview.0 = None`,
+  `src/input/dispatch.rs:175`). Building the filter from `focused_webview.0` after
+  the loop would read `None` on a frame carrying both a leader claim and a release
+  chord, silently dropping the suppression.
+- After classifying, when a webview is focused, `filter.set(...)` with
+  `(webview_entity, key_code, ms)` for each claimed `key_code`, where `ms` is the
+  frame's `Modifiers { ctrl, shift, alt, meta }` mapped once to
+  `ModifiersState { alt, ctrl, shift, logo: meta }`. When `webview_suppressed` is
+  empty (non-webview path, or webview focused but nothing claimed), `set([])`
+  clears it.
+- On the coarse-guard early return (tmux modal prompt / IME composing / unfocused
+  window — `src/input/dispatch.rs:137`), also `cef_filter.set([])` before
+  returning, so a stale claim never lingers on a guarded frame.
+
+The `ModifiersState` computed here matches what `send_key_event` derives at
+delivery: both read the live `ButtonInput<KeyCode>` in the same frame.
+
+### Ordering and registration (`src/input/dispatch.rs`)
+
+`resolve_shortcuts` must write the filter before bevy_cef reads it. The claims are
+computed in the same `classify_key_batch` pass that decides the effects — each
+key's suppression is recorded at the exact phase state that decides its effect —
+so no separate `LeaderPhase` snapshot is needed (`send_key_event` never reads
+`LeaderPhase`; it reads the filter plus the live `ButtonInput`). This holds
+because `resolve_shortcuts` IS the sole phase-advancing system and already owns
+the classification:
+
+- Add `.before(KeyboardDeliverSet)` to `resolve_shortcuts` in `DispatchPlugin`
+  (import `KeyboardDeliverSet` from `bevy_cef::prelude`). This is the only new
+  ordering edge; bevy_cef's delivery systems have no dependency on ozmux input
+  sets, so no cycle is introduced.
+- Existing set membership (`InputPhase::FocusedKey`, `ShortcutSet::Resolve`,
+  `LeaderGate::Advance`, `run_if(on_message::<KeyboardInput>)`) is unchanged.
+
+`CefKeyboardFilter` is `init_resource`d by bevy_cef's `KeyboardPlugin` (wired via
+`OzmaWebviewPlugin` / `cef_plugin`), so it exists at runtime; tests init it
+explicitly.
+
+## Components and data flow
+
+```
+KeyboardInput (reaches Bevy even while a webview is focused)
+   │
+   ├─ detect_modifier_tap  (LeaderGate::Detect)  → LeaderPhase::Pending on Cmd tap
+   │
+   ▼
+resolve_shortcuts  (InputPhase::FocusedKey, ShortcutSet::Resolve,
+   │                LeaderGate::Advance, .before(KeyboardDeliverSet))
+   │   classify_key_batch(...) → ClassifiedKeys { effects, webview_suppressed }
+   │        webview_focused branch:
+   │            Swallow / RunAction → claim key + (RunAction) push Action{via_leader}
+   │            Passthrough         → release / forward / swallow (unchanged)
+   │   ├─ ShortcutBatch{effects, focused, ..}  → per-mode appliers (unchanged)
+   │   └─ CefKeyboardFilter.set(webview_suppressed)  ─┐
+   ▼                                                  │
+bevy_cef KeyboardDeliverSet::send_key_event  ◄────────┘  skips filtered keys
+        delivers non-filtered keys to FocusedWebview
+```
+
+- Leader actions target `batch.focused`, the current `KeyboardFocused` surface —
+  always the active pane, resolved independently of `FocusedWebview`
+  (`resolve_shortcuts`, `Query<Entity, With<KeyboardFocused>>`). It is valid
+  during webview focus: a webview-surface pane carries `KeyboardFocused` itself,
+  and a freshly-focused inline child's parent pane is the active
+  (`KeyboardFocused`) pane (`sync_focused_webview`, `src/input/focus.rs`). Note
+  that inline webview focus is *preserved* for a child of any live surface —
+  active or not — so `FocusedWebview` and `KeyboardFocused` can diverge once the
+  leader is allowed to run under webview focus (see Risks). Paste targets the
+  terminal, not the page (intended).
+- The appliers already handle `KeyEffect::Action { via_leader: true }` for every
+  leader action and are not gated on webview focus; no applier change is needed.
+
+## Testing
+
+Pure decider tests (`src/input/resolve.rs`, no `App`):
+
+- webview focused + `Pending` + bound second key → one `Action{via_leader:true}`;
+  `webview_suppressed` contains that key.
+- webview focused + `Idle` + configured chord-leader press → `Swallow`, phase
+  `Pending`, `webview_suppressed` contains the leader chord.
+- webview focused + `Pending` + unbound second key → `Swallow`, no `Action`,
+  key still in `webview_suppressed`.
+- webview focused + `Idle` + plain non-leader key → no effect (or `WebviewForward`
+  when a forward chord), phase `Idle`, `webview_suppressed` empty (Passthrough is
+  not suppressed).
+- Existing forward-chord and release-chord webview tests still pass; update
+  `webview_focus_clears_leader_and_forwards` for the new stepped behavior.
+
+Applier / ordering tests (`src/input/dispatch.rs`, `App`):
+
+- After a leader claim during webview focus, `CefKeyboardFilter.contains(webview,
+  code, ms)` is true for the claimed key.
+- A guarded frame (unfocused window) clears the filter and emits no batch.
+- A frame with nothing claimed (no webview, or plain webview typing) leaves the
+  filter empty.
+- `resolve_shortcuts` is ordered `.before(KeyboardDeliverSet)` (registration
+  mirrors production), and the input `App` builds with that edge added without a
+  schedule-graph cycle / ambiguity panic.
+
+## Behaviour-preservation checklist
+
+- Non-webview keyboard dispatch (terminal / tmux pane) is byte-for-byte
+  unchanged: the new struct field is empty and the filter is cleared.
+- Webview typing with no leader engaged is unchanged: keys pass through to CEF;
+  ozmux emits nothing.
+- `ReleaseWebviewFocus` and `forward_keys` continue to reach CEF and behave as
+  before.
+- Direct GUI chords keep their current webview-focus behavior (webview-owned).
+
+## Risks and staging
+
+- **Cmd-tap over a web app.** A bare Cmd tap now arms the leader even while a
+  webview is focused, so the next keystroke is consumed as the leader's second
+  key. This is the existing tap semantics extended to webview focus, and matches
+  the "leader works regardless of focus" goal; a bare Cmd is harmless to CEF
+  (no character, not an edit command). The same holds for a chord leader: the
+  chord's bare modifier(s) (e.g. `Ctrl` in `Ctrl+B`) are not claimed by
+  `step_leader` and still reach CEF — harmless for the same reason; only the
+  chord's main key is suppressed. Acceptable.
+- **Key releases are not suppressed.** The decider claims only pressed keys, but
+  bevy_cef's `send_key_event` delivers key-up events too, so a leader-claimed
+  key's release still reaches the page (the release usually lands a frame later,
+  when `LeaderPhase` is already `Idle`). A key-up inserts no text — text is
+  committed on keydown / `beforeinput` — so this is visually harmless for web
+  inputs; a page with a `keyup` listener would observe a lone key-up. Suppressing
+  releases would require cross-frame state (remember each claimed key-code until
+  its release); deferred as a known limitation.
+- **`batch.focused` can drift from the pane behind the webview.** Because the
+  leader may now run while a webview stays focused (and is never blurred by it),
+  a user can `<Leader>`-navigate panes while `FocusedWebview` is preserved,
+  moving `KeyboardFocused` (= `batch.focused`) to a pane other than the one
+  hosting the focused webview. This is intended and consistent with the
+  non-webview case: leader pane/split/window actions always target the active
+  (`KeyboardFocused`) pane. Key-leak suppression is unaffected — it targets the
+  snapshotted `focused_webview.0`, not `batch.focused`.
+- **Ordering assumption.** Correctness of same-frame suppression depends on
+  `resolve_shortcuts` running before `KeyboardDeliverSet`. Enforced by the
+  explicit `.before` edge and covered by a registration test.
+- Staging: Part 1 and Part 2 land together — Part 1 without Part 2 would leak the
+  claimed key into the page.
+
+## Alternatives considered
+
+- **Blur the webview when the leader engages.** Clearing `FocusedWebview` on
+  engage would route keys to the terminal path and need no CEF filter, but it
+  destroys the web page's focus/caret on every leader use and complicates the
+  first-key timing. Rejected — too invasive to focus state.
+- **Separate suppression system, decider signature unchanged.** A pre-delivery
+  system could populate the filter without touching `classify_key_batch`'s return
+  type, but the `Swallow` vs `Passthrough`-swallow ambiguity means it must
+  reproduce the leader claim decision — either by re-running `step_leader` on a
+  cloned phase (precise, but the machine runs twice and the coarse guards must be
+  mirrored to stay consistent) or by a phase→suppress heuristic (imprecise at the
+  Repeat-window and multi-key-per-frame edges, and duplicative). The chosen
+  approach computes claims in the same pass as effects, keeping one source of
+  truth and structural guard-consistency.
+
+## Out of scope
+
+- Direct GUI chords bypassing webview focus (a separate product decision).
+- Any change to `forward_keys` / `ReleaseWebviewFocus` routing or the tmux
+  `WebviewForward` → `send-keys` mapping.
+- Config surface for enabling/disabling per-webview leader behavior.

--- a/src/input/dispatch.rs
+++ b/src/input/dispatch.rs
@@ -158,10 +158,11 @@ fn resolve_shortcuts(
         webview_focused: focused_webview.0.is_some(),
         forward_chords,
     };
-    // Snapshot the webview entity BEFORE the effects loop below runs
-    // `ReleaseWebviewFocus`, which sets `focused_webview.0 = None`. Building the
-    // filter from `focused_webview.0` afterwards would drop the suppression on a
-    // frame carrying both a leader claim and a release chord.
+    // NOTE: snapshot the focused webview BEFORE the effects loop, which may set
+    // `focused_webview.0 = None` on a `ReleaseWebviewFocus` chord. Keying the
+    // filter to the value read here (not after the loop) keeps this frame's
+    // suppression tied to the webview the keys were classified against, rather
+    // than leaning on bevy_cef's None-target delivery guard to cover the gap.
     let suppress_target = focused_webview.0;
     let ClassifiedKeys {
         effects: all,

--- a/src/input/dispatch.rs
+++ b/src/input/dispatch.rs
@@ -225,6 +225,7 @@ mod tests {
     use bevy::input::keyboard::Key;
     use bevy::state::app::StatesPlugin;
     use ozmux_tmux::{PaneId, TmuxPane};
+    use std::time::Duration;
     use tmux_control_parser::CellDims;
 
     #[derive(Resource, Default)]
@@ -510,7 +511,7 @@ mod tests {
         let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
             KeyCode::KeyS,
             ShortcutAction::EnterCopyMode,
-            std::time::Duration::ZERO,
+            Duration::ZERO,
         ));
         app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         let webview = app.world_mut().spawn_empty().id();
@@ -533,7 +534,7 @@ mod tests {
         let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
             KeyCode::KeyS,
             ShortcutAction::EnterCopyMode,
-            std::time::Duration::ZERO,
+            Duration::ZERO,
         ));
         app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
         let webview = app.world_mut().spawn_empty().id();
@@ -543,7 +544,6 @@ mod tests {
             KeyCode::KeyS,
             ModifiersState::default(),
         )]);
-        // Window unfocused → coarse guard fires.
         {
             let mut windows = app
                 .world_mut()
@@ -573,7 +573,6 @@ mod tests {
             KeyCode::KeyS,
             ModifiersState::default(),
         )]);
-        // No webview focused; a plain key claims nothing.
         press_key(&mut app, KeyCode::KeyA, Key::Character("a".into()));
         app.update();
         assert!(

--- a/src/input/dispatch.rs
+++ b/src/input/dispatch.rs
@@ -222,6 +222,7 @@ mod tests {
         test_shortcuts_with_direct_chord, test_shortcuts_with_repeat_prefix,
     };
     use crate::surface::OzmaTerminal;
+    use bevy::ecs::schedule::{LogLevel, ScheduleBuildSettings};
     use bevy::input::ButtonState;
     use bevy::input::keyboard::Key;
     use bevy::state::app::StatesPlugin;
@@ -272,7 +273,9 @@ mod tests {
             .insert_state(AppMode::Default)
             .add_systems(
                 Update,
-                (capture_batch, capture_exit).in_set(ShortcutSet::Apply),
+                (capture_batch, capture_exit)
+                    .chain()
+                    .in_set(ShortcutSet::Apply),
             );
         app.world_mut().spawn((
             Window {
@@ -621,6 +624,12 @@ mod tests {
         app.world_mut().resource_mut::<ProbeWebview>().0 = Some(webview);
         *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
         press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.edit_schedule(Update, |schedule| {
+            schedule.set_build_settings(ScheduleBuildSettings {
+                ambiguity_detection: LogLevel::Error,
+                ..Default::default()
+            });
+        });
         app.update();
         assert!(
             app.world().resource::<DeliverProbe>().saw_claim,

--- a/src/input/dispatch.rs
+++ b/src/input/dispatch.rs
@@ -11,7 +11,7 @@ use crate::action::vi::ResolvedCopyModeKeys;
 use crate::app_mode::AppMode;
 use crate::input::focus::KeyboardFocused;
 use crate::input::ime::{ImeState, resolve_focused_surface};
-use crate::input::resolve::{BatchContext, KeyEffect, classify_key_batch};
+use crate::input::resolve::{BatchContext, ClassifiedKeys, KeyEffect, classify_key_batch};
 use crate::input::shortcuts::{LeaderGate, LeaderPhase, Shortcuts, clear_leader_phase};
 use crate::input::{InputPhase, current_modifiers};
 use crate::ui::copy_mode::CopyModeState;
@@ -23,7 +23,7 @@ use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::time::Real;
 use bevy::window::PrimaryWindow;
-use bevy_cef::prelude::FocusedWebview;
+use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, ModifiersState};
 use ozma_webview::ForwardKeys;
 use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
 
@@ -111,6 +111,7 @@ fn resolve_shortcuts(
     mut exit: MessageWriter<AppExit>,
     mut events: MessageReader<KeyboardInput>,
     mut focused_webview: ResMut<FocusedWebview>,
+    mut cef_filter: ResMut<CefKeyboardFilter>,
     mut leader_phase: ResMut<LeaderPhase>,
     mut batch: MessageWriter<ShortcutBatch>,
     guards: ModalGuards,
@@ -136,6 +137,7 @@ fn resolve_shortcuts(
             || guards.rename_prompt.is_some());
     if prompt_open || guards.ime.is_composing() || !focused_window {
         clear_leader_phase(&mut leader_phase);
+        clear_cef_filter(&mut cef_filter);
         events.clear();
         return;
     }
@@ -155,7 +157,15 @@ fn resolve_shortcuts(
         webview_focused: focused_webview.0.is_some(),
         forward_chords,
     };
-    let all = classify_key_batch(
+    // Snapshot the webview entity BEFORE the effects loop below runs
+    // `ReleaseWebviewFocus`, which sets `focused_webview.0 = None`. Building the
+    // filter from `focused_webview.0` afterwards would drop the suppression on a
+    // frame carrying both a leader claim and a release chord.
+    let suppress_target = focused_webview.0;
+    let ClassifiedKeys {
+        effects: all,
+        webview_suppressed,
+    } = classify_key_batch(
         &mut leader_phase,
         &inputs.shortcuts,
         &inputs.resolved_copy,
@@ -182,12 +192,34 @@ fn resolve_shortcuts(
         in_copy_mode,
         mods,
     });
+    let ms = ModifiersState {
+        alt: mods.alt,
+        ctrl: mods.ctrl,
+        shift: mods.shift,
+        logo: mods.meta,
+    };
+    match suppress_target {
+        Some(webview) => cef_filter.set(
+            webview_suppressed
+                .into_iter()
+                .map(|code| (webview, code, ms)),
+        ),
+        None => clear_cef_filter(&mut cef_filter),
+    }
+}
+
+/// Empties `CefKeyboardFilter`. Used on the coarse-guard early return and when no
+/// webview owns the keyboard, so a stale leader claim never withholds a later key.
+fn clear_cef_filter(cef_filter: &mut CefKeyboardFilter) {
+    cef_filter.set(Vec::<(Entity, KeyCode, ModifiersState)>::new());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::input::shortcuts::test_shortcuts_with_direct_chord;
+    use crate::input::shortcuts::{
+        test_shortcuts_with_direct_chord, test_shortcuts_with_repeat_prefix,
+    };
     use crate::surface::OzmaTerminal;
     use bevy::input::ButtonState;
     use bevy::input::keyboard::Key;
@@ -229,6 +261,7 @@ mod tests {
             .init_resource::<ButtonInput<KeyCode>>()
             .init_resource::<ImeState>()
             .init_resource::<FocusedWebview>()
+            .init_resource::<CefKeyboardFilter>()
             .init_resource::<LeaderPhase>()
             .init_resource::<ResolvedCopyModeKeys>()
             .init_resource::<CopyPrompt>()
@@ -470,5 +503,87 @@ mod tests {
             )),
             "no Quit effect reaches the batch even when nothing is focused"
         );
+    }
+
+    #[test]
+    fn filter_holds_leader_claim_under_webview_focus() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            std::time::Duration::ZERO,
+        ));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            app.world().resource::<CefKeyboardFilter>().contains(
+                webview,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "the leader-claimed second key is withheld from CEF for the focused webview"
+        );
+    }
+
+    #[test]
+    fn filter_cleared_on_guarded_frame() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            std::time::Duration::ZERO,
+        ));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        app.world_mut().resource_mut::<CefKeyboardFilter>().set([(
+            webview,
+            KeyCode::KeyS,
+            ModifiersState::default(),
+        )]);
+        // Window unfocused → coarse guard fires.
+        {
+            let mut windows = app
+                .world_mut()
+                .query_filtered::<&mut Window, With<PrimaryWindow>>();
+            windows.single_mut(app.world_mut()).unwrap().focused = false;
+        }
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            !app.world().resource::<CefKeyboardFilter>().contains(
+                webview,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "a guarded frame clears the filter so a stale claim never lingers"
+        );
+    }
+
+    #[test]
+    fn filter_cleared_when_nothing_claimed() {
+        let mut app = resolve_app(Shortcuts::default());
+        let term = app.world_mut().spawn((OzmaTerminal, KeyboardFocused)).id();
+        let stale = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<CefKeyboardFilter>().set([(
+            stale,
+            KeyCode::KeyS,
+            ModifiersState::default(),
+        )]);
+        // No webview focused; a plain key claims nothing.
+        press_key(&mut app, KeyCode::KeyA, Key::Character("a".into()));
+        app.update();
+        assert!(
+            !app.world().resource::<CefKeyboardFilter>().contains(
+                stale,
+                KeyCode::KeyS,
+                ModifiersState::default()
+            ),
+            "a frame that claims nothing clears the filter"
+        );
+        let _ = term;
     }
 }

--- a/src/input/dispatch.rs
+++ b/src/input/dispatch.rs
@@ -23,7 +23,7 @@ use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::prelude::*;
 use bevy::time::Real;
 use bevy::window::PrimaryWindow;
-use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, ModifiersState};
+use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, KeyboardDeliverSet, ModifiersState};
 use ozma_webview::ForwardKeys;
 use ozmux_configs::shortcuts::{Modifiers, ShortcutAction};
 
@@ -71,6 +71,7 @@ impl Plugin for DispatchPlugin {
                 resolve_shortcuts
                     .in_set(ShortcutSet::Resolve)
                     .in_set(LeaderGate::Advance)
+                    .before(KeyboardDeliverSet)
                     .run_if(on_message::<KeyboardInput>),
             );
     }
@@ -584,5 +585,46 @@ mod tests {
             "a frame that claims nothing clears the filter"
         );
         let _ = term;
+    }
+
+    #[derive(Resource, Default)]
+    struct DeliverProbe {
+        saw_claim: bool,
+    }
+
+    fn deliver_probe(
+        mut probe: ResMut<DeliverProbe>,
+        filter: Res<CefKeyboardFilter>,
+        webview: Res<ProbeWebview>,
+    ) {
+        if let Some(webview) = webview.0 {
+            probe.saw_claim = filter.contains(webview, KeyCode::KeyS, ModifiersState::default());
+        }
+    }
+
+    #[derive(Resource, Default)]
+    struct ProbeWebview(Option<Entity>);
+
+    #[test]
+    fn filter_is_populated_before_keyboard_deliver_set() {
+        let mut app = resolve_app(test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        ));
+        app.init_resource::<DeliverProbe>()
+            .init_resource::<ProbeWebview>()
+            .add_systems(Update, deliver_probe.in_set(KeyboardDeliverSet));
+        app.world_mut().spawn((OzmaTerminal, KeyboardFocused));
+        let webview = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<FocusedWebview>().0 = Some(webview);
+        app.world_mut().resource_mut::<ProbeWebview>().0 = Some(webview);
+        *app.world_mut().resource_mut::<LeaderPhase>() = LeaderPhase::Pending;
+        press_key(&mut app, KeyCode::KeyS, Key::Character("s".into()));
+        app.update();
+        assert!(
+            app.world().resource::<DeliverProbe>().saw_claim,
+            "resolve_shortcuts must populate CefKeyboardFilter before KeyboardDeliverSet runs"
+        );
     }
 }

--- a/src/input/resolve.rs
+++ b/src/input/resolve.rs
@@ -64,6 +64,15 @@ pub(crate) struct BatchContext<'a> {
     pub(crate) forward_chords: &'a [NormalizedChord],
 }
 
+/// The decided output of `classify_key_batch`: the per-key `KeyEffect`s, plus the
+/// physical keys the leader claimed while a webview owned the keyboard. The caller
+/// applies the frame's modifier snapshot when withholding `webview_suppressed`
+/// from CEF via `CefKeyboardFilter`; it is empty on the non-webview path.
+pub(crate) struct ClassifiedKeys {
+    pub(crate) effects: Vec<KeyEffect>,
+    pub(crate) webview_suppressed: Vec<KeyCode>,
+}
+
 /// Classifies one frame's pressed `KeyboardInput` events into `KeyEffect`s,
 /// threading the shared leader state machine across the batch. Pure: no ECS
 /// handles, so callers can drive it in a unit test with no `App`.
@@ -78,7 +87,7 @@ pub(crate) fn classify_key_batch<'a>(
     resolved_copy: &ResolvedCopyModeKeys,
     events: impl Iterator<Item = &'a KeyboardInput>,
     ctx: BatchContext<'a>,
-) -> Vec<KeyEffect> {
+) -> ClassifiedKeys {
     // NOTE: an open repeat window must not intercept copy-mode keys — a
     // repeat-marked key doubling as a copy-mode key would re-fire its bound
     // action into the hidden live terminal instead of being resolved as a
@@ -88,24 +97,40 @@ pub(crate) fn classify_key_batch<'a>(
         *leader_phase = LeaderPhase::Idle;
     }
     let mut effects = Vec::new();
+    let mut webview_suppressed = Vec::new();
     for ev in events.filter(|ev| ev.state == ButtonState::Pressed) {
         if ctx.webview_focused {
-            // NOTE: the leader is honored only when a webview does not own
-            // the keyboard; resetting the phase here (instead of stepping
-            // the state machine) prevents a stale leader from firing once
-            // keyboard focus returns to the terminal.
-            *leader_phase = LeaderPhase::Idle;
-            if shortcuts.is_release_webview_focus(ev.key_code, ctx.mods) {
-                effects.push(KeyEffect::ReleaseWebviewFocus);
-            } else if ctx
-                .forward_chords
-                .iter()
-                .any(|chord| chord_matches(chord, ev.key_code, ctx.mods))
-            {
-                effects.push(KeyEffect::WebviewForward {
-                    logical: ev.logical_key.clone(),
-                    key_code: ev.key_code,
-                });
+            // NOTE: the leader runs even while a webview owns the keyboard, so
+            // `<Leader>` shortcuts work regardless of focus. Keys the leader
+            // claims (the leader chord itself, an abandoned second key, or a
+            // fired binding) are recorded in `webview_suppressed` so the caller
+            // withholds them from CEF; a key the leader does not claim
+            // (`Passthrough`) still resolves to release / forward as before.
+            match step_with_repeat(leader_phase, shortcuts, ev, ctx.mods, ctx.now) {
+                LeaderStep::Swallow => {
+                    webview_suppressed.push(ev.key_code);
+                }
+                LeaderStep::RunAction(action) => {
+                    webview_suppressed.push(ev.key_code);
+                    effects.push(KeyEffect::Action {
+                        action,
+                        via_leader: true,
+                    });
+                }
+                LeaderStep::Passthrough => {
+                    if shortcuts.is_release_webview_focus(ev.key_code, ctx.mods) {
+                        effects.push(KeyEffect::ReleaseWebviewFocus);
+                    } else if ctx
+                        .forward_chords
+                        .iter()
+                        .any(|chord| chord_matches(chord, ev.key_code, ctx.mods))
+                    {
+                        effects.push(KeyEffect::WebviewForward {
+                            logical: ev.logical_key.clone(),
+                            key_code: ev.key_code,
+                        });
+                    }
+                }
             }
             continue;
         }
@@ -139,7 +164,10 @@ pub(crate) fn classify_key_batch<'a>(
             key_code: ev.key_code,
         });
     }
-    effects
+    ClassifiedKeys {
+        effects,
+        webview_suppressed,
+    }
 }
 
 /// Advances the leader machine for one pressed event, honoring OS auto-repeat:
@@ -234,6 +262,16 @@ mod tests {
         events: &'a [KeyboardInput],
         ctx: BatchContext<'a>,
     ) -> Vec<KeyEffect> {
+        classify_key_batch(leader_phase, shortcuts, resolved_copy, events.iter(), ctx).effects
+    }
+
+    fn run_full<'a>(
+        leader_phase: &mut LeaderPhase,
+        shortcuts: &Shortcuts,
+        resolved_copy: &ResolvedCopyModeKeys,
+        events: &'a [KeyboardInput],
+        ctx: BatchContext<'a>,
+    ) -> ClassifiedKeys {
         classify_key_batch(leader_phase, shortcuts, resolved_copy, events.iter(), ctx)
     }
 
@@ -758,10 +796,113 @@ mod tests {
     }
 
     #[test]
-    fn webview_focus_clears_leader_and_forwards() {
-        let sc = Shortcuts::default();
+    fn webview_pending_leader_fires_action_and_suppresses() {
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
         let resolved_copy = ResolvedCopyModeKeys::default();
         let mut phase = LeaderPhase::Pending;
+        let events = [press(KeyCode::KeyS, Key::Character("s".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(
+            out.effects,
+            vec![KeyEffect::Action {
+                action: ShortcutAction::EnterCopyMode,
+                via_leader: true,
+            }],
+            "a bound second key fires its leader action even while a webview is focused"
+        );
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyS],
+            "the fired key is withheld from CEF"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_leader_chord_engages_and_suppresses() {
+        // The fixture's leader is the Ctrl+A chord.
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
+        let events = [press(KeyCode::KeyA, Key::Character("a".into()))];
+        let mut c = ctx(mods(true, false, false, false), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(
+            out.effects,
+            vec![],
+            "the leader chord itself emits no effect"
+        );
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyA],
+            "the leader chord is withheld from CEF"
+        );
+        assert_eq!(
+            phase,
+            LeaderPhase::Pending,
+            "pressing the leader chord under webview focus engages Pending"
+        );
+    }
+
+    #[test]
+    fn webview_pending_unbound_key_swallowed_and_suppressed() {
+        let sc = test_shortcuts_with_repeat_prefix(
+            KeyCode::KeyS,
+            ShortcutAction::EnterCopyMode,
+            Duration::ZERO,
+        );
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Pending;
+        let events = [press(KeyCode::KeyZ, Key::Character("z".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(out.effects, vec![], "an unbound second key emits nothing");
+        assert_eq!(
+            out.webview_suppressed,
+            vec![KeyCode::KeyZ],
+            "the swallowed second key is still withheld from CEF"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_plain_key_not_suppressed() {
+        let sc = Shortcuts::default();
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
+        let events = [press(KeyCode::KeyB, Key::Character("b".into()))];
+        let mut c = ctx(no_mods(), ms(0));
+        c.webview_focused = true;
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
+        assert_eq!(
+            out.effects,
+            vec![],
+            "a plain key under webview focus emits nothing"
+        );
+        assert!(
+            out.webview_suppressed.is_empty(),
+            "a non-leader key is NOT withheld — the webview must still receive it"
+        );
+        assert_eq!(phase, LeaderPhase::Idle);
+    }
+
+    #[test]
+    fn webview_idle_forward_chord_forwards_and_not_suppressed() {
+        let sc = Shortcuts::default();
+        let resolved_copy = ResolvedCopyModeKeys::default();
+        let mut phase = LeaderPhase::Idle;
         let chords = [NormalizedChord {
             code: KeyCode::KeyK,
             alt: false,
@@ -773,19 +914,20 @@ mod tests {
         let mut c = ctx(no_mods(), ms(0));
         c.webview_focused = true;
         c.forward_chords = &chords;
-        let effects = run(&mut phase, &sc, &resolved_copy, &events, c);
+        let out = run_full(&mut phase, &sc, &resolved_copy, &events, c);
         assert_eq!(
-            effects,
+            out.effects,
             vec![KeyEffect::WebviewForward {
                 logical: Key::Character("k".into()),
                 key_code: KeyCode::KeyK,
-            }]
+            }],
+            "with no leader engaged a declared forward chord still forwards"
         );
-        assert_eq!(
-            phase,
-            LeaderPhase::Idle,
-            "webview focus must clear any pending leader"
+        assert!(
+            out.webview_suppressed.is_empty(),
+            "a forward chord is not a leader claim — not withheld from CEF"
         );
+        assert_eq!(phase, LeaderPhase::Idle);
     }
 
     #[test]

--- a/src/input/resolve.rs
+++ b/src/input/resolve.rs
@@ -826,7 +826,6 @@ mod tests {
 
     #[test]
     fn webview_idle_leader_chord_engages_and_suppresses() {
-        // The fixture's leader is the Ctrl+A chord.
         let sc = test_shortcuts_with_repeat_prefix(
             KeyCode::KeyS,
             ShortcutAction::EnterCopyMode,


### PR DESCRIPTION
## Summary

Makes `<Leader>`-scoped shortcuts fire even while a CEF webview owns the keyboard (like tmux's prefix — a global escape hatch), and withholds the leader-claimed keys from the focused web page so they don't double-deliver.

Previously, once a webview was focused, `classify_key_batch`'s `webview_focused` branch reset the leader and swallowed everything, so `<Leader>` bindings were dead. bevy_cef also delivers every keystroke to the focused webview, so naively firing a leader action would type its key into the page too.

## Design (2 parts)

- **Decider** (`src/input/resolve.rs`): the `webview_focused` branch now steps the leader machine via `step_with_repeat` and returns `ClassifiedKeys { effects, webview_suppressed }`. `Swallow`/`RunAction` claim the key (recorded in `webview_suppressed`); `Passthrough` keeps the existing release/forward handling, so normal webview typing is unchanged.
- **Suppression** (`src/input/dispatch.rs`): `resolve_shortcuts` populates bevy_cef's `CefKeyboardFilter` from `webview_suppressed` (snapshotting the webview entity before the `ReleaseWebviewFocus` effect loop nulls it), clears it on guarded / unclaimed frames, and is ordered `.before(KeyboardDeliverSet)` so the filter is read after it's written the same frame.

Scope is leader-only. Direct GUI chords, `forward_keys`/`ReleaseWebviewFocus` semantics, and the tmux `WebviewForward` mapping are unchanged. Documented known limitations (accepted): key **releases** aren't suppressed (keyup inserts no text), and `batch.focused` may drift from the pane behind the webview (leader targets the active pane, consistent with the non-webview case).

Spec: `docs/specs/2026-07-05-leader-shortcuts-ignore-webview-focus-design.md`
Plan: `docs/plans/2026-07-05-leader-shortcuts-ignore-webview-focus.md`

## Testing

- `cargo test -p ozmux` — 533 pass, 0 fail; `cargo clippy --workspace --all-targets` clean.
- New pure-decider tests cover the webview leader path (Pending fires + suppresses, chord-leader engage, unbound-swallow, plain-key not-suppressed, forward-chord still forwards).
- New dispatch tests cover filter populate/clear; the ordering test is load-bearing via Bevy schedule ambiguity detection (verified it panics if the `.before(KeyboardDeliverSet)` edge is removed).

## Manual verification (please confirm before merge)

- [ ] With a focused inline webview: a `<Leader>` shortcut fires the ozmux action.
- [ ] The leader's second key does **not** appear in a focused web input.
- [ ] Plain typing into the webview and the release chord still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)