### PR TITLE
chore: trim Affected area and Alternatives considered from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,22 +35,6 @@ body:
         - Not sure
     validations:
       required: true
-  - type: dropdown
-    id: area
-    attributes:
-      label: Affected area
-      description: Select all that apply.
-      multiple: true
-      options:
-        - Terminal rendering
-        - Input
-        - IME
-        - Vi mode
-        - tmux integration
-        - Webview
-        - Configuration
-        - Other
-        - Not sure
   - type: input
     id: tmux_version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,27 +23,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Other approaches or workarounds you've considered.
-  - type: dropdown
-    id: area
-    attributes:
-      label: Affected area
-      description: Select all that apply.
-      multiple: true
-      options:
-        - Terminal rendering
-        - Input
-        - IME
-        - Vi mode
-        - tmux integration
-        - Webview
-        - Configuration
-        - Other
-        - Not sure
-  - type: textarea
     id: context
     attributes:
       label: Additional context


### PR DESCRIPTION
## Summary

Removes two fields from the GitHub issue templates:

- **Affected area** dropdown — removed from both `bug_report.yml` and `feature_request.yml`.
- **Alternatives considered** textarea — removed from `feature_request.yml` (it only existed there).

All other fields are unchanged.

## Test plan

- N/A — issue template YAML only. GitHub validates the form schema on render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019puB93p6wpEA2SwhLJrTJe