### PR TITLE
ci: add release.yml for categorized auto-generated release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,9 @@
      Mention which parts of the codebase are affected (engine, packages, mods, docs).
      For UI changes, include screenshots: <details><summary>Screenshots</summary>paste here</details>
      If this is a breaking change, add a ### Breaking Changes subsection below. -->
+
+<!-- Release notes are grouped by PR LABEL, not by title or body. Add a label
+     (breaking-change / enhancement / performance / bug / documentation /
+     dependencies) so this PR lands in the right section, or `skip-changelog`
+     to omit it. A "### Breaking Changes" body subsection does not route the PR
+     on its own — apply the `breaking-change` label too. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# Configures GitHub's automatically generated release notes.
+# Merged PRs are grouped into the categories below by their LABELS — labels,
+# not commit-message prefixes, drive this. Categories are first-match: a PR
+# with several labels lands in the first category it matches (so a breaking
+# enhancement appears under Breaking Changes, not Features). The release-macos
+# workflow passes generate_release_notes: true; GitHub loads this file from the
+# tree of the released tag's commit (for tags cut from main, that is main).
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels: [breaking-change]
+    - title: 🚀 Features
+      labels: [enhancement]
+    - title: ⚡ Performance
+      labels: [performance]
+    - title: 🐛 Fixes
+      labels: [bug]
+    - title: 📚 Documentation
+      labels: [documentation]
+    - title: 📦 Dependencies
+      labels: [dependencies]
+    - title: 🧹 Other Changes
+      labels: ["*"]

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -105,6 +105,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.meta.outputs.zip }}
+          generate_release_notes: true
 
       - name: Bump Homebrew cask
         if: github.ref_type == 'tag' && env.HOMEBREW_TAP_TOKEN != ''

--- a/scripts/setup-release-labels.sh
+++ b/scripts/setup-release-labels.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Create (or update) the labels that drive GitHub's release-notes categories
+# (.github/release.yml). Idempotent: `gh label create --force` updates an
+# existing label instead of failing. The reused GitHub defaults are re-created
+# with their existing color/description so no release.yml category ever
+# references a missing label. Requires `gh` authenticated with write access.
+set -euo pipefail
+
+ensure() {
+  gh label create "$1" --color "$2" --description "$3" --force
+}
+
+# New labels for release-notes categories.
+ensure "breaking-change" "B60205" "Backwards-incompatible change"
+ensure "performance"     "0E8A16" "Performance improvement"
+ensure "dependencies"    "0366D6" "Dependency update"
+ensure "skip-changelog"  "CFD3D7" "Exclude this PR from the release notes"
+
+# Reused GitHub default labels — re-created idempotently with their existing
+# metadata so their categories always match.
+ensure "enhancement"   "A2EEEF" "New feature or request"
+ensure "bug"           "D73A4A" "Something isn't working"
+ensure "documentation" "0075CA" "Improvements or additions to documentation"
+
+echo "Release-notes labels ensured."


### PR DESCRIPTION
## Problem

<!-- What problem does this PR solve? Link related issues: Closes #123 -->
Currently, the workflow for creating release notes has been set up, but the updates haven't been documented.


## Solution

<!-- What did you change and why this approach?
     Mention which parts of the codebase are affected (engine, packages, mods, docs).
     For UI changes, include screenshots: <details><summary>Screenshots</summary>paste here</details>
     If this is a breaking change, add a ### Breaking Changes subsection below. -->
Create `.github/release.yml`