### PR TITLE
feat(ozmd): display local images in Markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ name = "ozmd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "notify-debouncer-full",
  "pulldown-cmark",
  "ratatui",

--- a/apps/ozmd/Cargo.toml
+++ b/apps/ozmd/Cargo.toml
@@ -21,6 +21,7 @@ pulldown-cmark = "0.12"
 notify-debouncer-full = "0.3"
 rust-embed = "8"
 tempfile = { workspace = true }
+blake3 = "1"
 
 [lints]
 workspace = true

--- a/apps/ozmd/src/local_assets.rs
+++ b/apps/ozmd/src/local_assets.rs
@@ -1,0 +1,110 @@
+//! Stages local image files referenced by a Markdown document as symlinks
+//! under the served asset root's `_local/` directory, so the webview can load
+//! them as `ozma://<handle>/_local/<token>.<ext>` subresources.
+
+use crate::document::resolve_link;
+use std::fs;
+use std::io::ErrorKind;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+/// Stages the local file `raw` (resolved against `base_dir`) as a symlink under
+/// `local_root/_local/` and returns its root-relative served URL, or `None` if
+/// `raw` does not resolve to a regular file.
+///
+/// Idempotent: the same resolved target always maps to the same token, so a
+/// repeat call is a no-op that returns the same URL.
+pub(crate) fn stage(local_root: &Path, base_dir: &Path, raw: &str) -> Option<String> {
+    let resolved = resolve_link(base_dir, raw).ok()?;
+    let token = token_for(&resolved);
+    let dir = local_root.join("_local");
+    fs::create_dir_all(&dir).ok()?;
+    let link = dir.join(&token);
+    match symlink(&resolved, &link) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+        Err(_) => return None,
+    }
+    Some(format!("_local/{token}"))
+}
+
+/// A content-addressed, filename-safe token for `resolved`: the blake3 hex of
+/// its (canonical) path bytes, plus the original extension so the host's
+/// extension-based MIME inference stays correct.
+fn token_for(resolved: &Path) -> String {
+    let hash = blake3::hash(resolved.as_os_str().as_bytes()).to_hex();
+    match resolved.extension().and_then(|e| e.to_str()) {
+        Some(ext) => format!("{hash}.{ext}"),
+        None => hash.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn token_is_stable_and_keeps_extension() {
+        let p = Path::new("/tmp/whatever/a.PNG");
+        assert_eq!(token_for(p), token_for(p));
+        assert!(token_for(p).ends_with(".PNG"));
+    }
+
+    #[test]
+    fn token_differs_for_different_paths() {
+        assert_ne!(token_for(Path::new("/a/x.png")), token_for(Path::new("/b/x.png")));
+    }
+
+    #[test]
+    fn stage_creates_symlink_to_resolved_target_and_is_idempotent() {
+        let base = tempfile::tempdir().unwrap();
+        let img = base.path().join("pic.png");
+        fs::write(&img, b"\x89PNG\r\n").unwrap();
+        let root = tempfile::tempdir().unwrap();
+
+        let url1 = stage(root.path(), base.path(), "pic.png").unwrap();
+        assert!(url1.starts_with("_local/"));
+        assert!(url1.ends_with(".png"));
+
+        let link = root.path().join(&url1);
+        assert!(link.exists());
+        assert_eq!(fs::read_link(&link).unwrap(), fs::canonicalize(&img).unwrap());
+
+        assert_eq!(stage(root.path(), base.path(), "pic.png").unwrap(), url1);
+    }
+
+    #[test]
+    fn stage_relative_resolves_against_base_dir() {
+        let base = tempfile::tempdir().unwrap();
+        let sub = base.path().join("img");
+        fs::create_dir(&sub).unwrap();
+        let img = sub.join("a.gif");
+        fs::write(&img, b"x").unwrap();
+        let root = tempfile::tempdir().unwrap();
+
+        let url = stage(root.path(), base.path(), "img/a.gif").unwrap();
+        let link = root.path().join(&url);
+        assert_eq!(fs::read_link(&link).unwrap(), fs::canonicalize(&img).unwrap());
+    }
+
+    #[test]
+    fn stage_absolute_path_outside_base_dir() {
+        let elsewhere = tempfile::tempdir().unwrap();
+        let img = elsewhere.path().join("far.jpg");
+        fs::write(&img, b"x").unwrap();
+        let base = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+
+        let url = stage(root.path(), base.path(), img.to_str().unwrap()).unwrap();
+        assert!(url.ends_with(".jpg"));
+    }
+
+    #[test]
+    fn stage_missing_file_returns_none() {
+        let base = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        assert!(stage(root.path(), base.path(), "nope.png").is_none());
+    }
+}

--- a/apps/ozmd/src/local_assets.rs
+++ b/apps/ozmd/src/local_assets.rs
@@ -32,11 +32,18 @@ pub(crate) fn stage(local_root: &Path, base_dir: &Path, raw: &str) -> Option<Str
 /// A content-addressed, filename-safe token for `resolved`: the blake3 hex of
 /// its (canonical) path bytes, plus the original extension so the host's
 /// extension-based MIME inference stays correct.
+///
+/// The extension is appended only when it is ASCII-alphanumeric. A raw
+/// filesystem extension can contain URL-reserved characters (`#`, `?`, `%`);
+/// splicing one into the returned URL would make the browser parse it as a
+/// fragment/query and request a path that no longer matches the on-disk
+/// symlink, silently breaking the image. Dropping such an extension falls back
+/// to MIME sniffing rather than a broken request.
 fn token_for(resolved: &Path) -> String {
     let hash = blake3::hash(resolved.as_os_str().as_bytes()).to_hex();
     match resolved.extension().and_then(|e| e.to_str()) {
-        Some(ext) => format!("{hash}.{ext}"),
-        None => hash.to_string(),
+        Some(ext) if ext.chars().all(|c| c.is_ascii_alphanumeric()) => format!("{hash}.{ext}"),
+        _ => hash.to_string(),
     }
 }
 
@@ -58,6 +65,13 @@ mod tests {
             token_for(Path::new("/a/x.png")),
             token_for(Path::new("/b/x.png"))
         );
+    }
+
+    #[test]
+    fn token_drops_url_unsafe_extension() {
+        let t = token_for(Path::new("/x/photo.png#2"));
+        assert!(!t.contains('#'));
+        assert!(!t.contains('.'));
     }
 
     #[test]

