### PR TITLE
Update Bevy and CEF versions.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ orzma is a terminal multiplexer that runs as a single native GUI application. It
 
 The workspace root package is the one and only binary; library crates live under `crates/`. Edition 2024, toolchain pinned to `1.95` (`rust-toolchain.toml`).
 
-- `orzma` (workspace root, `src/main.rs`) — the single binary: a Bevy 0.18 app. `main()` builds one `App` and adds `DefaultPlugins` (configured with a `WindowPlugin` titled "orzma") plus `cef_plugin(orzma_registry.clone(), cef_profile.path())` (from `bevy_cef`), then `AppModePlugin`, then the orzma plugins:
+- `orzma` (workspace root, `src/main.rs`) — the single binary: a Bevy 0.19 app. `main()` builds one `App` and adds `DefaultPlugins` (configured with a `WindowPlugin` titled "orzma") plus `cef_plugin(orzma_registry.clone(), cef_profile.path())` (from `bevy_cef`), then `AppModePlugin`, then the orzma plugins:
   - `SurfacePlugin`, `DefaultSessionPlugin`, `ClipboardPlugin`, `TerminalHandlePlugin` (from `orzma_tty_engine`), `TerminalRendererPlugin` (from `orzma_tty_renderer`), `RenderPlugin` (`render::tmux`'s tmux grid/paint pipeline), `TmuxLifecyclePlugin` (`session::tmux`; wraps `TmuxSessionPlugin` from `orzma_tmux`, the sole multiplexer, plus `AdoptPlugin`, `TmuxLocalePlugin`, `WebviewTokensPlugin`), `ActionPlugin`, `OrzmaConfigsPlugin`, `FontBridgePlugin`, `OrzmaBootstrapPlugin`, `OrzmaInputPlugin` (`input`'s root plugin, aggregating `ShortcutsPlugin`, `OptionAsAltPlugin`, `KeyboardInputPlugin`, `MouseInputPlugin`, the tmux-mode and default-mode input dispatchers), `OrzmaUiPlugin` (`ui`'s root plugin, aggregating the UI root plus the tmux-mode and default-mode UI subtrees);
   - `OrzmaWebviewPlugin` (from `orzma_webview`), `CopyModePlugin`, `CopyModeIndicatorPlugin`, `CopyPromptPlugin`, `WindowTitlePlugin`;
   - the input plugins `FocusSyncPlugin`, `HyperlinkInputPlugin`, `ImePlugin`, and `ImeOverlayPlugin`.
   - The in-process webview feature — CEF render wiring, the control-socket listener, the `window.orzma` back-channel, OSC 5379 `mount` / `unmount`, and webviews — is aggregated under `OrzmaWebviewPlugin` (from `crates/orzma_webview`).
 
-  The root `Cargo.toml` depends on `orzma_webview` (path dep, `features = ["cef"]`) and on `bevy_cef` (git dep, `branch = "passthrough"`, `features = ["debug"]`). A root `[features] debug` flag enables the CEF `remote-debugging-port` (a local Chromium DevTools / CDP endpoint on `127.0.0.1:9222`) for inspecting the embedded webview; it is off by default (`cargo run --features debug`).
+  The root `Cargo.toml` depends on `orzma_webview` (path dep) and on `bevy_cef` (crates.io, `0.12`). A root `[features] debug` flag (forwarded through `orzma_webview/debug` to `bevy_cef/debug`) enables the CEF `remote-debugging-port` (a local Chromium DevTools / CDP endpoint on `127.0.0.1:9222`) for inspecting the embedded webview; it is off by default (`cargo run --features debug`).
 
 - `crates/orzma_tty_engine` (`orzma_tty_engine`) — Bevy-native terminal: PTY ownership and `alacritty_terminal` VT emulation, emitting coalesced `FrameSnapshot` / `FrameDelta` against the `orzma_tty_renderer` schema. Exposes `TerminalHandlePlugin`.
 - `crates/orzma_tty_renderer` (`orzma_tty_renderer`) — GPU terminal renderer plus the grid schema shared with `orzma_tty_engine`. `TerminalRendererPlugin` wires the grid, material, and glyph sub-plugins (`TerminalGridPlugin`, `TerminalMaterialPlugin`, `TerminalGlyphPlugin`) and hyperlink-hover state; `schema` holds the cell/grid types both crates render against.
@@ -25,7 +25,7 @@ The workspace root package is the one and only binary; library crates live under
 - `crates/orzma_tmux` (`orzma_tmux`) — the sole multiplexer: owns a `tmux -CC` control-mode connection, drains its transport events into the Bevy world, tracks connection lifecycle, and projects tmux session/window/pane state as ECS entities (`TmuxSession` / `TmuxWindow` / `TmuxPane`). Rendering lives in `src/` (the tmux render/input/UI plugins), not here. Exposes `TmuxSessionPlugin`. (Built on `crates/tmux_control` and `crates/tmux_control_parser`, the sans-io tmux control-mode client and parser.)
 - `crates/orzma_configs` (`orzma_configs`) — config loader. Reads `~/.config/orzma/config.toml` (or `$ORZMA_CONFIG` / `$XDG_CONFIG_HOME` overrides) and resolves it against built-in defaults.
 
-In-process webview rendering is provided by the external `bevy_cef` crate (a git dependency on the `passthrough` branch, CEF v145 pinned to `145.6.1+145.0.28` in the justfile). Both the renderer and the helper render process come from `bevy_cef` / `export-cef-dir`; see `just setup-cef`.
+In-process webview rendering is provided by the external `bevy_cef` crate (crates.io `0.12`, CEF v149 pinned to `149.3.0+149.0.6` in the justfile). Both the renderer and the helper render process come from `bevy_cef` / `export-cef-dir`; see `just setup-cef`.
 
 ### TypeScript workspace (`pnpm-workspace.yaml`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5083,7 +5083,6 @@ version = "0.2.0-dev"
 dependencies = [
  "bevy",
  "bevy_cef",
- "bevy_cef_core",
  "crossbeam-channel",
  "data-encoding",
  "getrandom 0.2.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,29 +20,42 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.37.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -50,23 +63,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -136,9 +149,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.13.0",
@@ -148,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -168,11 +181,10 @@ dependencies = [
  "jni 0.22.4",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
- "simd_cesu8",
  "thiserror 2.0.18",
 ]
 
@@ -441,18 +453,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
+checksum = "950238d3049d81006a6fd6b898a34cfc01bb5462a7668795a54d640aed19fd0a"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
+checksum = "e86f2cb45b000a9d121a5a7606f9af4a49e72b8b6a3885dc2acac2f0897a04f1"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -463,18 +475,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c58de772ac1148884112e8a456c4f127a94b95a0e42ab5b160b7a11895a241"
+checksum = "e6e5e2a949be318bf7184eb084622892afcc1e8b2af44973ac53ab53201756e0"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bf5b285f0d3fab983b4505e62e195e06930a29007ffc95bdabde834e163a2"
+checksum = "7da2fcd94cc32ba1c875c62e88506c0ba4775555a413e34cd172ea95fa26098e"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -505,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
+checksum = "4fa3d816d7788e27da936b9c7ec27f9828906d53cb1d06e26c58cac5c5ee799f"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -516,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_anti_alias"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726cc494eb7d6a84ce6291c23636fd451fa4846604dc059fa93febca4e60a928"
+checksum = "815414ea2e11afe1f2396d89279cfa0986907ef3ec673ec936d9fa695b2bfbf9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -538,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
+checksum = "671ae6f3a8d84f9ed696c531a138558596e041231a8414b6efeafa8469e841f9"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -548,7 +560,6 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
  "downcast-rs 2.0.2",
@@ -561,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f86fed15972b9fb1a3f7b092cf0390e67131caaedab15a2707c043e3a3c886"
+checksum = "43a05907de6a362d2c609a7a1d1b4dca3b58b768f746b719ca1a3c7dfa87d391"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -604,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
+checksum = "c9444998cc37b51dfd1572c23a501865733ea65619a7d88b47aa654ae2290a4f"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -616,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d68da32468ce7f4bb2863b71326acfaaa88e9aef8da8306257cd487d40cede4"
+checksum = "06af3bd91de885f2a5c024569779a7fb43349df611d92f7b795c66c8797378db"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -626,17 +637,15 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "bevy_transform",
- "coreaudio-sys",
- "cpal",
  "rodio",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_camera"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
+checksum = "20105c3e77c2fb391bf3ded3a473d60e4058b837c9bf4e3412225833e524c75a"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -660,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae24a3cff9b63c82e51c9e3a7f1bfe9db266c89df810d57b15e4fcc5cae06708"
+checksum = "fedf5d2e0ed359d58efc271afb5742448a6183d87573cafaef20be48c74bdfb3"
 dependencies = [
  "async-channel",
  "bevy",
@@ -677,19 +686,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_cef_core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2da9caa95038624f5defe19078b45dbbf2704bc9d67c909a9891bf98c0405c"
+checksum = "da95f7228b8f7c335c266e3bdc432a7431ad4ea9e8e357ac04ec41991b52dae3"
 dependencies = [
  "async-channel",
  "bevy",
  "bevy_remote",
  "cef",
  "cef-dll-sys",
- "metal",
  "objc",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal 0.3.2",
  "raw-window-handle",
  "serde",
  "serde_json",
@@ -698,10 +708,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_color"
-version = "0.18.1"
+name = "bevy_clipboard"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
+checksum = "6dc5fb913f25c5a16a2a1aa2942ba3f1365a6d0f2db3c0ea5bc0be01f85dca5d"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_log",
+ "bevy_platform",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "bevy_color"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2dfc0091be6eb62fec9158b2d3e6f21b002be7bdb42dd3b8322e949c8426b0"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -715,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
+checksum = "885d640bbff6c4fa3beadbb043d0d1ae53b2fda864da18a2bf2670fb90428865"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -727,6 +752,8 @@ dependencies = [
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
+ "bevy_light",
+ "bevy_log",
  "bevy_math",
  "bevy_platform",
  "bevy_reflect",
@@ -736,18 +763,15 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "bitflags 2.13.0",
+ "indexmap",
  "nonmax",
- "radsort",
- "smallvec",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
+checksum = "293df2b2f7ed65ef2ce02b2e7359faac1a9a92a8cc96c182c9de77eb06049ae0"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -756,20 +780,24 @@ dependencies = [
 
 [[package]]
 name = "bevy_dev_tools"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f1464a3f5ef5c23d917987714ee89881f9f791e9ff97ecf6600ee846b9569e"
+checksum = "db815000affd21545a6d6986f180a66393aee8c84330843e854d376c8537b10f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
+ "bevy_core_pipeline",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
  "bevy_input",
+ "bevy_log",
  "bevy_math",
+ "bevy_pbr",
  "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_shader",
@@ -779,15 +807,19 @@ dependencies = [
  "bevy_transform",
  "bevy_ui",
  "bevy_ui_render",
+ "bevy_utils",
  "bevy_window",
+ "ron",
+ "serde",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
+checksum = "a73e11555051f37c3e0e9ef7775e77108f2482310242996fb5bb6ef8b685b78e"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -803,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
+checksum = "4654b9b3535fa7813d2878a50e1b5ad80a361dc1c913b96ded57667f65d70a01"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -830,10 +862,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_ecs_macros"
-version = "0.18.1"
+name = "bevy_ecs_macro_logic"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
+checksum = "ee0b98a74141ce8dce4654c60020ebbaefab32646f42af6bbae55f282ae65ff7"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -842,10 +874,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_encase_derive"
-version = "0.18.1"
+name = "bevy_ecs_macros"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
+checksum = "4dc958a194d226d618404e0fea99a3c8b4146207a00a3ba07fa712bf71607240"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_encase_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dc5bf9e6cb46c4401a66625b5f7eb9654a7f3c8586423c428b79586a1c55cd"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -853,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_feathers"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb29be8f8443c5cc44e1c4710bbe02877e73703c60228ca043f20529a5496c6"
+checksum = "e744e047f9328a9c072982569fabbbc837db0474fd902473b5f438f8688c30b6"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -865,6 +910,7 @@ dependencies = [
  "bevy_color",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_input",
  "bevy_input_focus",
  "bevy_log",
  "bevy_math",
@@ -872,6 +918,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
+ "bevy_scene",
  "bevy_shader",
  "bevy_text",
  "bevy_ui",
@@ -883,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611827ab0ce43b88c0a695e6603901b5f34687efecaf526c861456c9d8e6fedb"
+checksum = "7998fe83c89d527efa83c85c574a17f7bb6e34881d638ecb7f706d9d79e82f3c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -899,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
+checksum = "9c0cbd55cc33b6412777d60d8c24a96bee148c82a5731f35ac85b2df4a7cf957"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -909,19 +956,22 @@ dependencies = [
  "bevy_color",
  "bevy_ecs",
  "bevy_gizmos_macros",
- "bevy_light",
+ "bevy_input",
+ "bevy_log",
  "bevy_math",
+ "bevy_mesh",
  "bevy_reflect",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
+ "bevy_window",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
+checksum = "9903f2614f53bacacb92bef1e407afe3a27a4abddb500bfd479909c5d7b254df"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -930,20 +980,24 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
+checksum = "dd569456c4b19bafa6d37c1bd9cc743fdadda3a2f23d79d2ceb0a088ea8d475f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_gizmos",
  "bevy_image",
+ "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
+ "bevy_reflect",
  "bevy_render",
  "bevy_shader",
  "bevy_sprite_render",
@@ -955,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
+checksum = "84e21ad83b7dc8d456491ea3d50057685d8c4cca8bc52a1b4a7161c86c369842"
 dependencies = [
  "async-lock",
  "base64",
@@ -969,15 +1023,14 @@ dependencies = [
  "bevy_ecs",
  "bevy_image",
  "bevy_light",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
- "bevy_pbr",
  "bevy_platform",
  "bevy_reflect",
- "bevy_render",
- "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
+ "bevy_world_serialization",
  "fixedbitset",
  "gltf",
  "itertools 0.14.0",
@@ -987,13 +1040,14 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_image"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
+checksum = "37bc41f69a0c6ade2e7961602517545b39ab8e42bc8c4a729bd24ffee3bcd904"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1020,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
+checksum = "fd221cf0732f5bf06caf594bdb233361ac735d4d416cf5849757b64bf4e8472a"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1037,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
+checksum = "0e1a14f56c6e722048ec9dc20dbbc6f46b8037f61e319ea776829199278da166"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1054,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
+checksum = "d52a85632a749f956f92b7b391c31ce1f229e57b06de879d1b60a3bb91e4e240"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -1066,6 +1120,7 @@ dependencies = [
  "bevy_asset",
  "bevy_audio",
  "bevy_camera",
+ "bevy_clipboard",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
@@ -1082,6 +1137,7 @@ dependencies = [
  "bevy_input_focus",
  "bevy_light",
  "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_pbr",
@@ -1102,37 +1158,44 @@ dependencies = [
  "bevy_transform",
  "bevy_ui",
  "bevy_ui_render",
+ "bevy_ui_widgets",
  "bevy_utils",
  "bevy_window",
  "bevy_winit",
+ "bevy_world_serialization",
 ]
 
 [[package]]
 name = "bevy_light"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9d2ac64390a9baacb3c0fa0f5456ac1553959d5a387874c102a09aab8b92cc"
+checksum = "bd7b5009e9cc765c30b21daf2277ea4423cbd347b05280ea0943b50c5a80cd42"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
  "bevy_ecs",
+ "bevy_gizmos",
  "bevy_image",
+ "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
+ "half",
+ "smallvec",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_log"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
+checksum = "2017a5fe12ea230d00cfdca00c65c262924be26e0324f7e0033c64f8cc265888"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1148,21 +1211,55 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
+checksum = "746a19912c6dc1bbe79188778573e8a253d5832c696b2fcb95578c17b29ff7ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
+name = "bevy_material"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423710403b4a4d8e9ee872c6ac8108787f2396422b582d15a660a40731ddfbf0"
+dependencies = [
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_material_macros",
+ "bevy_mesh",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_shader",
+ "bevy_utils",
+ "encase",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "variadics_please",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_material_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6928e167592472f6ee900f80de199cc2dafd31d4f082a86e8d594b81b973e3d"
+dependencies = [
+ "bevy_macro_utils",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
+checksum = "d7c280440d2a5bc07ea393b5346b5712eec73ea30f0133097b8b13dade385beb"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1180,15 +1277,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
+checksum = "c59863e6f37ef0ba1f37021bce9dd940f9dc31d15e03f548cda5fd3e674f409e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_image",
+ "bevy_encase_derive",
  "bevy_math",
  "bevy_mikktspace",
  "bevy_platform",
@@ -1197,6 +1294,9 @@ dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
+ "encase",
+ "glam",
+ "half",
  "hexasphere",
  "thiserror 2.0.18",
  "tracing",
@@ -1205,16 +1305,17 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.17.0-dev"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
+checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab6944ffc6fd71604c0fbca68cc3e2a3654edfcdbfd232f9d8b88e3d20fdc0"
+checksum = "38ebc777de2d7f45888c68e8e04949bfb8a40aee62f700283fc340f525e67f52"
 dependencies = [
+ "arrayvec",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
@@ -1223,34 +1324,39 @@ dependencies = [
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
+ "bevy_gltf",
  "bevy_image",
  "bevy_light",
  "bevy_log",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_shader",
+ "bevy_tasks",
  "bevy_transform",
  "bevy_utils",
  "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
+ "indexmap",
  "nonmax",
  "offset-allocator",
  "smallvec",
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_picking"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d524dbc8f2c9e73f7ab70c148c8f7886f3c24b8aa8c252a38ba68ed06cbf10"
+checksum = "93468ac5937f76be3af763d496f01e899edf6d9c1a1d39a87ae4ce8eba36f78b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1272,13 +1378,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
+checksum = "3120670bb2308980f723477c9d82476fcda31f08be9b256c3f0acdee82a65094"
 dependencies = [
+ "async-io",
  "critical-section",
  "foldhash 0.2.0",
  "futures-channel",
+ "futures-lite",
  "hashbrown 0.16.1",
  "js-sys",
  "portable-atomic",
@@ -1288,13 +1396,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "bevy_post_process"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f77a4e894aea992e3d6938f1d5898a1cdbb87dba6eebfb95cb4038d0a2600e9"
+checksum = "57379b51aa0f1b2066c956263e1f12686d22cf8939cf9644eebf2ee42d3dd460"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1309,12 +1418,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_render",
  "bevy_shader",
- "bevy_transform",
  "bevy_utils",
- "bevy_window",
- "bitflags 2.13.0",
- "nonmax",
- "radsort",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -1322,15 +1426,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
+checksum = "b511e89f7078fd21fdea77061a0ca3e737297c7011bb10c073e0aecb17c9fea6"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
+checksum = "92abd59cbba1524c1847e9a50f74d94e6b7836c80a8edfa9c47e59f7fd81021d"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1357,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
+checksum = "90fa4e6b97fd2d582dd5ed96762a70d04505a477c833cf4f69d016dcd03d2d04"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1371,20 +1475,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_remote"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0129e24bf3e281dd52996a9290c35f8c4821ca09e1ce8b8b222671e1ad9da0c"
+checksum = "2c3a8f11f0017b2b7b8b8bb907c499ace3baa9cda240065457fb7391a3fa2ee8"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-io",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_derive",
+ "bevy_dev_tools",
  "bevy_ecs",
  "bevy_log",
  "bevy_platform",
  "bevy_reflect",
+ "bevy_render",
  "bevy_tasks",
  "bevy_utils",
  "http-body-util",
@@ -1396,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
+checksum = "a89b2cc850a4c3fd12a6a088a4fc3e80118b2e1b569da8936f6d4d99ca1b6ee7"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1410,6 +1517,9 @@ dependencies = [
  "bevy_ecs",
  "bevy_encase_derive",
  "bevy_image",
+ "bevy_log",
+ "bevy_material",
+ "bevy_material_macros",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
@@ -1426,10 +1536,10 @@ dependencies = [
  "derive_more",
  "downcast-rs 2.0.2",
  "encase",
- "fixedbitset",
  "glam",
  "image",
  "indexmap",
+ "itertools 0.14.0",
  "js-sys",
  "naga",
  "nonmax",
@@ -1437,18 +1547,19 @@ dependencies = [
  "send_wrapper",
  "smallvec",
  "thiserror 2.0.18",
- "tracing",
  "variadics_please",
  "wasm-bindgen",
+ "weak-table",
  "web-sys",
  "wgpu",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
+checksum = "e0eb5cffe5253a6ab4e4b84b2e40a6a2f4673deb16fd63ab9dfc4a015449873a"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1458,48 +1569,62 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cc1047d85ec8048261b63ef675c12f1e6b5782dc0b422fbcee0c140d026bd4"
+checksum = "28a3c891148c40e1352fc41001c0e1894ba63fc4e2d3aca33447343c4122b782"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_camera",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_log",
  "bevy_platform",
  "bevy_reflect",
- "bevy_transform",
+ "bevy_scene_macros",
  "bevy_utils",
- "derive_more",
- "ron",
- "serde",
+ "smallvec",
  "thiserror 2.0.18",
- "uuid",
+ "tracing",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_scene_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bc33a36a4e9e344985a96cd8b4abc816cf2c5d2fa002d72fd7bcd11396589c"
+dependencies = [
+ "bevy_ecs_macro_logic",
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "bevy_shader"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
+checksum = "fa0ac51378bb6a021165ee334f846b515cd06082e24ce962adce58ad7df1c39a"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
  "bevy_reflect",
+ "bevy_utils",
  "naga",
  "naga_oil",
  "serde",
  "thiserror 2.0.18",
  "tracing",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_sprite"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
+checksum = "c679b88cc655881d403929bcdf02d30f688fd8916eb1635e6e7f8585d8ae6894"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1508,6 +1633,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
+ "bevy_log",
  "bevy_math",
  "bevy_mesh",
  "bevy_picking",
@@ -1522,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
+checksum = "e5a65ca9a286dd5815ca4d2d41d4f83bdbb22c8a639d10b4c33eac114b369c36"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1534,6 +1660,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
+ "bevy_material",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
@@ -1554,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
+checksum = "8c22e694ea52e42994aea6ed2d0b378fa1e9d5a9b615db88626e33508bc03f35"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1570,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
+checksum = "835f45091fa0df1ff3cb10f4ca5a397d4e9249b550f1be6893b08a2a06d6eed7"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1581,13 +1708,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
+checksum = "fa34e6b9b804851ec08a41c0346c859d82e2fa98c906d74b965ee61bbbb688e4"
 dependencies = [
  "async-channel",
  "async-executor",
- "async-io",
  "async-task",
  "atomic-waker",
  "bevy_platform",
@@ -1596,17 +1722,18 @@ dependencies = [
  "derive_more",
  "futures-lite",
  "heapless",
- "pin-project",
+ "web-task",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc5233291dfc22e584de2535f2e37ae9766d37cb5a01652de2133ba202dcb9b"
+checksum = "38e1d7eb8b10229f424b4fc56c864a26c32ac02b8cd184e2cc25eceea7b5e892"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_clipboard",
  "bevy_color",
  "bevy_derive",
  "bevy_ecs",
@@ -1616,9 +1743,11 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "cosmic-text",
+ "parley",
  "serde",
  "smallvec",
+ "smol_str",
+ "swash",
  "sys-locale",
  "thiserror 2.0.18",
  "tracing",
@@ -1627,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
+checksum = "c21e3be2aa4426ea1e0a7036d3d1dbbded84c319459d9f3e2a616b33563372f2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1642,13 +1771,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
+checksum = "c95fefe69c9223d10e6b52a0fdf12811bab9d0c7dcb27570cb86824b451f180d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_tasks",
@@ -1660,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1691a411014085e0d35f8bb8208e5f973edd7ace061a4b1c41c83de21579dc70"
+checksum = "e5519c799ecf14e2eeece8b9b823250a00c9df14523e2638b647fccfe4ff0d20"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1675,17 +1803,21 @@ dependencies = [
  "bevy_image",
  "bevy_input",
  "bevy_input_focus",
+ "bevy_log",
  "bevy_math",
  "bevy_picking",
  "bevy_platform",
  "bevy_reflect",
  "bevy_sprite",
  "bevy_text",
+ "bevy_time",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
  "derive_more",
+ "parley",
  "smallvec",
+ "swash",
  "taffy",
  "thiserror 2.0.18",
  "tracing",
@@ -1694,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_render"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c35402d8a052f512e3fec1f36b26e83eee713fcca57f965c244ee795e1fcb0"
+checksum = "4f1d3921936d88bd2638dd4d87bff8fc3b9908a046a50658548045102249f93e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1706,6 +1838,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_image",
+ "bevy_input_focus",
  "bevy_math",
  "bevy_mesh",
  "bevy_platform",
@@ -1720,14 +1853,15 @@ dependencies = [
  "bevy_utils",
  "bytemuck",
  "derive_more",
+ "indexmap",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_ui_widgets"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a63cb818b0de41bdb14990e0ce1aaaa347f871750ab280f80c427e83d72712"
+checksum = "d5fc616ccc51b36dea5cb1de91ed82569b41649923388e5ba82cb7d2f1ef18d8"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1740,25 +1874,31 @@ dependencies = [
  "bevy_math",
  "bevy_picking",
  "bevy_reflect",
+ "bevy_text",
  "bevy_ui",
+ "bevy_window",
+ "parley",
+ "smol_str",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
+checksum = "3aceea6c7ffdd568f866d5ca4dfe50c33440c54f7bc230c13a9ba7ab0c91aed1"
 dependencies = [
+ "async-channel",
  "bevy_platform",
  "disqualified",
+ "indexmap",
  "thread_local",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
+checksum = "efcc255b43db156fba393b2ff8fa552aac5e7e02ae4c6298eacdbab655ddf988"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1775,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2de1c13d32ab8528435b58eca7ab874a1068184c6d6f266ee11433ae99d4069"
+checksum = "308c9eb04f74f340593b3def6a7c1778fd42581d779c6db836d690c7d471f94c"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1798,7 +1938,6 @@ dependencies = [
  "bevy_tasks",
  "bevy_window",
  "bytemuck",
- "cfg-if",
  "js-sys",
  "tracing",
  "wasm-bindgen",
@@ -1808,37 +1947,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
+name = "bevy_world_serialization"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+checksum = "de58ae74410d4f940e3f00484f58603b4f1a53a7d84ebe3fca258d2a3aa96620"
 dependencies = [
- "bitflags 2.13.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.2",
- "shlex 1.3.0",
- "syn",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
+ "derive_more",
+ "ron",
+ "serde",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -1869,12 +2012,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -2052,14 +2189,14 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
 name = "cef"
-version = "145.6.1+145.0.28"
+version = "149.3.0+149.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549537e80f5655f48678e6496282cdea6f2b34b66d0e729d3517d7c7ec78954b"
+checksum = "614b93104c704b8d5580c22e61f87962ff383aaa7a1ae6f7c1cc299215f4edca"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2077,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "145.6.1+145.0.28"
+version = "149.3.0+149.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687f31c0937d9914d3e5887b94c6194bd8e3e533026cef2cc3ae7b4fe5245b6d"
+checksum = "058f3b1a05b64d10b56fec2d18853e3ecc28eb5dc7eca5df7dfa68d3d99adcdd"
 dependencies = [
  "anyhow",
  "cmake",
@@ -2092,15 +2229,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
 
 [[package]]
 name = "cfg-if"
@@ -2119,17 +2247,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.9",
-]
 
 [[package]]
 name = "clap"
@@ -2194,6 +2311,17 @@ name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -2347,16 +2475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,8 +2487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -2382,18 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -2408,69 +2515,46 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
-name = "cosmic-text"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
  "bitflags 2.13.0",
- "fontdb",
- "harfrust",
- "linebender_resource_handle",
- "log",
- "rangemap",
- "rustc-hash 1.1.0",
- "self_cell",
- "skrifa 0.39.0",
- "smol_str",
- "swash",
- "sys-locale",
- "unicode-bidi",
- "unicode-linebreak",
- "unicode-script",
- "unicode-segmentation",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2 0.6.4",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows",
 ]
 
 [[package]]
@@ -2984,15 +3068,6 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
@@ -3001,26 +3076,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "fontconfig-parser"
-version = "0.5.8"
+name = "fontique"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
 dependencies = [
- "roxmltree",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
-dependencies = [
- "fontconfig-parser",
- "log",
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
  "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser",
+ "parlance",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -3158,7 +3224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3235,7 +3301,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -3251,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.10"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 dependencies = [
  "bytemuck",
  "encase",
@@ -3263,16 +3329,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3326,34 +3386,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.13.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows",
 ]
 
 [[package]]
@@ -3398,6 +3441,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -3406,14 +3450,14 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.4.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
+checksum = "551ed25397e4b444e89686602877d5cf3a7f6e3d548dcac37a8357d1e195f4df"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
- "read-fonts 0.36.0",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -3443,6 +3487,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
  "serde",
@@ -3454,6 +3499,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -3480,9 +3528,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hexasphere"
-version = "16.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a164ceff4500f2a72b1d21beaa8aa8ad83aec2b641844c659b190cb3ea2e0b"
+checksum = "177ea6330876de4ef08e184f827b98acc037614a4ce409902c5b0d53a9c2e951"
 dependencies = [
  "constgebra",
  "glam",
@@ -3584,6 +3632,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,10 +3654,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3644,12 +3714,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "ident_case"
@@ -3864,7 +3957,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3968,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "ktx2"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
+checksum = "1d50be8a24c37debdf3170be6ca396d5b5b165f37f94837891adac735ca416b8"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -4011,7 +4104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4021,7 +4114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4108,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -4147,27 +4240,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.13.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4224,16 +4296,16 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "codespan-reporting",
+ "codespan-reporting 0.13.1",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -4243,7 +4315,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pp-rs",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -4251,33 +4323,19 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310c347db1b30e69581f3b84dc9a5c311ed583f67851b39b77953cb7a066c97f"
+checksum = "319f03062940ed85c03da020042618356bb8ca5263020322930883b05e30208e"
 dependencies = [
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "data-encoding",
  "indexmap",
  "naga",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
-]
-
-[[package]]
-name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.13.0",
- "jni-sys 0.3.1",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4289,7 +4347,7 @@ dependencies = [
  "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -4300,15 +4358,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys 0.3.1",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -4341,16 +4390,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -4420,6 +4459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,6 +4483,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4515,7 +4584,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -4527,6 +4596,31 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -4552,6 +4646,29 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -4601,7 +4718,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -4642,6 +4759,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -4695,6 +4814,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,7 +4836,20 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -4732,7 +4877,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -4760,29 +4905,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni 0.21.1",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4873,9 +4995,9 @@ dependencies = [
  "bevy",
  "bevy_cef",
  "bevy_cef_core",
- "cosmic-text",
  "crossbeam-channel",
  "data-encoding",
+ "fontique",
  "getrandom 0.2.17",
  "libc",
  "open",
@@ -5047,7 +5169,40 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+dependencies = [
+ "fontique",
+ "harfrust",
+ "hashbrown 0.17.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_data",
+ "skrifa",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -5212,6 +5367,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -5228,15 +5385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb458bb7f6e250e6eb79d5026badc10a3ebb8f9a15d1fff0f13d17c71f4d6dee"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -5338,38 +5486,25 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand",
@@ -5380,12 +5515,6 @@ name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
-
-[[package]]
-name = "rangemap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
@@ -5428,14 +5557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "read-fonts"
-version = "0.36.0"
+name = "raw-window-metal"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eaa2941a4c05443ee3a7b26ab076a553c343ad5995230cc2b1d3e993bdc6345"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "bytemuck",
- "core_maths",
- "font-types 0.10.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -5445,7 +5575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "font-types 0.11.3",
+ "font-types",
 ]
 
 [[package]]
@@ -5562,12 +5692,16 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
 dependencies = [
  "cpal",
+ "dasp_sample",
  "lewton",
+ "num-rational",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -5583,12 +5717,6 @@ dependencies = [
  "typeid",
  "unicode-ident",
 ]
-
-[[package]]
-name = "roxmltree"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rust-embed"
@@ -5629,12 +5757,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -5773,12 +5895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5911,12 +6027,6 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -5986,22 +6096,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9eb0b904a04d09bd68c65d946617b8ff733009999050f3b851c32fb3cfb60e"
-dependencies = [
- "bytemuck",
- "read-fonts 0.36.0",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts 0.39.2",
+ "read-fonts",
 ]
 
 [[package]]
@@ -6094,9 +6194,9 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -6174,7 +6274,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
- "skrifa 0.42.1",
+ "skrifa",
  "yazi",
  "zeno",
 ]
@@ -6212,23 +6312,23 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
 name = "taffy"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
 dependencies = [
  "arrayvec",
  "grid",
@@ -6394,6 +6494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -6460,15 +6561,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -6487,18 +6579,6 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
  "winnow 0.7.15",
 ]
 
@@ -6620,7 +6700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
- "nom 8.0.0",
+ "nom",
  "petgraph",
 ]
 
@@ -6629,9 +6709,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
 
 [[package]]
 name = "twox-hash"
@@ -6664,28 +6741,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-script"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7042,11 +7101,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
+
+[[package]]
 name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-task"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdc136a53ccd64a1211f107ccc34404769fbcc0f165f1afa065f5d88ab93538"
+dependencies = [
+ "async-task",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -7078,12 +7155,13 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "document-features",
@@ -7105,9 +7183,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7125,62 +7203,61 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
+checksum = "af1fb1798be2a912497d4c224f72d39bb0cb34af50e8bcc29865bc339c943059"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.13.0",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -7189,10 +7266,13 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "metal",
  "naga",
- "ndk-sys 0.6.0+11769913",
- "objc",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -7201,28 +7281,42 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
+ "raw-window-handle",
  "serde",
- "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -7259,56 +7353,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -7317,43 +7369,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -7362,22 +7378,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7386,20 +7391,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7407,17 +7401,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7437,25 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -7463,35 +7430,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -7500,26 +7440,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7528,7 +7449,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7582,7 +7503,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7637,7 +7558,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7650,20 +7571,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7861,14 +7773,14 @@ dependencies = [
  "calloop",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",
  "js-sys",
  "libc",
  "memmap2",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -8119,6 +8031,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -8127,6 +8040,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,17 @@ ab_glyph = "0.2"
 anyhow = { workspace = true }
 arboard = { version = "3", features = ["wayland-data-control"] }
 bevy = { workspace = true }
-bevy_cef = "0.11"
+bevy_cef = { workspace = true }
 bevy_cef_core = { workspace = true }
 orzma_tty_renderer = { path = "crates/orzma_tty_renderer" }
 orzma_tty_engine = { path = "crates/orzma_tty_engine" }
 orzma_webview = { path = "crates/orzma_webview" }
-cosmic-text = "0.16"
 crossbeam-channel = "0.5"
 data-encoding = "2"
+# NOTE: default-features = false keeps fontique's `system` backend off,
+# matching bevy_text's parley configuration — enabling it here would turn on
+# system font discovery for the whole dependency graph via feature unification.
+fontique = { version = "0.9", default-features = false, features = ["std"] }
 getrandom = "0.2"
 libc = "0.2"
 open = { workspace = true }
@@ -72,13 +75,13 @@ repository = "https://github.com/not-elm/orzma"
 publish = false
 
 [workspace.dependencies]
-# NOTE: default_font is load-bearing for src/font.rs::make_ui_font_handle —
-# the fallback when bevy_text rejects a font (e.g., parser divergence between
-# ab_glyph and cosmic-text/skrifa) uses Handle::<Font>::default() which only
-# resolves to FiraMono when default_font is enabled. The feature is currently
-# part of bevy's default set via 2d/3d/ui → default_platform → default_font,
-# but listing it explicitly here protects against future "default-features = false".
-bevy = { version = "0.18", features = ["default_font"] }
+# NOTE: default_font is load-bearing for every `Handle::<Font>::default()`
+# consumer (e.g. src/ui/vi_mode_indicator.rs before TerminalUiFont exists, and
+# the font.rs / ime_overlay.rs tests) — the default handle only resolves to
+# FiraMono when default_font is enabled. The feature is currently part of
+# bevy's default set via default_platform → default_font, but listing it
+# explicitly here protects against future "default-features = false".
+bevy = { version = "0.19", features = ["default_font"] }
 anyhow = { version = "1" }
 thiserror = { version = "2" }
 serde = { version = "1", features = ["derive"] }
@@ -92,7 +95,8 @@ dirs = "5"
 unicode-width = "0.2"
 unicode-segmentation = "1"
 open = "5"
-bevy_cef_core = "0.11"
+bevy_cef = "0.12"
+bevy_cef_core = "0.12"
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/crates/orzma_tmux/src/plugin.rs
+++ b/crates/orzma_tmux/src/plugin.rs
@@ -972,8 +972,9 @@ mod tests {
             MessageWriter<PaneOutput>,
         )> = SystemState::new(app.world_mut());
         {
-            let (mut commands, mut client_q, mut pane_output) =
-                system_state.get_mut(app.world_mut());
+            let (mut commands, mut client_q, mut pane_output) = system_state
+                .get_mut(app.world_mut())
+                .expect("SystemState params must be valid for the test world");
             let (mut client, mut enumeration) = client_q
                 .single_mut()
                 .expect("gateway entity must carry TmuxClient + EnumerationState");
@@ -1047,8 +1048,9 @@ mod tests {
             MessageWriter<PaneOutput>,
         )> = SystemState::new(app.world_mut());
         {
-            let (mut commands, mut client_q, mut pane_output) =
-                system_state.get_mut(app.world_mut());
+            let (mut commands, mut client_q, mut pane_output) = system_state
+                .get_mut(app.world_mut())
+                .expect("SystemState params must be valid for the test world");
             let (mut client, mut enumeration) = client_q
                 .single_mut()
                 .expect("gateway entity must carry TmuxClient + EnumerationState");

--- a/crates/orzma_tty_renderer/src/glyph.rs
+++ b/crates/orzma_tty_renderer/src/glyph.rs
@@ -74,7 +74,7 @@ fn sync_atlas_image(
     if atlas.generation == atlas_image.last_generation {
         return;
     }
-    if let Some(image) = images.get_mut(&atlas_image.handle) {
+    if let Some(mut image) = images.get_mut(&atlas_image.handle) {
         image.data = Some(expand_r8_to_rgba8(&atlas.pixels));
     }
     atlas_image.last_generation = atlas.generation;

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -67,7 +67,7 @@ impl Plugin for TerminalFontPlugin {
 }
 
 /// Inserts `TerminalCellMetricsResource` at Startup based on the
-/// PrimaryWindow's current scale_factor. Bevy 0.18's winit runner writes
+/// PrimaryWindow's current scale_factor. Bevy 0.19's winit runner writes
 /// the OS-reported scale_factor into the Window during `create_windows()`
 /// (in `resumed()`), which runs before the first `App::update()` — so this
 /// Startup system sees the correct DPR on its very first invocation,

--- a/crates/orzma_tty_renderer/src/material.rs
+++ b/crates/orzma_tty_renderer/src/material.rs
@@ -19,7 +19,7 @@ use bevy::{
             TextureViewDimension, UnpreparedBindGroup, encase::UniformBuffer,
         },
         renderer::RenderDevice,
-        storage::{GpuShaderStorageBuffer, ShaderStorageBuffer},
+        storage::{GpuShaderBuffer, ShaderBuffer},
         texture::{FallbackImage, GpuImage},
     },
     shader::ShaderRef,
@@ -77,8 +77,8 @@ impl Plugin for TerminalMaterialPlugin {
 #[derive(Asset, TypePath, Clone)]
 pub struct TerminalUiMaterial {
     params: TerminalParams,
-    cells: Handle<ShaderStorageBuffer>,
-    glyphs: Handle<ShaderStorageBuffer>,
+    cells: Handle<ShaderBuffer>,
+    glyphs: Handle<ShaderBuffer>,
     atlas: Handle<Image>,
     overlays: [Option<Handle<Image>>; OVERLAY_SLOTS],
 }
@@ -105,7 +105,7 @@ impl AsBindGroup for TerminalUiMaterial {
     type Param = (
         SRes<RenderAssets<GpuImage>>,
         SRes<FallbackImage>,
-        SRes<RenderAssets<GpuShaderStorageBuffer>>,
+        SRes<RenderAssets<GpuShaderBuffer>>,
     );
 
     fn label() -> &'static str {
@@ -637,7 +637,7 @@ fn padding_color(default_bg: [u8; 3], fallback: [u8; 3]) -> Vec4 {
 fn update_terminal_material(
     mut atlas: ResMut<GlyphAtlas>,
     mut materials: ResMut<Assets<TerminalUiMaterial>>,
-    mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
+    mut buffers: ResMut<Assets<ShaderBuffer>>,
     mut terminals: Query<(
         Entity,
         &MaterialNode<TerminalUiMaterial>,
@@ -659,7 +659,7 @@ fn update_terminal_material(
     // load-bearing for rendering correctness: it forces `AssetEvent::Modified`
     // on the material every frame so `PreparedUiMaterial::prepare_asset` runs
     // and rebuilds the bind group against the latest `GpuImage` /
-    // `GpuShaderStorageBuffer`. Without this, the bind group keeps a stale
+    // `GpuShaderBuffer`. Without this, the bind group keeps a stale
     // reference to the initial (empty) atlas texture even after
     // `sync_atlas_image` re-uploads pixels — the glyphs are present on GPU
     // but the shader's `textureSampleLevel` returns 0. The actual GPU upload
@@ -759,10 +759,10 @@ fn update_terminal_material(
                 state.cpu_glyphs.push(GpuGlyph::default());
             }
 
-            if let Some(buf) = buffers.get_mut(&cells_handle) {
+            if let Some(mut buf) = buffers.get_mut(&cells_handle) {
                 buf.set_data(std::mem::take(&mut state.cpu_cells));
             }
-            if let Some(buf) = buffers.get_mut(&glyphs_handle) {
+            if let Some(mut buf) = buffers.get_mut(&glyphs_handle) {
                 buf.set_data(state.cpu_glyphs.clone());
             }
 
@@ -788,7 +788,7 @@ fn update_terminal_material(
                     s.overlay_desaturate.clamp(0.0, 1.0),
                 )
             });
-        if let Some(mat) = materials.get_mut(&handle.0) {
+        if let Some(mut mat) = materials.get_mut(&handle.0) {
             let mut params = TerminalParams::new(
                 grid,
                 cell_size_phys,

--- a/crates/orzma_tty_renderer/src/material/state.rs
+++ b/crates/orzma_tty_renderer/src/material/state.rs
@@ -9,7 +9,7 @@ use bevy::{
     ecs::{lifecycle::HookContext, world::DeferredWorld},
     platform::collections::HashMap,
     prelude::*,
-    render::storage::ShaderStorageBuffer,
+    render::storage::ShaderBuffer,
 };
 
 /// Registers a `MaterialNode<TerminalUiMaterial>` on-add hook that seeds the SSBO buffers, attaches the glyph atlas image, and inserts the per-entity [`TerminalMaterialState`] cache.
@@ -80,17 +80,17 @@ fn on_add_material_node(mut world: DeferredWorld, ctx: HookContext) {
     //       zero-sized storage buffers at bind time, so the bind group would
     //       fail to materialize before the first wire snapshot arrived and
     //       the whole material would silently drop out of the UI pass.
-    let mut cells_seed = ShaderStorageBuffer::default();
+    let mut cells_seed = ShaderBuffer::default();
     cells_seed.set_data(vec![GpuCell::default()]);
-    let mut glyphs_seed = ShaderStorageBuffer::default();
+    let mut glyphs_seed = ShaderBuffer::default();
     glyphs_seed.set_data(vec![GpuGlyph::default()]);
 
     let (cells_buffer, glyphs_buffer) = {
-        let mut buffers = world.resource_mut::<Assets<ShaderStorageBuffer>>();
+        let mut buffers = world.resource_mut::<Assets<ShaderBuffer>>();
         (buffers.add(cells_seed), buffers.add(glyphs_seed))
     };
 
-    if let Some(material) = world
+    if let Some(mut material) = world
         .resource_mut::<Assets<TerminalUiMaterial>>()
         .get_mut(&material_handle)
     {

--- a/crates/orzma_webview/Cargo.toml
+++ b/crates/orzma_webview/Cargo.toml
@@ -14,7 +14,7 @@ debug = ["bevy_cef/debug"]
 
 [dependencies]
 bevy = { workspace = true }
-bevy_cef = "0.11"
+bevy_cef = { workspace = true }
 bevy_cef_core = { workspace = true }
 orzma_tty_engine = { path = "../orzma_tty_engine" }
 orzma_tty_renderer = { path = "../orzma_tty_renderer" }

--- a/crates/orzma_webview/Cargo.toml
+++ b/crates/orzma_webview/Cargo.toml
@@ -15,7 +15,6 @@ debug = ["bevy_cef/debug"]
 [dependencies]
 bevy = { workspace = true }
 bevy_cef = { workspace = true }
-bevy_cef_core = { workspace = true }
 orzma_tty_engine = { path = "../orzma_tty_engine" }
 orzma_tty_renderer = { path = "../orzma_tty_renderer" }
 orzma_webview_host = { path = "../webview_host", features = ["cef"] }

--- a/justfile
+++ b/justfile
@@ -2,12 +2,12 @@
 # docs/superpowers/specs/2026-06-21-makefile-to-just-migration-design.md.
 # https://just.systems/
 
-cef_version := "145.6.1+145.0.28"
+cef_version := "149.3.0+149.0.6"
 cef_dir := home_directory() / ".local/share/cef"
 cef_framework_lib := cef_dir / "Chromium Embedded Framework.framework" / "Libraries"
 cef_debug_render_process := "bevy_cef_debug_render_process"
 bevy_cef_render_process := "bevy_cef_render_process"
-bevy_cef_version := "0.11.0"
+bevy_cef_version := "0.12.0"
 cargo_about_version := "0.9.0"
 pnpm_licenses_version := "2.4.2"
 

--- a/licenses/THIRD-PARTY-LICENSES.md
+++ b/licenses/THIRD-PARTY-LICENSES.md
@@ -221,6 +221,216 @@ Used by:
 ### Apache License 2.0 — `Apache-2.0`
 
 Used by:
+- ktx2 0.5.0
+
+~~~text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 The BVE-Reborn Developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+~~~
+
+### Apache License 2.0 — `Apache-2.0`
+
+Used by:
 - moxcms 0.8.1
 - pxfm 0.1.29
 
@@ -433,9 +643,8 @@ Used by:
 
 Used by:
 - codespan-reporting 0.12.0
-- cpal 0.15.3
-- self_cell 1.2.2
-- unicode-linebreak 0.1.5
+- codespan-reporting 0.13.1
+- cpal 0.17.3
 
 ~~~text
                                  Apache License
@@ -627,216 +836,6 @@ Used by:
       identification within third-party archives.
 
    Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-~~~
-
-### Apache License 2.0 — `Apache-2.0`
-
-Used by:
-- ktx2 0.4.0
-
-~~~text
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2021 The BVE-Reborn Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -1487,7 +1486,7 @@ Apache License
 Used by:
 - ab_glyph 0.2.32
 - ab_glyph_rasterizer 0.1.10
-- accesskit_winit 0.29.2
+- accesskit_winit 0.32.2
 - blake3 1.8.5
 - constant_time_eq 0.4.2
 - owned_ttf_parser 0.25.1
@@ -1888,36 +1887,6 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- harfrust 0.4.1
-
-~~~text
-    MIT License
-
-    Copyright (c) Microsoft Corporation.
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
-
-~~~
-
-### MIT License — `MIT`
-
-Used by:
 - instability 0.3.12
 
 ~~~text
@@ -1986,7 +1955,6 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 - lazy_static 1.5.0
-- metal 0.32.0
 
 ~~~text
 Copyright (c) 2010 The Rust Project Developers
@@ -2021,10 +1989,8 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 - core-foundation-sys 0.8.7
-- core-foundation 0.10.1
 - core-foundation 0.9.4
 - core-graphics-types 0.1.3
-- core-graphics-types 0.2.0
 - core-graphics 0.23.2
 - euclid 0.22.14
 
@@ -2231,6 +2197,9 @@ Used by:
 - bitflags 2.13.0
 - getopts 0.2.24
 - log 0.4.32
+- num-bigint 0.4.8
+- num-integer 0.1.46
+- num-rational 0.4.2
 - num-traits 0.2.19
 - regex-automata 0.4.14
 - regex-syntax 0.8.11
@@ -2393,8 +2362,7 @@ THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- coreaudio-rs 0.11.3
-- coreaudio-sys 0.2.18
+- coreaudio-rs 0.14.2
 - either 1.16.0
 - itertools 0.13.0
 - itertools 0.14.0
@@ -2494,7 +2462,6 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 - heck 0.5.0
-- unicode-bidi 0.3.18
 - unicode-segmentation 1.13.3
 - unicode-width 0.1.14
 - unicode-width 0.2.0
@@ -3198,7 +3165,7 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- bevy_mikktspace 0.17.0-dev
+- bevy_mikktspace 1.0.0
 
 ~~~text
 Copyright (c) 2017 The mikktspace Library Developers
@@ -3497,6 +3464,40 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
+- rand_core 0.10.1
+
+~~~text
+Copyright (c) 2018-2026 The Rand Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
 - getrandom 0.4.3
 
 ~~~text
@@ -3600,11 +3601,8 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- font-types 0.10.1
 - font-types 0.11.3
-- read-fonts 0.36.0
 - read-fonts 0.39.2
-- skrifa 0.39.0
 - skrifa 0.42.1
 
 ~~~text
@@ -3729,7 +3727,7 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- mach2 0.4.3
+- mach2 0.5.0
 
 ~~~text
 Copyright (c) 2019 Nick Fitzgerald, 2021 Yuki Okushi
@@ -4349,8 +4347,7 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- bit-set 0.8.0
-- bit-vec 0.8.0
+- bit-vec 0.9.1
 
 ~~~text
 Copyright (c) 2023 The Rust Project Developers
@@ -4412,6 +4409,40 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
+- bit-set 0.9.1
+
+~~~text
+Copyright (c) 2026 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
 - anstream 1.0.0
 - anstyle-parse 1.0.0
 - anstyle-query 1.1.5
@@ -4425,9 +4456,9 @@ Used by:
 - serde_spanned 0.6.9
 - toml 0.8.23
 - toml_datetime 0.6.11
-- toml_datetime 0.7.5+spec-1.1.0
+- toml_datetime 1.1.1+spec-1.1.0
 - toml_edit 0.22.27
-- toml_edit 0.23.10+spec-1.0.0
+- toml_edit 0.25.12+spec-1.1.0
 - toml_parser 1.1.2+spec-1.1.0
 - toml_write 0.1.2
 
@@ -4508,6 +4539,40 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
+- rodio 0.22.2
+
+~~~text
+Copyright (c) The Rodio Project Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 
 ~~~
 
@@ -4632,7 +4697,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### MIT License — `MIT`
 
 Used by:
-- rand_distr 0.5.1
+- rand_distr 0.6.0
 
 ~~~text
 Copyright 2018 Developers of the Rand project
@@ -4666,8 +4731,7 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- rand 0.9.4
-- rand_core 0.9.5
+- rand 0.10.2
 
 ~~~text
 Copyright 2018 Developers of the Rand project
@@ -4696,22 +4760,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-~~~
-
-### MIT License — `MIT`
-
-Used by:
-- rangemap 1.7.1
-
-~~~text
-Copyright 2019 Jeffrey Parsons
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ~~~
 
@@ -4752,11 +4800,81 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
+- parlance 0.1.0
+- parley 0.9.0
+- parley_data 0.9.0
+
+~~~text
+Copyright 2020 the Parley Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
 - zerocopy-derive 0.8.52
 - zerocopy 0.8.52
 
 ~~~text
 Copyright 2023 The Fuchsia Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
+- fontique 0.9.0
+
+~~~text
+Copyright 2024 the Parley Authors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -4935,6 +5053,36 @@ Used by:
 MIT License
 
 Copyright (c) 2017 Ted Driggs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
+- weak-table 0.3.2
+
+~~~text
+MIT License
+
+Copyright (c) 2018 Jesse A. Tov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -5429,12 +5577,13 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- naga 27.0.3
-- wgpu-core-deps-apple 27.0.0
-- wgpu-core 27.0.3
-- wgpu-hal 27.0.4
-- wgpu-types 27.0.1
-- wgpu 27.0.1
+- naga 29.0.4
+- wgpu-core-deps-apple 29.0.4
+- wgpu-core 29.0.4
+- wgpu-hal 29.0.4
+- wgpu-naga-bridge 29.0.4
+- wgpu-types 29.0.4
+- wgpu 29.0.4
 
 ~~~text
 MIT License
@@ -5464,7 +5613,7 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- bevy_cef 0.11.0
+- bevy_cef 0.12.0
 
 ~~~text
 MIT License
@@ -5523,16 +5672,16 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- ratatui_orzma 0.1.0
-- accesskit 0.21.1
-- accesskit_consumer 0.31.0
-- accesskit_macos 0.22.2
-- bevy_cef_core 0.11.0
+- ratatui_orzma 0.2.0-dev
+- accesskit 0.24.1
+- accesskit_consumer 0.37.0
+- accesskit_macos 0.26.2
+- bevy_cef_core 0.12.0
+- bevy_scene_macros 0.19.0
 - block2 0.5.1
 - block2 0.6.2
-- block 0.1.6
-- cef-dll-sys 145.6.1+145.0.28
-- cef 145.6.1+145.0.28
+- cef-dll-sys 149.3.0+149.0.6
+- cef 149.3.0+149.0.6
 - constgebra 0.1.4
 - dasp_sample 0.11.0
 - dispatch2 0.3.1
@@ -5546,6 +5695,9 @@ Used by:
 - objc-sys 0.3.5
 - objc2-app-kit 0.2.2
 - objc2-app-kit 0.3.2
+- objc2-audio-toolbox 0.3.2
+- objc2-core-audio-types 0.3.2
+- objc2-core-audio 0.3.2
 - objc2-core-foundation 0.3.2
 - objc2-core-graphics 0.3.2
 - objc2-encode 4.1.0
@@ -5553,11 +5705,13 @@ Used by:
 - objc2-foundation 0.3.2
 - objc2-io-kit 0.3.2
 - objc2-io-surface 0.3.2
+- objc2-metal 0.3.2
+- objc2-quartz-core 0.3.2
 - objc2 0.5.2
 - objc2 0.6.4
 - profiling 1.0.18
 - svg_fmt 0.4.5
-- taffy 0.9.2
+- taffy 0.10.1
 
 ~~~text
 MIT License
@@ -5774,67 +5928,74 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 - atomicow 1.2.0
-- bevy 0.18.1
-- bevy_a11y 0.18.1
-- bevy_animation 0.18.1
-- bevy_animation_macros 0.18.1
-- bevy_anti_alias 0.18.1
-- bevy_app 0.18.1
-- bevy_asset 0.18.1
-- bevy_asset_macros 0.18.1
-- bevy_audio 0.18.1
-- bevy_camera 0.18.1
-- bevy_color 0.18.1
-- bevy_core_pipeline 0.18.1
-- bevy_derive 0.18.1
-- bevy_diagnostic 0.18.1
-- bevy_ecs 0.18.1
-- bevy_ecs_macros 0.18.1
-- bevy_encase_derive 0.18.1
-- bevy_gilrs 0.18.1
-- bevy_gizmos 0.18.1
-- bevy_gizmos_macros 0.18.1
-- bevy_gizmos_render 0.18.1
-- bevy_gltf 0.18.1
-- bevy_image 0.18.1
-- bevy_input 0.18.1
-- bevy_input_focus 0.18.1
-- bevy_internal 0.18.1
-- bevy_light 0.18.1
-- bevy_log 0.18.1
-- bevy_macro_utils 0.18.1
-- bevy_math 0.18.1
-- bevy_mesh 0.18.1
-- bevy_pbr 0.18.1
-- bevy_picking 0.18.1
-- bevy_platform 0.18.1
-- bevy_post_process 0.18.1
-- bevy_ptr 0.18.1
-- bevy_reflect 0.18.1
-- bevy_reflect_derive 0.18.1
-- bevy_remote 0.18.1
-- bevy_render 0.18.1
-- bevy_render_macros 0.18.1
-- bevy_scene 0.18.1
-- bevy_shader 0.18.1
-- bevy_sprite 0.18.1
-- bevy_sprite_render 0.18.1
-- bevy_state 0.18.1
-- bevy_state_macros 0.18.1
-- bevy_tasks 0.18.1
-- bevy_text 0.18.1
-- bevy_time 0.18.1
-- bevy_transform 0.18.1
-- bevy_ui 0.18.1
-- bevy_ui_render 0.18.1
-- bevy_utils 0.18.1
-- bevy_window 0.18.1
-- bevy_winit 0.18.1
+- bevy 0.19.0
+- bevy_a11y 0.19.0
+- bevy_animation 0.19.0
+- bevy_animation_macros 0.19.0
+- bevy_anti_alias 0.19.0
+- bevy_app 0.19.0
+- bevy_asset 0.19.0
+- bevy_asset_macros 0.19.0
+- bevy_audio 0.19.0
+- bevy_camera 0.19.0
+- bevy_clipboard 0.19.0
+- bevy_color 0.19.0
+- bevy_core_pipeline 0.19.0
+- bevy_derive 0.19.0
+- bevy_dev_tools 0.19.0
+- bevy_diagnostic 0.19.0
+- bevy_ecs 0.19.0
+- bevy_ecs_macro_logic 0.19.0
+- bevy_ecs_macros 0.19.0
+- bevy_encase_derive 0.19.0
+- bevy_gilrs 0.19.0
+- bevy_gizmos 0.19.0
+- bevy_gizmos_macros 0.19.0
+- bevy_gizmos_render 0.19.0
+- bevy_gltf 0.19.0
+- bevy_image 0.19.0
+- bevy_input 0.19.0
+- bevy_input_focus 0.19.0
+- bevy_internal 0.19.0
+- bevy_light 0.19.0
+- bevy_log 0.19.0
+- bevy_macro_utils 0.19.0
+- bevy_material 0.19.0
+- bevy_material_macros 0.19.0
+- bevy_math 0.19.0
+- bevy_mesh 0.19.0
+- bevy_pbr 0.19.0
+- bevy_picking 0.19.0
+- bevy_platform 0.19.0
+- bevy_post_process 0.19.0
+- bevy_ptr 0.19.0
+- bevy_reflect 0.19.0
+- bevy_reflect_derive 0.19.0
+- bevy_remote 0.19.0
+- bevy_render 0.19.0
+- bevy_render_macros 0.19.0
+- bevy_scene 0.19.0
+- bevy_shader 0.19.0
+- bevy_sprite 0.19.0
+- bevy_sprite_render 0.19.0
+- bevy_state 0.19.0
+- bevy_state_macros 0.19.0
+- bevy_tasks 0.19.0
+- bevy_text 0.19.0
+- bevy_time 0.19.0
+- bevy_transform 0.19.0
+- bevy_ui 0.19.0
+- bevy_ui_render 0.19.0
+- bevy_ui_widgets 0.19.0
+- bevy_utils 0.19.0
+- bevy_window 0.19.0
+- bevy_winit 0.19.0
+- bevy_world_serialization 0.19.0
 - disqualified 1.0.0
 - half 2.7.1
 - ident_case 1.0.1
 - linebender_resource_handle 0.1.1
-- naga_oil 0.20.0
+- naga_oil 0.22.0
 
 ~~~text
 MIT License
@@ -5856,42 +6017,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-~~~
-
-### MIT License — `MIT`
-
-Used by:
-- unicode-script 0.5.8
-
-~~~text
-MIT License
-
-Copyright (c) 2019 Manish Goregaokar
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 
 ~~~
 
@@ -6037,7 +6162,8 @@ Used by:
 - event-listener 5.4.1
 - fastrand 2.4.1
 - futures-lite 2.6.1
-- glam 0.30.10
+- glam 0.32.1
+- hexasphere 18.0.0
 - home 0.5.12
 - indoc 2.0.7
 - inventory 0.3.24
@@ -6051,7 +6177,6 @@ Used by:
 - polling 3.11.0
 - proc-macro2 1.0.106
 - quote 1.0.45
-- rodio 0.20.1
 - rustc-hash 1.1.0
 - rustix-openpty 0.2.0
 - rustix 0.38.44
@@ -6105,7 +6230,6 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 - allocator-api2 0.2.21
-- hexasphere 16.0.0
 
 ~~~text
 Permission is hereby granted, free of charge, to any
@@ -6159,6 +6283,32 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+~~~
+
+### MIT License — `MIT`
+
+Used by:
+- raw-window-metal 1.1.0
+
+~~~text
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ~~~
 
@@ -6428,7 +6578,7 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- sysinfo 0.37.2
+- sysinfo 0.38.4
 
 ~~~text
 The MIT License (MIT)
@@ -6711,36 +6861,6 @@ DEALINGS IN THE SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- fontdb 0.23.0
-
-~~~text
-The MIT License (MIT)
-
-Copyright (c) 2020 Yevhenii Reizner
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-~~~
-
-### MIT License — `MIT`
-
-Used by:
 - async-broadcast 0.7.2
 
 ~~~text
@@ -6771,12 +6891,13 @@ SOFTWARE.
 ### MIT License — `MIT`
 
 Used by:
-- cosmic-text 0.16.0
+- harfrust 0.6.2
 
 ~~~text
 The MIT License (MIT)
 
-Copyright (c) 2022 System76
+Copyright (c) HarfBuzz developers
+Copyright (c) 2020 Yevhenii Reizner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -7467,12 +7588,16 @@ authorization of the copyright holder.
 
 Used by:
 - icu_collections 2.2.0
+- icu_locale 2.2.0
 - icu_locale_core 2.2.0
+- icu_locale_data 2.2.0
 - icu_normalizer 2.2.0
 - icu_normalizer_data 2.2.0
 - icu_properties 2.2.0
 - icu_properties_data 2.2.0
 - icu_provider 2.2.0
+- icu_segmenter 2.2.0
+- icu_segmenter_data 2.2.0
 - litemap 0.8.2
 - potential_utf 0.1.5
 - tinystr 0.8.3
@@ -7644,7 +7769,7 @@ the following restrictions:
 ### zlib License — `Zlib`
 
 Used by:
-- bevy_mikktspace 0.17.0-dev
+- bevy_mikktspace 1.0.0
 
 ~~~text
 zlib License

--- a/src/font.rs
+++ b/src/font.rs
@@ -11,7 +11,8 @@
 
 use crate::configs::OrzmaConfigsResource;
 use bevy::prelude::*;
-use bevy::text::{CosmicFontSystem, Font};
+use bevy::text::{Font, FontCx};
+use fontique::{Blob, Script};
 use orzma_configs::font::FontConfig;
 use orzma_configs::path::{SystemEnv, expand_user_path};
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
@@ -39,7 +40,7 @@ impl Plugin for FontBridgePlugin {
             Startup,
             (
                 bridge_font_config.before(TerminalFontInitSet::InitCellMetrics),
-                register_cjk_fallback_with_cosmic,
+                register_cjk_fallback,
             ),
         );
     }
@@ -86,26 +87,39 @@ fn validate_or_bundled(bytes: Vec<u8>, bundled: &'static [u8], face: FontFace) -
     }
 }
 
-/// Registers the bundled CJK fallback font directly into cosmic-text's
-/// fontdb, making it discoverable as a script-fallback for spans whose
+/// Registers the bundled CJK fallback font into parley's fontique
+/// collection and appends its family to the Han / Hiragana / Katakana
+/// script-fallback chains, making it discoverable for spans whose
 /// primary `TextFont` lacks CJK coverage.
 ///
 /// NOTE: Bevy's `Assets<Font>::add(...)` is NOT sufficient here —
-/// `bevy_text::load_font_to_fontdb` only runs when a `TextFont`
-/// handle pointing at the asset reaches the text pipeline
-/// (`bevy_text-0.18.1/src/pipeline.rs:597-620`). For a fallback that
-/// is never referenced as a primary `TextFont`, call
-/// `db_mut().load_font_source(...)` explicitly so cosmic-text's
-/// `FontFallbackIter::other_i` last-resort loop sees it.
-fn register_cjk_fallback_with_cosmic(mut font_system: ResMut<CosmicFontSystem>) {
-    let source = cosmic_text::fontdb::Source::Binary(std::sync::Arc::new(
-        orzma_tty_renderer::bundled::FALLBACK_REGULAR,
-    )
-        as std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>);
-    font_system.db_mut().load_font_source(source);
+/// `bevy_text::load_font_assets_into_font_collection` registers every
+/// `Font` asset in the collection, but fontique resolves missing glyphs
+/// only through per-script fallback chains, which stay empty without
+/// system font discovery. `append_fallbacks` is what makes the family
+/// reachable. Conversely, that same bevy_text system CLEARS the
+/// collection (dropping this registration and its fallback chains) if
+/// any `Font` asset is ever removed — orzma never removes font assets
+/// after Startup; re-run this registration if that changes.
+fn register_cjk_fallback(mut font_cx: ResMut<FontCx>) {
+    let blob = Blob::new(
+        std::sync::Arc::new(orzma_tty_renderer::bundled::FALLBACK_REGULAR)
+            as std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>,
+    );
+    let registered = font_cx.collection.register_fonts(blob, None);
+    let family_ids: Vec<_> = registered.iter().map(|(id, _)| *id).collect();
+    for script in [
+        Script::from_str_unchecked("Hani"),
+        Script::from_str_unchecked("Hira"),
+        Script::from_str_unchecked("Kana"),
+    ] {
+        font_cx
+            .collection
+            .append_fallbacks(script, family_ids.iter().copied());
+    }
     tracing::info!(
         target: "orzma::font",
-        "registered UDEVGothic35-Regular into cosmic-text fontdb",
+        "registered UDEVGothic35-Regular into the parley font collection as CJK fallback",
     );
 }
 
@@ -176,29 +190,12 @@ fn bridge_font_config(
     commands.insert_resource(TerminalUiFont(handle));
 }
 
-/// Builds the UI-side `Handle<Font>` from the regular face bytes. On
-/// `Font::try_from_bytes` rejection (rare; ab_glyph and bevy_text use
-/// different parser families, so a font accepted by one may be rejected
-/// by the other), falls back to Bevy's default FiraMono via
-/// `Handle::<Font>::default()`.
+/// Builds the UI-side `Handle<Font>` from the regular face bytes.
+/// `Font::from_bytes` is infallible in Bevy 0.19 (parsing happens later,
+/// at fontique registration); the bytes reaching this point were already
+/// validated per-face by `validate_or_bundled`.
 fn make_ui_font_handle(regular_bytes: Vec<u8>, fonts_assets: &mut Assets<Font>) -> Handle<Font> {
-    match Font::try_from_bytes(regular_bytes) {
-        Ok(font_asset) => fonts_assets.add(font_asset),
-        Err(err) => {
-            // ERROR not warn: the user's terminal and UI overlay will now
-            // render in different typefaces (terminal: user-supplied or
-            // bundled JetBrains Mono; UI: Bevy's FiraMono), a visible
-            // inconsistency that operators should know about.
-            tracing::error!(
-                %err,
-                "bevy_text::Font::try_from_bytes rejected the regular face; \
-                 the terminal grid will render in the resolved JetBrains Mono or user override \
-                 while the UI overlay falls back to Bevy's bundled FiraMono — \
-                 expect a visible typeface mismatch between the grid and chrome"
-            );
-            Handle::<Font>::default()
-        }
-    }
+    fonts_assets.add(Font::from_bytes(regular_bytes))
 }
 
 #[cfg(test)]
@@ -437,18 +434,27 @@ mod tests {
     }
 
     #[test]
-    fn cjk_fallback_registered_in_cosmic_fontdb() {
+    fn cjk_fallback_registered_in_font_collection() {
         let (mut app, _guard, _env) = make_test_app();
         app.update();
 
-        let font_system = app.world().resource::<bevy::text::CosmicFontSystem>();
-        let has_udev_face = font_system
-            .db()
-            .faces()
-            .any(|face| face.families.iter().any(|(name, _)| name.contains("UDEV")));
+        let mut font_cx = app.world_mut().resource_mut::<FontCx>();
+        let has_udev_family = font_cx
+            .collection
+            .family_names()
+            .any(|name| name.contains("UDEV"));
         assert!(
-            has_udev_face,
-            "UDEVGothic35 must be registered in cosmic-text fontdb after Startup",
+            has_udev_family,
+            "UDEVGothic35 must be registered in the parley font collection after Startup",
+        );
+        let hira_chain_nonempty = font_cx
+            .collection
+            .fallback_families(Script::from_str_unchecked("Hira"))
+            .next()
+            .is_some();
+        assert!(
+            hira_chain_nonempty,
+            "the Hiragana script-fallback chain must contain the bundled CJK family",
         );
     }
 

--- a/src/input/default_mode.rs
+++ b/src/input/default_mode.rs
@@ -19,7 +19,7 @@ use crate::surface::geometry::topmost_surface_at;
 use crate::ui::vi_mode::ViModeState;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
-use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
 use bevy::window::{PrimaryWindow, Window};
 use bevy_cef::prelude::FocusedWebview;
 use orzma_tmux::TmuxPane;
@@ -62,7 +62,12 @@ struct WebviewClaimParams<'w, 's> {
     surfaces: Query<
         'w,
         's,
-        (Entity, &'static ComputedNode, &'static UiGlobalTransform),
+        (
+            Entity,
+            &'static ComputedNode,
+            &'static ComputedStackIndex,
+            &'static UiGlobalTransform,
+        ),
         With<OrzmaTerminal>,
     >,
     children: Query<'w, 's, &'static Children>,
@@ -126,7 +131,7 @@ fn cursor_claims_webview(window: &Window, claim: &WebviewClaimParams) -> Option<
     let cell_h = metrics.metrics.line_height_phys.floor().max(1.0);
     let cursor_phys = window.cursor_position()? * scale;
     let terminal = topmost_surface_at(cursor_phys, claim.surfaces.iter())?;
-    let (_, node, transform) = claim.surfaces.get(terminal).ok()?;
+    let (_, node, _, transform) = claim.surfaces.get(terminal).ok()?;
     let local_phys = phys_to_pane_local(node, transform, cursor_phys)?;
     let overlays = claim.overlay_rects.get(terminal).ok()?;
     webview_hit_at(

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -22,7 +22,7 @@ use bevy::input::ButtonInput;
 use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::input::mouse::MouseMotion;
 use bevy::prelude::*;
-use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
 use bevy::window::{CursorIcon, CursorMoved, PrimaryWindow, SystemCursorIcon, Window};
 use bevy_cef::prelude::WebviewSource;
 use orzma_configs::shortcuts::Modifiers;
@@ -39,8 +39,8 @@ impl Plugin for HyperlinkInputPlugin {
             hyperlink_hover_and_cursor
                 .run_if(
                     on_message::<MouseMotion>
-                        .or(on_message::<CursorMoved>)
-                        .or(on_message::<KeyboardInput>),
+                        .or_else(on_message::<CursorMoved>)
+                        .or_else(on_message::<KeyboardInput>),
                 )
                 .in_set(InputPhase::Hover),
         );
@@ -62,7 +62,12 @@ fn hyperlink_hover_and_cursor(
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     surfaces: Query<
-        (Entity, &ComputedNode, &UiGlobalTransform),
+        (
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+        ),
         (With<OrzmaTerminal>, Without<MouseDisabled>),
     >,
     grids: Query<&TerminalGrid>,
@@ -99,7 +104,7 @@ fn hyperlink_hover_and_cursor(
                 let id = surfaces
                     .get(entity)
                     .ok()
-                    .and_then(|(_, node, transform)| {
+                    .and_then(|(_, node, _, transform)| {
                         phys_to_pane_local(node, transform, cursor_phys)
                     })
                     .map(|local| {

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -261,16 +261,16 @@ fn ime_policy_system(
     // anchors one row down because macOS treats the rect
     // `set_ime_cursor_area(origin, size)` as the marked-text
     // bounding box and places the candidate window just below
-    // `origin.y + size.height`. Bevy 0.18 hard-codes that size to
+    // `origin.y + size.height`. Bevy 0.19 hard-codes that size to
     // `PhysicalSize::new(10, 10)`
-    // (`bevy_winit-0.18.1/src/system.rs:510`) with no way for us
+    // (`bevy_winit-0.19.0/src/system.rs:544-546`) with no way for us
     // to pass the actual cell height. Net effect: candidate window
     // appears one full row below the cursor — i.e. one row below
     // the preedit row, which is what users expect.
     //
     // NOTE: `UiGlobalTransform.translation` is the CENTER of the
-    // node in PHYSICAL pixels (verified via Bevy 0.18 source:
-    // `bevy_ui-0.18.1/src/layout/mod.rs:239-275` writes
+    // node in PHYSICAL pixels (verified via Bevy 0.19 source:
+    // `bevy_ui-0.19.0/src/layout/mod.rs:269-299` writes
     // `local_center` into the global transform; `ComputedNode.size`
     // is also physical px). To get the node's top-left in physical
     // px, subtract `0.5 * node.size()`. Do NOT multiply translation

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -17,7 +17,7 @@ use crate::input::mouse::wheel::MouseWheelInputPlugin;
 use crate::surface::OrzmaTerminal;
 use bevy::input::mouse::{MouseButtonInput, MouseWheel};
 use bevy::prelude::*;
-use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
 use bevy::window::CursorMoved;
 pub(crate) use button::tmux::divider_at;
 use orzma_tty_engine::{CellCoord, Point, SelectionType, Side, TermMode, TerminalHandle};
@@ -52,8 +52,8 @@ impl Plugin for MouseInputPlugin {
 /// two per-file plugins' gating in lockstep.
 fn on_any_mouse_message() -> impl SystemCondition<()> {
     on_message::<MouseButtonInput>
-        .or(on_message::<CursorMoved>)
-        .or(on_message::<MouseWheel>)
+        .or_else(on_message::<CursorMoved>)
+        .or_else(on_message::<MouseWheel>)
 }
 
 /// Host-private decision IR for the button path: `decide_button` returns an
@@ -151,20 +151,29 @@ type TerminalSurfaces<'w, 's> = Query<
         Entity,
         &'static TerminalHandle,
         &'static ComputedNode,
+        &'static ComputedStackIndex,
         &'static UiGlobalTransform,
         &'static TerminalGrid,
     ),
     (With<OrzmaTerminal>, Without<MouseDisabled>),
 >;
 
-/// The `(entity, node, transform)` candidates `topmost_surface_at` hit-tests,
-/// projected from the surface query — one adapter shared by both dispatchers.
+/// The `(entity, node, stack, transform)` candidates `topmost_surface_at`
+/// hit-tests, projected from the surface query — one adapter shared by both
+/// dispatchers.
 fn hit_candidates<'a>(
     terminals: &'a TerminalSurfaces<'_, '_>,
-) -> impl Iterator<Item = (Entity, &'a ComputedNode, &'a UiGlobalTransform)> {
+) -> impl Iterator<
+    Item = (
+        Entity,
+        &'a ComputedNode,
+        &'a ComputedStackIndex,
+        &'a UiGlobalTransform,
+    ),
+> {
     terminals
         .iter()
-        .map(|(e, _, node, transform, _)| (e, node, transform))
+        .map(|(e, _, node, stack, transform, _)| (e, node, stack, transform))
 }
 
 /// The `(cell_w, cell_h)` pitch in physical px, floored and clamped to `>= 1` so
@@ -211,7 +220,7 @@ fn cell_context_for<'a>(
     cell_w: f32,
     cell_h: f32,
 ) -> Option<(CellContext<'a>, TermMode)> {
-    let (_, handle, node, transform, grid) = terminals.get(target).ok()?;
+    let (_, handle, node, _, transform, grid) = terminals.get(target).ok()?;
     let ctx = CellContext {
         node,
         transform,

--- a/src/input/mouse/webview/default_mode.rs
+++ b/src/input/mouse/webview/default_mode.rs
@@ -27,7 +27,7 @@ use crate::surface::geometry::topmost_surface_at;
 use crate::ui::vi_search::ViModePrompt;
 use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseWheel};
 use bevy::prelude::*;
-use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
 use bevy::window::{CursorMoved, PrimaryWindow};
 use bevy_cef::prelude::FocusedWebview;
 use bevy_cef_core::prelude::Browsers;
@@ -51,13 +51,13 @@ impl Plugin for MouseWebviewDefaultModePlugin {
             Update,
             forward_default_webview_mouse_moves
                 .in_set(InputPhase::Hover)
-                .run_if(in_state(AppMode::Default).and(on_message::<CursorMoved>)),
+                .run_if(in_state(AppMode::Default).and_then(on_message::<CursorMoved>)),
         )
         .add_systems(
             Update,
             forward_default_webview_wheel
                 .in_set(InputPhase::Dispatch)
-                .run_if(in_state(AppMode::Default).and(on_message::<MouseWheel>)),
+                .run_if(in_state(AppMode::Default).and_then(on_message::<MouseWheel>)),
         );
     }
 }
@@ -70,7 +70,15 @@ fn default_webview_pointer(
     mut webview_press: ResMut<WebviewPress>,
     mut webview_route: WebviewRouteParams,
     mut buttons: MessageReader<MouseButtonInput>,
-    surfaces: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<OrzmaTerminal>>,
+    surfaces: Query<
+        (
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+        ),
+        With<OrzmaTerminal>,
+    >,
     metrics: Res<TerminalCellMetricsResource>,
     vi_mode_prompt: Res<ViModePrompt>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -103,7 +111,7 @@ fn default_webview_pointer(
         let Some(terminal) = topmost_surface_at(cursor_phys, surfaces.iter()) else {
             continue;
         };
-        let Ok((_, node, transform)) = surfaces.get(terminal) else {
+        let Ok((_, node, _, transform)) = surfaces.get(terminal) else {
             continue;
         };
         let Some(local_phys) = phys_to_pane_local(node, transform, cursor_phys) else {
@@ -128,7 +136,15 @@ fn default_webview_pointer(
 /// while a vi-search prompt owns input.
 fn forward_default_webview_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
-    surfaces: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<OrzmaTerminal>>,
+    surfaces: Query<
+        (
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+        ),
+        With<OrzmaTerminal>,
+    >,
     children: Query<'_, '_, &'static Children>,
     webviews: Query<'_, '_, (&'static Webview, Has<NonInteractive>)>,
     overlay_rects: Query<'_, '_, &'static TerminalOverlays>,
@@ -160,7 +176,7 @@ fn forward_default_webview_mouse_moves(
         &deps,
         |c| {
             let t = topmost_surface_at(c, surfaces.iter())?;
-            let (_, node, transform) = surfaces.get(t).ok()?;
+            let (_, node, _, transform) = surfaces.get(t).ok()?;
             Some((t, phys_to_pane_local(node, transform, c)?))
         },
         cursor_phys,
@@ -178,7 +194,15 @@ fn forward_default_webview_wheel(
     mut wheel: MessageReader<MouseWheel>,
     focused_webview: Res<FocusedWebview>,
     webview_parents: Query<&ChildOf, With<Webview>>,
-    surfaces: Query<(Entity, &ComputedNode, &UiGlobalTransform), With<OrzmaTerminal>>,
+    surfaces: Query<
+        (
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+        ),
+        With<OrzmaTerminal>,
+    >,
     children: Query<&Children>,
     webviews: Query<(&Webview, Has<NonInteractive>)>,
     overlay_rects: Query<&TerminalOverlays>,
@@ -200,7 +224,7 @@ fn forward_default_webview_wheel(
     let target = window.cursor_position().and_then(|c| {
         let cursor_phys = c * scale;
         let terminal = topmost_surface_at(cursor_phys, surfaces.iter())?;
-        let (_, node, transform) = surfaces.get(terminal).ok()?;
+        let (_, node, _, transform) = surfaces.get(terminal).ok()?;
         let local_phys = phys_to_pane_local(node, transform, cursor_phys)?;
         webview_wheel_target(
             &focused_webview,

--- a/src/input/mouse/wheel.rs
+++ b/src/input/mouse/wheel.rs
@@ -276,6 +276,7 @@ mod tests {
     };
     use crate::surface::OrzmaTerminal;
     use bevy::input::mouse::MouseScrollUnit;
+    use bevy::input::touch::TouchPhase;
     use bevy::ui::{ComputedNode, UiGlobalTransform};
     use orzma_tty_engine::TerminalHandle;
     use orzma_tty_renderer::schema::TerminalGrid;
@@ -330,6 +331,7 @@ mod tests {
                 x,
                 y,
                 window: Entity::PLACEHOLDER,
+                phase: TouchPhase::Moved,
             });
     }
 
@@ -548,6 +550,7 @@ mod tests {
                 x: 16.0 * phys_right_sign(),
                 y: 16.0,
                 window: Entity::PLACEHOLDER,
+                phase: TouchPhase::Moved,
             });
         app.update();
         let cap = app.world().resource::<CapturedEffects>();

--- a/src/input/mouse/wheel/tmux.rs
+++ b/src/input/mouse/wheel/tmux.rs
@@ -396,6 +396,7 @@ mod tests {
     use crate::input::shortcuts::tmux::{tmux_pane_direction, tmux_split_direction};
     use bevy::ecs::system::RunSystemOnce;
     use bevy::input::mouse::MouseScrollUnit;
+    use bevy::input::touch::TouchPhase;
     use orzma_configs::shortcuts::{
         PaneDirection as CfgPaneDirection, SplitOrientation as CfgSplitOrientation,
     };
@@ -609,6 +610,7 @@ mod tests {
             x: 0.0,
             y,
             window: Entity::PLACEHOLDER,
+            phase: TouchPhase::Moved,
         }
     }
 

--- a/src/input/option_as_alt.rs
+++ b/src/input/option_as_alt.rs
@@ -40,7 +40,7 @@ mod macos {
         let Ok(entity) = primary.single() else {
             return;
         };
-        // NOTE: Bevy 0.18 keeps WinitWindows in a main-thread thread-local, not a world
+        // NOTE: Bevy 0.19 keeps WinitWindows in a main-thread thread-local, not a world
         // non-send resource (bevy ECS #17667 workaround). NonSendMarker pins this system
         // to the main thread so the borrow sees the populated instance, not an empty one.
         WINIT_WINDOWS.with_borrow(|winit_windows| {

--- a/src/input/shortcuts/tmux.rs
+++ b/src/input/shortcuts/tmux.rs
@@ -310,7 +310,7 @@ pub(in crate::input) fn tmux_split_direction(orientation: CfgSplitOrientation) -
 /// Run condition for `apply_tmux_forward`: true on any frame carrying a key to
 /// forward (typed or webview-forwarded). The two never coexist in a frame.
 fn on_tmux_forward_message() -> impl SystemCondition<()> {
-    on_message::<TypeMessage>.or(on_message::<WebviewForwardMessage>)
+    on_message::<TypeMessage>.or_else(on_message::<WebviewForwardMessage>)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
 ///
 /// `ime_enabled` starts `false` deliberately: bevy_winit applies the IME state
 /// to the OS window only on a live `false -> true` change of `Window::ime_enabled`
-/// (`bevy_winit-0.18.1/src/system.rs:503-504`) and never at window creation, so
+/// (`bevy_winit-0.19.0/src/system.rs:539-540`) and never at window creation, so
 /// starting `true` would leave the OS IME un-armed. `ime_policy_system` flips it
 /// to `true` on the first focused-surface tick, producing the arming transition.
 fn primary_window() -> Window {

--- a/src/render/tmux.rs
+++ b/src/render/tmux.rs
@@ -104,7 +104,7 @@ impl Plugin for RenderPlugin {
                     attach_tmux_window_container,
                     attach_tmux_pane_terminal,
                     route_tmux_output
-                        .run_if(on_message::<PaneOutput>.or(pending_pane_output_waiting)),
+                        .run_if(on_message::<PaneOutput>.or_else(pending_pane_output_waiting)),
                     sync_active_window,
                     layout_tmux_panes.in_set(TmuxLayoutSet),
                 )

--- a/src/session/default/layout.rs
+++ b/src/session/default/layout.rs
@@ -24,8 +24,8 @@ impl Plugin for DefaultLayoutPlugin {
                     .run_if(resource_exists::<TerminalCellMetricsResource>)
                     .run_if(
                         resource_exists_and_changed::<OrzmaLastSize>
-                            .or(resource_exists_and_changed::<TerminalCellMetricsResource>)
-                            .or(on_message::<WindowResized>),
+                            .or_else(resource_exists_and_changed::<TerminalCellMetricsResource>)
+                            .or_else(on_message::<WindowResized>),
                     ),
             );
     }

--- a/src/session/tmux/adopt.rs
+++ b/src/session/tmux/adopt.rs
@@ -61,7 +61,7 @@ impl Plugin for AdoptPlugin {
                 Update,
                 sync_gateway_size.before(TeardownOnExitSet).run_if(
                     any_with_component::<TmuxClient>
-                        .and(resource_exists::<TerminalCellMetricsResource>),
+                        .and_then(resource_exists::<TerminalCellMetricsResource>),
                 ),
             );
     }

--- a/src/surface/geometry.rs
+++ b/src/surface/geometry.rs
@@ -5,7 +5,7 @@
 
 use bevy::ecs::entity::Entity;
 use bevy::math::Vec2;
-use bevy::ui::{ComputedNode, UiGlobalTransform};
+use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
 
 /// Which half of a cell the pointer fell in (left vs. right of the midline).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,18 +94,25 @@ pub(crate) fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16,
 
 /// Returns the topmost `OrzmaTerminal` surface whose node contains `cursor_phys`,
 /// or `None` when the cursor is over none. "Topmost" is the highest
-/// `ComputedNode::stack_index` (Bevy's resolved front-to-back UI order); ties
+/// `ComputedStackIndex` (Bevy's resolved front-to-back UI order); ties
 /// break by `Entity` for determinism. The Default-mode pointer/gate path uses
 /// this to pick the single shell (or the frontmost surface) under the cursor;
 /// tmux keeps its own multi-pane `tmux_pane_at_phys` resolution.
 pub(crate) fn topmost_surface_at<'a>(
     cursor_phys: Vec2,
-    candidates: impl Iterator<Item = (Entity, &'a ComputedNode, &'a UiGlobalTransform)>,
+    candidates: impl Iterator<
+        Item = (
+            Entity,
+            &'a ComputedNode,
+            &'a ComputedStackIndex,
+            &'a UiGlobalTransform,
+        ),
+    >,
 ) -> Option<Entity> {
     candidates
-        .filter(|&(_, node, transform)| node.contains_point(*transform, cursor_phys))
-        .max_by_key(|&(entity, node, _)| (node.stack_index(), entity))
-        .map(|(entity, _, _)| entity)
+        .filter(|&(_, node, _, transform)| node.contains_point(*transform, cursor_phys))
+        .max_by_key(|&(entity, _, stack, _)| (stack.0, entity))
+        .map(|(entity, _, _, _)| entity)
 }
 
 #[cfg(test)]
@@ -211,26 +218,26 @@ mod tests {
         // C: left half, stack 9 — overlaps A and sits on top.
         let node_a = ComputedNode {
             size: Vec2::new(400.0, 600.0),
-            stack_index: 5,
             ..ComputedNode::DEFAULT
         };
+        let stack_a = ComputedStackIndex(5);
         let tf_a = UiGlobalTransform::from_xy(200.0, 300.0);
         let node_b = ComputedNode {
             size: Vec2::new(400.0, 600.0),
-            stack_index: 3,
             ..ComputedNode::DEFAULT
         };
+        let stack_b = ComputedStackIndex(3);
         let tf_b = UiGlobalTransform::from_xy(600.0, 300.0);
         let node_c = ComputedNode {
             size: Vec2::new(400.0, 600.0),
-            stack_index: 9,
             ..ComputedNode::DEFAULT
         };
+        let stack_c = ComputedStackIndex(9);
         let tf_c = UiGlobalTransform::from_xy(200.0, 300.0);
         let candidates = [
-            (a, &node_a, &tf_a),
-            (b, &node_b, &tf_b),
-            (c, &node_c, &tf_c),
+            (a, &node_a, &stack_a, &tf_a),
+            (b, &node_b, &stack_b, &tf_b),
+            (c, &node_c, &stack_c, &tf_c),
         ];
 
         assert_eq!(
@@ -260,12 +267,12 @@ mod tests {
         // depend on candidate iteration order.
         let node = ComputedNode {
             size: Vec2::new(400.0, 600.0),
-            stack_index: 0,
             ..ComputedNode::DEFAULT
         };
+        let stack = ComputedStackIndex(0);
         let tf = UiGlobalTransform::from_xy(200.0, 300.0);
-        let forward = [(lower, &node, &tf), (higher, &node, &tf)];
-        let reversed = [(higher, &node, &tf), (lower, &node, &tf)];
+        let forward = [(lower, &node, &stack, &tf), (higher, &node, &stack, &tf)];
+        let reversed = [(higher, &node, &stack, &tf), (lower, &node, &stack, &tf)];
         let winner = topmost_surface_at(Vec2::new(100.0, 300.0), forward.iter().copied());
         assert_eq!(
             winner,

--- a/src/ui/default_mode.rs
+++ b/src/ui/default_mode.rs
@@ -27,8 +27,9 @@ impl Plugin for DefaultModeUiPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             Update,
-            ensure_default_mode_ui
-                .run_if(in_state(AppMode::Default).and(not(any_with_component::<DefaultModeUi>))),
+            ensure_default_mode_ui.run_if(
+                in_state(AppMode::Default).and_then(not(any_with_component::<DefaultModeUi>)),
+            ),
         );
     }
 }

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -22,7 +22,7 @@ use bevy::ecs::schedule::SystemCondition;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists_and_changed};
 use bevy::ecs::system::{Commands, Query, Res, ResMut};
 use bevy::prelude::default;
-use bevy::text::{LineBreak, TextColor, TextFont, TextLayout};
+use bevy::text::{FontSize, LineBreak, TextColor, TextFont, TextLayout};
 use bevy::ui::widget::Text;
 use bevy::ui::{
     BackgroundColor, BorderColor, ComputedNode, Display, GlobalZIndex, Node, PositionType,
@@ -48,15 +48,15 @@ impl Plugin for ImeOverlayPlugin {
                 spawn_ime_overlay_once.after(TerminalFontInitSet::InitCellMetrics),
             )
             // NOTE: must run BEFORE `UiSystems::Content`. Bevy's
-            // `detect_text_needs_rerender::<Text>` and `measure_text_system`
-            // run in `UiSystems::Content` (`bevy_ui-0.18.1/src/lib.rs:226-243`)
-            // and that's where `ComputedTextBlock` is refreshed from
-            // ECS `TextSpan`s (`bevy_text-0.18.1/src/pipeline.rs:245-272`).
-            // If we mutate `TextSpan.0` after `Content`, detection sees no
-            // change this frame, `text_system` in `PostLayout` is gated off
-            // (`bevy_ui-0.18.1/src/widget/text.rs:343-393`), the root's
+            // `detect_text_needs_rerender` and `measure_text_system`
+            // run in `UiSystems::Content` (`bevy_ui-0.19.0/src/lib.rs:236-252`)
+            // and that's where changed ECS `TextSpan`s are detected
+            // (`bevy_text-0.19.0/src/text.rs:1223`). If we mutate
+            // `TextSpan.0` after `Content`, detection sees no change
+            // this frame, `text_system` in `PostLayout` is gated off
+            // (`bevy_ui-0.19.0/src/widget/text.rs:357`), the root's
             // `ComputedNode` stays at 0×0, and `bevy_ui_render` skips empty
-            // nodes (`bevy_ui_render-0.18.1/src/lib.rs:1044-1046`) —
+            // nodes (`bevy_ui_render-0.19.0/src/lib.rs:997`) —
             // explaining why the inline preedit was invisible.
             //
             // Side effect of running before `Layout`: the anchor's
@@ -73,10 +73,12 @@ impl Plugin for ImeOverlayPlugin {
                         .run_if(ime_is_composing)
                         .before(UiSystems::Content),
                     hide_ime_overlay
-                        .run_if(resource_exists_and_changed::<ImeState>.and(not(ime_is_composing)))
+                        .run_if(
+                            resource_exists_and_changed::<ImeState>.and_then(not(ime_is_composing)),
+                        )
                         .before(UiSystems::Content),
                     suppress_terminal_cursor_during_ime
-                        .run_if(resource_exists_and_changed::<ImeState>.or(ime_is_composing))
+                        .run_if(resource_exists_and_changed::<ImeState>.or_else(ime_is_composing))
                         .before(TerminalMaterialSystems::UpdateMaterial),
                 ),
             );
@@ -130,7 +132,7 @@ const INITIAL_POOL_CAP: usize = 16;
 
 /// Run condition: true while an IME preedit composition is active. Takes
 /// `Option<Res<ImeState>>` so it returns `false` rather than panicking when
-/// `ImeState` is absent, keeping the `.or()` / `.and()` gates safe.
+/// `ImeState` is absent, keeping the `.or_else()` / `.and_then()` gates safe.
 fn ime_is_composing(state: Option<Res<ImeState>>) -> bool {
     state.is_some_and(|state| state.is_composing())
 }
@@ -462,14 +464,14 @@ const IME_OVERLAY_BG_Z: i32 = IME_OVERLAY_Z - 1;
 ///
 /// NOTE: `Text` root and caret bar are spawned as INDEPENDENT
 /// top-level UI entities (no `ChildOf` between them). Required by
-/// Bevy 0.18 + Taffy 0.9.2: `NodeMeasure::Text` is only consulted by
+/// Bevy 0.19 + Taffy 0.10.1: `NodeMeasure::Text` is only consulted by
 /// `compute_leaf_layout`, dispatched at `(_, has_children == false)`
-/// in `taffy-0.9.2/src/tree/taffy_tree.rs:364-394`. Adding any UI
+/// in `taffy-0.10.1/src/tree/taffy_tree.rs:304-330`. Adding any UI
 /// child (even an absolute-positioned one that contributes 0 to flex
 /// container size) puts the Text node on the `compute_flexbox_layout`
 /// branch, which ignores the measure function — `ComputedNode.size`
 /// becomes (0, 0), `bevy_ui_render` then skips text + underline at
-/// `uinode.is_empty()` (`bevy_ui_render-0.18.1/src/lib.rs:939, 1197`),
+/// `uinode.is_empty()` (`bevy_ui_render-0.19.0/src/lib.rs:997, 1308`),
 /// while the child caret bar still renders because its own
 /// `ComputedNode` is non-empty (explicit width/height). Both
 /// entities are positioned in window-absolute coords each frame in
@@ -477,8 +479,8 @@ const IME_OVERLAY_BG_Z: i32 = IME_OVERLAY_Z - 1;
 ///
 /// `LineBreak::NoWrap` is set as defense-in-depth: with it,
 /// `measure_text_system` uses `FixedMeasure { size: measure.max }`
-/// (`bevy_ui-0.18.1/src/widget/text.rs:292-295`) and `text_system`
-/// uses `TextBounds::UNBOUNDED` (`:351-353`) — bypassing any residual
+/// (`bevy_ui-0.19.0/src/widget/text.rs:301-302`) and `text_system`
+/// uses `TextBounds::UNBOUNDED` (`:363-365`) — bypassing any residual
 /// zero-bound shaping. Single-line preedit text never needs wrapping
 /// anyway.
 ///
@@ -648,8 +650,8 @@ fn spawn_grapheme_cell(
         .spawn((
             Text::new(text),
             TextFont {
-                font: ui_font.0.clone(),
-                font_size: font_size.0,
+                font: ui_font.0.clone().into(),
+                font_size: FontSize::Px(font_size.0),
                 ..default()
             },
             TextColor(Color::WHITE),
@@ -807,7 +809,7 @@ mod tests {
         let mut query = app.world_mut().query::<&TextFont>();
         let matched = query
             .iter(app.world())
-            .any(|tf| (tf.font_size - 9.0).abs() < f32::EPSILON);
+            .any(|tf| tf.font_size == FontSize::Px(9.0));
         assert!(
             matched,
             "IME overlay TextFont must use TerminalFontSize (9.0), not the constant"
@@ -1181,8 +1183,9 @@ mod tests {
             PostUpdate,
             (
                 position_ime_overlay.run_if(ime_is_composing),
-                hide_ime_overlay
-                    .run_if(resource_exists_and_changed::<ImeState>.and(not(ime_is_composing))),
+                hide_ime_overlay.run_if(
+                    resource_exists_and_changed::<ImeState>.and_then(not(ime_is_composing)),
+                ),
             ),
         );
         app.world_mut().spawn((

--- a/src/ui/tmux/confirm_prompt.rs
+++ b/src/ui/tmux/confirm_prompt.rs
@@ -97,8 +97,8 @@ fn spawn_confirm_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font,
-                    font_size: theme::UI_FONT_SIZE,
+                    font: font.into(),
+                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },
                 TextColor(theme::SELECTION_FG),

--- a/src/ui/tmux/mode_ui.rs
+++ b/src/ui/tmux/mode_ui.rs
@@ -27,7 +27,7 @@ impl Plugin for TmuxModeUiPlugin {
         app.add_systems(
             Update,
             ensure_tmux_mode_ui
-                .run_if(in_state(AppMode::Tmux).and(not(any_with_component::<TmuxModeUi>))),
+                .run_if(in_state(AppMode::Tmux).and_then(not(any_with_component::<TmuxModeUi>))),
         );
     }
 }

--- a/src/ui/tmux/rename_prompt.rs
+++ b/src/ui/tmux/rename_prompt.rs
@@ -161,8 +161,8 @@ fn spawn_rename_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font,
-                    font_size: theme::UI_FONT_SIZE,
+                    font: font.into(),
+                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },
                 TextColor(theme::SELECTION_FG),

--- a/src/ui/tmux/window_bar.rs
+++ b/src/ui/tmux/window_bar.rs
@@ -211,8 +211,8 @@ fn build_session_block(
         Text::new(session_name.to_string()),
         TextColor(palette::FOREGROUND),
         TextFont {
-            font: font.clone(),
-            font_size: theme::UI_FONT_SIZE,
+            font: font.clone().into(),
+            font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
         ChildOf(block),
@@ -221,8 +221,8 @@ fn build_session_block(
         Text::new(theme::POWERLINE_RIGHT.to_string()),
         TextColor(palette::SESSION_BG),
         TextFont {
-            font: pl_font.clone(),
-            font_size: theme::UI_FONT_SIZE,
+            font: pl_font.clone().into(),
+            font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
         ChildOf(bar),
@@ -318,8 +318,8 @@ fn build_window_entry(
         Text::new(theme::POWERLINE_RIGHT.to_string()),
         TextColor(chevron_color),
         TextFont {
-            font: pl_font.clone(),
-            font_size: theme::UI_FONT_SIZE,
+            font: pl_font.clone().into(),
+            font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
         ChildOf(entry),
@@ -341,8 +341,8 @@ fn spawn_entry_label(
         Text::new(label.to_string()),
         TextColor(label_color),
         TextFont {
-            font: font.clone(),
-            font_size: theme::UI_FONT_SIZE,
+            font: font.clone().into(),
+            font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
         ChildOf(parent),
@@ -352,8 +352,8 @@ fn spawn_entry_label(
             Text::new(suffix.to_string()),
             TextColor(flag_color),
             TextFont {
-                font: font.clone(),
-                font_size: theme::UI_FONT_SIZE,
+                font: font.clone().into(),
+                font_size: FontSize::Px(theme::UI_FONT_SIZE),
                 ..default()
             },
             ChildOf(parent),

--- a/src/ui/vi_mode_indicator.rs
+++ b/src/ui/vi_mode_indicator.rs
@@ -70,8 +70,12 @@ fn attach_indicator_to_surface_host(
                 IndicatorCache::default(),
                 Text::new(""),
                 TextFont {
-                    font: ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default(),
-                    font_size: theme::VI_MODE_INDICATOR_FONT_SIZE_PX,
+                    font: ui_font
+                        .as_deref()
+                        .map(|f| f.0.clone())
+                        .unwrap_or_default()
+                        .into(),
+                    font_size: FontSize::Px(theme::VI_MODE_INDICATOR_FONT_SIZE_PX),
                     ..default()
                 },
                 BackgroundColor(palette::VI_MODE_INDICATOR_BG),

--- a/src/ui/vi_search.rs
+++ b/src/ui/vi_search.rs
@@ -131,8 +131,8 @@ fn spawn_prompt_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font,
-                    font_size: theme::UI_FONT_SIZE,
+                    font: font.into(),
+                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },
                 TextColor(theme::FOREGROUND),


### PR DESCRIPTION
## Problem

<!-- What problem does this PR solve? Link related issues: Closes #123 -->
The version of Bevy we currently depend on is v0.18, which means we can’t use the latest APIs.
Since v0.19 includes additional APIs that are useful for this app such as clipboard support, text input, and font-family configuration, we will enable them.

## Solution

<!-- What did you change and why this approach?
     Mention which parts of the codebase are affected (engine, packages, mods, docs).
     For UI changes, include screenshots: <details><summary>Screenshots</summary>paste here</details>
     If this is a breaking change, add a ### Breaking Changes subsection below. -->

<!-- Release notes are grouped by PR LABEL, not by title or body. Add a label
     (breaking-change / enhancement / performance / bug / documentation /
     dependencies) so this PR lands in the right section, or `skip-changelog`
     to omit it. A "### Breaking Changes" body subsection does not route the PR
     on its own — apply the `breaking-change` label too. -->
This PR performs only the minimal version update, without replacing the API.
Migrations for each feature will be carried out later.
