### PR TITLE
Replace hand-rolled prompt text input with Bevy EditableText (#256)

### DIFF
--- a/src/action/tmux/rename_session.rs
+++ b/src/action/tmux/rename_session.rs
@@ -2,9 +2,8 @@
 //! target session's current name.
 
 use crate::font::TerminalUiFont;
-use crate::theme;
-use crate::ui::text_prompt::{ActiveTextPrompt, TextPromptSpec, spawn_text_prompt};
-use crate::ui::tmux::rename_prompt::{RenameIntent, RenameSubject};
+use crate::ui::text_prompt::ActiveTextPrompt;
+use crate::ui::tmux::rename_prompt::{RenameSubject, open_rename_prompt};
 use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
 use orzma_tmux::TmuxSession;
@@ -37,32 +36,22 @@ fn on_rename_session(
     let Ok(session) = sessions.get(ev.entity) else {
         return;
     };
-    let subject = RenameSubject::Session {
-        id: session.id,
-        current_name: session.name.clone(),
-    };
     let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
-    let editable = spawn_text_prompt(
+    open_rename_prompt(
         &mut commands,
         &mut input_focus,
         &mut active,
         font,
-        TextPromptSpec {
-            label: subject.label().to_string(),
-            initial: subject.current_name().to_string(),
-            submit_on_first_char: false,
-            select_all: true,
-            bg: theme::SELECTION,
-            fg: theme::SELECTION_FG,
-        },
+        RenameSubject::Session { id: session.id },
+        session.name.clone(),
     );
-    commands.entity(editable).insert(RenameIntent(subject));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ui::text_prompt::TextPrompt;
+    use crate::ui::tmux::rename_prompt::RenameIntent;
     use tmux_control_parser::SessionId;
 
     #[test]

--- a/src/action/tmux/rename_session.rs
+++ b/src/action/tmux/rename_session.rs
@@ -1,7 +1,11 @@
 //! `RenameSessionRequest` — opens the orzma rename prompt pre-filled with the
 //! target session's current name.
 
-use crate::ui::tmux::rename_prompt::{RenamePrompt, RenameSubject};
+use crate::font::TerminalUiFont;
+use crate::theme;
+use crate::ui::text_prompt::{ActiveTextPrompt, TextPromptSpec, spawn_text_prompt};
+use crate::ui::tmux::rename_prompt::{RenameIntent, RenameSubject};
+use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
 use orzma_tmux::TmuxSession;
 
@@ -25,26 +29,48 @@ impl Plugin for RenameSessionPlugin {
 fn on_rename_session(
     ev: On<RenameSessionRequest>,
     mut commands: Commands,
+    mut input_focus: ResMut<InputFocus>,
+    mut active: ResMut<ActiveTextPrompt>,
     sessions: Query<&TmuxSession>,
+    ui_font: Option<Res<TerminalUiFont>>,
 ) {
     let Ok(session) = sessions.get(ev.entity) else {
         return;
     };
-    commands.insert_resource(RenamePrompt::new(RenameSubject::Session {
+    let subject = RenameSubject::Session {
         id: session.id,
         current_name: session.name.clone(),
-    }));
+    };
+    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let editable = spawn_text_prompt(
+        &mut commands,
+        &mut input_focus,
+        &mut active,
+        font,
+        TextPromptSpec {
+            label: subject.label().to_string(),
+            initial: subject.current_name().to_string(),
+            submit_on_first_char: false,
+            select_all: true,
+            bg: theme::SELECTION,
+            fg: theme::SELECTION_FG,
+        },
+    );
+    commands.entity(editable).insert(RenameIntent(subject));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::text_prompt::TextPrompt;
     use tmux_control_parser::SessionId;
 
     #[test]
     fn rename_session_opens_prompt() {
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<InputFocus>()
+            .init_resource::<ActiveTextPrompt>();
         app.add_observer(on_rename_session);
         let target = app
             .world_mut()
@@ -56,6 +82,12 @@ mod tests {
         app.world_mut()
             .trigger(RenameSessionRequest { entity: target });
         app.update();
-        assert!(app.world().contains_resource::<RenamePrompt>());
+        assert!(
+            app.world().resource::<ActiveTextPrompt>().0.is_some(),
+            "opening a rename prompt must set ActiveTextPrompt"
+        );
+        let editable = app.world().resource::<ActiveTextPrompt>().0.unwrap();
+        assert!(app.world().get::<RenameIntent>(editable).is_some());
+        assert!(app.world().get::<TextPrompt>(editable).is_some());
     }
 }

--- a/src/action/tmux/rename_window.rs
+++ b/src/action/tmux/rename_window.rs
@@ -2,9 +2,8 @@
 //! target window's current name.
 
 use crate::font::TerminalUiFont;
-use crate::theme;
-use crate::ui::text_prompt::{ActiveTextPrompt, TextPromptSpec, spawn_text_prompt};
-use crate::ui::tmux::rename_prompt::{RenameIntent, RenameSubject};
+use crate::ui::text_prompt::ActiveTextPrompt;
+use crate::ui::tmux::rename_prompt::{RenameSubject, open_rename_prompt};
 use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
 use orzma_tmux::TmuxWindow;
@@ -37,32 +36,22 @@ fn on_rename_window(
     let Ok(window) = windows.get(ev.entity) else {
         return;
     };
-    let subject = RenameSubject::Window {
-        id: window.id,
-        current_name: window.name.clone(),
-    };
     let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
-    let editable = spawn_text_prompt(
+    open_rename_prompt(
         &mut commands,
         &mut input_focus,
         &mut active,
         font,
-        TextPromptSpec {
-            label: subject.label().to_string(),
-            initial: subject.current_name().to_string(),
-            submit_on_first_char: false,
-            select_all: true,
-            bg: theme::SELECTION,
-            fg: theme::SELECTION_FG,
-        },
+        RenameSubject::Window { id: window.id },
+        window.name.clone(),
     );
-    commands.entity(editable).insert(RenameIntent(subject));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ui::text_prompt::TextPrompt;
+    use crate::ui::tmux::rename_prompt::RenameIntent;
     use tmux_control_parser::WindowId;
 
     #[test]

--- a/src/action/tmux/rename_window.rs
+++ b/src/action/tmux/rename_window.rs
@@ -1,7 +1,11 @@
 //! `RenameWindowRequest` — opens the orzma rename prompt pre-filled with the
 //! target window's current name.
 
-use crate::ui::tmux::rename_prompt::{RenamePrompt, RenameSubject};
+use crate::font::TerminalUiFont;
+use crate::theme;
+use crate::ui::text_prompt::{ActiveTextPrompt, TextPromptSpec, spawn_text_prompt};
+use crate::ui::tmux::rename_prompt::{RenameIntent, RenameSubject};
+use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
 use orzma_tmux::TmuxWindow;
 
@@ -25,26 +29,48 @@ impl Plugin for RenameWindowPlugin {
 fn on_rename_window(
     ev: On<RenameWindowRequest>,
     mut commands: Commands,
+    mut input_focus: ResMut<InputFocus>,
+    mut active: ResMut<ActiveTextPrompt>,
     windows: Query<&TmuxWindow>,
+    ui_font: Option<Res<TerminalUiFont>>,
 ) {
     let Ok(window) = windows.get(ev.entity) else {
         return;
     };
-    commands.insert_resource(RenamePrompt::new(RenameSubject::Window {
+    let subject = RenameSubject::Window {
         id: window.id,
         current_name: window.name.clone(),
-    }));
+    };
+    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let editable = spawn_text_prompt(
+        &mut commands,
+        &mut input_focus,
+        &mut active,
+        font,
+        TextPromptSpec {
+            label: subject.label().to_string(),
+            initial: subject.current_name().to_string(),
+            submit_on_first_char: false,
+            select_all: true,
+            bg: theme::SELECTION,
+            fg: theme::SELECTION_FG,
+        },
+    );
+    commands.entity(editable).insert(RenameIntent(subject));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::text_prompt::TextPrompt;
     use tmux_control_parser::WindowId;
 
     #[test]
     fn rename_window_opens_prompt() {
         let mut app = App::new();
-        app.add_plugins(MinimalPlugins);
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<InputFocus>()
+            .init_resource::<ActiveTextPrompt>();
         app.add_observer(on_rename_window);
         let target = app
             .world_mut()
@@ -57,6 +83,12 @@ mod tests {
         app.world_mut()
             .trigger(RenameWindowRequest { entity: target });
         app.update();
-        assert!(app.world().contains_resource::<RenamePrompt>());
+        let editable = app
+            .world()
+            .resource::<ActiveTextPrompt>()
+            .0
+            .expect("prompt opened");
+        assert!(app.world().get::<RenameIntent>(editable).is_some());
+        assert!(app.world().get::<TextPrompt>(editable).is_some());
     }
 }

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -186,6 +186,10 @@ fn no_text_prompt_focused(active_text_prompt: Res<ActiveTextPrompt>) -> bool {
 /// the active pane, the anchor instead comes from that child's overlay
 /// rect origin (`webview_ime_position`), since inline entities carry no UI
 /// node for `webview_anchors` to read (spec §7).
+///
+/// Gated off (`run_if(no_text_prompt_focused)`) while a text prompt owns
+/// focus, so the widget's IME systems own `ime_enabled`/`ime_position` for
+/// the prompt.
 fn ime_policy_system(
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
     focused: Query<Entity, With<KeyboardFocused>>,
@@ -904,6 +908,7 @@ mod tests {
 
     #[test]
     fn ime_commit_suppressed_to_terminal_while_text_prompt_focused() {
+        use bevy::ecs::message::Messages;
         use bevy::prelude::On;
 
         #[derive(Resource, Default)]
@@ -913,18 +918,34 @@ mod tests {
         app.init_resource::<Hits>();
         app.add_observer(|_ev: On<ImeCommit>, mut hits: ResMut<Hits>| hits.0 += 1);
 
-        // A text prompt owns focus.
+        // A text prompt owns focus for the whole suppressed phase.
         let prompt = app.world_mut().spawn_empty().id();
         app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(prompt);
 
+        // A preedit while suppressed: apply_event must STILL run (drain), so the
+        // composition is set. If read_ime_events were skipped, this would stay None.
         app.world_mut()
-            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .resource_mut::<Messages<Ime>>()
+            .write(Ime::Preedit {
+                window: Entity::PLACEHOLDER,
+                value: "あ".into(),
+                cursor: Some((3, 3)),
+            });
+        app.update();
+        assert!(
+            app.world().resource::<ImeState>().is_composing(),
+            "preedit must set composition even while suppressed — proves apply_event ran (drain, not skip)"
+        );
+
+        // A commit while suppressed: no terminal ImeCommit, and the composition is
+        // cleared (apply_event consumed it) rather than left buffered.
+        app.world_mut()
+            .resource_mut::<Messages<Ime>>()
             .write(Ime::Commit {
                 window: Entity::PLACEHOLDER,
                 value: "あ".into(),
             });
         app.update();
-
         assert_eq!(
             app.world().resource::<Hits>().0,
             0,
@@ -932,7 +953,16 @@ mod tests {
         );
         assert!(
             !app.world().resource::<ImeState>().is_composing(),
-            "read_ime_events must still drain and run apply_event so ImeState stays consistent"
+            "the commit must be drained/applied (composition cleared), not left buffered"
+        );
+
+        // Close the prompt: the already-drained commit must NOT replay to the terminal.
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = None;
+        app.update();
+        assert_eq!(
+            app.world().resource::<Hits>().0,
+            0,
+            "a drained commit must not replay to the terminal after the prompt closes"
         );
     }
 

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -8,6 +8,7 @@
 
 use crate::input::InputPhase;
 use crate::input::focus::KeyboardFocused;
+use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::entity::Entity;
@@ -49,7 +50,10 @@ impl Plugin for ImePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ImeState>().add_systems(
             Update,
-            (ime_policy_system, read_ime_events)
+            (
+                ime_policy_system.run_if(no_text_prompt_focused),
+                read_ime_events,
+            )
                 .chain()
                 .in_set(InputPhase::Dispatch),
         );
@@ -160,6 +164,11 @@ pub(crate) fn resolve_focused_surface(
     focused: &Query<Entity, With<KeyboardFocused>>,
 ) -> Option<Entity> {
     focused.single().ok()
+}
+
+/// True when no text prompt owns focus — the terminal IME policy should run.
+fn no_text_prompt_focused(active_text_prompt: Res<ActiveTextPrompt>) -> bool {
+    active_text_prompt.0.is_none()
 }
 
 /// Derives whether IME should be on this tick and writes
@@ -296,9 +305,9 @@ fn ime_policy_system(
 
 /// Drains `Ime` events, updates `ImeState`, and on `Ime::Commit` triggers
 /// `ImeCommit` to the keyboard-focused surface. The commit is suppressed (the
-/// state machine still runs, so `ImeState` stays consistent) when EITHER any
-/// webview owns keyboard focus OR the focused surface is in vi mode. The
-/// commit transport is applied by per-backend observers
+/// state machine still runs, so `ImeState` stays consistent) when a webview
+/// or a text prompt owns keyboard focus, or the focused surface is in vi
+/// mode. The commit transport is applied by per-backend observers
 /// (`src/input/tmux/forward.rs`, `src/input/default_mode.rs`).
 fn read_ime_events(
     mut commands: Commands,
@@ -306,6 +315,7 @@ fn read_ime_events(
     mut state: ResMut<ImeState>,
     focused: Query<Entity, With<KeyboardFocused>>,
     focused_webview: Res<FocusedWebview>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     vi_modes: Query<(), With<ViModeState>>,
 ) {
     let surface = resolve_focused_surface(&focused);
@@ -318,8 +328,11 @@ fn read_ime_events(
         // bevy_cef, and `sync_focused_webview` deliberately keeps focus on an
         // inline webview even when its pane is no longer the active surface — a
         // surface-relative check would miss it and inject the commit into the
-        // newly-active pane's shell.
-        if focused_webview.0.is_some() {
+        // newly-active pane's shell. A focused text prompt is suppressed the same
+        // way: the EditableText widget consumes the winit `Ime` events itself, so
+        // `apply_event` still ran above (ImeState stays consistent, the reader is
+        // drained) but the commit must not replay into the terminal.
+        if focused_webview.0.is_some() || active_text_prompt.0.is_some() {
             continue;
         }
         if commit_text.is_empty() {
@@ -570,6 +583,7 @@ mod tests {
             .add_systems(Update, read_ime_events);
         app.init_resource::<ImeState>();
         app.init_resource::<FocusedWebview>();
+        app.init_resource::<ActiveTextPrompt>();
         app.add_message::<Ime>();
 
         let pane_entity = app
@@ -889,6 +903,40 @@ mod tests {
     }
 
     #[test]
+    fn ime_commit_suppressed_to_terminal_while_text_prompt_focused() {
+        use bevy::prelude::On;
+
+        #[derive(Resource, Default)]
+        struct Hits(usize);
+
+        let (mut app, _pane) = build_app_with_active_pane();
+        app.init_resource::<Hits>();
+        app.add_observer(|_ev: On<ImeCommit>, mut hits: ResMut<Hits>| hits.0 += 1);
+
+        // A text prompt owns focus.
+        let prompt = app.world_mut().spawn_empty().id();
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(prompt);
+
+        app.world_mut()
+            .resource_mut::<bevy::ecs::message::Messages<Ime>>()
+            .write(Ime::Commit {
+                window: Entity::PLACEHOLDER,
+                value: "あ".into(),
+            });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Hits>().0,
+            0,
+            "IME commit must not route to the terminal while a text prompt is focused"
+        );
+        assert!(
+            !app.world().resource::<ImeState>().is_composing(),
+            "read_ime_events must still drain and run apply_event so ImeState stays consistent"
+        );
+    }
+
+    #[test]
     fn ime_commit_triggers_imecommit_for_focused_surface() {
         use bevy::prelude::On;
 
@@ -900,6 +948,7 @@ mod tests {
             .add_systems(Update, read_ime_events);
         app.init_resource::<ImeState>();
         app.init_resource::<FocusedWebview>();
+        app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<Hits>();
         app.add_message::<Ime>();
         app.add_observer(|ev: On<ImeCommit>, mut hits: ResMut<Hits>| {

--- a/src/input/keyboard/handler.rs
+++ b/src/input/keyboard/handler.rs
@@ -97,7 +97,7 @@ fn resolve_key_effects(
 ) {
     let mode = guards.app_mode.get().clone();
     let focused_window = windows.single().map(|w| w.focused).unwrap_or(false);
-    // NOTE: the prompt guards (confirm-before, rename) are
+    // NOTE: the prompt guards (vi prompt, confirm-before, rename) are
     // tmux-only by design. Those resources are set by tmux actions and cleared
     // only by their own handlers — never on a mode transition — so a prompt left
     // open when the tmux connection drops (falling back to Default) would

--- a/src/input/keyboard/handler.rs
+++ b/src/input/keyboard/handler.rs
@@ -23,7 +23,6 @@ use crate::input::shortcuts::{
 use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::tmux::confirm_prompt::ConfirmState;
 use crate::ui::vi_mode::ViModeState;
-use crate::ui::vi_search::ViModePrompt;
 use bevy::ecs::system::SystemParam;
 use bevy::input::keyboard::{KeyCode, KeyboardInput};
 use bevy::prelude::*;
@@ -54,7 +53,6 @@ impl Plugin for KeyboardHandlerPlugin {
 /// guards.
 #[derive(SystemParam)]
 struct ModalGuards<'w> {
-    vi_mode_prompt: Res<'w, ViModePrompt>,
     confirm_state: Option<Res<'w, ConfirmState>>,
     active_text_prompt: Res<'w, ActiveTextPrompt>,
     ime: Res<'w, ImeState>,
@@ -99,7 +97,7 @@ fn resolve_key_effects(
 ) {
     let mode = guards.app_mode.get().clone();
     let focused_window = windows.single().map(|w| w.focused).unwrap_or(false);
-    // NOTE: the prompt guards (vi-mode prompt, confirm-before, rename) are
+    // NOTE: the prompt guards (confirm-before, rename) are
     // tmux-only by design. Those resources are set by tmux actions and cleared
     // only by their own handlers — never on a mode transition — so a prompt left
     // open when the tmux connection drops (falling back to Default) would
@@ -108,9 +106,7 @@ fn resolve_key_effects(
     // frame's keys and write no messages, so no key leaks to the terminal,
     // tmux, or the prefix state machine (and no preedit key is double-sent).
     let prompt_open = mode == AppMode::Tmux
-        && (guards.vi_mode_prompt.open.is_some()
-            || guards.confirm_state.is_some()
-            || guards.active_text_prompt.0.is_some());
+        && (guards.confirm_state.is_some() || guards.active_text_prompt.0.is_some());
     if prompt_open || guards.ime.is_composing() || !focused_window {
         clear_leader_phase(&mut leader_phase);
         if held_repeat.0.is_some() {
@@ -307,7 +303,6 @@ mod tests {
             .init_resource::<LeaderPhase>()
             .init_resource::<HeldRepeatKey>()
             .init_resource::<ResolvedViModeKeys>()
-            .init_resource::<ViModePrompt>()
             .init_resource::<ActiveTextPrompt>()
             .init_resource::<Captured>()
             .insert_resource(shortcuts)

--- a/src/input/keyboard/handler.rs
+++ b/src/input/keyboard/handler.rs
@@ -20,8 +20,8 @@ use crate::input::shortcuts::{
     HeldRepeatKey, LeaderGate, LeaderPhase, ShortcutMessage, ShortcutMessages, ShortcutSet,
     Shortcuts, TypeMessage, ViModeMessage, WebviewForwardMessage, clear_leader_phase,
 };
+use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::tmux::confirm_prompt::ConfirmState;
-use crate::ui::tmux::rename_prompt::RenamePrompt;
 use crate::ui::vi_mode::ViModeState;
 use crate::ui::vi_search::ViModePrompt;
 use bevy::ecs::system::SystemParam;
@@ -56,7 +56,7 @@ impl Plugin for KeyboardHandlerPlugin {
 struct ModalGuards<'w> {
     vi_mode_prompt: Res<'w, ViModePrompt>,
     confirm_state: Option<Res<'w, ConfirmState>>,
-    rename_prompt: Option<Res<'w, RenamePrompt>>,
+    active_text_prompt: Res<'w, ActiveTextPrompt>,
     ime: Res<'w, ImeState>,
     app_mode: Res<'w, State<AppMode>>,
 }
@@ -110,7 +110,7 @@ fn resolve_key_effects(
     let prompt_open = mode == AppMode::Tmux
         && (guards.vi_mode_prompt.open.is_some()
             || guards.confirm_state.is_some()
-            || guards.rename_prompt.is_some());
+            || guards.active_text_prompt.0.is_some());
     if prompt_open || guards.ime.is_composing() || !focused_window {
         clear_leader_phase(&mut leader_phase);
         if held_repeat.0.is_some() {
@@ -308,6 +308,7 @@ mod tests {
             .init_resource::<HeldRepeatKey>()
             .init_resource::<ResolvedViModeKeys>()
             .init_resource::<ViModePrompt>()
+            .init_resource::<ActiveTextPrompt>()
             .init_resource::<Captured>()
             .insert_resource(shortcuts)
             .insert_state(AppMode::Default)

--- a/src/input/mouse/button/tmux.rs
+++ b/src/input/mouse/button/tmux.rs
@@ -29,8 +29,8 @@ use crate::input::mouse::webview::{
 use crate::input::tmux::pane_hit::tmux_pane_at_phys;
 use crate::render::tmux::{DividerPixelRect, PackedTmuxLayout};
 use crate::surface::geometry::{Side as CellSide, cell_at_pane};
+use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
-use crate::ui::vi_search::ViModePrompt;
 use bevy::ecs::system::SystemParam;
 use bevy::input::ButtonState;
 use bevy::input::mouse::{MouseButton, MouseButtonInput};
@@ -91,7 +91,7 @@ impl Plugin for MouseButtonTmuxPlugin {
 /// This system owns the single `MouseButtonInput` reader for the tmux pointer
 /// pipeline and runs EVERY frame within `TmuxActiveSet` (it is NOT gated by
 /// `pointer_active`); it computes the suppressed/active decision in-body. On a
-/// suppressed frame (no focused primary window, or a vi-search prompt owns
+/// suppressed frame (no focused primary window, or a text prompt owns
 /// input) it drains the reader and the buffer, resets the gesture to
 /// `Idle`, and resolves an in-flight inline press: with no window it drops
 /// `WebviewPress` WITHOUT a CEF mouse-up (there is no cursor/scale to place
@@ -120,7 +120,7 @@ fn tmux_webview_pointer(
     mut buttons: MessageReader<MouseButtonInput>,
     panes: Query<(Entity, &TmuxPane, &ComputedNode, &UiGlobalTransform)>,
     metrics: Res<TerminalCellMetricsResource>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     buffer.0.clear();
@@ -131,7 +131,7 @@ fn tmux_webview_pointer(
         return;
     };
     let frame = webview_pointer_frame(window, &metrics);
-    if !window.focused || vi_mode_prompt.open.is_some() {
+    if !window.focused || active_text_prompt.0.is_some() {
         buttons.clear();
         gesture.state = GestureState::Idle;
         release_webview_press(
@@ -182,7 +182,7 @@ fn tmux_webview_pointer(
 /// under the cursor to the child's CEF browser via the shared
 /// `forward_webview_move_at`. `CursorMoved`-driven (one forward per frame, latest
 /// position), so the one system serves both hover and an in-rect drag. Skipped
-/// while a vi-search prompt owns input. `Browsers` is optional so CEF-less
+/// while a text prompt owns input. `Browsers` is optional so CEF-less
 /// tests construct it.
 fn forward_tmux_webview_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
@@ -193,13 +193,13 @@ fn forward_tmux_webview_mouse_moves(
     windows: Query<&Window, With<PrimaryWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     browsers: Option<NonSend<Browsers>>,
 ) {
     let Some(moved) = cursor_msg.read().last() else {
         return;
     };
-    if vi_mode_prompt.open.is_some() {
+    if active_text_prompt.0.is_some() {
         return;
     }
     let Ok(window) = windows.single() else {
@@ -236,7 +236,7 @@ fn forward_tmux_webview_mouse_moves(
 struct TmuxGestureButtons(Vec<MouseButtonInput>);
 
 /// Run condition for the active tmux gesture pipeline: `true` iff a focused
-/// primary window exists AND no modal (vi-search prompt) owns input.
+/// primary window exists AND no modal (text prompt) owns input.
 ///
 /// Gates `tmux_gesture` only (which reads the hand-off buffer, not
 /// `MouseButtonInput`). `tmux_webview_pointer` is NOT gated by this — it owns the
@@ -245,9 +245,9 @@ struct TmuxGestureButtons(Vec<MouseButtonInput>);
 /// suppressor here — the `tmux_webview_pointer` pre-step owns webview focus.
 fn pointer_active(
     windows: Query<&Window, With<PrimaryWindow>>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
 ) -> bool {
-    windows.single().is_ok_and(|window| window.focused) && vi_mode_prompt.open.is_none()
+    windows.single().is_ok_and(|window| window.focused) && active_text_prompt.0.is_none()
 }
 
 /// Bundles the immutable vi-mode query read used by `tmux_gesture`.
@@ -345,7 +345,7 @@ fn engine_side(side: CellSide) -> Side {
 /// as a fallback click.
 ///
 /// Gated by `run_if(pointer_active)`: this system runs only when a focused
-/// primary window exists and no modal (vi-search prompt) owns input.
+/// primary window exists and no modal (text prompt) owns input.
 /// The suppressed path — clearing the buffer, resetting the gesture, and
 /// releasing or dropping an in-flight inline press — is owned by
 /// `tmux_webview_pointer`, which runs every frame upstream of this system.
@@ -638,14 +638,12 @@ mod tests {
     }
 
     fn set_modal_open(app: &mut App, open: bool) {
-        use crate::ui::vi_search::ViModePromptState;
-        use orzma_tmux::{PaneId, PromptKind};
-
-        app.world_mut().resource_mut::<ViModePrompt>().open = open.then(|| ViModePromptState {
-            kind: PromptKind::SearchForward,
-            pane: PaneId(0),
-            text: String::new(),
-        });
+        let target = if open {
+            Some(app.world_mut().spawn_empty().id())
+        } else {
+            None
+        };
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = target;
     }
 
     #[test]
@@ -656,7 +654,7 @@ mod tests {
         app.init_resource::<TmuxMouseGesture>();
         app.init_resource::<TmuxGestureButtons>();
         app.init_resource::<WebviewPress>();
-        app.init_resource::<ViModePrompt>();
+        app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<FocusedWebview>();
         app.insert_resource(test_metrics());
         app.add_systems(
@@ -694,7 +692,7 @@ mod tests {
         app.init_resource::<TmuxMouseGesture>();
         app.init_resource::<TmuxGestureButtons>();
         app.init_resource::<WebviewPress>();
-        app.init_resource::<ViModePrompt>();
+        app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<FocusedWebview>();
         app.insert_resource(test_metrics());
         app.add_systems(

--- a/src/input/mouse/webview/default_mode.rs
+++ b/src/input/mouse/webview/default_mode.rs
@@ -24,7 +24,7 @@ use crate::input::mouse::webview::{
 use crate::surface::OrzmaTerminal;
 use crate::surface::geometry::phys_to_pane_local;
 use crate::surface::geometry::topmost_surface_at;
-use crate::ui::vi_search::ViModePrompt;
+use crate::ui::text_prompt::ActiveTextPrompt;
 use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseWheel};
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, ComputedStackIndex, UiGlobalTransform};
@@ -64,7 +64,7 @@ impl Plugin for MouseWebviewDefaultModePlugin {
 
 /// Forwards left press/release to the inline CEF child under the cursor on the
 /// Default shell. Runs every frame in `AppMode::Default`: a suppressed frame
-/// (window unfocused / vi-search prompt) drains the reader and releases an
+/// (window unfocused / text prompt) drains the reader and releases an
 /// in-flight press so the focused page is not left logically pressed.
 fn default_webview_pointer(
     mut webview_press: ResMut<WebviewPress>,
@@ -80,7 +80,7 @@ fn default_webview_pointer(
         With<OrzmaTerminal>,
     >,
     metrics: Res<TerminalCellMetricsResource>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
     let Ok(window) = windows.single() else {
@@ -89,7 +89,7 @@ fn default_webview_pointer(
         return;
     };
     let frame = webview_pointer_frame(window, &metrics);
-    if !window.focused || vi_mode_prompt.open.is_some() {
+    if !window.focused || active_text_prompt.0.is_some() {
         buttons.clear();
         release_webview_press(
             &mut webview_press,
@@ -133,7 +133,7 @@ fn default_webview_pointer(
 
 /// Forwards pointer motion over an interactive inline rect of the Default shell
 /// to the child's CEF browser via the shared `forward_webview_move_at`. Skipped
-/// while a vi-search prompt owns input.
+/// while a text prompt owns input.
 fn forward_default_webview_mouse_moves(
     mut cursor_msg: MessageReader<CursorMoved>,
     surfaces: Query<
@@ -151,13 +151,13 @@ fn forward_default_webview_mouse_moves(
     windows: Query<&Window, With<PrimaryWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     browsers: Option<NonSend<Browsers>>,
 ) {
     let Some(moved) = cursor_msg.read().last() else {
         return;
     };
-    if vi_mode_prompt.open.is_some() {
+    if active_text_prompt.0.is_some() {
         return;
     }
     let Ok(window) = windows.single() else {
@@ -208,14 +208,14 @@ fn forward_default_webview_wheel(
     overlay_rects: Query<&TerminalOverlays>,
     windows: Query<&Window, With<PrimaryWindow>>,
     metrics: Res<TerminalCellMetricsResource>,
-    vi_mode_prompt: Res<ViModePrompt>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     browsers: Option<NonSend<Browsers>>,
 ) {
     let Ok(window) = windows.single() else {
         wheel.clear();
         return;
     };
-    if !window.focused || vi_mode_prompt.open.is_some() {
+    if !window.focused || active_text_prompt.0.is_some() {
         wheel.clear();
         return;
     }
@@ -284,7 +284,7 @@ mod tests {
         app.add_plugins(MinimalPlugins);
         app.add_message::<MouseButtonInput>();
         app.init_resource::<WebviewPress>();
-        app.init_resource::<ViModePrompt>();
+        app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<FocusedWebview>();
         app.insert_resource(test_metrics());
         app.add_systems(Update, default_webview_pointer);

--- a/src/input/mouse/wheel/tmux.rs
+++ b/src/input/mouse/wheel/tmux.rs
@@ -12,7 +12,7 @@ use crate::configs::OrzmaConfigsResource;
 use crate::input::InputPhase;
 use crate::input::mouse::webview::{webview_wheel_delta, webview_wheel_target};
 use crate::input::tmux::pane_hit::tmux_pane_at_phys;
-use crate::ui::tmux::rename_prompt::RenamePrompt;
+use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
 use crate::ui::vi_search::ViModePrompt;
 use bevy::ecs::system::SystemParam;
@@ -207,7 +207,7 @@ fn forward_wheel_to_tmux(
     mut handles: Query<(&mut TerminalHandle, &mut Coalescer)>,
     wheel_params: TmuxWebviewWheelParams,
     vi_mode_prompt: Res<ViModePrompt>,
-    rename_prompt: Option<Res<RenamePrompt>>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     configs: Res<OrzmaConfigsResource>,
     metrics: Res<TerminalCellMetricsResource>,
     vi_modes: Query<(), With<ViModeState>>,
@@ -245,7 +245,7 @@ fn forward_wheel_to_tmux(
     // can't accumulate behind a modal / unfocused window and lurch on resume.
     // focused_webview is NOT a guard here — the pointer-gated target above owns
     // webview scrolling, so a focused webview must not steal terminal wheel.
-    if !window.focused || vi_mode_prompt.open.is_some() || rename_prompt.is_some() {
+    if !window.focused || vi_mode_prompt.open.is_some() || active_text_prompt.0.is_some() {
         accumulator.residual_cells = 0.0;
         return;
     }
@@ -551,6 +551,7 @@ mod tests {
         app.add_message::<MouseWheel>();
         app.init_resource::<FocusedWebview>();
         app.init_resource::<ViModePrompt>();
+        app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<TmuxWheelAccumulator>();
         app.insert_resource(OrzmaConfigsResource::default());
         app.insert_resource(TerminalCellMetricsResource {

--- a/src/input/mouse/wheel/tmux.rs
+++ b/src/input/mouse/wheel/tmux.rs
@@ -14,7 +14,6 @@ use crate::input::mouse::webview::{webview_wheel_delta, webview_wheel_target};
 use crate::input::tmux::pane_hit::tmux_pane_at_phys;
 use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
-use crate::ui::vi_search::ViModePrompt;
 use bevy::ecs::system::SystemParam;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
@@ -206,7 +205,6 @@ fn forward_wheel_to_tmux(
     mut client: Option<Single<&mut TmuxClient>>,
     mut handles: Query<(&mut TerminalHandle, &mut Coalescer)>,
     wheel_params: TmuxWebviewWheelParams,
-    vi_mode_prompt: Res<ViModePrompt>,
     active_text_prompt: Res<ActiveTextPrompt>,
     configs: Res<OrzmaConfigsResource>,
     metrics: Res<TerminalCellMetricsResource>,
@@ -245,7 +243,7 @@ fn forward_wheel_to_tmux(
     // can't accumulate behind a modal / unfocused window and lurch on resume.
     // focused_webview is NOT a guard here — the pointer-gated target above owns
     // webview scrolling, so a focused webview must not steal terminal wheel.
-    if !window.focused || vi_mode_prompt.open.is_some() || active_text_prompt.0.is_some() {
+    if !window.focused || active_text_prompt.0.is_some() {
         accumulator.residual_cells = 0.0;
         return;
     }
@@ -550,7 +548,6 @@ mod tests {
         app.add_plugins(MinimalPlugins);
         app.add_message::<MouseWheel>();
         app.init_resource::<FocusedWebview>();
-        app.init_resource::<ViModePrompt>();
         app.init_resource::<ActiveTextPrompt>();
         app.init_resource::<TmuxWheelAccumulator>();
         app.insert_resource(OrzmaConfigsResource::default());

--- a/src/input/tmux/gate.rs
+++ b/src/input/tmux/gate.rs
@@ -10,7 +10,7 @@ use crate::input::InputPhase;
 use crate::input::focus::KeyboardDisabled;
 use crate::input::focus::MouseDisabled;
 use crate::input::ime::ImeState;
-use crate::ui::tmux::rename_prompt::RenamePrompt;
+use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
 use crate::ui::vi_search::ViModePrompt;
 use bevy::prelude::*;
@@ -40,7 +40,7 @@ fn maintain_tmux_input_gates(
     mut commands: Commands,
     ime: Res<ImeState>,
     vi_mode_prompt: Res<ViModePrompt>,
-    rename_prompt: Option<Res<RenamePrompt>>,
+    active_text_prompt: Res<ActiveTextPrompt>,
     focused_webview: Res<FocusedWebview>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -64,7 +64,7 @@ fn maintain_tmux_input_gates(
     let modal = ime.is_composing()
         || !window_focused
         || vi_mode_prompt.open.is_some()
-        || rename_prompt.is_some();
+        || active_text_prompt.0.is_some();
     // NOTE: gate only the focused webview's OWNING pane, not all panes — a
     // global `focused_webview.0.is_some()` would kill scroll/selection on every
     // other pane while any webview is focused.

--- a/src/input/tmux/gate.rs
+++ b/src/input/tmux/gate.rs
@@ -12,7 +12,6 @@ use crate::input::focus::MouseDisabled;
 use crate::input::ime::ImeState;
 use crate::ui::text_prompt::ActiveTextPrompt;
 use crate::ui::vi_mode::ViModeState;
-use crate::ui::vi_search::ViModePrompt;
 use bevy::prelude::*;
 use bevy::ui::{ComputedNode, UiGlobalTransform};
 use bevy::window::{PrimaryWindow, Window};
@@ -39,7 +38,6 @@ impl Plugin for GatePlugin {
 fn maintain_tmux_input_gates(
     mut commands: Commands,
     ime: Res<ImeState>,
-    vi_mode_prompt: Res<ViModePrompt>,
     active_text_prompt: Res<ActiveTextPrompt>,
     focused_webview: Res<FocusedWebview>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
@@ -61,10 +59,7 @@ fn maintain_tmux_input_gates(
 ) {
     let window = windows.single().ok();
     let window_focused = window.map(|w| w.focused).unwrap_or(false);
-    let modal = ime.is_composing()
-        || !window_focused
-        || vi_mode_prompt.open.is_some()
-        || active_text_prompt.0.is_some();
+    let modal = ime.is_composing() || !window_focused || active_text_prompt.0.is_some();
     // NOTE: gate only the focused webview's OWNING pane, not all panes — a
     // global `focused_webview.0.is_some()` would kill scroll/selection on every
     // other pane while any webview is focused.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,12 +2,14 @@
 //! (via `OrzmaUiRootPlugin`) that each mode's UI subtree attaches under.
 
 use crate::ui::root::OrzmaUiRootPlugin;
+use crate::ui::text_prompt::TextPromptPlugin;
 use bevy::prelude::*;
 
 pub(crate) mod default_mode;
 pub(crate) mod ime_overlay;
 pub mod palette;
 pub mod root;
+pub(crate) mod text_prompt;
 pub(crate) mod tmux;
 pub mod vi_mode;
 pub mod vi_mode_indicator;
@@ -26,6 +28,7 @@ impl Plugin for OrzmaUiPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
             OrzmaUiRootPlugin,
+            TextPromptPlugin,
             default_mode::DefaultModeUiPlugin,
             tmux::TmuxUiPlugin,
         ));

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -1,0 +1,100 @@
+//! Shared single-line text-input overlay built on Bevy's `EditableText`.
+//!
+//! Both the tmux rename prompt and the vi-search prompt spawn one of these,
+//! set `InputFocus` to the `EditableText` entity, and let `bevy_ui_widgets`'
+//! `EditableTextInputPlugin` drive keyboard, IME, clipboard, and pointer
+//! editing. This module owns keyboard suppression (via `ActiveTextPrompt`),
+//! submit/cancel, and teardown; per-prompt modules observe `TextPromptSubmit`
+//! and run the tmux command.
+
+use bevy::input::keyboard::Key;
+use bevy::prelude::*;
+
+/// Single "a text prompt is open/focused" signal, read by every input gate to
+/// suppress the terminal while a prompt owns the keyboard. Mirrors `InputFocus`
+/// but is app-owned; a self-heal system keeps them in sync.
+#[derive(Resource, Default)]
+pub(crate) struct ActiveTextPrompt(pub(crate) Option<Entity>);
+
+/// Marks the `EditableText` entity of an open prompt. `bar` is the overlay
+/// container despawned on close; `submit_on_first_char` is set for vi jump
+/// prompts, which submit as soon as one character is inserted.
+#[derive(Component)]
+pub(crate) struct TextPrompt {
+    pub(crate) submit_on_first_char: bool,
+    pub(crate) bar: Entity,
+}
+
+/// Emitted (targeted at the prompt's `EditableText` entity) when the user
+/// submits. Per-prompt observers read their intent component off the entity and
+/// run the tmux command with `text`.
+#[derive(EntityEvent, Debug, Clone)]
+pub(crate) struct TextPromptSubmit {
+    #[event_target]
+    pub(crate) entity: Entity,
+    pub(crate) text: String,
+}
+
+/// Registers the shared text-prompt resource, systems, and observers.
+pub(crate) struct TextPromptPlugin;
+
+impl Plugin for TextPromptPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ActiveTextPrompt>();
+    }
+}
+
+/// What one Enter/Escape key press means for an open prompt.
+#[derive(Debug, PartialEq, Eq)]
+enum PromptAction {
+    Submit,
+    Cancel,
+    Continue,
+}
+
+/// Maps a key press to a prompt action. Enter submits (unless the IME is
+/// composing, so a conversion-confirming Enter is not mistaken for submit);
+/// Escape cancels; every other key is left to the widget's own editing.
+fn decide_prompt_key(key: &Key, composing: bool) -> PromptAction {
+    match key {
+        Key::Enter if !composing => PromptAction::Submit,
+        Key::Escape => PromptAction::Cancel,
+        _ => PromptAction::Continue,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn char_key(s: &str) -> Key {
+        Key::Character(s.into())
+    }
+
+    #[test]
+    fn enter_submits_when_not_composing() {
+        assert_eq!(decide_prompt_key(&Key::Enter, false), PromptAction::Submit);
+    }
+
+    #[test]
+    fn enter_is_continue_while_composing() {
+        assert_eq!(decide_prompt_key(&Key::Enter, true), PromptAction::Continue);
+    }
+
+    #[test]
+    fn escape_cancels() {
+        assert_eq!(decide_prompt_key(&Key::Escape, false), PromptAction::Cancel);
+    }
+
+    #[test]
+    fn other_keys_continue() {
+        assert_eq!(
+            decide_prompt_key(&char_key("a"), false),
+            PromptAction::Continue
+        );
+        assert_eq!(
+            decide_prompt_key(&Key::Backspace, false),
+            PromptAction::Continue
+        );
+    }
+}

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -7,11 +7,12 @@
 //! submit/cancel, and teardown; per-prompt modules observe `TextPromptSubmit`
 //! and run the tmux command.
 
+use crate::app_mode::AppMode;
 use crate::theme;
 use bevy::input::keyboard::{Key, KeyboardInput};
 use bevy::input_focus::{FocusCause, FocusedInput, InputFocus};
 use bevy::prelude::*;
-use bevy::text::{EditableText, TextEditChange};
+use bevy::text::{EditableText, EditableTextSystems, TextEditChange};
 use bevy::ui_widgets::SelectAllOnFocus;
 
 const TEXT_PROMPT_Z: i32 = 340;
@@ -58,6 +59,10 @@ pub(crate) struct TextPromptSpec {
 /// `ActiveTextPrompt` at the field, and returns the `EditableText` entity so the
 /// caller can attach a per-prompt intent component. Focus is set with
 /// `FocusCause::Navigated` so a `SelectAllOnFocus` field selects its text.
+///
+/// The bar carries `DespawnOnExit(AppMode::Tmux)`: both callers open the prompt
+/// only in tmux mode, so a prompt still open when the tmux connection drops is
+/// torn down with the mode instead of surviving to freeze Default-mode input.
 pub(crate) fn spawn_text_prompt(
     commands: &mut Commands,
     input_focus: &mut InputFocus,
@@ -79,6 +84,7 @@ pub(crate) fn spawn_text_prompt(
             },
             BackgroundColor(spec.bg),
             GlobalZIndex(TEXT_PROMPT_Z),
+            DespawnOnExit(AppMode::Tmux),
         ))
         .id();
     commands.entity(bar).with_children(|parent| {
@@ -124,7 +130,7 @@ impl Plugin for TextPromptPlugin {
             .add_observer(on_prompt_key)
             .add_observer(on_prompt_edit)
             .add_systems(Update, reconcile_active_text_prompt)
-            .add_systems(PostUpdate, apply_prompt_close);
+            .add_systems(PostUpdate, apply_prompt_close.after(EditableTextSystems));
     }
 }
 
@@ -136,13 +142,20 @@ enum PromptAction {
     Continue,
 }
 
-/// Marks a prompt whose submit/cancel has been decided; `apply_prompt_close`
-/// tears it down in `PostUpdate`. Teardown is deferred (not done in the
-/// `FocusedInput` observer, which runs in `PreUpdate`) so `ActiveTextPrompt`
-/// stays set through the Update-phase input gates on the close frame — otherwise
-/// the terminating Enter/Escape leaks past the drain guard into the focused pane.
+/// Marks a prompt whose submit/cancel has been decided. `apply_prompt_close`
+/// (`PostUpdate`, after `EditableTextSystems`) reads the field's final value and,
+/// when `submit` is set, fires `TextPromptSubmit` — after the same-frame
+/// keystrokes have been applied — then tears the prompt down. Teardown is
+/// deferred (not done in the `FocusedInput` observer, which runs in `PreUpdate`)
+/// so `ActiveTextPrompt` stays set through the Update-phase input gates on the
+/// close frame — otherwise the terminating Enter/Escape leaks past the drain
+/// guard into the focused pane. Because each entity carries exactly one
+/// `PromptClosing` and is processed once, submit fires exactly once even if two
+/// Enter events land in the same frame.
 #[derive(Component)]
-struct PromptClosing;
+struct PromptClosing {
+    submit: bool,
+}
 
 /// Maps a key press to a prompt action. Enter submits (unless the IME is
 /// composing, so a conversion-confirming Enter is not mistaken for submit);
@@ -155,17 +168,28 @@ fn decide_prompt_key(key: &Key, composing: bool) -> PromptAction {
     }
 }
 
-/// Tears down prompts marked `PromptClosing` (despawns the bar, clears focus and
-/// the active signal). Runs in `PostUpdate`, after the Update-phase input gates,
-/// so the closing frame's terminating key is still drained while the prompt was
+/// Applies submit and tears down prompts marked `PromptClosing`: for each closing
+/// entity, fires `TextPromptSubmit` with the post-edit value when `submit` is set,
+/// then despawns the bar and clears focus and the active signal. Runs in
+/// `PostUpdate` after `EditableTextSystems`, so `value()` already reflects the
+/// same-frame keystrokes (no stale read) and, because each entity carries one
+/// `PromptClosing` processed once here, submit fires exactly once (no double
+/// submit from two Enter events). Running after the Update-phase input gates also
+/// keeps the closing frame's terminating key drained while the prompt was
 /// nominally open. Idempotent and tolerant of an already-cleared prompt.
 fn apply_prompt_close(
     mut commands: Commands,
     mut input_focus: ResMut<InputFocus>,
     mut active: ResMut<ActiveTextPrompt>,
-    closing: Query<(Entity, &TextPrompt), With<PromptClosing>>,
+    closing: Query<(Entity, &TextPrompt, &EditableText, &PromptClosing)>,
 ) {
-    for (entity, prompt) in &closing {
+    for (entity, prompt, editable, closing) in &closing {
+        if closing.submit {
+            commands.trigger(TextPromptSubmit {
+                entity,
+                text: editable.value().to_string(),
+            });
+        }
         commands.entity(prompt.bar).despawn();
         if active.0 == Some(entity) {
             active.0 = None;
@@ -176,15 +200,20 @@ fn apply_prompt_close(
     }
 }
 
-/// Decides submit/cancel for a focused `TextPrompt`: emits `TextPromptSubmit`
-/// (with the current value) on Enter, or marks cancel on Escape. Either way the
-/// entity is marked `PromptClosing` for `apply_prompt_close` to tear down in
-/// `PostUpdate`, rather than tearing down synchronously here.
+/// Decides submit/cancel for a focused `TextPrompt` and marks it
+/// `PromptClosing { submit }` — Enter marks `submit: true`, Escape marks
+/// `submit: false`, every other key is left to the widget. It does NOT read the
+/// value or fire `TextPromptSubmit` itself: `apply_prompt_close` (PostUpdate,
+/// after `EditableTextSystems`) reads the post-edit value and fires submit once
+/// per closing entity, which avoids both a stale same-frame value read and a
+/// double submit from two Enter events in one frame. The `Without<PromptClosing>`
+/// filter skips an already-closing entity as belt-and-suspenders. The only
+/// `EditableText` read left is `is_composing()`.
 ///
 /// This is a GLOBAL observer for a bubbling event: `FocusedInput` auto-propagates
 /// editable → bar → window, and the widget does NOT consume `Enter`
 /// (`allow_newlines == false`), so without a guard this observer fires once per
-/// bubble hop — submitting three times for one Enter. `event_target()` is
+/// bubble hop — closing three times for one Enter. `event_target()` is
 /// `focused_entity`, which Bevy mutates in place at each hop, so it always
 /// equals `event_target()`; the `original_event_target()` guard below compares
 /// against the propagation-invariant original target instead, firing exactly
@@ -193,7 +222,7 @@ fn apply_prompt_close(
 fn on_prompt_key(
     key: On<FocusedInput<KeyboardInput>>,
     mut commands: Commands,
-    prompts: Query<(&TextPrompt, &EditableText)>,
+    prompts: Query<(&TextPrompt, &EditableText), Without<PromptClosing>>,
 ) {
     if key.event_target() != key.original_event_target() {
         return;
@@ -207,28 +236,28 @@ fn on_prompt_key(
     match decide_prompt_key(&key.input.logical_key, editable.is_composing()) {
         PromptAction::Continue => {}
         PromptAction::Submit => {
-            let text = editable.value().to_string();
-            commands.trigger(TextPromptSubmit {
-                entity: key.focused_entity,
-                text,
-            });
-            commands.entity(key.focused_entity).insert(PromptClosing);
+            commands
+                .entity(key.focused_entity)
+                .insert(PromptClosing { submit: true });
         }
         PromptAction::Cancel => {
-            commands.entity(key.focused_entity).insert(PromptClosing);
+            commands
+                .entity(key.focused_entity)
+                .insert(PromptClosing { submit: false });
         }
     }
 }
 
-/// Submits a vi jump prompt (`submit_on_first_char`) the moment its value
-/// becomes non-empty. `EditableText::new("")` queues an empty-value edit whose
-/// `TextEditChange` is ignored here; the first inserted char triggers submit.
-/// Marks the entity `PromptClosing` for `apply_prompt_close` rather than tearing
-/// down synchronously.
+/// Marks a vi jump prompt (`submit_on_first_char`) `PromptClosing { submit: true }`
+/// the moment its value becomes non-empty. `EditableText::new("")` queues an
+/// empty-value edit whose `TextEditChange` is ignored here; the first inserted
+/// char marks the prompt. The actual submitted text is re-read by
+/// `apply_prompt_close` (which runs after `EditableTextSystems`, so `value()` is
+/// current); the non-empty check here only decides whether to submit at all.
 fn on_prompt_edit(
     change: On<TextEditChange>,
     mut commands: Commands,
-    prompts: Query<(&TextPrompt, &EditableText)>,
+    prompts: Query<(&TextPrompt, &EditableText), Without<PromptClosing>>,
 ) {
     let entity = change.event_target();
     let Ok((prompt, editable)) = prompts.get(entity) else {
@@ -237,12 +266,12 @@ fn on_prompt_edit(
     if !prompt.submit_on_first_char {
         return;
     }
-    let text = editable.value().to_string();
-    if text.is_empty() {
+    if editable.value() == "" {
         return;
     }
-    commands.trigger(TextPromptSubmit { entity, text });
-    commands.entity(entity).insert(PromptClosing);
+    commands
+        .entity(entity)
+        .insert(PromptClosing { submit: true });
 }
 
 /// Clears `ActiveTextPrompt` when its entity was despawned by something other
@@ -340,7 +369,8 @@ mod tests {
             .init_resource::<ActiveTextPrompt>()
             .init_resource::<SubmitCount>()
             .add_observer(on_prompt_key)
-            .add_observer(count_submits);
+            .add_observer(count_submits)
+            .add_systems(PostUpdate, apply_prompt_close.after(EditableTextSystems));
 
         let window = app
             .world_mut()
@@ -392,6 +422,66 @@ mod tests {
     }
 
     #[test]
+    fn two_enter_events_in_one_frame_submit_exactly_once() {
+        #[derive(Resource, Default)]
+        struct SubmitCount(u32);
+
+        fn count_submits(_submit: On<TextPromptSubmit>, mut count: ResMut<SubmitCount>) {
+            count.0 += 1;
+        }
+
+        let mut app = App::new();
+        app.add_plugins((InputPlugin, InputFocusPlugin, InputDispatchPlugin))
+            .init_resource::<ActiveTextPrompt>()
+            .init_resource::<SubmitCount>()
+            .add_observer(on_prompt_key)
+            .add_observer(count_submits)
+            .add_systems(PostUpdate, apply_prompt_close.after(EditableTextSystems));
+
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        app.update();
+
+        let bar = app.world_mut().spawn_empty().id();
+        let editable = app
+            .world_mut()
+            .spawn((
+                EditableText::new("x"),
+                TextPrompt {
+                    submit_on_first_char: false,
+                    bar,
+                },
+                ChildOf(bar),
+            ))
+            .id();
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(editable, FocusCause::Navigated);
+
+        for _ in 0..2 {
+            app.world_mut().write_message(KeyboardInput {
+                key_code: KeyCode::Enter,
+                logical_key: Key::Enter,
+                state: ButtonState::Pressed,
+                text: None,
+                repeat: false,
+                window,
+            });
+        }
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SubmitCount>().0,
+            1,
+            "two Enter events buffered in one frame (auto-repeat) must submit exactly once: \
+             submit is applied once per PromptClosing entity in PostUpdate, not once per \
+             FocusedInput event in PreUpdate"
+        );
+    }
+
+    #[test]
     fn active_text_prompt_stays_some_through_update_on_close_frame() {
         #[derive(Resource, Default)]
         struct SawActiveDuringUpdate(bool);
@@ -411,7 +501,7 @@ mod tests {
             .init_resource::<SawActiveDuringUpdate>()
             .add_observer(on_prompt_key)
             .add_systems(Update, probe_active_during_update)
-            .add_systems(PostUpdate, apply_prompt_close);
+            .add_systems(PostUpdate, apply_prompt_close.after(EditableTextSystems));
 
         let window = app
             .world_mut()
@@ -458,6 +548,52 @@ mod tests {
         assert!(
             app.world().get_entity(bar).is_err(),
             "PostUpdate teardown must despawn the prompt bar"
+        );
+    }
+
+    #[test]
+    fn open_prompt_despawns_and_active_clears_on_tmux_exit() {
+        use bevy::state::app::StatesPlugin;
+
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin))
+            .init_resource::<ActiveTextPrompt>()
+            .init_resource::<InputFocus>()
+            .add_systems(Update, reconcile_active_text_prompt);
+        app.insert_state(AppMode::Tmux);
+
+        let bar = app
+            .world_mut()
+            .spawn((Node::default(), DespawnOnExit(AppMode::Tmux)))
+            .id();
+        let editable = app
+            .world_mut()
+            .spawn((
+                EditableText::new("x"),
+                TextPrompt {
+                    submit_on_first_char: false,
+                    bar,
+                },
+                ChildOf(bar),
+            ))
+            .id();
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(editable);
+        app.update();
+
+        app.world_mut()
+            .resource_mut::<NextState<AppMode>>()
+            .set(AppMode::Default);
+        app.update();
+        app.update();
+
+        assert!(
+            app.world().get_entity(bar).is_err(),
+            "leaving Tmux mode must despawn the DespawnOnExit-scoped prompt bar"
+        );
+        assert!(
+            app.world().resource::<ActiveTextPrompt>().0.is_none(),
+            "reconcile must clear ActiveTextPrompt after the tmux-scoped prompt despawns, \
+             else Default-mode mouse/IME gates keep suppressing input (frozen keyboard)"
         );
     }
 }

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -165,10 +165,12 @@ fn close_prompt(
 /// This is a GLOBAL observer for a bubbling event: `FocusedInput` auto-propagates
 /// editable → bar → window, and the widget does NOT consume `Enter`
 /// (`allow_newlines == false`), so without a guard this observer fires once per
-/// bubble hop — submitting three times for one Enter. The
-/// `event_target() != focused_entity` guard fires it exactly once, at the
-/// editable's own hop. (`propagate(false)` alone is unreliable: observer order
-/// lets the widget re-set propagation.)
+/// bubble hop — submitting three times for one Enter. `event_target()` is
+/// `focused_entity`, which Bevy mutates in place at each hop, so it always
+/// equals `event_target()`; the `original_event_target()` guard below compares
+/// against the propagation-invariant original target instead, firing exactly
+/// once, at the editable's own hop. (`propagate(false)` alone is unreliable:
+/// observer order lets the widget re-set propagation.)
 fn on_prompt_key(
     key: On<FocusedInput<KeyboardInput>>,
     mut commands: Commands,
@@ -176,9 +178,8 @@ fn on_prompt_key(
     mut active: ResMut<ActiveTextPrompt>,
     prompts: Query<(&TextPrompt, &EditableText)>,
 ) {
-    // NOTE: without this guard the observer fires once per bubble hop
-    // (editable → bar → window), submitting three times for one Enter.
-    if key.event_target() != key.focused_entity {
+    // Fire only at the original target (the editable), not each bubble ancestor.
+    if key.event_target() != key.original_event_target() {
         return;
     }
     if !key.input.state.is_pressed() {
@@ -246,6 +247,10 @@ fn reconcile_active_text_prompt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::input::keyboard::KeyCode;
+    use bevy::input::{ButtonState, InputPlugin};
+    use bevy::input_focus::{InputDispatchPlugin, InputFocusPlugin};
+    use bevy::window::{PrimaryWindow, Window};
 
     fn char_key(s: &str) -> Key {
         Key::Character(s.into())
@@ -286,7 +291,6 @@ mod tests {
             .init_resource::<InputFocus>()
             .add_systems(Update, reconcile_active_text_prompt);
 
-        // A prompt entity carrying TextPrompt, pointed to by ActiveTextPrompt.
         let bar = app.world_mut().spawn_empty().id();
         let editable = app
             .world_mut()
@@ -297,13 +301,77 @@ mod tests {
             .id();
         app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(editable);
 
-        // External teardown despawns the prompt entity without going through close_prompt.
         app.world_mut().entity_mut(editable).despawn();
         app.update();
 
         assert!(
             app.world().resource::<ActiveTextPrompt>().0.is_none(),
             "self-heal must clear ActiveTextPrompt when its entity no longer exists, or the keyboard freezes"
+        );
+    }
+
+    #[test]
+    fn on_prompt_key_fires_once_even_when_ancestor_also_matches_query() {
+        #[derive(Resource, Default)]
+        struct SubmitCount(u32);
+
+        fn count_submits(_submit: On<TextPromptSubmit>, mut count: ResMut<SubmitCount>) {
+            count.0 += 1;
+        }
+
+        let mut app = App::new();
+        app.add_plugins((InputPlugin, InputFocusPlugin, InputDispatchPlugin))
+            .init_resource::<ActiveTextPrompt>()
+            .init_resource::<SubmitCount>()
+            .add_observer(on_prompt_key)
+            .add_observer(count_submits);
+
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        app.update();
+
+        let bar = app
+            .world_mut()
+            .spawn((
+                EditableText::new(""),
+                TextPrompt {
+                    submit_on_first_char: false,
+                    bar: Entity::PLACEHOLDER,
+                },
+            ))
+            .id();
+        let editable = app
+            .world_mut()
+            .spawn((
+                EditableText::new("x"),
+                TextPrompt {
+                    submit_on_first_char: false,
+                    bar,
+                },
+                ChildOf(bar),
+            ))
+            .id();
+
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(editable, FocusCause::Navigated);
+        app.world_mut().write_message(KeyboardInput {
+            key_code: KeyCode::Enter,
+            logical_key: Key::Enter,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window,
+        });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<SubmitCount>().0,
+            1,
+            "on_prompt_key must fire exactly once, at the editable's own hop, not at every \
+             bubble ancestor that also matches the (TextPrompt, EditableText) query"
         );
     }
 }

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -27,8 +27,8 @@ pub(crate) struct ActiveTextPrompt(pub(crate) Option<Entity>);
 /// prompts, which submit as soon as one character is inserted.
 #[derive(Component)]
 pub(crate) struct TextPrompt {
-    pub(crate) submit_on_first_char: bool,
-    pub(crate) bar: Entity,
+    submit_on_first_char: bool,
+    bar: Entity,
 }
 
 /// Emitted (targeted at the prompt's `EditableText` entity) when the user
@@ -123,7 +123,8 @@ impl Plugin for TextPromptPlugin {
         app.init_resource::<ActiveTextPrompt>()
             .add_observer(on_prompt_key)
             .add_observer(on_prompt_edit)
-            .add_systems(Update, reconcile_active_text_prompt);
+            .add_systems(Update, reconcile_active_text_prompt)
+            .add_systems(PostUpdate, apply_prompt_close);
     }
 }
 
@@ -134,6 +135,14 @@ enum PromptAction {
     Cancel,
     Continue,
 }
+
+/// Marks a prompt whose submit/cancel has been decided; `apply_prompt_close`
+/// tears it down in `PostUpdate`. Teardown is deferred (not done in the
+/// `FocusedInput` observer, which runs in `PreUpdate`) so `ActiveTextPrompt`
+/// stays set through the Update-phase input gates on the close frame — otherwise
+/// the terminating Enter/Escape leaks past the drain guard into the focused pane.
+#[derive(Component)]
+struct PromptClosing;
 
 /// Maps a key press to a prompt action. Enter submits (unless the IME is
 /// composing, so a conversion-confirming Enter is not mistaken for submit);
@@ -146,21 +155,31 @@ fn decide_prompt_key(key: &Key, composing: bool) -> PromptAction {
     }
 }
 
-/// Tears the prompt down: despawns the overlay bar (and its children), clears
-/// the focus and the active-prompt signal. Idempotent.
-fn close_prompt(
-    commands: &mut Commands,
-    input_focus: &mut InputFocus,
-    active: &mut ActiveTextPrompt,
-    bar: Entity,
+/// Tears down prompts marked `PromptClosing` (despawns the bar, clears focus and
+/// the active signal). Runs in `PostUpdate`, after the Update-phase input gates,
+/// so the closing frame's terminating key is still drained while the prompt was
+/// nominally open. Idempotent and tolerant of an already-cleared prompt.
+fn apply_prompt_close(
+    mut commands: Commands,
+    mut input_focus: ResMut<InputFocus>,
+    mut active: ResMut<ActiveTextPrompt>,
+    closing: Query<(Entity, &TextPrompt), With<PromptClosing>>,
 ) {
-    commands.entity(bar).despawn();
-    input_focus.clear();
-    active.0 = None;
+    for (entity, prompt) in &closing {
+        commands.entity(prompt.bar).despawn();
+        if active.0 == Some(entity) {
+            active.0 = None;
+        }
+        if input_focus.get() == Some(entity) {
+            input_focus.clear();
+        }
+    }
 }
 
-/// Handles Enter/Escape for a focused `TextPrompt`: emits `TextPromptSubmit`
-/// (with the current value) on Enter, or tears the prompt down on Escape.
+/// Decides submit/cancel for a focused `TextPrompt`: emits `TextPromptSubmit`
+/// (with the current value) on Enter, or marks cancel on Escape. Either way the
+/// entity is marked `PromptClosing` for `apply_prompt_close` to tear down in
+/// `PostUpdate`, rather than tearing down synchronously here.
 ///
 /// This is a GLOBAL observer for a bubbling event: `FocusedInput` auto-propagates
 /// editable → bar → window, and the widget does NOT consume `Enter`
@@ -174,18 +193,15 @@ fn close_prompt(
 fn on_prompt_key(
     key: On<FocusedInput<KeyboardInput>>,
     mut commands: Commands,
-    mut input_focus: ResMut<InputFocus>,
-    mut active: ResMut<ActiveTextPrompt>,
     prompts: Query<(&TextPrompt, &EditableText)>,
 ) {
-    // Fire only at the original target (the editable), not each bubble ancestor.
     if key.event_target() != key.original_event_target() {
         return;
     }
     if !key.input.state.is_pressed() {
         return;
     }
-    let Ok((prompt, editable)) = prompts.get(key.focused_entity) else {
+    let Ok((_prompt, editable)) = prompts.get(key.focused_entity) else {
         return;
     };
     match decide_prompt_key(&key.input.logical_key, editable.is_composing()) {
@@ -196,10 +212,10 @@ fn on_prompt_key(
                 entity: key.focused_entity,
                 text,
             });
-            close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+            commands.entity(key.focused_entity).insert(PromptClosing);
         }
         PromptAction::Cancel => {
-            close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+            commands.entity(key.focused_entity).insert(PromptClosing);
         }
     }
 }
@@ -207,11 +223,11 @@ fn on_prompt_key(
 /// Submits a vi jump prompt (`submit_on_first_char`) the moment its value
 /// becomes non-empty. `EditableText::new("")` queues an empty-value edit whose
 /// `TextEditChange` is ignored here; the first inserted char triggers submit.
+/// Marks the entity `PromptClosing` for `apply_prompt_close` rather than tearing
+/// down synchronously.
 fn on_prompt_edit(
     change: On<TextEditChange>,
     mut commands: Commands,
-    mut input_focus: ResMut<InputFocus>,
-    mut active: ResMut<ActiveTextPrompt>,
     prompts: Query<(&TextPrompt, &EditableText)>,
 ) {
     let entity = change.event_target();
@@ -226,11 +242,11 @@ fn on_prompt_edit(
         return;
     }
     commands.trigger(TextPromptSubmit { entity, text });
-    close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+    commands.entity(entity).insert(PromptClosing);
 }
 
 /// Clears `ActiveTextPrompt` when its entity was despawned by something other
-/// than `close_prompt` (e.g. surface teardown). `InputFocus` self-heals on
+/// than `apply_prompt_close` (e.g. surface teardown). `InputFocus` self-heals on
 /// despawn but `ActiveTextPrompt` does not; without this every input gate keeps
 /// draining keys → keyboard freeze.
 fn reconcile_active_text_prompt(
@@ -372,6 +388,76 @@ mod tests {
             1,
             "on_prompt_key must fire exactly once, at the editable's own hop, not at every \
              bubble ancestor that also matches the (TextPrompt, EditableText) query"
+        );
+    }
+
+    #[test]
+    fn active_text_prompt_stays_some_through_update_on_close_frame() {
+        #[derive(Resource, Default)]
+        struct SawActiveDuringUpdate(bool);
+
+        fn probe_active_during_update(
+            mut saw: ResMut<SawActiveDuringUpdate>,
+            active: Res<ActiveTextPrompt>,
+        ) {
+            if active.0.is_some() {
+                saw.0 = true;
+            }
+        }
+
+        let mut app = App::new();
+        app.add_plugins((InputPlugin, InputFocusPlugin, InputDispatchPlugin))
+            .init_resource::<ActiveTextPrompt>()
+            .init_resource::<SawActiveDuringUpdate>()
+            .add_observer(on_prompt_key)
+            .add_systems(Update, probe_active_during_update)
+            .add_systems(PostUpdate, apply_prompt_close);
+
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        app.update();
+
+        let bar = app.world_mut().spawn_empty().id();
+        let editable = app
+            .world_mut()
+            .spawn((
+                EditableText::new("x"),
+                TextPrompt {
+                    submit_on_first_char: false,
+                    bar,
+                },
+                ChildOf(bar),
+            ))
+            .id();
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(editable);
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(editable, FocusCause::Navigated);
+
+        app.world_mut().write_message(KeyboardInput {
+            key_code: KeyCode::Enter,
+            logical_key: Key::Enter,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window,
+        });
+        app.update();
+
+        assert!(
+            app.world().resource::<SawActiveDuringUpdate>().0,
+            "ActiveTextPrompt must remain Some through Update on the close frame so the \
+             terminating key is still drained — else it leaks to the pane"
+        );
+        assert!(
+            app.world().resource::<ActiveTextPrompt>().0.is_none(),
+            "PostUpdate teardown must clear ActiveTextPrompt after the close frame"
+        );
+        assert!(
+            app.world().get_entity(bar).is_err(),
+            "PostUpdate teardown must despawn the prompt bar"
         );
     }
 }

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -100,6 +100,15 @@ pub(crate) fn spawn_text_prompt(
     });
     let mut editable = commands.spawn((
         EditableText::new(&spec.initial),
+        // NOTE: EditableText defaults to `visible_width: None`, whose content-size
+        // measure reports width 0; in the bar's Row layout that collapses the node
+        // to zero width, and `ComputedNode::is_empty()` makes the UI render
+        // extractors skip it entirely — no glyphs or cursor draw. `flex_grow`
+        // fills the bar's remaining width so the field is visible.
+        Node {
+            flex_grow: 1.0,
+            ..default()
+        },
         TextFont {
             font: font.into(),
             font_size: FontSize::Px(theme::UI_FONT_SIZE),
@@ -329,6 +338,89 @@ mod tests {
     }
 
     #[test]
+    fn editable_value_populates_prefill_and_typed_char() {
+        use bevy::asset::AssetPlugin;
+        use bevy::picking::events::{Pointer, Release};
+        use bevy::text::{Font, FontSize, TextFont, TextPlugin};
+        use bevy::ui::UiScale;
+        use bevy::ui_widgets::{EditableTextInputPlugin, SelectAllOnFocus};
+        use bevy::window::Ime;
+
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins,
+            AssetPlugin::default(),
+            InputPlugin,
+            InputFocusPlugin,
+            InputDispatchPlugin,
+            TextPlugin,
+            EditableTextInputPlugin,
+        ))
+        .add_message::<Ime>()
+        .add_message::<Pointer<Release>>()
+        .init_resource::<UiScale>();
+
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        app.update();
+
+        let editable = app
+            .world_mut()
+            .spawn((
+                EditableText::new("nvim"),
+                TextFont {
+                    font: Handle::<Font>::default().into(),
+                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
+                    ..default()
+                },
+                SelectAllOnFocus,
+            ))
+            .id();
+
+        let prefill = app
+            .world()
+            .get::<EditableText>(editable)
+            .unwrap()
+            .value()
+            .to_string();
+        assert_eq!(
+            prefill, "nvim",
+            "EditableText::new must store the prefill in value() synchronously, before any update"
+        );
+
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(editable, FocusCause::Navigated);
+        app.update();
+
+        app.world_mut().write_message(KeyboardInput {
+            key_code: KeyCode::KeyX,
+            logical_key: Key::Character("x".into()),
+            state: ButtonState::Pressed,
+            text: Some("x".into()),
+            repeat: false,
+            window,
+        });
+        app.update();
+        app.update();
+
+        let typed = app
+            .world()
+            .get::<EditableText>(editable)
+            .unwrap()
+            .value()
+            .to_string();
+        assert!(
+            typed.contains('x'),
+            "the widget's on_focused_keyboard_input + apply_text_edits must insert the typed \
+             char into value() (got {typed:?}); if this holds, the empty-display bug is a RENDER \
+             bug (Case A), not a widget-insert bug (Case B)"
+        );
+    }
+
+    #[test]
     fn self_heal_clears_active_when_prompt_entity_despawned() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
@@ -418,6 +510,49 @@ mod tests {
             1,
             "on_prompt_key must fire exactly once, at the editable's own hop, not at every \
              bubble ancestor that also matches the (TextPrompt, EditableText) query"
+        );
+    }
+
+    #[test]
+    fn spawn_text_prompt_gives_the_field_an_explicit_width() {
+        use bevy::ecs::system::RunSystemOnce;
+
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<InputFocus>()
+            .init_resource::<ActiveTextPrompt>();
+        let editable = app
+            .world_mut()
+            .run_system_once(
+                |mut commands: Commands,
+                 mut input_focus: ResMut<InputFocus>,
+                 mut active: ResMut<ActiveTextPrompt>| {
+                    spawn_text_prompt(
+                        &mut commands,
+                        &mut input_focus,
+                        &mut active,
+                        Handle::default(),
+                        TextPromptSpec {
+                            label: "Rename: ".into(),
+                            initial: "nvim".into(),
+                            submit_on_first_char: false,
+                            select_all: true,
+                            bg: Color::BLACK,
+                            fg: Color::WHITE,
+                        },
+                    )
+                },
+            )
+            .unwrap();
+        let node = app
+            .world()
+            .get::<Node>(editable)
+            .expect("the EditableText field must have a Node");
+        assert!(
+            node.flex_grow > 0.0,
+            "the EditableText field needs an explicit width source (flex_grow): EditableText's \
+             visible_width defaults to None, whose measure reports width 0, which collapses the \
+             node and makes the UI render extractors skip it — no glyphs draw (the empty-field bug)"
         );
     }
 

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -7,8 +7,14 @@
 //! submit/cancel, and teardown; per-prompt modules observe `TextPromptSubmit`
 //! and run the tmux command.
 
-use bevy::input::keyboard::Key;
+use crate::theme;
+use bevy::input::keyboard::{Key, KeyboardInput};
+use bevy::input_focus::{FocusCause, FocusedInput, InputFocus};
 use bevy::prelude::*;
+use bevy::text::{EditableText, TextEditChange};
+use bevy::ui_widgets::SelectAllOnFocus;
+
+const TEXT_PROMPT_Z: i32 = 340;
 
 /// Single "a text prompt is open/focused" signal, read by every input gate to
 /// suppress the terminal while a prompt owns the keyboard. Mirrors `InputFocus`
@@ -35,12 +41,89 @@ pub(crate) struct TextPromptSubmit {
     pub(crate) text: String,
 }
 
+/// Describes a prompt to open: leading `label`, pre-filled `initial` text,
+/// whether to submit on the first inserted char (vi jump), whether to
+/// select-all on focus (rename, so the first keystroke replaces the name), and
+/// the bar background / text colors (each prompt keeps its own theme).
+pub(crate) struct TextPromptSpec {
+    pub(crate) label: String,
+    pub(crate) initial: String,
+    pub(crate) submit_on_first_char: bool,
+    pub(crate) select_all: bool,
+    pub(crate) bg: Color,
+    pub(crate) fg: Color,
+}
+
+/// Spawns the overlay bar (label + `EditableText`), points `InputFocus` and
+/// `ActiveTextPrompt` at the field, and returns the `EditableText` entity so the
+/// caller can attach a per-prompt intent component. Focus is set with
+/// `FocusCause::Navigated` so a `SelectAllOnFocus` field selects its text.
+pub(crate) fn spawn_text_prompt(
+    commands: &mut Commands,
+    input_focus: &mut InputFocus,
+    active: &mut ActiveTextPrompt,
+    font: Handle<Font>,
+    spec: TextPromptSpec,
+) -> Entity {
+    let bar = commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                bottom: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Auto,
+                align_items: AlignItems::Center,
+                padding: UiRect::axes(Val::Px(6.0), Val::Px(3.0)),
+                ..default()
+            },
+            BackgroundColor(spec.bg),
+            GlobalZIndex(TEXT_PROMPT_Z),
+        ))
+        .id();
+    commands.entity(bar).with_children(|parent| {
+        parent.spawn((
+            Text::new(spec.label),
+            TextFont {
+                font: font.clone().into(),
+                font_size: FontSize::Px(theme::UI_FONT_SIZE),
+                ..default()
+            },
+            TextColor(spec.fg),
+        ));
+    });
+    let mut editable = commands.spawn((
+        EditableText::new(&spec.initial),
+        TextFont {
+            font: font.into(),
+            font_size: FontSize::Px(theme::UI_FONT_SIZE),
+            ..default()
+        },
+        TextColor(spec.fg),
+        TextPrompt {
+            submit_on_first_char: spec.submit_on_first_char,
+            bar,
+        },
+        ChildOf(bar),
+    ));
+    if spec.select_all {
+        editable.insert(SelectAllOnFocus);
+    }
+    let editable = editable.id();
+    active.0 = Some(editable);
+    input_focus.set(editable, FocusCause::Navigated);
+    editable
+}
+
 /// Registers the shared text-prompt resource, systems, and observers.
 pub(crate) struct TextPromptPlugin;
 
 impl Plugin for TextPromptPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ActiveTextPrompt>();
+        app.init_resource::<ActiveTextPrompt>()
+            .add_observer(on_prompt_key)
+            .add_observer(on_prompt_edit)
+            .add_systems(Update, reconcile_active_text_prompt);
     }
 }
 
@@ -60,6 +143,102 @@ fn decide_prompt_key(key: &Key, composing: bool) -> PromptAction {
         Key::Enter if !composing => PromptAction::Submit,
         Key::Escape => PromptAction::Cancel,
         _ => PromptAction::Continue,
+    }
+}
+
+/// Tears the prompt down: despawns the overlay bar (and its children), clears
+/// the focus and the active-prompt signal. Idempotent.
+fn close_prompt(
+    commands: &mut Commands,
+    input_focus: &mut InputFocus,
+    active: &mut ActiveTextPrompt,
+    bar: Entity,
+) {
+    commands.entity(bar).despawn();
+    input_focus.clear();
+    active.0 = None;
+}
+
+/// Handles Enter/Escape for a focused `TextPrompt`: emits `TextPromptSubmit`
+/// (with the current value) on Enter, or tears the prompt down on Escape.
+///
+/// This is a GLOBAL observer for a bubbling event: `FocusedInput` auto-propagates
+/// editable → bar → window, and the widget does NOT consume `Enter`
+/// (`allow_newlines == false`), so without a guard this observer fires once per
+/// bubble hop — submitting three times for one Enter. The
+/// `event_target() != focused_entity` guard fires it exactly once, at the
+/// editable's own hop. (`propagate(false)` alone is unreliable: observer order
+/// lets the widget re-set propagation.)
+fn on_prompt_key(
+    key: On<FocusedInput<KeyboardInput>>,
+    mut commands: Commands,
+    mut input_focus: ResMut<InputFocus>,
+    mut active: ResMut<ActiveTextPrompt>,
+    prompts: Query<(&TextPrompt, &EditableText)>,
+) {
+    // Fire only at the editable's own hop, not at each bubble ancestor.
+    if key.event_target() != key.focused_entity {
+        return;
+    }
+    if !key.input.state.is_pressed() {
+        return;
+    }
+    let Ok((prompt, editable)) = prompts.get(key.focused_entity) else {
+        return;
+    };
+    match decide_prompt_key(&key.input.logical_key, editable.is_composing()) {
+        PromptAction::Continue => {}
+        PromptAction::Submit => {
+            let text = editable.value().to_string();
+            commands.trigger(TextPromptSubmit {
+                entity: key.focused_entity,
+                text,
+            });
+            close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+        }
+        PromptAction::Cancel => {
+            close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+        }
+    }
+}
+
+/// Submits a vi jump prompt (`submit_on_first_char`) the moment its value
+/// becomes non-empty. `EditableText::new("")` queues an empty-value edit whose
+/// `TextEditChange` is ignored here; the first inserted char triggers submit.
+fn on_prompt_edit(
+    change: On<TextEditChange>,
+    mut commands: Commands,
+    mut input_focus: ResMut<InputFocus>,
+    mut active: ResMut<ActiveTextPrompt>,
+    prompts: Query<(&TextPrompt, &EditableText)>,
+) {
+    let entity = change.event_target();
+    let Ok((prompt, editable)) = prompts.get(entity) else {
+        return;
+    };
+    if !prompt.submit_on_first_char {
+        return;
+    }
+    let text = editable.value().to_string();
+    if text.is_empty() {
+        return;
+    }
+    commands.trigger(TextPromptSubmit { entity, text });
+    close_prompt(&mut commands, &mut input_focus, &mut active, prompt.bar);
+}
+
+/// Clears `ActiveTextPrompt` when its entity was despawned by something other
+/// than `close_prompt` (e.g. surface teardown). `InputFocus` self-heals on
+/// despawn but `ActiveTextPrompt` does not; without this every input gate keeps
+/// draining keys → keyboard freeze.
+fn reconcile_active_text_prompt(
+    mut active: ResMut<ActiveTextPrompt>,
+    prompts: Query<(), With<TextPrompt>>,
+) {
+    if let Some(entity) = active.0
+        && !prompts.contains(entity)
+    {
+        active.0 = None;
     }
 }
 
@@ -95,6 +274,35 @@ mod tests {
         assert_eq!(
             decide_prompt_key(&Key::Backspace, false),
             PromptAction::Continue
+        );
+    }
+
+    #[test]
+    fn self_heal_clears_active_when_prompt_entity_despawned() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .init_resource::<ActiveTextPrompt>()
+            .init_resource::<InputFocus>()
+            .add_systems(Update, reconcile_active_text_prompt);
+
+        // A prompt entity carrying TextPrompt, pointed to by ActiveTextPrompt.
+        let bar = app.world_mut().spawn_empty().id();
+        let editable = app
+            .world_mut()
+            .spawn(TextPrompt {
+                submit_on_first_char: false,
+                bar,
+            })
+            .id();
+        app.world_mut().resource_mut::<ActiveTextPrompt>().0 = Some(editable);
+
+        // External teardown despawns the prompt entity without going through close_prompt.
+        app.world_mut().entity_mut(editable).despawn();
+        app.update();
+
+        assert!(
+            app.world().resource::<ActiveTextPrompt>().0.is_none(),
+            "self-heal must clear ActiveTextPrompt when its entity no longer exists, or the keyboard freezes"
         );
     }
 }

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -222,7 +222,7 @@ fn apply_prompt_close(
 fn on_prompt_key(
     key: On<FocusedInput<KeyboardInput>>,
     mut commands: Commands,
-    prompts: Query<(&TextPrompt, &EditableText), Without<PromptClosing>>,
+    prompts: Query<&EditableText, (With<TextPrompt>, Without<PromptClosing>)>,
 ) {
     if key.event_target() != key.original_event_target() {
         return;
@@ -230,7 +230,7 @@ fn on_prompt_key(
     if !key.input.state.is_pressed() {
         return;
     }
-    let Ok((_prompt, editable)) = prompts.get(key.focused_entity) else {
+    let Ok(editable) = prompts.get(key.focused_entity) else {
         return;
     };
     match decide_prompt_key(&key.input.logical_key, editable.is_composing()) {

--- a/src/ui/text_prompt.rs
+++ b/src/ui/text_prompt.rs
@@ -176,7 +176,8 @@ fn on_prompt_key(
     mut active: ResMut<ActiveTextPrompt>,
     prompts: Query<(&TextPrompt, &EditableText)>,
 ) {
-    // Fire only at the editable's own hop, not at each bubble ancestor.
+    // NOTE: without this guard the observer fires once per bubble hop
+    // (editable → bar → window), submitting three times for one Enter.
     if key.event_target() != key.focused_entity {
         return;
     }

--- a/src/ui/tmux/rename_prompt.rs
+++ b/src/ui/tmux/rename_prompt.rs
@@ -2,38 +2,30 @@
 //! shared `text_prompt` pre-filled with the current name; on submit this
 //! module's observer rebuilds a safely-quoted rename command and sends it.
 
-use crate::ui::text_prompt::TextPromptSubmit;
+use crate::theme;
+use crate::ui::text_prompt::{
+    ActiveTextPrompt, TextPromptSpec, TextPromptSubmit, spawn_text_prompt,
+};
+use bevy::input_focus::InputFocus;
 use bevy::prelude::*;
 use orzma_tmux::{RenameSession, RenameWindow, SessionId, TmuxClient, TmuxCommand, WindowId};
 
-/// What is being renamed: the captured target id plus its current name. One
-/// enum so an invalid kind/id pairing is unrepresentable.
+/// What is being renamed: the captured target id. One enum so an invalid
+/// kind/id pairing is unrepresentable.
 pub(crate) enum RenameSubject {
     /// A window, targeted by `@id`.
     Window {
         /// tmux window id captured at prompt-open.
         id: WindowId,
-        /// The window's name at prompt-open (used to pre-fill the field).
-        current_name: String,
     },
     /// A session, targeted by `$id`.
     Session {
         /// tmux session id captured at prompt-open.
         id: SessionId,
-        /// The session's name at prompt-open (used to pre-fill the field).
-        current_name: String,
     },
 }
 
 impl RenameSubject {
-    /// The subject's current name, used to pre-fill the prompt field.
-    pub(crate) fn current_name(&self) -> &str {
-        match self {
-            RenameSubject::Window { current_name, .. }
-            | RenameSubject::Session { current_name, .. } => current_name,
-        }
-    }
-
     /// The prompt bar's leading label for this subject.
     pub(crate) fn label(&self) -> &'static str {
         match self {
@@ -45,18 +37,48 @@ impl RenameSubject {
     /// Builds the tmux rename command from the subject and the submitted text.
     fn submit_command(&self, text: &str) -> String {
         match self {
-            RenameSubject::Window { id, .. } => RenameWindow {
+            RenameSubject::Window { id } => RenameWindow {
                 id: *id,
                 name: text,
             }
             .into_raw_command(),
-            RenameSubject::Session { id, .. } => RenameSession {
+            RenameSubject::Session { id } => RenameSession {
                 id: *id,
                 name: text,
             }
             .into_raw_command(),
         }
     }
+}
+
+/// Opens a rename prompt for `subject`, pre-filled with `current_name` and
+/// selected-all, and tags the field with `RenameIntent` so the submit observer
+/// can rebuild the command. Returns the `EditableText` entity.
+pub(crate) fn open_rename_prompt(
+    commands: &mut Commands,
+    input_focus: &mut InputFocus,
+    active: &mut ActiveTextPrompt,
+    font: Handle<Font>,
+    subject: RenameSubject,
+    current_name: String,
+) -> Entity {
+    let label = subject.label().to_string();
+    let editable = spawn_text_prompt(
+        commands,
+        input_focus,
+        active,
+        font,
+        TextPromptSpec {
+            label,
+            initial: current_name,
+            submit_on_first_char: false,
+            select_all: true,
+            bg: theme::SELECTION,
+            fg: theme::SELECTION_FG,
+        },
+    );
+    commands.entity(editable).insert(RenameIntent(subject));
+    editable
 }
 
 /// Attached to a rename prompt's `EditableText` entity so the submit observer
@@ -95,10 +117,7 @@ mod tests {
 
     #[test]
     fn window_submit_command_matches_legacy_format() {
-        let subject = RenameSubject::Window {
-            id: WindowId(2),
-            current_name: "old".to_string(),
-        };
+        let subject = RenameSubject::Window { id: WindowId(2) };
         assert_eq!(
             subject.submit_command("new name"),
             "rename-window -t @2 -- 'new name'"
@@ -107,10 +126,7 @@ mod tests {
 
     #[test]
     fn session_submit_command_matches_legacy_format() {
-        let subject = RenameSubject::Session {
-            id: SessionId(1),
-            current_name: "old".to_string(),
-        };
+        let subject = RenameSubject::Session { id: SessionId(1) };
         assert_eq!(
             subject.submit_command("proj"),
             "rename-session -t $1 -- proj"
@@ -120,19 +136,11 @@ mod tests {
     #[test]
     fn label_matches_subject() {
         assert_eq!(
-            RenameSubject::Window {
-                id: WindowId(0),
-                current_name: String::new()
-            }
-            .label(),
+            RenameSubject::Window { id: WindowId(0) }.label(),
             "Rename window: "
         );
         assert_eq!(
-            RenameSubject::Session {
-                id: SessionId(0),
-                current_name: String::new()
-            }
-            .label(),
+            RenameSubject::Session { id: SessionId(0) }.label(),
             "Rename session: "
         );
     }

--- a/src/ui/tmux/rename_prompt.rs
+++ b/src/ui/tmux/rename_prompt.rs
@@ -1,43 +1,10 @@
-//! orzma-owned rename prompt: the rename-window / rename-session shortcut
-//! actions open this prompt. It owns the keyboard, pre-fills the current
-//! name, and on submit sends a freshly-rebuilt, safely-quoted rename command.
+//! orzma-owned rename prompt. The rename-window / rename-session actions open a
+//! shared `text_prompt` pre-filled with the current name; on submit this
+//! module's observer rebuilds a safely-quoted rename command and sends it.
 
-use crate::font::TerminalUiFont;
-use crate::input::InputPhase;
-use crate::theme;
-use bevy::app::{App, Plugin};
-use bevy::ecs::message::MessageReader;
-use bevy::ecs::schedule::common_conditions::{
-    resource_exists, resource_exists_and_changed, resource_removed,
-};
-use bevy::input::ButtonState;
-use bevy::input::keyboard::{Key, KeyboardInput};
+use crate::ui::text_prompt::TextPromptSubmit;
 use bevy::prelude::*;
 use orzma_tmux::{RenameSession, RenameWindow, SessionId, TmuxClient, TmuxCommand, WindowId};
-
-const RENAME_Z: i32 = 340;
-
-/// Registers the rename-prompt input system and the show/hide render systems.
-pub(super) struct RenamePromptPlugin;
-
-impl Plugin for RenamePromptPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_rename_ui)
-            .add_systems(
-                Update,
-                handle_rename_input
-                    .after(InputPhase::FocusedKey)
-                    .run_if(resource_exists::<RenamePrompt>),
-            )
-            .add_systems(
-                PostUpdate,
-                (
-                    hide_rename_ui.run_if(resource_removed::<RenamePrompt>),
-                    show_rename_ui.run_if(resource_exists_and_changed::<RenamePrompt>),
-                ),
-            );
-    }
-}
 
 /// What is being renamed: the captured target id plus its current name. One
 /// enum so an invalid kind/id pairing is unrepresentable.
@@ -59,7 +26,8 @@ pub(crate) enum RenameSubject {
 }
 
 impl RenameSubject {
-    fn current_name(&self) -> &str {
+    /// The subject's current name, used to pre-fill the prompt field.
+    pub(crate) fn current_name(&self) -> &str {
         match self {
             RenameSubject::Window { current_name, .. }
             | RenameSubject::Session { current_name, .. } => current_name,
@@ -67,248 +35,86 @@ impl RenameSubject {
     }
 
     /// The prompt bar's leading label for this subject.
-    fn label(&self) -> &'static str {
+    pub(crate) fn label(&self) -> &'static str {
         match self {
             RenameSubject::Window { .. } => "Rename window: ",
             RenameSubject::Session { .. } => "Rename session: ",
         }
     }
-}
 
-/// The active rename prompt. Present as a resource only while editing; its
-/// existence owns the keyboard like the confirm prompt and the session picker.
-#[derive(Resource)]
-pub(crate) struct RenamePrompt {
-    /// What is being renamed.
-    subject: RenameSubject,
-    /// The edit buffer, pre-filled with the subject's current name.
-    text: String,
-}
-
-impl RenamePrompt {
-    /// Opens a prompt for `subject`, pre-filling the edit buffer with its
-    /// current name.
-    pub(crate) fn new(subject: RenameSubject) -> Self {
-        let text = subject.current_name().to_string();
-        Self { subject, text }
-    }
-
-    /// Applies one key: Enter submits, Escape cancels, Backspace deletes the
-    /// last char, a character is appended. Other keys are ignored.
-    fn apply_key(&mut self, key: &Key) -> RenameStep {
-        match key {
-            Key::Escape => RenameStep::Cancel,
-            Key::Enter => RenameStep::Submit,
-            Key::Backspace => {
-                self.text.pop();
-                RenameStep::Continue
-            }
-            Key::Character(s) => {
-                self.text.push_str(s);
-                RenameStep::Continue
-            }
-            _ => RenameStep::Continue,
-        }
-    }
-
-    /// Builds the tmux command sent on submit from the subject and typed text.
-    fn submit_command(&self) -> String {
-        match &self.subject {
+    /// Builds the tmux rename command from the subject and the submitted text.
+    fn submit_command(&self, text: &str) -> String {
+        match self {
             RenameSubject::Window { id, .. } => RenameWindow {
                 id: *id,
-                name: &self.text,
+                name: text,
             }
             .into_raw_command(),
             RenameSubject::Session { id, .. } => RenameSession {
                 id: *id,
-                name: &self.text,
+                name: text,
             }
             .into_raw_command(),
         }
     }
 }
 
-/// The effect of one key on an open rename prompt.
-#[derive(Debug, PartialEq, Eq)]
-enum RenameStep {
-    Continue,
-    Submit,
-    Cancel,
-}
-
+/// Attached to a rename prompt's `EditableText` entity so the submit observer
+/// can rebuild the rename command from the captured target.
 #[derive(Component)]
-struct RenameBar;
+pub(crate) struct RenameIntent(pub(crate) RenameSubject);
 
-fn spawn_rename_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>) {
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
-    commands
-        .spawn((
-            Node {
-                position_type: PositionType::Absolute,
-                left: Val::Px(0.0),
-                bottom: Val::Px(0.0),
-                width: Val::Percent(100.0),
-                height: Val::Auto,
-                display: Display::None,
-                padding: UiRect::axes(Val::Px(6.0), Val::Px(3.0)),
-                ..default()
-            },
-            BackgroundColor(theme::SELECTION),
-            GlobalZIndex(RENAME_Z),
-            RenameBar,
-        ))
-        .with_children(|parent| {
-            parent.spawn((
-                Text::new(""),
-                TextFont {
-                    font: font.into(),
-                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                    ..default()
-                },
-                TextColor(theme::SELECTION_FG),
-            ));
-        });
-}
+/// Registers the rename-prompt submit observer.
+pub(super) struct RenamePromptPlugin;
 
-fn hide_rename_ui(mut bar: Query<&mut Node, With<RenameBar>>) {
-    if let Ok(mut node) = bar.single_mut() {
-        node.display = Display::None;
+impl Plugin for RenamePromptPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_rename_submit);
     }
 }
 
-fn show_rename_ui(
-    mut bar: Query<&mut Node, With<RenameBar>>,
-    mut texts: Query<&mut Text>,
-    prompt: Res<RenamePrompt>,
-    children_query: Query<&Children, With<RenameBar>>,
+fn on_rename_submit(
+    submit: On<TextPromptSubmit>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    intents: Query<&RenameIntent>,
 ) {
-    let Ok(mut node) = bar.single_mut() else {
+    let Ok(RenameIntent(subject)) = intents.get(submit.entity) else {
         return;
     };
-    node.display = Display::Flex;
-    if let Ok(children) = children_query.single() {
-        for child in children.iter() {
-            if let Ok(mut text) = texts.get_mut(child) {
-                text.0 = format!("{}{}\u{258f}", prompt.subject.label(), prompt.text);
-            }
-        }
-    }
-}
-
-fn handle_rename_input(
-    mut commands: Commands,
-    mut prompt: ResMut<RenamePrompt>,
-    mut events: MessageReader<KeyboardInput>,
-    mut armed: Local<bool>,
-    mut client: Option<Single<&mut TmuxClient>>,
-) {
-    // NOTE: the bound key that opened the prompt (`,` / `$`) is still in the
-    // shared KeyboardInput buffer; this reader has its own cursor, so skip the
-    // open frame — drain past the opening key — or it is appended to the name.
-    if !*armed {
-        events.clear();
-        *armed = true;
-        return;
-    }
-    for ev in events.read() {
-        if ev.state != ButtonState::Pressed {
-            continue;
-        }
-        match prompt.apply_key(&ev.logical_key) {
-            RenameStep::Continue => {}
-            RenameStep::Submit => {
-                let cmd = prompt.submit_command();
-                if let Some(client) = client.as_deref_mut()
-                    && let Err(e) = client.send_raw(&cmd)
-                {
-                    tracing::warn!(?e, "rename submit failed");
-                }
-                commands.remove_resource::<RenamePrompt>();
-                *armed = false;
-                break;
-            }
-            RenameStep::Cancel => {
-                commands.remove_resource::<RenamePrompt>();
-                *armed = false;
-                break;
-            }
-        }
+    let cmd = subject.submit_command(&submit.text);
+    if let Some(client) = client.as_deref_mut()
+        && let Err(e) = client.send_raw(&cmd)
+    {
+        tracing::warn!(?e, "rename submit failed");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::input::ButtonState;
-    use bevy::input::keyboard::KeyCode;
 
-    fn win_subject() -> RenameSubject {
-        RenameSubject::Window {
+    #[test]
+    fn window_submit_command_matches_legacy_format() {
+        let subject = RenameSubject::Window {
             id: WindowId(2),
-            current_name: "nvim".to_string(),
-        }
-    }
-
-    fn char_key(s: &str) -> Key {
-        Key::Character(s.into())
-    }
-
-    #[test]
-    fn new_prefills_text_from_current_name() {
-        let p = RenamePrompt::new(win_subject());
-        assert_eq!(p.text, "nvim");
-    }
-
-    #[test]
-    fn escape_cancels() {
-        let mut p = RenamePrompt::new(win_subject());
-        assert_eq!(p.apply_key(&Key::Escape), RenameStep::Cancel);
-    }
-
-    #[test]
-    fn enter_submits() {
-        let mut p = RenamePrompt::new(win_subject());
-        assert_eq!(p.apply_key(&Key::Enter), RenameStep::Submit);
-    }
-
-    #[test]
-    fn char_appends_and_continues() {
-        let mut p = RenamePrompt::new(win_subject());
-        p.text.clear();
-        assert_eq!(p.apply_key(&char_key("a")), RenameStep::Continue);
-        assert_eq!(p.apply_key(&char_key("b")), RenameStep::Continue);
-        assert_eq!(p.text, "ab");
-    }
-
-    #[test]
-    fn backspace_pops_last_char() {
-        let mut p = RenamePrompt::new(win_subject());
-        assert_eq!(p.apply_key(&Key::Backspace), RenameStep::Continue);
-        assert_eq!(p.text, "nvi");
-    }
-
-    #[test]
-    fn submit_command_uses_window_builder() {
-        let p = RenamePrompt {
-            subject: RenameSubject::Window {
-                id: WindowId(2),
-                current_name: "old".to_string(),
-            },
-            text: "new name".to_string(),
+            current_name: "old".to_string(),
         };
-        assert_eq!(p.submit_command(), "rename-window -t @2 -- 'new name'");
+        assert_eq!(
+            subject.submit_command("new name"),
+            "rename-window -t @2 -- 'new name'"
+        );
     }
 
     #[test]
-    fn submit_command_uses_session_builder() {
-        let p = RenamePrompt {
-            subject: RenameSubject::Session {
-                id: SessionId(1),
-                current_name: "old".to_string(),
-            },
-            text: "proj".to_string(),
+    fn session_submit_command_matches_legacy_format() {
+        let subject = RenameSubject::Session {
+            id: SessionId(1),
+            current_name: "old".to_string(),
         };
-        assert_eq!(p.submit_command(), "rename-session -t $1 -- proj");
+        assert_eq!(
+            subject.submit_command("proj"),
+            "rename-session -t $1 -- proj"
+        );
     }
 
     #[test]
@@ -316,7 +122,7 @@ mod tests {
         assert_eq!(
             RenameSubject::Window {
                 id: WindowId(0),
-                current_name: String::new(),
+                current_name: String::new()
             }
             .label(),
             "Rename window: "
@@ -324,73 +130,10 @@ mod tests {
         assert_eq!(
             RenameSubject::Session {
                 id: SessionId(0),
-                current_name: String::new(),
+                current_name: String::new()
             }
             .label(),
             "Rename session: "
-        );
-    }
-
-    fn key_event(logical: Key, code: KeyCode) -> KeyboardInput {
-        KeyboardInput {
-            key_code: code,
-            logical_key: logical,
-            state: ButtonState::Pressed,
-            text: None,
-            repeat: false,
-            window: Entity::PLACEHOLDER,
-        }
-    }
-
-    fn armed_skip_app() -> App {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<KeyboardInput>()
-            .add_systems(
-                Update,
-                handle_rename_input.run_if(resource_exists::<RenamePrompt>),
-            );
-        app
-    }
-
-    #[test]
-    fn open_frame_skips_the_opening_key() {
-        let mut app = armed_skip_app();
-        app.world_mut()
-            .insert_resource(RenamePrompt::new(win_subject()));
-        // The opening `,` is still in the shared buffer when the prompt opens.
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(Key::Character(",".into()), KeyCode::Comma));
-        app.update();
-
-        let p = app.world().resource::<RenamePrompt>();
-        assert_eq!(
-            p.text, "nvim",
-            "the opening key must not leak into the prefilled text"
-        );
-    }
-
-    #[test]
-    fn escape_after_open_frame_removes_resource() {
-        let mut app = armed_skip_app();
-        app.world_mut()
-            .insert_resource(RenamePrompt::new(win_subject()));
-        // Open frame drains the opening key.
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(Key::Character(",".into()), KeyCode::Comma));
-        app.update();
-        assert!(app.world().get_resource::<RenamePrompt>().is_some());
-
-        // Next frame: Escape cancels → resource removed.
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(Key::Escape, KeyCode::Escape));
-        app.update();
-        assert!(
-            app.world().get_resource::<RenamePrompt>().is_none(),
-            "Escape must close the prompt"
         );
     }
 }

--- a/src/ui/vi_search.rs
+++ b/src/ui/vi_search.rs
@@ -16,9 +16,9 @@ use orzma_tmux::{PaneId, Prompt, PromptKind, TmuxClient};
 /// Attached to a vi prompt's `EditableText` entity so the submit observer can
 /// target the right pane and copy-mode command.
 #[derive(Component)]
-pub(crate) struct ViPromptIntent {
-    pub(crate) pane: PaneId,
-    pub(crate) kind: PromptKind,
+struct ViPromptIntent {
+    pane: PaneId,
+    kind: PromptKind,
 }
 
 /// Registers the vi-mode prompt submit observer.
@@ -34,7 +34,7 @@ impl Plugin for ViModePromptPlugin {
 // NOTE: `#[expect]` is impractical here — dead in the non-test build (inert
 // until a local search applier reconnects this prompt) but live under tests.
 #[allow(dead_code)]
-pub(crate) fn prompt_label(kind: PromptKind) -> &'static str {
+fn prompt_label(kind: PromptKind) -> &'static str {
     match kind {
         PromptKind::SearchForward => "/",
         PromptKind::SearchBackward => "?",

--- a/src/ui/vi_search.rs
+++ b/src/ui/vi_search.rs
@@ -1,101 +1,40 @@
-//! Vi-mode search and jump-char prompt overlay.
+//! Vi-mode search / jump prompt.
 //!
-//! Currently inert: nothing in the codebase sets `ViModePrompt.open`. This
-//! module used to open in response to the tmux VI applier's `on_vi_prompt`
-//! observer handling a `ViPromptRequest`, but that applier (`tmux_mode.rs`)
-//! was deleted as part of the vi-mode-to-local migration, so the trigger
-//! no longer exists. Reconnecting this prompt to a local search applier is
-//! expected in a future change.
-//!
-//! When active, it owns the keyboard until the user submits (Enter / first
-//! char for jump kinds) or cancels (Escape). On submit, it sends
-//! `send-keys -X -t %N <kind> -- '<text>'` to tmux via the active
-//! connection.
+//! Inert: nothing opens this prompt yet (the tmux VI applier that used to
+//! trigger it was removed in the vi-mode-to-local migration). This module now
+//! provides the EditableText-based submit path and `ViPromptIntent` so a future
+//! local search applier can open a shared `text_prompt` (with
+//! `submit_on_first_char = kind.is_single_char()`, label `prompt_label(kind)`,
+//! and colors `bg: theme::PANEL` / `fg: theme::FOREGROUND`) and attach
+//! `ViPromptIntent`. On submit, this observer runs
+//! `send-keys -X -t %N <kind> -- '<text>'` against the active tmux connection.
 
-use crate::font::TerminalUiFont;
-use crate::input::InputPhase;
-use crate::theme;
-use bevy::app::{App, Plugin};
-use bevy::ecs::message::MessageReader;
-use bevy::ecs::schedule::common_conditions::resource_exists_and_changed;
-use bevy::input::ButtonState;
-use bevy::input::keyboard::{Key, KeyboardInput};
+use crate::ui::text_prompt::TextPromptSubmit;
 use bevy::prelude::*;
 use orzma_tmux::{PaneId, Prompt, PromptKind, TmuxClient};
 
-const PROMPT_Z: i32 = 320;
+/// Attached to a vi prompt's `EditableText` entity so the submit observer can
+/// target the right pane and copy-mode command.
+#[derive(Component)]
+pub(crate) struct ViPromptIntent {
+    pub(crate) pane: PaneId,
+    pub(crate) kind: PromptKind,
+}
 
-/// Registers the vi-mode prompt resource, input system, and render system.
+/// Registers the vi-mode prompt submit observer.
 pub(crate) struct ViModePromptPlugin;
 
 impl Plugin for ViModePromptPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ViModePrompt>()
-            .add_systems(Startup, spawn_prompt_ui)
-            .add_systems(
-                Update,
-                handle_prompt_input
-                    .after(InputPhase::FocusedKey)
-                    .run_if(|p: Res<ViModePrompt>| p.open.is_some()),
-            )
-            .add_systems(
-                PostUpdate,
-                sync_prompt_ui.run_if(resource_exists_and_changed::<ViModePrompt>),
-            );
+        app.add_observer(on_vi_prompt_submit);
     }
 }
 
-/// The active vi-mode prompt (search regex or jump char). Present while the
-/// user is typing; owns the keyboard like the session picker.
-#[derive(Resource, Default)]
-pub(crate) struct ViModePrompt {
-    /// The pending prompt, if open.
-    pub(crate) open: Option<ViModePromptState>,
-}
-
-/// In-progress vi-mode prompt input.
-pub(crate) struct ViModePromptState {
-    /// Which copy command to run on submit.
-    pub(crate) kind: PromptKind,
-    /// The pane the result targets.
-    pub(crate) pane: PaneId,
-    /// Text typed so far.
-    pub(crate) text: String,
-}
-
-/// The effect of one key on an open prompt.
-#[derive(Debug, PartialEq)]
-enum PromptStep {
-    Continue,
-    Submit,
-    Cancel,
-}
-
-/// Applies one key press to the prompt text, returning what to do. Jump prompts
-/// (single-char) submit on the first typed character; search prompts submit on
-/// Enter. Escape cancels; Backspace edits.
-fn apply_prompt_key(state: &mut ViModePromptState, key: &Key) -> PromptStep {
-    match key {
-        Key::Escape => PromptStep::Cancel,
-        Key::Enter => PromptStep::Submit,
-        Key::Backspace => {
-            state.text.pop();
-            PromptStep::Continue
-        }
-        Key::Character(s) => {
-            state.text.push_str(s);
-            if state.kind.is_single_char() {
-                PromptStep::Submit
-            } else {
-                PromptStep::Continue
-            }
-        }
-        _ => PromptStep::Continue,
-    }
-}
-
-/// Returns the prompt label character (shown before the typed text).
-fn prompt_label(kind: PromptKind) -> &'static str {
+/// The prompt label glyph shown before the typed text (`/`, `?`, `f`, …).
+// NOTE: `#[expect]` is impractical here — dead in the non-test build (inert
+// until a local search applier reconnects this prompt) but live under tests.
+#[allow(dead_code)]
+pub(crate) fn prompt_label(kind: PromptKind) -> &'static str {
     match kind {
         PromptKind::SearchForward => "/",
         PromptKind::SearchBackward => "?",
@@ -106,312 +45,28 @@ fn prompt_label(kind: PromptKind) -> &'static str {
     }
 }
 
-#[derive(Component)]
-struct PromptBar;
-
-fn spawn_prompt_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>) {
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
-    commands
-        .spawn((
-            Node {
-                position_type: PositionType::Absolute,
-                left: Val::Px(0.0),
-                bottom: Val::Px(0.0),
-                width: Val::Percent(100.0),
-                height: Val::Auto,
-                display: Display::None,
-                padding: UiRect::axes(Val::Px(4.0), Val::Px(2.0)),
-                ..default()
-            },
-            BackgroundColor(theme::PANEL),
-            GlobalZIndex(PROMPT_Z),
-            PromptBar,
-        ))
-        .with_children(|parent| {
-            parent.spawn((
-                Text::new(""),
-                TextFont {
-                    font: font.into(),
-                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                    ..default()
-                },
-                TextColor(theme::FOREGROUND),
-            ));
-        });
-}
-
-fn sync_prompt_ui(
-    mut bar: Query<&mut Node, With<PromptBar>>,
-    mut texts: Query<&mut Text>,
-    prompt: Res<ViModePrompt>,
-    children_query: Query<&Children, With<PromptBar>>,
+fn on_vi_prompt_submit(
+    submit: On<TextPromptSubmit>,
+    mut client: Option<Single<&mut TmuxClient>>,
+    intents: Query<&ViPromptIntent>,
 ) {
-    let Ok(mut node) = bar.single_mut() else {
+    let Ok(intent) = intents.get(submit.entity) else {
         return;
     };
-    match &prompt.open {
-        None => {
-            node.display = Display::None;
-        }
-        Some(state) => {
-            node.display = Display::Flex;
-            if let Ok(children) = children_query.single() {
-                for child in children.iter() {
-                    if let Ok(mut text) = texts.get_mut(child) {
-                        text.0 = format!("{}{}", prompt_label(state.kind), state.text);
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn handle_prompt_input(
-    mut vi_mode_prompt: ResMut<ViModePrompt>,
-    mut events: MessageReader<KeyboardInput>,
-    mut armed: Local<bool>,
-    mut client: Option<Single<&mut TmuxClient>>,
-) {
-    // NOTE: the keystroke that opened the prompt (e.g. `/`, or `f` for a jump)
-    // is still in the shared KeyboardInput buffer; each reader has its own
-    // cursor, so `apply_tmux_shortcuts` clearing it does not advance ours. Skip
-    // the open frame — drain past the opening key without processing it — or the
-    // opening char leaks into the prompt text (and single-char jumps submit on
-    // it immediately).
-    if !*armed {
-        events.clear();
-        *armed = true;
-        return;
-    }
-    for ev in events.read() {
-        if ev.state != ButtonState::Pressed {
-            continue;
-        }
-        let Some(state) = vi_mode_prompt.open.as_mut() else {
-            continue;
-        };
-        let step = apply_prompt_key(state, &ev.logical_key);
-        match step {
-            PromptStep::Continue => {}
-            PromptStep::Submit => {
-                if let Some(client) = client.as_deref_mut()
-                    && let Err(e) = client.send(Prompt {
-                        pane: state.pane,
-                        kind: state.kind,
-                        text: &state.text,
-                    })
-                {
-                    tracing::warn!(?e, "vi-mode prompt submit failed");
-                }
-                vi_mode_prompt.open = None;
-                *armed = false;
-                break;
-            }
-            PromptStep::Cancel => {
-                vi_mode_prompt.open = None;
-                *armed = false;
-                break;
-            }
-        }
+    if let Some(client) = client.as_deref_mut()
+        && let Err(e) = client.send(Prompt {
+            pane: intent.pane,
+            kind: intent.kind,
+            text: &submit.text,
+        })
+    {
+        tracing::warn!(?e, "vi-mode prompt submit failed");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tmux_control_parser::PaneId;
-
-    fn state(kind: PromptKind) -> ViModePromptState {
-        ViModePromptState {
-            kind,
-            pane: PaneId(0),
-            text: String::new(),
-        }
-    }
-
-    fn char_key(s: &str) -> Key {
-        Key::Character(s.into())
-    }
-
-    #[test]
-    fn escape_cancels() {
-        let mut s = state(PromptKind::SearchForward);
-        assert_eq!(apply_prompt_key(&mut s, &Key::Escape), PromptStep::Cancel);
-    }
-
-    #[test]
-    fn enter_submits_search() {
-        let mut s = state(PromptKind::SearchForward);
-        s.text = "foo".into();
-        assert_eq!(apply_prompt_key(&mut s, &Key::Enter), PromptStep::Submit);
-    }
-
-    #[test]
-    fn backspace_pops_last_char() {
-        let mut s = state(PromptKind::SearchForward);
-        s.text = "ab".into();
-        assert_eq!(
-            apply_prompt_key(&mut s, &Key::Backspace),
-            PromptStep::Continue
-        );
-        assert_eq!(s.text, "a");
-    }
-
-    #[test]
-    fn backspace_on_empty_continues() {
-        let mut s = state(PromptKind::SearchForward);
-        assert_eq!(
-            apply_prompt_key(&mut s, &Key::Backspace),
-            PromptStep::Continue
-        );
-        assert_eq!(s.text, "");
-    }
-
-    #[test]
-    fn search_accumulates_chars_and_waits_for_enter() {
-        let mut s = state(PromptKind::SearchForward);
-        assert_eq!(
-            apply_prompt_key(&mut s, &char_key("h")),
-            PromptStep::Continue
-        );
-        assert_eq!(
-            apply_prompt_key(&mut s, &char_key("i")),
-            PromptStep::Continue
-        );
-        assert_eq!(s.text, "hi");
-        assert_eq!(apply_prompt_key(&mut s, &Key::Enter), PromptStep::Submit);
-    }
-
-    #[test]
-    fn backward_search_also_multi_char() {
-        let mut s = state(PromptKind::SearchBackward);
-        assert_eq!(
-            apply_prompt_key(&mut s, &char_key("x")),
-            PromptStep::Continue
-        );
-        assert_eq!(
-            apply_prompt_key(&mut s, &char_key("y")),
-            PromptStep::Continue
-        );
-        assert_eq!(s.text, "xy");
-        assert_eq!(apply_prompt_key(&mut s, &Key::Enter), PromptStep::Submit);
-    }
-
-    #[test]
-    fn jump_forward_submits_on_first_char() {
-        let mut s = state(PromptKind::JumpForward);
-        assert_eq!(apply_prompt_key(&mut s, &char_key("w")), PromptStep::Submit);
-        assert_eq!(s.text, "w");
-    }
-
-    #[test]
-    fn jump_backward_submits_on_first_char() {
-        let mut s = state(PromptKind::JumpBackward);
-        assert_eq!(apply_prompt_key(&mut s, &char_key("a")), PromptStep::Submit);
-        assert_eq!(s.text, "a");
-    }
-
-    #[test]
-    fn jump_to_forward_submits_on_first_char() {
-        let mut s = state(PromptKind::JumpToForward);
-        assert_eq!(apply_prompt_key(&mut s, &char_key("e")), PromptStep::Submit);
-        assert_eq!(s.text, "e");
-    }
-
-    #[test]
-    fn jump_to_backward_submits_on_first_char() {
-        let mut s = state(PromptKind::JumpToBackward);
-        assert_eq!(apply_prompt_key(&mut s, &char_key("b")), PromptStep::Submit);
-        assert_eq!(s.text, "b");
-    }
-
-    #[test]
-    fn unknown_key_continues() {
-        let mut s = state(PromptKind::SearchForward);
-        assert_eq!(
-            apply_prompt_key(&mut s, &Key::ArrowUp),
-            PromptStep::Continue
-        );
-        assert_eq!(s.text, "");
-    }
-
-    use bevy::input::ButtonState;
-    use bevy::input::keyboard::KeyCode;
-
-    fn key_event(logical: Key, code: KeyCode) -> KeyboardInput {
-        KeyboardInput {
-            key_code: code,
-            logical_key: logical,
-            state: ButtonState::Pressed,
-            text: None,
-            repeat: false,
-            window: Entity::PLACEHOLDER,
-        }
-    }
-
-    fn armed_skip_app() -> App {
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_message::<KeyboardInput>()
-            .init_resource::<ViModePrompt>()
-            .add_systems(
-                Update,
-                handle_prompt_input.run_if(|p: Res<ViModePrompt>| p.open.is_some()),
-            );
-        app
-    }
-
-    #[test]
-    fn open_frame_skips_the_opening_key_for_a_jump_prompt() {
-        let mut app = armed_skip_app();
-        app.world_mut().resource_mut::<ViModePrompt>().open = Some(ViModePromptState {
-            kind: PromptKind::JumpForward,
-            pane: PaneId(0),
-            text: String::new(),
-        });
-        // The opening `f` is still in the shared buffer when the prompt opens.
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(char_key("f"), KeyCode::KeyF));
-        app.update();
-
-        let prompt = app.world().resource::<ViModePrompt>();
-        assert!(
-            prompt.open.is_some(),
-            "single-char jump must NOT submit on the opening key (open frame is skipped)"
-        );
-        assert_eq!(
-            prompt.open.as_ref().unwrap().text,
-            "",
-            "the opening key must not leak into the prompt text"
-        );
-    }
-
-    #[test]
-    fn target_key_after_open_frame_submits_a_jump_prompt() {
-        let mut app = armed_skip_app();
-        app.world_mut().resource_mut::<ViModePrompt>().open = Some(ViModePromptState {
-            kind: PromptKind::JumpForward,
-            pane: PaneId(0),
-            text: String::new(),
-        });
-        // Open frame: the opening `f` is drained, prompt stays open.
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(char_key("f"), KeyCode::KeyF));
-        app.update();
-        assert!(app.world().resource::<ViModePrompt>().open.is_some());
-
-        // Next frame: the real target char submits (no client → just closes).
-        app.world_mut()
-            .resource_mut::<Messages<KeyboardInput>>()
-            .write(key_event(char_key("x"), KeyCode::KeyX));
-        app.update();
-        assert!(
-            app.world().resource::<ViModePrompt>().open.is_none(),
-            "the first post-open char submits a single-char jump"
-        );
-    }
 
     #[test]
     fn prompt_label_returns_correct_glyphs() {
@@ -421,5 +76,11 @@ mod tests {
         assert_eq!(prompt_label(PromptKind::JumpBackward), "F");
         assert_eq!(prompt_label(PromptKind::JumpToForward), "t");
         assert_eq!(prompt_label(PromptKind::JumpToBackward), "T");
+    }
+
+    #[test]
+    fn jump_kinds_submit_on_first_char() {
+        assert!(PromptKind::JumpForward.is_single_char());
+        assert!(!PromptKind::SearchForward.is_single_char());
     }
 }


### PR DESCRIPTION
## Problem

Two prompts hand-rolled single-line text editing with raw `String` push/pop on
each keystroke — the tmux rename prompt (`src/ui/tmux/rename_prompt.rs`) and the
vi-search prompt (`src/ui/vi_search.rs`). Besides duplicating a small text
editor (cursor handling, backspace, the "skip the opening keystroke" hack), the
hand-rolled path only saw `Key::Character` events and never `Ime::Commit`, so
**IME input was impossible** — you could not type Japanese (or any composed
text) into a rename prompt.

Closes #256.

## Solution

Replace both hand-rolled editors with Bevy 0.19's `EditableText` widget, driven
by `bevy_input_focus::InputFocus`, behind one shared widget.

- **New `src/ui/text_prompt.rs`** — a headless single-line prompt built on
  `EditableText`. It spawns the overlay bar + field, sets `InputFocus`, owns the
  keyboard while open, and hands submit/cancel to per-prompt observers via a
  `TextPromptSubmit` `EntityEvent`. Submit is applied in `PostUpdate` (after the
  widget's edits apply) so the terminating key can't leak to the pane and a
  same-frame keystroke isn't dropped.
- **Single modal signal** — a new `ActiveTextPrompt` resource replaces the
  `RenamePrompt` and `ViModePrompt` resources across every input gate site
  (`src/input/keyboard/handler.rs`, `src/input/tmux/gate.rs`,
  `src/input/mouse/{wheel,button}/tmux.rs`, `src/input/mouse/webview/default_mode.rs`),
  collapsing three separate resource reads into one.
- **IME** — while a prompt is focused, the project's IME systems
  (`src/input/ime.rs`) cede to Bevy's widget IME systems, so **IME now works in
  the rename prompt**. `read_ime_events` keeps draining events (no replay), and
  `ime_policy_system` is `run_if`-gated off.
- **vi-search** is migrated onto the same widget but stays inert (no opener —
  reconnecting it to a local search applier is a separate change).

Affected areas: `src/ui/*`, `src/input/*`, `src/action/tmux/*`. No public API or
data changes.

### Notes / follow-ups

- The rename field **selects-all on open**, so the first keystroke replaces the
  pre-filled name (a small UX change from the old edit-at-end behavior).
- An open rename prompt now also suppresses tmux / default-mode webview **mouse**
  pointer + gesture routing (the modal signal migrated from the previously-inert
  `ViModePrompt`, which preserves an existing tested suppression feature).
- Prompt copy/paste is **in-memory only** — `bevy/system_clipboard` is not
  enabled (would need reconciling with the existing `ClipboardPlugin`).

### Testing

`cargo test --workspace` (1589 tests) and
`cargo clippy --workspace --all-targets -- -D warnings` both pass; `cargo fmt`
clean. Runtime IME / focus behavior is best confirmed by running the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ga8m6DiuYrv5SdC28xvm6