--- a/apps/ozmd/src/local_assets.rs
+++ b/apps/ozmd/src/local_assets.rs
@@ -54,7 +54,10 @@ mod tests {
 
     #[test]
     fn token_differs_for_different_paths() {
-        assert_ne!(token_for(Path::new("/a/x.png")), token_for(Path::new("/b/x.png")));
+        assert_ne!(
+            token_for(Path::new("/a/x.png")),
+            token_for(Path::new("/b/x.png"))
+        );
     }
 
     #[test]
@@ -70,7 +73,10 @@ mod tests {
 
         let link = root.path().join(&url1);
         assert!(link.exists());
-        assert_eq!(fs::read_link(&link).unwrap(), fs::canonicalize(&img).unwrap());
+        assert_eq!(
+            fs::read_link(&link).unwrap(),
+            fs::canonicalize(&img).unwrap()
+        );
 
         assert_eq!(stage(root.path(), base.path(), "pic.png").unwrap(), url1);
     }
@@ -86,7 +92,10 @@ mod tests {
 
         let url = stage(root.path(), base.path(), "img/a.gif").unwrap();
         let link = root.path().join(&url);
-        assert_eq!(fs::read_link(&link).unwrap(), fs::canonicalize(&img).unwrap());
+        assert_eq!(
+            fs::read_link(&link).unwrap(),
+            fs::canonicalize(&img).unwrap()
+        );
     }
 
     #[test]

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -14,7 +14,7 @@ use crate::app::{App, Cmd};
 use crate::document::Document;
 use crate::protocol::{
     Content, NavigateRequest, OpenExternal, OpenPath, Scroll, ScrollState, ScrollTo, Search,
-    SearchCount, SearchNav,
+    SearchCount, SearchNav, StageAssetsRequest, StageAssetsResponse,
 };
 use crate::ui::LiveStatus;
 use crate::watcher::FileWatcher;
@@ -274,6 +274,8 @@ fn register_view(
     shared: Arc<Mutex<Document>>,
 ) -> anyhow::Result<WebviewHandle> {
     let ready_doc = Arc::clone(&shared);
+    let stage_doc = Arc::clone(&shared);
+    let local_root = asset_dir.path().to_path_buf();
     let view = ozma.register(
         Webview::dir(asset_dir.path(), "index.html")
             .interactive(true)
@@ -291,6 +293,21 @@ fn register_view(
                 let doc = ready_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
                 Ok(content_for(&doc, ScrollTo::Preserve))
             })
+            .on(
+                "stageAssets",
+                move |req: StageAssetsRequest| -> Result<StageAssetsResponse, RpcError> {
+                    let base_dir = {
+                        let doc = stage_doc.lock().map_err(|_| RpcError::new("poisoned"))?;
+                        doc.base_dir.clone()
+                    };
+                    let urls = req
+                        .paths
+                        .iter()
+                        .map(|p| local_assets::stage(&local_root, &base_dir, p))
+                        .collect();
+                    Ok(StageAssetsResponse { urls })
+                },
+            )
             .add_event::<SearchCount>("searchCount")
             .add_event::<ScrollState>("scrollState")
             .add_event::<NavigateRequest>("navigate")

--- a/apps/ozmd/src/main.rs
+++ b/apps/ozmd/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 mod assets;
 mod document;
 mod keymap;
+mod local_assets;
 mod outline;
 mod protocol;
 mod ui;

--- a/apps/ozmd/src/protocol.rs
+++ b/apps/ozmd/src/protocol.rs
@@ -77,6 +77,24 @@ pub(crate) struct Content {
     pub(crate) scroll_to: ScrollTo,
 }
 
+/// A page request to stage local image files referenced by the current
+/// document (`stageAssets` call).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StageAssetsRequest {
+    /// Percent-decoded, query/fragment-stripped local paths to stage.
+    pub(crate) paths: Vec<String>,
+}
+
+/// The staged served URLs for a `stageAssets` request, aligned to the request
+/// order; an entry is `None` when that path could not be staged.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StageAssetsResponse {
+    /// Root-relative served URL (`_local/<token>.<ext>`) per input path.
+    pub(crate) urls: Vec<Option<String>>,
+}
+
 /// Search-result counts the page reports back (`searchCount` event).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -213,5 +231,23 @@ mod tests {
         let b: NavigateRequest =
             serde_json::from_value(json!({"path": "a.md", "fragment": null})).unwrap();
         assert_eq!(b.fragment, None);
