### PR TITLE
feat(font): resolve terminal + UI font by system family name

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libfontconfig1-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Free runner disk space
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libfontconfig1-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -103,7 +103,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v5
-      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libfontconfig1-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,9 +3076,17 @@ dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
  "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
  "parlance",
  "read-fonts",
+ "roxmltree",
  "smallvec",
+ "windows",
+ "windows-core",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -4725,6 +4733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5700,6 +5718,15 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7909,6 +7936,17 @@ name = "yazi"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ name = "orzma"
 path = "src/main.rs"
 
 [features]
-# Default-on for development: `cargo run` / `just run` load CEF from
-# ~/.local/share/cef via bevy_cef's debug loader. Distribution builds MUST
-# drop this — the bundler builds with `--no-default-features` so the release
-# binary loads CEF from the app's bundled Contents/Frameworks instead.
 default = ["debug"]
 debug = ["orzma_webview/debug"]
 
@@ -76,12 +72,6 @@ repository = "https://github.com/not-elm/orzma"
 publish = false
 
 [workspace.dependencies]
-# NOTE: default_font is load-bearing for every `Handle::<Font>::default()`
-# consumer (e.g. src/ui/vi_mode_indicator.rs before TerminalUiFont exists, and
-# the font.rs / ime_overlay.rs tests) — the default handle only resolves to
-# FiraMono when default_font is enabled. The feature is currently part of
-# bevy's default set via default_platform → default_font, but listing it
-# explicitly here protects against future "default-features = false".
 bevy = { version = "0.19", features = ["default_font", "system_clipboard", "system_font_discovery"] }
 anyhow = { version = "1" }
 thiserror = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,6 @@ orzma_tty_engine = { path = "crates/orzma_tty_engine" }
 orzma_webview = { path = "crates/orzma_webview" }
 crossbeam-channel = "0.5"
 data-encoding = "2"
-# NOTE: system font discovery is enabled via bevy's public
-# `system_font_discovery` feature (workspace dep), which pulls
-# parley/system -> fontique/system. Feature unification turns `system` on for
-# THIS direct fontique dep too, so family resolution sees OS fonts. Keep
-# default-features off + std here; the crate is used for Blob/Script/Query/
-# Attributes types.
 fontique = { version = "0.9", default-features = false, features = ["std"] }
 getrandom = "0.2"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,12 @@ orzma_tty_engine = { path = "crates/orzma_tty_engine" }
 orzma_webview = { path = "crates/orzma_webview" }
 crossbeam-channel = "0.5"
 data-encoding = "2"
-# NOTE: default-features = false keeps fontique's `system` backend off,
-# matching bevy_text's parley configuration — enabling it here would turn on
-# system font discovery for the whole dependency graph via feature unification.
+# NOTE: system font discovery is enabled via bevy's public
+# `system_font_discovery` feature (workspace dep), which pulls
+# parley/system -> fontique/system. Feature unification turns `system` on for
+# THIS direct fontique dep too, so family resolution sees OS fonts. Keep
+# default-features off + std here; the crate is used for Blob/Script/Query/
+# Attributes types.
 fontique = { version = "0.9", default-features = false, features = ["std"] }
 getrandom = "0.2"
 libc = "0.2"
@@ -85,7 +88,7 @@ publish = false
 # FiraMono when default_font is enabled. The feature is currently part of
 # bevy's default set via default_platform → default_font, but listing it
 # explicitly here protects against future "default-features = false".
-bevy = { version = "0.19", features = ["default_font", "system_clipboard"] }
+bevy = { version = "0.19", features = ["default_font", "system_clipboard", "system_font_discovery"] }
 anyhow = { version = "1" }
 thiserror = { version = "2" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/orzma_configs/src/error.rs
+++ b/crates/orzma_configs/src/error.rs
@@ -72,10 +72,11 @@ pub enum OrzmaConfigsError {
         size: f32,
     },
 
-    /// A `[font]` face's `style` string contained an unrecognized token.
+    /// A `[font].<face>.style` string (face ∈ normal / bold / italic /
+    /// bold_italic / ui) did not parse to a known weight + slant.
     #[error("invalid font style {value:?} for the {face} face")]
     InvalidFontStyle {
-        /// The face label (`normal` / `bold` / `italic` / `bold_italic`).
+        /// The face label (`normal` / `bold` / `italic` / `bold_italic` / `ui`).
         face: &'static str,
         /// The offending style string.
         value: String,

--- a/crates/orzma_configs/src/error.rs
+++ b/crates/orzma_configs/src/error.rs
@@ -72,6 +72,15 @@ pub enum OrzmaConfigsError {
         size: f32,
     },
 
+    /// A `[font]` face's `style` string contained an unrecognized token.
+    #[error("invalid font style {value:?} for the {face} face")]
+    InvalidFontStyle {
+        /// The face label (`normal` / `bold` / `italic` / `bold_italic`).
+        face: &'static str,
+        /// The offending style string.
+        value: String,
+    },
+
     /// Neither `$XDG_CONFIG_HOME` nor a home directory could be resolved.
     #[error("could not determine config directory (no $XDG_CONFIG_HOME and no home dir)")]
     HomeDirNotFound,
@@ -103,6 +112,18 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "could not determine config directory (no $XDG_CONFIG_HOME and no home dir)"
+        );
+    }
+
+    #[test]
+    fn invalid_font_style_display() {
+        let err = OrzmaConfigsError::InvalidFontStyle {
+            face: "italic",
+            value: "Blod".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "invalid font style \"Blod\" for the italic face"
         );
     }
 }

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -1,7 +1,6 @@
 //! Font configuration: the `[font]` section.
 
 use serde::Deserialize;
-use std::path::PathBuf;
 
 const DEFAULT_SIZE: f32 = 11.25;
 
@@ -13,24 +12,28 @@ pub struct FontConfig {
     /// `scale_factor` to device pixels — Alacritty's model (not literal
     /// typographic points; no 96/72 conversion is applied).
     pub size: f32,
-    /// Absolute or `~`-prefixed path to the regular-face TTF (Bevy GUI only).
-    pub normal: Option<PathBuf>,
-    /// Absolute or `~`-prefixed path to the bold-face TTF (Bevy GUI only).
-    pub bold: Option<PathBuf>,
-    /// Absolute or `~`-prefixed path to the italic-face TTF (Bevy GUI only).
-    pub italic: Option<PathBuf>,
-    /// Absolute or `~`-prefixed path to the bold-italic-face TTF (Bevy GUI only).
-    pub bold_italic: Option<PathBuf>,
+    /// Base font-family name resolved against the system font database. `None`
+    /// uses the bundled JetBrains Mono Nerd Font.
+    pub family: Option<String>,
+    /// Optional family-name override for the bold face; `None` derives it from
+    /// `family`.
+    pub bold_family: Option<String>,
+    /// Optional family-name override for the italic face; `None` derives it from
+    /// `family`.
+    pub italic_family: Option<String>,
+    /// Optional family-name override for the bold-italic face; `None` derives it
+    /// from `family`.
+    pub bold_italic_family: Option<String>,
 }
 
 impl Default for FontConfig {
     fn default() -> Self {
         Self {
             size: DEFAULT_SIZE,
-            normal: None,
-            bold: None,
-            italic: None,
-            bold_italic: None,
+            family: None,
+            bold_family: None,
+            italic_family: None,
+            bold_italic_family: None,
         }
     }
 }
@@ -51,36 +54,31 @@ mod tests {
     }
 
     #[test]
-    fn parses_flat_paths() {
-        let f: FontConfig =
-            toml::from_str("size = 14.0\nnormal = \"/abs/Regular.ttf\"\nbold = \"/abs/Bold.ttf\"")
-                .unwrap();
+    fn parses_family_and_per_face_overrides() {
+        let f: FontConfig = toml::from_str(
+            "size = 14.0\nfamily = \"JetBrains Mono\"\nitalic_family = \"Cascadia Code\"",
+        )
+        .unwrap();
         assert_eq!(f.size, 14.0);
-        assert_eq!(
-            f.normal.as_deref(),
-            Some(std::path::Path::new("/abs/Regular.ttf"))
-        );
-        assert_eq!(
-            f.bold.as_deref(),
-            Some(std::path::Path::new("/abs/Bold.ttf"))
-        );
-        assert_eq!(f.italic, None);
-        assert_eq!(f.bold_italic, None);
+        assert_eq!(f.family.as_deref(), Some("JetBrains Mono"));
+        assert_eq!(f.italic_family.as_deref(), Some("Cascadia Code"));
+        assert_eq!(f.bold_family, None);
+        assert_eq!(f.bold_italic_family, None);
     }
 
     #[test]
-    fn size_override_keeps_paths_none() {
+    fn size_only_leaves_families_none() {
         let f: FontConfig = toml::from_str("size = 18.0").unwrap();
         assert_eq!(f.size, 18.0);
-        assert_eq!(f.normal, None);
+        assert_eq!(f.family, None);
     }
 
     #[test]
-    fn old_nested_table_form_is_rejected() {
-        let err = toml::from_str::<FontConfig>("[normal]\npath = \"/x.ttf\"").is_err();
-        assert!(
-            err,
-            "old nested [font.normal] path= form must fail to parse"
-        );
+    fn old_path_keys_are_ignored_not_families() {
+        // Clean break: the removed `normal`/`bold` path keys no longer populate
+        // any face — they are unknown keys and silently ignored.
+        let f: FontConfig = toml::from_str("normal = \"/x.ttf\"\nbold = \"/y.ttf\"").unwrap();
+        assert_eq!(f.family, None);
+        assert_eq!(f.bold_family, None);
     }
 }

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -75,8 +75,6 @@ mod tests {
 
     #[test]
     fn old_path_keys_are_ignored_not_families() {
-        // Clean break: the removed `normal`/`bold` path keys no longer populate
-        // any face — they are unknown keys and silently ignored.
         let f: FontConfig = toml::from_str("normal = \"/x.ttf\"\nbold = \"/y.ttf\"").unwrap();
         assert_eq!(f.family, None);
         assert_eq!(f.bold_family, None);

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -14,26 +14,26 @@ pub struct FontConfig {
     pub size: f32,
     /// Base font-family name resolved against the system font database. `None`
     /// uses the bundled JetBrains Mono Nerd Font.
-    pub family: Option<String>,
+    pub normal: Option<String>,
     /// Optional family-name override for the bold face; `None` derives it from
-    /// `family`.
-    pub bold_family: Option<String>,
+    /// `normal`.
+    pub bold: Option<String>,
     /// Optional family-name override for the italic face; `None` derives it from
-    /// `family`.
-    pub italic_family: Option<String>,
+    /// `normal`.
+    pub italic: Option<String>,
     /// Optional family-name override for the bold-italic face; `None` derives it
-    /// from `family`.
-    pub bold_italic_family: Option<String>,
+    /// from `normal`.
+    pub bold_italic: Option<String>,
 }
 
 impl Default for FontConfig {
     fn default() -> Self {
         Self {
             size: DEFAULT_SIZE,
-            family: None,
-            bold_family: None,
-            italic_family: None,
-            bold_italic_family: None,
+            normal: None,
+            bold: None,
+            italic: None,
+            bold_italic: None,
         }
     }
 }
@@ -54,29 +54,21 @@ mod tests {
     }
 
     #[test]
-    fn parses_family_and_per_face_overrides() {
-        let f: FontConfig = toml::from_str(
-            "size = 14.0\nfamily = \"JetBrains Mono\"\nitalic_family = \"Cascadia Code\"",
-        )
-        .unwrap();
+    fn parses_normal_and_per_face_overrides() {
+        let f: FontConfig =
+            toml::from_str("size = 14.0\nnormal = \"JetBrains Mono\"\nitalic = \"Cascadia Code\"")
+                .unwrap();
         assert_eq!(f.size, 14.0);
-        assert_eq!(f.family.as_deref(), Some("JetBrains Mono"));
-        assert_eq!(f.italic_family.as_deref(), Some("Cascadia Code"));
-        assert_eq!(f.bold_family, None);
-        assert_eq!(f.bold_italic_family, None);
+        assert_eq!(f.normal.as_deref(), Some("JetBrains Mono"));
+        assert_eq!(f.italic.as_deref(), Some("Cascadia Code"));
+        assert_eq!(f.bold, None);
+        assert_eq!(f.bold_italic, None);
     }
 
     #[test]
     fn size_only_leaves_families_none() {
         let f: FontConfig = toml::from_str("size = 18.0").unwrap();
         assert_eq!(f.size, 18.0);
-        assert_eq!(f.family, None);
-    }
-
-    #[test]
-    fn old_path_keys_are_ignored_not_families() {
-        let f: FontConfig = toml::from_str("normal = \"/x.ttf\"\nbold = \"/y.ttf\"").unwrap();
-        assert_eq!(f.family, None);
-        assert_eq!(f.bold_family, None);
+        assert_eq!(f.normal, None);
     }
 }

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -55,16 +55,22 @@ impl FontConfig {
     /// `style` is silently ignored (D5/D9). Used to emit a load-time warning.
     pub fn faces_with_ignored_style(&self) -> Vec<&'static str> {
         let base_present = self.normal.family.is_some();
+        self.faces()
+            .into_iter()
+            .filter(|(_, face)| face.style.is_some() && face.family.is_none() && !base_present)
+            .map(|(label, _)| label)
+            .collect()
+    }
+
+    /// The four terminal faces paired with their `[font]` key labels, in fixed
+    /// order — the single source of truth for the face set.
+    pub(crate) fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
         [
             ("normal", &self.normal),
             ("bold", &self.bold),
             ("italic", &self.italic),
             ("bold_italic", &self.bold_italic),
         ]
-        .into_iter()
-        .filter(|(_, face)| face.style.is_some() && face.family.is_none() && !base_present)
-        .map(|(label, _)| label)
-        .collect()
     }
 }
 

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -1,6 +1,9 @@
 //! Font configuration: the `[font]` section.
 
+mod style;
+
 use serde::Deserialize;
+pub use style::{FontSlant, FontStyleSpec, InvalidFontStyleToken};
 
 const DEFAULT_SIZE: f32 = 11.25;
 

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -7,37 +7,64 @@ pub use style::{FontSlant, FontStyleSpec, InvalidFontStyleToken};
 
 const DEFAULT_SIZE: f32 = 11.25;
 
-/// Fully-resolved font configuration for the terminal grid.
+/// One face's font configuration: a family name and a style string, both
+/// optional. Omitted `family` inherits `normal`'s; omitted `style` uses the
+/// face's canonical default (applied in `src/font`).
+#[derive(Deserialize, Clone, Debug, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct FontFaceConfig {
+    /// Font-family name resolved against the system font database.
+    pub family: Option<String>,
+    /// Alacritty-style style string (e.g. `"Bold"`, `"SemiBold Italic"`).
+    pub style: Option<String>,
+}
+
+/// The `[font]` section: a size plus the four terminal faces.
 #[derive(Deserialize, Clone, Debug, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FontConfig {
     /// Terminal font size in logical (CSS) pixels, scaled by the display's
     /// `scale_factor` to device pixels — Alacritty's model (not literal
     /// typographic points; no 96/72 conversion is applied).
     pub size: f32,
-    /// Base font-family name resolved against the system font database. `None`
-    /// uses the bundled JetBrains Mono Nerd Font.
-    pub normal: Option<String>,
-    /// Optional family-name override for the bold face; `None` derives it from
-    /// `normal`.
-    pub bold: Option<String>,
-    /// Optional family-name override for the italic face; `None` derives it from
-    /// `normal`.
-    pub italic: Option<String>,
-    /// Optional family-name override for the bold-italic face; `None` derives it
-    /// from `normal`.
-    pub bold_italic: Option<String>,
+    /// The regular face; its `family` is the base every other face inherits.
+    pub normal: FontFaceConfig,
+    /// The bold face; `family`/`style` default from `normal` / Bold.
+    pub bold: FontFaceConfig,
+    /// The italic face; `family`/`style` default from `normal` / Italic.
+    pub italic: FontFaceConfig,
+    /// The bold-italic face; `family`/`style` default from `normal` / Bold Italic.
+    pub bold_italic: FontFaceConfig,
 }
 
 impl Default for FontConfig {
     fn default() -> Self {
         Self {
             size: DEFAULT_SIZE,
-            normal: None,
-            bold: None,
-            italic: None,
-            bold_italic: None,
+            normal: FontFaceConfig::default(),
+            bold: FontFaceConfig::default(),
+            italic: FontFaceConfig::default(),
+            bold_italic: FontFaceConfig::default(),
         }
+    }
+}
+
+impl FontConfig {
+    /// Face labels whose `style` is set but whose effective family (own or
+    /// inherited from `normal`) is absent — so the bundled default is used and
+    /// `style` is silently ignored (D5/D9). Used to emit a load-time warning.
+    pub fn faces_with_ignored_style(&self) -> Vec<&'static str> {
+        let base_present = self.normal.family.is_some();
+        [
+            ("normal", &self.normal),
+            ("bold", &self.bold),
+            ("italic", &self.italic),
+            ("bold_italic", &self.bold_italic),
+        ]
+        .into_iter()
+        .filter(|(_, face)| face.style.is_some() && face.family.is_none() && !base_present)
+        .map(|(label, _)| label)
+        .collect()
     }
 }
 
@@ -57,21 +84,47 @@ mod tests {
     }
 
     #[test]