+    }
+
+    #[test]
+    fn stage_assets_request_reads_paths() {
+        let r: StageAssetsRequest =
+            serde_json::from_value(json!({"paths": ["a.png", "/b.png"]})).unwrap();
+        assert_eq!(r.paths, vec!["a.png".to_string(), "/b.png".to_string()]);
+    }
+
+    #[test]
+    fn stage_assets_response_serializes_urls_with_nulls() {
+        let r = StageAssetsResponse {
+            urls: vec![Some("_local/x.png".to_string()), None],
+        };
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            json!({"urls": ["_local/x.png", null]})
+        );
     }
 }

--- a/apps/ozmd/web/images.test.ts
+++ b/apps/ozmd/web/images.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { collectLocalImages, isLocalImageSrc, toLocalPath } from './images';
+import { __testables, collectLocalImages } from './images';
+
+const { isLocalImageSrc, toLocalPath } = __testables;
 
 describe('isLocalImageSrc', () => {
   it('accepts relative and absolute filesystem paths', () => {

--- a/apps/ozmd/web/images.test.ts
+++ b/apps/ozmd/web/images.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { collectLocalImages, isLocalImageSrc, toLocalPath } from './images';
+
+describe('isLocalImageSrc', () => {
+  it('accepts relative and absolute filesystem paths', () => {
+    expect(isLocalImageSrc('img/a.png')).toBe(true);
+    expect(isLocalImageSrc('/Users/me/a.png')).toBe(true);
+    expect(isLocalImageSrc('../shared/a.png')).toBe(true);
+  });
+
+  it('rejects remote, data, blob, file, protocol-relative, anchors, and empty', () => {
+    expect(isLocalImageSrc('https://x/a.png')).toBe(false);
+    expect(isLocalImageSrc('http://x/a.png')).toBe(false);
+    expect(isLocalImageSrc('data:image/png;base64,AAAA')).toBe(false);
+    expect(isLocalImageSrc('blob:abc')).toBe(false);
+    expect(isLocalImageSrc('file:///a.png')).toBe(false);
+    expect(isLocalImageSrc('//cdn/a.png')).toBe(false);
+    expect(isLocalImageSrc('#frag')).toBe(false);
+    expect(isLocalImageSrc('')).toBe(false);
+  });
+});
+
+describe('toLocalPath', () => {
+  it('strips query and fragment and percent-decodes', () => {
+    expect(toLocalPath('img/a%20b.png?v=2#x')).toBe('img/a b.png');
+    expect(toLocalPath('/abs/p.png')).toBe('/abs/p.png');
+  });
+});
+
+describe('collectLocalImages', () => {
+  it('collects local imgs with decoded paths and skips remote', () => {
+    document.body.innerHTML =
+      '<img src="img/a.png"><img src="https://x/b.png"><img src="/c%20d.png?z">';
+    const got = collectLocalImages(document.body);
+    expect(got.map((g) => g.path)).toEqual(['img/a.png', '/c d.png']);
+    expect(got.every((g) => g.el instanceof HTMLImageElement)).toBe(true);
+  });
+});

--- a/apps/ozmd/web/images.ts
+++ b/apps/ozmd/web/images.ts
@@ -5,7 +5,7 @@ import { decode, schemeOf } from './url';
  * ozmd should stage. Excludes in-page anchors, protocol-relative URLs, and any
  * URL carrying a scheme (`http:`, `https:`, `data:`, `blob:`, `file:`, …).
  */
-export function isLocalImageSrc(raw: string): boolean {
+function isLocalImageSrc(raw: string): boolean {
   const s = raw.trim();
   if (s.length === 0 || s.startsWith('#') || s.startsWith('//')) {
     return false;
@@ -14,7 +14,7 @@ export function isLocalImageSrc(raw: string): boolean {
 }
 
 /** Strips any `?query` / `#fragment` from `raw` and percent-decodes the rest. */
-export function toLocalPath(raw: string): string {
+function toLocalPath(raw: string): string {
   const s = raw.trim();
   const noFragment = s.split('#', 1)[0];
   const noQuery = noFragment.split('?', 1)[0];
@@ -36,3 +36,6 @@ export function collectLocalImages(root: HTMLElement): { el: HTMLImageElement; p
   }
   return out;
 }
+
+/** Test-only exports of the file-local helpers (see typescript.md visibility rule). */
+export const __testables = { isLocalImageSrc, toLocalPath };

--- a/apps/ozmd/web/images.ts
+++ b/apps/ozmd/web/images.ts
@@ -1,0 +1,38 @@
+import { decode, schemeOf } from './url';
+
+/**
+ * Whether `raw` (an `<img src>` attribute value) is a local filesystem path
+ * ozmd should stage. Excludes in-page anchors, protocol-relative URLs, and any
+ * URL carrying a scheme (`http:`, `https:`, `data:`, `blob:`, `file:`, …).
+ */
+export function isLocalImageSrc(raw: string): boolean {
+  const s = raw.trim();
+  if (s.length === 0 || s.startsWith('#') || s.startsWith('//')) {
+    return false;
+  }
+  return schemeOf(s) === null;
+}
+
+/** Strips any `?query` / `#fragment` from `raw` and percent-decodes the rest. */
+export function toLocalPath(raw: string): string {
+  const s = raw.trim();
+  const noFragment = s.split('#', 1)[0];
+  const noQuery = noFragment.split('?', 1)[0];
+  return decode(noQuery);
+}
+
+/**
+ * Finds every `<img>` under `root` with a local `src` (read via
+ * `getAttribute('src')`, i.e. the raw authored path), paired with its
+ * decoded filesystem path.
+ */
+export function collectLocalImages(root: HTMLElement): { el: HTMLImageElement; path: string }[] {
+  const out: { el: HTMLImageElement; path: string }[] = [];
+  for (const el of root.querySelectorAll('img')) {
+    const raw = el.getAttribute('src');
+    if (raw !== null && isLocalImageSrc(raw)) {
+      out.push({ el, path: toLocalPath(raw) });
+    }
+  }
+  return out;
+}

--- a/apps/ozmd/web/links.ts
+++ b/apps/ozmd/web/links.ts
@@ -1,3 +1,5 @@
+import { decode, schemeOf } from './url';
+
 /** A classified `<a href>` target: where a click should be routed. */
 export type LinkTarget =
   | { kind: 'anchor'; fragment: string }
@@ -33,17 +35,4 @@ export function classifyLink(href: string): LinkTarget {
     return { kind: 'markdown', path, fragment };
   }
   return { kind: 'file', path };
-}
-
-function schemeOf(raw: string): string | null {
-  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(raw);
-  return m === null ? null : m[1].toLowerCase();
-}
-
-function decode(s: string): string {
-  try {
-    return decodeURIComponent(s);
-  } catch {
-    return s;
-  }
 }

--- a/apps/ozmd/web/main.ts
+++ b/apps/ozmd/web/main.ts
@@ -4,6 +4,7 @@ import { ozma } from '@ozma/web';
 import DOMPurify from 'dompurify';
 import mermaid from 'mermaid';
 import { installHeadingAnchors } from './anchors';
+import { collectLocalImages } from './images';
 import { classifyLink } from './links';
 import { renderMarkdown } from './render';
 import { Search } from './search';
@@ -143,12 +144,47 @@ async function renderMermaid(): Promise<void> {
   }
 }
 
+async function stageLocalImages(root: HTMLElement): Promise<void> {
+  const found = collectLocalImages(root);
+  if (found.length === 0) {
+    return;
+  }
+  const paths = [...new Set(found.map((f) => f.path))];
+  let urls: (string | null)[];
+  try {
+    const res = await ozma.call<{ urls: (string | null)[] }, { paths: string[] }>('stageAssets', {
+      paths,
+    });
+    urls = res.urls;
+  } catch (e) {
+    console.error(e);
+    return;
+  }
+  const byPath = new Map<string, string>();
+  paths.forEach((p, i) => {
+    const u = urls[i];
+    if (u != null) {
+      byPath.set(p, u);
+    }
+  });
+  const decoded: Promise<unknown>[] = [];
+  for (const { el, path } of found) {
+    const url = byPath.get(path);
+    if (url !== undefined) {
+      el.setAttribute('src', url);
+      decoded.push(el.decode().catch(() => {}));
+    }
+  }
+  await Promise.all(decoded);
+}
+
 async function setContent(payload: ContentPayload): Promise<void> {
   const generation = ++renderGeneration;
   const anchor = captureScrollAnchor();
   content.innerHTML = renderMarkdown(payload.markdown);
   installHeadingAnchors(content);
   await renderMermaid();
+  await stageLocalImages(content);
   // NOTE: a newer setContent superseded this one during the await (rapid reloads
   // race) — skip the stale scroll so only the latest render positions the viewport.
   if (generation !== renderGeneration) {

--- a/apps/ozmd/web/url.ts
+++ b/apps/ozmd/web/url.ts
@@ -1,0 +1,14 @@
+/** Extracts the lowercased URL scheme of `raw`, or `null` if it has none. */
+export function schemeOf(raw: string): string | null {
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(raw);
+  return m === null ? null : m[1].toLowerCase();
+}
+
+/** Percent-decodes `s`, falling back to the raw string on malformed escapes. */
+export function decode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}


### PR DESCRIPTION
## Problem

Local images referenced by a Markdown file did not display in `ozmd`. `![alt](photo.png)`, `![alt](img/a.png)`, `![alt](../shared/a.png)`, and absolute `![alt](/abs/a.png)` all rendered as broken images.

The cause was subresource resolution, not `marked`: the ozmd page is served from a temp dir at origin `ozma://<handle>/`, so the browser resolves an image `src` against that origin (`ozma://<handle>/photo.png`), which the asset registry does not have → 404. `file://` cannot rescue it either — the `ozma://` scheme is `SECURE | DISPLAY_ISOLATED`, so Chromium blocks `file://` subresources. Remote `https://` images and `data:` URIs already worked; only local filesystem paths were broken.

## Solution

**Symlink staging**, scoped entirely to `apps/ozmd` (engine/SDK untouched):

After render, the page walks `#content img`, collects each local `src`, and calls a new Rust `stageAssets` RPC. Rust resolves each path against the document's `base_dir` (reusing `document::resolve_link`), symlinks the real file into a `_local/` subdir of ozmd's own served temp dir under a content-addressed `blake3` token that preserves the original extension, and returns a handle-free root-relative URL `_local/<token>.<ext>`. The page rewrites `img.src`, and the existing `serve_static_asset` path serves it by following the symlink (its request path is a safe filename, so it rides the current guard unchanged). Real subresource loading, no base64.

Details:
- **Rust** — new `local_assets` module (idempotent ensure-exists staging, no clear, no mutex), `stageAssets` wire types in `protocol.rs`, and the RPC handler registered in `register_view` (`main.rs`). Adds a `blake3` dep.
- **Web** — new `web/images.ts` (local-src classification, query/fragment strip + percent-decode, DOM collection) sharing `schemeOf`/`decode` with `links.ts` via a new `web/url.ts`; `main.ts`'s `setContent` collects → stages → rewrites → `await img.decode()` before restoring scroll (so image heights settle first).

Affected: `apps/ozmd` (docs viewer app) only.

**Scope / accepted limitations:** local images only (remote/`data:` unchanged). No image hot-reload (watcher/reload key off the `.md` fingerprint); `avif`/`heic`/`tiff` fall back to octet-stream and may not render (host MIME map is unchanged by design); images over the host's 64 MiB cap show broken. One documented coupling: this relies on `serve_static_asset` following symlinks — if that guard is ever tightened with a canonicalize+prefix check (`asset.rs` TODO), staging must switch to copying bytes.

### Testing

`cargo test -p ozmd` (49 passing) · `pnpm test` (31 passing) · clippy / rustfmt / `check-types` / biome lint clean · `pnpm build` succeeds. New unit tests cover token stability/distinctness, idempotent staging, relative/absolute/missing resolution, the local-src classification truth table, and query/fragment/decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