-    fn parses_normal_and_per_face_overrides() {
-        let f: FontConfig =
-            toml::from_str("size = 14.0\nnormal = \"JetBrains Mono\"\nitalic = \"Cascadia Code\"")
-                .unwrap();
+    fn parses_nested_face_tables() {
+        let f: FontConfig = toml::from_str(
+            "size = 14.0\n[normal]\nfamily = \"JetBrains Mono\"\nstyle = \"Medium\"\n[italic]\nfamily = \"Cascadia Code\"",
+        )
+        .unwrap();
         assert_eq!(f.size, 14.0);
-        assert_eq!(f.normal.as_deref(), Some("JetBrains Mono"));
-        assert_eq!(f.italic.as_deref(), Some("Cascadia Code"));
-        assert_eq!(f.bold, None);
-        assert_eq!(f.bold_italic, None);
+        assert_eq!(f.normal.family.as_deref(), Some("JetBrains Mono"));
+        assert_eq!(f.normal.style.as_deref(), Some("Medium"));
+        assert_eq!(f.italic.family.as_deref(), Some("Cascadia Code"));
+        assert_eq!(f.italic.style, None);
+        assert_eq!(f.bold, FontFaceConfig::default());
     }
 
     #[test]
-    fn size_only_leaves_families_none() {
-        let f: FontConfig = toml::from_str("size = 18.0").unwrap();
-        assert_eq!(f.size, 18.0);
-        assert_eq!(f.normal, None);
+    fn parses_inline_face_tables() {
+        let f: FontConfig =
+            toml::from_str("normal = { family = \"Iosevka\", style = \"Bold\" }").unwrap();
+        assert_eq!(f.normal.family.as_deref(), Some("Iosevka"));
+        assert_eq!(f.normal.style.as_deref(), Some("Bold"));
+    }
+
+    #[test]
+    fn unknown_face_field_is_rejected() {
+        assert!(
+            toml::from_str::<FontConfig>("[normal]\nfamilly = \"x\"").is_err(),
+            "a typo'd face field must error under deny_unknown_fields"
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_font_field_is_rejected() {
+        assert!(toml::from_str::<FontConfig>("weight = 700").is_err());
+    }
+
+    #[test]
+    fn faces_with_ignored_style_flags_style_without_family() {
+        let f: FontConfig = toml::from_str("[bold]\nstyle = \"Bold\"").unwrap();
+        assert_eq!(f.faces_with_ignored_style(), vec!["bold"]);
+
+        let inherited: FontConfig =
+            toml::from_str("[normal]\nfamily = \"Iosevka\"\n[bold]\nstyle = \"Bold\"").unwrap();
+        assert!(inherited.faces_with_ignored_style().is_empty());
     }
 }

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -62,9 +62,16 @@ impl FontConfig {
             .collect()
     }
 
+    /// Whether no face configures a font family — every face's `family` is
+    /// absent, so the bundled default font is used.
+    #[inline]
+    pub fn has_no_configured_family(&self) -> bool {
+        self.faces().iter().all(|(_, c)| c.family.is_none())
+    }
+
     /// The four terminal faces paired with their `[font]` key labels, in fixed
     /// order — the single source of truth for the face set.
-    pub fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
+    pub const fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
         [
             ("normal", &self.normal),
             ("bold", &self.bold),

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -64,7 +64,7 @@ impl FontConfig {
 
     /// The four terminal faces paired with their `[font]` key labels, in fixed
     /// order — the single source of truth for the face set.
-    pub(crate) fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
+    pub fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
         [
             ("normal", &self.normal),
             ("bold", &self.bold),

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -35,6 +35,10 @@ pub struct FontConfig {
     pub italic: FontFaceConfig,
     /// The bold-italic face; `family`/`style` default from `normal` / Bold Italic.
     pub bold_italic: FontFaceConfig,
+    /// The UI-chrome face (window bar, prompts, indicators). `family` and
+    /// `style` each inherit from `normal` when omitted (not from this face's
+    /// own defaults); resolution and rendering live in `src/font`.
+    pub ui: FontFaceConfig,
 }
 
 impl Default for FontConfig {
@@ -45,6 +49,7 @@ impl Default for FontConfig {
             bold: FontFaceConfig::default(),
             italic: FontFaceConfig::default(),
             bold_italic: FontFaceConfig::default(),
+            ui: FontFaceConfig::default(),
         }
     }
 }
@@ -139,5 +144,24 @@ mod tests {
         let inherited: FontConfig =
             toml::from_str("[normal]\nfamily = \"Iosevka\"\n[bold]\nstyle = \"Bold\"").unwrap();
         assert!(inherited.faces_with_ignored_style().is_empty());
+    }
+
+    #[test]
+    fn parses_ui_face_inline_and_section() {
+        let inline: FontConfig =
+            toml::from_str("ui = { family = \"Inter\", style = \"Medium\" }").unwrap();
+        assert_eq!(inline.ui.family.as_deref(), Some("Inter"));
+        assert_eq!(inline.ui.style.as_deref(), Some("Medium"));
+
+        let section: FontConfig =
+            toml::from_str("[ui]\nfamily = \"Inter\"\nstyle = \"Bold Italic\"").unwrap();
+        assert_eq!(section.ui.family.as_deref(), Some("Inter"));
+        assert_eq!(section.ui.style.as_deref(), Some("Bold Italic"));
+    }
+
+    #[test]
+    fn ui_defaults_to_empty_face() {
+        let f: FontConfig = toml::from_str("").unwrap();
+        assert_eq!(f.ui, FontFaceConfig::default());
     }
 }

--- a/crates/orzma_configs/src/font/style.rs
+++ b/crates/orzma_configs/src/font/style.rs
@@ -1,0 +1,183 @@
+//! Parser for Alacritty-style `style` strings into a font weight + slant.
+
+use std::str::FromStr;
+
+/// A parsed font `style` string: an OpenType weight (100–950) plus slant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FontStyleSpec {
+    /// Numeric weight on the CSS/OpenType scale (100–950); 400 = Regular, 700 = Bold.
+    pub weight: u16,
+    /// Slant selector for the face.
+    pub slant: FontSlant,
+}
+
+/// Slant component of a parsed `style`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FontSlant {
+    /// Upright.
+    Normal,
+    /// Italic.
+    Italic,
+    /// Oblique (slanted upright design).
+    Oblique,
+}
+
+/// A `style` string that contained a token matching neither a weight nor a
+/// slant name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidFontStyleToken {
+    /// The offending token, as written by the user.
+    pub token: String,
+}
+
+impl FromStr for FontStyleSpec {
+    type Err = InvalidFontStyleToken;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut weight = None;
+        let mut slant = None;
+        for raw in s.split_whitespace() {
+            let word: String = raw
+                .chars()
+                .filter(|c| *c != '-')
+                .flat_map(char::to_lowercase)
+                .collect();
+            if let Some(w) = weight_name(&word) {
+                weight = Some(w);
+            } else if let Some(sl) = slant_name(&word) {
+                slant = Some(sl);
+            } else {
+                return Err(InvalidFontStyleToken {
+                    token: raw.to_string(),
+                });
+            }
+        }
+        Ok(Self {
+            weight: weight.unwrap_or(400),
+            slant: slant.unwrap_or(FontSlant::Normal),
+        })
+    }
+}
+
+fn weight_name(word: &str) -> Option<u16> {
+    Some(match word {
+        "thin" | "hairline" => 100,
+        "extralight" | "ultralight" => 200,
+        "light" => 300,
+        "regular" | "normal" | "book" => 400,
+        "medium" => 500,
+        "semibold" | "demibold" => 600,
+        "bold" => 700,
+        "extrabold" | "ultrabold" => 800,
+        "black" | "heavy" => 900,
+        _ => return None,
+    })
+}
+
+fn slant_name(word: &str) -> Option<FontSlant> {
+    Some(match word {
+        "italic" => FontSlant::Italic,
+        "oblique" => FontSlant::Oblique,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn spec(s: &str) -> FontStyleSpec {
+        FontStyleSpec::from_str(s).expect("valid style")
+    }
+
+    #[test]
+    fn parses_standard_four() {
+        assert_eq!(
+            spec("Regular"),
+            FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Normal
+            }
+        );
+        assert_eq!(
+            spec("Bold"),
+            FontStyleSpec {
+                weight: 700,
+                slant: FontSlant::Normal
+            }
+        );
+        assert_eq!(
+            spec("Italic"),
+            FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Italic
+            }
+        );
+        assert_eq!(
+            spec("Bold Italic"),
+            FontStyleSpec {
+                weight: 700,
+                slant: FontSlant::Italic
+            }
+        );
+    }
+
+    #[test]
+    fn parses_common_weight_names_case_insensitively() {
+        assert_eq!(spec("semibold").weight, 600);
+        assert_eq!(spec("SemiBold").weight, 600);
+        assert_eq!(spec("DemiBold").weight, 600);
+        assert_eq!(
+            spec("Medium Italic"),
+            FontStyleSpec {
+                weight: 500,
+                slant: FontSlant::Italic
+            }
+        );
+        assert_eq!(spec("thin").weight, 100);
+        assert_eq!(spec("Black").weight, 900);
+    }
+
+    #[test]
+    fn accepts_hyphenated_and_concatenated_weight_names() {
+        assert_eq!(spec("extra-bold").weight, 800);
+        assert_eq!(spec("ExtraBold").weight, 800);
+        assert_eq!(spec("ultra-light").weight, 200);
+    }
+
+    #[test]
+    fn slant_only_and_weight_only_default_the_other() {
+        assert_eq!(
+            spec("Oblique"),
+            FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Oblique
+            }
+        );
+        assert_eq!(
+            spec("Medium"),
+            FontStyleSpec {
+                weight: 500,
+                slant: FontSlant::Normal
+            }
+        );
+    }
+
+    #[test]
+    fn empty_string_is_regular() {
+        assert_eq!(
+            spec(""),
+            FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Normal
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_token_errors_and_names_the_token() {
+        let err = FontStyleSpec::from_str("Blod").unwrap_err();
+        assert_eq!(err.token, "Blod");
+    }
+}

--- a/crates/orzma_configs/src/font/style.rs
+++ b/crates/orzma_configs/src/font/style.rs
@@ -44,7 +44,7 @@ impl FromStr for FontStyleSpec {
                 .collect();
             if let Some(w) = weight_name(&word) {
                 weight = Some(w);
-            } else if let Some(sl) = slant_name(&word) {
+            } else if let Some(sl) = FontSlant::parse(&word) {
                 slant = Some(sl);
             } else {
                 return Err(InvalidFontStyleToken {
@@ -74,12 +74,14 @@ fn weight_name(word: &str) -> Option<u16> {
     })
 }
 
-fn slant_name(word: &str) -> Option<FontSlant> {
-    Some(match word {
-        "italic" => FontSlant::Italic,
-        "oblique" => FontSlant::Oblique,
-        _ => return None,
-    })
+impl FontSlant {
+    fn parse(word: &str) -> Option<Self> {
+        Some(match word {
+            "italic" => Self::Italic,
+            "oblique" => Self::Oblique,
+            _ => return None,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/orzma_configs/src/font/style.rs
+++ b/crates/orzma_configs/src/font/style.rs
@@ -34,24 +34,23 @@ impl FromStr for FontStyleSpec {
     type Err = InvalidFontStyleToken;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut weight = None;
-        let mut slant = None;
-        for raw in s.split_whitespace() {
-            let word = raw.replace('-', "").to_lowercase();
-            if let Some(w) = weight_name(&word) {
-                weight = Some(w);
-            } else if let Some(sl) = FontSlant::parse(&word) {
-                slant = Some(sl);
-            } else {
-                return Err(InvalidFontStyleToken {
-                    token: raw.to_string(),
-                });
-            }
-        }
-        Ok(Self {
-            weight: weight.unwrap_or(400),
-            slant: slant.unwrap_or(FontSlant::Normal),
-        })
+        // Collapse away spaces and hyphens so "Extra Bold", "extra-bold", and
+        // "ExtraBold" all reduce to one token, and "Bold Italic" / "BoldItalic"
+        // both become "bolditalic".
+        let normalized: String = s
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '-')
+            .flat_map(char::to_lowercase)
+            .collect();
+        let (rest, slant) = FontSlant::strip(&normalized);
+        let weight = if rest.is_empty() {
+            400
+        } else {
+            weight_name(rest).ok_or_else(|| InvalidFontStyleToken {
+                token: s.trim().to_string(),
+            })?
+        };
+        Ok(Self { weight, slant })
     }
 }
 
@@ -71,19 +70,25 @@ fn weight_name(word: &str) -> Option<u16> {
 }
 
 impl FontSlant {
-    fn parse(word: &str) -> Option<Self> {
-        Some(match word {
-            "italic" => Self::Italic,
-            "oblique" => Self::Oblique,
-            _ => return None,
-        })
+    /// Strips a leading or trailing slant name (`italic` / `oblique`) from the
+    /// normalized `token`, returning the remaining weight portion and the slant
+    /// (`Normal` when none is present).
+    fn strip(token: &str) -> (&str, Self) {
+        for (name, slant) in [("italic", Self::Italic), ("oblique", Self::Oblique)] {
+            if let Some(rest) = token.strip_suffix(name) {
+                return (rest, slant);
+            }
+            if let Some(rest) = token.strip_prefix(name) {
+                return (rest, slant);
+            }
+        }
+        (token, Self::Normal)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     fn spec(s: &str) -> FontStyleSpec {
         FontStyleSpec::from_str(s).expect("valid style")
@@ -138,10 +143,32 @@ mod tests {
     }
 
     #[test]
-    fn accepts_hyphenated_and_concatenated_weight_names() {
+    fn accepts_hyphenated_concatenated_and_space_separated_weight_names() {
         assert_eq!(spec("extra-bold").weight, 800);
         assert_eq!(spec("ExtraBold").weight, 800);
         assert_eq!(spec("ultra-light").weight, 200);
+        // Space-separated multi-word weight names, as macOS Font Book displays.
+        assert_eq!(spec("Extra Bold").weight, 800);
+        assert_eq!(spec("Semi Bold").weight, 600);
+        assert_eq!(spec("Ultra Light").weight, 200);
+    }
+
+    #[test]
+    fn accepts_concatenated_and_multiword_weight_slant() {
+        assert_eq!(
+            spec("BoldItalic"),
+            FontStyleSpec {
+                weight: 700,
+                slant: FontSlant::Italic
+            }
+        );
+        assert_eq!(
+            spec("Extra Bold Italic"),
+            FontStyleSpec {
+                weight: 800,
+                slant: FontSlant::Italic
+            }
+        );
     }
 
     #[test]

--- a/crates/orzma_configs/src/font/style.rs
+++ b/crates/orzma_configs/src/font/style.rs
@@ -37,11 +37,7 @@ impl FromStr for FontStyleSpec {
         let mut weight = None;
         let mut slant = None;
         for raw in s.split_whitespace() {
-            let word: String = raw
-                .chars()
-                .filter(|c| *c != '-')
-                .flat_map(char::to_lowercase)
-                .collect();
+            let word = raw.replace('-', "").to_lowercase();
             if let Some(w) = weight_name(&word) {
                 weight = Some(w);
             } else if let Some(sl) = FontSlant::parse(&word) {

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![warn(missing_docs)]
 
+use crate::font::FontStyleSpec;
 use crate::inactive_pane::InactivePaneConfig;
 use crate::keyboard::KeyboardConfig;
 use crate::mouse::MouseConfig;
@@ -13,6 +14,7 @@ use crate::shortcuts::Shortcuts;
 use crate::{font::FontConfig, vi_mode::ViModeConfig};
 pub use error::{OrzmaConfigsError, OrzmaConfigsResult};
 use serde::Deserialize;
+use std::str::FromStr;
 
 pub mod error;
 pub mod font;
@@ -126,6 +128,27 @@ impl OrzmaConfigs {
         if !(size > 0.0 && size <= 200.0) {
             return Err(OrzmaConfigsError::InvalidFontSize { size });
         }
+        for (face, cfg) in [
+            ("normal", &self.font.normal),
+            ("bold", &self.font.bold),
+            ("italic", &self.font.italic),
+            ("bold_italic", &self.font.bold_italic),
+        ] {
+            if let Some(style) = cfg.style.as_deref()
+                && FontStyleSpec::from_str(style).is_err()
+            {
+                return Err(OrzmaConfigsError::InvalidFontStyle {
+                    face,
+                    value: style.to_string(),
+                });
+            }
+        }
+        for face in self.font.faces_with_ignored_style() {
+            tracing::warn!(
+                face,
+                "[font].{face}.style is set but no family is configured for it; using the bundled font and ignoring style"
+            );
+        }
         Ok(())
     }
 }
@@ -189,6 +212,25 @@ mod validate_tests {
         assert!(configs.validate().is_err(), "size 0.0 must fail validation");
         configs.font.size = 11.25;
         assert!(configs.validate().is_ok(), "in-range size validates");
+    }
+
+    #[test]
+    fn validate_rejects_unparseable_font_style() {
+        let mut configs = OrzmaConfigs::default();
+        configs.font.normal.style = Some("Blod".into());
+        let err = configs.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            OrzmaConfigsError::InvalidFontStyle { face: "normal", .. }
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_valid_font_style() {
+        let mut configs = OrzmaConfigs::default();
+        configs.font.bold.style = Some("SemiBold Italic".into());
+        configs.font.bold.family = Some("Iosevka".into());
+        assert!(configs.validate().is_ok());
     }
 
     #[test]

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -310,9 +310,6 @@ mod integration_tests {
 
     #[test]
     fn old_nested_font_table_is_ignored_not_shimmed() {
-        // Clean break: `FontConfig` has no `deny_unknown_fields`, so the old
-        // nested `[font.normal]` path table is an unknown field within `font`
-        // and is silently dropped rather than populating any family.
         let c = parse("[font.normal]\npath = \"/x.ttf\"");
         assert_eq!(c.font, OrzmaConfigs::default().font);
     }

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -309,12 +309,6 @@ mod integration_tests {
     }
 
     #[test]
-    fn old_nested_font_table_is_ignored_not_shimmed() {
-        let c = parse("[font.normal]\npath = \"/x.ttf\"");
-        assert_eq!(c.font, OrzmaConfigs::default().font);
-    }
-
-    #[test]
     fn inactive_pane_section_merges_and_clamps() {
         let c = parse("[inactive_pane]\nenabled = false\ntint = 2.0\ntint_color = \"#102030\"\n");
         assert!(!c.inactive_pane.enabled);

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -128,12 +128,7 @@ impl OrzmaConfigs {
         if !(size > 0.0 && size <= 200.0) {
             return Err(OrzmaConfigsError::InvalidFontSize { size });
         }
-        for (face, cfg) in [
-            ("normal", &self.font.normal),
-            ("bold", &self.font.bold),
-            ("italic", &self.font.italic),
-            ("bold_italic", &self.font.bold_italic),
-        ] {
+        for (face, cfg) in self.font.faces() {
             if let Some(style) = cfg.style.as_deref()
                 && FontStyleSpec::from_str(style).is_err()
             {

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -128,7 +128,12 @@ impl OrzmaConfigs {
         if !(size > 0.0 && size <= 200.0) {
             return Err(OrzmaConfigsError::InvalidFontSize { size });
         }
-        for (face, cfg) in self.font.faces() {
+        for (face, cfg) in self
+            .font
+            .faces()
+            .into_iter()
+            .chain(std::iter::once(("ui", &self.font.ui)))
+        {
             if let Some(style) = cfg.style.as_deref()
                 && FontStyleSpec::from_str(style).is_err()
             {
@@ -226,6 +231,17 @@ mod validate_tests {
         configs.font.bold.style = Some("SemiBold Italic".into());
         configs.font.bold.family = Some("Iosevka".into());
         assert!(configs.validate().is_ok());
+    }
+
+    #[test]
+    fn invalid_ui_style_is_rejected() {
+        let mut configs = OrzmaConfigs::default();
+        configs.font.ui.style = Some("Blod".into());
+        let err = configs.validate().unwrap_err();
+        assert!(
+            matches!(err, OrzmaConfigsError::InvalidFontStyle { face: "ui", .. }),
+            "ui.style typo must be reported with face = \"ui\", got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -309,11 +309,12 @@ mod integration_tests {
     }
 
     #[test]
-    fn old_nested_font_table_fails_at_top_level() {
-        assert!(
-            toml::from_str::<OrzmaConfigs>("[font.normal]\npath = \"/x.ttf\"").is_err(),
-            "old nested font schema must fail to load through OrzmaConfigs, not be shimmed"
-        );
+    fn old_nested_font_table_is_ignored_not_shimmed() {
+        // Clean break: `FontConfig` has no `deny_unknown_fields`, so the old
+        // nested `[font.normal]` path table is an unknown field within `font`
+        // and is silently dropped rather than populating any family.
+        let c = parse("[font.normal]\npath = \"/x.ttf\"");
+        assert_eq!(c.font, OrzmaConfigs::default().font);
     }
 
     #[test]

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -234,6 +234,12 @@ fn primary_face(bytes: Vec<u8>, index: u32, face: FontFace) -> Result<FontArc, F
         .map_err(|source| FontLoadError::ParseFailed { face, source })
 }
 
+/// Builds one fallback `FontArc` from owned bytes (always face index 0),
+/// tagging parse failures with the offending face.
+fn fallback_face(bytes: Vec<u8>, face: FontFace) -> Result<FontArc, FontLoadError> {
+    FontArc::try_from_vec(bytes).map_err(|source| FontLoadError::ParseFailed { face, source })
+}
+
 impl TerminalFonts {
     /// Constructs a `TerminalFonts` from four primary `(bytes, .ttc index)`
     /// pairs plus four fallback byte buffers. Each primary face is loaded at its
@@ -255,30 +261,10 @@ impl TerminalFonts {
         let bold = primary_face(bold.0, bold.1, FontFace::Bold)?;
         let italic = primary_face(italic.0, italic.1, FontFace::Italic)?;
         let bold_italic = primary_face(bold_italic.0, bold_italic.1, FontFace::BoldItalic)?;
-        let fallback_regular = FontArc::try_from_vec(fallback_regular).map_err(|source| {
-            FontLoadError::ParseFailed {
-                face: FontFace::Regular,
-                source,
-            }
-        })?;
-        let fallback_bold =
-            FontArc::try_from_vec(fallback_bold).map_err(|source| FontLoadError::ParseFailed {
-                face: FontFace::Bold,
-                source,
-            })?;
-        let fallback_italic = FontArc::try_from_vec(fallback_italic).map_err(|source| {
-            FontLoadError::ParseFailed {
-                face: FontFace::Italic,
-                source,
-            }
-        })?;
-        let fallback_bold_italic =
-            FontArc::try_from_vec(fallback_bold_italic).map_err(|source| {
-                FontLoadError::ParseFailed {
-                    face: FontFace::BoldItalic,
-                    source,
-                }
-            })?;
+        let fallback_regular = fallback_face(fallback_regular, FontFace::Regular)?;
+        let fallback_bold = fallback_face(fallback_bold, FontFace::Bold)?;
+        let fallback_italic = fallback_face(fallback_italic, FontFace::Italic)?;
+        let fallback_bold_italic = fallback_face(fallback_bold_italic, FontFace::BoldItalic)?;
         let symbol = bundled_symbol_face();
         Ok(Self {
             regular,

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -7,8 +7,10 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ttf_parser::Face as TtfFace;
 
-/// Error returned by `TerminalFonts::from_bytes` when one of the supplied
-/// per-face byte buffers fails `ab_glyph::FontArc::try_from_vec`.
+/// Error returned by `TerminalFonts::from_faces` (the actual producer;
+/// `from_bytes` delegates to it) when a face's bytes fail to parse — primary
+/// faces via `ab_glyph::FontVec::try_from_vec_and_index`, fallback faces via
+/// `FontArc::try_from_vec`.
 #[derive(Debug, thiserror::Error)]
 pub enum FontLoadError {
     /// `FontArc::try_from_vec` rejected the bytes for this face.
@@ -173,7 +175,7 @@ pub struct TerminalFonts {
     /// `.ttc` face index of the regular face. Every ttf-parser reparse of the
     /// regular face (cell metrics, em-scale) MUST use this index — parsing a
     /// collection face at index 0 reads a different face and yields wrong metrics.
-    pub regular_index: u32,
+    regular_index: u32,
 }
 
 /// Computes the worst-case rightward overflow (in physical px) over ASCII

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -2,7 +2,7 @@ use crate::bundled::{
     BOLD, BOLD_ITALIC, FALLBACK_BOLD, FALLBACK_BOLD_ITALIC, FALLBACK_ITALIC, FALLBACK_REGULAR,
     ITALIC, REGULAR, SYMBOL_REGULAR,
 };
-use ab_glyph::{Font, FontArc, ScaleFont};
+use ab_glyph::{Font, FontArc, FontVec, ScaleFont};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ttf_parser::Face as TtfFace;
@@ -170,6 +170,10 @@ pub struct TerminalFonts {
     /// no weight/style variants, so one face serves every `FontFace`. Always
     /// the bundled Noto Sans Symbols 2 — never user-overridable.
     pub symbol: FontArc,
+    /// `.ttc` face index of the regular face. Every ttf-parser reparse of the
+    /// regular face (cell metrics, em-scale) MUST use this index — parsing a
+    /// collection face at index 0 reads a different face and yields wrong metrics.
+    pub regular_index: u32,
 }
 
 /// Computes the worst-case rightward overflow (in physical px) over ASCII
@@ -204,8 +208,8 @@ fn max_ascii_overflow_for_face(face: &FontArc, px_scale: f32, cell_w_phys_floor:
 /// Returns a face's em-scale `(ascender − descender) / units_per_em` — the
 /// factor that maps a physical font size in pixels to the `ab_glyph::PxScale`
 /// whose em-square renders at exactly that pixel size.
-fn em_scale_of(font: &FontArc) -> f32 {
-    let face = TtfFace::parse(font.font_data(), 0)
+fn em_scale_of(font: &FontArc, index: u32) -> f32 {
+    let face = TtfFace::parse(font.font_data(), index)
         .expect("ttf-parser parse failed for a face ab_glyph already accepted");
     let asc = i32::from(face.ascender());
     let desc = i32::from(face.descender());
@@ -220,47 +224,35 @@ fn bundled_symbol_face() -> FontArc {
     FontArc::try_from_slice(SYMBOL_REGULAR).expect("bundled NotoSansSymbols2-Regular load")
 }
 
+/// Builds one primary `FontArc` from owned bytes at a `.ttc` face index,
+/// tagging parse failures with the offending face.
+fn primary_face(bytes: Vec<u8>, index: u32, face: FontFace) -> Result<FontArc, FontLoadError> {
+    FontVec::try_from_vec_and_index(bytes, index)
+        .map(FontArc::from)
+        .map_err(|source| FontLoadError::ParseFailed { face, source })
+}
+
 impl TerminalFonts {
-    /// Constructs a `TerminalFonts` from eight owned TTF byte buffers, one
-    /// per face (four primary + four fallback). `Vec<u8>` is required by
-    /// `ab_glyph::FontArc::try_from_vec`; callers responsible for runtime
-    /// font loading (e.g., the Bevy font-bridge plugin) read bytes from disk,
-    /// build `Vec<u8>`, and call this. On per-face parse failure, returns
-    /// `FontLoadError::ParseFailed` naming the offending face — callers may
-    /// then substitute bundled bytes for that face and retry.
-    ///
-    /// The symbol fallback face is loaded internally from the bundled
-    /// Noto Sans Symbols 2 — it is not user-overridable, so callers do not
-    /// supply it.
-    pub fn from_bytes(
-        regular: Vec<u8>,
-        bold: Vec<u8>,
-        italic: Vec<u8>,
-        bold_italic: Vec<u8>,
+    /// Constructs a `TerminalFonts` from four primary `(bytes, .ttc index)`
+    /// pairs plus four fallback byte buffers. Each primary face is loaded at its
+    /// own collection index; fallback + symbol faces are always index 0. Stores
+    /// the regular face's index for later metric reparses. On per-face parse
+    /// failure returns `FontLoadError::ParseFailed` naming the face.
+    pub fn from_faces(
+        regular: (Vec<u8>, u32),
+        bold: (Vec<u8>, u32),
+        italic: (Vec<u8>, u32),
+        bold_italic: (Vec<u8>, u32),
         fallback_regular: Vec<u8>,
         fallback_bold: Vec<u8>,
         fallback_italic: Vec<u8>,
         fallback_bold_italic: Vec<u8>,
     ) -> Result<Self, FontLoadError> {
-        let regular =
-            FontArc::try_from_vec(regular).map_err(|source| FontLoadError::ParseFailed {
-                face: FontFace::Regular,
-                source,
-            })?;
-        let bold = FontArc::try_from_vec(bold).map_err(|source| FontLoadError::ParseFailed {
-            face: FontFace::Bold,
-            source,
-        })?;
-        let italic =
-            FontArc::try_from_vec(italic).map_err(|source| FontLoadError::ParseFailed {
-                face: FontFace::Italic,
-                source,
-            })?;
-        let bold_italic =
-            FontArc::try_from_vec(bold_italic).map_err(|source| FontLoadError::ParseFailed {
-                face: FontFace::BoldItalic,
-                source,
-            })?;
+        let regular_index = regular.1;
+        let regular = primary_face(regular.0, regular.1, FontFace::Regular)?;
+        let bold = primary_face(bold.0, bold.1, FontFace::Bold)?;
+        let italic = primary_face(italic.0, italic.1, FontFace::Italic)?;
+        let bold_italic = primary_face(bold_italic.0, bold_italic.1, FontFace::BoldItalic)?;
         let fallback_regular = FontArc::try_from_vec(fallback_regular).map_err(|source| {
             FontLoadError::ParseFailed {
                 face: FontFace::Regular,
@@ -296,7 +288,44 @@ impl TerminalFonts {
             fallback_italic,
             fallback_bold_italic,
             symbol,
+            regular_index,
         })
+    }
+
+    /// Constructs a `TerminalFonts` from eight owned TTF byte buffers, one
+    /// per face (four primary + four fallback). `Vec<u8>` is required by
+    /// `ab_glyph::FontArc::try_from_vec`; callers responsible for runtime
+    /// font loading (e.g., the Bevy font-bridge plugin) read bytes from disk,
+    /// build `Vec<u8>`, and call this. On per-face parse failure, returns
+    /// `FontLoadError::ParseFailed` naming the offending face — callers may
+    /// then substitute bundled bytes for that face and retry.
+    ///
+    /// The symbol fallback face is loaded internally from the bundled
+    /// Noto Sans Symbols 2 — it is not user-overridable, so callers do not
+    /// supply it.
+    ///
+    /// Delegates to [`Self::from_faces`] with face index 0 for all four
+    /// primary faces.
+    pub fn from_bytes(
+        regular: Vec<u8>,
+        bold: Vec<u8>,
+        italic: Vec<u8>,
+        bold_italic: Vec<u8>,
+        fallback_regular: Vec<u8>,
+        fallback_bold: Vec<u8>,
+        fallback_italic: Vec<u8>,
+        fallback_bold_italic: Vec<u8>,
+    ) -> Result<Self, FontLoadError> {
+        Self::from_faces(
+            (regular, 0),
+            (bold, 0),
+            (italic, 0),
+            (bold_italic, 0),
+            fallback_regular,
+            fallback_bold,
+            fallback_italic,
+            fallback_bold_italic,
+        )
     }
 
     /// Returns the primary face matching `face`.
@@ -328,7 +357,7 @@ impl TerminalFonts {
     /// Returns full pixel metrics for the regular face at the requested
     /// physical pixel size. See [`CellMetrics`] for individual field semantics.
     pub fn cell_metrics_px(&self, phys_size_px: u16) -> CellMetrics {
-        let face = TtfFace::parse(self.regular.font_data(), 0)
+        let face = TtfFace::parse(self.regular.font_data(), self.regular_index)
             .expect(
                 "regular face: ttf-parser parse failed (bundled or user-supplied via FontBridgePlugin); \
                  if a user override is in effect this means the override file passed ab_glyph but \
@@ -393,7 +422,7 @@ impl TerminalFonts {
     /// Returns the `ab_glyph::PxScale` value for the primary regular face at the
     /// given physical pixel size. Used by `cell_metrics_px` and `glyph/atlas.rs`.
     pub(crate) fn px_scale_value(&self, phys_size_px: u16) -> f32 {
-        f32::from(phys_size_px) * em_scale_of(&self.regular)
+        f32::from(phys_size_px) * em_scale_of(&self.regular, self.regular_index)
     }
 
     /// Returns the `PxScale` value for the CJK fallback face so its em-square
@@ -401,14 +430,14 @@ impl TerminalFonts {
     /// fallback from rasterizing larger than the grid expects. Mirrors
     /// [`Self::px_scale_value`] but reads `self.fallback_regular`'s metrics.
     pub(crate) fn fallback_px_scale_value(&self, phys_size_px: u16) -> f32 {
-        f32::from(phys_size_px) * em_scale_of(&self.fallback_regular)
+        f32::from(phys_size_px) * em_scale_of(&self.fallback_regular, 0)
     }
 
     /// Returns the `PxScale` value for the symbol fallback face so its
     /// em-square renders at the same physical pixel size as the primary's.
     /// Mirrors [`Self::px_scale_value`] but reads `self.symbol`'s metrics.
     pub(crate) fn symbol_px_scale_value(&self, phys_size_px: u16) -> f32 {
-        f32::from(phys_size_px) * em_scale_of(&self.symbol)
+        f32::from(phys_size_px) * em_scale_of(&self.symbol, 0)
     }
 
     /// Returns the primary regular face's `'0'` advance in physical pixels —
@@ -445,6 +474,7 @@ impl Default for TerminalFonts {
             fallback_bold_italic: FontArc::try_from_slice(FALLBACK_BOLD_ITALIC)
                 .expect("UDEVGothic35-BoldItalic load"),
             symbol: bundled_symbol_face(),
+            regular_index: 0,
         }
     }
 }
@@ -482,6 +512,48 @@ impl FontFace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bundled;
+
+    #[test]
+    fn from_faces_index_zero_matches_from_bytes() {
+        let via_bytes = TerminalFonts::from_bytes(
+            bundled::REGULAR.to_vec(),
+            bundled::BOLD.to_vec(),
+            bundled::ITALIC.to_vec(),
+            bundled::BOLD_ITALIC.to_vec(),
+            bundled::FALLBACK_REGULAR.to_vec(),
+            bundled::FALLBACK_BOLD.to_vec(),
+            bundled::FALLBACK_ITALIC.to_vec(),
+            bundled::FALLBACK_BOLD_ITALIC.to_vec(),
+        )
+        .expect("from_bytes");
+        let via_faces = TerminalFonts::from_faces(
+            (bundled::REGULAR.to_vec(), 0),
+            (bundled::BOLD.to_vec(), 0),
+            (bundled::ITALIC.to_vec(), 0),
+            (bundled::BOLD_ITALIC.to_vec(), 0),
+            bundled::FALLBACK_REGULAR.to_vec(),
+            bundled::FALLBACK_BOLD.to_vec(),
+            bundled::FALLBACK_ITALIC.to_vec(),
+            bundled::FALLBACK_BOLD_ITALIC.to_vec(),
+        )
+        .expect("from_faces");
+        assert_eq!(via_faces.regular_index, 0);
+        assert_eq!(
+            via_bytes.regular.font_data(),
+            via_faces.regular.font_data(),
+            "from_faces(index 0) and from_bytes must produce the same regular face"
+        );
+        let mb = via_bytes.cell_metrics_px(12);
+        let mf = via_faces.cell_metrics_px(12);
+        assert!((mb.advance_phys - mf.advance_phys).abs() < 0.001);
+        assert!((mb.line_height_phys - mf.line_height_phys).abs() < 0.001);
+    }
+
+    #[test]
+    fn default_terminal_fonts_regular_index_is_zero() {
+        assert_eq!(TerminalFonts::default().regular_index, 0);
+    }
 
     /// `cell_metrics_px(12)` returns sensible values for JetBrains Mono
     /// Nerd Font Mono Regular at 12px. Empirical ranges were measured

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -54,6 +54,14 @@ size = 11.25              # f32, logical px. Must be 0 < size <= 200, else start
 # style  = "Italic"
 # [font.bold_italic]
 # style  = "Bold Italic"
+#
+# ui = { family = "Inter", style = "Medium" }
+# The UI-chrome face (window bar, prompts, indicators). `family` and `style`
+# each inherit from `normal` when omitted (ui.family -> normal.family,
+# ui.style -> normal.style). A configured `ui.family` that is not installed is
+# a startup error, same as the terminal faces. `style` uses the same weight +
+# slant syntax and is applied to UI text. When no family resolves anywhere
+# (bundled fallback), style rounds to the nearest of the four bundled faces.
 
 [keyboard]
 # macOS only. Which Option key sends Meta instead of composing.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -12,8 +12,8 @@ orzma resolves the config path in this order:
 3. `~/.config/orzma/config.toml` — the default.
 
 Unknown sections are rejected at startup, as are unknown keys in `[orzma]`,
-`[keyboard]`, `[shortcuts]`, and `[vi-mode]`. Unknown keys in `[font]`,
-`[mouse]`, and `[inactive_pane]` are silently ignored. Most invalid values are
+`[keyboard]`, `[shortcuts]`, `[vi-mode]`, and `[font]`. Unknown keys in
+`[mouse]` and `[inactive_pane]` are silently ignored. Most invalid values are
 startup errors too; the few that are silently clamped or reverted are noted
 inline below.
 
@@ -32,15 +32,28 @@ change — omitted keys fall back to these defaults.
 
 [font]
 size = 11.25              # f32, logical px. Must be 0 < size <= 200, else startup error.
-# Font family resolved against installed system fonts. Omit to use the bundled
-# JetBrains Mono Nerd Font. An unknown family falls back to the bundled face; a
-# present family missing a requested weight/style uses that family's closest
-# available face.
-# normal = "JetBrains Mono"
-# Optional per-face family overrides (each omitted → derived from `normal`):
-# bold        = "JetBrains Mono"
-# italic      = "Cascadia Code"
-# bold_italic = "Cascadia Code"
+# Each face is a table of { family, style }. Omit [font] entirely to use the
+# bundled JetBrains Mono Nerd Font. A face's `family`, when omitted, inherits
+# `normal.family`; its `style`, when omitted, uses the face's default
+# (Regular / Bold / Italic / Bold Italic).
+#
+# `family` is resolved against installed system fonts; a configured family that
+# is not installed is a STARTUP ERROR (no silent fallback). `style` selects a
+# weight + slant: standard names (Regular/Bold/Italic/Bold Italic) plus common
+# weights (Thin, Light, Medium, SemiBold, ExtraBold, Black, ...) optionally with
+# Italic/Oblique. An unknown style token is a config error. (Unlike Alacritty,
+# `style` is matched by weight+slant attributes, not by exact subfamily name.)
+#
+# [font.normal]
+# family = "JetBrains Mono"
+# style  = "Regular"
+# [font.bold]
+# style  = "Bold"                 # inherits family = "JetBrains Mono"
+# [font.italic]
+# family = "Cascadia Code"
+# style  = "Italic"
+# [font.bold_italic]
+# style  = "Bold Italic"
 
 [keyboard]
 # macOS only. Which Option key sends Meta instead of composing.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -36,11 +36,11 @@ size = 11.25              # f32, logical px. Must be 0 < size <= 200, else start
 # JetBrains Mono Nerd Font. An unknown family falls back to the bundled face; a
 # present family missing a requested weight/style uses that family's closest
 # available face.
-# family = "JetBrains Mono"
-# Optional per-face family overrides (each omitted → derived from `family`):
-# bold_family        = "JetBrains Mono"
-# italic_family      = "Cascadia Code"
-# bold_italic_family = "Cascadia Code"
+# normal = "JetBrains Mono"
+# Optional per-face family overrides (each omitted → derived from `normal`):
+# bold        = "JetBrains Mono"
+# italic      = "Cascadia Code"
+# bold_italic = "Cascadia Code"
 
 [keyboard]
 # macOS only. Which Option key sends Meta instead of composing.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -32,12 +32,15 @@ change — omitted keys fall back to these defaults.
 
 [font]
 size = 11.25              # f32, logical px. Must be 0 < size <= 200, else startup error.
-# Optional font-file overrides for the GUI (absolute path or ~/...).
-# Omit to use the bundled JetBrains Mono.
-# normal      = "~/Library/Fonts/MyMono-Regular.ttf"
-# bold        = "~/Library/Fonts/MyMono-Bold.ttf"
-# italic      = "~/Library/Fonts/MyMono-Italic.ttf"
-# bold_italic = "~/Library/Fonts/MyMono-BoldItalic.ttf"
+# Font family resolved against installed system fonts. Omit to use the bundled
+# JetBrains Mono Nerd Font. An unknown family falls back to the bundled face; a
+# present family missing a requested weight/style uses that family's closest
+# available face.
+# family = "JetBrains Mono"
+# Optional per-face family overrides (each omitted → derived from `family`):
+# bold_family        = "JetBrains Mono"
+# italic_family      = "Cascadia Code"
+# bold_italic_family = "Cascadia Code"
 
 [keyboard]
 # macOS only. Which Option key sends Meta instead of composing.

--- a/licenses/THIRD-PARTY-LICENSES.md
+++ b/licenses/THIRD-PARTY-LICENSES.md
@@ -5626,6 +5626,7 @@ Used by:
 - objc2-core-audio 0.3.2
 - objc2-core-foundation 0.3.2
 - objc2-core-graphics 0.3.2
+- objc2-core-text 0.3.2
 - objc2-encode 4.1.0
 - objc2-foundation 0.2.2
 - objc2-foundation 0.3.2

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -2,10 +2,10 @@
 //! a Bevy Resource. Config validation errors (duplicate direct or prefix
 //! chords, duplicate `[vi-mode]` keys, a leader that shadows a direct
 //! binding, prefix bindings with no leader, an unmappable leader key, an
-//! out-of-range font size) are fatal (exit 2) so a mistake in one field
-//! never silently discards the whole config. Parse / IO errors warn and
-//! fall back to defaults so the GUI remains startable for users with stale
-//! or invalid config files.
+//! out-of-range font size, an unparseable `[font]` face `style`) are fatal
+//! (exit 2) so a mistake in one field never silently discards the whole
+//! config. Parse / IO errors warn and fall back to defaults so the GUI
+//! remains startable for users with stale or invalid config files.
 
 use bevy::prelude::*;
 use orzma_configs::OrzmaConfigs;
@@ -37,7 +37,8 @@ impl Plugin for OrzmaConfigsPlugin {
             | orzma_configs::OrzmaConfigsError::DuplicateViModeKeys(_)
             | orzma_configs::OrzmaConfigsError::LeaderShadowsDirectBinding { .. }
             | orzma_configs::OrzmaConfigsError::UnmappableLeader { .. }
-            | orzma_configs::OrzmaConfigsError::InvalidFontSize { .. } => {
+            | orzma_configs::OrzmaConfigsError::InvalidFontSize { .. }
+            | orzma_configs::OrzmaConfigsError::InvalidFontStyle { .. } => {
                 eprintln!("orzma: config is invalid:\n  {err}");
                 std::process::exit(2);
             }

--- a/src/font.rs
+++ b/src/font.rs
@@ -11,18 +11,19 @@
 
 use crate::configs::OrzmaConfigsResource;
 use bevy::prelude::*;
-use bevy::text::{Font, FontCx};
+use bevy::text::{Font, FontCx, FontSource};
 use fontique::{Blob, Script};
 use orzma_configs::font::FontConfig;
 use orzma_configs::path::{SystemEnv, expand_user_path};
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use std::path::Path;
 
-/// Strong handle to the UI font asset (regular face). Inserted by
-/// `bridge_font_config`. UI builders read this resource to set
-/// `TextFont { font, ... }`.
+/// UI font source (regular face) consumed by UI text builders as
+/// `TextFont { font: ui_font.0.clone(), ... }`. Either a `FontSource::Family`
+/// (when a system family resolved) or a `FontSource::Handle` to the bundled
+/// regular face. Inserted by `bridge_font_config`.
 #[derive(Resource, Clone)]
-pub struct TerminalUiFont(pub Handle<Font>);
+pub struct TerminalUiFont(pub FontSource);
 
 /// Strong handle to the bundled Nerd Font, used only for the window-bar
 /// powerline separator glyphs (U+E0B0 / U+E0B2). Independent of
@@ -145,7 +146,7 @@ fn bridge_font_config(
         && font.italic.is_none()
         && font.bold_italic.is_none();
     if no_override {
-        commands.insert_resource(TerminalUiFont(powerline));
+        commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
     }
 
@@ -187,7 +188,7 @@ fn bridge_font_config(
     *terminal_fonts = new_fonts;
 
     let handle = make_ui_font_handle(ui_regular_bytes, &mut fonts_assets);
-    commands.insert_resource(TerminalUiFont(handle));
+    commands.insert_resource(TerminalUiFont(FontSource::Handle(handle)));
 }
 
 /// Builds the UI-side `Handle<Font>` from the regular face bytes.
@@ -297,11 +298,17 @@ mod tests {
             .world()
             .get_resource::<TerminalUiFont>()
             .expect("TerminalUiFont must be inserted on the cold path");
+        let FontSource::Handle(handle) = &ui_font.0 else {
+            panic!(
+                "cold path must insert a FontSource::Handle, got {:?}",
+                ui_font.0
+            );
+        };
         // A strong handle from Assets::add stores the asset under the
         // returned handle. Look it up to verify it resolves.
         let assets = app.world().resource::<Assets<Font>>();
         assert!(
-            assets.get(&ui_font.0).is_some(),
+            assets.get(handle).is_some(),
             "TerminalUiFont handle must resolve to an asset stored in Assets<Font>"
         );
     }

--- a/src/font.rs
+++ b/src/font.rs
@@ -10,10 +10,9 @@
 //! metrics + invalidate the glyph atlas — see the renderer crate).
 
 use crate::configs::OrzmaConfigsResource;
-use ab_glyph::FontRef;
 use bevy::prelude::*;
 use bevy::text::{Font, FontCx, FontSource};
-use fontique::{Attributes, Blob, Collection, Script, SourceCache};
+use fontique::{Blob, Script};
 use orzma_configs::font::FontStyleSpec;
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use std::str::FromStr;
@@ -143,24 +142,35 @@ fn bridge_font_config(
             bundled::BOLD_ITALIC,
         ),
     ]
-    .map(|(family, style, face, bundled)| {
-        // NOTE: style was validated at config load; a parse here cannot fail.
-        // If a future change loosens `validate()`'s style check, this
-        // `.expect()` starts panicking at Startup instead of returning
-        // InvalidFontStyle before the app ever gets here.
-        let attributes = match style {
-            Some(s) => resolve::attributes_of(
-                FontStyleSpec::from_str(s).expect("style validated at config load"),
-            ),
-            None => resolve::face_attributes(face),
-        };
-        resolve_or_bundled(
-            &mut cx.collection,
-            &mut cx.source_cache,
-            family,
-            attributes,
-            bundled,
-        )
+    .map(|(family, style, face, bundled)| match family {
+        None => ResolvedFace::bundled(bundled),
+        Some(family) => {
+            // NOTE: style was validated at config load; a parse here cannot
+            // fail. If a future change loosens `validate()`'s style check,
+            // this `.expect()` starts panicking at Startup instead of
+            // returning InvalidFontStyle before the app ever gets here.
+            let attributes = match style {
+                Some(s) => resolve::attributes_of(
+                    FontStyleSpec::from_str(s).expect("style validated at config load"),
+                ),
+                None => resolve::face_attributes(face),
+            };
+            match resolve::resolve_configured_face(
+                &mut cx.collection,
+                &mut cx.source_cache,
+                family,
+                attributes,
+            ) {
+                Ok((bytes, index)) => ResolvedFace {
+                    bytes,
+                    index,
+                    from_family: true,
+                },
+                Err(resolve::FamilyNotFound) => panic!(
+                    "orzma: font family {family:?} configured for the {face:?} face was not found; install it or fix [font] in your config",
+                ),
+            }
+        }
     });
 
     let regular_from_family = regular.from_family;
@@ -200,38 +210,6 @@ impl ResolvedFace {
             bytes: bundled.to_vec(),
             index: 0,
             from_family: false,
-        }
-    }
-}
-
-/// Resolves `family` at `attributes`, validating the result at its index. Falls
-/// back to `bundled` (index 0) — with a warning — when `family` is `None`, the
-/// family name is absent, or the resolved bytes fail to parse.
-fn resolve_or_bundled(
-    collection: &mut Collection,
-    source_cache: &mut SourceCache,
-    family: Option<&str>,
-    attributes: Attributes,
-    bundled: &'static [u8],
-) -> ResolvedFace {
-    let Some(family) = family else {
-        return ResolvedFace::bundled(bundled);
-    };
-    match resolve::resolve_face_bytes(collection, source_cache, family, attributes) {
-        Some((bytes, index)) if FontRef::try_from_slice_and_index(&bytes, index).is_ok() => {
-            ResolvedFace {
-                bytes,
-                index,
-                from_family: true,
-            }
-        }
-        Some(_) => {
-            tracing::warn!(family, "resolved font failed to parse; using bundled");
-            ResolvedFace::bundled(bundled)
-        }
-        None => {
-            tracing::warn!(family, "font family not found; using bundled");
-            ResolvedFace::bundled(bundled)
         }
     }
 }
@@ -440,11 +418,11 @@ mod tests {
     }
 
     #[test]
-    fn unknown_family_falls_back_to_bundled_and_ui_handle() {
-        let tmp = std::env::temp_dir().join("orzma_font_family_unknown.toml");
+    #[should_panic(expected = "was not found")]
+    fn configured_absent_family_aborts_startup() {
+        let tmp = std::env::temp_dir().join("orzma_font_absent_family.toml");
         std::fs::write(&tmp, "[font.normal]\nfamily = \"no-such-family-8b3d2\"\n")
             .expect("write toml");
-
         let _guard = crate::configs::env_guard();
         let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
         let mut app = App::new();
@@ -462,19 +440,6 @@ mod tests {
         app.add_plugins(OrzmaConfigsPlugin);
         app.add_plugins(FontBridgePlugin);
         app.update();
-
-        let fonts = app.world().resource::<TerminalFonts>();
-        assert_eq!(
-            fonts.regular.font_data(),
-            bundled::REGULAR,
-            "unknown family must fall back to bundled regular"
-        );
-        let ui = app.world().resource::<TerminalUiFont>();
-        assert!(
-            matches!(ui.0, bevy::text::FontSource::Handle(_)),
-            "unknown family must leave the UI on the bundled handle, not a Family"
-        );
-
         let _ = std::fs::remove_file(&tmp);
     }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -13,8 +13,10 @@ use crate::configs::OrzmaConfigsResource;
 use ab_glyph::FontRef;
 use bevy::prelude::*;
 use bevy::text::{Font, FontCx, FontSource};
-use fontique::{Blob, Collection, Script, SourceCache};
+use fontique::{Attributes, Blob, Collection, Script, SourceCache};
+use orzma_configs::font::FontStyleSpec;
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
+use std::str::FromStr;
 
 mod resolve;
 
@@ -116,21 +118,47 @@ fn bridge_font_config(
     // instead would borrow all of FontCx twice and fail to compile.
     let cx = &mut **font_cx;
     let [regular, bold, italic, bold_italic] = [
-        (regular_family, FontFace::Regular, bundled::REGULAR),
-        (bold_family, FontFace::Bold, bundled::BOLD),
-        (italic_family, FontFace::Italic, bundled::ITALIC),
+        (
+            regular_family,
+            font.normal.style.as_deref(),
+            FontFace::Regular,
+            bundled::REGULAR,
+        ),
+        (
+            bold_family,
+            font.bold.style.as_deref(),
+            FontFace::Bold,
+            bundled::BOLD,
+        ),
+        (
+            italic_family,
+            font.italic.style.as_deref(),
+            FontFace::Italic,
+            bundled::ITALIC,
+        ),
         (
             bold_italic_family,
+            font.bold_italic.style.as_deref(),
             FontFace::BoldItalic,
             bundled::BOLD_ITALIC,
         ),
     ]
-    .map(|(family, face, bundled)| {
+    .map(|(family, style, face, bundled)| {
+        // NOTE: style was validated at config load; a parse here cannot fail.
+        // If a future change loosens `validate()`'s style check, this
+        // `.expect()` starts panicking at Startup instead of returning
+        // InvalidFontStyle before the app ever gets here.
+        let attributes = match style {
+            Some(s) => resolve::attributes_of(
+                FontStyleSpec::from_str(s).expect("style validated at config load"),
+            ),
+            None => resolve::face_attributes(face),
+        };
         resolve_or_bundled(
             &mut cx.collection,
             &mut cx.source_cache,
             family,
-            face,
+            attributes,
             bundled,
         )
     });
@@ -176,20 +204,19 @@ impl ResolvedFace {
     }
 }
 
-/// Resolves `family` for `face`, validating the result at its index. Falls back
-/// to `bundled` (index 0) — with a warning — when `family` is `None`, the family
-/// name is absent, or the resolved bytes fail to parse.
+/// Resolves `family` at `attributes`, validating the result at its index. Falls
+/// back to `bundled` (index 0) — with a warning — when `family` is `None`, the
+/// family name is absent, or the resolved bytes fail to parse.
 fn resolve_or_bundled(
     collection: &mut Collection,
     source_cache: &mut SourceCache,
     family: Option<&str>,
-    face: FontFace,
+    attributes: Attributes,
     bundled: &'static [u8],
 ) -> ResolvedFace {
     let Some(family) = family else {
         return ResolvedFace::bundled(bundled);
     };
-    let attributes = resolve::face_attributes(face);
     match resolve::resolve_face_bytes(collection, source_cache, family, attributes) {
         Some((bytes, index)) if FontRef::try_from_slice_and_index(&bytes, index).is_ok() => {
             ResolvedFace {
@@ -199,15 +226,11 @@ fn resolve_or_bundled(
             }
         }
         Some(_) => {
-            tracing::warn!(
-                ?face,
-                family,
-                "resolved font failed to parse; using bundled"
-            );
+            tracing::warn!(family, "resolved font failed to parse; using bundled");
             ResolvedFace::bundled(bundled)
         }
         None => {
-            tracing::warn!(?face, family, "font family not found; using bundled");
+            tracing::warn!(family, "font family not found; using bundled");
             ResolvedFace::bundled(bundled)
         }
     }
@@ -221,7 +244,7 @@ mod tests {
     use bevy::asset::AssetPlugin;
     use bevy::text::TextPlugin;
     use bevy::window::{PrimaryWindow, Window, WindowResolution};
-    use fontique::FontInfoOverride;
+    use fontique::{FontInfoOverride, FontWeight};
     use orzma_tty_renderer::TerminalFontPlugin;
     use orzma_tty_renderer::bundled;
     use std::sync::Arc;
@@ -534,6 +557,74 @@ mod tests {
             fonts.italic.font_data(),
             bundled::REGULAR,
             "italic face (no italic override) must fall back to `normal` via .or()"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    /// Registers TWO faces (weight 400 and weight 700) under the SAME family
+    /// name, then configures `normal.style = "Bold"`. A single-face family
+    /// would resolve regardless of style, so this proves the style-derived
+    /// attributes actually drove weight selection: the `normal` slot must
+    /// pick the weight-700 face, not the family's first-registered weight-400
+    /// face.
+    #[test]
+    fn configured_style_selects_weight_within_same_family() {
+        let tmp = std::env::temp_dir().join("orzma_font_style_selects_weight.toml");
+        std::fs::write(
+            &tmp,
+            "[font.normal]\nfamily = \"OrzmaWeighted\"\nstyle = \"Bold\"\n",
+        )
+        .expect("write toml");
+
+        let _guard = crate::configs::env_guard();
+        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(AssetPlugin::default())
+            .add_plugins(TextPlugin)
+            .init_asset::<Font>();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        app.add_plugins(TerminalFontPlugin);
+        app.add_plugins(OrzmaConfigsPlugin);
+        app.add_plugins(FontBridgePlugin);
+
+        {
+            let mut font_cx = app.world_mut().resource_mut::<FontCx>();
+            let regular_blob =
+                Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+            font_cx.collection.register_fonts(
+                regular_blob,
+                Some(FontInfoOverride {
+                    family_name: Some("OrzmaWeighted"),
+                    weight: Some(FontWeight::new(400.0)),
+                    ..Default::default()
+                }),
+            );
+            let bold_blob =
+                Blob::new(Arc::new(bundled::BOLD) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+            font_cx.collection.register_fonts(
+                bold_blob,
+                Some(FontInfoOverride {
+                    family_name: Some("OrzmaWeighted"),
+                    weight: Some(FontWeight::new(700.0)),
+                    ..Default::default()
+                }),
+            );
+        }
+
+        app.update();
+
+        let fonts = app.world().resource::<TerminalFonts>();
+        assert_eq!(
+            fonts.regular.font_data(),
+            bundled::BOLD,
+            "style = \"Bold\" must select the weight-700 face, not the family's weight-400 face"
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/src/font.rs
+++ b/src/font.rs
@@ -97,8 +97,6 @@ fn bridge_font_config(
     let powerline = make_ui_font_handle(bundled::REGULAR.to_vec(), &mut fonts_assets);
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    // Fast path: no family configured at all -> bundled TerminalFonts (already
-    // present) + bundled UI handle.
     let no_family = font.family.is_none()
         && font.bold_family.is_none()
         && font.italic_family.is_none()
@@ -113,9 +111,9 @@ fn bridge_font_config(
     let italic_family = font.italic_family.as_deref().or(regular_family);
     let bold_italic_family = font.bold_italic_family.as_deref().or(regular_family);
 
-    // Materialize &mut FontContext once so its `collection` and `source_cache`
-    // fields can be borrowed as disjoint places (going through DerefMut per call
-    // would borrow all of FontCx twice and fail to compile).
+    // NOTE: materialize &mut FontContext once so `collection` and `source_cache`
+    // borrow as disjoint places. Going through `DerefMut` on `font_cx` per call
+    // instead would borrow all of FontCx twice and fail to compile.
     let cx = &mut **font_cx;
     let regular = resolve_or_bundled(
         &mut cx.collection,
@@ -160,8 +158,6 @@ fn bridge_font_config(
     .expect("validated bytes must parse");
     *terminal_fonts = new_fonts;
 
-    // UI: FontSource::Family only when the regular face actually resolved from a
-    // system family; otherwise the bundled handle.
     let ui_font = match (regular_from_family, regular_family) {
         (true, Some(family)) => FontSource::Family(family.into()),
         _ => FontSource::Handle(powerline),
@@ -242,8 +238,10 @@ mod tests {
     use bevy::asset::AssetPlugin;
     use bevy::text::TextPlugin;
     use bevy::window::{PrimaryWindow, Window, WindowResolution};
+    use fontique::FontInfoOverride;
     use orzma_tty_renderer::TerminalFontPlugin;
     use orzma_tty_renderer::bundled;
+    use std::sync::Arc;
 
     /// RAII guard for a process-environment variable. Constructing it via
     /// `EnvVarGuard::set(...)` sets the variable; dropping it removes
@@ -468,6 +466,90 @@ mod tests {
         assert!(
             matches!(ui.0, bevy::text::FontSource::Handle(_)),
             "unknown family must leave the UI on the bundled handle, not a Family"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    /// Registers the bundled JBM regular/bold faces into the test app's
+    /// `FontCx` collection under known family names BEFORE `app.update()`
+    /// runs `bridge_font_config`, so the resolution is deterministic and
+    /// does not depend on any host-installed font.
+    #[test]
+    fn configured_family_resolves_terminal_fonts_ui_font_and_bold_override() {
+        let tmp = std::env::temp_dir().join("orzma_font_family_success_path.toml");
+        std::fs::write(
+            &tmp,
+            "[font]\nfamily = \"OrzmaTestMono\"\nbold_family = \"OrzmaTestMonoBold\"\n",
+        )
+        .expect("write toml");
+
+        let _guard = crate::configs::env_guard();
+        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(AssetPlugin::default())
+            .add_plugins(TextPlugin)
+            .init_asset::<Font>();
+        let mut window = Window {
+            resolution: WindowResolution::new(800, 600),
+            ..default()
+        };
+        window.resolution.set_scale_factor(1.0);
+        app.world_mut().spawn((window, PrimaryWindow));
+        app.add_plugins(TerminalFontPlugin);
+        app.add_plugins(OrzmaConfigsPlugin);
+        app.add_plugins(FontBridgePlugin);
+
+        {
+            let mut font_cx = app.world_mut().resource_mut::<FontCx>();
+            let regular_blob =
+                Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+            font_cx.collection.register_fonts(
+                regular_blob,
+                Some(FontInfoOverride {
+                    family_name: Some("OrzmaTestMono"),
+                    ..Default::default()
+                }),
+            );
+            let bold_blob =
+                Blob::new(Arc::new(bundled::BOLD) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+            font_cx.collection.register_fonts(
+                bold_blob,
+                Some(FontInfoOverride {
+                    family_name: Some("OrzmaTestMonoBold"),
+                    ..Default::default()
+                }),
+            );
+        }
+
+        app.update();
+
+        let ui_font = app
+            .world()
+            .get_resource::<TerminalUiFont>()
+            .expect("TerminalUiFont must be inserted when the configured family resolves");
+        assert_eq!(
+            ui_font.0,
+            FontSource::Family("OrzmaTestMono".into()),
+            "a family that resolves must produce FontSource::Family, not the bundled handle"
+        );
+
+        let fonts = app.world().resource::<TerminalFonts>();
+        assert_eq!(
+            fonts.regular.font_data(),
+            bundled::REGULAR,
+            "regular face must resolve to the bytes registered under `family`"
+        );
+        assert_eq!(
+            fonts.bold.font_data(),
+            bundled::BOLD,
+            "bold face must resolve via `bold_family`, not fall back to `family`'s bytes"
+        );
+        assert_eq!(
+            fonts.italic.font_data(),
+            bundled::REGULAR,
+            "italic face (no italic_family override) must fall back to `family` via .or()"
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/src/font.rs
+++ b/src/font.rs
@@ -94,7 +94,7 @@ fn bridge_font_config(
     font_size.0 = configs.font.size;
     let font = &configs.font;
 
-    let powerline = make_ui_font_handle(bundled::REGULAR.to_vec(), &mut fonts_assets);
+    let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
     let no_family = font.family.is_none()
@@ -165,20 +165,24 @@ fn bridge_font_config(
     commands.insert_resource(TerminalUiFont(ui_font));
 }
 
-/// Builds the UI-side `Handle<Font>` from the regular face bytes.
-/// `Font::from_bytes` is infallible in Bevy 0.19 (parsing happens later,
-/// at fontique registration); the bytes reaching this point were already
-/// validated per-face by `resolve_or_bundled`.
-fn make_ui_font_handle(regular_bytes: Vec<u8>, fonts_assets: &mut Assets<Font>) -> Handle<Font> {
-    fonts_assets.add(Font::from_bytes(regular_bytes))
-}
-
 /// One primary face resolved for the terminal grid: its bytes, `.ttc` index,
 /// and whether it came from a system family (vs a bundled fallback).
 struct ResolvedFace {
     bytes: Vec<u8>,
     index: u32,
     from_family: bool,
+}
+
+impl ResolvedFace {
+    /// Bundled fallback for one face: the bundled bytes at index 0, marked as not
+    /// resolved from a family.
+    fn bundled(bundled: &[u8]) -> Self {
+        Self {
+            bytes: bundled.to_vec(),
+            index: 0,
+            from_family: false,
+        }
+    }
 }
 
 /// Resolves `family` for `face`, validating the result at its index. Falls back
@@ -192,11 +196,7 @@ fn resolve_or_bundled(
     bundled: &'static [u8],
 ) -> ResolvedFace {
     let Some(family) = family else {
-        return ResolvedFace {
-            bytes: bundled.to_vec(),
-            index: 0,
-            from_family: false,
-        };
+        return ResolvedFace::bundled(bundled);
     };
     let attributes = resolve::face_attributes(face);
     match resolve::resolve_face_bytes(collection, source_cache, family, attributes) {
@@ -213,19 +213,11 @@ fn resolve_or_bundled(
                 family,
                 "resolved font failed to parse; using bundled"
             );
-            ResolvedFace {
-                bytes: bundled.to_vec(),
-                index: 0,
-                from_family: false,
-            }
+            ResolvedFace::bundled(bundled)
         }
         None => {
             tracing::warn!(?face, family, "font family not found; using bundled");
-            ResolvedFace {
-                bytes: bundled.to_vec(),
-                index: 0,
-                from_family: false,
-            }
+            ResolvedFace::bundled(bundled)
         }
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -14,8 +14,10 @@ use bevy::prelude::*;
 use bevy::text::{Font, FontCx, FontSource};
 use fontique::{Blob, Collection, Script, SourceCache};
 use orzma_configs::font::FontStyleSpec;
+use orzma_tty_renderer::bundled::FALLBACK_REGULAR;
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use std::str::FromStr;
+use std::sync::Arc;
 
 mod resolve;
 
@@ -63,10 +65,7 @@ impl Plugin for FontBridgePlugin {
 /// any `Font` asset is ever removed — orzma never removes font assets
 /// after Startup; re-run this registration if that changes.
 fn register_cjk_fallback(mut font_cx: ResMut<FontCx>) {
-    let blob = Blob::new(
-        std::sync::Arc::new(orzma_tty_renderer::bundled::FALLBACK_REGULAR)
-            as std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>,
-    );
+    let blob = Blob::new(Arc::new(FALLBACK_REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
     let registered = font_cx.collection.register_fonts(blob, None);
     let family_ids: Vec<_> = registered.iter().map(|(id, _)| *id).collect();
     for script in [

--- a/src/font.rs
+++ b/src/font.rs
@@ -97,19 +97,19 @@ fn bridge_font_config(
     let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    let no_family = font.normal.is_none()
-        && font.bold.is_none()
-        && font.italic.is_none()
-        && font.bold_italic.is_none();
+    let no_family = font.normal.family.is_none()
+        && font.bold.family.is_none()
+        && font.italic.family.is_none()
+        && font.bold_italic.family.is_none();
     if no_family {
         commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
     }
 
-    let regular_family = font.normal.as_deref();
-    let bold_family = font.bold.as_deref().or(regular_family);
-    let italic_family = font.italic.as_deref().or(regular_family);
-    let bold_italic_family = font.bold_italic.as_deref().or(regular_family);
+    let regular_family = font.normal.family.as_deref();
+    let bold_family = font.bold.family.as_deref().or(regular_family);
+    let italic_family = font.italic.family.as_deref().or(regular_family);
+    let bold_italic_family = font.bold_italic.family.as_deref().or(regular_family);
 
     // NOTE: materialize &mut FontContext once so `collection` and `source_cache`
     // borrow as disjoint places. Going through `DerefMut` on `font_cx` per call
@@ -419,7 +419,8 @@ mod tests {
     #[test]
     fn unknown_family_falls_back_to_bundled_and_ui_handle() {
         let tmp = std::env::temp_dir().join("orzma_font_family_unknown.toml");
-        std::fs::write(&tmp, "[font]\nnormal = \"no-such-family-8b3d2\"\n").expect("write toml");
+        std::fs::write(&tmp, "[font.normal]\nfamily = \"no-such-family-8b3d2\"\n")
+            .expect("write toml");
 
         let _guard = crate::configs::env_guard();
         let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
@@ -463,7 +464,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("orzma_font_family_success_path.toml");
         std::fs::write(
             &tmp,
-            "[font]\nnormal = \"OrzmaTestMono\"\nbold = \"OrzmaTestMonoBold\"\n",
+            "[font.normal]\nfamily = \"OrzmaTestMono\"\n[font.bold]\nfamily = \"OrzmaTestMonoBold\"\n",
         )
         .expect("write toml");
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,7 +12,7 @@
 use crate::configs::OrzmaConfigsResource;
 use bevy::prelude::*;
 use bevy::text::{Font, FontCx, FontSource};
-use fontique::{Blob, Script};
+use fontique::{Blob, Collection, Script, SourceCache};
 use orzma_configs::font::FontStyleSpec;
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use std::str::FromStr;
@@ -142,35 +142,15 @@ fn bridge_font_config(
             bundled::BOLD_ITALIC,
         ),
     ]
-    .map(|(family, style, face, bundled)| match family {
-        None => ResolvedFace::bundled(bundled),
-        Some(family) => {
-            // NOTE: style was validated at config load; a parse here cannot
-            // fail. If a future change loosens `validate()`'s style check,
-            // this `.expect()` starts panicking at Startup instead of
-            // returning InvalidFontStyle before the app ever gets here.
-            let attributes = match style {
-                Some(s) => resolve::attributes_of(
-                    FontStyleSpec::from_str(s).expect("style validated at config load"),
-                ),
-                None => resolve::face_attributes(face),
-            };
-            match resolve::resolve_configured_face(
-                &mut cx.collection,
-                &mut cx.source_cache,
-                family,
-                attributes,
-            ) {
-                Ok((bytes, index)) => ResolvedFace {
-                    bytes,
-                    index,
-                    from_family: true,
-                },
-                Err(resolve::FamilyNotFound) => panic!(
-                    "orzma: font family {family:?} configured for the {face:?} face was not found; install it or fix [font] in your config",
-                ),
-            }
-        }
+    .map(|(family, style, face, bundled)| {
+        ResolvedFace::resolve(
+            &mut cx.collection,
+            &mut cx.source_cache,
+            family,
+            style,
+            face,
+            bundled,
+        )
     });
 
     let regular_from_family = regular.from_family;
@@ -203,6 +183,43 @@ struct ResolvedFace {
 }
 
 impl ResolvedFace {
+    /// Resolves one face: a configured `family` at its `style` (or the face's
+    /// default attributes when `style` is omitted) through the system font
+    /// collection. A face with no configured family uses `bundled`; a configured
+    /// family that cannot be resolved aborts startup (no silent fallback).
+    fn resolve(
+        collection: &mut Collection,
+        source_cache: &mut SourceCache,
+        family: Option<&str>,
+        style: Option<&str>,
+        face: FontFace,
+        bundled: &'static [u8],
+    ) -> Self {
+        let Some(family) = family else {
+            return Self::bundled(bundled);
+        };
+        // NOTE: style was validated at config load; a parse here cannot fail. If
+        // a future change loosens `validate()`'s style check, this `.expect()`
+        // starts panicking at Startup instead of returning InvalidFontStyle
+        // before the app ever gets here.
+        let attributes = match style {
+            Some(s) => resolve::attributes_of(
+                FontStyleSpec::from_str(s).expect("style validated at config load"),
+            ),
+            None => resolve::face_attributes(face),
+        };
+        match resolve::resolve_configured_face(collection, source_cache, family, attributes) {
+            Ok((bytes, index)) => Self {
+                bytes,
+                index,
+                from_family: true,
+            },
+            Err(resolve::FamilyNotFound) => panic!(
+                "orzma: font family {family:?} configured for the {face:?} face was not found; install it or fix [font] in your config",
+            ),
+        }
+    }
+
     /// Bundled fallback for one face: the bundled bytes at index 0, marked as not
     /// resolved from a family.
     fn bundled(bundled: &[u8]) -> Self {

--- a/src/font.rs
+++ b/src/font.rs
@@ -97,19 +97,19 @@ fn bridge_font_config(
     let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    let no_family = font.family.is_none()
-        && font.bold_family.is_none()
-        && font.italic_family.is_none()
-        && font.bold_italic_family.is_none();
+    let no_family = font.normal.is_none()
+        && font.bold.is_none()
+        && font.italic.is_none()
+        && font.bold_italic.is_none();
     if no_family {
         commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
     }
 
-    let regular_family = font.family.as_deref();
-    let bold_family = font.bold_family.as_deref().or(regular_family);
-    let italic_family = font.italic_family.as_deref().or(regular_family);
-    let bold_italic_family = font.bold_italic_family.as_deref().or(regular_family);
+    let regular_family = font.normal.as_deref();
+    let bold_family = font.bold.as_deref().or(regular_family);
+    let italic_family = font.italic.as_deref().or(regular_family);
+    let bold_italic_family = font.bold_italic.as_deref().or(regular_family);
 
     // NOTE: materialize &mut FontContext once so `collection` and `source_cache`
     // borrow as disjoint places. Going through `DerefMut` on `font_cx` per call
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     fn unknown_family_falls_back_to_bundled_and_ui_handle() {
         let tmp = std::env::temp_dir().join("orzma_font_family_unknown.toml");
-        std::fs::write(&tmp, "[font]\nfamily = \"no-such-family-8b3d2\"\n").expect("write toml");
+        std::fs::write(&tmp, "[font]\nnormal = \"no-such-family-8b3d2\"\n").expect("write toml");
 
         let _guard = crate::configs::env_guard();
         let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
@@ -463,7 +463,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("orzma_font_family_success_path.toml");
         std::fs::write(
             &tmp,
-            "[font]\nfamily = \"OrzmaTestMono\"\nbold_family = \"OrzmaTestMonoBold\"\n",
+            "[font]\nnormal = \"OrzmaTestMono\"\nbold = \"OrzmaTestMonoBold\"\n",
         )
         .expect("write toml");
 
@@ -522,17 +522,17 @@ mod tests {
         assert_eq!(
             fonts.regular.font_data(),
             bundled::REGULAR,
-            "regular face must resolve to the bytes registered under `family`"
+            "regular face must resolve to the bytes registered under `normal`"
         );
         assert_eq!(
             fonts.bold.font_data(),
             bundled::BOLD,
-            "bold face must resolve via `bold_family`, not fall back to `family`'s bytes"
+            "bold face must resolve via `bold`, not fall back to `normal`'s bytes"
         );
         assert_eq!(
             fonts.italic.font_data(),
             bundled::REGULAR,
-            "italic face (no italic_family override) must fall back to `family` via .or()"
+            "italic face (no italic override) must fall back to `normal` via .or()"
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/src/font.rs
+++ b/src/font.rs
@@ -10,13 +10,13 @@
 //! metrics + invalidate the glyph atlas — see the renderer crate).
 
 use crate::configs::OrzmaConfigsResource;
+use ab_glyph::FontRef;
 use bevy::prelude::*;
 use bevy::text::{Font, FontCx, FontSource};
-use fontique::{Blob, Script};
-use orzma_configs::font::FontConfig;
-use orzma_configs::path::{SystemEnv, expand_user_path};
+use fontique::{Blob, Collection, Script, SourceCache};
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
-use std::path::Path;
+
+mod resolve;
 
 /// UI font source (regular face) consumed by UI text builders as
 /// `TextFont { font: ui_font.0.clone(), ... }`. Either a `FontSource::Family`
@@ -44,47 +44,6 @@ impl Plugin for FontBridgePlugin {
                 register_cjk_fallback,
             ),
         );
-    }
-}
-
-/// Loads bytes for one face. Returns the file contents if `path` is set
-/// AND expansion succeeds AND read succeeds; otherwise returns the
-/// bundled bytes. Failures are warned, not propagated — partial override
-/// is a feature.
-fn load_face_bytes(path: Option<&Path>, bundled: &'static [u8], face: FontFace) -> Vec<u8> {
-    let Some(p) = path else {
-        return bundled.to_vec();
-    };
-    let Some(expanded) = expand_user_path(p, &SystemEnv) else {
-        tracing::warn!(?face, path = %p.display(), "font path expansion failed; using bundled");
-        return bundled.to_vec();
-    };
-    match std::fs::read(&expanded) {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            tracing::warn!(?face, path = %expanded.display(), %err, "font path read failed; using bundled");
-            bundled.to_vec()
-        }
-    }
-}
-
-/// Validates one face's bytes by attempting to parse them as a font.
-/// Returns the original bytes on success; on failure (parse error), warns
-/// and returns the bundled bytes for that face.
-fn validate_or_bundled(bytes: Vec<u8>, bundled: &'static [u8], face: FontFace) -> Vec<u8> {
-    // Zero-copy validation: FontRef borrows the slice instead of consuming
-    // a Vec, so we don't clone 13 MB of font data just to throw away the
-    // parsed FontArc immediately after.
-    match ab_glyph::FontRef::try_from_slice(&bytes) {
-        Ok(_) => bytes,
-        Err(err) => {
-            tracing::warn!(
-                ?face,
-                %err,
-                "font face failed to parse; substituting bundled bytes for THAT face only"
-            );
-            bundled.to_vec()
-        }
     }
 }
 
@@ -129,74 +88,150 @@ fn bridge_font_config(
     mut fonts_assets: ResMut<Assets<Font>>,
     mut terminal_fonts: ResMut<TerminalFonts>,
     mut font_size: ResMut<TerminalFontSize>,
+    mut font_cx: ResMut<FontCx>,
     configs: Res<OrzmaConfigsResource>,
 ) {
     font_size.0 = configs.font.size;
-    let font: &FontConfig = &configs.font;
+    let font = &configs.font;
 
     let powerline = make_ui_font_handle(bundled::REGULAR.to_vec(), &mut fonts_assets);
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    // Fast path: no override → use the renderer's default TerminalFonts
-    // (already inserted by TerminalFontPlugin) and feed the same bundled
-    // regular bytes to Assets<Font>. Skips ~52 MB of needless allocations
-    // and ~5 redundant ab_glyph / bevy_text parses on the common cold path.
-    let no_override = font.normal.is_none()
-        && font.bold.is_none()
-        && font.italic.is_none()
-        && font.bold_italic.is_none();
-    if no_override {
+    // Fast path: no family configured at all -> bundled TerminalFonts (already
+    // present) + bundled UI handle.
+    let no_family = font.family.is_none()
+        && font.bold_family.is_none()
+        && font.italic_family.is_none()
+        && font.bold_italic_family.is_none();
+    if no_family {
         commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
     }
 
-    let regular_bytes =
-        load_face_bytes(font.normal.as_deref(), bundled::REGULAR, FontFace::Regular);
-    let bold_bytes = load_face_bytes(font.bold.as_deref(), bundled::BOLD, FontFace::Bold);
-    let italic_bytes = load_face_bytes(font.italic.as_deref(), bundled::ITALIC, FontFace::Italic);
-    let bold_italic_bytes = load_face_bytes(
-        font.bold_italic.as_deref(),
-        bundled::BOLD_ITALIC,
+    let regular_family = font.family.as_deref();
+    let bold_family = font.bold_family.as_deref().or(regular_family);
+    let italic_family = font.italic_family.as_deref().or(regular_family);
+    let bold_italic_family = font.bold_italic_family.as_deref().or(regular_family);
+
+    // Materialize &mut FontContext once so its `collection` and `source_cache`
+    // fields can be borrowed as disjoint places (going through DerefMut per call
+    // would borrow all of FontCx twice and fail to compile).
+    let cx = &mut **font_cx;
+    let regular = resolve_or_bundled(
+        &mut cx.collection,
+        &mut cx.source_cache,
+        regular_family,
+        FontFace::Regular,
+        bundled::REGULAR,
+    );
+    let bold = resolve_or_bundled(
+        &mut cx.collection,
+        &mut cx.source_cache,
+        bold_family,
+        FontFace::Bold,
+        bundled::BOLD,
+    );
+    let italic = resolve_or_bundled(
+        &mut cx.collection,
+        &mut cx.source_cache,
+        italic_family,
+        FontFace::Italic,
+        bundled::ITALIC,
+    );
+    let bold_italic = resolve_or_bundled(
+        &mut cx.collection,
+        &mut cx.source_cache,
+        bold_italic_family,
         FontFace::BoldItalic,
+        bundled::BOLD_ITALIC,
     );
 
-    // NOTE: validate-per-face is load-bearing. Without it, a corrupt
-    // override on ANY face drops ALL overrides — the all-or-nothing
-    // regression that commit 09213e7 fixed.
-    let regular_bytes = validate_or_bundled(regular_bytes, bundled::REGULAR, FontFace::Regular);
-    let bold_bytes = validate_or_bundled(bold_bytes, bundled::BOLD, FontFace::Bold);
-    let italic_bytes = validate_or_bundled(italic_bytes, bundled::ITALIC, FontFace::Italic);
-    let bold_italic_bytes = validate_or_bundled(
-        bold_italic_bytes,
-        bundled::BOLD_ITALIC,
-        FontFace::BoldItalic,
-    );
-
-    let ui_regular_bytes = regular_bytes.clone();
-
-    let new_fonts = TerminalFonts::from_bytes(
-        regular_bytes,
-        bold_bytes,
-        italic_bytes,
-        bold_italic_bytes,
-        orzma_tty_renderer::bundled::FALLBACK_REGULAR.to_vec(),
-        orzma_tty_renderer::bundled::FALLBACK_BOLD.to_vec(),
-        orzma_tty_renderer::bundled::FALLBACK_ITALIC.to_vec(),
-        orzma_tty_renderer::bundled::FALLBACK_BOLD_ITALIC.to_vec(),
+    let regular_from_family = regular.from_family;
+    let new_fonts = TerminalFonts::from_faces(
+        (regular.bytes, regular.index),
+        (bold.bytes, bold.index),
+        (italic.bytes, italic.index),
+        (bold_italic.bytes, bold_italic.index),
+        bundled::FALLBACK_REGULAR.to_vec(),
+        bundled::FALLBACK_BOLD.to_vec(),
+        bundled::FALLBACK_ITALIC.to_vec(),
+        bundled::FALLBACK_BOLD_ITALIC.to_vec(),
     )
     .expect("validated bytes must parse");
     *terminal_fonts = new_fonts;
 
-    let handle = make_ui_font_handle(ui_regular_bytes, &mut fonts_assets);
-    commands.insert_resource(TerminalUiFont(FontSource::Handle(handle)));
+    // UI: FontSource::Family only when the regular face actually resolved from a
+    // system family; otherwise the bundled handle.
+    let ui_font = match (regular_from_family, regular_family) {
+        (true, Some(family)) => FontSource::Family(family.into()),
+        _ => FontSource::Handle(powerline),
+    };
+    commands.insert_resource(TerminalUiFont(ui_font));
 }
 
 /// Builds the UI-side `Handle<Font>` from the regular face bytes.
 /// `Font::from_bytes` is infallible in Bevy 0.19 (parsing happens later,
 /// at fontique registration); the bytes reaching this point were already
-/// validated per-face by `validate_or_bundled`.
+/// validated per-face by `resolve_or_bundled`.
 fn make_ui_font_handle(regular_bytes: Vec<u8>, fonts_assets: &mut Assets<Font>) -> Handle<Font> {
     fonts_assets.add(Font::from_bytes(regular_bytes))
+}
+
+/// One primary face resolved for the terminal grid: its bytes, `.ttc` index,
+/// and whether it came from a system family (vs a bundled fallback).
+struct ResolvedFace {
+    bytes: Vec<u8>,
+    index: u32,
+    from_family: bool,
+}
+
+/// Resolves `family` for `face`, validating the result at its index. Falls back
+/// to `bundled` (index 0) — with a warning — when `family` is `None`, the family
+/// name is absent, or the resolved bytes fail to parse.
+fn resolve_or_bundled(
+    collection: &mut Collection,
+    source_cache: &mut SourceCache,
+    family: Option<&str>,
+    face: FontFace,
+    bundled: &'static [u8],
+) -> ResolvedFace {
+    let Some(family) = family else {
+        return ResolvedFace {
+            bytes: bundled.to_vec(),
+            index: 0,
+            from_family: false,
+        };
+    };
+    let attributes = resolve::face_attributes(face);
+    match resolve::resolve_face_bytes(collection, source_cache, family, attributes) {
+        Some((bytes, index)) if FontRef::try_from_slice_and_index(&bytes, index).is_ok() => {
+            ResolvedFace {
+                bytes,
+                index,
+                from_family: true,
+            }
+        }
+        Some(_) => {
+            tracing::warn!(
+                ?face,
+                family,
+                "resolved font failed to parse; using bundled"
+            );
+            ResolvedFace {
+                bytes: bundled.to_vec(),
+                index: 0,
+                from_family: false,
+            }
+        }
+        None => {
+            tracing::warn!(?face, family, "font family not found; using bundled");
+            ResolvedFace {
+                bytes: bundled.to_vec(),
+                index: 0,
+                from_family: false,
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -209,7 +244,6 @@ mod tests {
     use bevy::window::{PrimaryWindow, Window, WindowResolution};
     use orzma_tty_renderer::TerminalFontPlugin;
     use orzma_tty_renderer::bundled;
-    use std::io::Write;
 
     /// RAII guard for a process-environment variable. Constructing it via
     /// `EnvVarGuard::set(...)` sets the variable; dropping it removes
@@ -314,133 +348,6 @@ mod tests {
     }
 
     #[test]
-    fn configured_normal_path_overrides_regular_face() {
-        // Use the bundled JetBrains Mono regular bytes as the "override" — the
-        // test verifies the bytes flow through std::fs::read, not that
-        // they differ from bundled. Write to a temp file and point
-        // ORZMA_CONFIG at a TOML that uses it.
-        let tmp_dir = std::env::temp_dir().join("orzma_font_bridge_test_normal");
-        let _ = std::fs::create_dir_all(&tmp_dir);
-        let ttf_path = tmp_dir.join("regular.ttf");
-        std::fs::write(&ttf_path, bundled::REGULAR).expect("write temp ttf");
-
-        let toml_path = tmp_dir.join("config.toml");
-        let mut f = std::fs::File::create(&toml_path).expect("create toml");
-        writeln!(f, "[font]\nnormal = \"{}\"\n", ttf_path.to_string_lossy()).expect("write toml");
-        drop(f);
-
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &toml_path);
-
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
-        app.update();
-
-        let fonts = app.world().resource::<TerminalFonts>();
-        assert_eq!(
-            fonts.regular.font_data(),
-            bundled::REGULAR,
-            "regular face bytes equal the override file (which happens to contain bundled bytes)"
-        );
-
-        let _ = std::fs::remove_file(&ttf_path);
-        let _ = std::fs::remove_file(&toml_path);
-    }
-
-    #[test]
-    fn missing_normal_path_falls_back_to_bundled() {
-        let nonexistent = std::env::temp_dir().join("orzma_font_bridge_test_missing.ttf");
-        let _ = std::fs::remove_file(&nonexistent);
-        let toml = std::env::temp_dir().join("orzma_font_bridge_test_missing.toml");
-        std::fs::write(
-            &toml,
-            format!("[font]\nnormal = \"{}\"\n", nonexistent.to_string_lossy()),
-        )
-        .expect("write toml");
-
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &toml);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
-        app.update();
-
-        let fonts = app.world().resource::<TerminalFonts>();
-        assert_eq!(
-            fonts.regular.font_data(),
-            bundled::REGULAR,
-            "regular face falls back to bundled when configured path does not exist"
-        );
-
-        let _ = std::fs::remove_file(&toml);
-    }
-
-    #[test]
-    fn normal_path_set_does_not_inherit_to_bold() {
-        let tmp_dir = std::env::temp_dir().join("orzma_font_bridge_test_no_inherit");
-        let _ = std::fs::create_dir_all(&tmp_dir);
-        let normal_path = tmp_dir.join("only-regular.ttf");
-        std::fs::write(&normal_path, bundled::REGULAR).expect("write");
-        let toml = tmp_dir.join("config.toml");
-        std::fs::write(
-            &toml,
-            format!("[font]\nnormal = \"{}\"\n", normal_path.to_string_lossy()),
-        )
-        .expect("write toml");
-
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &toml);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
-        app.update();
-
-        let fonts = app.world().resource::<TerminalFonts>();
-        assert_eq!(
-            fonts.bold.font_data(),
-            bundled::BOLD,
-            "bold face must NOT inherit from normal_path; it stays bundled bold"
-        );
-
-        let _ = std::fs::remove_file(&normal_path);
-        let _ = std::fs::remove_file(&toml);
-    }
-
-    #[test]
     fn cjk_fallback_registered_in_font_collection() {
         let (mut app, _guard, _env) = make_test_app();
         app.update();
@@ -529,30 +436,12 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_bold_path_falls_back_per_face_without_dropping_normal_override() {
-        // Write a corrupt "bold" TTF (just random bytes that won't parse)
-        // and a valid "normal" TTF (bundled JetBrains Mono regular). Verify
-        // bridge_font_config keeps the normal override AND replaces only
-        // the corrupt bold with bundled bold.
-        let tmp_dir = std::env::temp_dir().join("orzma_font_bridge_test_corrupt_bold");
-        let _ = std::fs::create_dir_all(&tmp_dir);
-        let normal_path = tmp_dir.join("regular.ttf");
-        std::fs::write(&normal_path, bundled::REGULAR).expect("write regular");
-        let bold_path = tmp_dir.join("bold.ttf");
-        std::fs::write(&bold_path, b"this is not a valid TTF").expect("write corrupt bold");
-        let toml = tmp_dir.join("config.toml");
-        std::fs::write(
-            &toml,
-            format!(
-                "[font]\nnormal = \"{}\"\nbold = \"{}\"\n",
-                normal_path.to_string_lossy(),
-                bold_path.to_string_lossy(),
-            ),
-        )
-        .expect("write toml");
+    fn unknown_family_falls_back_to_bundled_and_ui_handle() {
+        let tmp = std::env::temp_dir().join("orzma_font_family_unknown.toml");
+        std::fs::write(&tmp, "[font]\nfamily = \"no-such-family-8b3d2\"\n").expect("write toml");
 
         let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &toml);
+        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(AssetPlugin::default())
@@ -570,23 +459,17 @@ mod tests {
         app.update();
 
         let fonts = app.world().resource::<TerminalFonts>();
-        // Regular must remain the user-supplied (= bundled-regular bytes
-        // here, but reached via the override path).
         assert_eq!(
             fonts.regular.font_data(),
             bundled::REGULAR,
-            "normal override must survive a corrupt bold override"
+            "unknown family must fall back to bundled regular"
         );
-        // Bold must fall back to bundled because the user-supplied bold
-        // is corrupt.
-        assert_eq!(
-            fonts.bold.font_data(),
-            bundled::BOLD,
-            "corrupt bold override must fall back to bundled bold"
+        let ui = app.world().resource::<TerminalUiFont>();
+        assert!(
+            matches!(ui.0, bevy::text::FontSource::Handle(_)),
+            "unknown family must leave the UI on the bundled handle, not a Family"
         );
 
-        let _ = std::fs::remove_file(&normal_path);
-        let _ = std::fs::remove_file(&bold_path);
-        let _ = std::fs::remove_file(&toml);
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -98,8 +98,7 @@ fn bridge_font_config(
     let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    let no_family = font.faces().iter().all(|(_, face)| face.family.is_none());
-    if no_family {
+    if font.has_no_configured_family() {
         commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
     }

--- a/src/font.rs
+++ b/src/font.rs
@@ -27,11 +27,11 @@ mod resolve;
 #[derive(Resource, Clone, Default)]
 pub struct TerminalUiFont {
     /// Family or bundled-handle source handed to `TextFont.font`.
-    pub source: FontSource,
+    source: FontSource,
     /// Weight applied to `TextFont.weight`.
-    pub weight: FontWeight,
+    weight: FontWeight,
     /// Slant applied to `TextFont.style`.
-    pub style: FontStyle,
+    style: FontStyle,
 }
 
 impl TerminalUiFont {
@@ -725,6 +725,32 @@ mod tests {
             .expect("write toml");
         let (mut app, _guard, _env) = make_test_app(Some(&tmp));
         app.update();
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn configured_ui_style_only_no_family_uses_bundled_handle() {
+        let tmp = std::env::temp_dir().join("orzma_ui_style_only_no_family.toml");
+        std::fs::write(&tmp, "[font.ui]\nstyle = \"Bold\"\n").expect("write toml");
+
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
+        app.update();
+
+        let ui_font = app
+            .world()
+            .get_resource::<TerminalUiFont>()
+            .expect("TerminalUiFont must be inserted on the bundled fallback path");
+        assert!(
+            matches!(ui_font.source, FontSource::Handle(_)),
+            "style-only with no family anywhere must take the bundled Handle branch, got {:?}",
+            ui_font.source
+        );
+        assert_eq!(
+            ui_font.weight,
+            bevy::text::FontWeight(700),
+            "ui.style = Bold must resolve to weight 700"
+        );
+
         let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -11,9 +11,9 @@
 
 use crate::configs::OrzmaConfigsResource;
 use bevy::prelude::*;
-use bevy::text::{Font, FontCx, FontSource};
+use bevy::text::{Font, FontCx, FontSize, FontSource, FontStyle, FontWeight, TextFont};
 use fontique::{Blob, Collection, Script, SourceCache};
-use orzma_configs::font::FontStyleSpec;
+use orzma_configs::font::{FontFaceConfig, FontSlant, FontStyleSpec};
 use orzma_tty_renderer::bundled::FALLBACK_REGULAR;
 use orzma_tty_renderer::{FontFace, TerminalFontInitSet, TerminalFontSize, TerminalFonts, bundled};
 use std::str::FromStr;
@@ -21,12 +21,81 @@ use std::sync::Arc;
 
 mod resolve;
 
-/// UI font source (regular face) consumed by UI text builders as
-/// `TextFont { font: ui_font.0.clone(), ... }`. Either a `FontSource::Family`
-/// (when a system family resolved) or a `FontSource::Handle` to the bundled
-/// regular face. Inserted by `bridge_font_config`.
-#[derive(Resource, Clone)]
-pub struct TerminalUiFont(pub FontSource);
+/// UI-chrome font: the family `source` plus the `weight`/`slant` applied at
+/// every UI `TextFont` site (window bar, prompts, indicators). Built by
+/// `bridge_font_config` from `[font].ui`, inheriting `[font].normal` per field.
+#[derive(Resource, Clone, Default)]
+pub struct TerminalUiFont {
+    /// Family or bundled-handle source handed to `TextFont.font`.
+    pub source: FontSource,
+    /// Weight applied to `TextFont.weight`.
+    pub weight: FontWeight,
+    /// Slant applied to `TextFont.style`.
+    pub style: FontStyle,
+}
+
+impl TerminalUiFont {
+    /// A `TextFont` for a UI text node at `size`, carrying this face's family,
+    /// weight, and slant.
+    pub fn text_font(&self, size: FontSize) -> TextFont {
+        TextFont {
+            font: self.source.clone(),
+            font_size: size,
+            weight: self.weight,
+            style: self.style,
+            ..default()
+        }
+    }
+
+    /// Resolves the UI face from `[font].ui`, inheriting `normal` per field:
+    /// `family` falls back to `normal`'s (using its already-resolved result via
+    /// `regular_from_family`), `style` falls back to `normal.style` then
+    /// Regular. A configured `ui.family` that is absent aborts startup. When no
+    /// family resolves, the bundled face matching the resolved weight/slant is
+    /// used (bundled has only four faces).
+    fn resolve(
+        collection: &mut Collection,
+        fonts_assets: &mut Assets<Font>,
+        ui: &FontFaceConfig,
+        normal: &FontFaceConfig,
+        regular_from_family: bool,
+    ) -> Self {
+        let spec = ui
+            .style
+            .as_deref()
+            .or(normal.style.as_deref())
+            .map(|s| FontStyleSpec::from_str(s).expect("style validated at config load"))
+            .unwrap_or(FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Normal,
+            });
+        let (weight, style) = ui_text_attrs(spec);
+
+        let source = if let Some(family) = ui.family.as_deref() {
+            if !resolve::family_present(collection, family) {
+                panic!(
+                    "orzma: font family {family:?} configured for the ui face was not found; install it or fix [font].ui in your config",
+                );
+            }
+            FontSource::Family(family.into())
+        } else if regular_from_family {
+            let inherited = normal
+                .family
+                .as_deref()
+                .expect("regular_from_family implies a normal family");
+            FontSource::Family(inherited.into())
+        } else {
+            let handle = fonts_assets.add(Font::from_bytes(bundled_face_bytes(spec).to_vec()));
+            FontSource::Handle(handle)
+        };
+
+        Self {
+            source,
+            weight,
+            style,
+        }
+    }
+}
 
 /// Strong handle to the bundled Nerd Font, used only for the window-bar
 /// powerline separator glyphs (U+E0B0 / U+E0B2). Independent of
@@ -95,78 +164,81 @@ fn bridge_font_config(
     let font = &configs.font;
 
     let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
-    commands.insert_resource(PowerlineFont(powerline.clone()));
+    commands.insert_resource(PowerlineFont(powerline));
 
-    if font.has_no_configured_family() {
-        commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
-        return;
-    }
+    // NOTE: materialize &mut FontContext once, before the terminal-family
+    // branch, so both the terminal-face resolution and the UI family probe
+    // borrow `collection` / `source_cache` as disjoint places (going through
+    // DerefMut per call would borrow all of FontCx twice and fail to compile).
+    let cx = &mut **font_cx;
 
     let regular_family = font.normal.family.as_deref();
-    let bold_family = font.bold.family.as_deref().or(regular_family);
-    let italic_family = font.italic.family.as_deref().or(regular_family);
-    let bold_italic_family = font.bold_italic.family.as_deref().or(regular_family);
 
-    // NOTE: materialize &mut FontContext once so `collection` and `source_cache`
-    // borrow as disjoint places. Going through `DerefMut` on `font_cx` per call
-    // instead would borrow all of FontCx twice and fail to compile.
-    let cx = &mut **font_cx;
-    let [regular, bold, italic, bold_italic] = [
-        (
-            regular_family,
-            font.normal.style.as_deref(),
-            FontFace::Regular,
-            bundled::REGULAR,
-        ),
-        (
-            bold_family,
-            font.bold.style.as_deref(),
-            FontFace::Bold,
-            bundled::BOLD,
-        ),
-        (
-            italic_family,
-            font.italic.style.as_deref(),
-            FontFace::Italic,
-            bundled::ITALIC,
-        ),
-        (
-            bold_italic_family,
-            font.bold_italic.style.as_deref(),
-            FontFace::BoldItalic,
-            bundled::BOLD_ITALIC,
-        ),
-    ]
-    .map(|(family, style, face, bundled)| {
-        ResolvedFace::resolve(
-            &mut cx.collection,
-            &mut cx.source_cache,
-            family,
-            style,
-            face,
-            bundled,
+    let regular_from_family = if font.has_no_configured_family() {
+        false
+    } else {
+        let bold_family = font.bold.family.as_deref().or(regular_family);
+        let italic_family = font.italic.family.as_deref().or(regular_family);
+        let bold_italic_family = font.bold_italic.family.as_deref().or(regular_family);
+        let [regular, bold, italic, bold_italic] = [
+            (
+                regular_family,
+                font.normal.style.as_deref(),
+                FontFace::Regular,
+                bundled::REGULAR,
+            ),
+            (
+                bold_family,
+                font.bold.style.as_deref(),
+                FontFace::Bold,
+                bundled::BOLD,
+            ),
+            (
+                italic_family,
+                font.italic.style.as_deref(),
+                FontFace::Italic,
+                bundled::ITALIC,
+            ),
+            (
+                bold_italic_family,
+                font.bold_italic.style.as_deref(),
+                FontFace::BoldItalic,
+                bundled::BOLD_ITALIC,
+            ),
+        ]
+        .map(|(family, style, face, bundled)| {
+            ResolvedFace::resolve(
+                &mut cx.collection,
+                &mut cx.source_cache,
+                family,
+                style,
+                face,
+                bundled,
+            )
+        });
+        let regular_from_family = regular.from_family;
+        *terminal_fonts = TerminalFonts::from_faces(
+            (regular.bytes, regular.index),
+            (bold.bytes, bold.index),
+            (italic.bytes, italic.index),
+            (bold_italic.bytes, bold_italic.index),
+            bundled::FALLBACK_REGULAR.to_vec(),
+            bundled::FALLBACK_BOLD.to_vec(),
+            bundled::FALLBACK_ITALIC.to_vec(),
+            bundled::FALLBACK_BOLD_ITALIC.to_vec(),
         )
-    });
-
-    let regular_from_family = regular.from_family;
-    let new_fonts = TerminalFonts::from_faces(
-        (regular.bytes, regular.index),
-        (bold.bytes, bold.index),
-        (italic.bytes, italic.index),
-        (bold_italic.bytes, bold_italic.index),
-        bundled::FALLBACK_REGULAR.to_vec(),
-        bundled::FALLBACK_BOLD.to_vec(),
-        bundled::FALLBACK_ITALIC.to_vec(),
-        bundled::FALLBACK_BOLD_ITALIC.to_vec(),
-    )
-    .expect("validated bytes must parse");
-    *terminal_fonts = new_fonts;
-
-    let ui_font = match (regular_from_family, regular_family) {
-        (true, Some(family)) => FontSource::Family(family.into()),
-        _ => FontSource::Handle(powerline),
+        .expect("validated bytes must parse");
+        regular_from_family
     };
-    commands.insert_resource(TerminalUiFont(ui_font));
+
+    let ui_font = TerminalUiFont::resolve(
+        &mut cx.collection,
+        &mut fonts_assets,
+        &font.ui,
+        &font.normal,
+        regular_from_family,
+    );
+    commands.insert_resource(ui_font);
 }
 
 /// One primary face resolved for the terminal grid: its bytes, `.ttc` index,
@@ -223,6 +295,30 @@ impl ResolvedFace {
             index: 0,
             from_family: false,
         }
+    }
+}
+
+/// Maps a parsed `FontStyleSpec` to bevy_text's `TextFont` weight + slant.
+fn ui_text_attrs(spec: FontStyleSpec) -> (FontWeight, FontStyle) {
+    let style = match spec.slant {
+        FontSlant::Normal => FontStyle::Normal,
+        FontSlant::Italic => FontStyle::Italic,
+        FontSlant::Oblique => FontStyle::Oblique(None),
+    };
+    (FontWeight(spec.weight), style)
+}
+
+/// Picks the bundled static face nearest to `spec`. The bundle ships only four
+/// faces, so intermediate weights (Light/Medium/SemiBold) round to Regular or
+/// Bold. Used only when no system family resolves for the UI face.
+fn bundled_face_bytes(spec: FontStyleSpec) -> &'static [u8] {
+    let bold = spec.weight >= 600;
+    let italic = spec.slant != FontSlant::Normal;
+    match (bold, italic) {
+        (false, false) => bundled::REGULAR,
+        (true, false) => bundled::BOLD,
+        (false, true) => bundled::ITALIC,
+        (true, true) => bundled::BOLD_ITALIC,
     }
 }
 
@@ -331,10 +427,10 @@ mod tests {
             .world()
             .get_resource::<TerminalUiFont>()
             .expect("TerminalUiFont must be inserted on the cold path");
-        let FontSource::Handle(handle) = &ui_font.0 else {
+        let FontSource::Handle(handle) = &ui_font.source else {
             panic!(
                 "cold path must insert a FontSource::Handle, got {:?}",
-                ui_font.0
+                ui_font.source
             );
         };
         // A strong handle from Assets::add stores the asset under the
@@ -474,7 +570,7 @@ mod tests {
             .get_resource::<TerminalUiFont>()
             .expect("TerminalUiFont must be inserted when the configured family resolves");
         assert_eq!(
-            ui_font.0,
+            ui_font.source,
             FontSource::Family("OrzmaTestMono".into()),
             "a family that resolves must produce FontSource::Family, not the bundled handle"
         );
@@ -549,6 +645,87 @@ mod tests {
             "style = \"Bold\" must select the weight-700 face, not the family's weight-400 face"
         );
 
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn ui_text_attrs_maps_weight_and_slant() {
+        let (w, s) = ui_text_attrs(FontStyleSpec {
+            weight: 600,
+            slant: FontSlant::Italic,
+        });
+        assert_eq!(w, bevy::text::FontWeight(600));
+        assert_eq!(s, bevy::text::FontStyle::Italic);
+    }
+
+    #[test]
+    fn bundled_face_bytes_selects_by_weight_and_slant() {
+        // NOTE: compare by content (`==`), not `std::ptr::eq`. `bundled::REGULAR`
+        // et al. are `pub const`, not `static` (see `bundled.rs`'s module doc);
+        // without LTO, each `include_bytes!` reference across the
+        // orzma_tty_renderer -> orzma crate boundary gets its own embedded copy,
+        // so two textually distinct usage sites hold equal bytes at different
+        // addresses. `std::ptr::eq` would spuriously fail here in a plain `cargo
+        // test` build (no LTO), even though the selection logic is correct.
+        let case = |weight, slant| bundled_face_bytes(FontStyleSpec { weight, slant });
+        assert_eq!(case(400, FontSlant::Normal), bundled::REGULAR);
+        assert_eq!(case(700, FontSlant::Normal), bundled::BOLD);
+        assert_eq!(case(400, FontSlant::Italic), bundled::ITALIC);
+        assert_eq!(case(800, FontSlant::Italic), bundled::BOLD_ITALIC);
+        // Intermediate weight rounds down to Regular.
+        assert_eq!(case(500, FontSlant::Normal), bundled::REGULAR);
+    }
+
+    #[test]
+    fn configured_ui_family_and_style_resolve_independently() {
+        let tmp = std::env::temp_dir().join("orzma_ui_font_independent.toml");
+        std::fs::write(
+            &tmp,
+            "[font.normal]\nfamily = \"OrzmaTestMono\"\n[font.ui]\nfamily = \"OrzmaTestUi\"\nstyle = \"Bold\"\n",
+        )
+        .expect("write toml");
+
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
+        {
+            let mut font_cx = app.world_mut().resource_mut::<FontCx>();
+            for (name, bytes) in [
+                ("OrzmaTestMono", bundled::REGULAR),
+                ("OrzmaTestUi", bundled::BOLD),
+            ] {
+                let blob = Blob::new(Arc::new(bytes) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+                font_cx.collection.register_fonts(
+                    blob,
+                    Some(FontInfoOverride {
+                        family_name: Some(name),
+                        ..Default::default()
+                    }),
+                );
+            }
+        }
+        app.update();
+
+        let ui_font = app.world().get_resource::<TerminalUiFont>().unwrap();
+        assert_eq!(
+            ui_font.source,
+            FontSource::Family("OrzmaTestUi".into()),
+            "ui.family must win independently of normal"
+        );
+        assert_eq!(
+            ui_font.weight,
+            bevy::text::FontWeight(700),
+            "ui.style = Bold"
+        );
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    #[should_panic(expected = "was not found")]
+    fn configured_absent_ui_family_aborts_startup() {
+        let tmp = std::env::temp_dir().join("orzma_absent_ui_family.toml");
+        std::fs::write(&tmp, "[font.ui]\nfamily = \"no-such-ui-family-1a2b\"\n")
+            .expect("write toml");
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
+        app.update();
         let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -115,34 +115,25 @@ fn bridge_font_config(
     // borrow as disjoint places. Going through `DerefMut` on `font_cx` per call
     // instead would borrow all of FontCx twice and fail to compile.
     let cx = &mut **font_cx;
-    let regular = resolve_or_bundled(
-        &mut cx.collection,
-        &mut cx.source_cache,
-        regular_family,
-        FontFace::Regular,
-        bundled::REGULAR,
-    );
-    let bold = resolve_or_bundled(
-        &mut cx.collection,
-        &mut cx.source_cache,
-        bold_family,
-        FontFace::Bold,
-        bundled::BOLD,
-    );
-    let italic = resolve_or_bundled(
-        &mut cx.collection,
-        &mut cx.source_cache,
-        italic_family,
-        FontFace::Italic,
-        bundled::ITALIC,
-    );
-    let bold_italic = resolve_or_bundled(
-        &mut cx.collection,
-        &mut cx.source_cache,
-        bold_italic_family,
-        FontFace::BoldItalic,
-        bundled::BOLD_ITALIC,
-    );
+    let [regular, bold, italic, bold_italic] = [
+        (regular_family, FontFace::Regular, bundled::REGULAR),
+        (bold_family, FontFace::Bold, bundled::BOLD),
+        (italic_family, FontFace::Italic, bundled::ITALIC),
+        (
+            bold_italic_family,
+            FontFace::BoldItalic,
+            bundled::BOLD_ITALIC,
+        ),
+    ]
+    .map(|(family, face, bundled)| {
+        resolve_or_bundled(
+            &mut cx.collection,
+            &mut cx.source_cache,
+            family,
+            face,
+            bundled,
+        )
+    });
 
     let regular_from_family = regular.from_family;
     let new_fonts = TerminalFonts::from_faces(

--- a/src/font.rs
+++ b/src/font.rs
@@ -672,7 +672,6 @@ mod tests {
         assert_eq!(case(700, FontSlant::Normal), bundled::BOLD);
         assert_eq!(case(400, FontSlant::Italic), bundled::ITALIC);
         assert_eq!(case(800, FontSlant::Italic), bundled::BOLD_ITALIC);
-        // Intermediate weight rounds down to Regular.
         assert_eq!(case(500, FontSlant::Normal), bundled::REGULAR);
     }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -98,10 +98,7 @@ fn bridge_font_config(
     let powerline = fonts_assets.add(Font::from_bytes(bundled::REGULAR.to_vec()));
     commands.insert_resource(PowerlineFont(powerline.clone()));
 
-    let no_family = font.normal.family.is_none()
-        && font.bold.family.is_none()
-        && font.italic.family.is_none()
-        && font.bold_italic.family.is_none();
+    let no_family = font.faces().iter().all(|(_, face)| face.family.is_none());
     if no_family {
         commands.insert_resource(TerminalUiFont(FontSource::Handle(powerline)));
         return;
@@ -287,9 +284,14 @@ mod tests {
         }
     }
 
-    fn make_test_app() -> (App, std::sync::MutexGuard<'static, ()>, EnvVarGuard) {
+    fn make_test_app(
+        config: Option<&std::path::Path>,
+    ) -> (App, std::sync::MutexGuard<'static, ()>, EnvVarGuard) {
         let guard = crate::configs::env_guard();
-        let env = EnvVarGuard::unset("ORZMA_CONFIG");
+        let env = match config {
+            Some(path) => EnvVarGuard::set("ORZMA_CONFIG", path),
+            None => EnvVarGuard::unset("ORZMA_CONFIG"),
+        };
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(AssetPlugin::default())
@@ -313,7 +315,7 @@ mod tests {
 
     #[test]
     fn default_config_keeps_bundled_jbm_in_terminal_fonts() {
-        let (mut app, _guard, _env) = make_test_app();
+        let (mut app, _guard, _env) = make_test_app(None);
         app.update();
         let fonts = app.world().resource::<TerminalFonts>();
         assert_eq!(
@@ -325,7 +327,7 @@ mod tests {
 
     #[test]
     fn default_config_inserts_terminal_ui_font_with_strong_handle() {
-        let (mut app, _guard, _env) = make_test_app();
+        let (mut app, _guard, _env) = make_test_app(None);
         app.update();
         let ui_font = app
             .world()
@@ -348,7 +350,7 @@ mod tests {
 
     #[test]
     fn cjk_fallback_registered_in_font_collection() {
-        let (mut app, _guard, _env) = make_test_app();
+        let (mut app, _guard, _env) = make_test_app(None);
         app.update();
 
         let mut font_cx = app.world_mut().resource_mut::<FontCx>();
@@ -373,7 +375,7 @@ mod tests {
 
     #[test]
     fn bridge_sets_terminal_font_size_from_default_config() {
-        let (mut app, _guard, _env) = make_test_app();
+        let (mut app, _guard, _env) = make_test_app(None);
         app.update();
         let size = app.world().resource::<TerminalFontSize>();
         assert_eq!(
@@ -387,22 +389,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("orzma_font_size_override.toml");
         std::fs::write(&tmp, "[font]\nsize = 16.0\n").expect("write toml");
 
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
         app.update();
 
         let size = app.world().resource::<TerminalFontSize>();
@@ -416,7 +403,7 @@ mod tests {
 
     #[test]
     fn powerline_font_resource_is_inserted_and_resolves() {
-        let (mut app, _guard, _env) = make_test_app();
+        let (mut app, _guard, _env) = make_test_app(None);
         app.update();
 
         let handle = app
@@ -440,22 +427,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("orzma_font_absent_family.toml");
         std::fs::write(&tmp, "[font.normal]\nfamily = \"no-such-family-8b3d2\"\n")
             .expect("write toml");
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
         app.update();
         let _ = std::fs::remove_file(&tmp);
     }
@@ -473,22 +445,7 @@ mod tests {
         )
         .expect("write toml");
 
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
 
         {
             let mut font_cx = app.world_mut().resource_mut::<FontCx>();
@@ -559,22 +516,7 @@ mod tests {
         )
         .expect("write toml");
 
-        let _guard = crate::configs::env_guard();
-        let _env = EnvVarGuard::set("ORZMA_CONFIG", &tmp);
-        let mut app = App::new();
-        app.add_plugins(MinimalPlugins)
-            .add_plugins(AssetPlugin::default())
-            .add_plugins(TextPlugin)
-            .init_asset::<Font>();
-        let mut window = Window {
-            resolution: WindowResolution::new(800, 600),
-            ..default()
-        };
-        window.resolution.set_scale_factor(1.0);
-        app.world_mut().spawn((window, PrimaryWindow));
-        app.add_plugins(TerminalFontPlugin);
-        app.add_plugins(OrzmaConfigsPlugin);
-        app.add_plugins(FontBridgePlugin);
+        let (mut app, _guard, _env) = make_test_app(Some(&tmp));
 
         {
             let mut font_cx = app.world_mut().resource_mut::<FontCx>();

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -52,9 +52,7 @@ mod tests {
     use orzma_tty_renderer::bundled;
     use std::sync::Arc;
 
-    fn collection() -> (Collection, SourceCache) {
-        // Deterministic + fast: skip the host font scan. After Task 2,
-        // CollectionOptions::default() has system_fonts: true.
+    fn deterministic_collection() -> (Collection, SourceCache) {
         (
             Collection::new(CollectionOptions {
                 system_fonts: false,
@@ -66,7 +64,7 @@ mod tests {
 
     #[test]
     fn registered_family_resolves_to_bytes() {
-        let (mut collection, mut source_cache) = collection();
+        let (mut collection, mut source_cache) = deterministic_collection();
         let blob = Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
         let registered = collection.register_fonts(blob, None);
         let family_id = registered.first().expect("at least one family").0;
@@ -87,7 +85,7 @@ mod tests {
 
     #[test]
     fn absent_family_returns_none() {
-        let (mut collection, mut source_cache) = collection();
+        let (mut collection, mut source_cache) = deterministic_collection();
         let resolved = resolve_face_bytes(
             &mut collection,
             &mut source_cache,

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -49,7 +49,10 @@ pub(super) struct FamilyNotFound;
 /// font bytes. Used by the UI-font path, which hands parley a
 /// `FontSource::Family` and needs only a presence check (parley selects the
 /// face at render time).
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used only by tests until the UI-font path wires it into TerminalUiFont resolution; #[expect] would fail because the test target compiles it as live"
+)]
 pub(super) fn family_present(collection: &mut Collection, family: &str) -> bool {
     collection.family_id(family).is_some()
 }

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -39,28 +39,6 @@ pub(super) fn attributes_of(spec: FontStyleSpec) -> Attributes {
     }
 }
 
-/// Resolves `family` at `attributes` to `(font-file bytes, .ttc face index)`,
-/// or `None` when no face resolves — either the family name is absent from the
-/// collection, or it is present but the query returns no match. A present family
-/// that merely lacks the exact requested weight/style still returns `Some` (the
-/// closest match). `resolve_configured_face` maps a `None` here to `FamilyNotFound`.
-fn resolve_face_bytes(
-    collection: &mut Collection,
-    source_cache: &mut SourceCache,
-    family: &str,
-    attributes: Attributes,
-) -> Option<(Vec<u8>, u32)> {
-    let mut query = collection.query(source_cache);
-    query.set_families([QueryFamily::Named(family)]);
-    query.set_attributes(attributes);
-    let mut resolved = None;
-    query.matches_with(|font| {
-        resolved = Some((font.blob.as_ref().to_vec(), font.index));
-        QueryStatus::Stop
-    });
-    resolved
-}
-
 /// The configured family did not resolve to a usable face — either its name is
 /// absent from the collection (system font DB), or it is present but no face
 /// matched the query.
@@ -81,6 +59,28 @@ pub(super) fn resolve_configured_face(
         return Err(FamilyNotFound);
     }
     resolve_face_bytes(collection, source_cache, family, attributes).ok_or(FamilyNotFound)
+}
+
+/// Resolves `family` at `attributes` to `(font-file bytes, .ttc face index)`,
+/// or `None` when no face resolves — either the family name is absent from the
+/// collection, or it is present but the query returns no match. A present family
+/// that merely lacks the exact requested weight/style still returns `Some` (the
+/// closest match). `resolve_configured_face` maps a `None` here to `FamilyNotFound`.
+fn resolve_face_bytes(
+    collection: &mut Collection,
+    source_cache: &mut SourceCache,
+    family: &str,
+    attributes: Attributes,
+) -> Option<(Vec<u8>, u32)> {
+    let mut query = collection.query(source_cache);
+    query.set_families([QueryFamily::Named(family)]);
+    query.set_attributes(attributes);
+    let mut resolved = None;
+    query.matches_with(|font| {
+        resolved = Some((font.blob.as_ref().to_vec(), font.index));
+        QueryStatus::Stop
+    });
+    resolved
 }
 
 #[cfg(test)]

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -1,0 +1,110 @@
+//! Resolves a font-family name and face attributes to font-file bytes plus a
+//! collection face index, via a `fontique` collection. Pure over the borrowed
+//! collection + source cache, so tests inject a collection preloaded from known
+//! font files instead of relying on the host's installed fonts.
+
+use fontique::{
+    Attributes, Collection, FontStyle, FontWeight, FontWidth, QueryFamily, QueryStatus, SourceCache,
+};
+use orzma_tty_renderer::FontFace;
+
+/// Returns the fontique query attributes (weight + style, normal width) for
+/// `face`.
+pub(super) fn face_attributes(face: FontFace) -> Attributes {
+    let (weight, style) = match face {
+        FontFace::Regular => (FontWeight::NORMAL, FontStyle::Normal),
+        FontFace::Bold => (FontWeight::BOLD, FontStyle::Normal),
+        FontFace::Italic => (FontWeight::NORMAL, FontStyle::Italic),
+        FontFace::BoldItalic => (FontWeight::BOLD, FontStyle::Italic),
+    };
+    Attributes {
+        width: FontWidth::NORMAL,
+        style,
+        weight,
+    }
+}
+
+/// Resolves `family` at `attributes` to `(font-file bytes, .ttc face index)`,
+/// or `None` when the family name is absent from the collection. A family that
+/// is present but lacks the requested weight/style still returns `Some` (the
+/// closest match) — the caller substitutes bundled bytes only on `None`.
+pub(super) fn resolve_face_bytes(
+    collection: &mut Collection,
+    source_cache: &mut SourceCache,
+    family: &str,
+    attributes: Attributes,
+) -> Option<(Vec<u8>, u32)> {
+    let mut query = collection.query(source_cache);
+    query.set_families([QueryFamily::Named(family)]);
+    query.set_attributes(attributes);
+    let mut resolved = None;
+    query.matches_with(|font| {
+        resolved = Some((font.blob.as_ref().to_vec(), font.index));
+        QueryStatus::Stop
+    });
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fontique::{Blob, CollectionOptions};
+    use orzma_tty_renderer::bundled;
+    use std::sync::Arc;
+
+    fn collection() -> (Collection, SourceCache) {
+        // Deterministic + fast: skip the host font scan. After Task 2,
+        // CollectionOptions::default() has system_fonts: true.
+        (
+            Collection::new(CollectionOptions {
+                system_fonts: false,
+                ..Default::default()
+            }),
+            SourceCache::new(Default::default()),
+        )
+    }
+
+    #[test]
+    fn registered_family_resolves_to_bytes() {
+        let (mut collection, mut source_cache) = collection();
+        let blob = Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+        let registered = collection.register_fonts(blob, None);
+        let family_id = registered.first().expect("at least one family").0;
+        let family = collection
+            .family_name(family_id)
+            .expect("family name")
+            .to_string();
+
+        let resolved = resolve_face_bytes(
+            &mut collection,
+            &mut source_cache,
+            &family,
+            face_attributes(FontFace::Regular),
+        );
+        let (bytes, _index) = resolved.expect("registered family must resolve");
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn absent_family_returns_none() {
+        let (mut collection, mut source_cache) = collection();
+        let resolved = resolve_face_bytes(
+            &mut collection,
+            &mut source_cache,
+            "no-such-family-9c2f1a",
+            face_attributes(FontFace::Regular),
+        );
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn attributes_differ_by_face() {
+        assert_eq!(
+            face_attributes(FontFace::Regular).weight,
+            FontWeight::NORMAL
+        );
+        assert_eq!(face_attributes(FontFace::Bold).weight, FontWeight::BOLD);
+        assert_eq!(face_attributes(FontFace::Italic).style, FontStyle::Italic);
+        assert_eq!(face_attributes(FontFace::Regular).style, FontStyle::Normal);
+    }
+}

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -45,6 +45,15 @@ pub(super) fn attributes_of(spec: FontStyleSpec) -> Attributes {
 #[derive(Debug)]
 pub(super) struct FamilyNotFound;
 
+/// Whether `family` exists in the collection, without resolving or copying any
+/// font bytes. Used by the UI-font path, which hands parley a
+/// `FontSource::Family` and needs only a presence check (parley selects the
+/// face at render time).
+#[allow(dead_code)]
+pub(super) fn family_present(collection: &mut Collection, family: &str) -> bool {
+    collection.family_id(family).is_some()
+}
+
 /// Resolves a *configured* face, distinguishing an absent family (`Err`) from a
 /// present family (fontique returns its closest match for the attributes). Looks
 /// up `family_id` first because `Query::set_families` silently skips unknown
@@ -187,5 +196,20 @@ mod tests {
         )
         .expect("registered family resolves");
         assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn family_present_true_for_registered_family() {
+        let (mut collection, _sc) = deterministic_collection();
+        let blob = Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+        let registered = collection.register_fonts(blob, None);
+        let family = collection.family_name(registered[0].0).unwrap().to_string();
+        assert!(family_present(&mut collection, &family));
+    }
+
+    #[test]
+    fn family_present_false_for_absent_family() {
+        let (mut collection, _sc) = deterministic_collection();
+        assert!(!family_present(&mut collection, "no-such-family-7fe12"));
     }
 }

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -40,10 +40,11 @@ pub(super) fn attributes_of(spec: FontStyleSpec) -> Attributes {
 }
 
 /// Resolves `family` at `attributes` to `(font-file bytes, .ttc face index)`,
-/// or `None` when the family name is absent from the collection. A family that
-/// is present but lacks the requested weight/style still returns `Some` (the
-/// closest match) — the caller substitutes bundled bytes only on `None`.
-pub(super) fn resolve_face_bytes(
+/// or `None` when no face resolves — either the family name is absent from the
+/// collection, or it is present but the query returns no match. A present family
+/// that merely lacks the exact requested weight/style still returns `Some` (the
+/// closest match). `resolve_configured_face` maps a `None` here to `FamilyNotFound`.
+fn resolve_face_bytes(
     collection: &mut Collection,
     source_cache: &mut SourceCache,
     family: &str,
@@ -60,7 +61,9 @@ pub(super) fn resolve_face_bytes(
     resolved
 }
 
-/// The configured family name is absent from the collection (system font DB).
+/// The configured family did not resolve to a usable face — either its name is
+/// absent from the collection (system font DB), or it is present but no face
+/// matched the query.
 #[derive(Debug)]
 pub(super) struct FamilyNotFound;
 

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -49,10 +49,6 @@ pub(super) struct FamilyNotFound;
 /// font bytes. Used by the UI-font path, which hands parley a
 /// `FontSource::Family` and needs only a presence check (parley selects the
 /// face at render time).
-#[allow(
-    dead_code,
-    reason = "used only by tests until the UI-font path wires it into TerminalUiFont resolution; #[expect] would fail because the test target compiles it as live"
-)]
 pub(super) fn family_present(collection: &mut Collection, family: &str) -> bool {
     collection.family_id(family).is_some()
 }

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -60,6 +60,26 @@ pub(super) fn resolve_face_bytes(
     resolved
 }
 
+/// The configured family name is absent from the collection (system font DB).
+#[derive(Debug)]
+pub(super) struct FamilyNotFound;
+
+/// Resolves a *configured* face, distinguishing an absent family (`Err`) from a
+/// present family (fontique returns its closest match for the attributes). Looks
+/// up `family_id` first because `Query::set_families` silently skips unknown
+/// names, which `resolve_face_bytes` alone reports only as `None`.
+pub(super) fn resolve_configured_face(
+    collection: &mut Collection,
+    source_cache: &mut SourceCache,
+    family: &str,
+    attributes: Attributes,
+) -> Result<(Vec<u8>, u32), FamilyNotFound> {
+    if collection.family_id(family).is_none() {
+        return Err(FamilyNotFound);
+    }
+    resolve_face_bytes(collection, source_cache, family, attributes).ok_or(FamilyNotFound)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +150,39 @@ mod tests {
         assert_eq!(a.weight, FontWeight::new(600.0));
         assert_eq!(a.style, FontStyle::Italic);
         assert_eq!(a.width, FontWidth::NORMAL);
+    }
+
+    #[test]
+    fn resolve_configured_face_errors_on_absent_family() {
+        let (mut collection, mut source_cache) = deterministic_collection();
+        let r = resolve_configured_face(
+            &mut collection,
+            &mut source_cache,
+            "no-such-family-4d1",
+            attributes_of(FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Normal,
+            }),
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn resolve_configured_face_returns_bytes_for_registered_family() {
+        let (mut collection, mut source_cache) = deterministic_collection();
+        let blob = Blob::new(Arc::new(bundled::REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
+        let registered = collection.register_fonts(blob, None);
+        let family = collection.family_name(registered[0].0).unwrap().to_string();
+        let (bytes, _index) = resolve_configured_face(
+            &mut collection,
+            &mut source_cache,
+            &family,
+            attributes_of(FontStyleSpec {
+                weight: 400,
+                slant: FontSlant::Normal,
+            }),
+        )
+        .expect("registered family resolves");
+        assert!(!bytes.is_empty());
     }
 }

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -6,6 +6,7 @@
 use fontique::{
     Attributes, Collection, FontStyle, FontWeight, FontWidth, QueryFamily, QueryStatus, SourceCache,
 };
+use orzma_configs::font::{FontSlant, FontStyleSpec};
 use orzma_tty_renderer::FontFace;
 
 /// Returns the fontique query attributes (weight + style, normal width) for
@@ -21,6 +22,20 @@ pub(super) fn face_attributes(face: FontFace) -> Attributes {
         width: FontWidth::NORMAL,
         style,
         weight,
+    }
+}
+
+/// Maps a parsed `FontStyleSpec` to fontique query attributes (normal width).
+pub(super) fn attributes_of(spec: FontStyleSpec) -> Attributes {
+    let style = match spec.slant {
+        FontSlant::Normal => FontStyle::Normal,
+        FontSlant::Italic => FontStyle::Italic,
+        FontSlant::Oblique => FontStyle::Oblique(None),
+    };
+    Attributes {
+        width: FontWidth::NORMAL,
+        style,
+        weight: FontWeight::new(f32::from(spec.weight)),
     }
 }
 
@@ -104,5 +119,16 @@ mod tests {
         assert_eq!(face_attributes(FontFace::Bold).weight, FontWeight::BOLD);
         assert_eq!(face_attributes(FontFace::Italic).style, FontStyle::Italic);
         assert_eq!(face_attributes(FontFace::Regular).style, FontStyle::Normal);
+    }
+
+    #[test]
+    fn attributes_of_maps_weight_and_slant() {
+        let a = attributes_of(FontStyleSpec {
+            weight: 600,
+            slant: FontSlant::Italic,
+        });
+        assert_eq!(a.weight, FontWeight::new(600.0));
+        assert_eq!(a.style, FontStyle::Italic);
+        assert_eq!(a.width, FontWidth::NORMAL);
     }
 }

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -650,7 +650,7 @@ fn spawn_grapheme_cell(
         .spawn((
             Text::new(text),
             TextFont {
-                font: ui_font.0.clone().into(),
+                font: ui_font.0.clone(),
                 font_size: FontSize::Px(font_size.0),
                 ..default()
             },
@@ -795,12 +795,13 @@ mod tests {
 
     #[test]
     fn ime_overlay_uses_terminal_font_size() {
-        use bevy::asset::Handle;
         use bevy::text::TextFont;
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(9.0));
         app.init_resource::<ImeGraphemePool>();
         app.add_systems(Startup, spawn_ime_overlay_once);
@@ -819,13 +820,14 @@ mod tests {
     #[test]
     fn overlay_background_matches_pane_default_bg_while_composing() {
         use crate::surface::OrzmaTerminal;
-        use bevy::asset::Handle;
         use bevy::window::WindowResolution;
         use orzma_tty_renderer::prelude::Cursor;
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(8.0, 16.0),
@@ -895,13 +897,14 @@ mod tests {
 
     fn run_overlay_with_composition(value: &str, caret: Option<(usize, usize)>) -> App {
         use crate::surface::OrzmaTerminal;
-        use bevy::asset::Handle;
         use bevy::window::WindowResolution;
         use orzma_tty_renderer::prelude::Cursor;
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(12.0));
         // advance 10, line height 16 → cell pitch 10×16 logical px at scale 1.
         app.insert_resource(TerminalCellMetricsResource {
@@ -986,11 +989,11 @@ mod tests {
 
     #[test]
     fn spawn_creates_grapheme_pool_and_underline() {
-        use bevy::asset::Handle;
-
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(12.0));
         app.init_resource::<ImeGraphemePool>();
         app.add_systems(Startup, spawn_ime_overlay_once);
@@ -1015,7 +1018,6 @@ mod tests {
     fn overlay_geometry_not_rechanged_on_unchanged_composition() {
         use crate::surface::OrzmaTerminal;
         use bevy::app::Update;
-        use bevy::asset::Handle;
         use bevy::ecs::query::{Changed, Or};
         use bevy::window::WindowResolution;
         use orzma_tty_renderer::prelude::Cursor;
@@ -1044,7 +1046,9 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(10.0, 16.0),
@@ -1163,13 +1167,14 @@ mod tests {
     fn overlay_hidden_and_idle_after_composition_ends() {
         use crate::surface::OrzmaTerminal;
         use bevy::app::PostUpdate;
-        use bevy::asset::Handle;
         use bevy::window::WindowResolution;
         use orzma_tty_renderer::prelude::Cursor;
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(Handle::default()));
+        app.insert_resource(crate::font::TerminalUiFont(
+            bevy::text::FontSource::default(),
+        ));
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(10.0, 16.0),

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -22,7 +22,7 @@ use bevy::ecs::schedule::SystemCondition;
 use bevy::ecs::schedule::common_conditions::{not, resource_exists_and_changed};
 use bevy::ecs::system::{Commands, Query, Res, ResMut};
 use bevy::prelude::default;
-use bevy::text::{FontSize, LineBreak, TextColor, TextFont, TextLayout};
+use bevy::text::{FontSize, LineBreak, TextColor, TextLayout};
 use bevy::ui::widget::Text;
 use bevy::ui::{
     BackgroundColor, BorderColor, ComputedNode, Display, GlobalZIndex, Node, PositionType,
@@ -649,11 +649,7 @@ fn spawn_grapheme_cell(
     commands
         .spawn((
             Text::new(text),
-            TextFont {
-                font: ui_font.0.clone(),
-                font_size: FontSize::Px(font_size.0),
-                ..default()
-            },
+            ui_font.text_font(FontSize::Px(font_size.0)),
             TextColor(Color::WHITE),
             TextLayout {
                 linebreak: LineBreak::NoWrap,
@@ -799,9 +795,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(9.0));
         app.init_resource::<ImeGraphemePool>();
         app.add_systems(Startup, spawn_ime_overlay_once);
@@ -825,9 +819,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(8.0, 16.0),
@@ -902,9 +894,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(12.0));
         // advance 10, line height 16 → cell pitch 10×16 logical px at scale 1.
         app.insert_resource(TerminalCellMetricsResource {
@@ -991,9 +981,7 @@ mod tests {
     fn spawn_creates_grapheme_pool_and_underline() {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(12.0));
         app.init_resource::<ImeGraphemePool>();
         app.add_systems(Startup, spawn_ime_overlay_once);
@@ -1046,9 +1034,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(10.0, 16.0),
@@ -1172,9 +1158,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.insert_resource(crate::font::TerminalUiFont(
-            bevy::text::FontSource::default(),
-        ));
+        app.insert_resource(crate::font::TerminalUiFont::default());
         app.insert_resource(TerminalFontSize(12.0));
         app.insert_resource(TerminalCellMetricsResource {
             metrics: metrics(10.0, 16.0),

--- a/src/ui/tmux/confirm_prompt.rs
+++ b/src/ui/tmux/confirm_prompt.rs
@@ -76,7 +76,7 @@ fn confirm_step(key: &Key) -> Option<ConfirmStep> {
 struct ConfirmBar;
 
 fn spawn_confirm_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>) {
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let ui = ui_font.as_deref().cloned().unwrap_or_default();
     commands
         .spawn((
             Node {
@@ -96,11 +96,7 @@ fn spawn_confirm_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>
         .with_children(|parent| {
             parent.spawn((
                 Text::new(""),
-                TextFont {
-                    font,
-                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                    ..default()
-                },
+                ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
                 TextColor(theme::SELECTION_FG),
             ));
         });

--- a/src/ui/tmux/confirm_prompt.rs
+++ b/src/ui/tmux/confirm_prompt.rs
@@ -97,7 +97,7 @@ fn spawn_confirm_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font: font.into(),
+                    font,
                     font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },

--- a/src/ui/tmux/rename_prompt.rs
+++ b/src/ui/tmux/rename_prompt.rs
@@ -161,7 +161,7 @@ fn spawn_rename_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font: font.into(),
+                    font,
                     font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },

--- a/src/ui/tmux/rename_prompt.rs
+++ b/src/ui/tmux/rename_prompt.rs
@@ -140,7 +140,7 @@ enum RenameStep {
 struct RenameBar;
 
 fn spawn_rename_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>) {
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let ui = ui_font.as_deref().cloned().unwrap_or_default();
     commands
         .spawn((
             Node {
@@ -160,11 +160,7 @@ fn spawn_rename_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
         .with_children(|parent| {
             parent.spawn((
                 Text::new(""),
-                TextFont {
-                    font,
-                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                    ..default()
-                },
+                ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
                 TextColor(theme::SELECTION_FG),
             ));
         });

--- a/src/ui/tmux/window_bar.rs
+++ b/src/ui/tmux/window_bar.rs
@@ -7,7 +7,6 @@ use crate::font::{PowerlineFont, TerminalUiFont};
 use crate::theme;
 use crate::ui::palette;
 use bevy::prelude::*;
-use bevy::text::FontSource;
 use bevy::ui::{AlignItems, FlexDirection, UiRect, Val};
 use orzma_tmux::{ActiveWindow, TmuxProjectionSet, TmuxSession, TmuxWindow, WindowFlags, WindowId};
 use orzma_tty_renderer::TerminalCellMetricsResource;
@@ -149,14 +148,14 @@ fn rebuild_window_bar(
     };
     commands.entity(bar).despawn_related::<Children>();
 
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let ui = ui_font.as_deref().cloned().unwrap_or_default();
     let pl_font = powerline_font
         .as_deref()
         .map(|f| f.0.clone())
         .unwrap_or_default();
 
     let session_name = session.iter().next().map(|s| s.name.as_str()).unwrap_or("");
-    build_session_block(&mut commands, bar, session_name, &font, &pl_font);
+    build_session_block(&mut commands, bar, session_name, &ui, &pl_font);
 
     let mut entries: Vec<(u32, WindowId, String, bool, WindowFlags)> = windows
         .iter()
@@ -181,7 +180,7 @@ fn rebuild_window_bar(
             &name,
             active,
             flags,
-            &font,
+            &ui,
             &pl_font,
         );
     }
@@ -193,7 +192,7 @@ fn build_session_block(
     commands: &mut Commands,
     bar: Entity,
     session_name: &str,
-    font: &FontSource,
+    ui: &TerminalUiFont,
     pl_font: &Handle<Font>,
 ) {
     let block = commands
@@ -211,11 +210,7 @@ fn build_session_block(
     commands.spawn((
         Text::new(session_name.to_string()),
         TextColor(palette::FOREGROUND),
-        TextFont {
-            font: font.clone(),
-            font_size: FontSize::Px(theme::UI_FONT_SIZE),
-            ..default()
-        },
+        ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
         ChildOf(block),
     ));
     commands.spawn((
@@ -246,7 +241,7 @@ fn build_window_entry(
     name: &str,
     active: bool,
     flags: WindowFlags,
-    font: &FontSource,
+    ui: &TerminalUiFont,
     pl_font: &Handle<Font>,
 ) {
     let (label_color, flag_color) = entry_colors(active, flags);
@@ -280,15 +275,7 @@ fn build_window_entry(
                 ChildOf(entry),
             ))
             .id();
-        spawn_entry_label(
-            commands,
-            fill,
-            &label,
-            &suffix,
-            label_color,
-            flag_color,
-            font,
-        );
+        spawn_entry_label(commands, fill, &label, &suffix, label_color, flag_color, ui);
     } else {
         let pad = commands
             .spawn((
@@ -300,15 +287,7 @@ fn build_window_entry(
                 ChildOf(entry),
             ))
             .id();
-        spawn_entry_label(
-            commands,
-            pad,
-            &label,
-            &suffix,
-            label_color,
-            flag_color,
-            font,
-        );
+        spawn_entry_label(commands, pad, &label, &suffix, label_color, flag_color, ui);
     }
 
     // Always spawn the chevron so active and inactive entries share the same
@@ -336,27 +315,19 @@ fn spawn_entry_label(
     suffix: &str,
     label_color: Color,
     flag_color: Color,
-    font: &FontSource,
+    ui: &TerminalUiFont,
 ) {
     commands.spawn((
         Text::new(label.to_string()),
         TextColor(label_color),
-        TextFont {
-            font: font.clone(),
-            font_size: FontSize::Px(theme::UI_FONT_SIZE),
-            ..default()
-        },
+        ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
         ChildOf(parent),
     ));
     if !suffix.is_empty() {
         commands.spawn((
             Text::new(suffix.to_string()),
             TextColor(flag_color),
-            TextFont {
-                font: font.clone(),
-                font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                ..default()
-            },
+            ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
             ChildOf(parent),
         ));
     }

--- a/src/ui/tmux/window_bar.rs
+++ b/src/ui/tmux/window_bar.rs
@@ -7,6 +7,7 @@ use crate::font::{PowerlineFont, TerminalUiFont};
 use crate::theme;
 use crate::ui::palette;
 use bevy::prelude::*;
+use bevy::text::FontSource;
 use bevy::ui::{AlignItems, FlexDirection, UiRect, Val};
 use orzma_tmux::{ActiveWindow, TmuxProjectionSet, TmuxSession, TmuxWindow, WindowFlags, WindowId};
 use orzma_tty_renderer::TerminalCellMetricsResource;
@@ -152,7 +153,7 @@ fn rebuild_window_bar(
     let pl_font = powerline_font
         .as_deref()
         .map(|f| f.0.clone())
-        .unwrap_or_else(|| font.clone());
+        .unwrap_or_default();
 
     let session_name = session.iter().next().map(|s| s.name.as_str()).unwrap_or("");
     build_session_block(&mut commands, bar, session_name, &font, &pl_font);
@@ -192,7 +193,7 @@ fn build_session_block(
     commands: &mut Commands,
     bar: Entity,
     session_name: &str,
-    font: &Handle<Font>,
+    font: &FontSource,
     pl_font: &Handle<Font>,
 ) {
     let block = commands
@@ -211,7 +212,7 @@ fn build_session_block(
         Text::new(session_name.to_string()),
         TextColor(palette::FOREGROUND),
         TextFont {
-            font: font.clone().into(),
+            font: font.clone(),
             font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
@@ -245,7 +246,7 @@ fn build_window_entry(
     name: &str,
     active: bool,
     flags: WindowFlags,
-    font: &Handle<Font>,
+    font: &FontSource,
     pl_font: &Handle<Font>,
 ) {
     let (label_color, flag_color) = entry_colors(active, flags);
@@ -335,13 +336,13 @@ fn spawn_entry_label(
     suffix: &str,
     label_color: Color,
     flag_color: Color,
-    font: &Handle<Font>,
+    font: &FontSource,
 ) {
     commands.spawn((
         Text::new(label.to_string()),
         TextColor(label_color),
         TextFont {
-            font: font.clone().into(),
+            font: font.clone(),
             font_size: FontSize::Px(theme::UI_FONT_SIZE),
             ..default()
         },
@@ -352,7 +353,7 @@ fn spawn_entry_label(
             Text::new(suffix.to_string()),
             TextColor(flag_color),
             TextFont {
-                font: font.clone().into(),
+                font: font.clone(),
                 font_size: FontSize::Px(theme::UI_FONT_SIZE),
                 ..default()
             },

--- a/src/ui/vi_mode_indicator.rs
+++ b/src/ui/vi_mode_indicator.rs
@@ -70,11 +70,7 @@ fn attach_indicator_to_surface_host(
                 IndicatorCache::default(),
                 Text::new(""),
                 TextFont {
-                    font: ui_font
-                        .as_deref()
-                        .map(|f| f.0.clone())
-                        .unwrap_or_default()
-                        .into(),
+                    font: ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default(),
                     font_size: FontSize::Px(theme::VI_MODE_INDICATOR_FONT_SIZE_PX),
                     ..default()
                 },

--- a/src/ui/vi_mode_indicator.rs
+++ b/src/ui/vi_mode_indicator.rs
@@ -69,11 +69,11 @@ fn attach_indicator_to_surface_host(
                 ViModeIndicator,
                 IndicatorCache::default(),
                 Text::new(""),
-                TextFont {
-                    font: ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default(),
-                    font_size: FontSize::Px(theme::VI_MODE_INDICATOR_FONT_SIZE_PX),
-                    ..default()
-                },
+                ui_font
+                    .as_deref()
+                    .cloned()
+                    .unwrap_or_default()
+                    .text_font(FontSize::Px(theme::VI_MODE_INDICATOR_FONT_SIZE_PX)),
                 BackgroundColor(palette::VI_MODE_INDICATOR_BG),
                 TextColor(palette::VI_MODE_INDICATOR_FG),
                 Node {

--- a/src/ui/vi_search.rs
+++ b/src/ui/vi_search.rs
@@ -110,7 +110,7 @@ fn prompt_label(kind: PromptKind) -> &'static str {
 struct PromptBar;
 
 fn spawn_prompt_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>) {
-    let font = ui_font.as_deref().map(|f| f.0.clone()).unwrap_or_default();
+    let ui = ui_font.as_deref().cloned().unwrap_or_default();
     commands
         .spawn((
             Node {
@@ -130,11 +130,7 @@ fn spawn_prompt_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
         .with_children(|parent| {
             parent.spawn((
                 Text::new(""),
-                TextFont {
-                    font,
-                    font_size: FontSize::Px(theme::UI_FONT_SIZE),
-                    ..default()
-                },
+                ui.text_font(FontSize::Px(theme::UI_FONT_SIZE)),
                 TextColor(theme::FOREGROUND),
             ));
         });

--- a/src/ui/vi_search.rs
+++ b/src/ui/vi_search.rs
@@ -131,7 +131,7 @@ fn spawn_prompt_ui(mut commands: Commands, ui_font: Option<Res<TerminalUiFont>>)
             parent.spawn((
                 Text::new(""),
                 TextFont {
-                    font: font.into(),
+                    font,
                     font_size: FontSize::Px(theme::UI_FONT_SIZE),
                     ..default()
                 },


### PR DESCRIPTION
## Problem

The `[font]` config section only accepted absolute / `~`-prefixed TTF file paths
(`normal`, `bold`, `italic`, `bold_italic`). Users had to locate each face file
on disk and wire all four paths by hand — there was no way to select an
installed system font by its family name, nor to pull weight/style variants from
a single family.

## Solution

Repurpose the `[font]` keys to resolve **font-family names** against the system
font database (via `fontique`), keeping the symmetric
`normal` / `bold` / `italic` / `bold_italic` shape.

- **Config schema** (`orzma_configs`): the `[font]` keys `normal` / `bold` /
  `italic` / `bold_italic` change meaning from TTF file paths to system
  font-family names. `normal` is the base family; each per-face key, when
  omitted, derives from `normal`. Omitting all of them uses the bundled
  JetBrains Mono Nerd Font.
- **Resolver** (`src/font/resolve.rs`, new): a pure `fontique`-backed function
  that turns `(family, weight/style)` into `(font bytes, .ttc face index)`.
  Pure over a borrowed collection + source cache, so it is unit-testable with
  injected fonts instead of the host's installed fonts.
- **Renderer** (`orzma_tty_renderer`): `TerminalFonts::from_faces` loads each
  primary face at its own `.ttc` collection index and records the regular
  face's index, so later `ttf-parser` metric reparses (`cell_metrics_px`,
  `em_scale_of`) target the correct face. `from_bytes` now delegates with
  index 0 (signature unchanged for existing callers).
- **UI** (`src/`): `TerminalUiFont` becomes bevy_text's `FontSource` enum;
  `bridge_font_config` resolves each face and sets `FontSource::Family` when the
  regular face resolves from a system family, otherwise falling back to bundled
  bytes. An unknown family — or a present family missing a requested
  weight/style — falls back per the resolver's contract.
- **Build**: enable bevy's `system_font_discovery` feature.
- **Docs**: `docs/configs.md` updated to the family-name `[font]` schema and its
  fallback behavior.

Affected areas: engine renderer (`orzma_tty_renderer`), config crate
(`orzma_configs`), UI (`src/ui/*`), and docs. Tests cover per-face family
override parsing plus a deterministic bridge success-path test that registers
bundled JBM faces under known family names in the test app's `FontCx` before
`Startup`, proving a configured family resolves through both `TerminalFonts` and
`TerminalUiFont` and that `bold.or(normal)` is honored on each side.

### Breaking Changes

The `[font]` keys `normal` / `bold` / `italic` / `bold_italic` change meaning
from **TTF file paths** to **system font-family names**. The key names are
unchanged, so existing configs still parse — but a value that used to be a file
path (e.g. `normal = "/Users/me/MyMono.ttf"`) is now read as a family name,
fails to resolve, and silently falls back to the bundled JetBrains Mono. Users
who set custom font-file paths must replace them with the family name of an
installed font (e.g. `normal = "JetBrains Mono"`).
