### PR TITLE
refactor!: unify webview placement identifiers into one host-minted InstanceId

### DIFF
--- a/.claude/skills/enumerate-test-cases/SKILL.md
+++ b/.claude/skills/enumerate-test-cases/SKILL.md
@@ -430,7 +430,7 @@ A case whose `Expect:` lines are all kind 2 has no manual behind it at all.
 Number it `TC-A1`, `TC-A2`, … rather than `TC-01`, keep it in the same list, and
 say in one sentence why it is there. `PlacementStore::reset` earns one: the most
 natural implementation, `*self = Self::new()`, rewinds the id counter and breaks
-the invariant `PlacementId` states, and no manual has an opinion about that.
+the invariant `InstanceId` states, and no manual has an opinion about that.
 
 The separate numbering is the whole mechanism. The list stays complete, and a
 reader can still tell at a glance which rows the specification demands from the
@@ -897,9 +897,9 @@ the one case where the path does not mean what it appears to.
 `docs/todo/` already holds hand-written design notes, and they propose APIs.
 Search it for the target type, the method, and each control function the run
 touched, and list what disagrees under "Conflicts with docs/todo" in the
-appendix. `ris.md` proposes `pub(crate) fn clear(&mut self) -> Vec<PlacementId>`
+appendix. `ris.md` proposes `pub(crate) fn clear(&mut self) -> Vec<InstanceId>`
 for dropping every placement, while `tdd-placement-reset.md` is written against
-`pub(crate) fn reset(&mut self) -> Vec<PlacementId>` — one operation under two
+`pub(crate) fn reset(&mut self) -> Vec<InstanceId>` — one operation under two
 names, which is exactly what nobody notices unless something looks.
 
 Report the conflict; do not resolve it, and do not adopt the note's version. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ In-process webview rendering is provided by the external `bevy_cef` crate (crate
 ### How the pieces connect at runtime
 
 1. `orzma` boots a single Bevy `App` and spawns one PTY-backed `OrzmaTerminal` entity: `bevy_orzma_tty` wraps an `orzma_tty`-owned PTY driving an `orzma_vt::OrzmaVt`, pumping coalesced frames as `TtyFrameSignal`s that `orzma_tty_renderer` draws on the GPU. Layout, input, vi mode, IME, and shortcuts are all plugins in the same world.
-2. A program registers webview content over the control socket (`OrzmaWebviewPlugin`, from `crates/bevy_orzma_webview`) to mint an opaque handle, then writes an APC `Omount;v=<handle>` sequence to mount it as an in-process `bevy_cef` webview (assets served from disk/memory via `orzma://`, one origin per handle). The page talks back to the registering program through `window.orzma.call/on` routed over the control socket.
+2. A program registers webview content over the control socket (`OrzmaWebviewPlugin`, from `crates/bevy_orzma_webview`) to mint an opaque handle and its first placement instance, then writes an APC `Omount;n=<instance>` sequence to mount it as an in-process `bevy_cef` webview (assets served from disk/memory via `orzma://`, one origin per handle). Additional placements of the same handle are minted with `new_instance` over the same socket. The page talks back to the registering program through `window.orzma.call/on` routed over the control socket.
 
 ### `src/` module map
 

--- a/apps/orzbrowser/src/main.rs
+++ b/apps/orzbrowser/src/main.rs
@@ -94,7 +94,7 @@ fn event_loop(
         }
 
         terminal.draw(|f| {
-            ui::draw(f, &mut orzma.frame(), &app, &view.id());
+            ui::draw(f, &mut orzma.frame(), &app, &view.instance_id());
         })?;
 
         if event::poll(Duration::from_millis(33))?

--- a/apps/orzbrowser/src/ui.rs
+++ b/apps/orzbrowser/src/ui.rs
@@ -14,7 +14,7 @@ pub(crate) fn draw(
     frame: &mut Frame<'_>,
     placements: &mut FramePlacements,
     app: &App,
-    handle_id: &str,
+    instance_id: &str,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -27,7 +27,7 @@ pub(crate) fn draw(
     }
 
     frame.render_stateful_widget(
-        WebviewWidget::new(handle_id).focused(app.mode() == Mode::Insert),
+        WebviewWidget::new(instance_id).focused(app.mode() == Mode::Insert),
         chunks[1],
         placements,
     );

--- a/apps/orzmd/src/main.rs
+++ b/apps/orzmd/src/main.rs
@@ -373,7 +373,7 @@ fn event_loop(
                 f,
                 &mut orzma.frame(),
                 &session.state,
-                &view.id(),
+                &view.instance_id(),
                 &session.file_name,
                 session.live,
                 percent,

--- a/apps/orzmd/src/ui.rs
+++ b/apps/orzmd/src/ui.rs
@@ -25,7 +25,7 @@ pub(crate) fn draw(
     frame: &mut Frame<'_>,
     placements: &mut FramePlacements,
     app: &App,
-    handle_id: &str,
+    instance_id: &str,
     file_name: &str,
     live: LiveStatus,
     scroll_percent: u16,
@@ -43,7 +43,7 @@ pub(crate) fn draw(
         .split(frame.area());
 
     draw_status(frame, vchunks[0], file_name, live, scroll_percent, flash);
-    draw_body(frame, placements, vchunks[1], app, handle_id);
+    draw_body(frame, placements, vchunks[1], app, instance_id);
     if search_open {
         draw_search(frame, vchunks[2], app, search);
     }
@@ -77,7 +77,7 @@ fn draw_body(
     placements: &mut FramePlacements,
     area: Rect,
     app: &App,
-    handle_id: &str,
+    instance_id: &str,
 ) {
     let webview_area = if app.outline_open() {
         let cols = Layout::default()
@@ -89,7 +89,7 @@ fn draw_body(
     } else {
         area
     };
-    frame.render_stateful_widget(WebviewWidget::new(handle_id), webview_area, placements);
+    frame.render_stateful_widget(WebviewWidget::new(instance_id), webview_area, placements);
 }
 
 fn draw_outline(frame: &mut Frame<'_>, area: Rect, app: &App) {

--- a/crates/bevy_orzma_tty/src/requests.rs
+++ b/crates/bevy_orzma_tty/src/requests.rs
@@ -5,7 +5,7 @@
 use crate::requests::{
     key_input::KeyInputPlugin, mouse_input::MouseInputPlugin, paste::PastePlugin,
     resize::ResizePlugin, scroll::ScrollPlugin, selection::SelectionPlugin, vi_mode::ViModePlugin,
-    vi_motion::ViMotionPlugin,
+    vi_motion::ViMotionPlugin, webview_remove::WebviewRemovePlugin,
 };
 use bevy::prelude::*;
 
@@ -17,6 +17,7 @@ mod scroll;
 mod selection;
 mod vi_mode;
 mod vi_motion;
+mod webview_remove;
 
 pub use key_input::RequestTtyKeyInput;
 pub use mouse_input::RequestTtyMouseInput;
@@ -30,6 +31,7 @@ pub use selection::{
 };
 pub use vi_mode::{RequestTtyViMode, ViModeSwitch};
 pub use vi_motion::{RequestTtyViMotion, ViMotion};
+pub use webview_remove::RequestTtyWebviewRemove;
 
 pub(crate) struct OrzmaEventRequestPlugin;
 
@@ -44,6 +46,7 @@ impl Plugin for OrzmaEventRequestPlugin {
             SelectionPlugin,
             ViModePlugin,
             ViMotionPlugin,
+            WebviewRemovePlugin,
         ));
     }
 }

--- a/crates/bevy_orzma_tty/src/requests/webview_remove.rs
+++ b/crates/bevy_orzma_tty/src/requests/webview_remove.rs
@@ -1,0 +1,79 @@
+//! `RequestTtyWebviewRemove`: the placements the control plane asks a
+//! terminal entity to drop when a registration is released.
+
+use crate::OrzmaTtyHandle;
+use bevy::prelude::*;
+use orzma_vt::prelude::InstanceId;
+
+/// Fired by the control plane to drop placements a terminal still holds
+/// for registrations that are gone.
+///
+/// The VT cannot know that a registration was released — that fact lives
+/// on the control socket — so without this the placements keep a cap slot
+/// until their anchor scrolls out of history.
+#[derive(EntityEvent, Debug, Clone)]
+pub struct RequestTtyWebviewRemove {
+    #[event_target]
+    pub terminal: Entity,
+    /// The instances to drop; ids the terminal does not hold are ignored.
+    pub instances: Vec<InstanceId>,
+}
+
+pub(super) struct WebviewRemovePlugin;
+
+impl Plugin for WebviewRemovePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(apply_webview_remove);
+    }
+}
+
+fn apply_webview_remove(e: On<RequestTtyWebviewRemove>, mut terms: Query<&mut OrzmaTtyHandle>) {
+    if let Ok(mut tty) = terms.get_mut(e.terminal) {
+        tty.remove_placements(&e.instances);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts that the request drops the named placement from the
+    /// terminal it targets and leaves an unnamed one standing.
+    ///
+    /// Case: one of two registrations on a pane is unregistered while
+    /// both of its views are mounted.
+    #[test]
+    fn a_remove_request_drops_only_the_instances_it_names() {
+        let a: InstanceId = "3f5a9c02d1e84b7690ab3cde12f45678"
+            .parse()
+            .expect("valid id");
+        let b: InstanceId = "81b4e77c05a3492fd6180e29ba735fc1"
+            .parse()
+            .expect("valid id");
+        let mut app = App::new();
+        app.add_plugins(WebviewRemovePlugin);
+        let (mut handle, _master) = OrzmaTtyHandle::detached(80, 24);
+        handle.feed_bytes(format!("\x1b_Omount;n={a},r=4,c=8\x1b\\").as_bytes());
+        handle.feed_bytes(format!("\x1b_Omount;n={b},r=4,c=8\x1b\\").as_bytes());
+        let terminal = app.world_mut().spawn(handle).id();
+
+        app.world_mut().trigger(RequestTtyWebviewRemove {
+            terminal,
+            instances: vec![a],
+        });
+        app.world_mut().flush();
+
+        let mut handle = app
+            .world_mut()
+            .get_mut::<OrzmaTtyHandle>(terminal)
+            .expect("the terminal keeps its handle");
+        let frame = handle.pump().frame.expect("the removal changed the list");
+        let ids: Vec<InstanceId> = frame
+            .placements
+            .expect("the placement list changed")
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(ids, vec![b]);
+    }
+}

--- a/crates/bevy_orzma_tty/src/signals.rs
+++ b/crates/bevy_orzma_tty/src/signals.rs
@@ -78,14 +78,10 @@ pub struct TtyCwdChangedSignal {
 pub struct TtyWebviewMountSignal {
     #[event_target]
     pub terminal: Entity,
-    /// The registered view's id.
-    pub view_id: String,
+    /// The host-minted instance this mount registered.
+    pub instance: InstanceId,
     /// The cell rectangle the mount reserved.
     pub size: PlacementSize,
-    /// The client-assigned instance id; `None` is the default instance.
-    pub instance_id: Option<String>,
-    /// The id the VT minted for this placement.
-    pub placement: PlacementId,
 }
 
 /// Fired for a mount the VT refused because the placement cap was full;
@@ -94,10 +90,8 @@ pub struct TtyWebviewMountSignal {
 pub struct TtyWebviewMountRejectedSignal {
     #[event_target]
     pub terminal: Entity,
-    /// The view the refused mount named.
-    pub view_id: String,
     /// The instance the refused mount named.
-    pub instance_id: Option<String>,
+    pub instance: InstanceId,
 }
 
 /// Fired for webview placements the PTY unmounted.
@@ -105,10 +99,8 @@ pub struct TtyWebviewMountRejectedSignal {
 pub struct TtyWebviewUnmountSignal {
     #[event_target]
     pub terminal: Entity,
-    /// The view to unmount; `None` unmounts every view.
-    pub view_id: Option<String>,
-    /// The instance to unmount; `None` unmounts every instance.
-    pub instance_id: Option<String>,
+    /// The instance to unmount; `None` unmounts every placement.
+    pub instance: Option<InstanceId>,
 }
 
 /// Fired when the VT evicts placements on its own authority (history
@@ -118,7 +110,7 @@ pub struct TtyWebviewUnmountSignal {
 pub struct TtyWebviewEvictedSignal {
     #[event_target]
     pub terminal: Entity,
-    pub placements: Vec<PlacementId>,
+    pub placements: Vec<InstanceId>,
 }
 
 /// Fired when the terminal emits a frame; a full repaint carries every
@@ -170,34 +162,17 @@ fn trigger_vt_signal(commands: &mut Commands, terminal: Entity, signal: VtSignal
             terminal,
             path: path_buf,
         }),
-        VtSignal::WebviewMount {
-            view_id,
+        VtSignal::WebviewMount { instance, size } => commands.trigger(TtyWebviewMountSignal {
+            terminal,
+            instance,
             size,
-            instance_id,
-            placement,
-        } => commands.trigger(TtyWebviewMountSignal {
-            terminal,
-            view_id,
-            size,
-            instance_id,
-            placement,
         }),
-        VtSignal::WebviewMountRejected {
-            view_id,
-            instance_id,
-        } => commands.trigger(TtyWebviewMountRejectedSignal {
-            terminal,
-            view_id,
-            instance_id,
-        }),
-        VtSignal::WebviewUnmount {
-            view_id,
-            instance_id,
-        } => commands.trigger(TtyWebviewUnmountSignal {
-            terminal,
-            view_id,
-            instance_id,
-        }),
+        VtSignal::WebviewMountRejected { instance } => {
+            commands.trigger(TtyWebviewMountRejectedSignal { terminal, instance })
+        }
+        VtSignal::WebviewUnmount { instance } => {
+            commands.trigger(TtyWebviewUnmountSignal { terminal, instance })
+        }
         VtSignal::WebviewEvicted { placements } => commands.trigger(TtyWebviewEvictedSignal {
             terminal,
             placements,

--- a/crates/bevy_orzma_tty/src/signals.rs
+++ b/crates/bevy_orzma_tty/src/signals.rs
@@ -110,6 +110,8 @@ pub struct TtyWebviewUnmountSignal {
 pub struct TtyWebviewEvictedSignal {
     #[event_target]
     pub terminal: Entity,
+    /// The instances the VT evicted. It has already dropped them, so a
+    /// consumer despawns its own side without asking for a second removal.
     pub placements: Vec<InstanceId>,
 }
 

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -14,9 +14,13 @@ use bevy_cef::prelude::{RequestGoBack, RequestGoForward, RequestReload, WebviewS
 use bevy_orzma_tty::prelude::OrzmaTtyHandle;
 use crossbeam_channel::{Receiver, Sender};
 use data_encoding::BASE32_NOPAD;
+use orzma_vt::prelude::InstanceId;
 use orzma_webview_host::WebviewAssetRegistry;
 use orzma_webview_host::host::RuntimeRoot;
+use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use url::Url;
@@ -85,26 +89,30 @@ impl OrzmaSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OrzmaView {
     /// The content source.
-    pub(crate) source: OrzmaSource,
+    pub source: OrzmaSource,
     /// HTML entry path relative to a `Dir` root (ignored for `Inline` and `Url`).
-    pub(crate) entry: String,
+    pub entry: String,
     /// Whether the mounted webview accepts pointer/keyboard input.
-    pub(crate) interactive: bool,
+    pub interactive: bool,
     /// The terminal surface a `mount;<handle>` must originate from. The
     /// registering program's PTY env token resolved to this surface, so only
     /// that surface may mount the handle (tighter than the spec's pane wording).
-    pub(crate) owner_surface: Entity,
+    pub owner_surface: Entity,
     /// The control-plane connection that registered it.
-    pub(crate) connection_id: u64,
+    pub connection_id: u64,
     /// The normalized forward-key chords for this view, derived from the
     /// `register` wire payload. Copied onto the mounted webview entity as
     /// `ForwardKeys` so Phase-4 systems can read them off the focused child.
-    pub(crate) forward_keys: Vec<NormalizedChord>,
+    pub forward_keys: Vec<NormalizedChord>,
     /// User-supplied preload scripts, copied verbatim from the register wire
     /// and injected onto the mounted webview's `PreloadScripts` after the host
     /// bridge/hints. No size cap or validation (the registering program is
     /// local and trusted).
-    pub(crate) preload: Vec<String>,
+    pub preload: Vec<String>,
+    /// Every instance minted for this registration, in mint order. The
+    /// registry keeps this list and its `by_instance` reverse index in
+    /// lockstep, so releasing the handle releases exactly these ids.
+    pub instances: Vec<InstanceId>,
 }
 
 /// Stamped on a Tier 1 webview entity at mount: the control-plane
@@ -117,53 +125,167 @@ pub(crate) struct WebviewOwner {
     pub(crate) handle: String,
 }
 
-/// Maps an opaque `handle` to its dynamic registration. The single Bevy-side
-/// registry for Tier 1 (the CEF scheme handler reads the thin `WebviewAssetRegistry`
-/// separately). Carries scoped removal for teardown.
+/// The opaque identity of one dynamic registration.
+///
+/// It is the host of that registration's `orzma://<handle>/` origin, the
+/// routing key for its back-channel, and the ownership unit `unregister`
+/// and connection teardown act on.
+///
+/// # Invariants
+///
+/// There is deliberately no `From<HandleId> for String`. That absence is
+/// what stops a handle from flowing into an `impl Into<String>` parameter
+/// that wants an instance id; adding the conversion for convenience
+/// silently reopens that path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HandleId(String);
+
+impl HandleId {
+    /// Borrows the wire spelling.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// NOTE: the inbound direction is safe and needed (the wire hands us
+// strings); it is the outbound `From<HandleId> for String` that must not
+// exist, or a handle flows into an `impl Into<String>` slot wanting an
+// instance id.
+impl From<&str> for HandleId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for HandleId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl Borrow<str> for HandleId {
+    // NOTE: lets `HashMap<HandleId, _>` be looked up by `&str` without
+    // allocating a HandleId for every probe.
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for HandleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Maps an opaque `handle` to its dynamic registration, and every minted
+/// instance back to the handle it belongs to.
+///
+/// The single Bevy-side registry for Tier 1 (the CEF scheme handler reads
+/// the thin `WebviewAssetRegistry` separately). Carries scoped removal for
+/// teardown.
+///
+/// # Invariants
+///
+/// The two maps are only ever touched through `&mut self` methods on this
+/// type, so an instance is in `by_instance` exactly while its handle's
+/// `OrzmaView.instances` lists it.
 #[derive(Resource, Default)]
 pub(crate) struct OrzmaRegistry {
-    by_handle: HashMap<String, OrzmaView>,
+    by_handle: HashMap<HandleId, OrzmaView>,
+    by_instance: HashMap<InstanceId, HandleId>,
+}
+
+/// One registration the registry released, with everything its teardown
+/// needs: the asset key, the terminal to clear, and the placements it
+/// reserved.
+pub(crate) struct RemovedRegistration {
+    /// The released handle, still the `WebviewAssetRegistry` key.
+    pub handle: HandleId,
+    /// The surface that owned the registration.
+    pub owner_surface: Entity,
+    /// Every instance the released handle had minted.
+    pub instances: Vec<InstanceId>,
 }
 
 impl OrzmaRegistry {
     /// Resolves a `handle` to its registration, if any.
-    pub(crate) fn get(&self, handle: &str) -> Option<&OrzmaView> {
+    pub fn get(&self, handle: &HandleId) -> Option<&OrzmaView> {
         self.by_handle.get(handle)
     }
 
-    /// Inserts/replaces a registration.
-    pub(crate) fn insert(&mut self, handle: String, view: OrzmaView) {
+    /// Resolves an instance to its handle and registration, if any.
+    pub fn resolve_instance(&self, instance: InstanceId) -> Option<(&HandleId, &OrzmaView)> {
+        let handle = self.by_instance.get(&instance)?;
+        let view = self.by_handle.get(handle)?;
+        Some((handle, view))
+    }
+
+    /// Inserts a registration with no instances yet.
+    ///
+    /// The caller mints its first instance with [`Self::mint_instance`]
+    /// immediately afterwards, so every id — the first one included —
+    /// comes from the one minting path.
+    pub fn insert(&mut self, handle: HandleId, view: OrzmaView) {
         self.by_handle.insert(handle, view);
     }
 
-    /// Removes one `handle`, returning its `owner_surface` when it existed.
-    pub(crate) fn remove(&mut self, handle: &str) -> Option<Entity> {
-        self.by_handle.remove(handle).map(|v| v.owner_surface)
+    /// Mints an instance for `handle`; `None` only when the handle is
+    /// unknown.
+    ///
+    /// This is the ONLY path that produces an [`InstanceId`], which is what
+    /// makes "every allocated instance is unique across the registry" hold.
+    pub fn mint_instance(&mut self, handle: &HandleId) -> Option<InstanceId> {
+        if !self.by_handle.contains_key(handle) {
+            return None;
+        }
+        let mut bytes = [0u8; 16];
+        getrandom::getrandom(&mut bytes).expect("OS CSPRNG is available");
+        let id = InstanceId::from_bytes(bytes);
+        debug_assert!(
+            !self.by_instance.contains_key(&id),
+            "128 bits of CSPRNG collided; the draw is broken"
+        );
+        self.by_instance.insert(id, handle.clone());
+        self.by_handle
+            .get_mut(handle)
+            .expect("the handle was present above")
+            .instances
+            .push(id);
+        Some(id)
     }
 
-    /// Removes every handle owned by `connection_id`, returning the removed
-    /// handles (so the caller can purge the `WebviewAssetRegistry` too).
-    pub(crate) fn remove_by_connection(&mut self, connection_id: u64) -> Vec<String> {
+    /// Removes one `handle` and everything its teardown needs.
+    pub fn remove(&mut self, handle: &HandleId) -> Option<RemovedRegistration> {
+        let view = self.by_handle.remove(handle)?;
+        for id in &view.instances {
+            self.by_instance.remove(id);
+        }
+        Some(RemovedRegistration {
+            handle: handle.clone(),
+            owner_surface: view.owner_surface,
+            instances: view.instances,
+        })
+    }
+
+    /// Removes every handle owned by `connection_id`.
+    pub fn remove_by_connection(&mut self, connection_id: u64) -> Vec<RemovedRegistration> {
         self.drain_where(|v| v.connection_id == connection_id)
     }
 
-    /// Removes every handle owned by `owner_surface`, returning the removed
-    /// handles (so the caller can purge the `WebviewAssetRegistry` too).
-    pub(crate) fn remove_by_surface(&mut self, owner_surface: Entity) -> Vec<String> {
+    /// Removes every handle owned by `owner_surface`.
+    pub fn remove_by_surface(&mut self, owner_surface: Entity) -> Vec<RemovedRegistration> {
         self.drain_where(|v| v.owner_surface == owner_surface)
     }
 
-    fn drain_where(&mut self, pred: impl Fn(&OrzmaView) -> bool) -> Vec<String> {
-        let drained: Vec<String> = self
+    fn drain_where(&mut self, pred: impl Fn(&OrzmaView) -> bool) -> Vec<RemovedRegistration> {
+        let handles: Vec<HandleId> = self
             .by_handle
             .iter()
             .filter(|(_, v)| pred(v))
             .map(|(h, _)| h.clone())
             .collect();
-        for h in &drained {
-            self.by_handle.remove(h);
-        }
-        drained
+        handles.iter().filter_map(|h| self.remove(h)).collect()
     }
 }
 
@@ -295,19 +417,19 @@ impl ConnectionWriters {
     }
 }
 
-/// Mints an opaque 128-bit identifier (CSPRNG), base32-encoded (unpadded) and
-/// lowercased. The alphabet `a-z2-7` is a subset of the OSC `view_id` charset
-/// `^[A-Za-z0-9._-]{1,128}$`, so a minted handle is a valid `mount;<id>`.
+/// Mints an opaque 128-bit [`HandleId`] (CSPRNG), base32-encoded (unpadded)
+/// and lowercased. The alphabet `a-z2-7` keeps a minted handle spellable in
+/// a URL host, which is where it is used.
 ///
 /// # Invariants
 /// The output MUST be lowercase. A handle is used as the host of the
 /// `orzma://<handle>/` URL, and Chromium canonicalizes (lowercases) the host
 /// of a STANDARD-scheme URL before it reaches the scheme handler; an uppercase
 /// handle would then miss the case-sensitive `WebviewAssetRegistry` lookup → 404.
-fn mint_id() -> String {
+fn mint_handle_id() -> HandleId {
     let mut bytes = [0u8; 16];
     getrandom::getrandom(&mut bytes).expect("OS CSPRNG is available");
-    BASE32_NOPAD.encode(&bytes).to_ascii_lowercase()
+    HandleId(BASE32_NOPAD.encode(&bytes).to_ascii_lowercase())
 }
 
 /// The receiver of `ControlEvent`s from the listener threads.
@@ -414,8 +536,8 @@ fn gc_despawned_surfaces(
     orzma_assets: Res<WebviewAssetRegistryRes>,
 ) {
     for entity in closed.read() {
-        for handle_str in registry.remove_by_surface(entity) {
-            orzma_assets.0.remove(&handle_str);
+        for removed in registry.remove_by_surface(entity) {
+            orzma_assets.0.remove(removed.handle.as_str());
         }
         if let Some(handle) = handle.as_ref() {
             handle.tokens.remove_entity(entity);
@@ -467,32 +589,32 @@ fn apply_control_events(
                         continue;
                     }
                 };
-                let handle = mint_id();
+                let handle = mint_handle_id();
                 match &view.source {
                     OrzmaSource::Dir(root) => {
-                        orzma_assets.0.insert_dir(handle.clone(), root.clone())
+                        orzma_assets.0.insert_dir(handle.as_str(), root.clone())
                     }
                     OrzmaSource::Inline(html) => {
                         orzma_assets
                             .0
-                            .insert_inline(handle.clone(), html.clone().into_bytes());
+                            .insert_inline(handle.as_str(), html.clone().into_bytes());
                     }
                     OrzmaSource::Url { .. } => {}
                 }
                 registry.insert(handle.clone(), view);
-                let _ = reply.send(ServerMsg::ok(handle));
+                let _ = reply.send(ServerMsg::ok(handle.to_string()));
             }
             ControlEvent::Unregister {
                 connection_id,
                 handle,
             } => {
-                let removed = if registry
+                let handle = HandleId::from(handle);
+                let removed: Vec<RemovedRegistration> = if registry
                     .get(&handle)
                     .is_some_and(|v| v.connection_id == connection_id)
                 {
-                    registry.remove(&handle);
-                    orzma_assets.0.remove(&handle);
-                    vec![handle]
+                    orzma_assets.0.remove(handle.as_str());
+                    registry.remove(&handle).into_iter().collect()
                 } else {
                     vec![]
                 };
@@ -500,8 +622,8 @@ fn apply_control_events(
             }
             ControlEvent::Disconnect { connection_id } => {
                 let removed = registry.remove_by_connection(connection_id);
-                for h in &removed {
-                    orzma_assets.0.remove(h);
+                for entry in &removed {
+                    orzma_assets.0.remove(entry.handle.as_str());
                 }
                 despawn_mounted(&mut commands, &webviews, &removed);
                 for (webview, page_req) in rpc.drain_connection(connection_id) {
@@ -537,6 +659,7 @@ fn apply_control_events(
                 event,
                 payload,
             } => {
+                let handle = HandleId::from(handle);
                 let deliver = registry
                     .get(&handle)
                     .is_some_and(|v| v.connection_id == connection_id && v.source.is_bridged());
@@ -545,7 +668,7 @@ fn apply_control_events(
                 }
                 let frame = serde_json::json!({ "event": event, "payload": payload });
                 for (entity, view) in &webviews {
-                    if view.view_id == handle {
+                    if view.view_id == handle.as_str() {
                         commands.trigger(HostEmitEvent::new(entity, "orzma.event", &frame));
                     }
                 }
@@ -561,6 +684,7 @@ fn apply_control_events(
                 };
                 match handle {
                     Some(h) => {
+                        let h = HandleId::from(h);
                         let owned = registry
                             .get(&h)
                             .is_some_and(|v| v.connection_id == connection_id);
@@ -569,7 +693,7 @@ fn apply_control_events(
                             continue;
                         }
                         let target = webviews.iter().find(|(entity, view)| {
-                            view.view_id == h
+                            view.view_id == h.as_str()
                                 && view.instance_id.as_deref() == instance.as_deref()
                                 && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
                                 && !non_interactive.contains(*entity)
@@ -598,6 +722,7 @@ fn apply_control_events(
                 handle,
                 action,
             } => {
+                let handle = HandleId::from(handle);
                 let Some(view) = registry.get(&handle) else {
                     continue;
                 };
@@ -607,7 +732,7 @@ fn apply_control_events(
                 }
                 let is_url = view.source.is_url();
                 let target = webviews.iter().find(|(entity, v)| {
-                    v.view_id == handle
+                    v.view_id == handle.as_str()
                         && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
                 });
                 let Some((entity, _)) = target else {
@@ -652,10 +777,13 @@ fn apply_control_events(
 fn despawn_mounted(
     commands: &mut Commands,
     webviews: &Query<(Entity, &Webview)>,
-    removed: &[String],
+    removed: &[RemovedRegistration],
 ) {
     for (entity, view) in webviews {
-        if removed.contains(&view.view_id) {
+        if removed
+            .iter()
+            .any(|entry| entry.handle.as_str() == view.view_id)
+        {
             commands.entity(entity).despawn();
         }
     }
@@ -691,6 +819,7 @@ fn build_view(
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
                 preload,
+                instances: Vec::new(),
             })
         }
         RegisterKind::Inline {
@@ -710,6 +839,7 @@ fn build_view(
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
                 preload,
+                instances: Vec::new(),
             })
         }
         RegisterKind::Url {
@@ -728,6 +858,7 @@ fn build_view(
                 connection_id,
                 forward_keys: forward_keys.iter().filter_map(normalize_chord).collect(),
                 preload,
+                instances: Vec::new(),
             })
         }
     }
@@ -878,15 +1009,24 @@ mod gc_tests {
                 connection_id: 1,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         app.update(); // no despawn yet
-        assert!(app.world().resource::<OrzmaRegistry>().get("h0").is_some());
+        assert!(
+            app.world()
+                .resource::<OrzmaRegistry>()
+                .get(&HandleId::from("h0"))
+                .is_some()
+        );
 
         app.world_mut().entity_mut(surface).despawn();
         app.update();
         assert!(
-            app.world().resource::<OrzmaRegistry>().get("h0").is_none(),
+            app.world()
+                .resource::<OrzmaRegistry>()
+                .get(&HandleId::from("h0"))
+                .is_none(),
             "despawning the owner surface purges its registrations"
         );
     }
@@ -900,7 +1040,8 @@ mod token_tests {
     #[test]
     fn minted_ids_match_the_osc_view_id_charset() {
         for _ in 0..50 {
-            let id = mint_id();
+            let id = mint_handle_id();
+            let id = id.as_str();
             assert!(
                 !id.is_empty() && id.len() <= 128,
                 "id length out of range: {id:?}"
@@ -919,8 +1060,8 @@ mod token_tests {
 
     #[test]
     fn minted_ids_are_unique() {
-        let a = mint_id();
-        let b = mint_id();
+        let a = mint_handle_id();
+        let b = mint_handle_id();
         assert_ne!(a, b);
     }
 
@@ -989,53 +1130,82 @@ mod registry_tests {
     #[test]
     fn insert_then_get_roundtrips() {
         let mut reg = OrzmaRegistry::default();
-        reg.insert(
-            "h1".into(),
-            OrzmaView {
-                source: OrzmaSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: surface(1),
-                connection_id: 7,
-                forward_keys: vec![],
-                preload: vec![],
-            },
+        reg.insert(HandleId::from("h1"), view(surface(1), 7));
+        assert_eq!(
+            reg.get(&HandleId::from("h1")).map(|v| v.interactive),
+            Some(true)
         );
-        assert_eq!(reg.get("h1").map(|v| v.interactive), Some(true));
-        assert!(reg.get("missing").is_none());
+        assert!(reg.get(&HandleId::from("missing")).is_none());
     }
 
     #[test]
     fn remove_by_connection_drops_only_that_connections_handles() {
         let mut reg = OrzmaRegistry::default();
-        reg.insert("a".into(), view(surface(1), 7));
-        reg.insert("b".into(), view(surface(1), 7));
-        reg.insert("c".into(), view(surface(2), 8));
+        reg.insert(HandleId::from("a"), view(surface(1), 7));
+        reg.insert(HandleId::from("b"), view(surface(1), 7));
+        reg.insert(HandleId::from("c"), view(surface(2), 8));
 
         let removed = reg.remove_by_connection(7);
         assert_eq!(removed.len(), 2);
-        assert!(reg.get("a").is_none() && reg.get("b").is_none());
-        assert!(reg.get("c").is_some());
+        assert!(reg.get(&HandleId::from("a")).is_none() && reg.get(&HandleId::from("b")).is_none());
+        assert!(reg.get(&HandleId::from("c")).is_some());
     }
 
     #[test]
     fn remove_by_surface_drops_only_that_surfaces_handles() {
         let mut reg = OrzmaRegistry::default();
-        reg.insert("a".into(), view(surface(1), 7));
-        reg.insert("c".into(), view(surface(2), 8));
+        reg.insert(HandleId::from("a"), view(surface(1), 7));
+        reg.insert(HandleId::from("c"), view(surface(2), 8));
 
         let removed = reg.remove_by_surface(surface(1));
-        assert_eq!(removed, vec!["a".to_string()]);
-        assert!(reg.get("a").is_none());
-        assert!(reg.get("c").is_some());
+        assert_eq!(
+            removed.iter().map(|r| r.handle.clone()).collect::<Vec<_>>(),
+            vec![HandleId::from("a")]
+        );
+        assert!(reg.get(&HandleId::from("a")).is_none());
+        assert!(reg.get(&HandleId::from("c")).is_some());
     }
 
     #[test]
     fn remove_one_returns_the_owner_surface_when_present() {
         let mut reg = OrzmaRegistry::default();
-        reg.insert("a".into(), view(surface(3), 9));
-        assert_eq!(reg.remove("a"), Some(surface(3)));
-        assert_eq!(reg.remove("a"), None);
+        reg.insert(HandleId::from("a"), view(surface(3), 9));
+        assert_eq!(
+            reg.remove(&HandleId::from("a")).map(|r| r.owner_surface),
+            Some(surface(3))
+        );
+        assert!(reg.remove(&HandleId::from("a")).is_none());
+    }
+
+    /// Asserts that minting binds an instance to its handle, that the
+    /// reverse lookup resolves it, and that releasing the handle takes
+    /// every instance with it.
+    ///
+    /// Case: a program registers one view, asks for a second placement,
+    /// then unregisters while both are mounted.
+    #[test]
+    fn minting_binds_an_instance_to_its_handle_and_release_takes_both() {
+        let mut registry = OrzmaRegistry::default();
+        // NOTE: Bevy 0.19 has no Entity::from_raw; the repo's other tests use
+        // from_bits.
+        let owner = Entity::from_bits(7);
+        let h = HandleId::from("h");
+        registry.insert(h.clone(), view(owner, 1));
+        let first = registry.mint_instance(&h).expect("a known handle mints");
+        let second = registry.mint_instance(&h).expect("a second mint succeeds");
+        assert_ne!(first, second, "each mint draws a distinct id");
+
+        assert_eq!(registry.resolve_instance(first).map(|(h, _)| h), Some(&h));
+        assert_eq!(registry.resolve_instance(second).map(|(h, _)| h), Some(&h));
+        assert!(registry.mint_instance(&HandleId::from("nope")).is_none());
+
+        let removed = registry.remove(&h).expect("the handle was registered");
+        assert_eq!(removed.owner_surface, owner);
+        assert_eq!(removed.instances.len(), 2);
+        assert!(removed.instances.contains(&first));
+        assert!(removed.instances.contains(&second));
+        assert!(registry.resolve_instance(first).is_none());
+        assert!(registry.resolve_instance(second).is_none());
     }
 
     fn view(owner: Entity, conn: u64) -> OrzmaView {
@@ -1047,6 +1217,7 @@ mod registry_tests {
             connection_id: conn,
             forward_keys: vec![],
             preload: vec![],
+            instances: Vec::new(),
         }
     }
 }
@@ -1097,7 +1268,7 @@ mod apply_tests {
         assert!(
             app.world()
                 .resource::<OrzmaRegistry>()
-                .get(&handle)
+                .get(&HandleId::from(handle.as_str()))
                 .is_some(),
             "OrzmaRegistry populated"
         );
@@ -1190,6 +1361,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         orzma_assets.insert_dir("h", "/x".into());
@@ -1203,7 +1375,12 @@ mod apply_tests {
             .send(ControlEvent::Disconnect { connection_id: 5 })
             .unwrap();
         app.update();
-        assert!(app.world().resource::<OrzmaRegistry>().get("h").is_none());
+        assert!(
+            app.world()
+                .resource::<OrzmaRegistry>()
+                .get(&HandleId::from("h"))
+                .is_none()
+        );
         assert!(orzma_assets.get("h").is_none());
     }
 
@@ -1234,6 +1411,7 @@ mod apply_tests {
                 connection_id: 9,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
@@ -1261,7 +1439,7 @@ mod apply_tests {
         assert!(
             app.world()
                 .resource::<OrzmaRegistry>()
-                .get("HMOUNT")
+                .get(&HandleId::from("HMOUNT"))
                 .is_none()
         );
     }
@@ -1379,6 +1557,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         app.world_mut().spawn(Webview {
@@ -1447,7 +1626,7 @@ mod apply_tests {
         assert!(
             app.world()
                 .resource::<OrzmaRegistry>()
-                .get(&handle)
+                .get(&HandleId::from(handle.as_str()))
                 .is_some(),
             "OrzmaRegistry populated"
         );
@@ -1473,6 +1652,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let mounted = app
@@ -1543,6 +1723,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let child = app
@@ -1599,6 +1780,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let child = app
@@ -1656,6 +1838,7 @@ mod apply_tests {
                 connection_id: 5,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let child = app
@@ -1723,6 +1906,7 @@ mod focus_tests {
                 connection_id: 1,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         let child = app
@@ -1788,6 +1972,7 @@ mod focus_tests {
                 connection_id: 99,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         // Spawn a VALID interactive inline child that WOULD be focused if the
@@ -1845,6 +2030,7 @@ mod focus_tests {
                 connection_id: 1,
                 forward_keys: vec![],
                 preload: vec![],
+                instances: Vec::new(),
             },
         );
         // Spawn the matching interactive inline child on surface_a.

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -222,9 +222,15 @@ impl OrzmaRegistry {
     ///
     /// The caller mints its first instance with [`Self::mint_instance`]
     /// immediately afterwards, so every id — the first one included —
-    /// comes from the one minting path.
+    /// comes from the one minting path. Inserting over an existing `handle`
+    /// first purges that handle's previous instances from `by_instance`, so
+    /// the two maps stay in lockstep even when a caller reuses a handle.
     pub fn insert(&mut self, handle: HandleId, view: OrzmaView) {
-        self.by_handle.insert(handle, view);
+        if let Some(previous) = self.by_handle.insert(handle, view) {
+            for id in previous.instances {
+                self.by_instance.remove(&id);
+            }
+        }
     }
 
     /// Mints an instance for `handle`; `None` only when the handle is
@@ -877,6 +883,7 @@ fn on_set_focus(
         return;
     };
     let Ok(id) = instance.parse::<InstanceId>() else {
+        tracing::debug!(%instance, "focus op for an unparseable instance, dropping");
         return;
     };
     let owned = registry
@@ -916,6 +923,7 @@ fn on_navigate(
     action: NavAction,
 ) {
     let Ok(id) = instance.parse::<InstanceId>() else {
+        tracing::debug!(%instance, "navigate for an unparseable instance, dropping");
         return;
     };
     let Some((_, view)) = registry.resolve_instance(id) else {
@@ -1414,6 +1422,35 @@ mod registry_tests {
         assert!(removed.instances.contains(&second));
         assert!(registry.resolve_instance(first).is_none());
         assert!(registry.resolve_instance(second).is_none());
+    }
+
+    /// Asserts that inserting over an existing handle purges that handle's
+    /// stale instances from the reverse `by_instance` index, so a released
+    /// registration's instances never keep resolving after a new one takes
+    /// its handle.
+    ///
+    /// Case: a handle is reused for a fresh registration before its previous
+    /// one was explicitly removed — production handles are CSPRNG-minted and
+    /// this cannot happen there, but the registry's own invariant must still
+    /// hold for a caller that reuses a literal handle.
+    #[test]
+    fn insert_over_an_existing_handle_purges_its_stale_instances() {
+        let mut registry = OrzmaRegistry::default();
+        let h = HandleId::from("h");
+        registry.insert(h.clone(), view(Entity::from_bits(1), 1));
+        let stale = registry.mint_instance(&h).expect("a known handle mints");
+
+        registry.insert(h.clone(), view(Entity::from_bits(2), 2));
+
+        assert!(
+            registry.resolve_instance(stale).is_none(),
+            "the previous registration's instance must no longer resolve"
+        );
+        assert_eq!(
+            registry.get(&h).map(|v| v.connection_id),
+            Some(2),
+            "the new registration must be the one in place"
+        );
     }
 
     fn view(owner: Entity, conn: u64) -> OrzmaView {

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -236,8 +236,11 @@ impl OrzmaRegistry {
     /// Mints an instance for `handle`; `None` only when the handle is
     /// unknown.
     ///
-    /// This is the ONLY path that produces an [`InstanceId`], which is what
-    /// makes "every allocated instance is unique across the registry" hold.
+    /// This is the ONLY path that produces an [`InstanceId`], so every
+    /// allocated instance is a fresh 128-bit CSPRNG draw. Registry-wide
+    /// uniqueness rests on that draw rather than on a structural check: the
+    /// `debug_assert!` below is a tripwire for a broken CSPRNG, and it
+    /// compiles out in release.
     pub fn mint_instance(&mut self, handle: &HandleId) -> Option<InstanceId> {
         if !self.by_handle.contains_key(handle) {
             return None;
@@ -927,6 +930,7 @@ fn on_navigate(
         return;
     };
     let Some((_, view)) = registry.resolve_instance(id) else {
+        tracing::debug!(%instance, "navigate for an unknown instance, dropping");
         return;
     };
     if view.connection_id != connection_id {

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -18,7 +18,7 @@ use orzma_vt::prelude::InstanceId;
 use orzma_webview_host::WebviewAssetRegistry;
 use orzma_webview_host::host::RuntimeRoot;
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
@@ -94,9 +94,10 @@ pub(crate) struct OrzmaView {
     pub entry: String,
     /// Whether the mounted webview accepts pointer/keyboard input.
     pub interactive: bool,
-    /// The terminal surface a `mount;<handle>` must originate from. The
-    /// registering program's PTY env token resolved to this surface, so only
-    /// that surface may mount the handle (tighter than the spec's pane wording).
+    /// The terminal surface an `Omount;n=<instance>` for this registration
+    /// must originate from. The registering program's PTY env token resolved
+    /// to this surface, so only that surface may mount an instance that
+    /// resolves to this handle (tighter than the spec's pane wording).
     pub owner_surface: Entity,
     /// The control-plane connection that registered it.
     pub connection_id: u64,
@@ -165,14 +166,6 @@ impl From<&str> for HandleId {
 impl From<String> for HandleId {
     fn from(s: String) -> Self {
         Self(s)
-    }
-}
-
-impl Borrow<str> for HandleId {
-    // NOTE: lets `HashMap<HandleId, _>` be looked up by `&str` without
-    // allocating a HandleId for every probe.
-    fn borrow(&self) -> &str {
-        &self.0
     }
 }
 
@@ -585,169 +578,83 @@ fn apply_control_events(
                 owner_surface,
                 kind,
                 reply,
-            } => {
-                let view = match build_view(kind, owner_surface, connection_id) {
-                    Ok(v) => v,
-                    Err(code) => {
-                        let _ = reply.send(ServerMsg::err(code));
-                        continue;
-                    }
-                };
-                let handle = mint_handle_id();
-                match &view.source {
-                    OrzmaSource::Dir(root) => {
-                        orzma_assets.0.insert_dir(handle.as_str(), root.clone())
-                    }
-                    OrzmaSource::Inline(html) => {
-                        orzma_assets
-                            .0
-                            .insert_inline(handle.as_str(), html.clone().into_bytes());
-                    }
-                    OrzmaSource::Url { .. } => {}
-                }
-                registry.insert(handle.clone(), view);
-                // NOTE: a failed mint must not leave a registered handle with
-                // no instance — the program could never mount it, and the
-                // asset entry would leak until the connection drops.
-                let Some(instance) = registry.mint_instance(&handle) else {
-                    registry.remove(&handle);
-                    orzma_assets.0.remove(handle.as_str());
-                    let _ = reply.send(ServerMsg::err("internal"));
-                    continue;
-                };
-                let _ = reply.send(ServerMsg::registered(handle, instance.to_string()));
-            }
+            } => on_register(
+                &mut registry,
+                &orzma_assets,
+                connection_id,
+                owner_surface,
+                kind,
+                &reply,
+            ),
             ControlEvent::NewInstance {
                 connection_id,
                 handle,
                 reply,
-            } => {
-                let owned = registry
-                    .get(&handle)
-                    .is_some_and(|v| v.connection_id == connection_id);
-                if !owned {
-                    let code = if registry.get(&handle).is_some() {
-                        "not_owner"
-                    } else {
-                        "unknown_handle"
-                    };
-                    let _ = reply.send(ServerMsg::err(code));
-                    continue;
-                }
-                match registry.mint_instance(&handle) {
-                    Some(instance) => {
-                        let _ = reply.send(ServerMsg::instanced(instance.to_string()));
-                    }
-                    None => {
-                        let _ = reply.send(ServerMsg::err("internal"));
-                    }
-                }
-            }
+            } => on_new_instance(&mut registry, connection_id, handle.as_str(), &reply),
             ControlEvent::Unregister {
                 connection_id,
                 handle,
-            } => {
-                let removed: Vec<RemovedRegistration> = if registry
-                    .get(&handle)
-                    .is_some_and(|v| v.connection_id == connection_id)
-                {
-                    orzma_assets.0.remove(handle.as_str());
-                    registry.remove(&handle).into_iter().collect()
-                } else {
-                    vec![]
-                };
-                release_registrations(&mut commands, &webviews, &removed);
-            }
-            ControlEvent::Disconnect { connection_id } => {
-                let removed = registry.remove_by_connection(connection_id);
-                for entry in &removed {
-                    orzma_assets.0.remove(entry.handle.as_str());
-                }
-                release_registrations(&mut commands, &webviews, &removed);
-                for (webview, page_req) in rpc.drain_connection(connection_id) {
-                    let payload = serde_json::json!({ "reqId": page_req, "ok": false, "error": "owner_disconnected" });
-                    commands.trigger(HostEmitEvent::new(webview, "orzma", &payload));
-                }
-            }
+            } => on_unregister(
+                &mut commands,
+                &mut registry,
+                &orzma_assets,
+                &webviews,
+                connection_id,
+                handle.as_str(),
+            ),
+            ControlEvent::Disconnect { connection_id } => on_disconnect(
+                &mut commands,
+                &mut registry,
+                &mut rpc,
+                &orzma_assets,
+                &webviews,
+                connection_id,
+            ),
             ControlEvent::Reply {
                 req_id,
                 ok,
                 value,
                 error,
                 connection_id,
-            } => {
-                // NOTE: take_for_connection drops a reply whose sending connection
-                // is not the one that originated the call, WITHOUT consuming the
-                // pending entry — a foreign program replaying another connection's
-                // (monotonic, guessable) global reqId must not settle or drop its call.
-                let Some((webview, page_req)) = rpc.take_for_connection(&req_id, connection_id)
-                else {
-                    continue;
-                };
-                let payload = if ok {
-                    serde_json::json!({ "reqId": page_req, "ok": true, "value": value })
-                } else {
-                    serde_json::json!({ "reqId": page_req, "ok": false, "error": error.unwrap_or_default() })
-                };
-                commands.trigger(HostEmitEvent::new(webview, "orzma", &payload));
-            }
+            } => on_reply(
+                &mut commands,
+                &mut rpc,
+                &req_id,
+                ok,
+                value,
+                error,
+                connection_id,
+            ),
             ControlEvent::Emit {
                 connection_id,
                 handle,
                 event,
                 payload,
-            } => {
-                let deliver = registry
-                    .get(&handle)
-                    .is_some_and(|v| v.connection_id == connection_id && v.source.is_bridged());
-                if !deliver {
-                    continue;
-                }
-                let frame = serde_json::json!({ "event": event, "payload": payload });
-                for (entity, view) in &webviews {
-                    if view.handle == handle {
-                        commands.trigger(HostEmitEvent::new(entity, "orzma.event", &frame));
-                    }
-                }
-            }
+            } => on_emit(
+                &mut commands,
+                &registry,
+                &webviews,
+                connection_id,
+                handle.as_str(),
+                &event,
+                &payload,
+            ),
             ControlEvent::SetFocus {
                 connection_id,
                 owner_surface,
                 instance,
             } => {
-                let Some(focused) = focused.as_mut() else {
-                    continue;
-                };
-                let Some(instance) = instance else {
-                    let owned_current = focused
-                        .0
-                        .is_some_and(|e| child_of.get(e).map(|c| c.parent()) == Ok(owner_surface));
-                    if owned_current {
-                        focused.0 = None;
-                    }
-                    continue;
-                };
-                let Ok(id) = instance.parse::<InstanceId>() else {
-                    continue;
-                };
-                let owned = registry
-                    .resolve_instance(id)
-                    .is_some_and(|(_, v)| v.connection_id == connection_id);
-                if !owned {
-                    tracing::debug!(%instance, "focus op for an unowned instance, dropping");
-                    continue;
-                }
-                let target = webviews.iter().find(|(entity, view)| {
-                    view.instance == id
-                        && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
-                        && !non_interactive.contains(*entity)
-                });
-                match target {
-                    Some((entity, _)) => focused.0 = Some(entity),
-                    None => tracing::debug!(
-                        %instance,
-                        "focus op for an unmounted/non-interactive instance, dropping"
-                    ),
+                if let Some(focused) = focused.as_mut() {
+                    on_set_focus(
+                        focused,
+                        &registry,
+                        &webviews,
+                        &child_of,
+                        &non_interactive,
+                        connection_id,
+                        owner_surface,
+                        instance.as_deref(),
+                    );
                 }
             }
             ControlEvent::Navigate {
@@ -755,58 +662,306 @@ fn apply_control_events(
                 owner_surface,
                 instance,
                 action,
-            } => {
-                let Ok(id) = instance.parse::<InstanceId>() else {
-                    continue;
-                };
-                let Some((_, view)) = registry.resolve_instance(id) else {
-                    continue;
-                };
-                if view.connection_id != connection_id {
-                    tracing::debug!(%instance, "navigate for an unowned instance, dropping");
-                    continue;
-                }
-                let is_url = view.source.is_url();
-                let target = webviews.iter().find(|(entity, v)| {
-                    v.instance == id
-                        && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
-                });
-                let Some((entity, _)) = target else {
-                    tracing::debug!(%instance, "navigate for an unmounted instance, dropping");
-                    continue;
-                };
-                match action {
-                    NavAction::To(url) => {
-                        if !is_url {
-                            tracing::debug!(%instance, "navigate To on a non-url view, dropping");
-                            continue;
-                        }
-                        match validate_url_source(&url) {
-                            Ok(valid) => {
-                                if let Ok(mut source) = sources.get_mut(entity) {
-                                    // Mutate only on a real change so navigating to the
-                                    // URL already loaded does not fire a spurious CEF
-                                    // reload (WebviewSource has no PartialEq for set_if_neq).
-                                    let unchanged = matches!(
-                                        &*source,
-                                        WebviewSource::Url(cur) if *cur == valid
-                                    );
-                                    if !unchanged {
-                                        *source = WebviewSource::Url(valid);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                tracing::debug!(%instance, error = e, "navigate To rejected url");
-                            }
+            } => on_navigate(
+                &mut commands,
+                &mut sources,
+                &registry,
+                &webviews,
+                &child_of,
+                connection_id,
+                owner_surface,
+                &instance,
+                action,
+            ),
+        }
+    }
+}
+
+/// Applies a `register`: validates the requested kind, mints a handle and its
+/// first instance, and populates the registry (+ the asset registry for
+/// `Dir`/`Inline` sources). Replies on `reply` with the minted `(handle,
+/// instance)` or a short error code.
+fn on_register(
+    registry: &mut OrzmaRegistry,
+    orzma_assets: &WebviewAssetRegistryRes,
+    connection_id: u64,
+    owner_surface: Entity,
+    kind: RegisterKind,
+    reply: &Sender<ServerMsg>,
+) {
+    let view = match build_view(kind, owner_surface, connection_id) {
+        Ok(v) => v,
+        Err(code) => {
+            let _ = reply.send(ServerMsg::err(code));
+            return;
+        }
+    };
+    let handle = mint_handle_id();
+    match &view.source {
+        OrzmaSource::Dir(root) => orzma_assets.0.insert_dir(handle.as_str(), root.clone()),
+        OrzmaSource::Inline(html) => {
+            orzma_assets
+                .0
+                .insert_inline(handle.as_str(), html.clone().into_bytes());
+        }
+        OrzmaSource::Url { .. } => {}
+    }
+    registry.insert(handle.clone(), view);
+    // NOTE: a failed mint must not leave a registered handle with
+    // no instance — the program could never mount it, and the
+    // asset entry would leak until the connection drops.
+    let Some(instance) = registry.mint_instance(&handle) else {
+        registry.remove(&handle);
+        orzma_assets.0.remove(handle.as_str());
+        let _ = reply.send(ServerMsg::err("internal"));
+        return;
+    };
+    let _ = reply.send(ServerMsg::registered(handle, instance.to_string()));
+}
+
+/// Applies a `new_instance`: mints an additional instance on a handle
+/// `connection_id` owns. Replies on `reply` with the minted instance or a
+/// short error code.
+fn on_new_instance(
+    registry: &mut OrzmaRegistry,
+    connection_id: u64,
+    handle: &str,
+    reply: &Sender<ServerMsg>,
+) {
+    let handle = HandleId::from(handle);
+    let owned = registry
+        .get(&handle)
+        .is_some_and(|v| v.connection_id == connection_id);
+    if !owned {
+        let code = if registry.get(&handle).is_some() {
+            "not_owner"
+        } else {
+            "unknown_handle"
+        };
+        let _ = reply.send(ServerMsg::err(code));
+        return;
+    }
+    match registry.mint_instance(&handle) {
+        Some(instance) => {
+            let _ = reply.send(ServerMsg::instanced(instance.to_string()));
+        }
+        None => {
+            let _ = reply.send(ServerMsg::err("internal"));
+        }
+    }
+}
+
+/// Applies an `unregister`: removes `handle` (+ its assets) when
+/// `connection_id` owns it, then tears down its mounted webviews and
+/// releases its placements back to the VT.
+fn on_unregister(
+    commands: &mut Commands,
+    registry: &mut OrzmaRegistry,
+    orzma_assets: &WebviewAssetRegistryRes,
+    webviews: &Query<(Entity, &Webview)>,
+    connection_id: u64,
+    handle: &str,
+) {
+    let handle = HandleId::from(handle);
+    let removed: Vec<RemovedRegistration> = if registry
+        .get(&handle)
+        .is_some_and(|v| v.connection_id == connection_id)
+    {
+        orzma_assets.0.remove(handle.as_str());
+        registry.remove(&handle).into_iter().collect()
+    } else {
+        vec![]
+    };
+    release_registrations(commands, webviews, &removed);
+}
+
+/// Applies a connection close: purges every handle `connection_id` owned (+
+/// their assets), tears down and releases their mounted webviews, and rejects
+/// every in-flight back-channel call the connection had pending.
+fn on_disconnect(
+    commands: &mut Commands,
+    registry: &mut OrzmaRegistry,
+    rpc: &mut OrzmaRpc,
+    orzma_assets: &WebviewAssetRegistryRes,
+    webviews: &Query<(Entity, &Webview)>,
+    connection_id: u64,
+) {
+    let removed = registry.remove_by_connection(connection_id);
+    for entry in &removed {
+        orzma_assets.0.remove(entry.handle.as_str());
+    }
+    release_registrations(commands, webviews, &removed);
+    for (webview, page_req) in rpc.drain_connection(connection_id) {
+        let payload =
+            serde_json::json!({ "reqId": page_req, "ok": false, "error": "owner_disconnected" });
+        commands.trigger(HostEmitEvent::new(webview, "orzma", &payload));
+    }
+}
+
+/// Applies a program's reply to an orzma-initiated back-channel `call`:
+/// settles the matching in-flight entry (if any, and only when
+/// `connection_id` is the one that originated it) and forwards the result to
+/// the page.
+fn on_reply(
+    commands: &mut Commands,
+    rpc: &mut OrzmaRpc,
+    req_id: &str,
+    ok: bool,
+    value: Value,
+    error: Option<String>,
+    connection_id: u64,
+) {
+    // NOTE: take_for_connection drops a reply whose sending connection
+    // is not the one that originated the call, WITHOUT consuming the
+    // pending entry — a foreign program replaying another connection's
+    // (monotonic, guessable) global reqId must not settle or drop its call.
+    let Some((webview, page_req)) = rpc.take_for_connection(req_id, connection_id) else {
+        return;
+    };
+    let payload = if ok {
+        serde_json::json!({ "reqId": page_req, "ok": true, "value": value })
+    } else {
+        serde_json::json!({ "reqId": page_req, "ok": false, "error": error.unwrap_or_default() })
+    };
+    commands.trigger(HostEmitEvent::new(webview, "orzma", &payload));
+}
+
+/// Applies a program-initiated `emit`: fans the event out to every mounted
+/// webview of `handle`, when `connection_id` owns it and the registration is
+/// bridged.
+fn on_emit(
+    commands: &mut Commands,
+    registry: &OrzmaRegistry,
+    webviews: &Query<(Entity, &Webview)>,
+    connection_id: u64,
+    handle: &str,
+    event: &str,
+    payload: &Value,
+) {
+    let handle = HandleId::from(handle);
+    let deliver = registry
+        .get(&handle)
+        .is_some_and(|v| v.connection_id == connection_id && v.source.is_bridged());
+    if !deliver {
+        return;
+    }
+    let frame = serde_json::json!({ "event": event, "payload": payload });
+    for (entity, view) in webviews {
+        if view.handle == handle {
+            commands.trigger(HostEmitEvent::new(entity, "orzma.event", &frame));
+        }
+    }
+}
+
+/// Applies an app-owned focus set/clear for `owner_surface`. `instance =
+/// None` blurs the surface's own current focus (a no-op if focus belongs to
+/// another surface); `Some` focuses the matching mounted, interactive webview
+/// when `connection_id` owns the instance.
+fn on_set_focus(
+    focused: &mut FocusedWebview,
+    registry: &OrzmaRegistry,
+    webviews: &Query<(Entity, &Webview)>,
+    child_of: &Query<&ChildOf>,
+    non_interactive: &Query<(), With<NonInteractive>>,
+    connection_id: u64,
+    owner_surface: Entity,
+    instance: Option<&str>,
+) {
+    let Some(instance) = instance else {
+        let owned_current = focused
+            .0
+            .is_some_and(|e| child_of.get(e).map(|c| c.parent()) == Ok(owner_surface));
+        if owned_current {
+            focused.0 = None;
+        }
+        return;
+    };
+    let Ok(id) = instance.parse::<InstanceId>() else {
+        return;
+    };
+    let owned = registry
+        .resolve_instance(id)
+        .is_some_and(|(_, v)| v.connection_id == connection_id);
+    if !owned {
+        tracing::debug!(%instance, "focus op for an unowned instance, dropping");
+        return;
+    }
+    let target = webviews.iter().find(|(entity, view)| {
+        view.instance == id
+            && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
+            && !non_interactive.contains(*entity)
+    });
+    match target {
+        Some((entity, _)) => focused.0 = Some(entity),
+        None => tracing::debug!(
+            %instance,
+            "focus op for an unmounted/non-interactive instance, dropping"
+        ),
+    }
+}
+
+/// Applies an app-initiated in-place navigation of the mounted placement for
+/// `instance`, when `connection_id` owns it: resolves the target webview
+/// child of `owner_surface` and either swaps its `WebviewSource::Url` or
+/// triggers the matching CEF back/forward/reload request.
+fn on_navigate(
+    commands: &mut Commands,
+    sources: &mut Query<&mut WebviewSource>,
+    registry: &OrzmaRegistry,
+    webviews: &Query<(Entity, &Webview)>,
+    child_of: &Query<&ChildOf>,
+    connection_id: u64,
+    owner_surface: Entity,
+    instance: &str,
+    action: NavAction,
+) {
+    let Ok(id) = instance.parse::<InstanceId>() else {
+        return;
+    };
+    let Some((_, view)) = registry.resolve_instance(id) else {
+        return;
+    };
+    if view.connection_id != connection_id {
+        tracing::debug!(%instance, "navigate for an unowned instance, dropping");
+        return;
+    }
+    let is_url = view.source.is_url();
+    let target = webviews.iter().find(|(entity, v)| {
+        v.instance == id && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
+    });
+    let Some((entity, _)) = target else {
+        tracing::debug!(%instance, "navigate for an unmounted instance, dropping");
+        return;
+    };
+    match action {
+        NavAction::To(url) => {
+            if !is_url {
+                tracing::debug!(%instance, "navigate To on a non-url view, dropping");
+                return;
+            }
+            match validate_url_source(&url) {
+                Ok(valid) => {
+                    if let Ok(mut source) = sources.get_mut(entity) {
+                        // Mutate only on a real change so navigating to the
+                        // URL already loaded does not fire a spurious CEF
+                        // reload (WebviewSource has no PartialEq for set_if_neq).
+                        let unchanged = matches!(
+                            &*source,
+                            WebviewSource::Url(cur) if *cur == valid
+                        );
+                        if !unchanged {
+                            *source = WebviewSource::Url(valid);
                         }
                     }
-                    NavAction::Back => commands.trigger(RequestGoBack { webview: entity }),
-                    NavAction::Forward => commands.trigger(RequestGoForward { webview: entity }),
-                    NavAction::Reload => commands.trigger(RequestReload { webview: entity }),
+                }
+                Err(e) => {
+                    tracing::debug!(%instance, error = e, "navigate To rejected url");
                 }
             }
         }
+        NavAction::Back => commands.trigger(RequestGoBack { webview: entity }),
+        NavAction::Forward => commands.trigger(RequestGoForward { webview: entity }),
+        NavAction::Reload => commands.trigger(RequestReload { webview: entity }),
     }
 }
 
@@ -1086,8 +1241,14 @@ mod token_tests {
     use super::*;
     use bevy::prelude::Entity;
 
+    /// Asserts that every minted handle is non-empty, length-bounded, and
+    /// spelled with only lowercase alphanumerics, `.`, `_`, or `-` — safe to
+    /// use verbatim as the host of an `orzma://<handle>/` URL.
+    ///
+    /// Case: a program registers a Tier 1 webview and the control plane
+    /// mints the handle that becomes that registration's origin.
     #[test]
-    fn minted_ids_match_the_osc_view_id_charset() {
+    fn minted_handles_are_lowercase_url_host_safe() {
         for _ in 0..50 {
             let id = mint_handle_id();
             let id = id.as_str();
@@ -1098,7 +1259,7 @@ mod token_tests {
             assert!(
                 id.chars()
                     .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-'),
-                "minted id {id} must satisfy the OSC charset"
+                "minted id {id} must be lowercase and URL-host-safe"
             );
             assert!(
                 !id.chars().any(|c| c.is_ascii_uppercase()),
@@ -1235,8 +1396,6 @@ mod registry_tests {
     #[test]
     fn minting_binds_an_instance_to_its_handle_and_release_takes_both() {
         let mut registry = OrzmaRegistry::default();
-        // NOTE: Bevy 0.19 has no Entity::from_raw; the repo's other tests use
-        // from_bits.
         let owner = Entity::from_bits(7);
         let h = HandleId::from("h");
         registry.insert(h.clone(), view(owner, 1));

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -602,13 +602,47 @@ fn apply_control_events(
                     OrzmaSource::Url { .. } => {}
                 }
                 registry.insert(handle.clone(), view);
-                let _ = reply.send(ServerMsg::ok(handle.to_string()));
+                // NOTE: a failed mint must not leave a registered handle with
+                // no instance — the program could never mount it, and the
+                // asset entry would leak until the connection drops.
+                let Some(instance) = registry.mint_instance(&handle) else {
+                    registry.remove(&handle);
+                    orzma_assets.0.remove(handle.as_str());
+                    let _ = reply.send(ServerMsg::err("internal"));
+                    continue;
+                };
+                let _ = reply.send(ServerMsg::registered(handle, instance.to_string()));
+            }
+            ControlEvent::NewInstance {
+                connection_id,
+                handle,
+                reply,
+            } => {
+                let owned = registry
+                    .get(&handle)
+                    .is_some_and(|v| v.connection_id == connection_id);
+                if !owned {
+                    let code = if registry.get(&handle).is_some() {
+                        "not_owner"
+                    } else {
+                        "unknown_handle"
+                    };
+                    let _ = reply.send(ServerMsg::err(code));
+                    continue;
+                }
+                match registry.mint_instance(&handle) {
+                    Some(instance) => {
+                        let _ = reply.send(ServerMsg::instanced(instance.to_string()));
+                    }
+                    None => {
+                        let _ = reply.send(ServerMsg::err("internal"));
+                    }
+                }
             }
             ControlEvent::Unregister {
                 connection_id,
                 handle,
             } => {
-                let handle = HandleId::from(handle);
                 let removed: Vec<RemovedRegistration> = if registry
                     .get(&handle)
                     .is_some_and(|v| v.connection_id == connection_id)
@@ -659,7 +693,6 @@ fn apply_control_events(
                 event,
                 payload,
             } => {
-                let handle = HandleId::from(handle);
                 let deliver = registry
                     .get(&handle)
                     .is_some_and(|v| v.connection_id == connection_id && v.source.is_bridged());
@@ -676,73 +709,72 @@ fn apply_control_events(
             ControlEvent::SetFocus {
                 connection_id,
                 owner_surface,
-                handle,
                 instance,
             } => {
                 let Some(focused) = focused.as_mut() else {
                     continue;
                 };
-                match handle {
-                    Some(h) => {
-                        let h = HandleId::from(h);
-                        let owned = registry
-                            .get(&h)
-                            .is_some_and(|v| v.connection_id == connection_id);
-                        if !owned {
-                            tracing::debug!(handle = %h, "focus op for unowned handle, dropping");
-                            continue;
-                        }
-                        let target = webviews.iter().find(|(entity, view)| {
-                            view.view_id == h.as_str()
-                                && view.instance_id.as_deref() == instance.as_deref()
-                                && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
-                                && !non_interactive.contains(*entity)
-                        });
-                        match target {
-                            Some((entity, _)) => focused.0 = Some(entity),
-                            None => tracing::debug!(
-                                handle = %h,
-                                "focus op for unmounted/non-interactive view, dropping"
-                            ),
-                        }
+                let Some(instance) = instance else {
+                    let owned_current = focused
+                        .0
+                        .is_some_and(|e| child_of.get(e).map(|c| c.parent()) == Ok(owner_surface));
+                    if owned_current {
+                        focused.0 = None;
                     }
-                    None => {
-                        let owned_current = focused.0.is_some_and(|e| {
-                            child_of.get(e).map(|c| c.parent()) == Ok(owner_surface)
-                        });
-                        if owned_current {
-                            focused.0 = None;
-                        }
-                    }
+                    continue;
+                };
+                let Ok(id) = instance.parse::<InstanceId>() else {
+                    continue;
+                };
+                let owned = registry
+                    .resolve_instance(id)
+                    .is_some_and(|(_, v)| v.connection_id == connection_id);
+                if !owned {
+                    tracing::debug!(%instance, "focus op for an unowned instance, dropping");
+                    continue;
+                }
+                let target = webviews.iter().find(|(entity, view)| {
+                    view.instance == id
+                        && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
+                        && !non_interactive.contains(*entity)
+                });
+                match target {
+                    Some((entity, _)) => focused.0 = Some(entity),
+                    None => tracing::debug!(
+                        %instance,
+                        "focus op for an unmounted/non-interactive instance, dropping"
+                    ),
                 }
             }
             ControlEvent::Navigate {
                 connection_id,
                 owner_surface,
-                handle,
+                instance,
                 action,
             } => {
-                let handle = HandleId::from(handle);
-                let Some(view) = registry.get(&handle) else {
+                let Ok(id) = instance.parse::<InstanceId>() else {
+                    continue;
+                };
+                let Some((_, view)) = registry.resolve_instance(id) else {
                     continue;
                 };
                 if view.connection_id != connection_id {
-                    tracing::debug!(handle = %handle, "navigate for unowned handle, dropping");
+                    tracing::debug!(%instance, "navigate for an unowned instance, dropping");
                     continue;
                 }
                 let is_url = view.source.is_url();
                 let target = webviews.iter().find(|(entity, v)| {
-                    v.view_id == handle.as_str()
+                    v.instance == id
                         && child_of.get(*entity).map(|c| c.parent()) == Ok(owner_surface)
                 });
                 let Some((entity, _)) = target else {
-                    tracing::debug!(handle = %handle, "navigate for unmounted view, dropping");
+                    tracing::debug!(%instance, "navigate for an unmounted instance, dropping");
                     continue;
                 };
                 match action {
                     NavAction::To(url) => {
                         if !is_url {
-                            tracing::debug!(handle = %handle, "navigate To on a non-url view, dropping");
+                            tracing::debug!(%instance, "navigate To on a non-url view, dropping");
                             continue;
                         }
                         match validate_url_source(&url) {
@@ -761,7 +793,7 @@ fn apply_control_events(
                                 }
                             }
                             Err(e) => {
-                                tracing::debug!(handle = %handle, error = e, "navigate To rejected url");
+                                tracing::debug!(%instance, error = e, "navigate To rejected url");
                             }
                         }
                     }
@@ -1258,17 +1290,17 @@ mod apply_tests {
         app.update();
 
         let handle = match reply_rx.try_recv().expect("apply must reply") {
-            ServerMsg::Ok { handle, .. } => handle,
-            ServerMsg::Err { error, .. } => panic!("unexpected err: {error}"),
+            ServerMsg::Registered { handle, .. } => handle,
+            other => panic!("unexpected reply: {other:?}"),
         };
         assert!(
-            orzma_assets.get(&handle).is_some(),
+            orzma_assets.get(handle.as_str()).is_some(),
             "WebviewAssetRegistry populated for Dir"
         );
         assert!(
             app.world()
                 .resource::<OrzmaRegistry>()
-                .get(&HandleId::from(handle.as_str()))
+                .get(&handle)
                 .is_some(),
             "OrzmaRegistry populated"
         );
@@ -1304,11 +1336,11 @@ mod apply_tests {
         app.update();
 
         let handle = match reply_rx.try_recv().expect("apply must reply") {
-            ServerMsg::Ok { handle, .. } => handle,
-            ServerMsg::Err { error, .. } => panic!("unexpected err: {error}"),
+            ServerMsg::Registered { handle, .. } => handle,
+            other => panic!("unexpected reply: {other:?}"),
         };
         assert!(
-            matches!(orzma_assets.get(&handle), Some(WebviewAsset::Inline(bytes)) if bytes == b"<h1>x</h1>"),
+            matches!(orzma_assets.get(handle.as_str()), Some(WebviewAsset::Inline(bytes)) if bytes == b"<h1>x</h1>"),
             "WebviewAssetRegistry must carry the inline HTML bytes for the minted handle"
         );
     }
@@ -1415,12 +1447,17 @@ mod apply_tests {
             },
         );
         let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let instance = reg
+            .mint_instance(&HandleId::from("HMOUNT"))
+            .expect("the handle mints");
         let mounted = app
             .world_mut()
             .spawn(Webview {
-                view_id: "HMOUNT".into(),
-                instance_id: None,
+                handle: "HMOUNT".into(),
+                instance,
                 slot: 0,
+                rows: 10,
+                cols: 40,
             })
             .id();
         app.insert_resource(reg);
@@ -1560,10 +1597,15 @@ mod apply_tests {
                 instances: Vec::new(),
             },
         );
+        let instance = reg
+            .mint_instance(&HandleId::from("disp"))
+            .expect("the handle mints");
         app.world_mut().spawn(Webview {
-            view_id: "disp".into(),
-            instance_id: None,
+            handle: "disp".into(),
+            instance,
             slot: 0,
+            rows: 10,
+            cols: 40,
         });
         app.insert_resource(reg);
         app.insert_resource(OrzmaRpc::default());
@@ -1620,18 +1662,18 @@ mod apply_tests {
         app.update();
 
         let handle = match reply_rx.try_recv().expect("apply must reply") {
-            ServerMsg::Ok { handle, .. } => handle,
-            ServerMsg::Err { error, .. } => panic!("unexpected err: {error}"),
+            ServerMsg::Registered { handle, .. } => handle,
+            other => panic!("unexpected reply: {other:?}"),
         };
         assert!(
             app.world()
                 .resource::<OrzmaRegistry>()
-                .get(&HandleId::from(handle.as_str()))
+                .get(&handle)
                 .is_some(),
             "OrzmaRegistry populated"
         );
         assert!(
-            orzma_assets.get(&handle).is_none(),
+            orzma_assets.get(handle.as_str()).is_none(),
             "WebviewAssetRegistry must NOT be populated for a url handle"
         );
     }
@@ -1655,17 +1697,23 @@ mod apply_tests {
                 instances: Vec::new(),
             },
         );
+        let instance = reg
+            .mint_instance(&HandleId::from("H"))
+            .expect("the handle mints");
         let mounted = app
             .world_mut()
             .spawn((
                 Webview {
-                    view_id: "H".into(),
-                    instance_id: None,
+                    handle: "H".into(),
+                    instance,
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
                 WebviewOwner {
                     connection_id: 5,
                     handle: "H".into(),
+                    instance,
                 },
             ))
             .id();
@@ -1726,13 +1774,18 @@ mod apply_tests {
                 instances: Vec::new(),
             },
         );
+        let instance = reg
+            .mint_instance(&HandleId::from("H"))
+            .expect("the handle mints");
         let child = app
             .world_mut()
             .spawn((
                 Webview {
-                    view_id: "H".into(),
-                    instance_id: None,
+                    handle: "H".into(),
+                    instance,
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
                 WebviewSource::new("https://example.com"),
                 ChildOf(surface),
@@ -1748,7 +1801,7 @@ mod apply_tests {
             .send(ControlEvent::Navigate {
                 connection_id: 5,
                 owner_surface: surface,
-                handle: "H".into(),
+                instance: instance.to_string(),
                 action: NavAction::To("https://example.com/next".into()),
             })
             .unwrap();
@@ -1783,13 +1836,18 @@ mod apply_tests {
                 instances: Vec::new(),
             },
         );
+        let instance = reg
+            .mint_instance(&HandleId::from("H"))
+            .expect("the handle mints");
         let child = app
             .world_mut()
             .spawn((
                 Webview {
-                    view_id: "H".into(),
-                    instance_id: None,
+                    handle: "H".into(),
+                    instance,
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
                 WebviewSource::new("https://example.com"),
                 ChildOf(surface),
@@ -1809,7 +1867,7 @@ mod apply_tests {
             .send(ControlEvent::Navigate {
                 connection_id: 5,
                 owner_surface: surface,
-                handle: "H".into(),
+                instance: instance.to_string(),
                 action: NavAction::Back,
             })
             .unwrap();
@@ -1841,13 +1899,18 @@ mod apply_tests {
                 instances: Vec::new(),
             },
         );
+        let instance = reg
+            .mint_instance(&HandleId::from("H"))
+            .expect("the handle mints");
         let child = app
             .world_mut()
             .spawn((
                 Webview {
-                    view_id: "H".into(),
-                    instance_id: None,
+                    handle: "H".into(),
+                    instance,
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
                 WebviewSource::new("https://example.com"),
                 ChildOf(surface),
@@ -1863,7 +1926,7 @@ mod apply_tests {
             .send(ControlEvent::Navigate {
                 connection_id: 9, // not the owner (5)
                 owner_surface: surface,
-                handle: "H".into(),
+                instance: instance.to_string(),
                 action: NavAction::To("https://evil.example/x".into()),
             })
             .unwrap();
@@ -1885,49 +1948,75 @@ mod focus_tests {
     use bevy_cef::prelude::FocusedWebview;
     use crossbeam_channel::unbounded;
 
-    #[test]
-    fn set_focus_points_focused_webview_at_the_owned_inline_child() {
-        let mut app = bevy::app::App::new();
-        app.add_plugins(bevy::MinimalPlugins)
+    fn focus_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
             .init_resource::<OrzmaRegistry>()
             .init_resource::<OrzmaRpc>()
             .init_resource::<FocusedWebview>()
             .insert_resource(WebviewAssetRegistryRes(WebviewAssetRegistry::default()));
+        app
+    }
 
-        let surface = app.world_mut().spawn_empty().id();
-
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "h1".into(),
+    /// Registers an inline view owned by `owner_surface` / `connection_id`
+    /// and mints its first instance, the way `register` does at runtime.
+    fn register_and_mint(
+        app: &mut App,
+        handle: &str,
+        owner_surface: Entity,
+        connection_id: u64,
+    ) -> InstanceId {
+        let handle = HandleId::from(handle);
+        let mut registry = app.world_mut().resource_mut::<OrzmaRegistry>();
+        registry.insert(
+            handle.clone(),
             OrzmaView {
                 source: OrzmaSource::Inline("<h1>x</h1>".into()),
                 entry: "index.html".into(),
                 interactive: true,
-                owner_surface: surface,
-                connection_id: 1,
+                owner_surface,
+                connection_id,
                 forward_keys: vec![],
                 preload: vec![],
                 instances: Vec::new(),
             },
         );
-        let child = app
-            .world_mut()
+        registry.mint_instance(&handle).expect("the handle mints")
+    }
+
+    fn spawn_mounted(app: &mut App, surface: Entity, handle: &str, instance: InstanceId) -> Entity {
+        app.world_mut()
             .spawn((
                 ChildOf(surface),
                 Webview {
-                    view_id: "h1".into(),
-                    instance_id: None,
+                    handle: handle.into(),
+                    instance,
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
-            .id();
+            .id()
+    }
+
+    /// Asserts that a focus op names the mounted child holding that
+    /// instance, and that a null instance from the owning surface clears it.
+    ///
+    /// Case: an app moves keyboard focus into the placement it just
+    /// mounted, then hands focus back to the shell.
+    #[test]
+    fn set_focus_points_focused_webview_at_the_owned_inline_child() {
+        let mut app = focus_app();
+        let surface = app.world_mut().spawn_empty().id();
+        let instance = register_and_mint(&mut app, "h1", surface, 1);
+        let child = spawn_mounted(&mut app, surface, "h1", instance);
 
         let (tx, rx) = unbounded::<ControlEvent>();
         app.insert_resource(ControlEvents(rx));
         tx.send(ControlEvent::SetFocus {
             connection_id: 1,
             owner_surface: surface,
-            handle: Some("h1".into()),
-            instance: None,
+            instance: Some(instance.to_string()),
         })
         .unwrap();
         app.world_mut()
@@ -1943,7 +2032,6 @@ mod focus_tests {
         tx.send(ControlEvent::SetFocus {
             connection_id: 1,
             owner_surface: surface,
-            handle: None,
             instance: None,
         })
         .unwrap();
@@ -1953,48 +2041,29 @@ mod focus_tests {
         assert_eq!(app.world().resource::<FocusedWebview>().0, None);
     }
 
+    /// Asserts that a focus op from a connection that does not own the
+    /// instance is dropped even though a focusable child is mounted.
+    ///
+    /// Case: a second program on the same surface guesses an instance id
+    /// another program's registration minted.
     #[test]
-    fn set_focus_rejects_unowned_handle() {
-        let mut app = bevy::app::App::new();
-        app.add_plugins(bevy::MinimalPlugins)
-            .init_resource::<OrzmaRegistry>()
-            .init_resource::<OrzmaRpc>()
-            .init_resource::<FocusedWebview>()
-            .insert_resource(WebviewAssetRegistryRes(WebviewAssetRegistry::default()));
+    fn set_focus_rejects_an_unowned_instance() {
+        let mut app = focus_app();
         let surface = app.world_mut().spawn_empty().id();
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "h1".into(),
-            OrzmaView {
-                source: OrzmaSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: surface,
-                connection_id: 99,
-                forward_keys: vec![],
-                preload: vec![],
-                instances: Vec::new(),
-            },
-        );
+        let instance = register_and_mint(&mut app, "h1", surface, 99);
         // Spawn a VALID interactive inline child that WOULD be focused if the
         // ownership check passed. This ensures the guard is the sole gate:
         // deleting the `connection_id` check would let focus be granted and
         // this assertion would FAIL.
-        app.world_mut().spawn((
-            ChildOf(surface),
-            Webview {
-                view_id: "h1".into(),
-                instance_id: None,
-                slot: 0,
-            },
-        ));
+        spawn_mounted(&mut app, surface, "h1", instance);
+
         let (tx, rx) = unbounded::<ControlEvent>();
         app.insert_resource(ControlEvents(rx));
         // connection_id 1 ≠ owner 99 — ownership guard must reject this.
         tx.send(ControlEvent::SetFocus {
             connection_id: 1,
             owner_surface: surface,
-            handle: Some("h1".into()),
-            instance: None,
+            instance: Some(instance.to_string()),
         })
         .unwrap();
         app.world_mut()
@@ -2007,44 +2076,19 @@ mod focus_tests {
         );
     }
 
+    /// Asserts that a blur only clears focus the requesting surface owns,
+    /// and does clear it when the owning surface asks.
+    ///
+    /// Case: a program on a second pane blurs while a webview on the first
+    /// pane holds keyboard focus.
     #[test]
     fn blur_does_not_clobber_another_surfaces_focus() {
-        let mut app = bevy::app::App::new();
-        app.add_plugins(bevy::MinimalPlugins)
-            .init_resource::<OrzmaRegistry>()
-            .init_resource::<OrzmaRpc>()
-            .init_resource::<FocusedWebview>()
-            .insert_resource(WebviewAssetRegistryRes(WebviewAssetRegistry::default()));
-
+        let mut app = focus_app();
         let surface_a = app.world_mut().spawn_empty().id();
         let surface_b = app.world_mut().spawn_empty().id();
 
-        // Register "ha" owned by connection 1 / surface_a.
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "ha".into(),
-            OrzmaView {
-                source: OrzmaSource::Inline("<h1>a</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: surface_a,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
-                instances: Vec::new(),
-            },
-        );
-        // Spawn the matching interactive inline child on surface_a.
-        let child_a = app
-            .world_mut()
-            .spawn((
-                ChildOf(surface_a),
-                Webview {
-                    view_id: "ha".into(),
-                    instance_id: None,
-                    slot: 0,
-                },
-            ))
-            .id();
+        let instance = register_and_mint(&mut app, "ha", surface_a, 1);
+        let child_a = spawn_mounted(&mut app, surface_a, "ha", instance);
 
         let (tx, rx) = unbounded::<ControlEvent>();
         app.insert_resource(ControlEvents(rx));
@@ -2053,8 +2097,7 @@ mod focus_tests {
         tx.send(ControlEvent::SetFocus {
             connection_id: 1,
             owner_surface: surface_a,
-            handle: Some("ha".into()),
-            instance: None,
+            instance: Some(instance.to_string()),
         })
         .unwrap();
         app.world_mut()
@@ -2071,7 +2114,6 @@ mod focus_tests {
         tx.send(ControlEvent::SetFocus {
             connection_id: 2,
             owner_surface: surface_b,
-            handle: None,
             instance: None,
         })
         .unwrap();
@@ -2088,7 +2130,6 @@ mod focus_tests {
         tx.send(ControlEvent::SetFocus {
             connection_id: 1,
             owner_surface: surface_a,
-            handle: None,
             instance: None,
         })
         .unwrap();

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 use bevy_cef::prelude::FocusedWebview;
 use bevy_cef::prelude::HostEmitEvent;
 use bevy_cef::prelude::{RequestGoBack, RequestGoForward, RequestReload, WebviewSource};
-use bevy_orzma_tty::prelude::OrzmaTtyHandle;
+use bevy_orzma_tty::prelude::{OrzmaTtyHandle, RequestTtyWebviewRemove};
 use crossbeam_channel::{Receiver, Sender};
 use data_encoding::BASE32_NOPAD;
 use orzma_vt::prelude::InstanceId;
@@ -116,13 +116,17 @@ pub(crate) struct OrzmaView {
 }
 
 /// Stamped on a Tier 1 webview entity at mount: the control-plane
-/// connection that registered it (back-channel routing target) and its handle.
+/// connection that registered it (back-channel routing target), its handle,
+/// and the instance the mount was addressed by.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WebviewOwner {
     /// The owning connection (push `call` frames here).
-    pub(crate) connection_id: u64,
+    pub connection_id: u64,
     /// The registration handle (for `emit` fan-out + ownership checks).
-    pub(crate) handle: String,
+    pub handle: HandleId,
+    /// The placement this webview was mounted under, so a back-channel
+    /// frame names which of a handle's placements it came from.
+    pub instance: InstanceId,
 }
 
 /// The opaque identity of one dynamic registration.
@@ -652,14 +656,14 @@ fn apply_control_events(
                 } else {
                     vec![]
                 };
-                despawn_mounted(&mut commands, &webviews, &removed);
+                release_registrations(&mut commands, &webviews, &removed);
             }
             ControlEvent::Disconnect { connection_id } => {
                 let removed = registry.remove_by_connection(connection_id);
                 for entry in &removed {
                     orzma_assets.0.remove(entry.handle.as_str());
                 }
-                despawn_mounted(&mut commands, &webviews, &removed);
+                release_registrations(&mut commands, &webviews, &removed);
                 for (webview, page_req) in rpc.drain_connection(connection_id) {
                     let payload = serde_json::json!({ "reqId": page_req, "ok": false, "error": "owner_disconnected" });
                     commands.trigger(HostEmitEvent::new(webview, "orzma", &payload));
@@ -701,7 +705,7 @@ fn apply_control_events(
                 }
                 let frame = serde_json::json!({ "event": event, "payload": payload });
                 for (entity, view) in &webviews {
-                    if view.view_id == handle.as_str() {
+                    if view.handle == handle {
                         commands.trigger(HostEmitEvent::new(entity, "orzma.event", &frame));
                     }
                 }
@@ -806,18 +810,31 @@ fn apply_control_events(
     }
 }
 
-fn despawn_mounted(
+/// Tears down the registrations `removed` released: despawns their mounted
+/// webviews and hands the reservations back to the VT on the surface that
+/// owned them.
+///
+/// The VT cannot learn that a registration is gone — that fact lives on the
+/// control socket — so without the second step each released placement keeps
+/// a per-terminal cap slot until its anchor scrolls out of history.
+fn release_registrations(
     commands: &mut Commands,
     webviews: &Query<(Entity, &Webview)>,
     removed: &[RemovedRegistration],
 ) {
     for (entity, view) in webviews {
-        if removed
-            .iter()
-            .any(|entry| entry.handle.as_str() == view.view_id)
-        {
+        if removed.iter().any(|entry| entry.handle == view.handle) {
             commands.entity(entity).despawn();
         }
+    }
+    for entry in removed {
+        if entry.instances.is_empty() {
+            continue;
+        }
+        commands.trigger(RequestTtyWebviewRemove {
+            terminal: entry.owner_surface,
+            instances: entry.instances.clone(),
+        });
     }
 }
 
@@ -1478,6 +1495,62 @@ mod apply_tests {
                 .resource::<OrzmaRegistry>()
                 .get(&HandleId::from("HMOUNT"))
                 .is_none()
+        );
+    }
+
+    /// Asserts that releasing a handle hands the placements it had minted
+    /// back to the VT on the surface that owned them.
+    ///
+    /// Case: a program unregisters a view whose placements the terminal
+    /// still holds, so their cap slots must be freed without waiting for
+    /// the anchors to scroll out of history.
+    #[test]
+    fn unregister_reclaims_the_released_placements_from_the_vt() {
+        #[derive(Resource, Default)]
+        struct Reclaimed(Vec<(Entity, Vec<InstanceId>)>);
+        let mut app = App::new();
+        let (ev_tx, ev_rx) = unbounded::<ControlEvent>();
+        let surface = app.world_mut().spawn_empty().id();
+        let handle = HandleId::from("h");
+        let mut reg = OrzmaRegistry::default();
+        reg.insert(
+            handle.clone(),
+            OrzmaView {
+                source: OrzmaSource::Inline("<h1>x</h1>".into()),
+                entry: "index.html".into(),
+                interactive: true,
+                owner_surface: surface,
+                connection_id: 5,
+                forward_keys: vec![],
+                preload: vec![],
+                instances: Vec::new(),
+            },
+        );
+        let instance = reg.mint_instance(&handle).expect("the handle mints");
+        app.insert_resource(reg);
+        app.insert_resource(OrzmaRpc::default());
+        app.insert_resource(ControlEvents(ev_rx));
+        app.insert_resource(WebviewAssetRegistryRes(WebviewAssetRegistry::default()));
+        app.init_resource::<Reclaimed>();
+        app.add_observer(
+            |e: On<RequestTtyWebviewRemove>, mut reclaimed: ResMut<Reclaimed>| {
+                reclaimed.0.push((e.terminal, e.instances.clone()));
+            },
+        );
+        app.add_systems(Update, apply_control_events);
+
+        ev_tx
+            .send(ControlEvent::Unregister {
+                connection_id: 5,
+                handle,
+            })
+            .unwrap();
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Reclaimed>().0,
+            vec![(surface, vec![instance])],
+            "unregister must drop the released placements on the owning surface"
         );
     }
 

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -722,7 +722,7 @@ fn on_register(
         let _ = reply.send(ServerMsg::err("internal"));
         return;
     };
-    let _ = reply.send(ServerMsg::registered(handle, instance.to_string()));
+    let _ = reply.send(ServerMsg::registered(handle, instance));
 }
 
 /// Applies a `new_instance`: mints an additional instance on a handle
@@ -749,7 +749,7 @@ fn on_new_instance(
     }
     match registry.mint_instance(&handle) {
         Some(instance) => {
-            let _ = reply.send(ServerMsg::instanced(instance.to_string()));
+            let _ = reply.send(ServerMsg::instanced(instance));
         }
         None => {
             let _ = reply.send(ServerMsg::err("internal"));

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -1434,9 +1434,7 @@ mod registry_tests {
     /// its handle.
     ///
     /// Case: a handle is reused for a fresh registration before its previous
-    /// one was explicitly removed — production handles are CSPRNG-minted and
-    /// this cannot happen there, but the registry's own invariant must still
-    /// hold for a caller that reuses a literal handle.
+    /// one was explicitly removed.
     #[test]
     fn insert_over_an_existing_handle_purges_its_stale_instances() {
         let mut registry = OrzmaRegistry::default();

--- a/crates/bevy_orzma_webview/src/control_plane/listener.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/listener.rs
@@ -374,6 +374,7 @@ fn handle_client_msg(
 mod tests {
     use super::*;
     use crate::control_plane::ConnectionWriters;
+    use orzma_vt::prelude::InstanceId;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -409,7 +410,9 @@ mod tests {
             }
             _ => panic!("expected a Register event"),
         };
-        reply.send(ServerMsg::registered("HANDLE1", "i1")).unwrap();
+        reply
+            .send(ServerMsg::registered("HANDLE1", InstanceId(1)))
+            .unwrap();
 
         let mut line = String::new();
         BufReader::new(client.try_clone().unwrap())

--- a/crates/bevy_orzma_webview/src/control_plane/listener.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/listener.rs
@@ -8,6 +8,7 @@
 //! through a single owner.
 
 use crate::control_plane::ConnectionWriters;
+use crate::control_plane::HandleId;
 use crate::control_plane::TokenRegistry;
 use crate::control_plane::protocol::{ClientMsg, NavAction, RegisterKind, ServerMsg};
 use bevy::prelude::Entity;
@@ -37,7 +38,17 @@ pub(crate) enum ControlEvent {
         /// Connection id (ownership check).
         connection_id: u64,
         /// The handle to release.
-        handle: String,
+        handle: HandleId,
+    },
+    /// A `new_instance` from a hello'd connection; the apply system mints an
+    /// instance on a handle this connection owns and replies on `reply`.
+    NewInstance {
+        /// Connection id (ownership check).
+        connection_id: u64,
+        /// The handle to mint an additional instance for.
+        handle: HandleId,
+        /// Where the apply system returns the `ServerMsg` reply.
+        reply: Sender<ServerMsg>,
     },
     /// A connection closed; purge all its handles.
     Disconnect {
@@ -62,7 +73,7 @@ pub(crate) enum ControlEvent {
         /// The connection that sent the emit (ownership is checked in apply).
         connection_id: u64,
         /// The target handle.
-        handle: String,
+        handle: HandleId,
         /// The event name.
         event: String,
         /// The event payload.
@@ -74,19 +85,17 @@ pub(crate) enum ControlEvent {
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
-        /// The handle to focus, or `None` to blur.
-        handle: Option<String>,
-        /// The mount instance id, or `None` for the default instance.
+        /// The instance to focus, or `None` to blur.
         instance: Option<String>,
     },
-    /// An app-initiated in-place navigation of a handle's mounted webview.
+    /// An app-initiated in-place navigation of one mounted placement.
     Navigate {
         /// Connection id (ownership check in apply).
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
-        /// The target handle.
-        handle: String,
+        /// The target instance.
+        instance: String,
         /// What to do.
         action: NavAction,
     },
@@ -292,6 +301,29 @@ fn handle_client_msg(
                 handle,
             });
         }
+        // NOTE: blocking on reply_rx.recv() before the reader reads the next
+        // line is what keeps one connection's replies in request order; the
+        // SDK matches them to its pending requests by position.
+        ClientMsg::NewInstance { handle } => {
+            let (reply_tx, reply_rx) = bounded::<ServerMsg>(1);
+            if events
+                .send(ControlEvent::NewInstance {
+                    connection_id,
+                    handle,
+                    reply: reply_tx,
+                })
+                .is_err()
+            {
+                return ControlFlow::Break(());
+            }
+            let reply = reply_rx
+                .recv()
+                .unwrap_or_else(|_| ServerMsg::err("internal"));
+            let line = serde_json::to_string(&reply).expect("ServerMsg serializes infallibly");
+            if out_tx.send(line).is_err() {
+                return ControlFlow::Break(());
+            }
+        }
         ClientMsg::Hello { .. } => {}
         ClientMsg::Reply {
             req_id,
@@ -319,19 +351,18 @@ fn handle_client_msg(
                 payload,
             });
         }
-        ClientMsg::Focus { handle, instance } => {
+        ClientMsg::Focus { instance } => {
             let _ = events.send(ControlEvent::SetFocus {
                 connection_id,
                 owner_surface,
-                handle,
                 instance,
             });
         }
-        ClientMsg::Navigate { handle, action } => {
+        ClientMsg::Navigate { instance, action } => {
             let _ = events.send(ControlEvent::Navigate {
                 connection_id,
                 owner_surface,
-                handle,
+                instance,
                 action,
             });
         }
@@ -378,7 +409,7 @@ mod tests {
             }
             _ => panic!("expected a Register event"),
         };
-        reply.send(ServerMsg::ok("HANDLE1")).unwrap();
+        reply.send(ServerMsg::registered("HANDLE1", "i1")).unwrap();
 
         let mut line = String::new();
         BufReader::new(client.try_clone().unwrap())
@@ -484,7 +515,7 @@ mod tests {
             if let Ok(ControlEvent::Emit { handle, event, .. }) =
                 events.recv_timeout(Duration::from_millis(50))
             {
-                assert_eq!(handle, "H");
+                assert_eq!(handle, HandleId::from("H"));
                 assert_eq!(event, "tick");
                 break;
             }
@@ -503,19 +534,19 @@ mod tests {
 
         let mut client = UnixStream::connect(&sock).unwrap();
         writeln!(client, r#"{{"op":"hello","token":"tok"}}"#).unwrap();
-        writeln!(client, r#"{{"op":"focus","handle":"h1","instance":null}}"#).unwrap();
+        writeln!(client, r#"{{"op":"focus","instance":"3f5a"}}"#).unwrap();
         client.flush().unwrap();
 
         let deadline = Instant::now() + Duration::from_secs(2);
         loop {
             if let Ok(ControlEvent::SetFocus {
                 owner_surface,
-                handle,
+                instance,
                 ..
             }) = events.recv_timeout(Duration::from_millis(50))
             {
                 assert_eq!(owner_surface, surface);
-                assert_eq!(handle.as_deref(), Some("h1"));
+                assert_eq!(instance.as_deref(), Some("3f5a"));
                 break;
             }
             assert!(Instant::now() < deadline, "no SetFocus within 2s");
@@ -565,7 +596,7 @@ mod tests {
 
         let flow = handle_client_msg(
             ClientMsg::Navigate {
-                handle: "H".into(),
+                instance: "3f5a".into(),
                 action: NavAction::Reload,
             },
             7,
@@ -579,12 +610,12 @@ mod tests {
             ControlEvent::Navigate {
                 connection_id,
                 owner_surface,
-                handle,
+                instance,
                 action,
             } => {
                 assert_eq!(connection_id, 7);
                 assert_eq!(owner_surface, surface);
-                assert_eq!(handle, "H");
+                assert_eq!(instance, "3f5a");
                 assert_eq!(action, NavAction::Reload);
             }
             _ => panic!("expected Navigate"),

--- a/crates/bevy_orzma_webview/src/control_plane/protocol.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/protocol.rs
@@ -3,6 +3,7 @@
 //! per request line. Unknown `op` values fail to parse (strict, matching the
 //! OSC parser ethos).
 
+use crate::control_plane::HandleId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -21,7 +22,12 @@ pub(crate) enum ClientMsg {
     /// Releases a previously-registered handle owned by this connection.
     Unregister {
         /// The handle returned by a prior `register`.
-        handle: String,
+        handle: HandleId,
+    },
+    /// Mints an additional placement slot for a handle this connection owns.
+    NewInstance {
+        /// The handle returned by a prior `register`.
+        handle: HandleId,
     },
     /// A program's reply to an orzma-initiated `call` (back-channel).
     Reply {
@@ -40,33 +46,30 @@ pub(crate) enum ClientMsg {
     /// A program-initiated push event to its handle's mounted webviews.
     Emit {
         /// The handle whose mounted webviews receive the event.
-        handle: String,
+        handle: HandleId,
         /// The event name dispatched to page `window.orzma.on(name, …)`.
         event: String,
         /// The event payload.
         #[serde(default)]
         payload: Value,
     },
-    /// Sets (or clears, with `handle: None`) the app-owned focus target for
-    /// this connection's surface.
+    /// Sets (or clears, with `instance: None`) the app-owned focus target
+    /// for this connection's surface.
     Focus {
-        /// The handle to focus, or `None` to blur.
-        #[serde(default)]
-        handle: Option<String>,
-        /// The mount instance id, or `None` for the default instance.
+        /// The instance to focus, or `None` to blur.
         #[serde(default)]
         instance: Option<String>,
     },
-    /// Navigate a handle's mounted webview in place.
+    /// Navigate one mounted placement in place.
     Navigate {
-        /// The target handle.
-        handle: String,
+        /// The target instance.
+        instance: String,
         /// What to do.
         action: NavAction,
     },
 }
 
-/// A navigation action on an already-registered handle's mounted webview.
+/// A navigation action on one mounted placement.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NavAction {
@@ -146,12 +149,21 @@ pub(crate) enum RegisterKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub(crate) enum ServerMsg {
-    /// A successful `register` carrying the minted handle.
-    Ok {
+    /// A successful `register`: the minted handle and its first instance.
+    Registered {
         /// Always `true`.
         ok: bool,
-        /// The opaque handle to mount via `APC Omount;v=<handle>`.
-        handle: String,
+        /// The opaque handle the registration is owned and released by.
+        handle: HandleId,
+        /// The instance to mount via `APC Omount;n=<instance>`.
+        instance: String,
+    },
+    /// A successful `new_instance`: the minted instance.
+    Instanced {
+        /// Always `true`.
+        ok: bool,
+        /// The instance to mount via `APC Omount;n=<instance>`.
+        instance: String,
     },
     /// A rejected request.
     Err {
@@ -163,16 +175,25 @@ pub(crate) enum ServerMsg {
 }
 
 impl ServerMsg {
-    /// An `ok` reply carrying the minted handle.
-    pub(crate) fn ok(handle: impl Into<String>) -> Self {
-        Self::Ok {
+    /// A `register` reply carrying the minted handle and its first instance.
+    pub fn registered(handle: impl Into<HandleId>, instance: impl Into<String>) -> Self {
+        Self::Registered {
             ok: true,
             handle: handle.into(),
+            instance: instance.into(),
+        }
+    }
+
+    /// A `new_instance` reply carrying the minted instance.
+    pub fn instanced(instance: impl Into<String>) -> Self {
+        Self::Instanced {
+            ok: true,
+            instance: instance.into(),
         }
     }
 
     /// An error reply carrying a short code.
-    pub(crate) fn err(error: impl Into<String>) -> Self {
+    pub fn err(error: impl Into<String>) -> Self {
         Self::Err {
             ok: false,
             error: error.into(),
@@ -189,7 +210,9 @@ pub(crate) enum PushMsg {
     /// unmounted after compositing (`active: false`).
     Compositing {
         /// The registered handle whose compositing state changed.
-        handle: String,
+        handle: HandleId,
+        /// The placement instance whose compositing state changed.
+        instance: String,
         /// `true` when compositing starts; `false` when it stops.
         active: bool,
     },
@@ -255,6 +278,22 @@ mod tests {
         );
     }
 
+    /// Asserts that a `new_instance` line parses into its own variant
+    /// carrying the handle the extra placement is minted under.
+    ///
+    /// Case: a program that already registered a view asks for a second
+    /// placement slot before writing its mount.
+    #[test]
+    fn parses_new_instance() {
+        let m: ClientMsg = serde_json::from_str(r#"{"op":"new_instance","handle":"h1"}"#).unwrap();
+        assert_eq!(
+            m,
+            ClientMsg::NewInstance {
+                handle: "h1".into()
+            }
+        );
+    }
+
     #[test]
     fn rejects_unknown_op() {
         assert!(serde_json::from_str::<ClientMsg>(r#"{"op":"nope"}"#).is_err());
@@ -302,29 +341,22 @@ mod tests {
         );
     }
 
+    /// Asserts that a `focus` line addresses one instance, and that a null
+    /// instance parses as the blur request.
+    ///
+    /// Case: an app moves keyboard focus onto one of its two mounted
+    /// placements, then hands focus back to the terminal.
     #[test]
-    fn parses_focus_with_handle() {
-        let m: ClientMsg =
-            serde_json::from_str(r#"{"op":"focus","handle":"h1","instance":null}"#).unwrap();
+    fn parses_focus_and_blur_by_instance() {
+        let focus: ClientMsg = serde_json::from_str(r#"{"op":"focus","instance":"3f5a"}"#).unwrap();
         assert_eq!(
-            m,
+            focus,
             ClientMsg::Focus {
-                handle: Some("h1".into()),
-                instance: None,
+                instance: Some("3f5a".into())
             }
         );
-    }
-
-    #[test]
-    fn parses_blur_with_null_handle() {
-        let m: ClientMsg = serde_json::from_str(r#"{"op":"focus","handle":null}"#).unwrap();
-        assert_eq!(
-            m,
-            ClientMsg::Focus {
-                handle: None,
-                instance: None,
-            }
-        );
+        let blur: ClientMsg = serde_json::from_str(r#"{"op":"focus","instance":null}"#).unwrap();
+        assert_eq!(blur, ClientMsg::Focus { instance: None });
     }
 
     #[test]
@@ -394,65 +426,78 @@ mod tests {
         );
     }
 
+    /// Asserts that each of the three reply shapes serializes to the exact
+    /// line the SDK's position-matched FIFO reads back.
+    ///
+    /// Case: one connection registers a view, asks for a second placement,
+    /// then sends a request the host rejects.
     #[test]
-    fn serializes_ok_and_err() {
+    fn serializes_the_three_reply_shapes() {
         assert_eq!(
-            serde_json::to_string(&ServerMsg::ok("h1")).unwrap(),
-            r#"{"ok":true,"handle":"h1"}"#
+            serde_json::to_string(&ServerMsg::registered("h1", "i1")).unwrap(),
+            r#"{"ok":true,"handle":"h1","instance":"i1"}"#
         );
         assert_eq!(
-            serde_json::to_string(&ServerMsg::err("invalid_root")).unwrap(),
-            r#"{"ok":false,"error":"invalid_root"}"#
+            serde_json::to_string(&ServerMsg::instanced("i2")).unwrap(),
+            r#"{"ok":true,"instance":"i2"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerMsg::err("unknown_handle")).unwrap(),
+            r#"{"ok":false,"error":"unknown_handle"}"#
         );
     }
 
+    /// Asserts that a compositing push names the placement it is about, not
+    /// only the registration it came from.
+    ///
+    /// Case: a program holding two placements of one handle is told that
+    /// the second of them started painting.
     #[test]
-    fn serializes_compositing_start() {
+    fn serializes_compositing_with_its_instance() {
         let msg = PushMsg::Compositing {
             handle: "abc123".into(),
+            instance: "i1".into(),
             active: true,
         };
         assert_eq!(
             serde_json::to_string(&msg).unwrap(),
-            r#"{"op":"compositing","handle":"abc123","active":true}"#
+            r#"{"op":"compositing","handle":"abc123","instance":"i1","active":true}"#
         );
     }
 
+    /// Asserts that a `navigate` line addresses one instance and carries a
+    /// history action.
+    ///
+    /// Case: an embedded browser UI sends Back for the placement the user
+    /// is looking at.
     #[test]
-    fn serializes_compositing_stop() {
-        let msg = PushMsg::Compositing {
-            handle: "abc123".into(),
-            active: false,
-        };
-        assert_eq!(
-            serde_json::to_string(&msg).unwrap(),
-            r#"{"op":"compositing","handle":"abc123","active":false}"#
-        );
-    }
-
-    #[test]
-    fn parses_navigate_back() {
+    fn parses_navigate_by_instance() {
         let m: ClientMsg =
-            serde_json::from_str(r#"{"op":"navigate","handle":"H","action":"back"}"#).unwrap();
+            serde_json::from_str(r#"{"op":"navigate","instance":"3f5a","action":"back"}"#).unwrap();
         assert_eq!(
             m,
             ClientMsg::Navigate {
-                handle: "H".into(),
+                instance: "3f5a".into(),
                 action: NavAction::Back,
             }
         );
     }
 
+    /// Asserts that the `to` action carries its target URL through the
+    /// instance-addressed navigate line.
+    ///
+    /// Case: an embedded browser UI loads a new page into the placement
+    /// the user typed the address for.
     #[test]
     fn parses_navigate_to_url() {
         let m: ClientMsg = serde_json::from_str(
-            r#"{"op":"navigate","handle":"H","action":{"to":"https://example.com"}}"#,
+            r#"{"op":"navigate","instance":"3f5a","action":{"to":"https://example.com"}}"#,
         )
         .unwrap();
         assert_eq!(
             m,
             ClientMsg::Navigate {
-                handle: "H".into(),
+                instance: "3f5a".into(),
                 action: NavAction::To("https://example.com".into()),
             }
         );

--- a/crates/bevy_orzma_webview/src/control_plane/protocol.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/protocol.rs
@@ -4,6 +4,7 @@
 //! OSC parser ethos).
 
 use crate::control_plane::HandleId;
+use orzma_vt::prelude::InstanceId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -176,19 +177,22 @@ pub(crate) enum ServerMsg {
 
 impl ServerMsg {
     /// A `register` reply carrying the minted handle and its first instance.
-    pub fn registered(handle: impl Into<HandleId>, instance: impl Into<String>) -> Self {
+    ///
+    /// Both id slots are typed, so neither can take the other's value: the
+    /// wire spelling is produced here rather than at the call site.
+    pub fn registered(handle: impl Into<HandleId>, instance: InstanceId) -> Self {
         Self::Registered {
             ok: true,
             handle: handle.into(),
-            instance: instance.into(),
+            instance: instance.to_string(),
         }
     }
 
     /// A `new_instance` reply carrying the minted instance.
-    pub fn instanced(instance: impl Into<String>) -> Self {
+    pub fn instanced(instance: InstanceId) -> Self {
         Self::Instanced {
             ok: true,
-            instance: instance.into(),
+            instance: instance.to_string(),
         }
     }
 
@@ -434,12 +438,12 @@ mod tests {
     #[test]
     fn serializes_the_three_reply_shapes() {
         assert_eq!(
-            serde_json::to_string(&ServerMsg::registered("h1", "i1")).unwrap(),
-            r#"{"ok":true,"handle":"h1","instance":"i1"}"#
+            serde_json::to_string(&ServerMsg::registered("h1", InstanceId(1))).unwrap(),
+            r#"{"ok":true,"handle":"h1","instance":"00000000000000000000000000000001"}"#
         );
         assert_eq!(
-            serde_json::to_string(&ServerMsg::instanced("i2")).unwrap(),
-            r#"{"ok":true,"instance":"i2"}"#
+            serde_json::to_string(&ServerMsg::instanced(InstanceId(2))).unwrap(),
+            r#"{"ok":true,"instance":"00000000000000000000000000000002"}"#
         );
         assert_eq!(
             serde_json::to_string(&ServerMsg::err("unknown_handle")).unwrap(),

--- a/crates/bevy_orzma_webview/src/lib.rs
+++ b/crates/bevy_orzma_webview/src/lib.rs
@@ -9,7 +9,7 @@ mod webview;
 
 use bevy::prelude::*;
 use control_plane::ControlPlanePlugin;
-pub use control_plane::{ControlPlaneHandle, NormalizedChord, TokenRegistry};
+pub use control_plane::{ControlPlaneHandle, HandleId, NormalizedChord, TokenRegistry};
 use orzma_webview_host::WebviewAssetRegistry;
 use webview::apc::ApcPlugin;
 pub use webview::apc::NonInteractive;

--- a/crates/bevy_orzma_webview/src/webview/apc.rs
+++ b/crates/bevy_orzma_webview/src/webview/apc.rs
@@ -36,11 +36,9 @@ pub(crate) fn on_webview_mount(
         &dynamic,
         WebviewMountContext {
             terminal_surface: req.terminal,
-            view_id: &req.view_id,
-            instance_id: req.instance_id.as_deref(),
+            instance: req.instance,
             rows: req.size.rows,
             cols: req.size.cols,
-            placement: req.placement,
         },
     );
 }
@@ -51,8 +49,7 @@ pub(crate) fn on_webview_mount(
 pub(crate) fn on_webview_mount_rejected(ev: On<TtyWebviewMountRejectedSignal>) {
     let req = ev.event();
     tracing::debug!(
-        view_id = %req.view_id,
-        instance_id = ?req.instance_id,
+        instance = %req.instance,
         "apc-webview: mount rejected by the VT, dropping"
     );
 }
@@ -60,10 +57,5 @@ pub(crate) fn on_webview_mount_rejected(ev: On<TtyWebviewMountRejectedSignal>) {
 /// Unmounts the webview(s) the VT signal names.
 pub(crate) fn on_webview_unmount(ev: On<TtyWebviewUnmountSignal>, mut webview: WebviewParams) {
     let req = ev.event();
-    unmount(
-        &mut webview,
-        req.terminal,
-        req.view_id.as_deref(),
-        req.instance_id.as_deref(),
-    );
+    unmount(&mut webview, req.terminal, req.instance);
 }

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -1550,7 +1550,7 @@ mod tests {
     /// Case: the frame carrying a fresh mount's placement is applied a
     /// Bevy tick before the mount signal's observer runs.
     #[test]
-    fn projection_ignores_an_unknown_placement_id() {
+    fn projection_ignores_an_unknown_instance() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
         app.world_mut()

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -8,7 +8,7 @@
 use super::apc::NonInteractive;
 use super::render::preload::build_preload;
 use crate::control_plane::{
-    ConnectionWriters, NormalizedChord, OrzmaRegistry, OrzmaSource, PushMsg, WebviewOwner,
+    ConnectionWriters, HandleId, NormalizedChord, OrzmaRegistry, OrzmaSource, PushMsg, WebviewOwner,
 };
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
@@ -19,11 +19,12 @@ use bevy_cef::prelude::{
     FocusedWebview, PreloadScripts, WebviewGpuImageInjectSet, WebviewSize, WebviewSource,
     WebviewTextureTarget,
 };
-use bevy_orzma_tty::prelude::TtyWebviewEvictedSignal;
+use bevy_orzma_tty::prelude::{RequestTtyWebviewRemove, TtyWebviewEvictedSignal};
 use orzma_tty_renderer::TerminalCellMetricsResource;
 use orzma_tty_renderer::material::{TerminalMaterialSystems, TerminalUiMaterial};
 use orzma_tty_renderer::prelude::{OVERLAY_SLOTS, TerminalOverlays};
-use orzma_tty_renderer::schema::{PlacementId, TerminalGrid};
+use orzma_tty_renderer::schema::TerminalGrid;
+use orzma_vt::prelude::InstanceId;
 
 /// The normalized forward-key chords for a mounted webview, copied from
 /// its registration. Read by the focused-key filter-fill and PTY-forward
@@ -31,39 +32,32 @@ use orzma_tty_renderer::schema::{PlacementId, TerminalGrid};
 #[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
 pub struct ForwardKeys(pub Vec<NormalizedChord>);
 
-/// Marks a webview entity and records its identity: the mounted
-/// `view_id` and the overlay texture `slot` (0..`OVERLAY_SLOTS`) it occupies
-/// on its parent terminal. The owning terminal surface is NOT duplicated
-/// here — it is the `ChildOf` parent, per the multiplexer's "no typed
-/// back-references" convention. Each child's `slot` is the single source of
-/// truth for slot allocation (no separate allocation table).
-#[derive(Component, Debug, Clone, PartialEq, Eq)]
-pub struct Webview {
-    /// The registered view id this webview was mounted from.
-    pub view_id: String,
-    /// The client-assigned instance id; `None` is the implicit default
-    /// instance. `(view_id, instance_id)` is the per-terminal address.
-    pub instance_id: Option<String>,
-    /// The overlay texture slot (0..`OVERLAY_SLOTS`) on the parent terminal.
-    pub slot: u8,
-}
-
-/// Where a webview sits: the VT-minted placement id the frame-carried
-/// list addresses, plus the rect extent in cells reserved at mount.
+/// Marks a webview entity and records its identity: the instance it was
+/// mounted under, the registration handle it came from, the overlay
+/// texture slot it occupies on its parent terminal, and the rectangle it
+/// reserved. The owning terminal surface is NOT duplicated here — it is
+/// the `ChildOf` parent, per the "no typed back-references" convention.
+/// Each child's `slot` is the single source of truth for slot allocation
+/// (no separate allocation table).
 ///
 /// # Invariants
 ///
-/// `AnchoredPlacement.size` for this id always equals `rows` / `cols`
-/// here — the VT treats a size change as a remount, so a drift between
-/// the CEF surface size and the painted rect cannot arise.
-#[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WebviewPlacement {
-    /// The VT-minted id; frames address this placement by it.
-    pub(crate) placement: PlacementId,
+/// `AnchoredPlacement.size` for this instance always equals `rows` /
+/// `cols` here — the VT treats a size change as a remount, so a drift
+/// between the CEF surface size and the painted rect cannot arise.
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+pub struct Webview {
+    /// The registration this webview's content came from.
+    pub handle: HandleId,
+    /// The host-minted instance this webview was mounted under; frames
+    /// address this placement by it.
+    pub instance: InstanceId,
+    /// The overlay texture slot (0..`OVERLAY_SLOTS`) on the parent terminal.
+    pub slot: u8,
     /// Rect height in terminal cells.
-    pub(crate) rows: u16,
+    pub rows: u16,
     /// Rect width in terminal cells.
-    pub(crate) cols: u16,
+    pub cols: u16,
 }
 
 /// Marks a bridged webview entity after it has produced its first
@@ -89,8 +83,7 @@ pub(crate) struct WebviewPlugin;
 
 impl Plugin for WebviewPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, sync_webview_size);
-        app.add_systems(
+        app.add_systems(Update, sync_webview_size).add_systems(
             PostUpdate,
             project_webview_overlays.before(TerminalMaterialSystems::UpdateMaterial),
         );
@@ -108,27 +101,23 @@ impl Plugin for WebviewPlugin {
                     .before(prepare_assets::<PreparedUiMaterial<TerminalUiMaterial>>),
             );
         }
-        app.add_observer(on_webview_evicted);
-        app.add_observer(on_placement_removed);
+        app.add_observer(on_webview_evicted)
+            .add_observer(on_webview_removed);
     }
 }
 
 /// Everything the `Mount` verb carries into `mount`: the target
-/// terminal surface and the parsed verb + placement payload.
-pub(crate) struct WebviewMountContext<'a> {
+/// terminal surface and the placement the VT registered.
+pub(crate) struct WebviewMountContext {
     /// The requesting terminal surface — the `ChildOf` parent of the mount.
-    pub(crate) terminal_surface: Entity,
-    /// The registered view id to mount.
-    pub(crate) view_id: &'a str,
-    /// The client-assigned instance id (`None` = implicit default instance).
-    pub(crate) instance_id: Option<&'a str>,
+    pub terminal_surface: Entity,
+    /// The instance the mount registered. A mount the VT refused never
+    /// reaches here — it arrives as `TtyWebviewMountRejectedSignal`.
+    pub instance: InstanceId,
     /// Rect height in terminal cells (validated 1..=200 by `orzma_vt`).
-    pub(crate) rows: u16,
+    pub rows: u16,
     /// Rect width in terminal cells (validated 1..=400 by `orzma_vt`).
-    pub(crate) cols: u16,
-    /// The VT-minted placement id. A mount the VT refused never reaches
-    /// here — it arrives as `TtyWebviewMountRejectedSignal` instead.
-    pub(crate) placement: PlacementId,
+    pub cols: u16,
 }
 
 /// The system params `mount` / `unmount` need, bundled so the
@@ -137,9 +126,11 @@ pub(crate) struct WebviewMountContext<'a> {
 pub(crate) struct WebviewParams<'w, 's> {
     commands: Commands<'w, 's>,
     images: ResMut<'w, Assets<Image>>,
-    placements: Query<'w, 's, &'static mut WebviewPlacement>,
+    // NOTE: this is the ONLY `Webview` query in this `SystemParam`. Adding a
+    // second, read-only one would conflict with this mutable access and panic
+    // at system init (Bevy B0001); read through `Query::get` instead.
+    views: Query<'w, 's, &'static mut Webview>,
     children: Query<'w, 's, &'static Children>,
-    views: Query<'w, 's, &'static Webview>,
     metrics: Option<Res<'w, TerminalCellMetricsResource>>,
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
@@ -150,21 +141,21 @@ pub(crate) struct WebviewParams<'w, 's> {
 /// registering program's `(connection_id, handle)` for back-channel routing.
 pub(crate) struct ResolvedWebviewMount {
     /// The URL to load (`WebviewSource::Url`). `None` signals a policy rejection.
-    pub(crate) url: Option<String>,
+    pub url: Option<String>,
     /// Whether the page receives pointer/keyboard input.
-    pub(crate) interactive: bool,
+    pub interactive: bool,
     /// `(connection_id, handle)` of the registering program, used to stamp
     /// `WebviewOwner` for `window.orzma` back-channel routing. `Some` only when
     /// the registration is bridged; a display-only `Url` view leaves it `None`,
     /// which is the gate that also withholds the preload at mount.
-    pub(crate) owner: Option<(u64, String)>,
+    pub owner: Option<(u64, HandleId)>,
     /// The normalized forward-key chords copied from the registration, stamped
     /// as a `ForwardKeys` component so the focused-key systems read them off
     /// the webview entity without a registry lookup (design spec §C).
-    pub(crate) forward_keys: Vec<NormalizedChord>,
+    pub forward_keys: Vec<NormalizedChord>,
     /// User-supplied preload scripts, injected after the host bridge (and as
     /// the only scripts for a display-only view).
-    pub(crate) preload: Vec<String>,
+    pub preload: Vec<String>,
 }
 
 /// Resolves a `mount` `<handle>` against the `OrzmaRegistry` (Tier 1).
@@ -175,7 +166,7 @@ pub(crate) struct ResolvedWebviewMount {
 /// populated only for a bridged registration (a display-only `Url` view leaves it
 /// `None`). Returns `None` for an unregistered or unowned handle.
 pub(crate) fn resolve_mount(
-    id: &str,
+    id: &HandleId,
     requesting_surface: Entity,
     dynamic: &OrzmaRegistry,
 ) -> Option<ResolvedWebviewMount> {
@@ -191,7 +182,7 @@ pub(crate) fn resolve_mount(
     let owner = view
         .source
         .is_bridged()
-        .then(|| (view.connection_id, id.to_string()));
+        .then(|| (view.connection_id, id.clone()));
     Some(ResolvedWebviewMount {
         url: Some(url),
         interactive: view.interactive,
@@ -202,10 +193,11 @@ pub(crate) fn resolve_mount(
 }
 
 /// Mounts a registered view as a webview child of the requesting
-/// terminal surface, applying the policy gates in order: a duplicate
-/// `view_id` / `instance_id` on this terminal updates the existing
-/// placement instead of minting a new one; an unregistered or unowned
-/// view and overlay-slot exhaustion are each a `tracing::debug!` + return.
+/// terminal surface, applying the policy gates in order: a second mount
+/// of an instance already live on this terminal updates its reserved
+/// rectangle instead of spawning again; an unknown instance, a handle the
+/// requesting surface does not own, and overlay-slot exhaustion are each a
+/// `tracing::debug!` plus a reclaim of the VT-side reservation.
 ///
 /// The parent (`ctx.terminal_surface`, the `TtyWebviewMountSignal` target) is
 /// the owning `OrzmaTerminal` surface entity: both the `OrzmaTtyHandle`
@@ -219,35 +211,44 @@ pub(crate) fn resolve_mount(
 /// primary window; when neither exists yet (headless tests, pre-first-render)
 /// a placeholder cell of 8×16 physical px at scale 1.0 is used —
 /// `sync_webview_size` corrects it once real metrics arrive.
-pub(crate) fn mount(
-    params: &mut WebviewParams,
-    dynamic: &OrzmaRegistry,
-    ctx: WebviewMountContext<'_>,
-) {
-    let placement = ctx.placement;
+pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: WebviewMountContext) {
     let live = live_webview_children(&params.children, &params.views, ctx.terminal_surface);
-    if let Some((existing, _)) = live
-        .iter()
-        .find(|(_, v)| v.view_id == ctx.view_id && v.instance_id.as_deref() == ctx.instance_id)
-    {
-        let next = WebviewPlacement {
-            placement,
-            rows: ctx.rows,
-            cols: ctx.cols,
-        };
-        if let Ok(mut placement) = params.placements.get_mut(*existing) {
+    if let Some(existing) = live.iter().find(|live| live.instance == ctx.instance) {
+        if let Ok(mut view) = params.views.get_mut(existing.entity) {
+            let next = Webview {
+                handle: view.handle.clone(),
+                instance: view.instance,
+                slot: view.slot,
+                rows: ctx.rows,
+                cols: ctx.cols,
+            };
             // NOTE: set_if_neq elides a no-op re-emit so an unchanged frame
             // triggers neither a projection move nor a CEF surface resize.
-            placement.set_if_neq(next);
+            view.set_if_neq(next);
         }
         return;
     }
-    let Some(resolved) = resolve_mount(ctx.view_id, ctx.terminal_surface, dynamic) else {
-        tracing::debug!(view_id = %ctx.view_id, "apc-webview: mount for unregistered or unowned id, dropping");
+    let Some(handle) = dynamic
+        .resolve_instance(ctx.instance)
+        .map(|(h, _)| h.clone())
+    else {
+        tracing::debug!(instance = %ctx.instance, "apc-webview: mount for an unknown instance, dropping");
+        reclaim(params, ctx.terminal_surface, ctx.instance);
+        return;
+    };
+    let Some(resolved) = resolve_mount(&handle, ctx.terminal_surface, dynamic) else {
+        tracing::debug!(%handle, "apc-webview: mount for an unowned handle, dropping");
+        reclaim(params, ctx.terminal_surface, ctx.instance);
+        return;
+    };
+    let Some(url) = resolved.url.clone() else {
+        tracing::debug!(%handle, "apc-webview: resolved mount had no url, dropping");
+        reclaim(params, ctx.terminal_surface, ctx.instance);
         return;
     };
     let Some(slot) = smallest_free_slot(&live) else {
-        tracing::debug!(view_id = %ctx.view_id, "apc-webview: all inline overlay slots occupied, dropping");
+        tracing::debug!(%handle, "apc-webview: all inline overlay slots occupied, dropping");
+        reclaim(params, ctx.terminal_surface, ctx.instance);
         return;
     };
     let scale_factor = params
@@ -259,10 +260,6 @@ pub(crate) fn mount(
     let (cell_w_phys, cell_h_phys) = cell_size_phys(params.metrics.as_deref());
     let size = seed_logical_size(ctx.rows, ctx.cols, cell_w_phys, cell_h_phys, scale_factor);
     let texture = WebviewTextureTarget(params.images.add(Image::default()));
-    let Some(url) = resolved.url.as_deref() else {
-        tracing::debug!(view_id = %ctx.view_id, "apc-webview: resolved mount had no url, dropping");
-        return;
-    };
     let source = WebviewSource::new(url);
     let webview = params.commands.spawn_empty().id();
     // NOTE: keep this entity free of Node / Mesh2d / Mesh3d / Sprite /
@@ -277,12 +274,9 @@ pub(crate) fn mount(
         texture,
         WebviewSize(size),
         Webview {
-            view_id: ctx.view_id.to_string(),
-            instance_id: ctx.instance_id.map(str::to_string),
+            handle: handle.clone(),
+            instance: ctx.instance,
             slot,
-        },
-        WebviewPlacement {
-            placement,
             rows: ctx.rows,
             cols: ctx.cols,
         },
@@ -301,6 +295,7 @@ pub(crate) fn mount(
             WebviewOwner {
                 connection_id,
                 handle,
+                instance: ctx.instance,
             },
         ));
     } else if !resolved.preload.is_empty() {
@@ -314,39 +309,31 @@ pub(crate) fn mount(
         .entity(webview)
         .insert(ForwardKeys(resolved.forward_keys.clone()));
     tracing::debug!(
-        view_id = %ctx.view_id,
+        %handle,
+        instance = %ctx.instance,
         terminal = ?ctx.terminal_surface,
         slot,
         rows = ctx.rows,
         cols = ctx.cols,
-        placement = ?placement,
         "apc-webview: webview mounted"
     );
 }
 
-/// Despawns the inline child(ren) of `terminal_surface` matching the scope:
-/// `(Some(vid), Some(inst))` removes that one instance; `(Some(vid), None)`
-/// removes every instance of `vid`; `(None, _)` removes all inline children
-/// for a client-issued unmount-all. VT-side evictions (history trim,
-/// alternate-screen teardown) arrive separately as `TtyWebviewEvictedSignal`
-/// handled by `on_webview_evicted`.
+/// Despawns the webview child(ren) of `terminal_surface` matching the
+/// scope: `Some(id)` removes that one instance; `None` removes every
+/// webview child, the shape a client-issued unmount-all takes. VT-side
+/// evictions (history trim, alternate-screen teardown) arrive separately as
+/// `TtyWebviewEvictedSignal` handled by `on_webview_evicted`.
 pub(crate) fn unmount(
     params: &mut WebviewParams,
     terminal_surface: Entity,
-    view_id: Option<&str>,
-    instance_id: Option<&str>,
+    instance: Option<InstanceId>,
 ) {
     let targets: Vec<Entity> =
         live_webview_children(&params.children, &params.views, terminal_surface)
             .into_iter()
-            .filter(|(_, v)| match (view_id, instance_id) {
-                (Some(vid), Some(inst)) => {
-                    v.view_id == vid && v.instance_id.as_deref() == Some(inst)
-                }
-                (Some(vid), None) => v.view_id == vid,
-                (None, _) => true,
-            })
-            .map(|(entity, _)| entity)
+            .filter(|live| instance.is_none_or(|id| live.instance == id))
+            .map(|live| live.entity)
             .collect();
     for entity in targets {
         params.commands.entity(entity).despawn();
@@ -457,6 +444,19 @@ pub fn webview_local_dip(
 const FALLBACK_CELL_W_PHYS: f32 = 8.0;
 const FALLBACK_CELL_H_PHYS: f32 = 16.0;
 
+/// Drops the reservation a refused mount left in the VT.
+///
+/// The VT cannot tell a minted instance from a fabricated one, so it
+/// registers a placement for any syntactically valid `n=`. Without this a
+/// client can exhaust the per-terminal cap with mounts the host will never
+/// place.
+fn reclaim(params: &mut WebviewParams, terminal: Entity, instance: InstanceId) {
+    params.commands.trigger(RequestTtyWebviewRemove {
+        terminal,
+        instances: vec![instance],
+    });
+}
+
 /// Despawns the placements named by a `TtyWebviewEvictedSignal` on the
 /// signalling terminal. Unknown ids are ignored, so a re-delivered or
 /// stale eviction is a no-op.
@@ -464,38 +464,53 @@ fn on_webview_evicted(
     event: On<TtyWebviewEvictedSignal>,
     mut commands: Commands,
     children: Query<&Children>,
-    placements: Query<&WebviewPlacement>,
+    views: Query<&Webview>,
 ) {
     let Ok(kids) = children.get(event.terminal) else {
         return;
     };
     for child in kids.iter() {
-        if let Ok(p) = placements.get(child)
-            && event.placements.contains(&p.placement)
+        if let Ok(view) = views.get(child)
+            && event.placements.contains(&view.instance)
         {
             commands.entity(child).despawn();
         }
     }
 }
 
+/// One live webview child of a terminal surface: the entity plus the
+/// identity the mount and unmount gates match on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LiveWebview {
+    entity: Entity,
+    instance: InstanceId,
+    slot: u8,
+}
+
 /// The live webview children of a terminal surface.
-fn live_webview_children<'a>(
+fn live_webview_children(
     children: &Query<&Children>,
-    views: &'a Query<&'static Webview>,
+    views: &Query<&'static mut Webview>,
     terminal_surface: Entity,
-) -> Vec<(Entity, &'a Webview)> {
+) -> Vec<LiveWebview> {
     let Ok(kids) = children.get(terminal_surface) else {
         return Vec::new();
     };
     kids.iter()
-        .filter_map(|child| views.get(child).ok().map(|view| (child, view)))
+        .filter_map(|child| {
+            views.get(child).ok().map(|view| LiveWebview {
+                entity: child,
+                instance: view.instance,
+                slot: view.slot,
+            })
+        })
         .collect()
 }
 
 /// The smallest slot in `0..OVERLAY_SLOTS` not occupied by a live child, or
 /// `None` when every slot is taken.
-fn smallest_free_slot(live: &[(Entity, &Webview)]) -> Option<u8> {
-    (0..OVERLAY_SLOTS as u8).find(|slot| live.iter().all(|(_, v)| v.slot != *slot))
+fn smallest_free_slot(live: &[LiveWebview]) -> Option<u8> {
+    (0..OVERLAY_SLOTS as u8).find(|slot| live.iter().all(|live| live.slot != *slot))
 }
 
 /// Physical cell pitch from the metrics resource (the same floor/max the
@@ -533,7 +548,7 @@ fn seed_logical_size(
 /// frame-to-frame unless metrics/scale actually changed, and this math is
 /// deterministic.
 fn sync_webview_size(
-    mut sizes: Query<(&mut WebviewSize, &WebviewPlacement)>,
+    mut sizes: Query<(&mut WebviewSize, &Webview)>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
     windows: Query<&Window, With<PrimaryWindow>>,
 ) {
@@ -543,14 +558,8 @@ fn sync_webview_size(
         .map(Window::scale_factor)
         .unwrap_or(1.0);
     let (cell_w_phys, cell_h_phys) = cell_size_phys(metrics.as_deref());
-    for (mut size, placement) in &mut sizes {
-        let next = seed_logical_size(
-            placement.rows,
-            placement.cols,
-            cell_w_phys,
-            cell_h_phys,
-            scale_factor,
-        );
+    for (mut size, view) in &mut sizes {
+        let next = seed_logical_size(view.rows, view.cols, cell_w_phys, cell_h_phys, scale_factor);
         size.set_if_neq(WebviewSize(next));
     }
 }
@@ -580,7 +589,6 @@ fn project_webview_overlays(
     )>,
     webviews: Query<(
         &Webview,
-        &WebviewPlacement,
         &WebviewTextureTarget,
         Has<CompositeNotified>,
         Option<&WebviewOwner>,
@@ -592,13 +600,11 @@ fn project_webview_overlays(
         let mut has_webview_child = false;
         if let Some(kids) = children {
             for child in kids.iter() {
-                let Ok((view, placement, texture, already_notified, owner)) = webviews.get(child)
-                else {
+                let Ok((view, texture, already_notified, owner)) = webviews.get(child) else {
                     continue;
                 };
                 has_webview_child = true;
-                let Some(projected) = grid.placements.iter().find(|p| p.id == placement.placement)
-                else {
+                let Some(projected) = grid.placements.iter().find(|p| p.id == view.instance) else {
                     continue;
                 };
                 let row = i64::from(projected.point.line.0) + i64::from(grid.display_offset);
@@ -626,6 +632,7 @@ fn project_webview_overlays(
                     if let Some(owner) = owner {
                         let msg = serde_json::to_string(&PushMsg::Compositing {
                             handle: owner.handle.clone(),
+                            instance: owner.instance.to_string(),
                             active: true,
                         })
                         .expect("PushMsg serializes infallibly");
@@ -644,8 +651,8 @@ fn project_webview_overlays(
 /// webview entity is despawned after having been notified at least once
 /// (i.e., after its first successful projection). Entities that were never
 /// projected (never stamped `CompositeNotified`) are silently ignored.
-fn on_placement_removed(
-    event: On<Remove, WebviewPlacement>,
+fn on_webview_removed(
+    event: On<Remove, Webview>,
     owners: Query<(&WebviewOwner, Has<CompositeNotified>)>,
     writers: Res<ConnectionWriters>,
 ) {
@@ -657,6 +664,7 @@ fn on_placement_removed(
     }
     let msg = serde_json::to_string(&PushMsg::Compositing {
         handle: owner.handle.clone(),
+        instance: owner.instance.to_string(),
         active: false,
     })
     .expect("PushMsg serializes infallibly");
@@ -666,6 +674,7 @@ fn on_placement_removed(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control_plane::OrzmaView;
     use crate::webview::apc::{on_webview_mount, on_webview_unmount};
     use bevy::ecs::system::RunSystemOnce;
     use bevy_cef::prelude::PreloadScripts;
@@ -674,9 +683,7 @@ mod tests {
         TtyWebviewUnmountSignal,
     };
     use orzma_tty_renderer::CellMetrics;
-    use orzma_vt::prelude::{
-        AnchoredPlacement, GridColumn, GridLine, GridPoint, PlacementId, PlacementSize,
-    };
+    use orzma_vt::prelude::{AnchoredPlacement, GridColumn, GridLine, GridPoint, PlacementSize};
 
     fn make_test_app() -> App {
         let mut app = App::new();
@@ -686,44 +693,73 @@ mod tests {
             .init_resource::<ConnectionWriters>()
             .add_observer(on_webview_mount)
             .add_observer(on_webview_unmount)
-            .add_observer(on_placement_removed)
+            .add_observer(on_webview_removed)
             .add_observer(on_webview_evicted);
         app
     }
 
-    fn register_orzma(app: &mut App, view_id: &str, owner_surface: Entity, interactive: bool) {
-        use crate::control_plane::OrzmaView;
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            view_id.into(),
-            OrzmaView {
-                source: OrzmaSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive,
-                owner_surface,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
-            },
-        );
+    /// Registers `view` under `handle` and mints its first instance, the
+    /// two-step the control plane's `register` performs.
+    fn register_view(app: &mut App, handle: &str, view: OrzmaView) -> InstanceId {
+        let handle = HandleId::from(handle);
+        let mut registry = app.world_mut().resource_mut::<OrzmaRegistry>();
+        registry.insert(handle.clone(), view);
+        registry.mint_instance(&handle).expect("the handle mints")
     }
 
-    fn register_url(app: &mut App, view_id: &str, owner_surface: Entity, url: &str, bridge: bool) {
-        use crate::control_plane::OrzmaView;
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            view_id.into(),
-            OrzmaView {
-                source: OrzmaSource::Url {
-                    url: url.into(),
-                    bridge,
-                },
-                entry: String::new(),
-                interactive: true,
-                owner_surface,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
+    fn mint_extra(app: &mut App, handle: &str) -> InstanceId {
+        app.world_mut()
+            .resource_mut::<OrzmaRegistry>()
+            .mint_instance(&HandleId::from(handle))
+            .expect("the handle mints")
+    }
+
+    fn inline_view(owner_surface: Entity, interactive: bool) -> OrzmaView {
+        OrzmaView {
+            source: OrzmaSource::Inline("<h1>x</h1>".into()),
+            entry: "index.html".into(),
+            interactive,
+            owner_surface,
+            connection_id: 1,
+            forward_keys: vec![],
+            preload: vec![],
+            instances: Vec::new(),
+        }
+    }
+
+    fn url_view(owner_surface: Entity, url: &str, bridge: bool) -> OrzmaView {
+        OrzmaView {
+            source: OrzmaSource::Url {
+                url: url.into(),
+                bridge,
             },
-        );
+            entry: String::new(),
+            interactive: true,
+            owner_surface,
+            connection_id: 1,
+            forward_keys: vec![],
+            preload: vec![],
+            instances: Vec::new(),
+        }
+    }
+
+    fn register_orzma(
+        app: &mut App,
+        handle: &str,
+        owner_surface: Entity,
+        interactive: bool,
+    ) -> InstanceId {
+        register_view(app, handle, inline_view(owner_surface, interactive))
+    }
+
+    fn register_url(
+        app: &mut App,
+        handle: &str,
+        owner_surface: Entity,
+        url: &str,
+        bridge: bool,
+    ) -> InstanceId {
+        register_view(app, handle, url_view(owner_surface, url, bridge))
     }
 
     fn spawn_terminal(app: &mut App) -> Entity {
@@ -732,25 +768,63 @@ mod tests {
         surface
     }
 
-    fn mount(app: &mut App, terminal: Entity, view_id: &str, placement: PlacementId) {
+    /// A terminal surface with one inline registration ("h") whose first
+    /// instance is already minted.
+    fn app_with_registration() -> (App, Entity, InstanceId) {
+        let mut app = make_test_app();
+        let terminal = spawn_terminal(&mut app);
+        let instance = register_orzma(&mut app, "h", terminal, true);
+        (app, terminal, instance)
+    }
+
+    fn mount(app: &mut App, terminal: Entity, instance: InstanceId) {
+        mount_sized(app, terminal, instance, 10, 40);
+    }
+
+    fn mount_sized(app: &mut App, terminal: Entity, instance: InstanceId, rows: u16, cols: u16) {
         app.world_mut().trigger(TtyWebviewMountSignal {
             terminal,
-            view_id: view_id.into(),
-            size: PlacementSize { rows: 10, cols: 40 },
-            instance_id: None,
-            placement,
+            instance,
+            size: PlacementSize { rows, cols },
         });
         app.world_mut().flush();
     }
 
-    fn unmount(app: &mut App, terminal: Entity, view_id: Option<&str>) {
-        app.world_mut().trigger(TtyWebviewUnmountSignal {
-            terminal,
-            view_id: view_id.map(str::to_string),
-            instance_id: None,
-        });
+    fn unmount(app: &mut App, terminal: Entity, instance: Option<InstanceId>) {
+        app.world_mut()
+            .trigger(TtyWebviewUnmountSignal { terminal, instance });
         app.world_mut().flush();
         // NOTE: despawn is deferred; a flush + update applies it.
+        app.update();
+    }
+
+    enum Op {
+        Mount(InstanceId),
+        Evict(InstanceId),
+    }
+
+    /// Queues every op from ONE system and applies the deferred commands
+    /// once, the batch shape a single VT pump produces. Triggering each op
+    /// through `World::trigger` instead would flush between them and would
+    /// not exercise the interleaving these signals really arrive in.
+    fn batch(app: &mut App, terminal: Entity, ops: Vec<Op>) {
+        app.world_mut()
+            .run_system_once(move |mut commands: Commands| {
+                for op in &ops {
+                    match op {
+                        Op::Mount(id) => commands.trigger(TtyWebviewMountSignal {
+                            terminal,
+                            instance: *id,
+                            size: PlacementSize { rows: 10, cols: 40 },
+                        }),
+                        Op::Evict(id) => commands.trigger(TtyWebviewEvictedSignal {
+                            terminal,
+                            placements: vec![*id],
+                        }),
+                    }
+                }
+            })
+            .expect("the batch system runs");
         app.update();
     }
 
@@ -786,7 +860,7 @@ mod tests {
 
     /// The canonical 10x40 frame-carried rect at grid line 2, column 3
     /// the projection tests share.
-    fn placed(id: PlacementId) -> AnchoredPlacement {
+    fn placed(id: InstanceId) -> AnchoredPlacement {
         AnchoredPlacement {
             id,
             point: GridPoint {
@@ -794,15 +868,6 @@ mod tests {
                 column: GridColumn(3),
             },
             size: PlacementSize { rows: 10, cols: 40 },
-        }
-    }
-
-    /// The `WebviewPlacement` carrying `placed`'s 10x40 reservation.
-    fn placement_10x40(id: PlacementId) -> WebviewPlacement {
-        WebviewPlacement {
-            placement: id,
-            rows: 10,
-            cols: 40,
         }
     }
 
@@ -819,67 +884,25 @@ mod tests {
             .unwrap_or_default()
     }
 
-    fn slot_of(app: &App, terminal: Entity, view_id: &str) -> Option<u8> {
+    fn live_webviews(app: &App, terminal: Entity) -> Vec<Webview> {
         webview_children_of(app, terminal)
             .into_iter()
-            .find_map(|child| {
-                app.world()
-                    .get::<Webview>(child)
-                    .filter(|v| v.view_id == view_id)
-                    .map(|v| v.slot)
-            })
+            .filter_map(|child| app.world().get::<Webview>(child).cloned())
+            .collect()
     }
 
-    fn mount_instance(
-        app: &mut App,
-        terminal: Entity,
-        view_id: &str,
-        instance_id: &str,
-        placement: PlacementId,
-    ) {
-        app.world_mut().trigger(TtyWebviewMountSignal {
-            terminal,
-            view_id: view_id.into(),
-            size: PlacementSize { rows: 10, cols: 40 },
-            instance_id: Some(instance_id.into()),
-            placement,
-        });
-        app.world_mut().flush();
-    }
-
-    fn unmount_instance(app: &mut App, terminal: Entity, view_id: &str, instance_id: &str) {
-        app.world_mut().trigger(TtyWebviewUnmountSignal {
-            terminal,
-            view_id: Some(view_id.into()),
-            instance_id: Some(instance_id.into()),
-        });
-        app.world_mut().flush();
-        app.update();
-    }
-
-    fn slot_of_instance(
-        app: &App,
-        terminal: Entity,
-        view_id: &str,
-        instance_id: Option<&str>,
-    ) -> Option<u8> {
-        webview_children_of(app, terminal)
+    fn slot_of(app: &App, terminal: Entity, instance: InstanceId) -> Option<u8> {
+        live_webviews(app, terminal)
             .into_iter()
-            .find_map(|child| {
-                app.world()
-                    .get::<Webview>(child)
-                    .filter(|v| v.view_id == view_id && v.instance_id.as_deref() == instance_id)
-                    .map(|v| v.slot)
-            })
+            .find(|view| view.instance == instance)
+            .map(|view| view.slot)
     }
 
     #[test]
     fn mount_spawns_child_with_inline_components() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
+        let (mut app, terminal, instance) = app_with_registration();
 
-        mount(&mut app, terminal, "dash", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1, "mount must spawn one inline child");
@@ -893,15 +916,9 @@ mod tests {
         assert_eq!(
             app.world().get::<Webview>(child),
             Some(&Webview {
-                view_id: "dash".into(),
-                instance_id: None,
-                slot: 0
-            }),
-        );
-        assert_eq!(
-            app.world().get::<WebviewPlacement>(child),
-            Some(&WebviewPlacement {
-                placement: PlacementId(1),
+                handle: "h".into(),
+                instance,
+                slot: 0,
                 rows: 10,
                 cols: 40,
             }),
@@ -911,7 +928,7 @@ mod tests {
             .get::<WebviewSource>(child)
             .expect("webview must carry WebviewSource")
         {
-            WebviewSource::Url(url) => assert_eq!(url, "orzma://dash/index.html"),
+            WebviewSource::Url(url) => assert_eq!(url, "orzma://h/index.html"),
             other => panic!("unexpected WebviewSource: {other:?}"),
         }
         assert!(
@@ -937,26 +954,22 @@ mod tests {
         );
     }
 
+    /// Asserts that a second mount of a live instance resizes it in place
+    /// rather than spawning a second child or reloading the page.
+    ///
+    /// Case: a program re-issues its mount with a bigger rectangle after
+    /// the user widens the window.
     #[test]
-    fn duplicate_mount_updates_placement_in_place() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
+    fn duplicate_mount_updates_the_reserved_rect_in_place() {
+        let (mut app, terminal, instance) = app_with_registration();
 
-        mount(&mut app, terminal, "dash", PlacementId(1));
+        mount(&mut app, terminal, instance);
         let before = webview_children_of(&app, terminal);
         assert_eq!(before.len(), 1, "first mount spawns one child");
         let entity = before[0];
         let slot_before = app.world().get::<Webview>(entity).unwrap().slot;
 
-        app.world_mut().trigger(TtyWebviewMountSignal {
-            terminal,
-            view_id: "dash".into(),
-            size: PlacementSize { rows: 12, cols: 50 },
-            instance_id: None,
-            placement: PlacementId(2),
-        });
-        app.world_mut().flush();
+        mount_sized(&mut app, terminal, instance, 12, 50);
 
         let after = webview_children_of(&app, terminal);
         assert_eq!(after.len(), 1, "re-mount must NOT spawn a second child");
@@ -965,18 +978,15 @@ mod tests {
             "re-mount must reuse the same entity (no reload)"
         );
         assert_eq!(
-            app.world().get::<WebviewPlacement>(entity),
-            Some(&WebviewPlacement {
-                placement: PlacementId(2),
+            app.world().get::<Webview>(entity),
+            Some(&Webview {
+                handle: "h".into(),
+                instance,
+                slot: slot_before,
                 rows: 12,
                 cols: 50,
             }),
-            "re-mount updates the placement in place"
-        );
-        assert_eq!(
-            app.world().get::<Webview>(entity).unwrap().slot,
-            slot_before,
-            "re-mount preserves the overlay slot"
+            "re-mount updates the reserved rect in place and preserves the slot"
         );
     }
 
@@ -984,18 +994,17 @@ mod tests {
     fn slots_fill_in_order_and_an_over_cap_mount_is_rejected() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        let ids: Vec<String> = (0..=OVERLAY_SLOTS).map(|i| format!("v{i}")).collect();
-        for id in &ids {
-            register_orzma(&mut app, id, terminal, true);
+        let instances: Vec<InstanceId> = (0..=OVERLAY_SLOTS)
+            .map(|i| register_orzma(&mut app, &format!("v{i}"), terminal, true))
+            .collect();
+
+        for (i, instance) in instances.iter().take(OVERLAY_SLOTS).enumerate() {
+            mount(&mut app, terminal, *instance);
+            assert_eq!(slot_of(&app, terminal, *instance), Some(i as u8));
         }
 
-        for (i, id) in ids.iter().take(OVERLAY_SLOTS).enumerate() {
-            mount(&mut app, terminal, id, PlacementId(1));
-            assert_eq!(slot_of(&app, terminal, id), Some(i as u8));
-        }
-
-        let overflow = &ids[OVERLAY_SLOTS];
-        mount(&mut app, terminal, overflow, PlacementId(1));
+        let overflow = instances[OVERLAY_SLOTS];
+        mount(&mut app, terminal, overflow);
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
@@ -1008,37 +1017,36 @@ mod tests {
     fn unmount_frees_the_slot_for_the_next_mount() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        for id in ["a", "b", "c"] {
-            register_orzma(&mut app, id, terminal, true);
-        }
+        let a = register_orzma(&mut app, "a", terminal, true);
+        let b = register_orzma(&mut app, "b", terminal, true);
+        let c = register_orzma(&mut app, "c", terminal, true);
 
-        mount(&mut app, terminal, "a", PlacementId(1));
-        mount(&mut app, terminal, "b", PlacementId(1));
-        unmount(&mut app, terminal, Some("a"));
+        mount(&mut app, terminal, a);
+        mount(&mut app, terminal, b);
+        unmount(&mut app, terminal, Some(a));
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             1,
-            "unmounting one view must despawn exactly its child"
+            "unmounting one instance must despawn exactly its child"
         );
 
-        mount(&mut app, terminal, "c", PlacementId(1));
+        mount(&mut app, terminal, c);
         assert_eq!(
-            slot_of(&app, terminal, "c"),
+            slot_of(&app, terminal, c),
             Some(0),
             "the freed slot 0 must be reused by the next mount"
         );
-        assert_eq!(slot_of(&app, terminal, "b"), Some(1));
+        assert_eq!(slot_of(&app, terminal, b), Some(1));
     }
 
     #[test]
     fn unmount_all_despawns_every_inline_child() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        for id in ["a", "b"] {
-            register_orzma(&mut app, id, terminal, true);
-        }
-        mount(&mut app, terminal, "a", PlacementId(1));
-        mount(&mut app, terminal, "b", PlacementId(1));
+        let a = register_orzma(&mut app, "a", terminal, true);
+        let b = register_orzma(&mut app, "b", terminal, true);
+        mount(&mut app, terminal, a);
+        mount(&mut app, terminal, b);
         let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 2);
 
@@ -1060,9 +1068,9 @@ mod tests {
     fn non_interactive_view_is_stamped_non_interactive() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "hud", terminal, false);
+        let instance = register_orzma(&mut app, "hud", terminal, false);
 
-        mount(&mut app, terminal, "hud", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1);
@@ -1079,15 +1087,10 @@ mod tests {
     /// refusal reaches the GUI on its own signal.
     #[test]
     fn a_rejected_mount_spawns_no_child() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
+        let (mut app, terminal, instance) = app_with_registration();
 
-        app.world_mut().trigger(TtyWebviewMountRejectedSignal {
-            terminal,
-            view_id: "dash".into(),
-            instance_id: None,
-        });
+        app.world_mut()
+            .trigger(TtyWebviewMountRejectedSignal { terminal, instance });
         app.world_mut().flush();
 
         assert!(
@@ -1096,135 +1099,138 @@ mod tests {
         );
     }
 
+    /// Asserts that a mount naming an instance the registry never minted
+    /// spawns nothing.
+    ///
+    /// Case: a program writes a mount for an id it made up rather than one
+    /// the control plane handed it.
     #[test]
-    fn mount_of_unregistered_view_is_dropped() {
+    fn mount_of_an_unknown_instance_is_dropped() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
 
-        mount(&mut app, terminal, "ghost", PlacementId(1));
+        mount(&mut app, terminal, InstanceId(0xdead));
 
         assert!(
             webview_children_of(&app, terminal).is_empty(),
-            "a mount for an unregistered view must be dropped"
+            "a mount for an unminted instance must be dropped"
+        );
+    }
+
+    /// Asserts that a mount the host refuses asks the VT to drop the
+    /// reservation it already registered for that instance.
+    ///
+    /// Case: a program mounts a fabricated instance id repeatedly, trying
+    /// to fill the terminal's placement table with rects the host will
+    /// never paint.
+    #[test]
+    fn a_refused_mount_reclaims_its_vt_reservation() {
+        #[derive(Resource, Default)]
+        struct Reclaimed(Vec<InstanceId>);
+        let mut app = make_test_app();
+        app.init_resource::<Reclaimed>().add_observer(
+            |e: On<RequestTtyWebviewRemove>, mut r: ResMut<Reclaimed>| {
+                r.0.extend(e.instances.iter().copied());
+            },
+        );
+        let terminal = spawn_terminal(&mut app);
+
+        mount(&mut app, terminal, InstanceId(0xdead));
+
+        assert_eq!(
+            app.world().resource::<Reclaimed>().0,
+            vec![InstanceId(0xdead)],
+            "a refused mount must hand its reservation back to the VT"
         );
     }
 
     #[test]
-    fn two_instances_of_same_view_both_mount_in_separate_slots() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
+    fn two_instances_of_one_handle_mount_in_separate_slots() {
+        let (mut app, terminal, first) = app_with_registration();
+        let second = mint_extra(&mut app, "h");
 
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-        mount_instance(&mut app, terminal, "memo", "b", PlacementId(1));
+        mount(&mut app, terminal, first);
+        mount(&mut app, terminal, second);
 
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             2,
-            "two distinct (view_id, instance_id) tuples must both mount"
+            "two instances of one handle must both mount"
         );
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), Some(0));
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("b")), Some(1));
-    }
-
-    #[test]
-    fn duplicate_view_instance_tuple_is_rejected() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-
-        assert_eq!(
-            webview_children_of(&app, terminal).len(),
-            1,
-            "a duplicate (view_id, instance_id) mount must be dropped"
-        );
-    }
-
-    #[test]
-    fn default_instance_and_named_instance_coexist() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-
-        mount(&mut app, terminal, "memo", PlacementId(1));
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-
-        assert_eq!(
-            webview_children_of(&app, terminal).len(),
-            2,
-            "the default (None) instance and a named instance are distinct"
-        );
-        assert_eq!(slot_of_instance(&app, terminal, "memo", None), Some(0));
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), Some(1));
+        assert_eq!(slot_of(&app, terminal, first), Some(0));
+        assert_eq!(slot_of(&app, terminal, second), Some(1));
     }
 
     #[test]
     fn unmount_one_instance_leaves_the_other() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
+        let (mut app, terminal, first) = app_with_registration();
+        let second = mint_extra(&mut app, "h");
 
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-        mount_instance(&mut app, terminal, "memo", "b", PlacementId(1));
+        mount(&mut app, terminal, first);
+        mount(&mut app, terminal, second);
 
-        unmount_instance(&mut app, terminal, "memo", "a");
+        unmount(&mut app, terminal, Some(first));
 
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             1,
             "unmounting one instance must despawn exactly that instance"
         );
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("a")), None);
-        assert_eq!(slot_of_instance(&app, terminal, "memo", Some("b")), Some(1));
-    }
-
-    #[test]
-    fn unmount_view_scope_despawns_every_instance_of_that_view() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        register_orzma(&mut app, "other", terminal, true);
-
-        mount_instance(&mut app, terminal, "memo", "a", PlacementId(1));
-        mount_instance(&mut app, terminal, "memo", "b", PlacementId(1));
-        mount(&mut app, terminal, "other", PlacementId(1));
-
-        unmount(&mut app, terminal, Some("memo"));
-
-        assert_eq!(
-            webview_children_of(&app, terminal).len(),
-            1,
-            "view-scoped unmount must despawn every instance of that view_id only"
-        );
-        assert_eq!(slot_of_instance(&app, terminal, "other", None), Some(2));
+        assert_eq!(slot_of(&app, terminal, first), None);
+        assert_eq!(slot_of(&app, terminal, second), Some(1));
     }
 
     #[test]
     fn slot_cap_counts_all_instances_together() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
+        let (mut app, terminal, first) = app_with_registration();
+        let mut instances = vec![first];
+        for _ in 0..OVERLAY_SLOTS {
+            instances.push(mint_extra(&mut app, "h"));
+        }
 
-        let insts: Vec<String> = (0..=OVERLAY_SLOTS).map(|i| format!("i{i}")).collect();
-        for inst in insts.iter().take(OVERLAY_SLOTS) {
-            mount_instance(&mut app, terminal, "memo", inst, PlacementId(1));
+        for instance in instances.iter().take(OVERLAY_SLOTS) {
+            mount(&mut app, terminal, *instance);
         }
         assert_eq!(webview_children_of(&app, terminal).len(), OVERLAY_SLOTS);
 
-        let overflow = &insts[OVERLAY_SLOTS];
-        mount_instance(&mut app, terminal, "memo", overflow, PlacementId(1));
+        let overflow = instances[OVERLAY_SLOTS];
+        mount(&mut app, terminal, overflow);
         assert_eq!(
             webview_children_of(&app, terminal).len(),
             OVERLAY_SLOTS,
             "the per-terminal slot cap counts all instances together; an over-cap mount is rejected"
         );
-        assert_eq!(
-            slot_of_instance(&app, terminal, "memo", Some(overflow.as_str())),
-            None
-        );
+        assert_eq!(slot_of(&app, terminal, overflow), None);
+    }
+
+    /// Asserts that an eviction followed by a re-mount of the same
+    /// instance in one signal batch leaves exactly one live webview,
+    /// pinning the per-command flush `bevy_ecs` performs between queued
+    /// triggers.
+    ///
+    /// Case: a program leaves the alternate screen — tearing down the
+    /// placements it held there — and immediately re-mounts the same view
+    /// on the primary screen, both within one pump.
+    #[test]
+    fn an_evict_then_remount_batch_leaves_one_live_webview() {
+        let (mut app, terminal, id) = app_with_registration();
+        batch(&mut app, terminal, vec![Op::Mount(id)]);
+        batch(&mut app, terminal, vec![Op::Evict(id), Op::Mount(id)]);
+        assert_eq!(live_webviews(&app, terminal).len(), 1);
+    }
+
+    /// Asserts that two mounts of the same instance in one batch collapse
+    /// to a single webview holding a single overlay slot.
+    ///
+    /// Case: two frames' worth of output land in one pump because the app
+    /// resized a view twice in quick succession.
+    #[test]
+    fn a_double_mount_batch_leaves_one_webview_in_one_slot() {
+        let (mut app, terminal, id) = app_with_registration();
+        batch(&mut app, terminal, vec![Op::Mount(id), Op::Mount(id)]);
+        let live = live_webviews(&app, terminal);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].slot, 0);
     }
 
     #[test]
@@ -1251,7 +1257,7 @@ mod tests {
         app: &mut App,
         terminal: Entity,
         slot: u8,
-        placement: WebviewPlacement,
+        instance: InstanceId,
     ) -> Handle<Image> {
         let handle = app
             .world_mut()
@@ -1260,11 +1266,12 @@ mod tests {
         app.world_mut().spawn((
             ChildOf(terminal),
             Webview {
-                view_id: format!("view-{slot}"),
-                instance_id: None,
+                handle: format!("view-{slot}").into(),
+                instance,
                 slot,
+                rows: 10,
+                cols: 40,
             },
-            placement,
             WebviewTextureTarget(handle.clone()),
         ));
         handle
@@ -1298,9 +1305,9 @@ mod tests {
         let mut app = make_test_app();
         let terminal = app
             .world_mut()
-            .spawn(grid_with_placements(24, 80, vec![placed(PlacementId(1))]))
+            .spawn(grid_with_placements(24, 80, vec![placed(InstanceId(1))]))
             .id();
-        let handle = spawn_projection_child(&mut app, terminal, 2, placement_10x40(PlacementId(1)));
+        let handle = spawn_projection_child(&mut app, terminal, 2, InstanceId(1));
 
         run_projection(&mut app);
         let overlays = overlays_of(&app, terminal);
@@ -1316,8 +1323,8 @@ mod tests {
         }
     }
 
-    /// Asserts that two children with distinct placement ids each
-    /// project into their own slot with their own texture handle.
+    /// Asserts that two children with distinct instances each project
+    /// into their own slot with their own texture handle.
     ///
     /// Case: two webview instances are mounted side by side and the
     /// same frame lists both rects.
@@ -1329,11 +1336,11 @@ mod tests {
             .spawn(grid_with_placements(
                 24,
                 80,
-                vec![placed(PlacementId(1)), placed(PlacementId(2))],
+                vec![placed(InstanceId(1)), placed(InstanceId(2))],
             ))
             .id();
-        let h0 = spawn_projection_child(&mut app, terminal, 0, placement_10x40(PlacementId(1)));
-        let h1 = spawn_projection_child(&mut app, terminal, 1, placement_10x40(PlacementId(2)));
+        let h0 = spawn_projection_child(&mut app, terminal, 0, InstanceId(1));
+        let h1 = spawn_projection_child(&mut app, terminal, 1, InstanceId(2));
 
         run_projection(&mut app);
         let overlays = overlays_of(&app, terminal);
@@ -1358,14 +1365,12 @@ mod tests {
     /// previous frame's overlay rects are still applied.
     #[test]
     fn stale_overlays_clear_after_unmount_all() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
+        let (mut app, terminal, instance) = app_with_registration();
 
-        mount(&mut app, terminal, "dash", PlacementId(1));
+        mount(&mut app, terminal, instance);
         app.world_mut()
             .entity_mut(terminal)
-            .insert(grid_with_placements(24, 80, vec![placed(PlacementId(1))]));
+            .insert(grid_with_placements(24, 80, vec![placed(instance)]));
         run_projection(&mut app);
         let overlays = overlays_of(&app, terminal);
         assert_ne!(overlays.rects[0], IVec4::ZERO);
@@ -1385,79 +1390,43 @@ mod tests {
     /// past the terminal's last column.
     #[test]
     fn projection_culls_fully_outside_rects() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
 
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(1),
-                    point: GridPoint {
-                        line: GridLine(-20),
-                        column: GridColumn(0),
-                    },
-                    size: PlacementSize { rows: 6, cols: 10 },
-                }],
-            ));
-        run_projection(&mut app);
-        let overlays = overlays_of(&app, terminal);
-        assert_eq!(
-            overlays.rects[0],
-            IVec4::ZERO,
-            "a rect fully above the viewport must be culled"
-        );
-        assert!(overlays.textures[0].is_none());
-
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(1),
-                    point: GridPoint {
-                        line: GridLine(30),
-                        column: GridColumn(0),
-                    },
-                    size: PlacementSize { rows: 6, cols: 10 },
-                }],
-            ));
-        run_projection(&mut app);
-        let overlays = overlays_of(&app, terminal);
-        assert_eq!(
-            overlays.rects[0],
-            IVec4::ZERO,
-            "a rect fully below the viewport must be culled"
-        );
-        assert!(overlays.textures[0].is_none());
-
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(1),
-                    point: GridPoint {
-                        line: GridLine(2),
-                        column: GridColumn(80),
-                    },
-                    size: PlacementSize { rows: 6, cols: 10 },
-                }],
-            ));
-        run_projection(&mut app);
-        let overlays = overlays_of(&app, terminal);
-        assert_eq!(
-            overlays.rects[0],
-            IVec4::ZERO,
-            "a rect anchored at or past the right edge must be culled"
-        );
-        assert!(overlays.textures[0].is_none());
+        for point in [
+            GridPoint {
+                line: GridLine(-20),
+                column: GridColumn(0),
+            },
+            GridPoint {
+                line: GridLine(30),
+                column: GridColumn(0),
+            },
+            GridPoint {
+                line: GridLine(2),
+                column: GridColumn(80),
+            },
+        ] {
+            app.world_mut()
+                .entity_mut(terminal)
+                .insert(grid_with_placements(
+                    24,
+                    80,
+                    vec![AnchoredPlacement {
+                        id: instance,
+                        point,
+                        size: PlacementSize { rows: 6, cols: 10 },
+                    }],
+                ));
+            run_projection(&mut app);
+            let overlays = overlays_of(&app, terminal);
+            assert_eq!(
+                overlays.rects[0],
+                IVec4::ZERO,
+                "a rect outside the viewport must be culled: {point:?}"
+            );
+            assert!(overlays.textures[0].is_none());
+        }
     }
 
     /// Asserts that a scrolled viewport moves a placement's rect down by
@@ -1468,10 +1437,8 @@ mod tests {
     /// anchored to.
     #[test]
     fn a_scrolled_viewport_moves_the_rect_down() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
 
         app.world_mut()
             .entity_mut(terminal)
@@ -1480,7 +1447,7 @@ mod tests {
                 80,
                 3,
                 vec![AnchoredPlacement {
-                    id: PlacementId(1),
+                    id: instance,
                     point: GridPoint {
                         line: GridLine(-2),
                         column: GridColumn(0),
@@ -1499,17 +1466,15 @@ mod tests {
     /// rightmost cell when the frame is captured.
     #[test]
     fn projection_keeps_rect_anchored_at_last_valid_column() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
         app.world_mut()
             .entity_mut(terminal)
             .insert(grid_with_placements(
                 24,
                 80,
                 vec![AnchoredPlacement {
-                    id: PlacementId(1),
+                    id: instance,
                     point: GridPoint {
                         line: GridLine(2),
                         column: GridColumn(79),
@@ -1527,12 +1492,186 @@ mod tests {
         );
     }
 
+    /// Asserts that a frame-carried placement is written through to the
+    /// overlay slot verbatim, including a negative row.
+    ///
+    /// Case: a mounted webview's rect sticks partway above the viewport
+    /// after the user scrolls, and the shader clips the negative rows.
     #[test]
-    fn size_sync_updates_webview_size_when_metrics_change() {
+    fn projection_passes_the_placement_rect_through() {
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
+        app.world_mut()
+            .entity_mut(terminal)
+            .insert(grid_with_placements(
+                24,
+                80,
+                vec![AnchoredPlacement {
+                    id: instance,
+                    point: GridPoint {
+                        line: GridLine(-2),
+                        column: GridColumn(4),
+                    },
+                    size: PlacementSize { rows: 6, cols: 20 },
+                }],
+            ));
+        run_projection(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(overlays.rects[0], IVec4::new(-2, 4, 6, 20));
+        assert!(overlays.textures[0].is_some());
+    }
+
+    /// Asserts that a mounted webview whose instance is absent from the
+    /// list paints nothing while its entity survives.
+    ///
+    /// Case: the webview scrolls fully out of the viewport; the VT
+    /// omits it from the frame list without unmounting it.
+    #[test]
+    fn projection_hides_a_placement_absent_from_the_list() {
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
+        app.world_mut()
+            .entity_mut(terminal)
+            .insert(grid_with_placements(24, 80, vec![]));
+        run_projection(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(overlays.rects[0], IVec4::ZERO);
+        assert_eq!(webview_children_of(&app, terminal).len(), 1);
+    }
+
+    /// Asserts that a listed instance with no matching child is ignored.
+    ///
+    /// Case: the frame carrying a fresh mount's placement is applied a
+    /// Bevy tick before the mount signal's observer runs.
+    #[test]
+    fn projection_ignores_an_unknown_placement_id() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
-        mount(&mut app, terminal, "dash", PlacementId(1));
+        app.world_mut()
+            .entity_mut(terminal)
+            .insert(grid_with_placements(
+                24,
+                80,
+                vec![AnchoredPlacement {
+                    id: InstanceId(9),
+                    point: GridPoint {
+                        line: GridLine(1),
+                        column: GridColumn(1),
+                    },
+                    size: PlacementSize { rows: 2, cols: 2 },
+                }],
+            ));
+        run_projection(&mut app);
+        assert!(app.world().get::<TerminalOverlays>(terminal).is_none());
+    }
+
+    /// Asserts that mount-then-frame and frame-then-mount converge to
+    /// the same painted overlay.
+    ///
+    /// Case: signal and frame arrival interleave differently across
+    /// coalescer windows for the same mount.
+    #[test]
+    fn mount_and_frame_order_converge() {
+        let rect = |instance| AnchoredPlacement {
+            id: instance,
+            point: GridPoint {
+                line: GridLine(3),
+                column: GridColumn(2),
+            },
+            size: PlacementSize { rows: 10, cols: 40 },
+        };
+        let (mut first, mounted_first, instance_a) = app_with_registration();
+        mount(&mut first, mounted_first, instance_a);
+        first
+            .world_mut()
+            .entity_mut(mounted_first)
+            .insert(grid_with_placements(24, 80, vec![rect(instance_a)]));
+        run_projection(&mut first);
+        let rect_a = first
+            .world()
+            .get::<TerminalOverlays>(mounted_first)
+            .expect("overlays")
+            .rects[0];
+
+        let (mut second, framed_first, instance_b) = app_with_registration();
+        second
+            .world_mut()
+            .entity_mut(framed_first)
+            .insert(grid_with_placements(24, 80, vec![rect(instance_b)]));
+        run_projection(&mut second);
+        assert!(
+            second
+                .world()
+                .get::<TerminalOverlays>(framed_first)
+                .is_none()
+        );
+        mount(&mut second, framed_first, instance_b);
+        run_projection(&mut second);
+        let rect_b = second
+            .world()
+            .get::<TerminalOverlays>(framed_first)
+            .expect("overlays")
+            .rects[0];
+        assert_eq!(rect_a, IVec4::new(3, 2, 10, 40));
+        assert_eq!(rect_a, rect_b);
+    }
+
+    /// Asserts that a re-mount keeps its slot painting under the same
+    /// instance once the frame list carries the new geometry.
+    ///
+    /// Case: a program re-issues `mount` for a placement it already holds
+    /// and the VT supersedes the reservation in place.
+    #[test]
+    fn remount_keeps_painting_under_the_same_instance() {
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
+        mount(&mut app, terminal, instance);
+        assert_eq!(webview_children_of(&app, terminal).len(), 1);
+        app.world_mut()
+            .entity_mut(terminal)
+            .insert(grid_with_placements(
+                24,
+                80,
+                vec![AnchoredPlacement {
+                    id: instance,
+                    point: GridPoint {
+                        line: GridLine(5),
+                        column: GridColumn(0),
+                    },
+                    size: PlacementSize { rows: 10, cols: 40 },
+                }],
+            ));
+        run_projection(&mut app);
+        let overlays = overlays_of(&app, terminal);
+        assert_eq!(overlays.rects[0], IVec4::new(5, 0, 10, 40));
+    }
+
+    /// Asserts that an eviction signal despawns exactly the named
+    /// placements and ignores unknown ids.
+    ///
+    /// Case: the scrollback trims past a webview's row while another
+    /// webview further down stays alive.
+    #[test]
+    fn eviction_despawns_by_id_and_ignores_unknowns() {
+        let (mut app, terminal, memo) = app_with_registration();
+        let clock = register_orzma(&mut app, "clock", terminal, true);
+        mount(&mut app, terminal, memo);
+        mount(&mut app, terminal, clock);
+        assert_eq!(webview_children_of(&app, terminal).len(), 2);
+        app.world_mut().trigger(TtyWebviewEvictedSignal {
+            terminal,
+            placements: vec![memo, InstanceId(99)],
+        });
+        app.world_mut().flush();
+        app.update();
+        assert_eq!(webview_children_of(&app, terminal).len(), 1);
+        assert_eq!(slot_of(&app, terminal, clock), Some(1));
+    }
+
+    #[test]
+    fn size_sync_updates_webview_size_when_metrics_change() {
+        let (mut app, terminal, instance) = app_with_registration();
+        mount(&mut app, terminal, instance);
         let child = webview_children_of(&app, terminal)[0];
         assert_eq!(
             app.world().get::<WebviewSize>(child),
@@ -1573,15 +1712,13 @@ mod tests {
 
     #[test]
     fn size_sync_is_quiescent_when_nothing_changed() {
-        let mut app = make_test_app();
+        let (mut app, terminal, instance) = app_with_registration();
         app.init_resource::<SizeChangeProbe>();
         app.add_systems(
             Update,
             (sync_webview_size, probe_webview_size_changed).chain(),
         );
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "dash", terminal, true);
-        mount(&mut app, terminal, "dash", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         app.update();
         assert!(
@@ -1612,9 +1749,11 @@ mod tests {
             .spawn((
                 ChildOf(terminal),
                 Webview {
-                    view_id: format!("view-{slot}"),
-                    instance_id: None,
+                    handle: format!("view-{slot}").into(),
+                    instance: InstanceId(u128::from(slot) + 1),
                     slot,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();
@@ -1790,29 +1929,26 @@ mod tests {
         );
     }
 
-    fn register_orzma_dir(app: &mut App, handle: &str, owner_surface: Entity) {
-        use crate::control_plane::OrzmaView;
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            handle.into(),
-            OrzmaView {
-                source: OrzmaSource::Dir("/abs/ui".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
-            },
-        );
+    fn dir_view(owner_surface: Entity, interactive: bool) -> OrzmaView {
+        OrzmaView {
+            source: OrzmaSource::Dir("/abs/ui".into()),
+            entry: "index.html".into(),
+            interactive,
+            owner_surface,
+            connection_id: 1,
+            forward_keys: vec![],
+            preload: vec![],
+            instances: Vec::new(),
+        }
     }
 
     #[test]
     fn mount_of_dynamic_handle_uses_orzma_url_and_no_bridge() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        register_orzma_dir(&mut app, "DYN1", terminal);
+        let instance = register_view(&mut app, "DYN1", dir_view(terminal, true));
 
-        mount(&mut app, terminal, "DYN1", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let children = webview_children_of(&app, terminal);
         assert_eq!(
@@ -1833,75 +1969,48 @@ mod tests {
 
     #[test]
     fn resolve_mount_enforces_owner_surface() {
-        use crate::control_plane::{OrzmaRegistry, OrzmaSource, OrzmaView};
         let owner = Entity::from_bits(1);
         let other = Entity::from_bits(2);
+        let handle = HandleId::from("DYNHANDLE");
         let mut dynamic = OrzmaRegistry::default();
-        dynamic.insert(
-            "DYNHANDLE".into(),
-            OrzmaView {
-                source: OrzmaSource::Dir("/abs/ui".into()),
-                entry: "index.html".into(),
-                interactive: false,
-                owner_surface: owner,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
-            },
-        );
+        dynamic.insert(handle.clone(), dir_view(owner, false));
 
-        let d = resolve_mount("DYNHANDLE", owner, &dynamic).expect("dynamic resolves");
+        let d = resolve_mount(&handle, owner, &dynamic).expect("dynamic resolves");
         assert_eq!(d.url.as_deref(), Some("orzma://DYNHANDLE/index.html"));
         assert!(!d.interactive);
 
         assert!(
-            resolve_mount("DYNHANDLE", other, &dynamic).is_none(),
+            resolve_mount(&handle, other, &dynamic).is_none(),
             "a handle resolves only from its owner surface"
         );
-        assert!(resolve_mount("ghost", owner, &dynamic).is_none());
+        assert!(resolve_mount(&HandleId::from("ghost"), owner, &dynamic).is_none());
     }
 
     #[test]
     fn resolve_mount_dynamic_inline_yields_orzma_url_via_index_html() {
-        use crate::control_plane::{OrzmaRegistry, OrzmaSource, OrzmaView};
         let owner = Entity::from_bits(1);
+        let handle = HandleId::from("INLINEH");
         let mut dynamic = OrzmaRegistry::default();
-        dynamic.insert(
-            "INLINEH".into(),
-            OrzmaView {
-                source: OrzmaSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: owner,
-                connection_id: 1,
-                forward_keys: vec![],
-                preload: vec![],
-            },
-        );
-        let r = resolve_mount("INLINEH", owner, &dynamic).expect("inline resolves");
+        dynamic.insert(handle.clone(), inline_view(owner, true));
+        let r = resolve_mount(&handle, owner, &dynamic).expect("inline resolves");
         assert_eq!(r.url.as_deref(), Some("orzma://INLINEH/index.html"));
         assert!(r.owner.is_some());
     }
 
     #[test]
     fn dynamic_mount_stamps_webview_owner() {
-        use crate::control_plane::{OrzmaSource, OrzmaView, WebviewOwner};
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "HANDLE".into(),
+        let instance = register_view(
+            &mut app,
+            "HANDLE",
             OrzmaView {
-                source: OrzmaSource::Inline("<h1>hi</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: terminal,
                 connection_id: 42,
-                forward_keys: vec![],
-                preload: vec![],
+                ..inline_view(terminal, true)
             },
         );
 
-        mount(&mut app, terminal, "HANDLE", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let children = webview_children_of(&app, terminal);
         assert_eq!(
@@ -1909,67 +2018,54 @@ mod tests {
             1,
             "dynamic mount must spawn one inline child"
         );
-        let child = children[0];
-        let owner = app
-            .world()
-            .get::<WebviewOwner>(child)
-            .expect("dynamic mount must stamp WebviewOwner");
-        assert_eq!(owner.connection_id, 42);
-        assert_eq!(owner.handle, "HANDLE");
+        assert_eq!(
+            app.world().get::<WebviewOwner>(children[0]),
+            Some(&WebviewOwner {
+                connection_id: 42,
+                handle: "HANDLE".into(),
+                instance,
+            }),
+            "dynamic mount must stamp WebviewOwner with the mounted instance"
+        );
     }
 
     #[test]
     fn resolve_mount_url_returns_verbatim_url_and_gates_owner_on_bridge() {
-        use crate::control_plane::{OrzmaSource, OrzmaView};
         let surface = Entity::from_bits(1);
+        let disp_handle = HandleId::from("disp");
+        let app_handle = HandleId::from("appv");
         let mut reg = OrzmaRegistry::default();
         reg.insert(
-            "disp".into(),
+            disp_handle.clone(),
             OrzmaView {
-                source: OrzmaSource::Url {
-                    url: "https://example.com".into(),
-                    bridge: false,
-                },
-                entry: String::new(),
-                interactive: true,
-                owner_surface: surface,
                 connection_id: 7,
-                forward_keys: vec![],
-                preload: vec![],
+                ..url_view(surface, "https://example.com", false)
             },
         );
         reg.insert(
-            "appv".into(),
+            app_handle.clone(),
             OrzmaView {
-                source: OrzmaSource::Url {
-                    url: "https://app.example.com".into(),
-                    bridge: true,
-                },
-                entry: String::new(),
-                interactive: true,
-                owner_surface: surface,
                 connection_id: 7,
-                forward_keys: vec![],
-                preload: vec![],
+                ..url_view(surface, "https://app.example.com", true)
             },
         );
 
-        let disp = resolve_mount("disp", surface, &reg).expect("registered");
+        let disp = resolve_mount(&disp_handle, surface, &reg).expect("registered");
         assert_eq!(disp.url.as_deref(), Some("https://example.com"));
         assert!(disp.owner.is_none(), "display-only url must have no owner");
 
-        let appv = resolve_mount("appv", surface, &reg).expect("registered");
+        let appv = resolve_mount(&app_handle, surface, &reg).expect("registered");
         assert_eq!(appv.url.as_deref(), Some("https://app.example.com"));
-        assert_eq!(appv.owner, Some((7, "appv".to_string())));
+        assert_eq!(appv.owner, Some((7, app_handle)));
     }
 
     #[test]
     fn mount_url_display_only_has_no_preload_or_owner() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        register_url(&mut app, "disp", terminal, "https://example.com", false);
+        let instance = register_url(&mut app, "disp", terminal, "https://example.com", false);
 
-        mount(&mut app, terminal, "disp", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let children = webview_children_of(&app, terminal);
         assert_eq!(children.len(), 1);
@@ -2005,9 +2101,9 @@ mod tests {
     fn mount_url_bridged_has_preload_and_owner() {
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        register_url(&mut app, "appv", terminal, "https://app.example.com", true);
+        let instance = register_url(&mut app, "appv", terminal, "https://app.example.com", true);
 
-        mount(&mut app, terminal, "appv", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let child = webview_children_of(&app, terminal)[0];
         let preload = app
@@ -2023,212 +2119,25 @@ mod tests {
             Some(&WebviewOwner {
                 connection_id: 1,
                 handle: "appv".into(),
+                instance,
             }),
-        );
-    }
-
-    fn compositing_writers(
-        connection_id: u64,
-    ) -> (ConnectionWriters, crossbeam_channel::Receiver<String>) {
-        use crossbeam_channel::bounded;
-        let (tx, rx) = bounded(16);
-        let writers = ConnectionWriters::default();
-        writers.insert(connection_id, tx);
-        (writers, rx)
-    }
-
-    fn spawn_owned_projection_child(
-        app: &mut App,
-        terminal: Entity,
-        slot: u8,
-        placement: WebviewPlacement,
-        connection_id: u64,
-        handle: &str,
-    ) -> Entity {
-        let image_handle = app
-            .world_mut()
-            .resource_mut::<Assets<Image>>()
-            .add(Image::default());
-        app.world_mut()
-            .spawn((
-                ChildOf(terminal),
-                Webview {
-                    view_id: format!("view-{slot}"),
-                    instance_id: None,
-                    slot,
-                },
-                placement,
-                WebviewTextureTarget(image_handle.clone()),
-                WebviewOwner {
-                    connection_id,
-                    handle: handle.to_string(),
-                },
-            ))
-            .id()
-    }
-
-    /// Asserts that a child's first successful projection stamps
-    /// `CompositeNotified` and sends exactly one
-    /// `Compositing { active: true }` push to its owning connection.
-    ///
-    /// Case: a bridged webview paints for the first time after its
-    /// mount while the registering program listens for compositing
-    /// pushes.
-    #[test]
-    fn first_projection_sends_compositing_start() {
-        let mut app = make_test_app();
-        let (writers, rx) = compositing_writers(1);
-        app.insert_resource(writers);
-        let terminal = app
-            .world_mut()
-            .spawn(grid_with_placements(24, 80, vec![placed(PlacementId(1))]))
-            .id();
-        let entity = spawn_owned_projection_child(
-            &mut app,
-            terminal,
-            0,
-            placement_10x40(PlacementId(1)),
-            1,
-            "myhandle",
-        );
-
-        run_projection(&mut app);
-
-        assert!(
-            app.world().get::<CompositeNotified>(entity).is_some(),
-            "first successful projection must stamp CompositeNotified"
-        );
-        let msg = rx
-            .try_recv()
-            .expect("compositing start must be sent after first projection");
-        assert_eq!(
-            msg,
-            r#"{"op":"compositing","handle":"myhandle","active":true}"#
-        );
-    }
-
-    /// Asserts that projecting an already-notified child sends no
-    /// duplicate compositing push.
-    ///
-    /// Case: the same webview keeps projecting frame after frame while
-    /// its owner stays connected.
-    #[test]
-    fn second_projection_does_not_resend() {
-        let mut app = make_test_app();
-        let (writers, rx) = compositing_writers(1);
-        app.insert_resource(writers);
-        let terminal = app
-            .world_mut()
-            .spawn(grid_with_placements(24, 80, vec![placed(PlacementId(1))]))
-            .id();
-        spawn_owned_projection_child(
-            &mut app,
-            terminal,
-            0,
-            placement_10x40(PlacementId(1)),
-            1,
-            "myhandle",
-        );
-
-        run_projection(&mut app);
-        let _ = rx.try_recv().expect("first projection must send start");
-
-        run_projection(&mut app);
-        assert!(
-            rx.try_recv().is_err(),
-            "second projection must NOT send a duplicate start"
-        );
-    }
-
-    /// Asserts that despawning a child that was notified at least once
-    /// sends `Compositing { active: false }` to its owner.
-    ///
-    /// Case: a webview that has been painting is unmounted, and the
-    /// registering program must learn that compositing ended.
-    #[test]
-    fn stop_observer_sends_compositing_stop_when_notified() {
-        let mut app = make_test_app();
-        let (writers, rx) = compositing_writers(1);
-        app.insert_resource(writers);
-        let terminal = app
-            .world_mut()
-            .spawn(grid_with_placements(24, 80, vec![placed(PlacementId(1))]))
-            .id();
-        let child = spawn_owned_projection_child(
-            &mut app,
-            terminal,
-            0,
-            placement_10x40(PlacementId(1)),
-            1,
-            "myhandle",
-        );
-
-        run_projection(&mut app);
-        let _ = rx.try_recv().expect("start notification must arrive");
-
-        app.world_mut().entity_mut(child).despawn();
-        app.world_mut().flush();
-
-        let msg = rx
-            .try_recv()
-            .expect("compositing stop must be sent on despawn");
-        assert_eq!(
-            msg,
-            r#"{"op":"compositing","handle":"myhandle","active":false}"#
-        );
-    }
-
-    /// Asserts that despawning a child that never projected sends no
-    /// stop push.
-    ///
-    /// Case: a webview is mounted and torn down again before any frame
-    /// lists its placement, so compositing never started.
-    #[test]
-    fn stop_observer_does_not_send_when_not_notified() {
-        let mut app = make_test_app();
-        let (writers, rx) = compositing_writers(1);
-        app.insert_resource(writers);
-        let terminal = app
-            .world_mut()
-            .spawn(grid_with_placements(24, 80, vec![]))
-            .id();
-        let child = spawn_owned_projection_child(
-            &mut app,
-            terminal,
-            0,
-            placement_10x40(PlacementId(1)),
-            1,
-            "myhandle",
-        );
-
-        app.world_mut().entity_mut(child).despawn();
-        app.world_mut().flush();
-
-        assert!(
-            rx.try_recv().is_err(),
-            "despawning a never-projected entity must NOT send a stop notification"
         );
     }
 
     #[test]
     fn mount_bridged_inline_appends_user_preload_after_bridge() {
-        use crate::control_plane::{OrzmaSource, OrzmaView};
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "h".into(),
+        let instance = register_view(
+            &mut app,
+            "h",
             OrzmaView {
-                source: OrzmaSource::Inline("<h1>x</h1>".into()),
-                entry: "index.html".into(),
-                interactive: true,
-                owner_surface: terminal,
-                connection_id: 1,
-                forward_keys: vec![],
                 preload: vec!["window.USER = 1;".into()],
+                ..inline_view(terminal, true)
             },
         );
 
-        mount(&mut app, terminal, "h", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let child = webview_children_of(&app, terminal)[0];
         let preload = app
@@ -2245,26 +2154,18 @@ mod tests {
 
     #[test]
     fn mount_bridged_url_appends_user_preload_after_bridge() {
-        use crate::control_plane::{OrzmaSource, OrzmaView};
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "u".into(),
+        let instance = register_view(
+            &mut app,
+            "u",
             OrzmaView {
-                source: OrzmaSource::Url {
-                    url: "https://app.example.com".into(),
-                    bridge: true,
-                },
-                entry: String::new(),
-                interactive: true,
-                owner_surface: terminal,
-                connection_id: 1,
-                forward_keys: vec![],
                 preload: vec!["window.USER = 1;".into()],
+                ..url_view(terminal, "https://app.example.com", true)
             },
         );
 
-        mount(&mut app, terminal, "u", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let child = webview_children_of(&app, terminal)[0];
         let preload = app
@@ -2280,26 +2181,18 @@ mod tests {
 
     #[test]
     fn mount_display_only_url_with_preload_injects_user_scripts_only() {
-        use crate::control_plane::{OrzmaSource, OrzmaView, WebviewOwner};
         let mut app = make_test_app();
         let terminal = spawn_terminal(&mut app);
-        app.world_mut().resource_mut::<OrzmaRegistry>().insert(
-            "disp".into(),
+        let instance = register_view(
+            &mut app,
+            "disp",
             OrzmaView {
-                source: OrzmaSource::Url {
-                    url: "https://example.com".into(),
-                    bridge: false,
-                },
-                entry: String::new(),
-                interactive: true,
-                owner_surface: terminal,
-                connection_id: 1,
-                forward_keys: vec![],
                 preload: vec!["window.USER = 1;".into()],
+                ..url_view(terminal, "https://example.com", false)
             },
         );
 
-        mount(&mut app, terminal, "disp", PlacementId(1));
+        mount(&mut app, terminal, instance);
 
         let child = webview_children_of(&app, terminal)[0];
         let preload = app
@@ -2317,198 +2210,169 @@ mod tests {
         );
     }
 
-    /// Asserts that a frame-carried placement is written through to the
-    /// overlay slot verbatim, including a negative row.
-    ///
-    /// Case: a mounted webview's rect sticks partway above the viewport
-    /// after the user scrolls, and the shader clips the negative rows.
-    #[test]
-    fn projection_passes_the_placement_rect_through() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(1),
-                    point: GridPoint {
-                        line: GridLine(-2),
-                        column: GridColumn(4),
-                    },
-                    size: PlacementSize { rows: 6, cols: 20 },
-                }],
-            ));
-        run_projection(&mut app);
-        let overlays = app
-            .world()
-            .get::<TerminalOverlays>(terminal)
-            .expect("overlays inserted");
-        assert_eq!(overlays.rects[0], IVec4::new(-2, 4, 6, 20));
-        assert!(overlays.textures[0].is_some());
+    fn compositing_writers(
+        connection_id: u64,
+    ) -> (ConnectionWriters, crossbeam_channel::Receiver<String>) {
+        use crossbeam_channel::bounded;
+        let (tx, rx) = bounded(16);
+        let writers = ConnectionWriters::default();
+        writers.insert(connection_id, tx);
+        (writers, rx)
     }
 
-    /// Asserts that a mounted webview whose id is absent from the list
-    /// paints nothing while its entity survives.
-    ///
-    /// Case: the webview scrolls fully out of the viewport; the VT
-    /// omits it from the frame list without unmounting it.
-    #[test]
-    fn projection_hides_a_placement_absent_from_the_list() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(24, 80, vec![]));
-        run_projection(&mut app);
-        let overlays = app
-            .world()
-            .get::<TerminalOverlays>(terminal)
-            .expect("overlays converge to sentinel");
-        assert_eq!(overlays.rects[0], IVec4::ZERO);
-        assert_eq!(webview_children_of(&app, terminal).len(), 1);
-    }
-
-    /// Asserts that a listed id with no matching child is ignored.
-    ///
-    /// Case: the frame carrying a fresh mount's placement is applied a
-    /// Bevy tick before the mount signal's observer runs.
-    #[test]
-    fn projection_ignores_an_unknown_placement_id() {
-        let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(9),
-                    point: GridPoint {
-                        line: GridLine(1),
-                        column: GridColumn(1),
-                    },
-                    size: PlacementSize { rows: 2, cols: 2 },
-                }],
-            ));
-        run_projection(&mut app);
-        assert!(app.world().get::<TerminalOverlays>(terminal).is_none());
-    }
-
-    /// Asserts that mount-then-frame and frame-then-mount converge to
-    /// the same painted overlay.
-    ///
-    /// Case: signal and frame arrival interleave differently across
-    /// coalescer windows for the same mount.
-    #[test]
-    fn mount_and_frame_order_converge() {
-        let placed = AnchoredPlacement {
-            id: PlacementId(1),
-            point: GridPoint {
-                line: GridLine(3),
-                column: GridColumn(2),
-            },
-            size: PlacementSize { rows: 10, cols: 40 },
-        };
-        let mut first = make_test_app();
-        let mounted_first = spawn_terminal(&mut first);
-        register_orzma(&mut first, "memo", mounted_first, true);
-        mount(&mut first, mounted_first, "memo", PlacementId(1));
-        first
+    fn spawn_owned_projection_child(
+        app: &mut App,
+        terminal: Entity,
+        slot: u8,
+        instance: InstanceId,
+        connection_id: u64,
+        handle: &str,
+    ) -> Entity {
+        let image_handle = app
             .world_mut()
-            .entity_mut(mounted_first)
-            .insert(grid_with_placements(24, 80, vec![placed]));
-        run_projection(&mut first);
-        let rect_a = first
-            .world()
-            .get::<TerminalOverlays>(mounted_first)
-            .expect("overlays")
-            .rects[0];
-        let mut second = make_test_app();
-        let framed_first = spawn_terminal(&mut second);
-        register_orzma(&mut second, "memo", framed_first, true);
-        second
+            .resource_mut::<Assets<Image>>()
+            .add(Image::default());
+        app.world_mut()
+            .spawn((
+                ChildOf(terminal),
+                Webview {
+                    handle: handle.into(),
+                    instance,
+                    slot,
+                    rows: 10,
+                    cols: 40,
+                },
+                WebviewTextureTarget(image_handle.clone()),
+                WebviewOwner {
+                    connection_id,
+                    handle: handle.into(),
+                    instance,
+                },
+            ))
+            .id()
+    }
+
+    /// Asserts that a child's first successful projection stamps
+    /// `CompositeNotified` and sends exactly one
+    /// `Compositing { active: true }` push naming its instance.
+    ///
+    /// Case: a bridged webview paints for the first time after its
+    /// mount while the registering program listens for compositing
+    /// pushes.
+    #[test]
+    fn first_projection_sends_compositing_start() {
+        let mut app = make_test_app();
+        let (writers, rx) = compositing_writers(1);
+        app.insert_resource(writers);
+        let terminal = app
             .world_mut()
-            .entity_mut(framed_first)
-            .insert(grid_with_placements(24, 80, vec![placed]));
-        run_projection(&mut second);
+            .spawn(grid_with_placements(24, 80, vec![placed(InstanceId(1))]))
+            .id();
+        let entity =
+            spawn_owned_projection_child(&mut app, terminal, 0, InstanceId(1), 1, "myhandle");
+
+        run_projection(&mut app);
+
         assert!(
-            second
-                .world()
-                .get::<TerminalOverlays>(framed_first)
-                .is_none()
+            app.world().get::<CompositeNotified>(entity).is_some(),
+            "first successful projection must stamp CompositeNotified"
         );
-        mount(&mut second, framed_first, "memo", PlacementId(1));
-        run_projection(&mut second);
-        let rect_b = second
-            .world()
-            .get::<TerminalOverlays>(framed_first)
-            .expect("overlays")
-            .rects[0];
-        assert_eq!(rect_a, IVec4::new(3, 2, 10, 40));
-        assert_eq!(rect_a, rect_b);
+        let msg = rx
+            .try_recv()
+            .expect("compositing start must be sent after first projection");
+        assert_eq!(
+            msg,
+            format!(
+                r#"{{"op":"compositing","handle":"myhandle","instance":"{}","active":true}}"#,
+                InstanceId(1)
+            )
+        );
     }
 
-    /// Asserts that a remount under a fresh id keeps rendering once the
-    /// frame list switches to the new id.
+    /// Asserts that projecting an already-notified child sends no
+    /// duplicate compositing push.
     ///
-    /// Case: a program re-issues `mount` for the same `(view_id,
-    /// instance)` and the VT mints a successor id.
+    /// Case: the same webview keeps projecting frame after frame while
+    /// its owner stays connected.
     #[test]
-    fn remount_hands_the_slot_to_the_new_id() {
+    fn second_projection_does_not_resend() {
         let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
-        mount(&mut app, terminal, "memo", PlacementId(2));
-        assert_eq!(webview_children_of(&app, terminal).len(), 1);
-        app.world_mut()
-            .entity_mut(terminal)
-            .insert(grid_with_placements(
-                24,
-                80,
-                vec![AnchoredPlacement {
-                    id: PlacementId(2),
-                    point: GridPoint {
-                        line: GridLine(5),
-                        column: GridColumn(0),
-                    },
-                    size: PlacementSize { rows: 10, cols: 40 },
-                }],
-            ));
+        let (writers, rx) = compositing_writers(1);
+        app.insert_resource(writers);
+        let terminal = app
+            .world_mut()
+            .spawn(grid_with_placements(24, 80, vec![placed(InstanceId(1))]))
+            .id();
+        spawn_owned_projection_child(&mut app, terminal, 0, InstanceId(1), 1, "myhandle");
+
         run_projection(&mut app);
-        let overlays = app
-            .world()
-            .get::<TerminalOverlays>(terminal)
-            .expect("overlays inserted");
-        assert_eq!(overlays.rects[0], IVec4::new(5, 0, 10, 40));
+        let _ = rx.try_recv().expect("first projection must send start");
+
+        run_projection(&mut app);
+        assert!(
+            rx.try_recv().is_err(),
+            "second projection must NOT send a duplicate start"
+        );
     }
 
-    /// Asserts that an eviction signal despawns exactly the named
-    /// placements and ignores unknown ids.
+    /// Asserts that despawning a child that was notified at least once
+    /// sends `Compositing { active: false }` naming its instance.
     ///
-    /// Case: the scrollback trims past a webview's row while another
-    /// webview further down stays alive.
+    /// Case: a webview that has been painting is unmounted, and the
+    /// registering program must learn that compositing ended.
     #[test]
-    fn eviction_despawns_by_id_and_ignores_unknowns() {
+    fn stop_observer_sends_compositing_stop_when_notified() {
         let mut app = make_test_app();
-        let terminal = spawn_terminal(&mut app);
-        register_orzma(&mut app, "memo", terminal, true);
-        register_orzma(&mut app, "clock", terminal, true);
-        mount(&mut app, terminal, "memo", PlacementId(1));
-        mount(&mut app, terminal, "clock", PlacementId(2));
-        assert_eq!(webview_children_of(&app, terminal).len(), 2);
-        app.world_mut().trigger(TtyWebviewEvictedSignal {
-            terminal,
-            placements: vec![PlacementId(1), PlacementId(99)],
-        });
+        let (writers, rx) = compositing_writers(1);
+        app.insert_resource(writers);
+        let terminal = app
+            .world_mut()
+            .spawn(grid_with_placements(24, 80, vec![placed(InstanceId(1))]))
+            .id();
+        let child =
+            spawn_owned_projection_child(&mut app, terminal, 0, InstanceId(1), 1, "myhandle");
+
+        run_projection(&mut app);
+        let _ = rx.try_recv().expect("start notification must arrive");
+
+        app.world_mut().entity_mut(child).despawn();
         app.world_mut().flush();
-        app.update();
-        assert_eq!(webview_children_of(&app, terminal).len(), 1);
+
+        let msg = rx
+            .try_recv()
+            .expect("compositing stop must be sent on despawn");
+        assert_eq!(
+            msg,
+            format!(
+                r#"{{"op":"compositing","handle":"myhandle","instance":"{}","active":false}}"#,
+                InstanceId(1)
+            )
+        );
+    }
+
+    /// Asserts that despawning a child that never projected sends no
+    /// stop push.
+    ///
+    /// Case: a webview is mounted and torn down again before any frame
+    /// lists its placement, so compositing never started.
+    #[test]
+    fn stop_observer_does_not_send_when_not_notified() {
+        let mut app = make_test_app();
+        let (writers, rx) = compositing_writers(1);
+        app.insert_resource(writers);
+        let terminal = app
+            .world_mut()
+            .spawn(grid_with_placements(24, 80, vec![]))
+            .id();
+        let child =
+            spawn_owned_projection_child(&mut app, terminal, 0, InstanceId(1), 1, "myhandle");
+
+        app.world_mut().entity_mut(child).despawn();
+        app.world_mut().flush();
+
+        assert!(
+            rx.try_recv().is_err(),
+            "despawning a never-projected entity must NOT send a stop notification"
+        );
     }
 }

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -135,8 +135,8 @@ pub(crate) struct WebviewParams<'w, 's> {
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
 }
 
-/// The resolved content + trust facts for a `mount;<handle>`: the URL to
-/// load (an `orzma://<handle>/…` origin for `Dir`/`Inline` sources, or the
+/// The resolved content + trust facts for an `Omount;n=<instance>`: the URL
+/// to load (an `orzma://<handle>/…` origin for `Dir`/`Inline` sources, or the
 /// verbatim remote URL for a `Url` source), the input policy, and the
 /// registering program's `(connection_id, handle)` for back-channel routing.
 pub(crate) struct ResolvedWebviewMount {
@@ -158,13 +158,14 @@ pub(crate) struct ResolvedWebviewMount {
     pub preload: Vec<String>,
 }
 
-/// Resolves a `mount` `<handle>` against the `OrzmaRegistry` (Tier 1).
-/// `Dir`/`Inline` handles resolve to an `orzma://<handle>/…` URL (one origin
-/// per handle); a `Url` handle resolves to its verbatim remote URL. A handle
-/// resolves ONLY when `requesting_surface` is its `owner_surface` — the scoping
-/// gate that stops one surface from mounting another's handle. `owner` is
-/// populated only for a bridged registration (a display-only `Url` view leaves it
-/// `None`). Returns `None` for an unregistered or unowned handle.
+/// Resolves a handle (already looked up from an `Omount;n=<instance>`'s
+/// instance) against the `OrzmaRegistry` (Tier 1). `Dir`/`Inline` handles
+/// resolve to an `orzma://<handle>/…` URL (one origin per handle); a `Url`
+/// handle resolves to its verbatim remote URL. A handle resolves ONLY when
+/// `requesting_surface` is its `owner_surface` — the scoping gate that stops
+/// one surface from mounting another's handle. `owner` is populated only for
+/// a bridged registration (a display-only `Url` view leaves it `None`).
+/// Returns `None` for an unregistered or unowned handle.
 pub(crate) fn resolve_mount(
     id: &HandleId,
     requesting_surface: Entity,

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -1145,6 +1145,11 @@ mod tests {
         );
     }
 
+    /// Asserts that two instances minted for the same handle mount as two
+    /// separate children, each in its own overlay slot.
+    ///
+    /// Case: a program calls `new_instance` on a handle it already mounted
+    /// once, then mounts the second instance on the same terminal.
     #[test]
     fn two_instances_of_one_handle_mount_in_separate_slots() {
         let (mut app, terminal, first) = app_with_registration();

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -140,8 +140,8 @@ pub(crate) struct WebviewParams<'w, 's> {
 /// verbatim remote URL for a `Url` source), the input policy, and the
 /// registering program's `(connection_id, handle)` for back-channel routing.
 pub(crate) struct ResolvedWebviewMount {
-    /// The URL to load (`WebviewSource::Url`). `None` signals a policy rejection.
-    pub url: Option<String>,
+    /// The URL to load (`WebviewSource::Url`).
+    pub url: String,
     /// Whether the page receives pointer/keyboard input.
     pub interactive: bool,
     /// `(connection_id, handle)` of the registering program, used to stamp
@@ -185,7 +185,7 @@ pub(crate) fn resolve_mount(
         .is_bridged()
         .then(|| (view.connection_id, id.clone()));
     Some(ResolvedWebviewMount {
-        url: Some(url),
+        url,
         interactive: view.interactive,
         owner,
         forward_keys: view.forward_keys.clone(),
@@ -242,11 +242,6 @@ pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: We
         reclaim(params, ctx.terminal_surface, ctx.instance);
         return;
     };
-    let Some(url) = resolved.url.clone() else {
-        tracing::debug!(%handle, "apc-webview: resolved mount had no url, dropping");
-        reclaim(params, ctx.terminal_surface, ctx.instance);
-        return;
-    };
     let Some(slot) = smallest_free_slot(&live) else {
         tracing::debug!(%handle, "apc-webview: all inline overlay slots occupied, dropping");
         reclaim(params, ctx.terminal_surface, ctx.instance);
@@ -261,7 +256,7 @@ pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: We
     let (cell_w_phys, cell_h_phys) = cell_size_phys(params.metrics.as_deref());
     let size = seed_logical_size(ctx.rows, ctx.cols, cell_w_phys, cell_h_phys, scale_factor);
     let texture = WebviewTextureTarget(params.images.add(Image::default()));
-    let source = WebviewSource::new(url);
+    let source = WebviewSource::new(resolved.url);
     let webview = params.commands.spawn_empty().id();
     // NOTE: keep this entity free of Node / Mesh2d / Mesh3d / Sprite /
     // MaterialNode (even for debug visualization). bevy_cef's mesh/sprite
@@ -1982,7 +1977,7 @@ mod tests {
         dynamic.insert(handle.clone(), dir_view(owner, false));
 
         let d = resolve_mount(&handle, owner, &dynamic).expect("dynamic resolves");
-        assert_eq!(d.url.as_deref(), Some("orzma://DYNHANDLE/index.html"));
+        assert_eq!(d.url, "orzma://DYNHANDLE/index.html");
         assert!(!d.interactive);
 
         assert!(
@@ -1999,7 +1994,7 @@ mod tests {
         let mut dynamic = OrzmaRegistry::default();
         dynamic.insert(handle.clone(), inline_view(owner, true));
         let r = resolve_mount(&handle, owner, &dynamic).expect("inline resolves");
-        assert_eq!(r.url.as_deref(), Some("orzma://INLINEH/index.html"));
+        assert_eq!(r.url, "orzma://INLINEH/index.html");
         assert!(r.owner.is_some());
     }
 
@@ -2057,11 +2052,11 @@ mod tests {
         );
 
         let disp = resolve_mount(&disp_handle, surface, &reg).expect("registered");
-        assert_eq!(disp.url.as_deref(), Some("https://example.com"));
+        assert_eq!(disp.url, "https://example.com");
         assert!(disp.owner.is_none(), "display-only url must have no owner");
 
         let appv = resolve_mount(&app_handle, surface, &reg).expect("registered");
-        assert_eq!(appv.url.as_deref(), Some("https://app.example.com"));
+        assert_eq!(appv.url, "https://app.example.com");
         assert_eq!(appv.owner, Some((7, app_handle)));
     }
 

--- a/crates/bevy_orzma_webview/src/webview/render.rs
+++ b/crates/bevy_orzma_webview/src/webview/render.rs
@@ -124,7 +124,12 @@ fn on_orzma_call_frame(
     };
     let global_id = rpc.mint();
     let line = serde_json::json!({
-        "op": "call", "handle": owner.handle, "reqId": global_id, "method": method, "params": params
+        "op": "call",
+        "handle": owner.handle,
+        "instance": owner.instance.to_string(),
+        "reqId": global_id,
+        "method": method,
+        "params": params,
     })
     .to_string();
     if !writers.send(owner.connection_id, line) {
@@ -179,7 +184,7 @@ fn on_orzma_emit_frame(
     .to_string();
     if !writers.send(owner.connection_id, line) {
         tracing::debug!(
-            handle = owner.handle,
+            handle = %owner.handle,
             "orzma.emit owner connection unavailable; dropping"
         );
     }
@@ -211,6 +216,7 @@ fn on_webview_address_changed(
     let line = serde_json::json!({
         "op": "call",
         "handle": owner.handle,
+        "instance": owner.instance.to_string(),
         "reqId": rpc.mint(),
         "method": "urlChanged",
         "params": { "url": addr.url },
@@ -258,6 +264,7 @@ fn log_webview_load_error(load: On<LoadError>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orzma_vt::prelude::InstanceId;
 
     #[test]
     fn orzma_frame_deserializes_from_bare_emitted_object() {
@@ -286,6 +293,7 @@ mod tests {
             .spawn(WebviewOwner {
                 connection_id: 7,
                 handle: "H".into(),
+                instance: InstanceId(1),
             })
             .id();
 
@@ -345,6 +353,7 @@ mod tests {
             .spawn(WebviewOwner {
                 connection_id: 7,
                 handle: "H".into(),
+                instance: InstanceId(1),
             })
             .id();
         app.world_mut().trigger(Receive {
@@ -378,6 +387,7 @@ mod tests {
             .spawn(WebviewOwner {
                 connection_id: 7,
                 handle: "H".into(),
+                instance: InstanceId(1),
             })
             .id();
 
@@ -425,6 +435,7 @@ mod tests {
                 WebviewOwner {
                     connection_id: 7,
                     handle: "H".into(),
+                    instance: InstanceId(1),
                 },
                 WebviewSource::new("https://example.com"),
             ))
@@ -461,6 +472,7 @@ mod tests {
                 WebviewOwner {
                     connection_id: 7,
                     handle: "H".into(),
+                    instance: InstanceId(1),
                 },
                 WebviewSource::new("orzma://H/index.html"),
             ))

--- a/crates/orzma_tty/src/lib.rs
+++ b/crates/orzma_tty/src/lib.rs
@@ -203,20 +203,6 @@ impl<V: Vt> OrzmaTty<V> {
         }
     }
 
-    /// Removes the placements the host names like [`Self::remove_placements`],
-    /// additionally reporting whether one actually went.
-    ///
-    /// Available to tests only: in-crate under `cfg(test)`, downstream via
-    /// the `test-support` feature.
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn remove_placements_reported_removal(&mut self, instances: &[InstanceId]) -> bool {
-        let removed = self.vt.remove_placements(instances);
-        if removed {
-            self.coalescer.arm_or_extend(Instant::now());
-        }
-        removed
-    }
-
     /// Encodes a key press and writes it to the PTY.
     ///
     /// Snaps a scrolled-back viewport to the live tail first
@@ -1035,14 +1021,14 @@ mod tests {
         // and the 3 ms IDLE window has not elapsed — so the assertion below
         // would read the arming left by the first removal.
         tty.coalescer.disarm();
-        assert!(tty.remove_placements_reported_removal(&[id]));
+        tty.remove_placements(&[id]);
         assert!(
             tty.coalescer.is_armed(),
             "a real removal arms the coalescer"
         );
 
         tty.coalescer.disarm();
-        assert!(!tty.remove_placements_reported_removal(&[id]));
+        tty.remove_placements(&[id]);
         assert!(
             !tty.coalescer.is_armed(),
             "a removal that names nothing does not"

--- a/crates/orzma_tty/src/lib.rs
+++ b/crates/orzma_tty/src/lib.rs
@@ -195,6 +195,28 @@ impl<V: Vt> OrzmaTty<V> {
         Ok(())
     }
 
+    /// Removes the placements the host names, arming the coalescer only
+    /// when one actually went so an unchanged frame is not woken.
+    pub fn remove_placements(&mut self, instances: &[InstanceId]) {
+        if self.vt.remove_placements(instances) {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+    }
+
+    /// Removes the placements the host names like [`Self::remove_placements`],
+    /// additionally reporting whether one actually went.
+    ///
+    /// Available to tests only: in-crate under `cfg(test)`, downstream via
+    /// the `test-support` feature.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn remove_placements_reported_removal(&mut self, instances: &[InstanceId]) -> bool {
+        let removed = self.vt.remove_placements(instances);
+        if removed {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+        removed
+    }
+
     /// Encodes a key press and writes it to the PTY.
     ///
     /// Snaps a scrolled-back viewport to the live tail first
@@ -985,5 +1007,45 @@ mod tests {
         });
         term.feed_bytes(b"\x1b[6n");
         assert!(!term.coalescer.is_armed());
+    }
+
+    /// Asserts that a host-driven removal arms the coalescer only when a
+    /// placement actually went, so a removal naming nothing does not wake
+    /// the owner for an unchanged frame.
+    ///
+    /// Case: two connections drop in the same tick and the host issues a
+    /// removal for each, but only the first names a live placement.
+    #[test]
+    fn a_host_removal_arms_the_coalescer_only_when_something_went() {
+        let id: InstanceId = "3f5a9c02d1e84b7690ab3cde12f45678"
+            .parse()
+            .expect("valid id");
+        let mut tty = OrzmaTty::detached(
+            OrzmaVt::new(GridSize { cols: 80, rows: 24 }, 100),
+            80,
+            24,
+            Box::new(CaptureSink::default()),
+        )
+        .expect("the detached constructor succeeds");
+        tty.feed_bytes(format!("\x1b_Omount;n={id},r=4,c=8\x1b\\").as_bytes());
+        let _ = tty.pump();
+
+        // NOTE: disarm explicitly between the two probes. A second pump()
+        // would not disarm on its own — the bootstrap debt is already spent
+        // and the 3 ms IDLE window has not elapsed — so the assertion below
+        // would read the arming left by the first removal.
+        tty.coalescer.disarm();
+        assert!(tty.remove_placements_reported_removal(&[id]));
+        assert!(
+            tty.coalescer.is_armed(),
+            "a real removal arms the coalescer"
+        );
+
+        tty.coalescer.disarm();
+        assert!(!tty.remove_placements_reported_removal(&[id]));
+        assert!(
+            !tty.coalescer.is_armed(),
+            "a removal that names nothing does not"
+        );
     }
 }

--- a/crates/orzma_tty/src/lib.rs
+++ b/crates/orzma_tty/src/lib.rs
@@ -453,13 +453,13 @@ mod tests {
     fn a_pump_reports_what_the_eviction_sweep_raised() {
         let (mut tty, _sink) = detached_term();
         tty.vt.sweeps.push_back(vec![VtSignal::WebviewEvicted {
-            placements: vec![PlacementId(7)],
+            placements: vec![InstanceId(7)],
         }]);
         let output = tty.pump();
         assert_eq!(
             output.signals,
             vec![TtySignal::Vt(VtSignal::WebviewEvicted {
-                placements: vec![PlacementId(7)]
+                placements: vec![InstanceId(7)]
             })]
         );
     }
@@ -475,7 +475,7 @@ mod tests {
         tty.vt.frames.push_back(a_frame());
         tty.pump();
         tty.vt.sweeps.push_back(vec![VtSignal::WebviewEvicted {
-            placements: vec![PlacementId(7)],
+            placements: vec![InstanceId(7)],
         }]);
         tty.pump();
         assert!(tty.coalescer.is_armed());

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -3,7 +3,7 @@
 //! the resize seam.
 
 use orzma_vt::prelude::{
-    DisplayOffset, Frame, GridSize, InterpretOutput, Scroll, Vt, VtModes, VtSignal,
+    DisplayOffset, Frame, GridSize, InstanceId, InterpretOutput, Scroll, Vt, VtModes, VtSignal,
 };
 #[cfg(any(test, feature = "test-support"))]
 use portable_pty::{MasterPty, PtySize};
@@ -108,6 +108,10 @@ impl Vt for FakeVt {
 
     fn sweep_evictions(&mut self) -> Vec<VtSignal> {
         self.sweeps.pop_front().unwrap_or_default()
+    }
+
+    fn remove_placements(&mut self, _instances: &[InstanceId]) -> bool {
+        false
     }
 
     fn resize(&mut self, size: GridSize) -> bool {

--- a/crates/orzma_tty_renderer/src/grid.rs
+++ b/crates/orzma_tty_renderer/src/grid.rs
@@ -54,7 +54,7 @@ fn apply_frame(signal: On<TtyFrameSignal>, mut terminals: Query<&mut TerminalGri
 mod tests {
     use super::*;
     use crate::schema::{
-        AnchoredPlacement, DisplayOffset, GridColumn, GridLine, GridPoint, PlacementId,
+        AnchoredPlacement, DisplayOffset, GridColumn, GridLine, GridPoint, InstanceId,
         PlacementSize, quiet_frame,
     };
     use bevy_orzma_tty::prelude::OrzmaTtyPlugin;
@@ -135,7 +135,7 @@ mod tests {
     fn a_frame_delivers_its_placements() {
         let (mut app, terminal) = app_with_grid();
         let placed = AnchoredPlacement {
-            id: PlacementId(1),
+            id: InstanceId(1),
             point: GridPoint {
                 line: GridLine(2),
                 column: GridColumn(3),

--- a/crates/orzma_tty_renderer/src/schema.rs
+++ b/crates/orzma_tty_renderer/src/schema.rs
@@ -9,6 +9,6 @@ pub use grid::*;
 pub use hover::*;
 pub use orzma_vt::prelude::{
     AnchoredPlacement, CURSOR_VISIBLE_BIT, Color, Cursor, CursorShape, DisplayOffset, GridColumn,
-    GridLine, GridPoint, Hyperlink, HyperlinkId, HyperlinkUri, Palette, PlacementId, PlacementSize,
+    GridLine, GridPoint, Hyperlink, HyperlinkId, HyperlinkUri, InstanceId, Palette, PlacementSize,
     Rgb, Row, Run, SelectionGeometry, SelectionKind, SelectionRange, Style, ViCursor, is_allowed,
 };

--- a/crates/orzma_tty_renderer/src/schema/grid.rs
+++ b/crates/orzma_tty_renderer/src/schema/grid.rs
@@ -380,7 +380,7 @@ pub(crate) fn quiet_frame() -> Frame {
 mod tests {
     use super::*;
     use crate::schema::{
-        Color, Cursor, CursorShape, GridColumn, GridLine, GridPoint, Hyperlink, PlacementId,
+        Color, Cursor, CursorShape, GridColumn, GridLine, GridPoint, Hyperlink, InstanceId,
         PlacementSize, Rgb, Row, Style,
     };
     use orzma_vt::prelude::{DirtyRow, ViewportLine};
@@ -956,7 +956,7 @@ mod tests {
     fn placements_replace_wholesale_and_none_keeps_them() {
         let mut grid = TerminalGrid::settled();
         let placed = AnchoredPlacement {
-            id: PlacementId(1),
+            id: InstanceId(1),
             point: GridPoint {
                 line: GridLine(2),
                 column: GridColumn(3),

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -277,10 +277,6 @@ impl DeviceState {
     /// Removes the placements the host names on either screen; returns
     /// whether anything went. Visits both screens without short-circuiting,
     /// for the same reason [`Self::unmount_placement`] does.
-    // NOTE: this is public API for the control plane's connection-drop
-    // handler, landing in a later task; nothing in this crate calls it yet,
-    // so the lint expectation is correctly fulfilled.
-    #[expect(dead_code, reason = "consumed by a later task's disconnect handler")]
     pub fn remove_placements(&mut self, ids: &[InstanceId]) -> bool {
         let primary = self.screens.primary.remove_placements(ids);
         let alternate = self.screens.alternate.remove_placements(ids);

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -12,7 +12,7 @@ pub(crate) mod modes;
 use crate::device::color::Palette;
 use crate::device::modes::{ScreenKind, VtModes};
 use crate::frame::damage::DamageSpan;
-use crate::placement::{MAX_PLACEMENTS, PlacementId, PlacementSize};
+use crate::placement::{InstanceId, MAX_PLACEMENTS, PlacementSize};
 use crate::screen::Screen;
 use crate::screen::grid::GridSize;
 use crate::screen::viewport::{DisplayOffset, Scroll};
@@ -24,14 +24,13 @@ use std::collections::VecDeque;
 /// It owns no parser, damage, or emission state — those are the VT's own
 /// machinery and sit beside it in [`crate::OrzmaVt`]. The placement
 /// table itself belongs to each [`Screen`]; what lives here is only what
-/// one screen cannot decide alone: the id counter, the cap across the
-/// pair, and the `(view_id, instance_id)` address space.
+/// one screen cannot decide alone: the cap across the pair, and a live
+/// id's uniqueness across it.
 pub(crate) struct DeviceState {
     screens: Screens,
     modes: VtModes,
     colors: ColorTable,
     title: TitleState,
-    next_placement_id: PlacementId,
 }
 
 impl DeviceState {
@@ -52,7 +51,6 @@ impl DeviceState {
                 palette: Palette::default(),
             },
             title: TitleState::default(),
-            next_placement_id: PlacementId(0),
         }
     }
 
@@ -240,51 +238,48 @@ impl DeviceState {
 
 /// Webview placements.
 ///
-/// The three terminal-scoped invariants live here because none of them
-/// can be satisfied by one screen alone: ids are minted per terminal,
-/// the cap counts both screens, and a `(view_id, instance_id)` address
-/// is unique across the pair.
+/// These terminal-scoped invariants live here because neither screen can
+/// satisfy them alone: the cap counts both screens, and a live id is
+/// unique across the pair.
 impl DeviceState {
-    /// Registers a mount at the active screen's cursor and mints its id;
-    /// `None` when the cap rejects it.
+    /// Registers a mount at the active screen's cursor under the id the
+    /// host minted; `false` when the cap rejects it.
     ///
     /// # Invariants
     ///
     /// Supersession runs before the cap check: a re-mount frees the slot
     /// it takes, so it must succeed even at the limit.
-    pub fn mount_placement(
-        &mut self,
-        size: PlacementSize,
-        view_id: String,
-        instance_id: Option<String>,
-    ) -> Option<PlacementId> {
-        self.supersede_placement(&view_id, instance_id.as_deref());
+    pub fn mount_placement(&mut self, size: PlacementSize, id: InstanceId) -> bool {
+        self.supersede_placement(id);
         if MAX_PLACEMENTS <= self.placement_count() {
-            return None;
+            return false;
         }
-        let id = self.mint_placement_id();
-        self.active_screen_mut()
-            .mount_placement(id, size, view_id, instance_id);
-        Some(id)
+        self.active_screen_mut().mount_placement(id, size);
+        true
     }
 
-    /// Removes the placements a client `unmount` addresses on either
+    /// Removes the placement a client `unmount` addresses on either
     /// screen; returns whether anything went.
     ///
     /// # Invariants
     ///
     /// Every screen is visited — the accumulation must not short-circuit.
-    /// A broad scope (`view_id` alone, or unmount-all) can match on both
-    /// screens, and the host despawns every matching child across the
-    /// terminal in one pass, so a VT that stopped at the first match
-    /// would keep a placement holding a cap slot whose host child is
-    /// already gone.
-    pub fn unmount_placement(&mut self, view_id: Option<&str>, instance_id: Option<&str>) -> bool {
-        let primary = self.screens.primary.unmount_placement(view_id, instance_id);
-        let alternate = self
-            .screens
-            .alternate
-            .unmount_placement(view_id, instance_id);
+    /// An unmount-all matches on both screens, and the host despawns every
+    /// matching child across the terminal in one pass, so a VT that stopped
+    /// at the first match would keep a placement holding a cap slot whose
+    /// host child is already gone.
+    pub fn unmount_placement(&mut self, id: Option<InstanceId>) -> bool {
+        let primary = self.screens.primary.unmount_placement(id);
+        let alternate = self.screens.alternate.unmount_placement(id);
+        primary || alternate
+    }
+
+    /// Removes the placements the host names on either screen; returns
+    /// whether anything went. Visits both screens without short-circuiting,
+    /// for the same reason [`Self::unmount_placement`] does.
+    pub fn remove_placements(&mut self, ids: &[InstanceId]) -> bool {
+        let primary = self.screens.primary.remove_placements(ids);
+        let alternate = self.screens.alternate.remove_placements(ids);
         primary || alternate
     }
 
@@ -296,7 +291,7 @@ impl DeviceState {
     /// The primary screen's ids come first. The order is observable —
     /// the host acts on the returned list in sequence — and this is the
     /// only operation that exposes it, so it is fixed here.
-    pub fn evict_lost_anchors(&mut self) -> Vec<PlacementId> {
+    pub fn evict_lost_anchors(&mut self) -> Vec<InstanceId> {
         let mut evicted = self.screens.primary.evict_lost_anchors();
         evicted.extend(self.screens.alternate.evict_lost_anchors());
         evicted
@@ -309,7 +304,7 @@ impl DeviceState {
     /// not destroyed. This operation stages no damage of its own: the
     /// flip itself must stage `DamageSpan::Full`, which carries the
     /// changed list.
-    pub fn switch_screen(&mut self, to: ScreenKind) -> Vec<PlacementId> {
+    pub fn switch_screen(&mut self, to: ScreenKind) -> Vec<InstanceId> {
         self.modes.active_screen = to;
         match to {
             ScreenKind::Alternate => Vec::new(),
@@ -317,35 +312,14 @@ impl DeviceState {
         }
     }
 
-    /// Drops the placement a re-mount replaces on either screen.
-    fn supersede_placement(&mut self, view_id: &str, instance_id: Option<&str>) {
-        self.screens
-            .primary
-            .supersede_placement(view_id, instance_id);
-        self.screens
-            .alternate
-            .supersede_placement(view_id, instance_id);
+    fn supersede_placement(&mut self, id: InstanceId) {
+        self.screens.primary.supersede_placement(id);
+        self.screens.alternate.supersede_placement(id);
     }
 
     /// Live placements across both screens — what the cap counts.
     fn placement_count(&self) -> usize {
         self.screens.primary.placement_count() + self.screens.alternate.placement_count()
-    }
-
-    /// Hands out the next unused placement id.
-    ///
-    /// # Invariants
-    ///
-    /// Ids only ever move forward, which is what lets a delayed
-    /// id-addressed lifecycle event be matched against a placement that
-    /// may already be gone; the overflow guard is what keeps that true.
-    fn mint_placement_id(&mut self) -> PlacementId {
-        let id = self.next_placement_id;
-        self.next_placement_id = PlacementId(
-            id.0.checked_add(1)
-                .expect("a session cannot mint u64::MAX placements"),
-        );
-        id
     }
 }
 
@@ -647,22 +621,6 @@ mod tests {
         assert!(mount(&mut device, "one-too-many").is_none());
     }
 
-    /// Asserts that ids keep moving forward across screens and across
-    /// unmounts, so a delayed id-addressed event can never name a
-    /// successor.
-    ///
-    /// Case: a program mounts on one screen, unmounts, flips screens, and
-    /// mounts again while the host is still acting on the first id.
-    #[test]
-    fn placement_ids_are_minted_ascending_across_screens() {
-        let mut device = device();
-        let first = mount(&mut device, "a").expect("first mount accepted");
-        device.unmount_placement(None, None);
-        device.set_active_screen_for_test(ScreenKind::Alternate);
-        let second = mount(&mut device, "b").expect("second mount accepted");
-        assert!(first < second);
-    }
-
     /// Asserts that a re-mount of the same address supersedes across the
     /// screen pair rather than leaving a twin on the other screen.
     ///
@@ -723,24 +681,6 @@ mod tests {
 
         assert_eq!(device.evict_lost_anchors(), vec![primary, alternate]);
         assert_eq!(device.placement_count(), 0);
-    }
-
-    /// Asserts that a reset does not rewind the device's placement id
-    /// counter.
-    ///
-    /// Case: a webview is mounted, the user runs `reset`, and the
-    /// program mounts a fresh view while the eviction signal for the old
-    /// one is still in flight.
-    #[test]
-    fn a_reset_does_not_rewind_the_device_placement_id_counter() {
-        let mut device = device();
-        let old = mount(&mut device, "a").expect("mount accepted");
-        assert_eq!(device.reset(), None);
-        device.evict_lost_anchors();
-
-        let new = mount(&mut device, "b").expect("mount after reset accepted");
-
-        assert!(old < new);
     }
 
     /// Asserts that a re-mount of a live address is accepted at the cap,

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -652,6 +652,26 @@ mod tests {
         assert_eq!(device.placement_count(), 0);
     }
 
+    /// Asserts that a host removal naming one instance per screen clears
+    /// both rather than stopping at the first match, and reports that
+    /// something went.
+    ///
+    /// Case: a program that mounted a view on each screen disconnects from
+    /// the control socket, so the host names every instance it registered
+    /// in one removal.
+    #[test]
+    fn a_host_removal_reaches_both_screens() {
+        let mut device = device();
+        let primary = InstanceId(1);
+        let alternate = InstanceId(2);
+        assert!(mount(&mut device, primary));
+        device.set_active_screen_for_test(ScreenKind::Alternate);
+        assert!(mount(&mut device, alternate));
+
+        assert!(device.remove_placements(&[primary, alternate]));
+        assert_eq!(device.placement_count(), 0);
+    }
+
     /// Asserts that the sweep reaches the inactive screen, so a placement
     /// whose anchor died there is still reclaimed.
     ///

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -277,6 +277,10 @@ impl DeviceState {
     /// Removes the placements the host names on either screen; returns
     /// whether anything went. Visits both screens without short-circuiting,
     /// for the same reason [`Self::unmount_placement`] does.
+    // NOTE: this is public API for the control plane's connection-drop
+    // handler, landing in a later task; nothing in this crate calls it yet,
+    // so the lint expectation is correctly fulfilled.
+    #[expect(dead_code, reason = "consumed by a later task's disconnect handler")]
     pub fn remove_placements(&mut self, ids: &[InstanceId]) -> bool {
         let primary = self.screens.primary.remove_placements(ids);
         let alternate = self.screens.alternate.remove_placements(ids);
@@ -366,8 +370,8 @@ mod tests {
         DeviceState::new(GridSize { cols: 8, rows: 3 }, 10)
     }
 
-    fn mount(device: &mut DeviceState, view: &str) -> Option<PlacementId> {
-        device.mount_placement(PlacementSize { rows: 2, cols: 4 }, view.to_string(), None)
+    fn mount(device: &mut DeviceState, id: InstanceId) -> bool {
+        device.mount_placement(PlacementSize { rows: 2, cols: 4 }, id)
     }
 
     /// Asserts that a scroll moves the screen on show and leaves the
@@ -444,7 +448,8 @@ mod tests {
     #[test]
     fn a_shrink_past_the_history_cap_leaves_its_placements_evictable() {
         let mut device = DeviceState::new(GridSize { cols: 4, rows: 4 }, 0);
-        let id = mount(&mut device, "v").expect("a mount under the cap is accepted");
+        let id = InstanceId(1);
+        assert!(mount(&mut device, id));
         device.active_screen_mut().move_cursor_to(Some(4), None);
         assert_eq!(
             device.resize(GridSize { cols: 4, rows: 2 }),
@@ -612,41 +617,42 @@ mod tests {
         let mut device = device();
         let per_screen = MAX_PLACEMENTS / 2;
         for index in 0..per_screen {
-            assert!(mount(&mut device, &format!("p{index}")).is_some());
+            assert!(mount(&mut device, InstanceId(index as u128)));
         }
         device.set_active_screen_for_test(ScreenKind::Alternate);
         for index in 0..MAX_PLACEMENTS - per_screen {
-            assert!(mount(&mut device, &format!("a{index}")).is_some());
+            assert!(mount(&mut device, InstanceId(1000 + index as u128)));
         }
-        assert!(mount(&mut device, "one-too-many").is_none());
+        assert!(!mount(&mut device, InstanceId(9999)));
     }
 
-    /// Asserts that a re-mount of the same address supersedes across the
+    /// Asserts that a re-mount of the same id supersedes across the
     /// screen pair rather than leaving a twin on the other screen.
     ///
-    /// Case: a program mounts a named view on the primary screen, flips
-    /// to the alternate screen, and re-mounts the same name there.
+    /// Case: a program mounts a view on the primary screen, flips
+    /// to the alternate screen, and re-mounts the same id there.
     #[test]
     fn a_remount_supersedes_across_screens() {
         let mut device = device();
-        mount(&mut device, "memo").expect("first mount accepted");
+        let id = InstanceId(1);
+        assert!(mount(&mut device, id));
         device.set_active_screen_for_test(ScreenKind::Alternate);
-        mount(&mut device, "memo").expect("re-mount accepted");
+        assert!(mount(&mut device, id));
         assert_eq!(device.placement_count(), 1);
     }
 
     /// Asserts that a broad unmount reaches both screens rather than
     /// stopping at the first match.
     ///
-    /// Case: a program mounted the same view on both screens and exits,
-    /// so the host despawns every child at that address in one pass.
+    /// Case: a program mounted a view on each screen and exits, so the
+    /// host despawns every child across the terminal in one pass.
     #[test]
     fn a_broad_unmount_reaches_both_screens() {
         let mut device = device();
-        mount(&mut device, "memo").expect("primary mount accepted");
+        assert!(mount(&mut device, InstanceId(1)));
         device.set_active_screen_for_test(ScreenKind::Alternate);
-        mount(&mut device, "chart").expect("alternate mount accepted");
-        assert!(device.unmount_placement(None, None));
+        assert!(mount(&mut device, InstanceId(2)));
+        assert!(device.unmount_placement(None));
         assert_eq!(device.placement_count(), 0);
     }
 
@@ -659,7 +665,8 @@ mod tests {
     fn a_sweep_reaches_the_inactive_screen() {
         let mut device = device();
         device.set_active_screen_for_test(ScreenKind::Alternate);
-        let id = mount(&mut device, "memo").expect("alternate mount accepted");
+        let id = InstanceId(1);
+        assert!(mount(&mut device, id));
         assert_eq!(device.active_screen_mut().reset(), None);
         device.set_active_screen_for_test(ScreenKind::Primary);
         assert_eq!(device.evict_lost_anchors(), vec![id]);
@@ -673,9 +680,11 @@ mod tests {
     #[test]
     fn a_reset_leaves_every_placement_unresolvable() {
         let mut device = device();
-        let primary = mount(&mut device, "shell").expect("primary mount accepted");
+        let primary = InstanceId(1);
+        assert!(mount(&mut device, primary));
         device.set_active_screen_for_test(ScreenKind::Alternate);
-        let alternate = mount(&mut device, "app").expect("alternate mount accepted");
+        let alternate = InstanceId(2);
+        assert!(mount(&mut device, alternate));
 
         let _ = device.reset();
 
@@ -683,18 +692,18 @@ mod tests {
         assert_eq!(device.placement_count(), 0);
     }
 
-    /// Asserts that a re-mount of a live address is accepted at the cap,
+    /// Asserts that a re-mount of a live id is accepted at the cap,
     /// because supersession frees the slot it takes before the check.
     ///
     /// Case: a program holding the terminal's last placement slot
-    /// re-renders that same named view.
+    /// re-renders that same view.
     #[test]
     fn re_mounting_a_live_address_succeeds_at_the_cap() {
         let mut device = device();
         for index in 0..MAX_PLACEMENTS {
-            mount(&mut device, &format!("v{index}")).expect("a mount under the cap is accepted");
+            assert!(mount(&mut device, InstanceId(index as u128)));
         }
-        assert!(mount(&mut device, "v0").is_some());
+        assert!(mount(&mut device, InstanceId(0)));
         assert_eq!(device.placement_count(), MAX_PLACEMENTS);
     }
 
@@ -707,9 +716,11 @@ mod tests {
     #[test]
     fn a_flip_to_primary_tears_down_only_the_alternate_placements() {
         let mut device = device();
-        let kept = mount(&mut device, "shell").expect("primary mount accepted");
+        let kept = InstanceId(1);
+        assert!(mount(&mut device, kept));
         assert!(device.switch_screen(ScreenKind::Alternate).is_empty());
-        let dropped = mount(&mut device, "app").expect("alternate mount accepted");
+        let dropped = InstanceId(2);
+        assert!(mount(&mut device, dropped));
         assert_eq!(device.switch_screen(ScreenKind::Primary), vec![dropped]);
         assert_eq!(device.placement_count(), 1);
         assert_eq!(device.active_screen_mut().take_placements(), vec![kept]);

--- a/crates/orzma_vt/src/frame.rs
+++ b/crates/orzma_vt/src/frame.rs
@@ -229,7 +229,7 @@ mod tests {
     use super::*;
     use crate::device::DeviceState;
     use crate::device::color::Color;
-    use crate::placement::PlacementSize;
+    use crate::placement::{InstanceId, PlacementSize};
     use crate::screen::grid::GridSize;
     use crate::screen::grid::coords::{GridColumn, GridLine};
 
@@ -279,9 +279,7 @@ mod tests {
         let mut tracker = FrameTracker::new();
         let mut device = DeviceState::new(GridSize { cols: 4, rows: 3 }, 10);
         assert_eq!(tracker.diff_placements(&device), None);
-        device
-            .mount_placement(PlacementSize { rows: 2, cols: 4 }, "v".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        assert!(device.mount_placement(PlacementSize { rows: 2, cols: 4 }, InstanceId(1)));
         let listed = tracker
             .diff_placements(&device)
             .expect("a mount changes the projection");
@@ -449,14 +447,15 @@ mod tests {
     #[test]
     fn a_placement_change_alone_emits_the_complete_list() {
         let mut rig = drained_rig();
-        rig.device
-            .mount_placement(PlacementSize { rows: 2, cols: 4 }, "v".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        assert!(
+            rig.device
+                .mount_placement(PlacementSize { rows: 2, cols: 4 }, InstanceId(1))
+        );
         let mounted = emit(&mut rig).expect("a placement change emits");
         assert_eq!(mounted.placements.as_ref().map(Vec::len), Some(1));
         assert!(mounted.rows.is_empty());
         assert_eq!(emit(&mut rig), None);
-        assert!(rig.device.unmount_placement(Some("v"), None));
+        assert!(rig.device.unmount_placement(Some(InstanceId(1))));
         let unmounted = emit(&mut rig).expect("an unmount emits");
         assert_eq!(unmounted.placements, Some(Vec::new()));
     }

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -350,39 +350,17 @@ impl VTActor for Executor<'_> {
         // these assignments would leave the changed placement list without
         // a frame to carry it — the webview would register and never draw.
         let signal = match request {
-            WebviewApcRequest::Mount {
-                view_id,
-                size,
-                instance_id,
-            } => match self
-                .device
-                .mount_placement(size, view_id.clone(), instance_id.clone())
-            {
-                Some(placement) => {
+            WebviewApcRequest::Mount { instance, size } => {
+                if self.device.mount_placement(size, instance) {
                     self.output.damaged = true;
-                    VtSignal::WebviewMount {
-                        view_id,
-                        size,
-                        instance_id,
-                        placement,
-                    }
+                    VtSignal::WebviewMount { instance, size }
+                } else {
+                    VtSignal::WebviewMountRejected { instance }
                 }
-                None => VtSignal::WebviewMountRejected {
-                    view_id,
-                    instance_id,
-                },
-            },
-            WebviewApcRequest::Unmount {
-                view_id,
-                instance_id,
-            } => {
-                self.output.damaged |= self
-                    .device
-                    .unmount_placement(view_id.as_deref(), instance_id.as_deref());
-                VtSignal::WebviewUnmount {
-                    view_id,
-                    instance_id,
-                }
+            }
+            WebviewApcRequest::Unmount { instance } => {
+                self.output.damaged |= self.device.unmount_placement(instance);
+                VtSignal::WebviewUnmount { instance }
             }
         };
         self.signal(signal);

--- a/crates/orzma_vt/src/interpreter/apc.rs
+++ b/crates/orzma_vt/src/interpreter/apc.rs
@@ -151,8 +151,6 @@ mod tests {
             instance: ID.parse().expect("the fixture is a valid id"),
             size: PlacementSize { rows: 24, cols: 80 },
         };
-        // NOTE: WebviewApcRequest is Clone but not Copy, so each comparison
-        // needs its own value.
         assert_eq!(
             parse(&format!("Omount;n={ID},r=24,c=80")),
             Some(expected.clone())
@@ -173,10 +171,6 @@ mod tests {
         assert_eq!(parse(&format!("Omount;v=abc,n={ID},r=24,c=80")), None);
         assert_eq!(parse("Omount;v=abc,r=24,c=80"), None);
     }
-
-    // NOTE: use a plain string literal wherever there is no interpolation —
-    // `format!` with no placeholder trips clippy::useless_format under
-    // `-D warnings`.
 
     /// Asserts that a mount whose instance is not exactly 32 lowercase
     /// hex digits is malformed, and that a repeated key is too.

--- a/crates/orzma_vt/src/interpreter/apc.rs
+++ b/crates/orzma_vt/src/interpreter/apc.rs
@@ -6,34 +6,25 @@
 //! `VtSignal::WebviewMount` or `VtSignal::WebviewMountRejected` — is the
 //! dispatcher's job, which is why this module needs no device state.
 
-use crate::placement::PlacementSize;
+use crate::placement::{InstanceId, PlacementSize};
 use std::str;
 
 /// What an orzma APC payload asked for: an inline mount or unmount of a
-/// registered view.
+/// registered webview instance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WebviewApcRequest {
     /// Mount a registered webview INLINE at the cursor anchor, sized in cells.
     Mount {
-        /// The registered view's id, addressed later by unmount and eviction.
-        view_id: String,
+        /// The host-minted instance this mount registers.
+        instance: InstanceId,
         /// The cell rectangle the mount reserves.
         size: PlacementSize,
-        /// Client-assigned instance id (Kitty placement model); `None` is the
-        /// implicit default instance. `(view_id, instance_id)` is the address.
-        instance_id: Option<String>,
     },
-    /// Unmount webview(s): a specific `(view_id, instance_id)`, all
-    /// instances of a `view_id`, or all for this terminal.
-    ///
-    /// # Invariants
-    /// `view_id == None` implies `instance_id == None` (an instance is
-    /// addressable only alongside its view id; enforced at the capture stage).
+    /// Unmount one instance, or — with no params section — every
+    /// placement on this terminal.
     Unmount {
-        /// The view to unmount; `None` unmounts every view for this terminal.
-        view_id: Option<String>,
-        /// The instance to unmount; `None` unmounts every instance of `view_id`.
-        instance_id: Option<String>,
+        /// The instance to unmount; `None` unmounts every placement.
+        instance: Option<InstanceId>,
     },
 }
 
@@ -63,7 +54,6 @@ impl WebviewApcRequest {
     }
 }
 
-const MAX_VIEW_ID: usize = 128;
 /// Upper bound on a mount's reserved rows. With the ~2:1 terminal cell
 /// aspect and DPR 2, a 200-row x 400-col mount is a near-square pixel
 /// region staying under the common 8192 px GPU texture dimension limit.
@@ -76,10 +66,9 @@ const ORZMA_APC_PREFIX: &[u8; 1] = b"O";
 
 fn parse_mount_action(payload: &str) -> Option<WebviewApcRequest> {
     let fields = payload.split(',');
-    let mut view_id = None;
+    let mut instance = None;
     let mut rows = None;
     let mut cols = None;
-    let mut instance_id = None;
     for f in fields {
         let mut params = f.split('=');
         let k = params.next()?;
@@ -102,221 +91,135 @@ fn parse_mount_action(payload: &str) -> Option<WebviewApcRequest> {
                 }
                 rows.replace(r);
             }
-            "v" if view_id.is_none() => {
-                let v = v.parse::<String>().ok()?;
-                if !valid_view_id(&v) {
-                    return None;
-                }
-                view_id.replace(v);
-            }
-            "n" if instance_id.is_none() => {
-                let v = v.parse::<String>().ok()?;
-                if !valid_view_id(&v) {
-                    return None;
-                }
-                instance_id.replace(v);
+            "n" if instance.is_none() => {
+                instance.replace(v.parse::<InstanceId>().ok()?);
             }
             _ => return None,
         }
     }
     Some(WebviewApcRequest::Mount {
+        instance: instance?,
         size: PlacementSize {
             rows: rows?,
             cols: cols?,
         },
-        view_id: view_id?,
-        instance_id,
     })
 }
 
 fn parse_unmount_action(payload: Option<&str>) -> Option<WebviewApcRequest> {
-    let mut view_id = None;
-    let mut instance_id = None;
-    if let Some(payload) = payload {
-        for f in payload.split(',') {
-            let mut p = f.split('=');
-            let k = p.next()?;
-            let v = p.next()?;
-            if p.next().is_some() {
-                return None;
+    let Some(payload) = payload else {
+        return Some(WebviewApcRequest::Unmount { instance: None });
+    };
+    let mut instance = None;
+    for f in payload.split(',') {
+        let mut p = f.split('=');
+        let k = p.next()?;
+        let v = p.next()?;
+        if p.next().is_some() {
+            return None;
+        }
+        match k {
+            "n" if instance.is_none() => {
+                instance.replace(v.parse::<InstanceId>().ok()?);
             }
-            match k {
-                "v" if view_id.is_none() => {
-                    if !valid_view_id(v) {
-                        return None;
-                    }
-                    view_id.replace(v.to_string());
-                }
-                "n" if instance_id.is_none() & view_id.is_some() => {
-                    if !valid_view_id(v) {
-                        return None;
-                    }
-                    instance_id.replace(v.to_string());
-                }
-                _ => return None,
-            }
+            _ => return None,
         }
     }
     Some(WebviewApcRequest::Unmount {
-        view_id,
-        instance_id,
+        instance: Some(instance?),
     })
-}
-
-fn valid_view_id(view_id: &str) -> bool {
-    if view_id.is_empty() || MAX_VIEW_ID < view_id.len() {
-        return false;
-    }
-    // NOTE: The accepted set must stay the documented view-id charset
-    // `[A-Za-z0-9._-]` (docs/orzma_webview_protocol.md): the control
-    // plane's mint_id() guarantees its base32 handles (`a-z2-7`) are
-    // valid view ids, so narrowing this — e.g. to alphabetic only —
-    // rejects nearly every minted handle.
-    view_id
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const ID: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+
     fn parse(payload: &str) -> Option<WebviewApcRequest> {
         WebviewApcRequest::parse(payload.as_bytes())
     }
 
-    #[test]
-    fn mount_parses_required_keys() {
-        assert_eq!(
-            parse("Omount;v=memo,r=3,c=20"),
-            Some(WebviewApcRequest::Mount {
-                view_id: "memo".into(),
-                size: PlacementSize { rows: 3, cols: 20 },
-                instance_id: None,
-            })
-        );
-    }
-
-    #[test]
-    fn mount_parses_instance_id() {
-        assert_eq!(
-            parse("Omount;v=memo,r=3,c=20,n=a"),
-            Some(WebviewApcRequest::Mount {
-                view_id: "memo".into(),
-                size: PlacementSize { rows: 3, cols: 20 },
-                instance_id: Some("a".into()),
-            })
-        );
-    }
-
-    #[test]
-    fn mount_keys_are_order_independent() {
-        let expected = Some(WebviewApcRequest::Mount {
-            view_id: "memo".into(),
-            size: PlacementSize { rows: 3, cols: 20 },
-            instance_id: None,
-        });
-        for payload in ["Omount;c=20,r=3,v=memo", "Omount;r=3,v=memo,c=20"] {
-            assert_eq!(parse(payload), expected, "payload={payload}");
-        }
-    }
-
-    /// Asserts that every character class of the documented view-id
-    /// charset `[A-Za-z0-9._-]` is accepted.
+    /// Asserts that a mount parses from the `n` / `r` / `c` trio in any
+    /// order and rejects a payload that omits any of them.
     ///
-    /// The control plane mints lowercase base32 handles from `a-z2-7`
-    /// and guarantees they are valid view ids, so the parser must not
-    /// be stricter than the documented charset.
+    /// Case: a program reserves a 24x80 rectangle for an instance the
+    /// control plane just handed it.
+    #[test]
+    fn a_mount_parses_its_three_required_keys_in_any_order() {
+        let expected = WebviewApcRequest::Mount {
+            instance: ID.parse().expect("the fixture is a valid id"),
+            size: PlacementSize { rows: 24, cols: 80 },
+        };
+        // NOTE: WebviewApcRequest is Clone but not Copy, so each comparison
+        // needs its own value.
+        assert_eq!(
+            parse(&format!("Omount;n={ID},r=24,c=80")),
+            Some(expected.clone())
+        );
+        assert_eq!(parse(&format!("Omount;c=80,n={ID},r=24")), Some(expected));
+        assert_eq!(parse("Omount;r=24,c=80"), None);
+        assert_eq!(parse(&format!("Omount;n={ID},c=80")), None);
+        assert_eq!(parse(&format!("Omount;n={ID},r=24")), None);
+    }
+
+    /// Asserts that a mount naming the retired `v=` key is malformed
+    /// rather than silently ignoring the key.
     ///
-    /// Case: a program mounts the handle the control socket handed it,
-    /// digits and all.
+    /// Case: a program built against the previous protocol writes the
+    /// handle-addressed form.
     #[test]
-    fn view_id_accepts_the_documented_charset() {
-        for id in ["mfrgg2lt2y", "DYN1", "my-view", "a.b_c"] {
-            assert_eq!(
-                parse(&format!("Omount;v={id},r=3,c=20")),
-                Some(WebviewApcRequest::Mount {
-                    view_id: id.into(),
-                    size: PlacementSize { rows: 3, cols: 20 },
-                    instance_id: None,
-                }),
-                "id={id}"
-            );
-        }
+    fn a_mount_naming_the_retired_view_key_is_malformed() {
+        assert_eq!(parse(&format!("Omount;v=abc,n={ID},r=24,c=80")), None);
+        assert_eq!(parse("Omount;v=abc,r=24,c=80"), None);
     }
 
+    // NOTE: use a plain string literal wherever there is no interpolation —
+    // `format!` with no placeholder trips clippy::useless_format under
+    // `-D warnings`.
+
+    /// Asserts that a mount whose instance is not exactly 32 lowercase
+    /// hex digits is malformed, and that a repeated key is too.
+    ///
+    /// Case: a program fabricates an instance id instead of using the one
+    /// the control plane minted.
     #[test]
-    fn view_id_length_boundary() {
-        let max = "x".repeat(MAX_VIEW_ID);
+    fn a_mount_with_a_malformed_instance_or_a_repeated_key_is_rejected() {
+        assert_eq!(parse("Omount;n=abc,r=24,c=80"), None);
         assert_eq!(
-            parse(&format!("Omount;v={max},r=3,c=20")),
-            Some(WebviewApcRequest::Mount {
-                view_id: max.clone(),
-                size: PlacementSize { rows: 3, cols: 20 },
-                instance_id: None,
-            }),
-            "a view id of exactly MAX_VIEW_ID chars is the accepted maximum"
+            parse(&format!("Omount;n={},r=24,c=80", ID.to_uppercase())),
+            None
         );
-        let over = "x".repeat(MAX_VIEW_ID + 1);
-        assert_eq!(
-            parse(&format!("Omount;v={over},r=3,c=20")),
-            None,
-            "a view id beyond MAX_VIEW_ID chars is rejected"
-        );
+        assert_eq!(parse(&format!("Omount;n={ID},n={ID},r=24,c=80")), None);
     }
 
+    /// Asserts that an unmount takes the instance key alone, in any
+    /// position, and that an empty params section stays malformed.
+    ///
+    /// Case: a program tears one placement down and later asks the
+    /// terminal to drop every placement it still holds.
     #[test]
-    fn unmount_without_target_is_unmount_all() {
+    fn an_unmount_addresses_one_instance_or_all() {
+        let one = WebviewApcRequest::Unmount {
+            instance: Some(ID.parse().expect("the fixture is a valid id")),
+        };
+        assert_eq!(parse(&format!("Ounmount;n={ID}")), Some(one));
         assert_eq!(
             parse("Ounmount"),
-            Some(WebviewApcRequest::Unmount {
-                view_id: None,
-                instance_id: None,
-            })
+            Some(WebviewApcRequest::Unmount { instance: None })
         );
-    }
-
-    #[test]
-    fn unmount_view_only() {
-        assert_eq!(
-            parse("Ounmount;v=memo"),
-            Some(WebviewApcRequest::Unmount {
-                view_id: Some("memo".into()),
-                instance_id: None,
-            })
-        );
-    }
-
-    #[test]
-    fn unmount_view_and_instance() {
-        assert_eq!(
-            parse("Ounmount;v=memo,n=a"),
-            Some(WebviewApcRequest::Unmount {
-                view_id: Some("memo".into()),
-                instance_id: Some("a".into()),
-            })
-        );
-    }
-
-    #[test]
-    fn mount_missing_required_key_rejected() {
-        for payload in [
-            "Omount",
-            "Omount;r=3,c=20",
-            "Omount;v=memo,c=20",
-            "Omount;v=memo,r=3",
-        ] {
-            assert_eq!(parse(payload), None, "payload={payload}");
-        }
+        assert_eq!(parse("Ounmount;"), None);
+        assert_eq!(parse("Ounmount;n="), None);
+        assert_eq!(parse(&format!("Ounmount;v=abc,n={ID}")), None);
     }
 
     #[test]
     fn mount_out_of_range_dims_rejected() {
         for payload in [
-            "Omount;v=memo,r=0,c=20".to_string(),
-            format!("Omount;v=memo,r={},c=20", MAX_ROWS + 1),
-            "Omount;v=memo,r=3,c=0".to_string(),
-            format!("Omount;v=memo,r=3,c={}", MAX_COLS + 1),
+            format!("Omount;n={ID},r=0,c=20"),
+            format!("Omount;n={ID},r={},c=20", MAX_ROWS + 1),
+            format!("Omount;n={ID},r=3,c=0"),
+            format!("Omount;n={ID},r=3,c={}", MAX_COLS + 1),
         ] {
             assert_eq!(parse(&payload), None, "payload={payload}");
         }
@@ -324,30 +227,11 @@ mod tests {
 
     #[test]
     fn mount_non_digit_dims_rejected() {
-        for payload in ["Omount;v=memo,r=x,c=20", "Omount;v=memo,r=,c=20"] {
-            assert_eq!(parse(payload), None, "payload={payload}");
-        }
-    }
-
-    #[test]
-    fn bad_view_id_rejected() {
         for payload in [
-            "Omount;v=../etc/passwd,r=3,c=20",
-            "Omount;v=,r=3,c=20",
-            "Omount;v=me mo,r=3,c=20",
-            "Omount;v=me=mo,r=3,c=20",
+            format!("Omount;n={ID},r=x,c=20"),
+            format!("Omount;n={ID},r=,c=20"),
         ] {
-            assert_eq!(parse(payload), None, "payload={payload}");
-        }
-    }
-
-    #[test]
-    fn mount_bad_instance_id_rejected() {
-        for payload in [
-            "Omount;v=memo,r=3,c=20,n=",
-            "Omount;v=memo,r=3,c=20,n=../etc",
-        ] {
-            assert_eq!(parse(payload), None, "payload={payload}");
+            assert_eq!(parse(&payload), None, "payload={payload}");
         }
     }
 
@@ -364,9 +248,12 @@ mod tests {
 
     #[test]
     fn extra_section_rejected() {
-        for payload in ["Omount;v=memo,r=3,c=20;x", "Ounmount;v=memo;x"] {
+        for payload in [
+            format!("Omount;n={ID},r=3,c=20;x"),
+            format!("Ounmount;n={ID};x"),
+        ] {
             assert_eq!(
-                parse(payload),
+                parse(&payload),
                 None,
                 "a third ';' section is reserved and rejected; payload={payload}"
             );
@@ -374,89 +261,67 @@ mod tests {
     }
 
     #[test]
-    fn unmount_empty_view_value_rejected() {
-        assert_eq!(
-            parse("Ounmount;v="),
-            None,
-            "an absent v key means unmount-all; an empty value is malformed"
-        );
-    }
-
-    #[test]
-    fn unmount_instance_without_view_rejected() {
-        assert_eq!(
-            parse("Ounmount;n=a"),
-            None,
-            "an instance id is addressable only alongside a view id"
-        );
-    }
-
-    #[test]
-    fn unmount_bad_instance_rejected() {
-        assert_eq!(parse("Ounmount;v=memo,n=../x"), None);
-    }
-
-    #[test]
-    fn unmount_with_mount_only_keys_rejected() {
-        for payload in ["Ounmount;v=memo,r=3", "Ounmount;c=20"] {
-            assert_eq!(parse(payload), None, "payload={payload}");
-        }
-    }
-
-    #[test]
     fn unknown_verb_rejected() {
         for payload in [
-            "Oresize;v=memo",
-            "OMOUNT;v=memo,r=3,c=20",
-            "Om;v=memo,r=3,c=20",
+            format!("Oresize;n={ID}"),
+            format!("OMOUNT;n={ID},r=3,c=20"),
+            format!("Om;n={ID},r=3,c=20"),
         ] {
-            assert_eq!(parse(payload), None, "payload={payload}");
+            assert_eq!(parse(&payload), None, "payload={payload}");
         }
     }
 
     #[test]
     fn foreign_or_missing_prefix_rejected() {
-        for payload in ["Ga=T,f=100", "mount;v=memo,r=3,c=20", "", "O"] {
-            assert_eq!(parse(payload), None, "payload={payload:?}");
+        for payload in [
+            "Ga=T,f=100".to_string(),
+            format!("mount;n={ID},r=3,c=20"),
+            String::new(),
+            "O".to_string(),
+        ] {
+            assert_eq!(parse(&payload), None, "payload={payload:?}");
         }
     }
 
     #[test]
     fn unknown_key_rejected() {
-        assert_eq!(parse("Omount;v=memo,r=3,c=20,z=9"), None);
+        assert_eq!(parse(&format!("Omount;n={ID},r=3,c=20,z=9")), None);
     }
 
     #[test]
     fn duplicate_key_rejected() {
-        for payload in ["Omount;v=memo,v=memo,r=3,c=20", "Omount;v=a,r=3,r=4,c=20"] {
-            assert_eq!(parse(payload), None, "payload={payload}");
+        for payload in [
+            format!("Omount;n={ID},n={ID},r=3,c=20"),
+            format!("Omount;n={ID},r=3,r=4,c=20"),
+        ] {
+            assert_eq!(parse(&payload), None, "payload={payload}");
         }
     }
 
     #[test]
     fn malformed_pair_rejected() {
         for payload in [
-            "Omount;vmemo,r=3,c=20",
-            "Ounmount;v=memo,",
-            "Omount;,v=memo,r=3,c=20",
-            "Ounmount;v=memo,,n=a",
+            "Omount;vmemo,r=3,c=20".to_string(),
+            format!("Ounmount;n={ID},"),
+            format!("Omount;,n={ID},r=3,c=20"),
+            format!("Ounmount;n={ID},,n=a"),
         ] {
-            assert_eq!(parse(payload), None, "payload={payload}");
+            assert_eq!(parse(&payload), None, "payload={payload}");
         }
     }
 
     #[test]
     fn out_of_charset_bytes_rejected() {
         assert_eq!(
-            WebviewApcRequest::parse(b"Omount;v=me\x07mo,r=3,c=20"),
+            WebviewApcRequest::parse(b"Omount;n=me\x07mo,r=3,c=20"),
             None
         );
         assert_eq!(
-            WebviewApcRequest::parse(b"Omount;v=me\x1bmo,r=3,c=20"),
+            WebviewApcRequest::parse(b"Omount;n=me\x1bmo,r=3,c=20"),
             None
         );
         assert_eq!(
-            WebviewApcRequest::parse("Omount;v=めも,r=3,c=20".as_bytes()),
+            WebviewApcRequest::parse("Omount;n=めも,r=3,c=20".as_bytes()),
             None,
             "multi-byte UTF-8 is outside the APC command-string charset"
         );

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::device::color::{Color, Rgb};
 use crate::device::modes::{MouseEncoding, MouseTracking};
 use crate::frame::Frame;
-use crate::placement::{MAX_PLACEMENTS, PlacementId, PlacementSize};
+use crate::placement::{InstanceId, MAX_PLACEMENTS, PlacementSize};
 use crate::screen::cell::Cell;
 use crate::screen::grid::GridSize;
 use crate::screen::grid::coords::GridColumn;
@@ -70,11 +70,13 @@ impl Session {
     }
 
     /// Mounts a one-cell placement at the active screen's cursor.
-    fn mount(&mut self, view: &str) -> PlacementId {
-        self.0
-            .device
-            .mount_placement(PlacementSize { rows: 1, cols: 1 }, view.to_string(), None)
-            .expect("a mount under the cap is accepted")
+    fn mount(&mut self, id: InstanceId) {
+        assert!(
+            self.0
+                .device
+                .mount_placement(PlacementSize { rows: 1, cols: 1 }, id),
+            "a mount under the cap is accepted"
+        );
     }
 
     fn active_screen(&self) -> ScreenKind {

--- a/crates/orzma_vt/src/interpreter/tests/alternate_screen.rs
+++ b/crates/orzma_vt/src/interpreter/tests/alternate_screen.rs
@@ -73,10 +73,12 @@ fn a_redundant_alternate_screen_switch_does_nothing() {
 #[test]
 fn leaving_the_alternate_screen_evicts_only_its_placements() {
     let mut session = Session::new();
-    let kept = session.mount("shell");
+    let kept = InstanceId(1);
+    session.mount(kept);
     session.frame();
     session.feed(b"\x1b[?47h");
-    let dropped = session.mount("app");
+    let dropped = InstanceId(2);
+    session.mount(dropped);
     session.frame();
     let output = session.feed(b"\x1b[?47l");
     assert_eq!(
@@ -86,7 +88,7 @@ fn leaving_the_alternate_screen_evicts_only_its_placements() {
         }]
     );
     let frame = session.frame().expect("the flip back emits");
-    let listed: Vec<PlacementId> = frame
+    let listed: Vec<InstanceId> = frame
         .placements
         .expect("a placement change is listed")
         .iter()

--- a/crates/orzma_vt/src/interpreter/tests/webview_apc.rs
+++ b/crates/orzma_vt/src/interpreter/tests/webview_apc.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 
+const ID: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+
 /// Asserts that an application program command is ignored rather
 /// than fatal, and that the parser returns to ground behind it.
 ///
@@ -17,21 +19,20 @@ fn an_application_program_command_is_ignored_rather_than_fatal() {
     );
 }
 
-/// Asserts that an APC mount mints a placement and reports it with the
-/// reservation the payload asked for.
+/// Asserts that an APC mount registers a placement and reports it with
+/// the reservation the payload asked for.
 ///
-/// Case: a companion app registers a view over the control socket
+/// Case: a companion app registers an instance over the control socket
 /// and writes the mount sequence to reserve room for its page.
 #[test]
-fn an_apc_mount_reports_the_placement_it_minted() {
-    let (_device, output) = interpret_fully(b"\x1b_Omount;v=memo,r=2,c=3\x1b\\");
+fn an_apc_mount_reports_the_placement_it_registered() {
+    let id: InstanceId = ID.parse().expect("the fixture is a valid id");
+    let (_device, output) = interpret_fully(format!("\x1b_Omount;n={id},r=2,c=3\x1b\\").as_bytes());
     assert_eq!(
         output.signals,
         vec![VtSignal::WebviewMount {
-            view_id: "memo".to_owned(),
+            instance: id,
             size: PlacementSize { rows: 2, cols: 3 },
-            instance_id: None,
-            placement: PlacementId(0),
         }]
     );
 }
@@ -39,38 +40,37 @@ fn an_apc_mount_reports_the_placement_it_minted() {
 /// Asserts that an APC-mounted placement is listed in the next
 /// emitted frame.
 ///
-/// Case: a companion app mounts its view, and the host must be told
+/// Case: a companion app mounts its instance, and the host must be told
 /// where to draw the webview on the frame that follows.
 #[test]
 fn an_apc_mount_reaches_the_next_frame() {
+    let id: InstanceId = ID.parse().expect("the fixture is a valid id");
     let mut session = Session::new();
-    session.feed(b"\x1b_Omount;v=memo,r=2,c=3\x1b\\");
+    session.feed(format!("\x1b_Omount;n={id},r=2,c=3\x1b\\").as_bytes());
     let frame = session.frame().expect("a mount emits");
-    let listed: Vec<PlacementId> = frame
+    let listed: Vec<InstanceId> = frame
         .placements
         .expect("a placement change is listed")
         .iter()
         .map(|placement| placement.id)
         .collect();
-    assert_eq!(listed, vec![PlacementId(0)]);
+    assert_eq!(listed, vec![id]);
 }
 
-/// Asserts that an APC unmount reports the address it named and drops
-/// the mounted view from the next frame.
+/// Asserts that an APC unmount reports the instance it named and drops
+/// the mounted placement from the next frame.
 ///
-/// Case: a companion app tears its view down on the way out.
+/// Case: a companion app tears its instance down on the way out.
 #[test]
 fn an_apc_unmount_reports_the_address_it_named() {
+    let id: InstanceId = ID.parse().expect("the fixture is a valid id");
     let mut session = Session::new();
-    session.feed(b"\x1b_Omount;v=memo,r=2,c=3\x1b\\");
+    session.feed(format!("\x1b_Omount;n={id},r=2,c=3\x1b\\").as_bytes());
     session.frame();
-    let output = session.feed(b"\x1b_Ounmount;v=memo\x1b\\");
+    let output = session.feed(format!("\x1b_Ounmount;n={id}\x1b\\").as_bytes());
     assert_eq!(
         output.signals,
-        vec![VtSignal::WebviewUnmount {
-            view_id: Some("memo".to_owned()),
-            instance_id: None,
-        }]
+        vec![VtSignal::WebviewUnmount { instance: Some(id) }]
     );
     let frame = session.frame().expect("the unmount emits");
     assert_eq!(frame.placements, Some(vec![]));
@@ -88,44 +88,44 @@ fn a_foreign_apc_payload_raises_no_signal() {
 }
 
 /// Asserts that a mount past the per-terminal cap is reported as a
-/// rejection naming the address it refused, rather than as a mount.
+/// rejection naming the instance it refused, rather than as a mount.
 ///
-/// Case: a program mounts more views than the terminal has overlay
+/// Case: a program mounts more instances than the terminal has overlay
 /// slots for.
 #[test]
 fn an_apc_mount_past_the_cap_is_rejected() {
     let mut session = Session::new();
-    for i in 0..MAX_PLACEMENTS {
-        session.mount(&format!("v{i}"));
+    for i in 0..MAX_PLACEMENTS as u128 {
+        session.mount(InstanceId(i));
     }
-    let output = session.feed(b"\x1b_Omount;v=over,r=1,c=1\x1b\\");
+    let over: InstanceId = ID.parse().expect("the fixture is a valid id");
+    let output = session.feed(format!("\x1b_Omount;n={over},r=1,c=1\x1b\\").as_bytes());
     assert_eq!(
         output.signals,
-        vec![VtSignal::WebviewMountRejected {
-            view_id: "over".to_owned(),
-            instance_id: None,
-        }]
+        vec![VtSignal::WebviewMountRejected { instance: over }]
     );
 }
 
 /// Asserts that an accepted mount raises the chunk liveness.
 ///
-/// Case: a companion app mounts its view in the very first chunk the
-/// terminal ever interprets, with no other output alongside it.
+/// Case: a companion app mounts its instance in the very first chunk
+/// the terminal ever interprets, with no other output alongside it.
 #[test]
 fn an_accepted_mount_raises_the_chunk_liveness() {
-    assert!(damage_of(b"\x1b_Omount;v=memo,r=2,c=3\x1b\\"));
+    assert!(damage_of(
+        format!("\x1b_Omount;n={ID},r=2,c=3\x1b\\").as_bytes()
+    ));
 }
 
 /// Asserts that a hit unmount raises the chunk liveness.
 ///
-/// Case: a companion app tears its view down in a chunk that carries no
-/// other terminal output.
+/// Case: a companion app tears its instance down in a chunk that
+/// carries no other terminal output.
 #[test]
 fn a_hit_unmount_raises_the_chunk_liveness() {
     assert!(liveness_after(
-        b"\x1b_Omount;v=memo,r=2,c=3\x1b\\",
-        b"\x1b_Ounmount;v=memo\x1b\\"
+        format!("\x1b_Omount;n={ID},r=2,c=3\x1b\\").as_bytes(),
+        format!("\x1b_Ounmount;n={ID}\x1b\\").as_bytes()
     ));
 }
 
@@ -137,9 +137,34 @@ fn a_hit_unmount_raises_the_chunk_liveness() {
 #[test]
 fn a_capped_mount_does_not_raise_the_chunk_liveness() {
     let mut session = Session::new();
-    for i in 0..MAX_PLACEMENTS {
-        session.mount(&format!("v{i}"));
+    for i in 0..MAX_PLACEMENTS as u128 {
+        session.mount(InstanceId(i));
     }
-    let output = session.feed(b"\x1b_Omount;v=over,r=1,c=1\x1b\\");
+    let output = session.feed(format!("\x1b_Omount;n={ID},r=1,c=1\x1b\\").as_bytes());
     assert!(!output.damaged);
+}
+
+/// Asserts that a re-mount of a live instance keeps the id and reports
+/// the new reservation, rather than minting a successor id.
+///
+/// Case: a program redraws the same view one row shorter after the
+/// surrounding layout changed.
+#[test]
+fn a_remount_of_a_live_instance_keeps_its_id() {
+    let id: InstanceId = ID.parse().expect("the fixture is a valid id");
+    let mut vt = OrzmaVt::new(GridSize { cols: 80, rows: 24 }, 100);
+    vt.interpret(format!("\x1b_Omount;n={id},r=10,c=40\x1b\\").as_bytes());
+    let out = vt.interpret(format!("\x1b_Omount;n={id},r=9,c=40\x1b\\").as_bytes());
+    assert_eq!(
+        out.signals,
+        vec![VtSignal::WebviewMount {
+            instance: id,
+            size: PlacementSize { rows: 9, cols: 40 },
+        }]
+    );
+    let frame = vt.frame().expect("the remount damages the chunk");
+    let placements = frame.placements.expect("the list changed");
+    assert_eq!(placements.len(), 1);
+    assert_eq!(placements[0].id, id);
+    assert_eq!(placements[0].size, PlacementSize { rows: 9, cols: 40 });
 }

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -9,7 +9,7 @@ use crate::{
     device::modes::VtModes,
     frame::{Frame, FrameTracker},
     interpreter::Interpreter,
-    placement::{PlacementId, PlacementSize},
+    placement::{InstanceId, PlacementSize},
     screen::grid::GridSize,
     screen::viewport::{DisplayOffset, Scroll},
 };
@@ -75,8 +75,8 @@ pub trait Vt {
     /// # Webview placements
     ///
     /// An APC webview `mount` the VT accepts becomes a
-    /// [`VtSignal::WebviewMount`] carrying the [`PlacementId`] the VT
-    /// minted for it; one the placement cap refuses becomes a
+    /// [`VtSignal::WebviewMount`] carrying the [`InstanceId`] the mount
+    /// named; one the placement cap refuses becomes a
     /// [`VtSignal::WebviewMountRejected`] instead, which registers
     /// nothing. The VT owns the placement table and projects every
     /// placement into [`Frame::placements`] on each emit; a mount, unmount,
@@ -84,7 +84,7 @@ pub trait Vt {
     /// liveness, so the frame carrying the new list is guaranteed to
     /// follow. Evictions the VT performs on its own authority (history
     /// trim, alternate-screen teardown) surface as
-    /// [`VtSignal::WebviewEvicted`]. Ids are never reused within a session.
+    /// [`VtSignal::WebviewEvicted`]. At any instant the live ids are unique.
     ///
     /// A placement projects only while the screen it was mounted on is
     /// active: while the alternate screen is shown, primary-screen
@@ -92,9 +92,8 @@ pub trait Vt {
     /// evicted). Returning to the primary screen tears the alternate
     /// screen's placements down instead, naming them in that chunk's
     /// [`VtSignal::WebviewEvicted`]. A re-issued `mount` for a live
-    /// `(view_id, instance)` registers a successor under a fresh id;
-    /// the superseded id simply stops being listed and is never named
-    /// by [`VtSignal::WebviewEvicted`].
+    /// instance updates that placement in place — the id does not
+    /// change, and nothing is named by [`VtSignal::WebviewEvicted`].
     fn interpret(&mut self, chunk: &[u8]) -> InterpretOutput;
 
     /// Builds the frame for the staged damage and section diffs,
@@ -205,43 +204,33 @@ pub enum VtSignal {
     /// A webview the PTY mounted inline, which the VT accepted and
     /// registered at the cursor anchor.
     WebviewMount {
-        /// The registered view's id, addressed later by unmount and eviction.
-        view_id: String,
+        /// The host-minted instance this mount registered.
+        instance: InstanceId,
         /// The cell rectangle the mount reserved.
         size: PlacementSize,
-        /// The client-assigned instance id; `None` is the implicit
-        /// default instance. `(view_id, instance_id)` is the address.
-        instance_id: Option<String>,
-        /// The id the VT minted for this placement.
-        placement: PlacementId,
     },
     /// A mount the VT refused because the per-terminal placement cap was
-    /// already full. Nothing was registered and no id was minted, so
-    /// there is nothing for the consumer to place; it exists so a
-    /// webview that never appears is diagnosable rather than silent.
+    /// already full. Nothing was registered, so there is nothing for the
+    /// consumer to place; it exists so a webview that never appears is
+    /// diagnosable rather than silent.
     WebviewMountRejected {
-        /// The view the refused mount named.
-        view_id: String,
         /// The instance the refused mount named.
-        instance_id: Option<String>,
+        instance: InstanceId,
     },
-    /// Webview placements the PTY unmounted: a specific
-    /// `(view_id, instance_id)`, every instance of a `view_id`, or —
-    /// when `view_id` is `None` — every placement on this terminal.
+    /// The placement the PTY unmounted, or — when `instance` is `None` —
+    /// every placement on this terminal.
     WebviewUnmount {
-        /// The view to unmount; `None` unmounts every view.
-        view_id: Option<String>,
-        /// The instance to unmount; `None` unmounts every instance.
-        instance_id: Option<String>,
+        /// The instance to unmount; `None` unmounts every placement.
+        instance: Option<InstanceId>,
     },
     /// Placements the VT evicted on its own authority (history trim,
     /// alternate-screen teardown). Consumers despawn them by id;
     /// unknown ids are ignored. A remount's superseded id is never
-    /// named here — supersession shows only as the id vanishing from
+    /// named here — supersession shows only as the geometry changing in
     /// the frame-carried placement lists.
     WebviewEvicted {
-        /// The placement IDs that were evicted.
-        placements: Vec<PlacementId>,
+        /// The instances that were evicted.
+        placements: Vec<InstanceId>,
     },
     /// Tracked `TermMode` flags that transitioned since the previous
     /// signal drain, as mode names (e.g. "alt-screen").
@@ -257,7 +246,7 @@ impl VtSignal {
     /// The eviction naming `placements`; `None` when there is nothing
     /// to name, so neither an empty sweep nor a flip that tore nothing
     /// down wakes the owner.
-    pub(crate) fn evicted(placements: Vec<PlacementId>) -> Option<Self> {
+    pub(crate) fn evicted(placements: Vec<InstanceId>) -> Option<Self> {
         (!placements.is_empty()).then_some(Self::WebviewEvicted { placements })
     }
 }
@@ -342,7 +331,7 @@ impl Vt for OrzmaVt {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::placement::PlacementSize;
+    use crate::placement::{InstanceId, PlacementSize};
     use crate::screen::grid::coords::GridLine;
     use crate::screen::viewport::ViewportLine;
 
@@ -368,10 +357,11 @@ mod tests {
     #[test]
     fn a_sweep_after_a_reset_names_the_stranded_placements() {
         let mut vt = vt();
-        let id = vt
-            .device
-            .mount_placement(PlacementSize { rows: 1, cols: 1 }, "v".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        let id = InstanceId(1);
+        assert!(
+            vt.device
+                .mount_placement(PlacementSize { rows: 1, cols: 1 }, id)
+        );
         vt.device.reset();
         assert_eq!(
             vt.sweep_evictions(),
@@ -390,10 +380,11 @@ mod tests {
     #[test]
     fn a_sweep_after_a_shrink_names_the_placement_it_stranded() {
         let mut vt = OrzmaVt::new(GridSize { cols: 4, rows: 4 }, 0);
-        let id = vt
-            .device
-            .mount_placement(PlacementSize { rows: 1, cols: 1 }, "v".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        let id = InstanceId(1);
+        assert!(
+            vt.device
+                .mount_placement(PlacementSize { rows: 1, cols: 1 }, id)
+        );
         vt.device.active_screen_mut().move_cursor_to(Some(4), None);
         assert!(vt.resize(GridSize { cols: 4, rows: 2 }));
         assert_eq!(
@@ -412,9 +403,10 @@ mod tests {
     #[test]
     fn a_second_sweep_raises_nothing() {
         let mut vt = vt();
-        vt.device
-            .mount_placement(PlacementSize { rows: 1, cols: 1 }, "v".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        assert!(
+            vt.device
+                .mount_placement(PlacementSize { rows: 1, cols: 1 }, InstanceId(1))
+        );
         vt.device.reset();
         assert_eq!(vt.sweep_evictions().len(), 1);
         assert!(vt.sweep_evictions().is_empty());
@@ -490,9 +482,10 @@ mod tests {
     fn a_screen_flip_replays_the_placement_list() {
         let mut vt = vt();
         vt.frame();
-        vt.device
-            .mount_placement(PlacementSize { rows: 2, cols: 4 }, "memo".to_string(), None)
-            .expect("a mount under the cap is accepted");
+        assert!(
+            vt.device
+                .mount_placement(PlacementSize { rows: 2, cols: 4 }, InstanceId(1))
+        );
         let mounted = vt.frame().expect("a placement change emits");
         assert_eq!(mounted.placements.as_ref().map(Vec::len), Some(1));
 

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -34,7 +34,7 @@ pub mod prelude {
     pub use crate::device::modes::{KeypadMode, MouseEncoding, MouseTracking, ScreenKind, VtModes};
     pub use crate::frame::{DirtyRow, Frame};
     pub use crate::hyperlink::{Hyperlink, HyperlinkId, HyperlinkUri, is_allowed};
-    pub use crate::placement::{AnchoredPlacement, PlacementId, PlacementSize};
+    pub use crate::placement::{AnchoredPlacement, InstanceId, PlacementSize};
     pub use crate::screen::cursor::{CURSOR_VISIBLE_BIT, Cursor, CursorShape};
     pub use crate::screen::grid::GridSize;
     pub use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -127,6 +127,27 @@ pub trait Vt {
     /// second sweep with nothing further lost raises nothing.
     fn sweep_evictions(&mut self) -> Vec<VtSignal>;
 
+    /// Removes the placements the host names, on either screen; returns
+    /// whether anything went.
+    ///
+    /// This is the control plane's entry point, used when a registration
+    /// is released, its connection drops, or a mount the host refuses
+    /// left a reservation behind. The VT cannot know any of those facts —
+    /// they live on the control socket — so without this the placements
+    /// keep a cap slot until their anchor scrolls out of history.
+    ///
+    /// # Invariants
+    ///
+    /// Unlike [`Vt::resize`], this stages no row damage. A placement list
+    /// is an emit-time diffed section, so a changed list is enough to
+    /// guarantee the frame that carries it; staging rows here would
+    /// repaint the whole viewport on every release.
+    ///
+    /// No [`VtSignal::WebviewEvicted`] is raised: the caller already
+    /// knows the ids and drops its own entities in the same pass, so a
+    /// signal would hand it back its own removal.
+    fn remove_placements(&mut self, instances: &[InstanceId]) -> bool;
+
     /// Resizes the grid, truncating rather than reflowing; returns
     /// whether the dimensions changed. Only a real change stages (full)
     /// damage.
@@ -305,6 +326,10 @@ impl Vt for OrzmaVt {
         VtSignal::evicted(self.device.evict_lost_anchors())
             .into_iter()
             .collect()
+    }
+
+    fn remove_placements(&mut self, instances: &[InstanceId]) -> bool {
+        self.device.remove_placements(instances)
     }
 
     fn resize(&mut self, size: GridSize) -> bool {
@@ -539,5 +564,38 @@ mod tests {
         let returned = vt.frame().expect("the flip back emits");
         assert_eq!(returned.rows[4].contents[0].text, "5   ");
         assert_eq!(returned.cursor.point.line, GridLine(4));
+    }
+
+    /// Asserts that a host-driven removal drops the named placements,
+    /// reports whether anything went, and — unlike a resize — stages no
+    /// row damage of its own.
+    ///
+    /// Case: a program's control-plane connection drops while two of its
+    /// views are mounted, and the host clears what the registrations had
+    /// reserved.
+    #[test]
+    fn a_host_removal_drops_the_named_placements_without_staging_rows() {
+        let a: InstanceId = "3f5a9c02d1e84b7690ab3cde12f45678"
+            .parse()
+            .expect("valid id");
+        let b: InstanceId = "81b4e77c05a3492fd6180e29ba735fc1"
+            .parse()
+            .expect("valid id");
+        let mut vt = OrzmaVt::new(GridSize { cols: 80, rows: 24 }, 100);
+        vt.interpret(format!("\x1b_Omount;n={a},r=4,c=8\x1b\\").as_bytes());
+        vt.interpret(format!("\x1b_Omount;n={b},r=4,c=8\x1b\\").as_bytes());
+        vt.frame().expect("the mounts damage the chunk");
+
+        assert!(vt.remove_placements(&[a]));
+        let frame = vt.frame().expect("the placement list changed");
+        assert!(frame.rows.is_empty(), "a removal stages no row damage");
+        let placements = frame.placements.expect("the list changed");
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].id, b);
+
+        assert!(
+            !vt.remove_placements(&[a]),
+            "a second removal names nothing"
+        );
     }
 }

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -9,16 +9,6 @@ use crate::screen::grid::coords::GridPoint;
 use std::fmt;
 use std::str::FromStr;
 
-/// VT-assigned identity of one mounted webview placement.
-///
-/// # Invariants
-///
-/// Ids are minted monotonically per terminal and never reused within a
-/// session, so a delayed id-addressed lifecycle event can never target
-/// a successor placement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PlacementId(pub u64);
-
 /// Host-minted identity of one webview placement.
 ///
 /// The control plane mints it and hands it to the registering program
@@ -31,17 +21,11 @@ pub struct PlacementId(pub u64);
 /// its spelling are in bijection. At any instant the live ids on one
 /// terminal are unique: `supersede` drops the existing entry for an id
 /// across both screens before a re-mount registers its successor.
-// NOTE: InstanceId and InstanceIdParseError are public API added in Task 1
-// but not yet used by the prelude or any non-test code; Task 2 will add
-// them to the prelude and integrate them into the mount handler. Until
-// then, this module is private, so the suppression is transient.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
 pub struct InstanceId(pub u128);
 
 /// The reason a wire spelling is not a valid [`InstanceId`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
 pub struct InstanceIdParseError;
 
 impl FromStr for InstanceId {
@@ -82,9 +66,6 @@ impl fmt::Debug for InstanceId {
 
 impl InstanceId {
     /// Digits in this id's wire spelling.
-    // NOTE: WIRE_DIGITS is unused outside of tests until Task 2 wires the
-    // parser and adds this type to the prelude, making the suppression transient.
-    #[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
     pub const WIRE_DIGITS: usize = 32;
 
     /// Builds an id from 16 bytes of caller-supplied entropy.
@@ -92,11 +73,6 @@ impl InstanceId {
     /// The randomness stays with the caller: the control plane mints
     /// ids, and putting a self-seeding constructor here would leave a
     /// way for the VT to start minting again.
-    // NOTE: from_bytes is public API added for the control plane but is
-    // not called in any code path yet, not even in tests, so the lint
-    // expectation is correctly fulfilled. Task 2 will wire the mount
-    // handler that calls this.
-    #[expect(dead_code, reason = "public API not yet integrated; called in Task 2")]
     pub fn from_bytes(bytes: [u8; 16]) -> Self {
         Self(u128::from_be_bytes(bytes))
     }
@@ -110,12 +86,14 @@ impl InstanceId {
 ///
 /// # Invariants
 ///
-/// `size` always equals the mount-time reservation for `id`; the VT
-/// treats a size change as a remount under a fresh id.
+/// `size` is the reservation the most recent mount for `id` made. A
+/// re-mount of a live id keeps the id and may change the size, so the
+/// consumer re-reads `size` from every frame rather than caching it
+/// against the id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchoredPlacement {
     /// The placement this geometry belongs to.
-    pub id: PlacementId,
+    pub id: InstanceId,
     /// Active-grid cell the rect's top-left corner sits at.
     pub point: GridPoint,
     /// The rect's extent, unchanged from the mount that reserved it.

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -82,6 +82,8 @@ impl fmt::Debug for InstanceId {
 
 impl InstanceId {
     /// Digits in this id's wire spelling.
+    // NOTE: WIRE_DIGITS is unused outside of tests until Task 2 wires the
+    // parser and adds this type to the prelude, making the suppression transient.
     #[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
     pub const WIRE_DIGITS: usize = 32;
 

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -6,6 +6,8 @@
 //! [`crate::screen::placements`].
 
 use crate::screen::grid::coords::GridPoint;
+use std::fmt;
+use std::str::FromStr;
 
 /// VT-assigned identity of one mounted webview placement.
 ///
@@ -16,6 +18,79 @@ use crate::screen::grid::coords::GridPoint;
 /// a successor placement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PlacementId(pub u64);
+
+/// Host-minted identity of one webview placement.
+///
+/// The control plane mints it and hands it to the registering program
+/// before that program writes its mount, so the program can address the
+/// placement it is about to create. The VT never mints one.
+///
+/// # Invariants
+///
+/// The wire spelling is exactly 32 lowercase hex digits, so a value and
+/// its spelling are in bijection. At any instant the live ids on one
+/// terminal are unique: `supersede` drops the existing entry for an id
+/// across both screens before a re-mount registers its successor.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(dead_code)]
+pub struct InstanceId(pub u128);
+
+/// The reason a wire spelling is not a valid [`InstanceId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct InstanceIdParseError;
+
+impl FromStr for InstanceId {
+    type Err = InstanceIdParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // NOTE: the length and charset are checked here rather than left
+        // to `from_str_radix`, which also accepts uppercase digits and a
+        // leading `+`; either would give one placement two spellings.
+        if s.len() != Self::WIRE_DIGITS
+            || !s
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(InstanceIdParseError);
+        }
+        u128::from_str_radix(s, 16)
+            .map(Self)
+            .map_err(|_| InstanceIdParseError)
+    }
+}
+
+impl fmt::Display for InstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: the width comes from WIRE_DIGITS so the parser and the
+        // renderer cannot drift apart.
+        write!(f, "{:0width$x}", self.0, width = Self::WIRE_DIGITS)
+    }
+}
+
+impl fmt::Debug for InstanceId {
+    // NOTE: derived Debug would print decimal, so every tracing line and
+    // every signal dump would disagree with the 32-hex wire spelling.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InstanceId({self})")
+    }
+}
+
+impl InstanceId {
+    /// Digits in this id's wire spelling.
+    #[allow(dead_code)]
+    pub const WIRE_DIGITS: usize = 32;
+
+    /// Builds an id from 16 bytes of caller-supplied entropy.
+    ///
+    /// The randomness stays with the caller: the control plane mints
+    /// ids, and putting a self-seeding constructor here would leave a
+    /// way for the VT to start minting again.
+    #[allow(dead_code)]
+    pub fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(u128::from_be_bytes(bytes))
+    }
+}
 
 /// One placement's grid-space geometry at emit time.
 ///
@@ -57,3 +132,74 @@ pub struct PlacementSize {
 /// the host allocates slots per terminal among live children, while this
 /// cap counts both screens, so it is strictly the stricter of the two.
 pub const MAX_PLACEMENTS: usize = 12;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts that a wire spelling parses only as exactly 32 lowercase
+    /// hex digits, rejecting the shorter, longer, uppercase, and
+    /// sign-prefixed forms `u128::from_str_radix` would otherwise accept.
+    ///
+    /// Case: a program writes an instance id into a mount APC, and the
+    /// terminal must decide whether the field is well-formed before it
+    /// reserves a rectangle for it.
+    #[test]
+    fn an_instance_id_parses_only_from_32_lowercase_hex_digits() {
+        let canonical = "3f5a9c02d1e84b7690ab3cde12f45678";
+        assert_eq!(
+            canonical
+                .parse::<InstanceId>()
+                .expect("canonical form parses"),
+            InstanceId(0x3f5a_9c02_d1e8_4b76_90ab_3cde_12f4_5678),
+        );
+        assert!("0".repeat(31).parse::<InstanceId>().is_err());
+        assert!("0".repeat(33).parse::<InstanceId>().is_err());
+        assert!(
+            "3F5A9C02D1E84B7690AB3CDE12F45678"
+                .parse::<InstanceId>()
+                .is_err()
+        );
+        assert!(
+            "+0000000000000000000000000000001"
+                .parse::<InstanceId>()
+                .is_err()
+        );
+        assert!(
+            "3f5a9c02d1e84b7690ab3cde12f4567g"
+                .parse::<InstanceId>()
+                .is_err()
+        );
+        assert!("".parse::<InstanceId>().is_err());
+    }
+
+    /// Asserts that `Display` renders the zero-padded 32-digit form and
+    /// that `Debug` renders the same spelling rather than the decimal one
+    /// the derive would produce.
+    ///
+    /// Case: an operator reads a `tracing` line naming an instance and
+    /// compares it against the bytes their program wrote to the PTY.
+    #[test]
+    fn an_instance_id_renders_as_its_wire_spelling() {
+        let id = InstanceId(1);
+        assert_eq!(id.to_string(), "00000000000000000000000000000001");
+        assert_eq!(
+            format!("{id:?}"),
+            "InstanceId(00000000000000000000000000000001)"
+        );
+    }
+
+    /// Asserts that the largest wire spelling is representable, so the
+    /// parser needs no overflow branch.
+    ///
+    /// Case: a mount names the maximal id the 32-digit grammar admits.
+    #[test]
+    fn the_widest_wire_spelling_is_representable() {
+        let max = "f".repeat(32);
+        assert_eq!(
+            max.parse::<InstanceId>().expect("max parses"),
+            InstanceId(u128::MAX)
+        );
+        assert_eq!(InstanceId(u128::MAX).to_string(), max);
+    }
+}

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -96,7 +96,7 @@ pub struct AnchoredPlacement {
     pub id: InstanceId,
     /// Active-grid cell the rect's top-left corner sits at.
     pub point: GridPoint,
-    /// The rect's extent, unchanged from the mount that reserved it.
+    /// The rect's extent in cells.
     pub size: PlacementSize,
 }
 

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -31,13 +31,17 @@ pub struct PlacementId(pub u64);
 /// its spelling are in bijection. At any instant the live ids on one
 /// terminal are unique: `supersede` drops the existing entry for an id
 /// across both screens before a re-mount registers its successor.
+// NOTE: InstanceId and InstanceIdParseError are public API added in Task 1
+// but not yet used by the prelude or any non-test code; Task 2 will add
+// them to the prelude and integrate them into the mount handler. Until
+// then, this module is private, so the suppression is transient.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[allow(dead_code)]
+#[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
 pub struct InstanceId(pub u128);
 
 /// The reason a wire spelling is not a valid [`InstanceId`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+#[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
 pub struct InstanceIdParseError;
 
 impl FromStr for InstanceId {
@@ -78,7 +82,7 @@ impl fmt::Debug for InstanceId {
 
 impl InstanceId {
     /// Digits in this id's wire spelling.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "public API not yet integrated; removed in Task 2")]
     pub const WIRE_DIGITS: usize = 32;
 
     /// Builds an id from 16 bytes of caller-supplied entropy.
@@ -86,7 +90,11 @@ impl InstanceId {
     /// The randomness stays with the caller: the control plane mints
     /// ids, and putting a self-seeding constructor here would leave a
     /// way for the VT to start minting again.
-    #[allow(dead_code)]
+    // NOTE: from_bytes is public API added for the control plane but is
+    // not called in any code path yet, not even in tests, so the lint
+    // expectation is correctly fulfilled. Task 2 will wire the mount
+    // handler that calls this.
+    #[expect(dead_code, reason = "public API not yet integrated; called in Task 2")]
     pub fn from_bytes(bytes: [u8; 16]) -> Self {
         Self(u128::from_be_bytes(bytes))
     }

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -41,7 +41,7 @@ use self::grid::Grid;
 use self::grid::LineId;
 use self::grid::row::Row;
 use crate::frame::damage::DamageSpan;
-use crate::placement::{AnchoredPlacement, PlacementId, PlacementSize};
+use crate::placement::{AnchoredPlacement, InstanceId, PlacementSize};
 use crate::screen::character_sets::{
     CharacterSet, CharacterSetMapping, GCode, GraphicChar, SingleShift,
 };
@@ -1028,38 +1028,38 @@ impl Screen {
 /// so a placement can only ever be resolved against the grid that minted
 /// its anchor.
 ///
-/// Four of these forward to [`ScreenPlacements`] unchanged. They stay
+/// Five of these forward to [`ScreenPlacements`] unchanged. They stay
 /// rather than exposing the table, so `DeviceState` never holds a
 /// `&mut ScreenPlacements` and every mutation of a screen's placements
 /// goes through the screen that owns them.
 impl Screen {
-    /// Registers a mount at the write cursor under an already-minted id.
-    pub fn mount_placement(
-        &mut self,
-        id: PlacementId,
-        size: PlacementSize,
-        view_id: String,
-        instance_id: Option<String>,
-    ) {
+    /// Registers a mount at the write cursor under the id the host minted.
+    pub fn mount_placement(&mut self, id: InstanceId, size: PlacementSize) {
         let anchor = self.cursor_line_id();
         let col = self.cursor_column();
-        self.placements
-            .mount(id, anchor, col, size, view_id, instance_id);
+        self.placements.mount(id, anchor, col, size);
     }
 
     /// Drops the placement a re-mount replaces, without reporting it.
-    pub fn supersede_placement(&mut self, view_id: &str, instance_id: Option<&str>) {
-        self.placements.supersede(view_id, instance_id);
+    pub fn supersede_placement(&mut self, id: InstanceId) {
+        self.placements.supersede(id);
     }
 
-    /// Removes the placements a client `unmount` addresses; returns
-    /// whether anything went.
-    pub fn unmount_placement(&mut self, view_id: Option<&str>, instance_id: Option<&str>) -> bool {
-        self.placements.unmount(view_id, instance_id)
+    /// Removes the placement a client `unmount` addresses (`None`
+    /// removes every placement on this screen); returns whether
+    /// anything went.
+    pub fn unmount_placement(&mut self, id: Option<InstanceId>) -> bool {
+        self.placements.unmount(id)
+    }
+
+    /// Removes the placements the host names; returns whether anything
+    /// went.
+    pub fn remove_placements(&mut self, ids: &[InstanceId]) -> bool {
+        self.placements.remove_many(ids)
     }
 
     /// Empties this screen's table and names every id it held.
-    pub fn take_placements(&mut self) -> Vec<PlacementId> {
+    pub fn take_placements(&mut self) -> Vec<InstanceId> {
         self.placements.take_all()
     }
 
@@ -1083,7 +1083,7 @@ impl Screen {
 
     /// Drops the placements whose anchor row left this screen's grid and
     /// names them.
-    pub fn evict_lost_anchors(&mut self) -> Vec<PlacementId> {
+    pub fn evict_lost_anchors(&mut self) -> Vec<InstanceId> {
         self.placements
             .evict_lost_anchors(|anchor| self.grid.grid_line(anchor))
     }

--- a/crates/orzma_vt/src/screen/placements.rs
+++ b/crates/orzma_vt/src/screen/placements.rs
@@ -2,7 +2,7 @@
 //! resolution of its anchors into grid coordinates, and the eviction
 //! sweep.
 
-use crate::placement::{AnchoredPlacement, PlacementId, PlacementSize};
+use crate::placement::{AnchoredPlacement, InstanceId, PlacementSize};
 use crate::screen::grid::LineId;
 use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint};
 
@@ -37,46 +37,41 @@ impl ScreenPlacements {
         self.placements.is_empty()
     }
 
-    /// Registers a mount; the caller has already minted `id` and resolved
-    /// the anchor.
-    pub fn mount(
-        &mut self,
-        id: PlacementId,
-        anchor: LineId,
-        col: GridColumn,
-        size: PlacementSize,
-        view_id: String,
-        instance_id: Option<String>,
-    ) {
+    /// Registers a mount; the caller has already resolved the anchor.
+    pub fn mount(&mut self, id: InstanceId, anchor: LineId, col: GridColumn, size: PlacementSize) {
         self.placements.push(Placement {
             id,
             anchor,
             col,
             size,
-            view_id,
-            instance_id,
         });
     }
 
-    /// Drops the placement a re-mount replaces, without reporting it.
+    /// Drops the placement a re-mount of `id` replaces, without reporting it.
     ///
-    /// A superseded id is deliberately unnamed: the host re-points the
-    /// same entity at the successor and would despawn it if the
-    /// superseded id were reported as evicted.
-    pub fn supersede(&mut self, view_id: &str, instance_id: Option<&str>) {
-        self.placements
-            .retain(|p| !p.addressed_by(view_id, instance_id));
+    /// A superseded id is deliberately unnamed: the re-mount registers a
+    /// successor under the same id, and reporting the predecessor as
+    /// evicted would tell the host to despawn the live view.
+    pub fn supersede(&mut self, id: InstanceId) {
+        self.placements.retain(|p| p.id != id);
     }
 
-    /// Removes the placements a client `unmount` addresses; returns
-    /// whether anything went.
-    pub fn unmount(&mut self, view_id: Option<&str>, instance_id: Option<&str>) -> bool {
+    /// Removes the placement an `unmount` addresses (`None` removes every
+    /// placement on this screen); returns whether anything went.
+    pub fn unmount(&mut self, id: Option<InstanceId>) -> bool {
         let before = self.placements.len();
-        self.placements.retain(|p| match (view_id, instance_id) {
-            (None, _) => false,
-            (Some(view), None) => p.view_id != view,
-            (Some(view), Some(instance)) => !p.addressed_by(view, Some(instance)),
-        });
+        match id {
+            None => self.placements.clear(),
+            Some(id) => self.placements.retain(|p| p.id != id),
+        }
+        before != self.placements.len()
+    }
+
+    /// Removes the placements the host names; returns whether anything went.
+    /// Ids the table does not hold are ignored.
+    pub fn remove_many(&mut self, ids: &[InstanceId]) -> bool {
+        let before = self.placements.len();
+        self.placements.retain(|p| !ids.contains(&p.id));
         before != self.placements.len()
     }
 
@@ -121,7 +116,7 @@ impl ScreenPlacements {
     pub fn evict_lost_anchors(
         &mut self,
         mut line_of: impl FnMut(LineId) -> Option<GridLine>,
-    ) -> Vec<PlacementId> {
+    ) -> Vec<InstanceId> {
         if self.is_empty() {
             return Vec::new();
         }
@@ -129,14 +124,11 @@ impl ScreenPlacements {
     }
 
     /// Empties the table and names every id it held.
-    pub fn take_all(&mut self) -> Vec<PlacementId> {
+    pub fn take_all(&mut self) -> Vec<InstanceId> {
         self.evict_where(|_| true)
     }
 
-    fn evict_where(
-        &mut self,
-        should_evict: impl FnMut(&mut Placement) -> bool,
-    ) -> Vec<PlacementId> {
+    fn evict_where(&mut self, should_evict: impl FnMut(&mut Placement) -> bool) -> Vec<InstanceId> {
         self.placements
             .extract_if(.., should_evict)
             .map(|p| p.id)
@@ -147,20 +139,10 @@ impl ScreenPlacements {
 /// One mounted webview on this screen.
 #[derive(Debug)]
 struct Placement {
-    id: PlacementId,
+    id: InstanceId,
     anchor: LineId,
     col: GridColumn,
     size: PlacementSize,
-    view_id: String,
-    instance_id: Option<String>,
-}
-
-impl Placement {
-    /// Whether this placement is the one `(view_id, instance_id)`
-    /// addresses.
-    fn addressed_by(&self, view_id: &str, instance_id: Option<&str>) -> bool {
-        self.view_id == view_id && self.instance_id.as_deref() == instance_id
-    }
 }
 
 #[cfg(test)]
@@ -178,62 +160,64 @@ mod tests {
         Grid::new(GridSize { cols: 8, rows: 3 }, 10)
     }
 
-    fn mount(table: &mut ScreenPlacements, grid: &Grid, id: u64, view: &str) {
+    fn mount(table: &mut ScreenPlacements, grid: &Grid, id: u128) {
         table.mount(
-            PlacementId(id),
+            InstanceId(id),
             grid.line_id(ScreenLine::TOP),
             GridColumn(0),
             PlacementSize { rows: 2, cols: 4 },
-            view.to_string(),
-            None,
         );
     }
 
-    /// Asserts that a re-mount of the same address replaces the live
+    /// Asserts that a re-mount of the same id replaces the live
     /// placement instead of stacking a second one beside it.
     ///
-    /// Case: a program re-renders the same named view after its content
+    /// Case: a program re-renders the same view after its content
     /// changed.
     #[test]
     fn a_supersede_replaces_the_live_placement_at_the_same_address() {
         let mut table = table();
         let grid = grid();
-        mount(&mut table, &grid, 1, "memo");
-        table.supersede("memo", None);
-        mount(&mut table, &grid, 2, "memo");
+        mount(&mut table, &grid, 1);
+        table.supersede(InstanceId(1));
+        mount(&mut table, &grid, 1);
         assert_eq!(table.len(), 1);
-        assert_eq!(table.take_all(), vec![PlacementId(2)]);
+        assert_eq!(table.take_all(), vec![InstanceId(1)]);
     }
 
-    /// Asserts that an unmount naming only a view id removes every
-    /// placement at that view, an unmount naming an instance id too
-    /// removes just that instance, and a `None` view id removes all.
+    /// Asserts that an unmount naming an id removes just that placement and
+    /// a `None` id removes every placement on the screen.
     ///
-    /// Case: a program tears down one of its views, then exits and asks
-    /// the terminal to drop whatever is left.
+    /// Case: a program tears down one of its views, then exits and asks the
+    /// terminal to drop whatever is left.
     #[test]
     fn an_unmount_removes_the_placements_its_address_names() {
         let mut table = table();
         let grid = grid();
-        mount(&mut table, &grid, 1, "memo");
-        mount(&mut table, &grid, 2, "chart");
-        assert!(table.unmount(Some("memo"), None));
+        mount(&mut table, &grid, 1);
+        mount(&mut table, &grid, 2);
+        assert!(table.unmount(Some(InstanceId(1))));
         assert_eq!(table.len(), 1);
-        assert!(!table.unmount(Some("memo"), None));
-        assert!(table.unmount(None, None));
+        assert!(!table.unmount(Some(InstanceId(1))));
+        assert!(table.unmount(None));
         assert!(table.is_empty());
+    }
 
-        table.mount(
-            PlacementId(3),
-            grid.line_id(ScreenLine::TOP),
-            GridColumn(0),
-            PlacementSize { rows: 2, cols: 4 },
-            "chart".to_string(),
-            Some("a".to_string()),
-        );
-        assert!(!table.unmount(Some("chart"), Some("b")));
-        assert!(table.unmount(Some("chart"), Some("a")));
-        assert!(table.is_empty());
+    /// Asserts that a host-driven removal drops exactly the named ids and
+    /// reports whether anything went, ignoring ids the table never held.
+    ///
+    /// Case: a program's control-plane connection drops, and the host clears
+    /// the placements its registrations had reserved.
+    #[test]
+    fn a_host_removal_drops_exactly_the_named_ids() {
+        let mut table = table();
+        let grid = grid();
+        mount(&mut table, &grid, 1);
+        mount(&mut table, &grid, 2);
+        mount(&mut table, &grid, 3);
+        assert!(table.remove_many(&[InstanceId(1), InstanceId(3), InstanceId(9)]));
+        assert_eq!(table.len(), 1);
+        assert!(!table.remove_many(&[InstanceId(9)]));
     }
 
     /// Asserts that projection omits the placements the resolver rejects
@@ -245,10 +229,10 @@ mod tests {
     fn a_projection_omits_what_the_resolver_rejects() {
         let mut table = table();
         let grid = grid();
-        mount(&mut table, &grid, 1, "memo");
+        mount(&mut table, &grid, 1);
         let projected = table.project(|_| Some(GridLine(-4)));
         assert_eq!(projected.len(), 1);
-        assert_eq!(projected[0].id, PlacementId(1));
+        assert_eq!(projected[0].id, InstanceId(1));
         assert_eq!(projected[0].point.line, GridLine(-4));
         assert_eq!(projected[0].point.column, GridColumn(0));
         assert!(table.project(|_| None).is_empty());
@@ -263,9 +247,9 @@ mod tests {
     fn a_sweep_drops_and_names_the_unresolvable_placements() {
         let mut table = table();
         let grid = grid();
-        mount(&mut table, &grid, 1, "memo");
+        mount(&mut table, &grid, 1);
         assert!(table.evict_lost_anchors(|_| Some(GridLine(0))).is_empty());
-        assert_eq!(table.evict_lost_anchors(|_| None), vec![PlacementId(1)]);
+        assert_eq!(table.evict_lost_anchors(|_| None), vec![InstanceId(1)]);
         assert!(table.is_empty());
     }
 

--- a/crates/orzma_vt/src/screen/tests/placements.rs
+++ b/crates/orzma_vt/src/screen/tests/placements.rs
@@ -2,13 +2,8 @@
 
 use super::*;
 
-fn mount(screen: &mut Screen, id: u64, view: &str) {
-    screen.mount_placement(
-        PlacementId(id),
-        PlacementSize { rows: 2, cols: 4 },
-        view.to_string(),
-        None,
-    );
+fn mount(screen: &mut Screen, id: InstanceId) {
+    screen.mount_placement(id, PlacementSize { rows: 2, cols: 4 });
 }
 
 /// Asserts that a mount anchors to the row the write cursor sits
@@ -21,7 +16,7 @@ fn a_mount_anchors_at_the_write_cursor() {
     let mut screen = screen();
     screen.state.line = ScreenLine(2);
     screen.state.column = GridColumn(3);
-    mount(&mut screen, 1, "memo");
+    mount(&mut screen, InstanceId(1));
     let projected = screen.project_placements();
     assert_eq!(projected.len(), 1);
     assert_eq!(projected[0].point.line, GridLine(2));
@@ -39,7 +34,7 @@ fn a_mount_anchors_at_the_write_cursor() {
 fn a_placement_the_projection_omits_is_also_swept() {
     let mut screen = screen();
     screen.state.line = ScreenLine(2);
-    mount(&mut screen, 1, "memo");
+    mount(&mut screen, InstanceId(1));
     assert_eq!(screen.project_placements().len(), 1);
 
     for _ in 0..3 {
@@ -47,7 +42,7 @@ fn a_placement_the_projection_omits_is_also_swept() {
     }
 
     assert!(screen.project_placements().is_empty());
-    assert_eq!(screen.evict_lost_anchors(), vec![PlacementId(1)]);
+    assert_eq!(screen.evict_lost_anchors(), vec![InstanceId(1)]);
     assert_eq!(screen.placement_count(), 0);
 }
 
@@ -62,7 +57,7 @@ fn a_placement_the_projection_omits_is_also_swept() {
 fn a_reset_drops_a_placement_the_sweep_alone_would_leave() {
     let mut screen = screen();
     screen.state.line = ScreenLine(2);
-    mount(&mut screen, 1, "memo");
+    mount(&mut screen, InstanceId(1));
     for _ in 0..3 {
         screen.line_feed();
     }
@@ -71,7 +66,7 @@ fn a_reset_drops_a_placement_the_sweep_alone_would_leave() {
 
     assert_eq!(screen.reset(), Some(DamageSpan::Full));
 
-    assert_eq!(screen.evict_lost_anchors(), vec![PlacementId(1)]);
+    assert_eq!(screen.evict_lost_anchors(), vec![InstanceId(1)]);
 }
 
 /// Asserts that a reset leaves this screen's placements
@@ -82,39 +77,39 @@ fn a_reset_drops_a_placement_the_sweep_alone_would_leave() {
 #[test]
 fn a_reset_leaves_this_screens_placements_unresolvable() {
     let mut screen = screen();
-    mount(&mut screen, 1, "memo");
-    mount(&mut screen, 2, "chart");
+    mount(&mut screen, InstanceId(1));
+    mount(&mut screen, InstanceId(2));
     assert_eq!(screen.reset(), None);
     assert!(screen.project_placements().is_empty());
     assert_eq!(
         screen.evict_lost_anchors(),
-        vec![PlacementId(1), PlacementId(2)]
+        vec![InstanceId(1), InstanceId(2)]
     );
 }
 
-/// Asserts that a re-mount at the same address supersedes the
-/// live placement without naming the superseded id.
+/// Asserts that a re-mount of a live id supersedes the placement it
+/// held without naming the superseded id.
 ///
-/// Case: a program re-renders the same named view.
+/// Case: a program re-renders the same view.
 #[test]
 fn a_remount_supersedes_without_naming_the_superseded_id() {
     let mut screen = screen();
-    mount(&mut screen, 1, "memo");
-    screen.supersede_placement("memo", None);
-    mount(&mut screen, 2, "memo");
+    mount(&mut screen, InstanceId(1));
+    screen.supersede_placement(InstanceId(1));
+    mount(&mut screen, InstanceId(1));
     assert_eq!(screen.placement_count(), 1);
-    assert_eq!(screen.take_placements(), vec![PlacementId(2)]);
+    assert_eq!(screen.take_placements(), vec![InstanceId(1)]);
 }
 
-/// Asserts that an unmount addressed to a view removes it and
+/// Asserts that an unmount addressed to an instance removes it and
 /// reports that something went.
 ///
 /// Case: a program tears down one of two mounted views.
 #[test]
 fn an_unmount_removes_the_addressed_placement() {
     let mut screen = screen();
-    mount(&mut screen, 1, "memo");
-    mount(&mut screen, 2, "chart");
-    assert!(screen.unmount_placement(Some("memo"), None));
+    mount(&mut screen, InstanceId(1));
+    mount(&mut screen, InstanceId(2));
+    assert!(screen.unmount_placement(Some(InstanceId(1))));
     assert_eq!(screen.placement_count(), 1);
 }

--- a/crates/orzma_vt/src/screen/tests/resize.rs
+++ b/crates/orzma_vt/src/screen/tests/resize.rs
@@ -291,12 +291,7 @@ fn a_narrowing_does_not_wrap_the_dropped_columns_onto_the_next_row() {
 fn a_placement_beyond_the_new_right_edge_survives() {
     let mut screen = wide_screen();
     screen.state.column = GridColumn(19);
-    screen.mount_placement(
-        PlacementId(1),
-        PlacementSize { rows: 1, cols: 1 },
-        "memo".to_string(),
-        None,
-    );
+    screen.mount_placement(InstanceId(1), PlacementSize { rows: 1, cols: 1 });
     assert_eq!(
         screen.resize(GridSize { cols: 4, rows: 3 }),
         Some(DamageSpan::Full)

--- a/docs/orzma_webview_protocol.md
+++ b/docs/orzma_webview_protocol.md
@@ -22,9 +22,10 @@ Three actors participate: the **registering program** (running in a pane), the
 runtime-registered) webview — the only kind this protocol describes.
 
 End to end: a program connects to the control socket, registers content and
-receives an opaque **handle**, writes an `ESC _ Omount;v=<handle>,…` sequence to
-display it, and then talks to the page through the `window.orzma` bridge routed
-over the same control socket. Unmounting (or disconnecting) tears it down.
+receives an opaque **handle** together with its first placement **instance**,
+writes an `ESC _ Omount;n=<instance>,…` sequence to display it, and then talks to
+the page through the `window.orzma` bridge routed over the same control socket.
+Unmounting (or disconnecting) tears it down.
 
 ## Architecture at a glance
 
@@ -34,14 +35,14 @@ over the same control socket. Unmounting (or disconnecting) tears it down.
         │  reads $ORZMA_SOCK / $ORZMA_TOKEN from its env
         │  hello{token} ───────────────►│
         │  register{kind,…} ───────────►│
-        │◄─────────────── {ok,handle} ──│
-        │  APC Omount;v=h,r=n,c=n ─────►│  mount orzma://handle/ ───►│ load page
+        │◄────── {ok,handle,instance} ──│
+        │  APC Omount;n=i,r=n,c=n ─────►│  mount orzma://handle/ ───►│ load page
         │                               │◄──── window.orzma.call ────│
         │◄──── {op:call,reqId,method} ──│                           │
         │  {op:reply,reqId,value} ─────►│──── resolve Promise ─────►│
         │  {op:emit,event,payload} ────►│──── window.orzma.on ──────►│
         │◄──── {op:event,…} ◄ window.orzma.emit ─────────────────────│
-        │  APC Ounmount;v=handle ──────►│  remove webview ──────────►│
+        │  APC Ounmount;n=instance ────►│  remove webview ──────────►│
 ```
 
 The control socket carries every horizontal arrow between the program and the
@@ -94,21 +95,23 @@ connection is ignored.
 After the handshake, two kinds of line arrive **from** the host on the same
 connection, and a client must tell them apart:
 
-- A **register reply** is the only host line with **no `op` field** — it is
-  either `{"ok":true,"handle":"…"}` or `{"ok":false,"error":"…"}`.
+- A **request reply** is the only host line with **no `op` field**. Both
+  `register` and `new_instance` are answered this way, and either can also
+  reply `{"ok":false,"error":"…"}`.
 - Every **host-initiated push** (`call`, `event`, `compositing`) carries an
   `op` field.
 
-So: a line with an `op` is a push; a line without one is the reply to your most
-recent `register`. This is the one framing rule a from-scratch client must get
-right.
+So: a line with an `op` is a push; a line without one is the reply to your
+oldest outstanding request. This is the one framing rule a from-scratch client
+must get right.
 
-### Register ordering
+### Request ordering
 
-Registrations are processed one at a time per connection, and each
-`register`'s reply arrives in request order. `register` has no request id —
-correlation is positional. (The back-channel `call`/`reply` pair below uses an
-explicit `reqId` instead.)
+`register` and `new_instance` are processed one at a time per connection, and
+each reply arrives in request order. Neither carries a request id, so
+correlation is positional: a client matches replies to its pending requests by
+their order. (The back-channel `call`/`reply` pair below uses an explicit
+`reqId` instead.)
 
 ### Program → host messages
 
@@ -117,12 +120,13 @@ Every program line carries an `op`:
 | `op` | Fields | Meaning |
 | --- | --- | --- |
 | `hello` | `token` | Handshake; first line only. |
-| `register` | `kind` + per-kind fields | Register content, mint a handle. |
+| `register` | `kind` + per-kind fields | Register content; mints a handle and its first instance. |
+| `new_instance` | `handle` | Mint an additional instance on a handle this connection owns. |
 | `unregister` | `handle` | Release a handle owned by this connection; removes its mounted views. |
 | `reply` | `reqId`, `ok`, `value?`, `error?` | Answer a host `call` (use the `call`'s `reqId`). |
-| `emit` | `handle`, `event`, `payload` | Push an event to the handle's pages (delivered to `window.orzma.on`). |
-| `focus` | `handle` (string or `null`), `instance` (string or `null`) | Set app-owned focus to a mounted view, or `null` to blur. |
-| `navigate` | `handle`, `action` | Navigate a mounted view in place. |
+| `emit` | `handle`, `event`, `payload` | Push an event to every page mounted from the handle (delivered to `window.orzma.on`). |
+| `focus` | `instance` (string or `null`) | Set app-owned focus to a mounted placement, or `null` to blur. |
+| `navigate` | `instance`, `action` | Navigate one mounted placement in place. |
 
 `navigate.action` is one of the strings `"back"`, `"forward"`, `"reload"`, or
 the object `{"to":"<http(s) url>"}` (`to` is valid only on a `url` view).
@@ -163,9 +167,9 @@ Every host push carries an `op`:
 
 | `op` | Fields | Meaning / response |
 | --- | --- | --- |
-| `call` | `handle`, `reqId`, `method`, `params` | A page `window.orzma.call(method, params)`. Respond with a `reply` carrying the same `reqId`. |
+| `call` | `handle`, `instance`, `reqId`, `method`, `params` | A page `window.orzma.call(method, params)`. Respond with a `reply` carrying the same `reqId`. |
 | `event` | `handle`, `event`, `payload` | A page `window.orzma.emit(event, payload)`. Fire-and-forget; no response. |
-| `compositing` | `handle`, `active` (bool) | The view first composited (`true`) or was unmounted after compositing (`false`). |
+| `compositing` | `handle`, `instance`, `active` (bool) | The placement first composited (`true`) or was unmounted after compositing (`false`). |
 
 Two directional details that are easy to get wrong:
 
@@ -178,10 +182,13 @@ Two directional details that are easy to get wrong:
   Despite the `call` shape it is fire-and-forget — any `reply` is discarded. Use
   it to track page-driven navigation.
 
-### Register reply & error codes
+### Request replies & error codes
 
-A successful `register` replies `{"ok":true,"handle":"<handle>"}`. A rejected one
-replies `{"ok":false,"error":"<code>"}`:
+A successful `register` replies
+`{"ok":true,"handle":"<handle>","instance":"<instance>"}` — the handle owns the
+registration, and the instance is its first placement. A successful
+`new_instance` replies `{"ok":true,"instance":"<instance>"}`. A rejected request
+of either kind replies `{"ok":false,"error":"<code>"}`:
 
 | `error` | Cause |
 | --- | --- |
@@ -190,14 +197,33 @@ replies `{"ok":false,"error":"<code>"}`:
 | `html_too_large` | `inline.html` exceeds 4 MiB. |
 | `invalid_url` | `url.url` does not parse or has no host. |
 | `unsupported_scheme` | `url.url` is not `http`/`https`. |
+| `unknown_handle` | `new_instance.handle` names no live registration. |
+| `not_owner` | `new_instance.handle` is registered, but by another connection. |
 | `internal` | The host failed to process the request. |
 
 ### Handle semantics
 
-A handle is opaque, unique per registration, lowercase, and matches
-`^[a-z0-9._-]{1,128}$` (a subset of the APC `view_id` charset, so a handle is
-always a valid `mount` argument). Treat it as a token: do not parse it. Each
-handle owns one isolated `orzma://<handle>/` origin.
+A handle is opaque, unique per registration, and lowercase: 128 CSPRNG bits
+base32-encoded over the alphabet `a-z2-7`, which keeps it spellable as a URL
+host. Treat it as a token: do not parse it. Each handle owns one isolated
+`orzma://<handle>/` origin, and it is what `unregister`, `emit`, and
+`new_instance` address. A handle is never mounted — a mount addresses an
+instance.
+
+### Instance semantics
+
+An instance is one placement of a registration, and it is the unit `mount`,
+`unmount`, `focus`, and `navigate` address. Its wire spelling is exactly 32
+lowercase hex digits (128 CSPRNG bits); any other spelling is malformed. Only
+the host mints instances — `register` mints the first, `new_instance` each
+additional one — so uniqueness is structural and nothing on the wire negotiates
+it.
+
+An instance stays valid for as long as its handle is registered, whether or not
+it is currently mounted. Mounting an instance that is already live updates its
+rectangle in place and leaves the page untouched; mounting one after it was
+unmounted builds the page again from scratch. Every instance of a handle serves
+that handle's registered content, and each one mounts independently.
 
 ### Example exchange
 
@@ -206,15 +232,17 @@ Program-to-host lines are marked `C→S`, host-to-program lines `S→C`:
 ```json
 C→S {"op":"hello","token":"orzma:4294967306"}
 C→S {"op":"register","kind":"inline","html":"<!doctype html><body>hi</body>"}
-S→C {"ok":true,"handle":"nf2k7q5w3x3m5a6b2c4d6e7f"}
-S→C {"op":"call","handle":"nf2k7q5w3x3m5a6b2c4d6e7f","reqId":"0","method":"save","params":{"text":"hi"}}
+S→C {"ok":true,"handle":"nf2k7q5w3x3m5a6b2c4d6e7f","instance":"3f5a9c02d1e84b7690ab3cde12f45678"}
+S→C {"op":"call","handle":"nf2k7q5w3x3m5a6b2c4d6e7f","instance":"3f5a9c02d1e84b7690ab3cde12f45678","reqId":"0","method":"save","params":{"text":"hi"}}
 C→S {"op":"reply","reqId":"0","ok":true,"value":{"saved":true}}
 C→S {"op":"emit","handle":"nf2k7q5w3x3m5a6b2c4d6e7f","event":"tick","payload":{"n":1}}
+C→S {"op":"new_instance","handle":"nf2k7q5w3x3m5a6b2c4d6e7f"}
+S→C {"ok":true,"instance":"a1b2c3d4e5f60718293a4b5c6d7e8f90"}
 ```
 
 ## APC webview verbs — mount / unmount
 
-Once a handle is registered, the program mounts it by writing an APC escape
+Once an instance is minted, the program mounts it by writing an APC escape
 sequence to its terminal. The sequence is framed `ESC _ <payload> ST`, where
 `ST` (string terminator) is `ESC \`. Unlike an OSC, a `BEL` does not terminate
 an APC — it is taken as payload data. The payload opens with `O` (orzma), so a
@@ -222,8 +250,8 @@ sequence another program owns — kitty's `G`, for example — is left alone. In
 raw bytes:
 
 ```text
-mount:    \x1b_Omount;v=<view_id>,r=<rows>,c=<cols>\x1b\
-unmount:  \x1b_Ounmount;v=<view_id>\x1b\
+mount:    \x1b_Omount;n=<instance>,r=<rows>,c=<cols>\x1b\
+unmount:  \x1b_Ounmount;n=<instance>\x1b\
 ```
 
 The payload is at most 1024 bytes. A multi-byte character inside a key or a
@@ -233,53 +261,55 @@ silently dropped by the terminal's APC collector rather than rejected.
 ### mount
 
 ```text
-ESC _ O mount ; v=<view_id>,r=<rows>,c=<cols>[,n=<instance_id>] ST
+ESC _ O mount ; n=<instance>,r=<rows>,c=<cols> ST
 ```
 
-- `view_id` — the handle from `register`; charset `^[A-Za-z0-9._-]{1,128}$`.
+- `instance` — an instance from `register` or `new_instance`; exactly 32
+  lowercase hex digits.
 - `rows` — decimal `1`–`200`. `cols` — decimal `1`–`400`. Digits only, no sign.
-- `instance_id` — optional, same charset as `view_id`. It lets one handle mount
-  several independent placements.
 
-Keys are order-independent (`c=20,r=3,v=memo` is the same mount as
-`v=memo,r=3,c=20`). A repeated key, an unknown key, a missing `v` / `r` / `c`,
-or an empty params section (`Omount;`) is malformed.
+All three keys are required and order-independent (`c=80,n=<instance>,r=24` is
+the same mount as `n=<instance>,r=24,c=80`). A repeated key, an unknown key —
+the retired `v=` included — a missing `n` / `r` / `c`, or an empty params
+section (`Omount;`) is malformed.
 
-The view occupies a `rows`×`cols` rectangle of terminal cells, inline at the
-cursor.
+The placement occupies a `rows`×`cols` rectangle of terminal cells, inline at
+the cursor.
 
 ### unmount
 
 ```text
-ESC _ O unmount [ ; v=<view_id>[,n=<instance_id>] ] ST
+ESC _ O unmount [ ; n=<instance> ] ST
 ```
 
-- No params section → unmount every inline view this program has on the terminal.
-- `v=` only → unmount **every instance** of that handle.
-- `v=` + `n=` → unmount that specific placement.
+- No params section → unmount every inline placement this program has on the
+  terminal.
+- `n=` → unmount that one placement.
 
-Unlike `mount`, the unmount keys are **not** order-independent: `n=` is accepted
-only once `v=` has been seen, so `v=memo,n=a` is valid and `n=a,v=memo` is
-malformed. An empty params section (`Ounmount;`) is malformed, as is an empty
-value (`Ounmount;v=`).
+`n` is the only key an unmount accepts, so no key-ordering rule applies. An
+empty params section (`Ounmount;`) is malformed, as are an empty value
+(`Ounmount;n=`) and the retired `v=` key.
 
 ### Ownership and malformed sequences
 
-A `mount` takes effect only in the pane whose `$ORZMA_TOKEN` registered that
-handle — a program mounts its own handles in its own pane. Any malformed
-sequence (bad charset, out-of-range dimensions, unknown or repeated keys) is
-silently dropped; the host reports no error.
+A `mount` takes effect only in the pane whose `$ORZMA_TOKEN` registered the
+instance's handle — a program mounts its own instances in its own pane. An
+instance the host never minted, or one whose handle belongs to another pane, is
+silently dropped, as is any malformed sequence (a bad instance spelling,
+out-of-range dimensions, an unknown or repeated key); the host reports no
+error.
 
 A mount the terminal accepts but cannot place — the per-terminal placement cap
 is full — is also dropped, and the host logs it at debug level.
 
 ### Example
 
-Mount handle `nf2k7q5w3x3m5a6b2c4d6e7f` as a 24×80 view, then unmount it:
+Mount instance `3f5a9c02d1e84b7690ab3cde12f45678` as a 24×80 placement, then
+unmount it:
 
 ```text
-\x1b_Omount;v=nf2k7q5w3x3m5a6b2c4d6e7f,r=24,c=80\x1b\
-\x1b_Ounmount;v=nf2k7q5w3x3m5a6b2c4d6e7f\x1b\
+\x1b_Omount;n=3f5a9c02d1e84b7690ab3cde12f45678,r=24,c=80\x1b\
+\x1b_Ounmount;n=3f5a9c02d1e84b7690ab3cde12f45678\x1b\
 ```
 
 ## The `orzma://` origin
@@ -349,21 +379,23 @@ if (isOrzmaAvailable()) {
 
 ## Lifecycle & teardown
 
-- `unregister{handle}` releases a handle and removes its mounted views.
+- `unregister{handle}` releases a handle, invalidates every instance minted
+  from it, and removes its mounted views.
 - Closing the control connection purges all of that program's handles, removes
   their views, and rejects every in-flight `call` with `owner_disconnected`.
-- The `compositing` push reports a view's first paint (`active:true`) and its
-  teardown after compositing (`active:false`).
+- The `compositing` push reports one placement's first paint (`active:true`) and
+  its teardown after compositing (`active:false`), naming both the `handle` and
+  the `instance` it belongs to.
 
 ## Security model
 
 - **Same user only.** The host rejects any control connection whose peer user id
   differs from orzma's.
 - **Scoped to one pane.** A connection's token binds it to the pane that issued
-  `$ORZMA_TOKEN`; a program may only mount, focus, navigate, and emit to handles
-  it registered.
-- **Unguessable, isolated handles.** Handles are 128-bit random values, each its
-  own `orzma://` origin.
+  `$ORZMA_TOKEN`; a program may only mount, focus, navigate, and emit to
+  registrations it made itself.
+- **Unguessable, isolated identifiers.** Handles and instances are both 128-bit
+  CSPRNG values, and each handle is its own `orzma://` origin.
 - **Authorized replies.** Back-channel `reqId`s are a shared, monotonic counter
   and therefore guessable, so the host authorizes a `reply` by its originating
   connection: a program replaying another connection's `reqId` can neither

--- a/docs/orzma_webview_protocol.md
+++ b/docs/orzma_webview_protocol.md
@@ -171,6 +171,11 @@ Every host push carries an `op`:
 | `event` | `handle`, `event`, `payload` | A page `window.orzma.emit(event, payload)`. Fire-and-forget; no response. |
 | `compositing` | `handle`, `instance`, `active` (bool) | The placement first composited (`true`) or was unmounted after compositing (`false`). |
 
+`call` names the instance whose page called; `event` does not, because a
+program reads events per handle rather than per placement. A program running
+two placements of one handle can therefore tell which page called it, but not
+which page emitted an event.
+
 Two directional details that are easy to get wrong:
 
 - **`emit` vs. `event`.** A page's `window.orzma.emit(name, …)` arrives at the
@@ -205,7 +210,8 @@ of either kind replies `{"ok":false,"error":"<code>"}`:
 
 A handle is opaque, unique per registration, and lowercase: 128 CSPRNG bits
 base32-encoded over the alphabet `a-z2-7`, which keeps it spellable as a URL
-host. Treat it as a token: do not parse it. Each handle owns one isolated
+host. That encoding is unpadded, so a handle is always 26 characters. Treat
+it as a token: do not parse it. Each handle owns one isolated
 `orzma://<handle>/` origin, and it is what `unregister`, `emit`, and
 `new_instance` address. A handle is never mounted — a mount addresses an
 instance.
@@ -232,11 +238,11 @@ Program-to-host lines are marked `C→S`, host-to-program lines `S→C`:
 ```json
 C→S {"op":"hello","token":"orzma:4294967306"}
 C→S {"op":"register","kind":"inline","html":"<!doctype html><body>hi</body>"}
-S→C {"ok":true,"handle":"nf2k7q5w3x3m5a6b2c4d6e7f","instance":"3f5a9c02d1e84b7690ab3cde12f45678"}
-S→C {"op":"call","handle":"nf2k7q5w3x3m5a6b2c4d6e7f","instance":"3f5a9c02d1e84b7690ab3cde12f45678","reqId":"0","method":"save","params":{"text":"hi"}}
+S→C {"ok":true,"handle":"nf2k7q5w3x3m5a6b2c4d6e7fgh","instance":"3f5a9c02d1e84b7690ab3cde12f45678"}
+S→C {"op":"call","handle":"nf2k7q5w3x3m5a6b2c4d6e7fgh","instance":"3f5a9c02d1e84b7690ab3cde12f45678","reqId":"0","method":"save","params":{"text":"hi"}}
 C→S {"op":"reply","reqId":"0","ok":true,"value":{"saved":true}}
-C→S {"op":"emit","handle":"nf2k7q5w3x3m5a6b2c4d6e7f","event":"tick","payload":{"n":1}}
-C→S {"op":"new_instance","handle":"nf2k7q5w3x3m5a6b2c4d6e7f"}
+C→S {"op":"emit","handle":"nf2k7q5w3x3m5a6b2c4d6e7fgh","event":"tick","payload":{"n":1}}
+C→S {"op":"new_instance","handle":"nf2k7q5w3x3m5a6b2c4d6e7fgh"}
 S→C {"ok":true,"instance":"a1b2c3d4e5f60718293a4b5c6d7e8f90"}
 ```
 
@@ -300,7 +306,9 @@ out-of-range dimensions, an unknown or repeated key); the host reports no
 error.
 
 A mount the terminal accepts but cannot place — the per-terminal placement cap
-is full — is also dropped, and the host logs it at debug level.
+of 12 is full — is also dropped, and the host logs it at debug level. The cap
+counts both screens, so it is reached before the renderer runs out of overlay
+slots.
 
 ### Example
 

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -178,8 +178,11 @@ socket 往復なしで回る。
 
 1. **allocated な `InstanceId` は host の registry 全体で一意。** mounted かどうかは
    関係ない。unmount 済みでも handle 存続中は再 mount 可能＝allocated なので、
-   instance → handle の逆引きが一意である必要がある。128bit CSPRNG に加えて
-   vacant-entry チェックで構造的に保証する（確率任せにしない）。
+   instance → handle の逆引きが一意である必要がある。根拠は 128bit の OS CSPRNG
+   であり、数千エントリ対 2^128 の衝突確率は到達不能である。この一意性は構造的では
+   なく確率的であり、mint 時の `debug_assert!`（§3.1）はその前提が破れたことを
+   デバッグビルドで捕まえる tripwire であって、リリースビルドで一意性を強制する
+   ものではない。
 2. **ある瞬間に live な `InstanceId` は端末内で一意。** `supersede` が両スクリーンを
    走査するので既存挙動のまま満たされる。端末間は、instance が handle に属し handle が
    `owner_surface` に属することから、既存の所有権ゲートが担保する。
@@ -556,11 +559,15 @@ ECS state の二重管理になるうえ、その整合性のための不変条�
 2. この端末に同じ instance  → in-place 更新して return
 3. resolve_mount(handle)    → 未登録 / owner_surface 不一致    → debug + 回収 + return
 4. overlay スロット枯渇                                        → debug + 回収 + return
-5. url が解決できない                                          → debug + 回収 + return
 ```
 
 1 を先頭に置くのは、handle が取れないと 3 以降が書けないためである。「回収」は §6 の
 VT 側 placement の削除を指す。
+
+url に対応するゲートは無い。url は登録時に検証済み（`invalid_url` /
+`unsupported_scheme`）であり、`resolve_mount` は3種の source すべてで必ず url を
+組み立てるためである。したがって `ResolvedWebviewMount::url` は `Option<String>`
+ではなく `String` である。
 
 ### 3.4 コンポーネントの統合
 

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -274,7 +274,7 @@ h.emit("tick", &n)?;   // コンテンツスコープ: 両方のページに届�
 
 ```rust
 // host 側（bevy_orzma_webview）
-pub(crate) struct HandleId(String);
+pub struct HandleId(String);   // pub — Webview.handle が pub でルートバイナリが構築するため
 
 // SDK 側（ratatui_orzma、orzma_vt に依存しない独立クレートなので自前で定義）
 pub struct HandleId(String);

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -1,40 +1,51 @@
 # webview 配置識別子を host 採番の `InstanceId` に一本化する
 
-`PlacementId` を削除し、コントロールソケットが払い出す `InstanceId` 1本に統合する。
-未着手。調査と設計判断まで完了した段階の記録。
-
-前提となる作業（APC ディスパッチの実装、SDK の APC 移植、仕様書の同期）は
-PR #269 で完了している。この文書はその次の段階を扱う。
+`PlacementId` と `instance_id` を削除し、コントロールプレーンが払い出す
+`InstanceId` 1本に統合する設計書。前提となる作業（APC ディスパッチの実装、
+SDK の APC 移植、仕様書の同期）は PR #269 で完了している。
 
 ## 現状: 識別子が3層ある
 
 | 識別子 | 誰が採番 | いつ | クライアントに返るか |
 | --- | --- | --- | --- |
-| `view_id`（handle） | **host**（コントロールプレーン、128bit 乱数） | `register` 時 | **返る**（コントロールソケット） |
-| `instance_id` | **クライアント** | mount を書く前（任意） | 返らない（自分で決めたので不要） |
-| `PlacementId` | **VT** | mount を処理した後 | **返らない**（host にのみ渡る） |
+| `view_id`（handle） | host（コントロールプレーン、128bit 乱数 base32） | `register` 時 | 返る（コントロールソケット） |
+| `instance_id` | クライアント | mount を書く前（任意） | 返らない |
+| `PlacementId(u64)` | VT | mount を処理した後 | 返らない（host にのみ渡る） |
 
-`(view_id, instance_id)` がクライアントから見たアドレスで、`PlacementId` は
-VT ↔ host 間の内部アドレス。フレームが運ぶ `AnchoredPlacement` も、
-`WebviewEvicted` が名指しするのも `PlacementId` のほう。
+`view_id` と `handle` は**同じ文字列**で、層ごとに名前が割れているだけである
+（`docs/orzma_webview_protocol.md` が「`view_id` — the handle from `register`」と
+定義し、`resolve_mount` は受け取った `view_id` をそのまま handle キーの registry に
+引いている）。
 
-`instance_id` は**現時点で誰も使っていない**。SDK の `mount()` に instance
-引数がなく、`Session` は focus 操作に常に `instance: None` を送る。`apps/`
-配下にも使用箇所はない。
+2つのアドレス空間が並走しているのが問題の核である。
+
+- `(view_id, instance_id)` — VT の supersede / unmount のアドレス。
+- `PlacementId` — フレームが運ぶ投影のアドレス、および eviction のアドレス。
+
+`instance_id` は現時点で誰も使っていない。SDK の `mount()` に instance 引数がなく
+（`sdk/ratatui_orzma/src/escape.rs` は `n=` を一切出さない）、`Session` は focus 操作に
+常に `instance: None` を送る。`apps/` 配下にも使用箇所はない。
+
+現状のワイヤ:
+
+```text
+ESC _ Omount;v=<handle>,r=<n>,c=<n>[,n=<instance>] ESC \
+ESC _ Ounmount[;v=<handle>[,n=<instance>]] ESC \
+```
 
 ## 何が問題か — 採番の方向が逆
 
-`instance_id` と `PlacementId` は名前が違うだけの2つの id ではない。
-**誰がいつ決めるか**が逆になっている。
+`instance_id` と `PlacementId` は名前が違うだけの2つの id ではない。**誰がいつ
+決めるか**が逆になっている。
 
-- `instance_id` は**クライアントが mount を書く前**に決めるので、後の
-  `unmount` で自分で指名できる。
-- `PlacementId` は**VT が mount を処理した後**に採番する。APC は一方通行
-  （プログラムが PTY に書くだけ）なので、クライアントは自分の placement の
-  id を知る手段がない。
+- `instance_id` はクライアントが mount を書く前に決めるので、後の `unmount` で
+  自分で指名できる。
+- `PlacementId` は VT が mount を処理した後に採番する。APC は一方通行
+  （プログラムが PTY に書くだけ）なので、クライアントは自分の placement の id を
+  知る手段がない。
 
-したがって「`PlacementId` だけにして `unmount` もそれで指名する」は、
-現行プロトコルのままでは成立しない。`instance_id` が存在する理由はここにある。
+したがって「`PlacementId` だけにして `unmount` もそれで指名する」は、現行プロトコル
+のままでは成立しない。`instance_id` が存在する理由はここにある。
 
 ## 先行事例調査
 
@@ -44,138 +55,959 @@ kitty の仕様原文（rst ソース）と kitty / Ghostty / WezTerm の実装�
 **kitty の `p=`（placement id）はグローバルではない。** 仕様が明記している —
 "Every placement is uniquely identified by the **pair** of the `image id` and
 the `placement id`." つまり per-image スコープで、`p=7` は image 10 と image 11
-で別物。削除も必ず image id 起点（`d=i,i=10,p=7`）で、**`p=` 単独でアドレスする
-削除は kitty に存在しない**。
+で別物。削除も必ず image id 起点（`d=i,i=10,p=7`）で、`p=` 単独でアドレスする
+削除は kitty に存在しない。
 
 **「端末が採番してクライアントに返す」経路は kitty に実在するが、返るのは
 image id であって placement id ではない。** `I=`（image number）を送ると端末が
 `i=`（image id）を採番して `<ESC>_Gi=99,I=13;OK<ESC>\` で返す。これは orzma の
-`register → {ok, handle}` と**構造的に同型**で、違いは kitty が帯域内、orzma が
-帯域外（Unix ソケット）という点だけ。
+`register → {ok, handle}` と構造的に同型で、違いは kitty が帯域内、orzma が
+帯域外（Unix ソケット）という点だけである。
 
-**グローバルなクライアント採番 id は kitty 自身が失敗と認めている。** "Since
-IDs are in a global namespace **there can easily be collisions**" と書かれ、
-`I=` はこの衝突を回避するために後から足された間接層。Ghostty はさらに、
-暗黙採番を `2147483647` から始めて「クライアントが選びがちな低域を避ける」と
-コメントしている。orzma は handle を host 採番の 128bit 乱数にしたことで、
-この問題を最初から消している。
+**衝突が問題になるのは container id の層であって、その下の placement id ではない。**
+kitty の "Since IDs are in a global namespace there can easily be collisions" という
+一文は、Unicode プレースホルダで **image ID を前景色に詰め込む**際のビット幅の話
+（256色モードで8bit、truecolor で24bit）であり、解決策として示されているのは3つ目の
+diacritic である。クライアント採番の placement id を否定した文ではない。`I=` の推奨は
+別の節にあり、対象は image id である。orzma は handle を host 採番の 128bit にしたことで、
+kitty が `I=` で解いたのと同じ問題を同じ層で既に解いている。
 
-| | 端末が placement id を採番するか | wire に出るか |
+**Ghostty が内部 placement id を持つ理由は、orzma には存在しない制約である。**
+ソースが明言している —
+
+```zig
+// The important piece here is that the placement ID needs to
+// be marked internal if it is zero. This allows multiple placements
+// to be added for the same image.
+```
+
+1つの image に**匿名 placement を N 個**持つためである。orzma の `instance_id` は
+`Option` で、`(view_id, None)` は匿名インスタンス1つを指すため、キーは既に全域的で
+内部 id を必要としない。
+
+なお `next_internal_placement_id` は **0 から始まる** — "This is never user-facing so we
+can start at 0. ... any number is valid." と書かれている。`2147483647` から始めて
+「クライアントが選びがちな低域を避ける」のは隣のフィールド `next_image_id`（＝orzma の
+handle に相当し、既に host 採番）のコメントである。
+
+| | placement のアドレス | 端末が内部 id を持つか |
 | --- | --- | --- |
-| kitty | しない | — |
-| Ghostty | する（`next_internal_placement_id`） | **出ない**（"never user-facing" と明記） |
-| WezTerm | しない | — |
+| kitty（仕様） | `(image id, placement id)` の組。placement id はクライアントが `1..=4294967295` から選ぶ | — |
+| Ghostty | 同左 | 持つ（匿名 placement を N 個許すため） |
+| WezTerm | `HashMap<(u32, Option<u32>), PlacementInfo>` — 組をそのままキーにする | **持たない** |
 | iTerm2 / Sixel | placement という概念自体がない | — |
 
-**「端末が採番したグローバル一意な placement id を唯一の wire アドレスにして
-いる実装」は見つからなかった。** orzma の `PlacementId` は Ghostty の internal
-placement id と同型で、その設計自体には先行事例がある。
+**「端末が採番したグローバル一意な placement id を唯一の wire アドレスにしている実装」は
+見つからなかった。** 逆に「サーバが払い出した親 id の下でクライアントが子 id を決める」
+構造は広く実在する — kitty の `(image id, placement id)`、WezTerm の実装、X11 の
+`resource-id-base` / `resource-id-mask`、Wayland のクライアント／サーバ id レンジ分割、
+HTTP/2 の奇数／偶数ストリーム ID、Google AIP-133（親はサーバ、子 id はクライアント指定）。
 
-## 決定
+## 設計判断
 
-**host（コントロールプレーン）が `InstanceId` を採番し、mount より前に
-コントロールソケットで払い出す。**
+### D1. `register` の応答に instance を同梱する
 
+```text
+C→S {"op":"register","kind":"inline","html":"…"}
+S→C {"ok":true,"handle":"nf2k7q5w…","instance":"3f5a9c02d1e84b7690ab3cde12f45678"}
+
+C→S {"op":"new_instance","handle":"nf2k7q5w…"}      ← 2配置目以降だけ
+S→C {"ok":true,"instance":"81b4e77c05a3492fd6180e29ba735fc1"}
 ```
-client → socket:  new_instance { handle }
-socket → client:  { ok, instance: "<128bit base32>" }
-client → PTY:     ESC _ Omount;v=<handle>,n=<instance>,r=<n>,c=<n> ESC \
-client → PTY:     ESC _ Ounmount;n=<instance> ESC \      ← view_id 不要
+
+1配置しか要らない大多数のケースは往復1回のまま。`mount` を常に `n=` 必須にでき、
+VT から「デフォルトインスタンス」という特例が消える。
+
+### 採用理由は1つだけである
+
+**`orzma_vt` から handle の概念を完全に排除するため。** 一本化後の VT の placement は
+`{ id, anchor, col, size }` だけになり、コンテンツ登録・オリジン・RPC ルーティング・
+所有権に使われる handle を VT は一切知らなくなる。`orzma_vt` を webview 登録モデルから
+独立した汎用 VT として保つことが、この設計の最上位要件である。
+
+**次の理由は成立しないので、根拠として使ってはならない**（いずれも調査で反証済み。
+詳細は「却下した案」節の A / A' を参照）:
+
+- ❌「衝突を防ぐため」— `(handle, instance)` の組は handle が host 採番の 128bit で
+  あるため構造的に衝突しない。クライアント採番でも衝突はゼロである。
+- ❌「識別子を1つにするため」— D1 は識別子を1つにしない。handle はコンテンツ識別子
+  として残るので、アドレス（`instance`）＋コンテンツ id（`handle`）の2つになる。
+- ❌「VT が内部 id を持ち続けずに済む唯一の方法だから」— D3 が非再利用の要求を
+  取り下げた時点で、クライアント採番でも内部 id は不要になった。
+
+### この設計が引き受けるコスト
+
+以下は設計2（`(handle, instance)` の組をアドレスにする案）なら発生しないもので、
+D1 を選ぶ以上、承知のうえで払う対価である。
+
+| コスト | 内容 |
+| --- | --- |
+| 既存呼び出しの書き換え | `WebviewWidget::new` の呼び出し16箇所が全て書き換え対象。**D8 の `HandleId` によりコンパイルエラーとして現れる**ので、無言スキップにはならない（D8 導入前は unit test も green のまま通り抜ける経路だった） |
+| 描画ループのブロック | 2配置目以降は `new_instance` のソケット往復が要る。セットアップ時のみ呼ぶ制約が付く |
+| reconnect の往復 | registration あたり 1 + N 回（設計2 は 1 回） |
+| 新設物 | registry の逆引きマップ、`RemovedRegistration`、`mint_instance`、`ClientMsg::NewInstance`、`ServerMsg` のバリアント分割、SDK の `Pending` enum |
+| id 形式の固定 | `InstanceId(u128)` + `^[0-9a-f]{32}$` が host の id 幅を `orzma_vt` の公開型と APC 文法に焼き込む。host は採番方式を変えられなくなる |
+
+### D2. mount APC から `v=` を落とし、`n=` だけにする
+
+```text
+ESC _ Omount;n=<instance>,r=<n>,c=<n> ESC \    既に live なら in-place 更新
+ESC _ Ounmount;n=<instance> ESC \              その配置だけ外す
+ESC _ Ounmount ESC \                           この端末の全配置
 ```
 
-`PlacementId` は削除し、`InstanceId` が VT の保持する id・フレームが運ぶ id・
-ワイヤのアドレスを兼ねる。名前は `InstanceId` だが、スコープはグローバル
-（実態は placement id）。
+instance → handle の対応は host が持つので `v=` は冗長。結果として `orzma_vt` から
+handle の概念が完全に消え、placement は `{ id, anchor, col, size }` だけになる。
+v/n の不整合というエラークラスも消滅する。
 
-採用理由:
+失われるのは `unmount;v=<handle>`（その handle の全インスタンス）という中間スコープ。
+これは D7 の host→VT 削除経路で置き換える。
 
-- **orzma が既に採用しているパターンの再適用**。`register → handle` と同じ形で、
-  新しい機構を導入しない。kitty がこれを placement に対してできなかったのは
-  側チャネルを持たないからで、orzma にはある。
-- **mount が fire-and-forget のまま**。id はクライアントが既に持っているので、
-  「VT が採番して後から返す」案に伴う非同期性・対応付けの曖昧さ・失敗通知の
-  設計が丸ごと不要になる。
-- 衝突は host 採番の 128bit 乱数で構造的に消える。
-- SDK は既存の pending-reply 機構をそのまま使える。
+### D3. `InstanceId` は恒久スロット名
+
+mint 後、handle が登録されている間ずっと有効。`unmount` → 同じ id で再 `mount` は
+正当である。SDK の差分 flush（レイアウトが変わるたび mount / 消えたら unmount）が
+socket 往復なしで回る。
+
+注意: **`unmount` → 再 `mount` はエンティティとブラウザを作り直す**ので、ページの
+状態は保存されない。in-place になるのは、live な instance へ再 mount した場合だけ
+である（下の D3 不変条件2）。
+
+`PlacementId` の doc が宣言していた「単調増加・セッション中再利用なし」
+（`crates/orzma_vt/src/placement.rs`）は、次の2つに置き換わる。
+
+1. **allocated な `InstanceId` は host の registry 全体で一意。** mounted かどうかは
+   関係ない。unmount 済みでも handle 存続中は再 mount 可能＝allocated なので、
+   instance → handle の逆引きが一意である必要がある。128bit CSPRNG に加えて
+   vacant-entry チェックで構造的に保証する（確率任せにしない）。
+2. **ある瞬間に live な `InstanceId` は端末内で一意。** `supersede` が両スクリーンを
+   走査するので既存挙動のまま満たされる。端末間は、instance が handle に属し handle が
+   `owner_surface` に属することから、既存の所有権ゲートが担保する。
+
+**遅延した eviction が後継を殺さない根拠**は、supersede が先にテーブルから消すことである。
+`mount_placement` は cap チェックの前に両スクリーンで `supersede_placement` を走らせるので、
+再 mount された id の旧エントリはテーブルから消えており、**`evict_lost_anchors` が
+superseded な id を名指しすることは原理的にありえない**。この論証は alternate screen の
+flip、resize による anchor の孤立、history trim、RIS、複数チャンクが1 pump に入る場合を
+一様にカバーし、signal の順序に依存しない（resize と history trim はテーブルを触らず、
+anchor が解決しなくなるだけである）。
+
+補足として、signal の順序自体も byte stream 順で保存される（`OrzmaTty::pump` は
+drain_chunks で chunk の signal を byte 順に積み、最後に `sweep_evictions` の分を足して
+1本で返す）。ただし「eviction が必ず最後に来る」わけではない — alternate screen の flip は
+`Executor::switch_screen`（`crates/orzma_vt/src/interpreter.rs`）が interpret 中にその場で
+`WebviewEvicted` を出すので、`Evicted{X} → Mount{X}` の順序は実際に起こる。その順序が
+安全に処理されることは §5 で保証されている。
+
+### D4. 型は `InstanceId(u128)`、ワイヤは16進32桁固定
+
+`^[0-9a-f]{32}$`。`format!("{:032x}")` と `u128::from_str_radix(s, 16)` だけで往復でき、
+`orzma_vt` に新しい依存が増えない。`AnchoredPlacement` が `Copy` のままで、フレーム
+毎の String アロケーションが発生しない。VT は「16進32桁でなければ malformed」という
+構文ゲートを無償で得る。
+
+**`u128::from_str_radix` 単体では `^[0-9a-f]{32}$` にならない** — 大文字と `+` 接頭辞を
+受理するので、長さ32＋全バイトが `0-9a-f` であることを明示検査する。
+
+JSON では数値にできない（u128 は JS の `Number` が 2^53 で壊れる）ので文字列として運ぶ。
+10進（桁数可変・先頭ゼロのぶれ）と base32（`orzma_vt` に `data-encoding` 依存が増え、
+handle と見分けがつかない）は却下した。
+
+型の細部:
+
+- **`Debug` は手で実装して16進を出す。** 導出すると10進で出るので、`tracing` の各行と
+  `TtyWebview*Signal` の `Debug` がワイヤの綴りと食い違う。
+- **`Default` は導出しない。** `InstanceId(0)` は `"0"×32` という正当なワイヤ値なので、
+  事故で入った全ゼロ id が本物と区別できなくなる。
+- `MAX_VIEW_ID` を削除しても長さの上限は失われない。`MAX_APC_LEN = 1024` がフィールド
+  解析より前にペイロード全体を弾く（`crates/orzma_vt/src/interpreter/apc.rs`）。
+- 16進ちょうど32桁の上限は `u128::MAX` と一致するので、**パースにオーバーフロー分岐が
+  要らない**。構文ゲートは全域的になる。
+
+### D5. `ServerMsg` はバリアントを分ける
+
+既存の `Ok` は `handle: String` が必須なので `{"ok":true,"instance":"…"}` を表現できない。
+
+```rust
+#[serde(untagged)]
+pub(crate) enum ServerMsg {
+    Registered { ok: bool, handle: String, instance: String },
+    Instanced  { ok: bool, instance: String },
+    Err        { ok: bool, error: String },
+}
+```
+
+host は serialize しかしないので untagged の曖昧さは発生しない。
+
+### D6. SDK は `WebviewHandle` が既定 instance を兼ねる
+
+```rust
+let h  = session.register(wv)?;      // handle + 既定 instance
+let h2 = session.new_instance(&h)?;  // WebviewInstance
+
+frame.render_stateful_widget(
+    WebviewWidget::new(h.instance_id()),  area_a, &mut placements);
+frame.render_stateful_widget(
+    WebviewWidget::new(h2.instance_id()), area_b, &mut placements);
+
+h.emit("tick", &n)?;   // コンテンツスコープ: 両方のページに届く
+```
+
+`WebviewWidget::new` は `impl Into<String>` のままとし、専用トレイトは導入しない。
+
+**ただし既存コードは無修正では通らない。** 現在の呼び出し元は5箇所すべてが
+`handle.id()`（base32）を渡している — `apps/orzmd/src/ui.rs`、`apps/orzbrowser/src/ui.rs`、
+`sdk/ratatui_orzma/examples/{simple,rpc,forward_keys}.rs`。`^[0-9a-f]{32}$` ゲートでは
+これらが `flush_placements` の防御スキップに落ち、**コンパイルエラーも警告もなく webview が
+出なくなる**。したがって:
+
+- 全呼び出し元を `handle.instance_id()` に書き換えることを、この変更の必須作業に含める。
+- `flush_placements` のスキップに `tracing::debug!` を足し、無言で落ちないようにする（§4.3）。
+
+型で塞ぐ案（`WebviewWidget::new(&WebviewInstance)` か `InstanceId` newtype）は、この5箇所を
+コンパイルエラーに変えられる。採用しないのは設計判断であり、代償は上の2項目で埋める。
+
+### D8. handle も newtype にする（`HandleId`）
+
+`handle` という名前は維持する。改名（`ViewId` 案）は検討して却下した — 理由は
+「却下した案」節の E を参照。代わりに**型で分ける**:
+
+```rust
+// host 側（bevy_orzma_webview）
+pub(crate) struct HandleId(String);
+
+// SDK 側（ratatui_orzma、orzma_vt に依存しない独立クレートなので自前で定義）
+pub struct HandleId(String);
+```
+
+**`From<HandleId> for String` は実装しない。** これが型ゲートの本体である。
+`WebviewWidget::new(impl Into<String>)` が handle を受け付けなくなるのは、この変換が
+存在しないからで、便利さのつもりで足すと塞いだ穴が黙って開く。`Display` は実装してよい
+（`ToString` は `Into<String>` を生やさないため）。`orzma://<handle>/` の構築も
+`format!` 経由で従来どおり書ける。
+
+serde は `#[serde(transparent)]` にして、ワイヤ表現は文字列のまま変えない。
+
+**効き目は SDK 側に集中する。** host 側では `InstanceId(u128)` と handle の `String` が
+既に別型なので取り違えは起こらず、newtype の価値は自己文書化
+（`HashMap<InstanceId, HandleId>` が「instance → handle」だと型で読める）にとどまる。
+一方 SDK では `id() -> String` と `instance_id() -> String` が同型で、実際に
+`WebviewWidget::new` の16箇所が無言で壊れる経路になっていた。`HandleId` はそれを
+コンパイルエラーに変える。
+
+instance 側は SDK でも `String` のままにする。事故の向きは常に「instance を期待する場所に
+handle を渡す」であり、その一方向を塞げば十分だからである。両方を newtype にすると
+API 表面が増えるだけで、防げる誤りは増えない。
+
+### D7. host→VT の placement 削除経路を新設する
+
+現在の `despawn_mounted`（`crates/bevy_orzma_webview/src/control_plane.rs`）は ECS の
+子を despawn するだけで、VT の placement table は無傷である。**12枠を mount して
+`unregister` すると cap が枯れたままになる**（既存バグ）。`unmount;v=` を落とす D2 と、
+multi-instance が実用になることの両方から、この設計に含める。
+
+```rust
+#[derive(EntityEvent)]
+pub struct RequestTtyWebviewRemove {
+    #[event_target] pub terminal: Entity,
+    pub instances: Vec<InstanceId>,
+}
+```
+
+## §1 識別子モデルとワイヤ
+
+識別子は1つになる。`InstanceId` が「クライアントが持つアドレス」「VT が保持する id」
+「フレームが運ぶ id」「エンティティの identity」を兼ね、`handle` はコンテンツの
+識別子（`orzma://<handle>/` オリジン、RPC ルーティング、所有権）に純化される。
+
+APC の面:
+
+| 綴り | 意味 |
+| --- | --- |
+| `Omount;n=<inst>,r=<n>,c=<n>` | その instance をカーソル位置に配置。既に live なら in-place 更新 |
+| `Ounmount;n=<inst>` | その配置だけ外す |
+| `Ounmount` | この端末の全配置を外す |
+
+unmount のキーが1つになるので、「`n=` は `v=` を見た後でのみ受理」という現在の
+順序依存が消え、**unmount のキーも順序独立**になる。
+
+## §2 `orzma_vt` の変更
+
+**命名方針**: 変わるのは識別子の所有者だけで、「placement = 端末に貼られた矩形」と
+いう概念語は残す。`AnchoredPlacement` / `PlacementSize` / `ScreenPlacements` /
+`MAX_PLACEMENTS` は改名しない。`InstanceId` は placement を指す id なので
+`placement.rs` に置く。
+
+### 2.1 `placement.rs`
+
+```rust
+pub struct InstanceId(pub u128);
+
+impl InstanceId {
+    /// Digits in this id's wire spelling.
+    pub const WIRE_DIGITS: usize = 32;
+    pub fn from_bytes(bytes: [u8; 16]) -> Self { /* u128::from_be_bytes */ }
+}
+
+impl FromStr for InstanceId { /* 長さ Self::WIRE_DIGITS + [0-9a-f] を明示検査 */ }
+impl Display  for InstanceId { /* {:0width$x}, width = Self::WIRE_DIGITS */ }
+impl Debug    for InstanceId { /* 導出だと10進になるので手で hex を出す */ }
+```
+
+桁数は `InstanceId::WIRE_DIGITS` を唯一の出所にする。`from_str` の長さ検査と `Display` の
+ゼロ埋め幅が別々のリテラルだと、片方だけ変えたときに黙って食い違う。
+
+`PlacementId(u64)` は削除。`AnchoredPlacement.id: InstanceId` で `Copy` は維持。
+`PlacementId` の doc の `# Invariants` は D3 の2条件に差し替える。
+
+**`AnchoredPlacement` の `# Invariants` も書き換える。** 現在は「`size` は常に `id` の
+mount 時の予約と一致する。VT はサイズ変更を新しい id での remount として扱う」と宣言し、
+`size` の field doc も「unchanged from the mount that reserved it」と書いている。id 一本化後は
+サイズ変更が id を保ったまま起きるので、この宣言は偽になる。実際に壊れる消費者はいない
+（host は毎フレーム size を読み直し、`diff_placements` は `Vec` の位置比較なのでサイズ変更で
+再 emit される）が、doc は直す必要がある。
+
+### 2.2 placement テーブルの縮小
+
+```rust
+struct Placement {
+    id: InstanceId,
+    anchor: LineId,
+    col: GridColumn,
+    size: PlacementSize,
+}
+```
+
+`view_id` / `instance_id` の2フィールドと `Placement::addressed_by` が消える。
+
+| メソッド | 現在 | 変更後 |
+| --- | --- | --- |
+| `ScreenPlacements::mount` | `(id, anchor, col, size, view_id, instance_id)` | `(id, anchor, col, size)` |
+| `ScreenPlacements::supersede` | `(view_id, Option<instance_id>)` | `(id: InstanceId)` |
+| `ScreenPlacements::unmount` | `(Option<view_id>, Option<instance_id>)` の3分岐 | `(Option<InstanceId>)` の2分岐 |
+| `ScreenPlacements::remove_many` | — | 新設 `(&[InstanceId]) -> bool` |
+
+`DeviceState` からは `next_placement_id` フィールドと `mint_placement_id()` が消える
+（VT はもう採番しない）。`mount_placement` の戻りは `Option<PlacementId>` から
+`bool`（cap が受け入れたか）になる。`DeviceState::remove_placements(&[InstanceId]) -> bool`
+は両スクリーンを走査し、既存の `unmount_placement` と同じく短絡しない。
+
+### 2.3 APC パーサ
+
+```rust
+enum WebviewApcRequest {
+    Mount   { instance: InstanceId, size: PlacementSize },
+    Unmount { instance: Option<InstanceId> },
+}
+```
+
+`mount` の必須キーは `n` / `r` / `c` の3つ。`v=` は未知キーとして malformed 扱い。
+`valid_view_id()` と `MAX_VIEW_ID` は削除できる（handle がワイヤから消え、
+`InstanceId::from_str` が唯一のゲートになる）。
+
+### 2.4 signal
+
+```rust
+WebviewMount         { instance: InstanceId, size: PlacementSize },
+WebviewMountRejected { instance: InstanceId },
+WebviewUnmount       { instance: Option<InstanceId> },
+WebviewEvicted       { placements: Vec<InstanceId> },
+```
+
+`view_id` が全バリアントから消え、`WebviewMount` の `placement` フィールドも消える
+（`instance` がそれを兼ねる）。
+
+### 2.5 host 駆動の削除（`Vt` トレイトのメソッド）
+
+D7 の受け口は `Vt` トレイトに載せる。`sweep_evictions` が既にトレイト上の placement 専用
+メソッドなので、`remove_placements` はその隣に並ぶ形になり、新しいカテゴリを持ち込まない。
+
+```rust
+// orzma_vt — Vt トレイト
+/// Removes the placements the host names, on either screen; returns
+/// whether anything went.
+fn remove_placements(&mut self, instances: &[InstanceId]) -> bool;
+
+// orzma_tty — ジェネリックのまま
+impl<V: Vt> OrzmaTty<V> {
+    pub fn remove_placements(&mut self, instances: &[InstanceId]) {
+        if self.vt.remove_placements(instances) {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+    }
+}
+```
+
+代償: `orzma_tty` のテスト用 `FakeVt` にスタブが1つ増える。`pub mod test_support` は
+無条件公開なので、そのスタブは `orzma_tty` の公開 API に出る。`FakeVt` は既に
+`sweep_evictions` を実装しているため増分は1つ分で、既存の形と対称である。
+
+### なぜこの経路が必要か
+
+発火点は4つあるが、**本質的に必要なのは下の2つ**である。
+
+| 発火点 | クライアント | 他の手段で代替できるか |
+| --- | --- | --- |
+| `unregister`（UDS op） | 生きている | できる（SDK が先に `Ounmount;n=` を書けばよい） |
+| **接続断 / プロセス死** | **いない** | **できない** — PTY に書く主体がもういない |
+| `gc_despawned_surfaces` | — | 不要 — 端末ごと消えるので observer は空振りする |
+| **mount ゲートでの却下** | 生きているが**知らない** | **できない** |
+
+mount ゲートでの却下がいちばん強い理由である。**APC は一方通行で返信がないので、
+クライアントは mount が成功したと思っている。** 未知の instance・非所有 handle・スロット
+枯渇・url 解決不能のいずれで host が却下しても伝わらない。一方 VT は `n=` の provenance を
+検証できないので、構文さえ合っていれば placement を登録し cap の1枠を消費する。その枠は
+アンカー行が履歴リングから落ちるまで解放されない（出力の少ないアプリでは実質永久）。
+「誰も unmount を書かない配置」を回収できるのは host だけである。
+
+`unregister` はこの経路に相乗りしているだけで、それ単独では必要条件ではない。ただし
+クライアント実装が SDK 経由とは限らない（手書きのプログラムが `unregister` だけ送って PTY に
+何も書かない、は普通に起こる）ので、経路がある以上は統一して使う。
+
+**damage は stage しない。** `resize` / `scroll` は `DamageSpan::Full` を stage するが、
+placement の削除は**行 damage を一切起こさない** — `apc_dispatch` も
+`output.damaged |= …` で liveness を上げるだけである（placement リストは
+`FrameTracker::emit` の差分セクションなので、変化しただけでフレーム発行が確定する）。
+`resize` と同じ規約で実装すると `unregister` のたびに全ビューポート再描画になる。
+戻り値の bool は「本当に消えたか」だけを表し、`OrzmaTty` が coalescer を arm する。
+
+削除処理そのものは `ScreenPlacements` の既存プリミティブ（`evict_where`）に集約する。
+id 一本化後、`supersede`・`unmount` のフル指定・host の削除は文字どおり同じ
+`retain(|p| p.id != id)` になるので、低層は1本にまとめ、**公開エンドポイントは分けたまま**に
+する（interpreter は `OrzmaVt` 全体ではなく分離借用された `DeviceState` / tracker / output を
+操作するため、トレイトメソッドを素直に再利用できない）。
+
+**`WebviewEvicted` は出さない。** 呼び出し元の host は既に対象を知っていて ECS 側も
+同時に落とすので、signal を返すと自分の despawn を二重に受け取ることになる。
+`supersede` が id を名指ししないのと同じ理屈である。
+
+### 2.6 supersede の意味が変わる
+
+現在は「新しい `PlacementId` を採番し、旧 id は名指しされず黙って消える」。一本化後は
+同じ `InstanceId` の table エントリを差し替えるだけになり、「観測できないまま消えた id」
+という歪みが解消され、kitty の in-place 更新（"without flicker"）に揃う。
+
+## §3 host — コントロールプレーンと `mount.rs`
+
+### 3.1 registry を instance の逆引き付きにする
+
+```rust
+pub(crate) struct OrzmaRegistry {
+    by_handle:   HashMap<String, OrzmaView>,   // OrzmaView に instances: Vec<InstanceId>
+    by_instance: HashMap<InstanceId, String>,  // instance → handle
+}
+
+pub(crate) struct RemovedRegistration {
+    pub handle: String,
+    pub owner_surface: Entity,
+    pub instances: Vec<InstanceId>,
+}
+```
+
+フィールドとメソッドは `pub` にする。可視性の上限は構造体自身の `pub(crate)` で既に
+決まっているので、各フィールドに `pub(crate)` を重ねても意味が変わらず、冗長なだけである。
+
+2つの map は同じ `&mut self` メソッドの中でしか触らないので原子的に保たれる。
+`remove` / `remove_by_connection` / `remove_by_surface` は `Vec<String>` ではなく
+`RemovedRegistration` を返し、呼び出し側は asset の purge・ECS の despawn・VT の
+削除を1つの値から駆動する。
+
+採番は `OrzmaRegistry::mint_instance(&mut self, handle: &HandleId) -> Option<InstanceId>` に
+置く。**これが `InstanceId` を生む唯一の経路**であり、D3 の不変条件1（allocated な id は
+registry 全体で一意）はここで成立する。
+
+**採番方式は `PlacementId` から変わる。** `PlacementId` は端末ごとの単調増加カウンタだったが、
+`InstanceId` は 16 バイトの OS CSPRNG である。理由は一意性ではなく**推測不可能性**である —
+`PlacementId` は VT から host にしか渡らなかったが、`InstanceId` はクライアントに渡り
+PTY 経由で戻ってくる。mount のゲートは `owner_surface`（ペイン単位であって接続単位ではない）
+なので、同じペインの別プログラムが id を推測できると他人の配置を mount / unmount できる。
+handle が既に 128bit CSPRNG なのと同じ理由である。一意性だけなら host グローバルな
+カウンタでも足りる。
+
+`Option` が意味するのは**「未知の handle」だけ**である。乱数の失敗は `mint_id()` と同じく
+`.expect()` する（CSPRNG が使えない環境ならアプリは継続できないし、handle 採番だけ panic して
+instance 採番だけ fallible という非対称も避ける）。衝突は数千エントリ対 2^128 で到達しないので
+`debug_assert!` に置き、`Option` には混ぜない — 到達しない分岐を戻り値に混ぜると、呼び出し側が
+書けもテストもできないエラー処理を強いられる。
+
+型を作る部分は `orzma_vt` 側の associated function `InstanceId::from_bytes([u8; 16])` に置き、
+乱数は host に残す。`orzma_vt` に `InstanceId::new()`（乱数を引く版）を置かないのは、依存を
+増やさないためだけでなく、**D1 で取り除いた「VT 採番」を復活させる引き金を残さないため**である。
+
+### 3.2 live state の権威は ECS のまま
+
+mount 済み webview の live state（どの instance がどの端末のどの slot にいるか）は、
+**`Webview` component と `ChildOf` 関係が唯一の権威**であり続ける。`mount()` の重複判定は
+現行どおり `live_webview_children` の `Children` スキャン、slot 割り当ては
+`smallest_free_slot` のままとする。1端末あたり最大12件なので走査コストは問題にならない。
+
+§3.1 の `by_instance` はこれとは別物で、**allocation と所有権の権威**である
+（instance → handle → `owner_surface`）。live かどうかは持たない。
+
+同一 signal バッチ内でこのスキャンが最新の状態を見ることは §5 で保証されている。
+派生索引（`TerminalWebviews` のような `HashMap<InstanceId, Mounted>`）は、
+ECS state の二重管理になるうえ、その整合性のための不変条件が索引自身の存在によって
+生じるハザードを守る循環になるため、採用しない。
+
+### 3.3 mount のゲート列
+
+```text
+1. 未知の instance          → registry の逆引きで解決できない  → debug + 回収 + return
+2. この端末に同じ instance  → in-place 更新して return
+3. resolve_mount(handle)    → 未登録 / owner_surface 不一致    → debug + 回収 + return
+4. overlay スロット枯渇                                        → debug + 回収 + return
+5. url が解決できない                                          → debug + 回収 + return
+```
+
+1 を先頭に置くのは、handle が取れないと 3 以降が書けないためである。「回収」は §6 の
+VT 側 placement の削除を指す。
+
+### 3.4 コンポーネントの統合
+
+id が1つになると `Webview.instance_id` と `WebviewPlacement.placement` が同じ値になり、
+二重持ちになる。1コンポーネントに畳む。
+
+```rust
+pub struct Webview {
+    pub handle: String,        // view_id からの改名
+    pub instance: InstanceId,
+    pub slot: u8,
+    pub rows: u16,
+    pub cols: u16,
+}
+```
+
+`WebviewPlacement` は削除。`on_placement_removed` は `On<Remove, Webview>` に移り、
+compositing 停止通知とマップの刈り取りの両方を担う。`sync_webview_size` は
+`(&mut WebviewSize, &Webview)`。`mount` の in-place 更新は `Webview` への `set_if_neq`。
+
+### 3.5 ワイヤの op
+
+追加:
+
+```rust
+ClientMsg::NewInstance { handle: String }
+ControlEvent::NewInstance { connection_id, owner_surface, handle, reply }
+```
+
+listener の dispatch は `Register` と同型（`reply_rx.recv()` でブロックしてから次の行を
+読む）ので、接続あたりの応答順序は厳密に保たれる。エラーコードは `unknown_handle` /
+`not_owner`。
+
+instance スコープ化するもの:
+
+| op | 現在 | 変更後 | 理由 |
+| --- | --- | --- | --- |
+| `focus` | `{handle, instance}` | `{instance}` | instance だけで一意に引ける |
+| `navigate` | `{handle, action}` | `{instance, action}` | 現在は `.find()` で先頭を選ぶので N インスタンスで曖昧 |
+| `compositing`（push） | `{handle, active}` | `{handle, instance, active}` | どの配置が composite したか SDK が判別できない |
+| `call`（push） | `{handle, reqId, …}` | `{handle, instance, reqId, …}` | どのページからの呼び出しか区別する |
+
+`WebviewOwner` に `instance: InstanceId` を足し、`call` の push がそれを載せる。
+
+handle スコープのまま残すもの: `emit`（全インスタンスのページに配るのが正しく、
+既存の loop がそのまま機能する）、`unregister`、`register`。
+
+### 3.6 D7 の配線
+
+`bevy_orzma_tty` に `RequestTtyWebviewRemove` を新設し、observer が §2.5 の
+`OrzmaTty::remove_placements` を叩く（`RequestTtyScroll` と同型）。焚くのは
+`Unregister`、`Disconnect`、`gc_despawned_surfaces` の3箇所。いずれも
+`RemovedRegistration` から `(owner_surface, instances)` を読む。
+`gc_despawned_surfaces` は端末エンティティ自体が消えているので observer が空振りするが、
+VT ごと消えているので正しい。
+
+### 3.7 `apply_control_events` の分割
+
+現在 `crates/bevy_orzma_webview/src/control_plane.rs` の 440–650 行（本体 ≈193行）で、
+Rust 規約の「system 本体 ~150行」を超えている。`NewInstance` を足すとさらに伸びるので、
+各 `ControlEvent` の腕を private helper fn に切り出し、system 本体を振り分けだけにする。
+
+## §4 SDK（`sdk/ratatui_orzma`）
+
+SDK は `orzma_vt` に依存しない独立クレート（`publish = true`）なので、instance は
+**不透明な文字列のまま**扱う。host が u128、SDK が String という非対称は意図的である。
+
+### 4.1 型
+
+```rust
+pub struct WebviewHandle {
+    handle:   Arc<Mutex<HandleId>>, // 登録の id
+    instance: Arc<Mutex<String>>,   // 既定 instance
+    events:   Arc<EventQueues>,
+    writer:   SharedWriter,
+}
+
+pub struct WebviewInstance {
+    id:     Arc<Mutex<String>>,
+    writer: SharedWriter,
+}
+```
+
+id スロットが両方 `Arc<Mutex<..>>` なのは、reconnect が中身を差し替えるだけで
+クローン済みのハンドルが追随するためである（handle が既に使っている仕組みの踏襲）。
+
+採番は **`Orzma::new_instance(&self, handle: &WebviewHandle) -> OrzmaResult<WebviewInstance>`**
+に置く。`WebviewHandle` には置けない — pending FIFO（`PendingRegisters`）にも
+`registrations` にも到達できないためで、`Clone` されるハンドルに `Arc` を2つ増やすのも
+避けたい。`Orzma` 側に置けば §4.5 の replay スロット登録を `Registration` の構築と同じ場所で
+行える。
+
+`WebviewHandle::handle_id()` は `HandleId` を、`instance_id()` は既定 instance の
+`String` を返す。**無印の `id()` は残さない** — 自然に手が伸びる名前が handle を返すのが
+事故の入口だったためで、改名により既存の `view.id()` 4箇所はコンパイルエラーになる。
+加えて D8 の newtype に `From<HandleId> for String` が無いので、`handle_id()` の戻り値を
+widget に渡しても `impl Into<String>` に適合せず、二重に塞がる。widget と navigate に
+渡すのは `instance_id()` である旨を、両メソッドの doc に明記する。
+
+### 4.2 描画モデルを instance キーにする
+
+```rust
+struct Placement { instance: String, area: Rect }
+
+struct FramePlacements {
+    placements: Vec<Placement>,
+    focused: Option<String>,                    // instance
+    pending_compositing: HashMap<String, bool>, // instance キー
+}
+
+struct FlushState {
+    last: HashMap<String, Rect>,                // instance キー
+    last_focused: Option<String>,               // instance
+}
+```
+
+`flush_placements` の畳み込みが instance キーになることで、同一 handle の N 配置が
+それぞれ独立して diff される。差分ロジック自体は無変更。
+
+### 4.3 `escape.rs`
+
+```rust
+mount(instance, rows, cols) → "\x1b_Omount;n={instance},r={rows},c={cols}\x1b\\"
+unmount(instance)           → "\x1b_Ounmount;n={instance}\x1b\\"
+```
+
+`valid_handle`（`^[A-Za-z0-9._-]{1,128}$`）は `valid_instance`（`^[0-9a-f]{32}$`）に
+置き換える。「不正な値の placement は1件だけスキップして flush 全体を落とさない」防御は
+そのまま残すが、**スキップ時に `tracing::debug!` を出す**。現在は無言で捨てており、
+D6 で述べた「handle を渡してしまった」ケースが診断不能になるためである。
+
+引数なしの `Ounmount` は SDK からは出さない。ワイヤの綴りとしては残す（手書きの
+エスケープハッチ、および RIS / screen flip とは別経路の一括解除として）。
+
+### 4.4 pending FIFO の enum 化
+
+現在の FIFO は `PendingRegister` 型固定で、応答パーサも `handle` 必須を前提にしている。
+
+```rust
+enum Pending {
+    Register    { reply: Sender<OrzmaResult<(String, String)>>, handlers, events },
+    NewInstance { reply: Sender<OrzmaResult<String>> },
+}
+
+struct ServerReply {
+    ok: bool,
+    handle:   Option<String>,
+    instance: Option<String>,
+    error:    Option<String>,
+}
+```
+
+どのフィールドが必須かは FIFO の先頭エントリが決める。**pop は検証より先に行う** —
+種別が食い違ったときにエントリを残すと FIFO が恒久的にずれるので、必ず1件消費してから
+待機側にプロトコル違反エラーを返しログする。
+
+**reqId は導入しない。** 接続あたりの応答順序は host 側で厳密に保たれており
+（listener は `register` / `new_instance` で `reply_rx.recv()` をブロックしてから次の行を
+読む）、SDK 側も writer lock を保持したまま FIFO に push している。位置対応で十分である。
+
+**現行の判別規則はドキュメントより緩い。** reader は「`call` / `compositing` / `event` の
+いずれでもなく、かつ `RegisterReply` としてパースできる行」を応答とみなしており、
+`RegisterReply` は `ok: bool` しか必須にしていない（`handle` と `error` は
+`#[serde(default)]`、`deny_unknown_fields` なし）。結果として、`"ok": <bool>` を持つ未知の
+`op` の行が FIFO を1件消費し得る。仕様書の「op のない行 = 直近リクエストへの応答」は
+「最も古い未処理リクエストへの応答」に一般化して書き直すと同時に、**reader 側も
+`op` フィールドの不在を明示的に確認する**ようにして、仕様と実装を揃える。
+
+### 4.5 reconnect
+
+```rust
+struct Registration {
+    kind: RegisterKind,
+    handle_slot: Arc<Mutex<HandleId>>,
+    instance_slot: Arc<Mutex<String>>,          // 既定 instance
+    extra_instances: Vec<Arc<Mutex<String>>>,   // new_instance で作った分
+    handlers, events,
+}
+```
+
+replay ループが registration ごとに、re-register で `handle_slot` と `instance_slot` を
+埋め、続けて `extra_instances` の数だけ `new_instance` を発行してスロットを埋める。
+既存の `generation.fetch_add(1)` はループを抜けた後にあるので、全スロットが埋まるまで
+世代は上がらず、`FlushState::reset()` → 全再 mount の順序は自動的に守られる。
+
+`Session` は生成した `WebviewInstance` のスロットを `Registration` に登録する経路が要る
+（§4.1 で `new_instance` を `Orzma` 側に置いたのはこのためでもある）。
+
+**失敗パスを設計に含める。** 現在の replay ループは、途中の失敗でどこからでも
+`disconnected = true` を立てて `return` し、generation を上げず、既に再登録済みの
+エントリのロールバックもしない。`new_instance` の往復が registration ごとに N 回増えるので
+この露出は増える。加えて応答待ちの `rx.recv()` にはタイムアウトがない。中途半端に
+埋まった replay は、`FlushState.last` に古い instance キーを残したまま `reset()` されない
+状態を作る。方針:
+
+- replay が途中で失敗したら、そのセッションは切断済みとして扱い、次の reconnect を待つ
+  （現行と同じ）。ただし **`FlushState` の無効化は generation ではなく切断フラグでも
+  行う**ようにして、古いキーで APC を書き続けないようにする。
+- 応答待ちには上限を設ける。
+
+### 4.6 focus と compositing
+
+`flush_focus` は `ClientMsg::Focus { instance: Option<String> }` を送る。reader スレッドは
+`compositing` push の `instance` で `pending_compositing` をキーする。
+`WebviewWidget::render` は `state.take_compositing(&self.instance)` を引く。
+「1フレームに focus を主張する widget は高々1つ」の `debug_assert` はそのまま。
+
+これで「同一 handle の A/B を同時表示し、A だけ unmount したら B まで非 active に
+見える」というクロストークが構造的に消える。ただし**別の欠落は残る** — `Orzma::frame()` は
+`pending_compositing` を `mem::take` で奪うので、その フレームで描画されなかった
+instance の通知は落ちる。これは再キーとは直交する問題で、この変更では扱わない。
+
+**この再キーは host と SDK をまたぐ原子的な切り替えである。** reader は
+`v["handle"]` と `v["active"]` が両方揃わない push を黙って捨てるので、§3.5（host が
+`instance` を載せる）と §4.6（SDK が `instance` でキーする）が同じコミットに入らないと、
+compositing コールバックが**無診断で発火しなくなる**。片方だけ先行させないこと。
+
+### 4.7 navigate と call の SDK 側
+
+§3.5 で instance スコープにした2つは SDK にも受け皿が要る。
+
+- `navigate` — `ClientMsg::Navigate` に `instance` を載せ、`WebviewInstance` に
+  `navigate` / `go_back` / `go_forward` / `reload` を生やす。`WebviewHandle` の同名メソッドは
+  **既定 instance を駆動する**（handle 全体へのブロードキャストではない）。
+- `call` push の `instance` — `IncomingCall` にフィールドを足す。足さなくても serde が
+  黙って捨てるだけでエラーにはならないが、それではハンドラがどのページからの呼び出しか
+  永久に判別できず、multi-instance を足す意味が半減する。ハンドラ側 API にどう見せるかは
+  この変更のスコープに含める。
+
+## §5 signal バッチ内の逐次可視性
+
+D3 が「unmount 後に同じ id で再 mount してよい」と言う以上、host の webview
+ライフサイクルは **signal 順に適用され、各ステップの結果が次のステップから見える**
+必要がある。`pump_terminals`（`crates/bevy_orzma_tty/src/signals.rs:143`）は1回の pump の
+signal をすべて `commands.trigger` でキューに積むので、この性質が本当に成り立つかは
+`bevy_ecs` の command 適用順に依存する。
+
+**成り立つ。** `bevy_ecs-0.19.0` は各コマンドのメタデータに次のトランポリンを
+埋め込んでおり（`world/command_queue.rs` の `RawCommandQueue::push`）、**1コマンドごとに
+`world.flush()` が走る**:
+
+```rust
+command.apply(world);
+// The command may have queued up world commands, which we flush here to ensure they are
+// also picked up. If the current command queue already the World Command queue, this will
+// still behave appropriately because the global cursor is still at the current `stop`,
+// ensuring only the newly queued Commands will be applied.
+world.flush();
+```
+
+したがって `commands.trigger(Evicted{X})` の observer が積んだ despawn は、次の
+`commands.trigger(Mount{X})` が走る**前に**適用される。`apply_or_drop_queued` が入口で
+`stop = bytes.len()` を固定するのは、この入れ子 flush が「新しく積まれた分だけ」を
+適用するための仕掛けであって、適用を妨げるものではない。
+
+実測でも確認済み（production 相当のプローブ）:
+
+```text
+[Evicted{X}, Mount{X}] → evict が despawn → mount は live=[] を見て spawn → entity 1つ
+[Mount{X}, Mount{X}]   → 1回目 spawn → 2回目は live に見えるので in-place → entity 1つ・slot 1つ
+```
+
+**この保証は文書化されていない実装詳細であり、近傍の docs はむしろ逆を述べている。**
+`Observer` の docs は "Commands sent by observers are currently not immediately applied.
+Instead, all queued observers will run, and then all of the commands from those observers
+will be applied" と書くが、これは**同一 trigger の複数 observer**とライフサイクル連鎖
+（`OnAdd`→`OnInsert`、bevyengine/bevy#20833）を指すもので、1つのキューに並んだ別々の
+`Commands::trigger` コマンド同士には当たらない。
+
+依存が壊れたら静かに壊れる種類のものなので、**この性質を固定する回帰ガードを2本置く**
+（§7 のテスト戦略）。既存の `mount.rs` のテストヘルパが `trigger` ごとに
+`world_mut().flush()` を挟んでいるのは production を忠実に再現しており、経路が
+覆われていないわけではない。ガードは「バージョンアップでこの前提が変わったら落ちる」
+ためのものである。
+
+### 検討して採用しなかった対策
+
+いずれも上の保証が成り立たない場合の備えとして検討したが、成り立つ以上は不要である。
+
+- host 側に権威マップ（`TerminalWebviews`）を持ち、observer が `ResMut` で即時更新する
+  — observer 内の `ResMut` が即時反映されること自体は正しい（実測で確認）が、ECS の
+  派生コピーを増やし、その整合性のための不変条件（entity 一致での刈り取り）が
+  マップ自身の存在によって生じるハザードを守るという循環になる。
+- `pump()` が signal 列を id ごとに coalesce する — signal が「起きたこと」ではなく
+  「正味の結果」になり、`orzma_tty` が VT の placement 意味論を知ることになる。
+- ライフサイクルを1つの順序付き適用システムに畳む — 最も原理的だが、signal の面と
+  既存テストの書き換えが最大。
+
+## §6 エラー処理と診断
+
+### mount ゲート失敗は VT の幽霊配置も回収する
+
+D7 で host→VT の削除経路ができたので、却下した mount の VT 側 placement を回収できる。
+
+```text
+mount() が却下（未知 instance / 非所有 / スロット枯渇 / url 解決不能）
+  → tracing::debug!
+  → commands.trigger(RequestTtyWebviewRemove { terminal, instances: vec![instance] })
+```
+
+現在は、未登録 handle への mount が VT に placement を登録したまま残り、cap の1枠を
+アンカーが履歴から落ちるまで占有する。回収を入れると、不正な `n=` を投げ続けても cap を
+枯らせない。`WebviewMountRejected`（VT の cap 満杯）は VT が何も登録していないので回収不要。
+
+### プログラムへの通知は入れない
+
+未知 instance の場合そもそも所有者を特定できず、既知だが非所有の場合だけ通知できると
+いう非対称が生まれる。既存の未登録 handle と同じ `tracing::debug!` に揃え、push 通知は
+将来の別変更とする。
+
+### エラーコード
+
+`new_instance` → `unknown_handle` / `not_owner`。SDK は `OrzmaError` にバリアントを1つ
+追加する。malformed な APC は現状どおり黙って捨てる。
+
+## §7 ドキュメント・移行・テスト戦略
+
+### 更新するドキュメント
+
+| 対象 | 内容 |
+| --- | --- |
+| `docs/orzma_webview_protocol.md` | op 表に `new_instance`、register 応答の形、「op なし行 = 最も古い未処理リクエストへの応答」への一般化、mount / unmount 節の全面書き換え、`instance` の意味論を新設、シーケンス図、例、エラーコード表 |
+| `CLAUDE.md` | 「writes an APC `Omount;v=<handle>` sequence」→ `new_instance` を挟む新しい流れ |
+| `.claude/skills/enumerate-test-cases/SKILL.md` | `PlacementId` への言及を `InstanceId` に |
+
+### 移行
+
+**破壊的変更で、互換期間は設けない。** `Omount;v=…` は parse しなくなる。根拠は、
+`instance_id` が現時点で誰にも使われておらず、リポジトリが `refactor!:` / `fix!` で
+破壊的変更を通常運用しているためである。
+
+破壊の内訳は一様ではないので、正確には次のとおり:
+
+| 変更 | 旧クライアントへの影響 |
+| --- | --- |
+| `Omount;v=…` の廃止 | **破壊的**。古い SDK の mount は malformed として捨てられる |
+| `register` 応答への `instance` 追加 | 無害。現行 SDK の `RegisterReply` は未知フィールドを無視する |
+| `compositing` push への `instance` 追加 | 無害（読まれないだけ）。ただし §4.6 の再キーと同時に入る必要がある |
+| `focus` / `navigate` の instance 化 | **破壊的**。host 側のフィールドが変わる |
+
+SDK と `apps/` 配下の呼び出し元は同じ PR で追随する。
+
+### テスト戦略
+
+§5 の2本は**回帰ガード**である。現在の `bevy_ecs` 0.19 では両方とも green になる
+（依存している逐次可視性が文書化されていない実装詳細なので、バージョンアップで壊れたら
+落ちるようにしておく）。production 相当の形にするには、`world.trigger()` を直接複数回
+呼ぶのではなく、**1つの system から複数の `commands.trigger` を積み、deferred の適用を
+1回走らせる**必要がある。既存ヘルパの per-trigger `flush()` は production を忠実に
+再現しているので、そちらはそのまま残す。
+
+**先行して必要な harness 変更がある。** SDK の `FakeServer::start`
+（`sdk/ratatui_orzma/tests/support/mod.rs`）は `{"ok":true,"handle":…}` を自動応答し
+`instance` を返さない。また `next_message()` は `hello` / `register` しか除外しないので、
+`new_instance` の行が後続のアサーションに漏れ込む。両方を先に直す。
+
+| 層 | 追加するテスト |
+| --- | --- |
+| `orzma_vt` | `InstanceId::from_str` の境界（31/32/33桁・大文字・`+` 接頭辞・非16進）／`remove_placements` が両スクリーンを走査し短絡しない・**行 damage を stage しない**（`resize` と違う点なので明示的に固定する）・消えたときだけ `true` を返す／unmount のキーが順序独立 |
+| `orzma_tty` | `remove_placements` が本当に消えたときだけ coalescer を arm する |
+| `bevy_orzma_webview` | **回帰ガード**: `[Evicted{X}, Mount{X}]` を production 形状の1バッチで処理して webview が1つ残る／`[Mount{X}, Mount{X}]` で entity が1つ・スロットが1つ。ほかに、未知 instance の mount が何も spawn せず VT 側も回収される／`new_instance` の handle ゲート／`unregister` が ECS と VT の両方を落とす（既存バグの回帰）／同一 handle の2 instance で `compositing{active:false}` が片方だけを名指しする |
+| `sdk/ratatui_orzma` | 同一 handle の2 instance が1フレームで2本の mount になる／片方だけ area 変更で片方だけ再 mount／`Pending` の enum が混在 FIFO で正しい待機者に届く（種別不一致でも FIFO がずれない）／reconnect 後に既定＋追加 instance の両スロットが埋まる／不正な instance のスキップが `tracing::debug!` を出す |
+
+既存テストで書き換えが要るもの（網羅ではない）: `escape.rs::rejects_out_of_range_dims`
+（handle `"h"` を使っており、charset ゲートで先に落ちて寸法範囲を検査しなくなる）、
+`flush_skips_degenerate_area`（誤った理由で通るようになる）、`WebviewHandle::new_shared` の
+3引数呼び出し2箇所、`interpreter/apc.rs` の unmount 順序テスト
+（`unmount_instance_without_view_rejected` は消え、代わりに順序独立を固定する）。
+
+`bevy_orzma_webview` のテストは CEF の provisioning（`just setup-cef`）が前提である。
 
 ## 却下した案
 
-**A. placement id をクライアントが採番する（kitty の実モデル）** — 実質
-「`instance_id` を改名して必須化する」だけ。VT は `PlacementId` の非再利用性を
-守るため内部 id を持ち続ける必要があり、**識別子は結局2つ残る**。
+**A. placement id をクライアントが採番する（kitty の実モデル）** — 当初は「VT は
+`PlacementId` の非再利用性を守るため内部 id を持ち続ける必要があり、識別子は結局2つ
+残る」として却下した。**この根拠は失効している** — D3 が不変条件を「同時に live な id の
+一意性」に弱めた時点で、内部 id は不要になった。したがって案 A は再評価が必要になり、
+その結果が次の A' である。
 
-**B. VT が採番して PTY 返信で返す** — クライアントが端末返信をパースする必要が
-あり（状態機械＋タイムアウト）、mount が request/response になる。さらに TTY は
-全チャンクを drain して reply を書いた**後で** signal を Bevy に返すので、
-**GUI mount 完了の acknowledgment にはならない**。reply 単独では damage も
-arm しない。先行事例もゼロ。
+**A'. `v=<handle>` を残し `n=` をクライアントが採番する（`(handle, instance)` の組を
+アドレスにする、通称「設計2」）** — 再評価の結果、**技術的には D1 より多くの点で優れて
+いた**。記録として差分を残す。
 
-**D. multi-placement 自体をやめる**（1ハンドル＝1配置、N 個欲しければ N ハンドル
-登録）— 現時点で `instance_id` が未使用なので回帰ゼロ、プロトコルは最小になる。
-ただし**同一論理ビューの N 配置が N オリジンになり、localStorage 等を共有できない**。
-「同一ハンドルの複数配置は必要」という判断により却下。
+- 往復ゼロ（`new_instance` op が不要）、reconnect の replay は 1 回、`WebviewWidget::new`
+  の既存16箇所が無変更、registry の逆引きも `ServerMsg` の分割も不要。
+- D7 は既存の `DeviceState::unmount_placement(Some(handle), None)` をそのまま再利用でき、
+  VT 側の新規テーブル処理はゼロ。
+- 衝突は構造的にゼロ（アドレスの先頭が host 採番の 128bit handle なので、別プログラムが
+  同じ `n=1` を選んでも組は異なる）。同一 handle 内の重複は自分の名前重複＝supersede で、
+  kitty が "without flicker" と呼ぶ意図された挙動。
+- 先行事例は圧倒的にこちら（kitty 仕様、WezTerm 実装、X11、Wayland、HTTP/2、AIP-133）。
+- 唯一の技術的代償は `AnchoredPlacement` が `Copy` を失うこと（64B）。実測では
+  `project() + diff_placements` が 1 emit あたり 28-49ns → 410-487ns だが、coalescer が
+  emit を約 333 回/秒に制限するため差は **約 140µs/秒 ≒ 1コアの 0.014%**
+  （レンダラ込みで 0.03%、webview 0 個ならゼロ）。決定的な反対理由にはならない。
+  なお `n=` を `1..=4294967295` に制限し handle を u128 にデコードすれば 32B で `Copy` を
+  維持できる（設計2b）。
 
-## 壊れるもの — `PlacementId` の非再利用に依存している箇所
+**それでも D1 を採る理由は1つ** — 設計2 では `orzma_vt` が `view_id: String` を持ち
+続ける（中身を解釈することは一度もない不透明な文字列として）。**VT から handle 概念を
+排除することを最上位要件とする**判断により、上記のコストを承知で D1 を採用した。
 
-`PlacementId` の doc は「単調増加・セッション中再利用なし」を不変条件として
-宣言している（`crates/orzma_vt/src/placement.rs:10-18`）。調査の結果、
-**単調な大小関係に依存する production コードは存在しない**。実際に必要なのは
-非再利用性だけで、これは host の 128bit 乱数採番で満たせる（tombstone 不要）。
+**B. VT が採番して PTY 返信で返す** — クライアントが端末返信をパースする必要があり
+（状態機械＋タイムアウト）、mount が request/response になる。さらに TTY は全チャンクを
+drain して reply を書いた後で signal を Bevy に返すので、GUI mount 完了の acknowledgment
+にはならない。reply 単独では damage も arm しない。先行事例もゼロ。
 
-再利用が起きた場合に壊れる箇所:
+**D. multi-placement 自体をやめる**（1ハンドル＝1配置、N 個欲しければ N ハンドル登録）—
+現時点で `instance_id` が未使用なので回帰ゼロ、プロトコルは最小になる。ただし同一論理
+ビューの N 配置が N オリジンになり、localStorage 等を共有できない。「同一ハンドルの
+複数配置は必要」という判断により却下。
 
-| 現象 | 箇所 |
-| --- | --- |
-| 遅延した `WebviewEvicted{X}` が id だけ見て despawn し、X を再利用した後継が破棄される | `crates/bevy_orzma_webview/src/webview/mount.rs:463,474` |
-| その誤 despawn が `on_placement_removed` を焚き、live なはずのビューに `compositing{active:false}` を送る | `mount.rs:647` |
-| 同一 id の live placement が複数あると、投影の `.find()` が最初の geometry を両方に割り当てる | `mount.rs:600` |
+**E. `handle` を `view_id` に改名する** — 「handle は OS/API の語彙では1つの生きた
+リソースへの参照を指すので、定義側を指す今の用法は直感と逆」という指摘から検討した。
+却下した理由:
 
-signal とフレームの到着順は入れ替わり得ることがテストで固定されているため、
-「同時に一意」では不十分で、契約は**セッション全期間で再利用しない**である必要がある。
+- **handle は実際には正確である。** orzma の handle は静的なクラス定義ではなく、
+  `register` で生成され `unregister` / 切断 / surface 消滅で失効する、接続に所有された
+  生存期間付きリソースへの参照である。X11 の resource ID（生成済みの window / pixmap /
+  font を指す）と DRM GEM の handle（file-local な参照で破棄時に参照を落とす）が同じ形。
+- **`view` は逆向きの曖昧さを持ち込む。** Wayland の `wl_surface`（画面上の矩形）が
+  示すように、ウィンドウシステムの語彙では「画面に出るもの」側に寄る。「1サイトと
+  複数タブ」の比喩で、`view` はサイトにもタブにも自然に読めるため、候補の中で最も
+  識別力が低い。
+- **影響範囲が改善に見合わない。** 単純全文検索で 591 hit / 24 files、ソケット JSON の
+  6〜7 メッセージ形、`orzma://<handle>/` の URL・scheme parser・`WebviewAssetRegistry`
+  の API、そして `publish = true` の SDK の公開型 `WebviewHandle`。
+- **そもそも名前は事故の原因ではなかった。** 実際の事故経路は、`WebviewHandle` が
+  `id()` と `instance_id()` を同居させていることである。D8 の newtype がそこを直接塞ぐ。
 
-## 積み残しの手当て
+### レビューで検討し、採用しなかったもの
 
-**1. VT は id を検証できない。** `orzma_vt` はコントロールプレーンを知らないため、
-ワイヤ上の `InstanceId` が正当に払い出されたものか判断できない。検証は host 側に
-移り、`mount()` の既存ゲート列（未登録ビュー、所有権不一致、オーバーレイスロット
-枯渇）に「未知の instance id の棄却」が1つ増える。所有権チェックは既に
-コントロールプレーンにあるので新概念ではない。
-
-**2. SDK の描画モデルを作り直す必要がある。** `flush_placements` は全 placement を
-`HashMap<String, Rect>`（handle をキー）に畳んでいる（`sdk/ratatui_orzma/src/session.rs:361`）。
-**同一ハンドルの複数配置が構造的に不可能**なので、multi-placement を使うにはここを
-`InstanceId` キーに変える必要がある。どの案を採っても必要な作業。
-
-**3. `PushMsg` は現在 `Compositing` の1バリアントのみ**
-（`crates/bevy_orzma_webview/src/control_plane/protocol.rs:187-196`）。
-`new_instance` は push ではなく request/reply なので、`ServerMsg`
-（`protocol.rs:150-155`、現在 `#[serde(untagged)]` で `Ok { ok, handle }` /
-`Err { ok, error }` の2形）にバリアントを足すことになる。**untagged なので
-デシリアライズ順序に依存する** — SDK 側で `handle` と `instance` を持つ2つの
-成功応答が区別できるか、フィールド名で判別できる形にするか要検討。
-
-**4. supersede の挙動が kitty と違う。** kitty は同じ `(i,p)` への再 put を
-**id 不変の in-place 更新**にする（"without flicker"）。orzma は現在 supersede で
-**新しい `PlacementId` を採番**し、旧 id は `WebviewEvicted` に名指しされず
-黙って消える。`InstanceId` 一本化後は同じ `InstanceId` への再 mount が自然に
-in-place 更新になり、kitty に揃うと同時に「消えた id が観測できない」歪みも解消する。
-
-## 未解決の論点
-
-- `unmount` を `n=` 単独で受けるとき、`view_id` は完全に不要にするのか、
-  互換のため `v=` 単独（全インスタンス）も残すのか。
-- クライアントが払い出しを受けずに `n=` を自作した場合の扱い。host のゲートで
-  落とすとして、ログだけか、`WebviewMountRejected` 相当を返すか。
-- `InstanceId` の型。`String`（handle と同じ base32）にするか、VT 内では
-  数値に落とすか。フレームが運ぶ以上、比較コストが効く。
-
-## 作業中に見つかった別件（この PR で修正済み）
-
-`crates/bevy_orzma_webview/src/control_plane/protocol.rs:153` の doc コメントが
-まだ `OSC mount;<handle>` と書いていた。PR #269 の一掃 grep
-（`5379|OSC-based|webview OSC|mount OSC|unmount OSC`）は `OSC mount;` という
-語順を拾わないため見逃していた。この文書と同じ PR で `APC Omount;v=<handle>` に
-直した。
+- **`uuid::Uuid` を `InstanceId` に使う**（`.simple()` がちょうど32桁小文字 hex を出す）—
+  v4 は6ビットを version / variant に使うので乱数が 122bit に減り、`Uuid::try_parse` は
+  ハイフン形・波括弧形も受けるので結局厳格形の検査が要る。なにより `orzma_vt` に
+  公開ワイヤ形式の依存が増え、D4 の採用条件（`orzma_vt` に依存を足さない）に反する。
+- **`ServerMsg` を1バリアント（`handle: Option<String>`）にまとめる** — SDK が既に
+  フラットな構造体でパースしているので §4.4 の差分は減る。ただし「register の成功応答には
+  必ず handle がある」を型で表現できなくなるため、D5 のバリアント分割を維持する。
+- **`WebviewWidget::new` を型付きにする**（`&WebviewInstance` か newtype）— D6 の5箇所の
+  無言破壊をコンパイルエラーに変えられる。設計判断としてトレイトを入れないと決めたので、
+  代わりに全呼び出し元の書き換えと `tracing::debug!` を必須作業に含めた（D6 参照）。
+- **素の `Ounmount`（全配置解除）も落とす** — パース分岐が1つ減り、`WebviewUnmount` が
+  `Option<InstanceId>` ではなく `InstanceId` になる。手書きのエスケープハッチとして残す。
+- **`getrandom` を 0.2 から 0.3 / 0.4 に上げる** — orzma の crate 群が 0.2 の唯一の消費者で、
+  0.3 / 0.4 は既に lock にいるため重複メジャーバージョンを1つ減らせる。この変更の
+  スコープ外とし、別途行う。
 
 ## 出典
 

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -245,13 +245,13 @@ host は serialize しかしないので untagged の曖昧さは発生しない
 ### D6. SDK は `WebviewHandle` が既定 instance を兼ねる
 
 ```rust
-let h  = session.register(wv)?;      // handle + 既定 instance
-let h2 = session.new_instance(&h)?;  // WebviewInstance
+let h  = session.register(wv)?;   // handle + 既定 instance
+let h2 = h.new_instance()?;       // WebviewInstance
 
 frame.render_stateful_widget(
-    WebviewWidget::new(h.instance_id()),  area_a, &mut placements);
+    WebviewWidget::new(h.instance_id()), area_a, &mut placements);
 frame.render_stateful_widget(
-    WebviewWidget::new(h2.instance_id()), area_b, &mut placements);
+    WebviewWidget::new(h2.id()),         area_b, &mut placements);
 
 h.emit("tick", &n)?;   // コンテンツスコープ: 両方のページに届く
 ```
@@ -643,6 +643,7 @@ pub struct WebviewHandle {
     instance: Arc<Mutex<String>>,   // 既定 instance
     events:   Arc<EventQueues>,
     writer:   SharedWriter,
+    session:  Weak<SessionCore>,    // pending FIFO + registrations
 }
 
 pub struct WebviewInstance {
@@ -654,11 +655,21 @@ pub struct WebviewInstance {
 id スロットが両方 `Arc<Mutex<..>>` なのは、reconnect が中身を差し替えるだけで
 クローン済みのハンドルが追随するためである（handle が既に使っている仕組みの踏襲）。
 
-採番は **`Orzma::new_instance(&self, handle: &WebviewHandle) -> OrzmaResult<WebviewInstance>`**
-に置く。`WebviewHandle` には置けない — pending FIFO（`PendingRegisters`）にも
-`registrations` にも到達できないためで、`Clone` されるハンドルに `Arc` を2つ増やすのも
-避けたい。`Orzma` 側に置けば §4.5 の replay スロット登録を `Registration` の構築と同じ場所で
-行える。
+採番は **`WebviewHandle::new_instance(&self) -> OrzmaResult<WebviewInstance>`** に置く。
+ハンドルが pending FIFO と `registrations` に到達できないという当初の制約は、その2つを
+`SessionCore` にまとめ、ハンドルに `Weak<SessionCore>` を1本持たせることで外した。`Weak`
+なのは `SessionCore → Registration → ハンドラのクロージャ → アプリ → WebviewHandle` と
+戻る参照循環を構造的に断つためである。`writer` は `SessionCore` に入れずハンドル側に残す
+ので、`emit` / `navigate` などの既存メソッドは `Orzma` の生存に依存しない — 失効するのは
+採番だけで、`Orzma` を drop した後の `new_instance` は `OrzmaError::SessionClosed` を返す。
+
+本体は `SessionCore::mint_instance` に置き、`WebviewHandle::new_instance` はその委譲に
+する。こうすると webview.rs が session.rs から取り込むのは `SessionCore` 一つで済み、
+`Pending` / `Registration` / `send_request` を `pub(crate)` に広げずに済む。
+
+**RPC ハンドラの中から呼んではならない。** ハンドラは reader スレッド上で同期実行され、
+採番はその同じ reader が応答を捌くのを待つので、ハンドラ内から呼ぶと応答が
+タイムアウトするまで停止する。この禁止はメソッドの doc に明記する。
 
 `WebviewHandle::handle_id()` は `HandleId` を、`instance_id()` は既定 instance の
 `String` を返す。**無印の `id()` は残さない** — 自然に手が伸びる名前が handle を返すのが
@@ -753,8 +764,8 @@ replay ループが registration ごとに、re-register で `handle_slot` と `
 既存の `generation.fetch_add(1)` はループを抜けた後にあるので、全スロットが埋まるまで
 世代は上がらず、`FlushState::reset()` → 全再 mount の順序は自動的に守られる。
 
-`Session` は生成した `WebviewInstance` のスロットを `Registration` に登録する経路が要る
-（§4.1 で `new_instance` を `Orzma` 側に置いたのはこのためでもある）。
+生成した `WebviewInstance` のスロットを `Registration` に登録する経路が要る。`SessionCore`
+が `registrations` を持つのはこのためで、`WebviewHandle` はそこへ `Weak` 経由で到達する。
 
 **失敗パスを設計に含める。** 現在の replay ループは、途中の失敗でどこからでも
 `disconnected = true` を立てて `return` し、generation を上げず、既に再登録済みの

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -761,6 +761,9 @@ struct Registration {
 
 replay ループが registration ごとに、re-register で `handle_slot` と `instance_slot` を
 埋め、続けて `extra_instances` の数だけ `new_instance` を発行してスロットを埋める。
+`registrations` のロックは**新しいソケットへ接続する前**に取り、replay を抜けるまで保持する。
+採番も同じロックを往復越しに握るので、両者は「完全に先行する」か「完全に後続する」かの
+どちらかになり、古い handle id の要求が新しい接続に乗ることがない。
 既存の `generation.fetch_add(1)` はループを抜けた後にあるので、全スロットが埋まるまで
 世代は上がらず、`FlushState::reset()` → 全再 mount の順序は自動的に守られる。
 

--- a/docs/todo/webview-instance-id.md
+++ b/docs/todo/webview-instance-id.md
@@ -773,10 +773,12 @@ replay ループが registration ごとに、re-register で `handle_slot` と `
 `pending_compositing` を `mem::take` で奪うので、その フレームで描画されなかった
 instance の通知は落ちる。これは再キーとは直交する問題で、この変更では扱わない。
 
-**この再キーは host と SDK をまたぐ原子的な切り替えである。** reader は
-`v["handle"]` と `v["active"]` が両方揃わない push を黙って捨てるので、§3.5（host が
-`instance` を載せる）と §4.6（SDK が `instance` でキーする）が同じコミットに入らないと、
-compositing コールバックが**無診断で発火しなくなる**。片方だけ先行させないこと。
+**この再キーは原子的な切り替えではない。** host は `instance` を足しても `handle` と
+`active` を送り続け、reader は未知フィールドを無視するので、§3.5（host が `instance` を
+載せる）だけが先行しても compositing コールバックはそのまま発火する。中間状態で起きるのは
+同一 handle の複数配置が1つのマップキーに衝突することだけ — それは §4.6 が解消しようと
+している既存欠陥そのものであって、この変更が持ち込む新たな破壊ではない。したがって
+§4.6 は「切り替えを壊さないため」ではなく、単に正しいから入れる。
 
 ### 4.7 navigate と call の SDK 側
 
@@ -898,7 +900,7 @@ mount() が却下（未知 instance / 非所有 / スロット枯渇 / url 解�
 | --- | --- |
 | `Omount;v=…` の廃止 | **破壊的**。古い SDK の mount は malformed として捨てられる |
 | `register` 応答への `instance` 追加 | 無害。現行 SDK の `RegisterReply` は未知フィールドを無視する |
-| `compositing` push への `instance` 追加 | 無害（読まれないだけ）。ただし §4.6 の再キーと同時に入る必要がある |
+| `compositing` push への `instance` 追加 | 無害（読まれないだけ）。§4.6 の再キーと同時である必要はない — 先行しても reader は `handle` で発火し続ける |
 | `focus` / `navigate` の instance 化 | **破壊的**。host 側のフィールドが変わる |
 
 SDK と `apps/` 配下の呼び出し元は同じ PR で追随する。

--- a/sdk/ratatui_orzma/examples/forward_keys.rs
+++ b/sdk/ratatui_orzma/examples/forward_keys.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     rows[0],
                 );
                 f.render_stateful_widget(
-                    WebviewWidget::new(view.id())
+                    WebviewWidget::new(view.instance_id())
                         .focused(web_focused)
                         .fallback(Block::bordered().title("webview")),
                     rows[1],

--- a/sdk/ratatui_orzma/examples/rpc.rs
+++ b/sdk/ratatui_orzma/examples/rpc.rs
@@ -51,7 +51,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     rows[0],
                 );
                 f.render_stateful_widget(
-                    WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                    WebviewWidget::new(view.instance_id())
+                        .fallback(Block::bordered().title("loading…")),
                     rows[1],
                     &mut *orzma.frame(),
                 );

--- a/sdk/ratatui_orzma/examples/simple.rs
+++ b/sdk/ratatui_orzma/examples/simple.rs
@@ -27,7 +27,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(f.area());
                 f.render_widget(Paragraph::new("simple webview · q to quit"), rows[0]);
                 f.render_stateful_widget(
-                    WebviewWidget::new(view.id()).fallback(Block::bordered().title("loading…")),
+                    WebviewWidget::new(view.instance_id())
+                        .fallback(Block::bordered().title("loading…")),
                     rows[1],
                     &mut *orzma.frame(),
                 );

--- a/sdk/ratatui_orzma/src/backend.rs
+++ b/sdk/ratatui_orzma/src/backend.rs
@@ -79,10 +79,6 @@ impl<B: Backend + Write> Backend for OrzmaBackend<B> {
             }
         }
 
-        // NOTE: a dropped connection has to reset as well. A replay that fails
-        // part way refills only some id slots and never bumps the generation,
-        // so gating the reset on the generation alone would keep diffing
-        // against dead instance keys and never re-mount the placements.
         if current_gen != self.last_gen || (disconnected && !self.was_disconnected) {
             self.flush_state.reset();
             self.last_gen = current_gen;
@@ -226,8 +222,6 @@ mod tests {
             f.set_focused(INSTANCE.into());
         }
 
-        // A socket whose peer is gone: every write to it fails, the way the
-        // real one does once orzma has exited.
         let (near, far) = UnixStream::pair().unwrap();
         drop(far);
 

--- a/sdk/ratatui_orzma/src/backend.rs
+++ b/sdk/ratatui_orzma/src/backend.rs
@@ -60,8 +60,13 @@ impl<B: Backend + Write> Backend for OrzmaBackend<B> {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
+        // NOTE: a disconnect must reset the flush state as well. A replay that
+        // fails part way refills only some id slots and never bumps the
+        // generation, so gating the reset on the generation alone would keep
+        // diffing against dead instance keys and never re-mount the placements.
         let current_gen = self.reconnect.generation.load(Ordering::Relaxed);
-        if current_gen != self.last_gen {
+        let disconnected = self.reconnect.disconnected.load(Ordering::Relaxed);
+        if current_gen != self.last_gen || disconnected {
             self.flush_state.reset();
             self.last_gen = current_gen;
         }
@@ -74,7 +79,7 @@ impl<B: Backend + Write> Backend for OrzmaBackend<B> {
             .map_err(to_io)?;
         drop(frame);
 
-        if self.reconnect.disconnected.load(Ordering::Relaxed) {
+        if disconnected {
             let should_retry = self
                 .last_attempt
                 .is_none_or(|t| t.elapsed() >= Duration::from_secs(2));
@@ -188,6 +193,45 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Backend::flush(&mut self.0)
         }
+    }
+
+    /// Asserts that a draw taken while the session is disconnected clears the
+    /// flush state, without waiting for a generation bump.
+    ///
+    /// Case: a reconnect replay fails part way, so some of a registration's ids
+    /// were re-minted and the generation never advanced.
+    #[test]
+    fn a_disconnected_draw_resets_flush_state() {
+        use std::os::unix::net::UnixStream;
+        use std::sync::{Arc, Mutex};
+        let disconnected = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let generation = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (tx, _rx) = crossbeam_channel::bounded::<()>(1);
+        let mut backend = OrzmaBackend {
+            inner: WritableTestBackend(ratatui::backend::TestBackend::new(80, 24)),
+            frame: Arc::new(Mutex::new(crate::session::FramePlacements::default())),
+            writer: Arc::new(Mutex::new(UnixStream::pair().unwrap().0)),
+            flush_state: FlushState::default(),
+            reconnect: ReconnectHandle {
+                disconnected,
+                generation,
+                reconnect_tx: tx,
+            },
+            last_gen: 0,
+            last_attempt: None,
+        };
+        backend
+            .flush_state
+            .last
+            .insert("stale".into(), ratatui::layout::Rect::new(0, 0, 10, 5));
+
+        let no_cells: Vec<(u16, u16, &ratatui::buffer::Cell)> = Vec::new();
+        Backend::draw(&mut backend, no_cells.into_iter()).unwrap();
+
+        assert!(
+            backend.flush_state.last.is_empty(),
+            "a disconnected draw must not keep diffing against dead instance keys"
+        );
     }
 
     #[test]

--- a/sdk/ratatui_orzma/src/backend.rs
+++ b/sdk/ratatui_orzma/src/backend.rs
@@ -38,6 +38,7 @@ pub struct OrzmaBackend<B> {
     reconnect: ReconnectHandle,
     last_gen: u64,
     last_attempt: Option<Instant>,
+    was_disconnected: bool,
 }
 
 impl<B> OrzmaBackend<B> {
@@ -51,6 +52,7 @@ impl<B> OrzmaBackend<B> {
             reconnect: orzma.reconnect_handle(),
             last_gen: 0,
             last_attempt: None,
+            was_disconnected: false,
         }
     }
 }
@@ -60,25 +62,13 @@ impl<B: Backend + Write> Backend for OrzmaBackend<B> {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
-        // NOTE: a disconnect must reset the flush state as well. A replay that
-        // fails part way refills only some id slots and never bumps the
-        // generation, so gating the reset on the generation alone would keep
-        // diffing against dead instance keys and never re-mount the placements.
         let current_gen = self.reconnect.generation.load(Ordering::Relaxed);
         let disconnected = self.reconnect.disconnected.load(Ordering::Relaxed);
-        if current_gen != self.last_gen || disconnected {
-            self.flush_state.reset();
-            self.last_gen = current_gen;
-        }
 
-        self.inner.draw(content)?;
-
-        let frame = self.frame.lock().unwrap_or_else(|e| e.into_inner());
-        self.flush_state
-            .emit_frame(&mut self.inner, &self.writer, &frame)
-            .map_err(to_io)?;
-        drop(frame);
-
+        // NOTE: schedule the retry before anything below can return early. This
+        // is the crate's only reconnect_tx sender, so a draw that bails out
+        // first leaves the session with no way back and every later draw takes
+        // the same path.
         if disconnected {
             let should_retry = self
                 .last_attempt
@@ -88,6 +78,28 @@ impl<B: Backend + Write> Backend for OrzmaBackend<B> {
                 self.last_attempt = Some(Instant::now());
             }
         }
+
+        // NOTE: a dropped connection has to reset as well. A replay that fails
+        // part way refills only some id slots and never bumps the generation,
+        // so gating the reset on the generation alone would keep diffing
+        // against dead instance keys and never re-mount the placements.
+        if current_gen != self.last_gen || (disconnected && !self.was_disconnected) {
+            self.flush_state.reset();
+            self.last_gen = current_gen;
+        }
+        self.was_disconnected = disconnected;
+
+        self.inner.draw(content)?;
+
+        let frame = self.frame.lock().unwrap_or_else(|e| e.into_inner());
+        let flushed = if disconnected {
+            self.flush_state.emit_placements(&mut self.inner, &frame)
+        } else {
+            self.flush_state
+                .emit_frame(&mut self.inner, &self.writer, &frame)
+        };
+        drop(frame);
+        flushed.map_err(to_io)?;
 
         Ok(())
     }
@@ -195,6 +207,60 @@ mod tests {
         }
     }
 
+    /// Asserts that a draw taken while the control socket is down still
+    /// succeeds and schedules a reconnect, even when a widget claims focus.
+    ///
+    /// Case: the user is typing in a focused webview when the orzma that owns
+    /// the control socket goes away.
+    #[test]
+    fn a_disconnected_draw_with_a_focused_widget_still_schedules_a_reconnect() {
+        use std::os::unix::net::UnixStream;
+        use std::sync::{Arc, Mutex};
+        const INSTANCE: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+
+        let frame = crate::session::FramePlacements::default();
+        let frame = Arc::new(Mutex::new(frame));
+        {
+            let mut f = frame.lock().unwrap();
+            f.record(INSTANCE.into(), ratatui::layout::Rect::new(0, 0, 10, 5));
+            f.set_focused(INSTANCE.into());
+        }
+
+        // A socket whose peer is gone: every write to it fails, the way the
+        // real one does once orzma has exited.
+        let (near, far) = UnixStream::pair().unwrap();
+        drop(far);
+
+        let (tx, rx) = crossbeam_channel::bounded::<()>(1);
+        let mut backend = OrzmaBackend {
+            inner: WritableTestBackend(ratatui::backend::TestBackend::new(80, 24)),
+            frame,
+            writer: Arc::new(Mutex::new(near)),
+            flush_state: FlushState::default(),
+            reconnect: ReconnectHandle {
+                disconnected: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                reconnect_tx: tx,
+            },
+            last_gen: 0,
+            last_attempt: None,
+            was_disconnected: false,
+        };
+
+        let no_cells: Vec<(u16, u16, &ratatui::buffer::Cell)> = Vec::new();
+        let drawn = Backend::draw(&mut backend, no_cells.into_iter());
+
+        assert!(
+            drawn.is_ok(),
+            "a dead control socket must not fail the draw: {:?}",
+            drawn.err()
+        );
+        assert!(
+            rx.try_recv().is_ok(),
+            "the draw must have scheduled a reconnect"
+        );
+    }
+
     /// Asserts that a draw taken while the session is disconnected clears the
     /// flush state, without waiting for a generation bump.
     ///
@@ -219,6 +285,7 @@ mod tests {
             },
             last_gen: 0,
             last_attempt: None,
+            was_disconnected: false,
         };
         backend
             .flush_state
@@ -255,6 +322,7 @@ mod tests {
             reconnect,
             last_gen: 0,
             last_attempt: None,
+            was_disconnected: false,
         };
         backend
             .flush_state

--- a/sdk/ratatui_orzma/src/error.rs
+++ b/sdk/ratatui_orzma/src/error.rs
@@ -56,6 +56,13 @@ pub enum OrzmaError {
     #[error("no reply to a control-socket request: the socket closed or the reply timed out")]
     Disconnected,
 
+    /// The [`crate::Orzma`] a handle was registered through has been dropped, so
+    /// there is nothing left to track a request through. Distinct from
+    /// [`OrzmaError::Disconnected`], which means a request went out and was
+    /// never answered; here none is sent at all.
+    #[error("the orzma session has been dropped")]
+    SessionClosed,
+
     /// A serde (de)serialization failure.
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),

--- a/sdk/ratatui_orzma/src/error.rs
+++ b/sdk/ratatui_orzma/src/error.rs
@@ -53,7 +53,7 @@ pub enum OrzmaError {
 
     /// The connection closed, or no reply arrived in time, while a request was
     /// pending.
-    #[error("control socket closed before the reply arrived")]
+    #[error("no reply to a control-socket request: the socket closed or the reply timed out")]
     Disconnected,
 
     /// A serde (de)serialization failure.

--- a/sdk/ratatui_orzma/src/error.rs
+++ b/sdk/ratatui_orzma/src/error.rs
@@ -42,8 +42,18 @@ pub enum OrzmaError {
         reason: String,
     },
 
-    /// The connection closed while a `register` reply was pending.
-    #[error("control socket closed before register reply")]
+    /// The control plane rejected a `new_instance` request, or a value that
+    /// had to be a minted instance id was not one.
+    #[error("instance rejected: {reason}")]
+    Instance {
+        /// The control-plane error string (e.g. `unknown_handle`, `not_owner`),
+        /// or a description of how the value failed to be an instance id.
+        reason: String,
+    },
+
+    /// The connection closed, or no reply arrived in time, while a request was
+    /// pending.
+    #[error("control socket closed before the reply arrived")]
     Disconnected,
 
     /// A serde (de)serialization failure.

--- a/sdk/ratatui_orzma/src/escape.rs
+++ b/sdk/ratatui_orzma/src/escape.rs
@@ -106,6 +106,7 @@ mod tests {
         assert!(!valid_instance(&ID.to_uppercase()));
         assert!(!valid_instance(&ID[..31]));
         assert!(valid_instance(ID));
+        assert!(mount("nf2k7q5w3x3m5a6b2c4d6e7f", 10, 10).is_err());
     }
 
     #[test]

--- a/sdk/ratatui_orzma/src/escape.rs
+++ b/sdk/ratatui_orzma/src/escape.rs
@@ -7,21 +7,21 @@ pub(crate) const MAX_ROWS: u16 = 200;
 /// Max webview cols accepted by the VT layer (`1..=MAX_COLS`).
 pub(crate) const MAX_COLS: u16 = 400;
 
-/// Returns the `mount` APC verb, or an error if the handle charset is
-/// invalid or the dimensions are out of range.
-pub(crate) fn mount(handle: &str, rows: u16, cols: u16) -> OrzmaResult<String> {
-    validate_handle(handle)?;
+/// Returns the `mount` APC verb, or an error if the instance id is not in
+/// its minted form or the dimensions are out of range.
+pub(crate) fn mount(instance: &str, rows: u16, cols: u16) -> OrzmaResult<String> {
+    validate_instance(instance)?;
     if !(1..=MAX_ROWS).contains(&rows) || !(1..=MAX_COLS).contains(&cols) {
         return Err(OrzmaError::Register {
             reason: format!("geometry out of range: {rows}x{cols}"),
         });
     }
-    Ok(format!("\x1b_Omount;v={handle},r={rows},c={cols}\x1b\\"))
+    Ok(format!("\x1b_Omount;n={instance},r={rows},c={cols}\x1b\\"))
 }
 
-/// Returns the `unmount` APC verb for a single view handle.
-pub(crate) fn unmount(handle: &str) -> String {
-    format!("\x1b_Ounmount;v={handle}\x1b\\")
+/// Returns the `unmount` APC verb for a single placement.
+pub(crate) fn unmount(instance: &str) -> String {
+    format!("\x1b_Ounmount;n={instance}\x1b\\")
 }
 
 /// Returns a CUP (cursor position) sequence for a 0-based viewport cell.
@@ -34,20 +34,21 @@ pub(crate) fn clamp_dims(rows: u16, cols: u16) -> (u16, u16) {
     (rows.clamp(1, MAX_ROWS), cols.clamp(1, MAX_COLS))
 }
 
-/// Returns whether a view handle matches the `^[A-Za-z0-9._-]{1,128}$` charset.
-pub(crate) fn valid_handle(handle: &str) -> bool {
-    (1..=128).contains(&handle.len())
-        && handle
+/// Returns whether a value is exactly 32 lowercase hex digits — the wire
+/// form of a control-plane-minted instance id.
+pub(crate) fn valid_instance(instance: &str) -> bool {
+    instance.len() == 32
+        && instance
             .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
-fn validate_handle(handle: &str) -> OrzmaResult<()> {
-    if valid_handle(handle) {
+fn validate_instance(instance: &str) -> OrzmaResult<()> {
+    if valid_instance(instance) {
         Ok(())
     } else {
-        Err(OrzmaError::Register {
-            reason: format!("invalid view handle: {handle:?}"),
+        Err(OrzmaError::Instance {
+            reason: format!("not a minted instance id: {instance:?}"),
         })
     }
 }
@@ -56,24 +57,24 @@ fn validate_handle(handle: &str) -> OrzmaResult<()> {
 mod tests {
     use super::*;
 
-    /// Asserts that a mount renders as the APC webview verb, with the
-    /// reservation carried as `r=` / `c=` key-value fields.
+    const ID: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+
+    /// Asserts that a mount renders as the instance-addressed APC verb.
     ///
-    /// Case: a companion app reserves a 12x48 region for a registered
-    /// view and writes the sequence to its terminal.
+    /// Case: a companion app reserves a 12x48 region for a placement the
+    /// control plane minted for it.
     #[test]
     fn mount_sequence_is_canonical() {
-        let s = mount("memo.main", 12, 48).unwrap();
-        assert_eq!(s, "\x1b_Omount;v=memo.main,r=12,c=48\x1b\\");
+        let s = mount(ID, 12, 48).unwrap();
+        assert_eq!(s, format!("\x1b_Omount;n={ID},r=12,c=48\x1b\\"));
     }
 
-    /// Asserts that an unmount renders as the APC webview verb naming
-    /// only the view.
+    /// Asserts that an unmount names only the instance.
     ///
-    /// Case: a companion app tears its view down on the way out.
+    /// Case: a companion app tears one of its placements down.
     #[test]
     fn unmount_sequence_is_canonical() {
-        assert_eq!(unmount("memo.main"), "\x1b_Ounmount;v=memo.main\x1b\\");
+        assert_eq!(unmount(ID), format!("\x1b_Ounmount;n={ID}\x1b\\"));
     }
 
     #[test]
@@ -82,17 +83,29 @@ mod tests {
         assert_eq!(cursor_to(4, 9), "\x1b[5;10H");
     }
 
+    /// Asserts that dimensions outside the accepted range are rejected
+    /// even when the instance is well-formed, so the range check is
+    /// reachable.
+    ///
+    /// Case: a layout collapses to zero rows before a draw.
     #[test]
     fn rejects_out_of_range_dims() {
-        assert!(mount("h", 0, 10).is_err());
-        assert!(mount("h", 201, 10).is_err());
-        assert!(mount("h", 10, 401).is_err());
+        assert!(mount(ID, 0, 10).is_err());
+        assert!(mount(ID, 201, 10).is_err());
+        assert!(mount(ID, 10, 401).is_err());
     }
 
+    /// Asserts that only the exact 32-lowercase-hex form is accepted, so a
+    /// value that is not a minted instance cannot reach the wire.
+    ///
+    /// Case: a caller hand-writes an id, or forwards one that arrived from
+    /// somewhere other than `instance_id()`.
     #[test]
-    fn rejects_bad_handle_charset() {
-        assert!(mount("bad handle", 10, 10).is_err());
-        assert!(mount("", 10, 10).is_err());
+    fn rejects_anything_but_the_canonical_instance_form() {
+        assert!(!valid_instance("nf2k7q5w3x3m5a6b2c4d6e7f"));
+        assert!(!valid_instance(&ID.to_uppercase()));
+        assert!(!valid_instance(&ID[..31]));
+        assert!(valid_instance(ID));
     }
 
     #[test]

--- a/sdk/ratatui_orzma/src/lib.rs
+++ b/sdk/ratatui_orzma/src/lib.rs
@@ -20,6 +20,7 @@ mod widget;
 pub use backend::OrzmaBackend;
 pub use error::{OrzmaError, OrzmaResult, RpcError};
 pub use keychord::KeyChord;
+pub use protocol::HandleId;
 pub use session::{FramePlacements, Orzma};
 pub use webview::{Webview, WebviewHandle};
 pub use widget::{WebviewDefaultPlaceholder, WebviewWidget};

--- a/sdk/ratatui_orzma/src/lib.rs
+++ b/sdk/ratatui_orzma/src/lib.rs
@@ -22,5 +22,5 @@ pub use error::{OrzmaError, OrzmaResult, RpcError};
 pub use keychord::KeyChord;
 pub use protocol::HandleId;
 pub use session::{FramePlacements, Orzma};
-pub use webview::{Webview, WebviewHandle};
+pub use webview::{Webview, WebviewHandle, WebviewInstance};
 pub use widget::{WebviewDefaultPlaceholder, WebviewWidget};

--- a/sdk/ratatui_orzma/src/protocol.rs
+++ b/sdk/ratatui_orzma/src/protocol.rs
@@ -3,18 +3,69 @@
 use crate::keychord::KeyChord;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Borrow;
+use std::fmt;
+
+/// The opaque identity of one registration, as minted by the control plane.
+///
+/// A handle addresses the registration itself — the unit `emit` fans out over
+/// and `new_instance` mints from. Mounting and navigation are addressed by an
+/// instance id instead, which [`crate::WebviewHandle::instance_id`] returns.
+///
+/// # Invariants
+///
+/// There is deliberately no `From<HandleId> for String`. That absence is what
+/// makes `WebviewWidget::new(handle.handle_id())` a compile error instead of a
+/// webview that silently never appears; adding the conversion for convenience
+/// reopens that path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HandleId(String);
+
+impl HandleId {
+    /// Borrows the wire spelling.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for HandleId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl fmt::Display for HandleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Borrow<str> for HandleId {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
 
 /// A message the SDK writes to the control socket.
+// NOTE: rename_all must stay snake_case so `NewInstance` renders as the host's
+// `new_instance`; under lowercase it would silently become an unknown op the
+// host rejects.
 #[derive(Debug, Serialize)]
-#[serde(tag = "op", rename_all = "lowercase")]
+#[serde(tag = "op", rename_all = "snake_case")]
 pub(crate) enum ClientMsg {
     /// Handshake with `$ORZMA_TOKEN`.
     Hello {
         /// The pane's `$ORZMA_TOKEN`.
         token: String,
     },
-    /// Register content; the reply mints a handle.
+    /// Register content; the reply mints a handle and its first instance.
     Register(RegisterKind),
+    /// Mint an additional placement instance on a handle this connection owns.
+    NewInstance {
+        /// The handle returned by a prior `register`.
+        handle: HandleId,
+    },
     /// Reply to an inbound `call`.
     Reply {
         /// Echoes the inbound `reqId` verbatim.
@@ -27,30 +78,28 @@ pub(crate) enum ClientMsg {
     /// Push an event to the mounted page(s) of a handle.
     Emit {
         /// The target handle.
-        handle: String,
+        handle: HandleId,
         /// The event name routed to `window.orzma.on(event, …)`.
         event: String,
         /// The event payload.
         payload: Value,
     },
-    /// Sets (or clears) the app-owned focus target. `handle: None` blurs any
+    /// Sets (or clears) the app-owned focus target. `instance: None` blurs any
     /// focused webview back to the app (native widget).
     Focus {
-        /// The webview handle to focus, or `None` to blur.
-        handle: Option<String>,
-        /// The mount instance id, or `None` for the default instance.
+        /// The placement to focus, or `None` to blur.
         instance: Option<String>,
     },
-    /// Navigate a handle's mounted webview in place (no re-registration).
+    /// Navigate one mounted placement in place (no re-registration).
     Navigate {
-        /// The target handle.
-        handle: String,
+        /// The target placement.
+        instance: String,
         /// What to do.
         action: NavAction,
     },
 }
 
-/// A navigation action on an already-registered handle's mounted webview.
+/// A navigation action on one mounted placement.
 // NOTE: rename_all must match the host's NavAction (snake_case) so the wire
 // contract agrees for any future multi-word variant, not just the current
 // single-word ones where lowercase and snake_case coincide.
@@ -116,17 +165,20 @@ pub(crate) enum RegisterKind {
     },
 }
 
-/// The untagged reply to a `register` request.
-#[derive(Debug, Deserialize)]
-pub(crate) struct RegisterReply {
-    /// Whether registration succeeded.
-    pub(crate) ok: bool,
-    /// The minted handle, present when `ok`.
+/// The untagged reply to a `register` or `new_instance` request.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct ServerReply {
+    /// Whether the request succeeded.
+    pub ok: bool,
+    /// The minted handle, present on a successful `register`.
     #[serde(default)]
-    pub(crate) handle: Option<String>,
+    pub handle: Option<HandleId>,
+    /// The minted instance, present on either successful reply.
+    #[serde(default)]
+    pub instance: Option<String>,
     /// The error string, present when `!ok`.
     #[serde(default)]
-    pub(crate) error: Option<String>,
+    pub error: Option<String>,
 }
 
 /// An inbound `call` frame forwarded from a page's `window.orzma.call`.
@@ -230,14 +282,42 @@ mod tests {
         assert_eq!(v["error"], "unknown_method");
     }
 
+    /// Asserts that one reply type covers both minting replies and the
+    /// rejection, with each absent field deserializing as `None`.
+    ///
+    /// Case: a program registers a view, asks that registration for a second
+    /// placement, and then asks for one more against a handle it does not own.
     #[test]
-    fn register_reply_deserializes_ok_and_err() {
-        let ok: RegisterReply = serde_json::from_str(r#"{"ok":true,"handle":"abc"}"#).unwrap();
-        assert_eq!(ok.handle.as_deref(), Some("abc"));
-        let err: RegisterReply =
-            serde_json::from_str(r#"{"ok":false,"error":"unsafe_entry"}"#).unwrap();
-        assert!(!err.ok);
-        assert_eq!(err.error.as_deref(), Some("unsafe_entry"));
+    fn server_reply_deserializes_both_mints_and_the_rejection() {
+        let registered: ServerReply =
+            serde_json::from_str(r#"{"ok":true,"handle":"abc","instance":"i1"}"#).unwrap();
+        assert_eq!(registered.handle.map(|h| h.to_string()), Some("abc".into()));
+        assert_eq!(registered.instance.as_deref(), Some("i1"));
+
+        let instanced: ServerReply =
+            serde_json::from_str(r#"{"ok":true,"instance":"i2"}"#).unwrap();
+        assert!(instanced.handle.is_none());
+        assert_eq!(instanced.instance.as_deref(), Some("i2"));
+
+        let rejected: ServerReply =
+            serde_json::from_str(r#"{"ok":false,"error":"unknown_handle"}"#).unwrap();
+        assert!(!rejected.ok);
+        assert_eq!(rejected.error.as_deref(), Some("unknown_handle"));
+    }
+
+    /// Asserts that a `new_instance` request renders under the host's
+    /// snake_case op name, carrying the handle it mints from.
+    ///
+    /// Case: an app that already registered a view asks for a second
+    /// placement so it can show that view twice in a split.
+    #[test]
+    fn new_instance_serializes_under_its_snake_case_op() {
+        let v = serde_json::to_value(ClientMsg::NewInstance {
+            handle: "H".to_owned().into(),
+        })
+        .unwrap();
+        assert_eq!(v["op"], "new_instance");
+        assert_eq!(v["handle"], "H");
     }
 
     #[test]
@@ -259,29 +339,30 @@ mod tests {
         assert_eq!(c.params, Value::Null);
     }
 
+    /// Asserts that a focus op names the placement it focuses.
+    ///
+    /// Case: the app moves focus into one of two side-by-side placements of
+    /// the same registration.
     #[test]
-    fn focus_serializes_with_handle() {
+    fn focus_serializes_with_instance() {
         let line = serde_json::to_string(&ClientMsg::Focus {
-            handle: Some("h1".into()),
-            instance: None,
+            instance: Some("i1".into()),
         })
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
         assert_eq!(v["op"], "focus");
-        assert_eq!(v["handle"], "h1");
-        assert_eq!(v["instance"], serde_json::Value::Null);
+        assert_eq!(v["instance"], "i1");
     }
 
+    /// Asserts that a blur renders as a focus op with a null instance.
+    ///
+    /// Case: the user tabs out of a webview and back to a native widget.
     #[test]
-    fn blur_serializes_with_null_handle() {
-        let line = serde_json::to_string(&ClientMsg::Focus {
-            handle: None,
-            instance: None,
-        })
-        .unwrap();
+    fn blur_serializes_with_null_instance() {
+        let line = serde_json::to_string(&ClientMsg::Focus { instance: None }).unwrap();
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
         assert_eq!(v["op"], "focus");
-        assert_eq!(v["handle"], serde_json::Value::Null);
+        assert_eq!(v["instance"], serde_json::Value::Null);
     }
 
     #[test]
@@ -319,22 +400,30 @@ mod tests {
         assert_eq!(v["bridge"], true);
     }
 
+    /// Asserts that a navigation names the placement it drives, not the
+    /// registration behind it.
+    ///
+    /// Case: the user presses the back key while one of two placements of a
+    /// browser view is focused.
     #[test]
     fn navigate_back_serializes() {
         let v = serde_json::to_value(ClientMsg::Navigate {
-            handle: "H".into(),
+            instance: "i1".into(),
             action: NavAction::Back,
         })
         .unwrap();
         assert_eq!(v["op"], "navigate");
-        assert_eq!(v["handle"], "H");
+        assert_eq!(v["instance"], "i1");
         assert_eq!(v["action"], "back");
     }
 
+    /// Asserts that a URL navigation carries its target under the `to` key.
+    ///
+    /// Case: the app follows a link by driving one placement to a new URL.
     #[test]
     fn navigate_to_serializes_url_under_to() {
         let v = serde_json::to_value(ClientMsg::Navigate {
-            handle: "H".into(),
+            instance: "i1".into(),
             action: NavAction::To("https://example.com/x".into()),
         })
         .unwrap();

--- a/sdk/ratatui_orzma/src/protocol.rs
+++ b/sdk/ratatui_orzma/src/protocol.rs
@@ -184,16 +184,18 @@ pub(crate) struct ServerReply {
 /// An inbound `call` frame forwarded from a page's `window.orzma.call`.
 #[derive(Debug, Deserialize)]
 pub(crate) struct IncomingCall {
-    /// The view handle the call targets.
-    pub(crate) handle: String,
+    /// The registration the call targets.
+    pub handle: String,
+    /// The placement the calling page is mounted in.
+    pub instance: String,
     /// The global request id to echo in the reply.
     #[serde(rename = "reqId")]
-    pub(crate) req_id: Value,
+    pub req_id: Value,
     /// The invoked method name.
-    pub(crate) method: String,
+    pub method: String,
     /// The single params value (any JSON shape; absent deserializes as null).
     #[serde(default)]
-    pub(crate) params: Value,
+    pub params: Value,
 }
 
 /// An inbound one-way `event` frame forwarded from a page's `window.orzma.emit`.
@@ -320,22 +322,33 @@ mod tests {
         assert_eq!(v["handle"], "H");
     }
 
+    /// Asserts that an inbound call carries the placement it came from
+    /// alongside the registration it targets.
+    ///
+    /// Case: a page mounted in one of two placements of a view calls back into
+    /// the app, and the handler needs to know which one asked.
     #[test]
     fn call_deserializes() {
         let c: IncomingCall = serde_json::from_str(
-            r#"{"op":"call","handle":"h","reqId":"3","method":"ping","params":"x"}"#,
+            r#"{"op":"call","handle":"h","instance":"i1","reqId":"3","method":"ping","params":"x"}"#,
         )
         .unwrap();
         assert_eq!(c.handle, "h");
+        assert_eq!(c.instance, "i1");
         assert_eq!(c.method, "ping");
         assert_eq!(c.params, serde_json::json!("x"));
     }
 
+    /// Asserts that an omitted `params` deserializes as null rather than
+    /// failing the whole frame.
+    ///
+    /// Case: a page calls a method that takes no argument.
     #[test]
     fn call_without_params_deserializes_as_null() {
-        let c: IncomingCall =
-            serde_json::from_str(r#"{"op":"call","handle":"h","reqId":"3","method":"ping"}"#)
-                .unwrap();
+        let c: IncomingCall = serde_json::from_str(
+            r#"{"op":"call","handle":"h","instance":"i1","reqId":"3","method":"ping"}"#,
+        )
+        .unwrap();
         assert_eq!(c.params, Value::Null);
     }
 

--- a/sdk/ratatui_orzma/src/protocol.rs
+++ b/sdk/ratatui_orzma/src/protocol.rs
@@ -3,7 +3,6 @@
 use crate::keychord::KeyChord;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::borrow::Borrow;
 use std::fmt;
 
 /// The opaque identity of one registration, as minted by the control plane.
@@ -38,12 +37,6 @@ impl From<String> for HandleId {
 impl fmt::Display for HandleId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
-    }
-}
-
-impl Borrow<str> for HandleId {
-    fn borrow(&self) -> &str {
-        &self.0
     }
 }
 

--- a/sdk/ratatui_orzma/src/protocol.rs
+++ b/sdk/ratatui_orzma/src/protocol.rs
@@ -166,7 +166,7 @@ pub(crate) enum RegisterKind {
 }
 
 /// The untagged reply to a `register` or `new_instance` request.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct ServerReply {
     /// Whether the request succeeded.
     pub ok: bool,

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -1,7 +1,7 @@
 //! The Orzma session: socket connection, reader thread, flush.
 
 use crate::error::{OrzmaError, OrzmaResult};
-use crate::escape::{clamp_dims, cursor_to, mount, unmount, valid_handle};
+use crate::escape::{clamp_dims, cursor_to, mount, unmount, valid_instance};
 use crate::events::{EventQueues, EventRegistry};
 use crate::handler::BoxedHandler;
 use crate::protocol::{ClientMsg, IncomingCall, IncomingEvent, RegisterKind, RegisterReply};
@@ -15,14 +15,17 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 
-/// One webview's requested position this frame.
+/// One placement's requested position this frame.
 #[derive(Debug, Clone)]
 pub(crate) struct Placement {
-    pub(crate) handle: String,
-    pub(crate) area: Rect,
+    pub instance: String,
+    pub area: Rect,
 }
 
 /// The per-frame collector handed to the [`crate::WebviewWidget`] as its state.
+///
+/// Everything it holds is keyed by placement instance, so two placements of one
+/// registration are two independent entries rather than one shared key.
 #[derive(Debug, Default)]
 pub struct FramePlacements {
     placements: Vec<Placement>,
@@ -31,25 +34,25 @@ pub struct FramePlacements {
 }
 
 impl FramePlacements {
-    pub(crate) fn record(&mut self, handle: String, area: Rect) {
-        self.placements.push(Placement { handle, area });
+    pub(crate) fn record(&mut self, instance: String, area: Rect) {
+        self.placements.push(Placement { instance, area });
     }
 
-    /// Marks `handle` focused for this frame. Last writer wins; a debug build
+    /// Marks `instance` focused for this frame. Last writer wins; a debug build
     /// trips an assertion if more than one widget claims focus in a single frame
-    /// (the app must focus at most one webview at a time).
-    pub(crate) fn set_focused(&mut self, handle: String) {
+    /// (the app must focus at most one placement at a time).
+    pub(crate) fn set_focused(&mut self, instance: String) {
         debug_assert!(
             self.focused.is_none(),
-            "multiple webviews marked focused in one frame (last wins): had {:?}, now {handle:?}",
+            "multiple webviews marked focused in one frame (last wins): had {:?}, now {instance:?}",
             self.focused
         );
-        self.focused = Some(handle);
+        self.focused = Some(instance);
     }
 
-    /// Removes and returns the buffered compositing state for `handle`, if any.
-    pub(crate) fn take_compositing(&mut self, handle: &str) -> Option<bool> {
-        self.pending_compositing.remove(handle)
+    /// Removes and returns the buffered compositing state for `instance`, if any.
+    pub(crate) fn take_compositing(&mut self, instance: &str) -> Option<bool> {
+        self.pending_compositing.remove(instance)
     }
 
     #[cfg(test)]
@@ -68,11 +71,11 @@ impl FramePlacements {
     }
 }
 
-/// Last-emitted geometry per handle, for diff-driven flush.
+/// Last-emitted geometry per instance, for diff-driven flush.
 #[derive(Debug, Default)]
 pub(crate) struct FlushState {
     #[cfg(test)]
-    pub(crate) last: HashMap<String, Rect>,
+    pub last: HashMap<String, Rect>,
     #[cfg(not(test))]
     last: HashMap<String, Rect>,
     last_focused: Option<String>,
@@ -82,7 +85,7 @@ impl FlushState {
     /// Emits this frame's geometry (mount/unmount APC verbs) to `out`
     /// and, when focus changed since the last frame, the control-plane
     /// focus op to `socket`.
-    pub(crate) fn emit_frame(
+    pub fn emit_frame(
         &mut self,
         out: &mut impl Write,
         socket: &SharedWriter,
@@ -99,7 +102,7 @@ impl FlushState {
         flush_focus(&mut *w, &mut self.last_focused, &frame.focused)
     }
 
-    pub(crate) fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.last.clear();
         self.last_focused = None;
     }
@@ -351,8 +354,14 @@ fn connect_sock(sock: &str) -> OrzmaResult<UnixStream> {
     }
 }
 
-/// Emits CUP + mount for new/changed placements and unmount for vanished
-/// handles, updating `state` to the new frame. Degenerate rects are skipped.
+/// Emits CUP + mount for new and moved placements, and unmount for instances
+/// that vanished, updating `state` to the new frame.
+///
+/// A placement whose rect is degenerate, or whose id is not a minted instance,
+/// is skipped and logged rather than propagated as an error: a single bad
+/// placement must not abort the flush, which would also desync `state` for
+/// every placement behind it. Such an id can never mount, so the log is the
+/// only trace the caller would otherwise get.
 fn flush_placements(
     out: &mut impl Write,
     state: &mut FlushState,
@@ -360,11 +369,11 @@ fn flush_placements(
 ) -> OrzmaResult<()> {
     let mut current: HashMap<String, Rect> = HashMap::new();
     for p in placements {
-        // Skip degenerate rects and invalid handles so a single bad placement
-        // can't abort the whole flush (which would also desync flush state for
-        // every later placement). An invalid handle never came from a minted
-        // WebviewHandle, so it can never mount.
-        if p.area.width == 0 || p.area.height == 0 || !valid_handle(&p.handle) {
+        if p.area.width == 0 || p.area.height == 0 || !valid_instance(&p.instance) {
+            tracing::debug!(
+                instance = %p.instance,
+                "skipping a placement with a degenerate area or an unusable instance id"
+            );
             continue;
         }
         let (rows, cols) = clamp_dims(p.area.height, p.area.width);
@@ -374,15 +383,15 @@ fn flush_placements(
             width: cols,
             height: rows,
         };
-        current.insert(p.handle.clone(), key);
-        if state.last.get(&p.handle) != Some(&key) {
-            let seq = mount(&p.handle, rows, cols)?;
+        current.insert(p.instance.clone(), key);
+        if state.last.get(&p.instance) != Some(&key) {
+            let seq = mount(&p.instance, rows, cols)?;
             write!(out, "{}{}", cursor_to(p.area.y, p.area.x), seq)?;
         }
     }
-    for handle in state.last.keys() {
-        if !current.contains_key(handle) {
-            write!(out, "{}", unmount(handle))?;
+    for instance in state.last.keys() {
+        if !current.contains_key(instance) {
+            write!(out, "{}", unmount(instance))?;
         }
     }
     out.flush()?;
@@ -390,9 +399,10 @@ fn flush_placements(
     Ok(())
 }
 
-/// Emits the control-plane focus op (`ClientMsg::Focus`) when the focused handle
-/// changed from the last flush. `Some(h)` focuses handle `h`; `None` blurs. No
-/// write when unchanged (diff-driven, like geometry in `flush_placements`).
+/// Emits the control-plane focus op (`ClientMsg::Focus`) when the focused
+/// instance changed from the last flush. `Some(i)` focuses placement `i`;
+/// `None` blurs. No write when unchanged (diff-driven, like geometry in
+/// `flush_placements`).
 fn flush_focus(
     out: &mut impl Write,
     last_focused: &mut Option<String>,
@@ -402,8 +412,7 @@ fn flush_focus(
         return Ok(());
     }
     let line = serde_json::to_string(&ClientMsg::Focus {
-        handle: focused.clone(),
-        instance: None,
+        instance: focused.clone(),
     })?;
     writeln!(out, "{line}")?;
     out.flush()?;
@@ -441,11 +450,11 @@ fn spawn_reader(
                 }
             } else if op == "compositing" {
                 if let Some(v) = parsed.as_ref()
-                    && let Some(handle) = v["handle"].as_str()
+                    && let Some(instance) = v["instance"].as_str()
                     && let Some(active) = v["active"].as_bool()
                     && let Ok(mut map) = pending_compositing.lock()
                 {
-                    map.insert(handle.to_owned(), active);
+                    map.insert(instance.to_owned(), active);
                 }
             } else if op == "event" {
                 if let Ok(ev) = serde_json::from_str::<IncomingEvent>(trimmed) {
@@ -673,6 +682,9 @@ mod tests {
     use super::*;
     use ratatui::layout::Rect;
 
+    const INSTANCE_A: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+    const INSTANCE_B: &str = "81b4e77c05a3492fd6180e29ba735fc1";
+
     fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
         Rect {
             x,
@@ -680,6 +692,68 @@ mod tests {
             width: w,
             height: h,
         }
+    }
+
+    /// Asserts that two instances of one registration recorded in the same
+    /// frame each get their own mount, rather than the later one replacing
+    /// the earlier.
+    ///
+    /// Case: an app shows the same view in a split, side by side.
+    #[test]
+    fn two_instances_of_one_registration_each_mount() {
+        let a = INSTANCE_A;
+        let b = INSTANCE_B;
+        let mut state = FlushState::default();
+        let mut frame = FramePlacements::default();
+        frame.record(a.into(), rect(0, 0, 10, 5));
+        frame.record(b.into(), rect(0, 6, 10, 5));
+
+        let mut out = Vec::new();
+        flush_placements(&mut out, &mut state, frame.placements_for_test()).unwrap();
+        let written = String::from_utf8(out).unwrap();
+        assert!(written.contains(&format!("n={a}")));
+        assert!(written.contains(&format!("n={b}")));
+        assert_eq!(state.last.len(), 2);
+    }
+
+    /// Asserts that only the instance whose rect moved is re-mounted.
+    ///
+    /// Case: a split is dragged, resizing one pane and leaving the other.
+    #[test]
+    fn only_the_moved_instance_is_remounted() {
+        let a = INSTANCE_A;
+        let b = INSTANCE_B;
+        let mut state = FlushState::default();
+        let first = vec![
+            Placement {
+                instance: a.into(),
+                area: rect(0, 0, 10, 5),
+            },
+            Placement {
+                instance: b.into(),
+                area: rect(0, 6, 10, 5),
+            },
+        ];
+        flush_placements(&mut Vec::new(), &mut state, &first).unwrap();
+
+        let second = vec![
+            Placement {
+                instance: a.into(),
+                area: rect(0, 0, 10, 5),
+            },
+            Placement {
+                instance: b.into(),
+                area: rect(0, 6, 10, 8),
+            },
+        ];
+        let mut out = Vec::new();
+        flush_placements(&mut out, &mut state, &second).unwrap();
+        let written = String::from_utf8(out).unwrap();
+        assert!(
+            !written.contains(&format!("n={a}")),
+            "the unchanged instance is not re-mounted"
+        );
+        assert!(written.contains(&format!("n={b}")));
     }
 
     #[test]
@@ -695,19 +769,24 @@ mod tests {
         );
     }
 
+    /// Asserts that a placement is mounted at its cursor position when new or
+    /// moved, and emits nothing on a frame where it did not move.
+    ///
+    /// Case: an app draws the same webview pane for several frames, then the
+    /// user widens the window.
     #[test]
     fn flush_emits_mount_then_skips_unchanged() {
-        let mut state = FlushState::default();
         let mut placements = vec![Placement {
-            handle: "h1".into(),
+            instance: INSTANCE_A.into(),
             area: rect(2, 3, 48, 12),
         }];
+        let mut state = FlushState::default();
 
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &placements).unwrap();
         let first = String::from_utf8(buf).unwrap();
         assert!(first.contains("\x1b[4;3H"));
-        assert!(first.contains("Omount;v=h1,r=12,c=48"));
+        assert!(first.contains(&format!("Omount;n={INSTANCE_A},r=12,c=48")));
 
         let mut buf2 = Vec::new();
         flush_placements(&mut buf2, &mut state, &placements).unwrap();
@@ -722,34 +801,64 @@ mod tests {
         assert!(
             String::from_utf8(buf3)
                 .unwrap()
-                .contains("Omount;v=h1,r=12,c=50")
+                .contains(&format!("Omount;n={INSTANCE_A},r=12,c=50"))
         );
     }
 
+    /// Asserts that an instance drawn last frame but not this one is unmounted.
+    ///
+    /// Case: the user closes the pane that held the only placement of a view.
     #[test]
-    fn flush_unmounts_vanished_handle() {
+    fn flush_unmounts_vanished_instance() {
         let mut state = FlushState::default();
         let placements = vec![Placement {
-            handle: "h1".into(),
+            instance: INSTANCE_A.into(),
             area: rect(0, 0, 10, 5),
         }];
         flush_placements(&mut Vec::new(), &mut state, &placements).unwrap();
 
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &[]).unwrap();
-        assert!(String::from_utf8(buf).unwrap().contains("Ounmount;v=h1"));
+        assert!(
+            String::from_utf8(buf)
+                .unwrap()
+                .contains(&format!("Ounmount;n={INSTANCE_A}"))
+        );
     }
 
+    /// Asserts that a zero-width area is skipped even when the instance is a
+    /// well-formed one, so the area gate alone decides.
+    ///
+    /// Case: a layout collapses a pane to nothing while its widget still
+    /// renders.
     #[test]
     fn flush_skips_degenerate_area() {
         let mut state = FlushState::default();
         let placements = vec![Placement {
-            handle: "h1".into(),
+            instance: INSTANCE_A.into(),
             area: rect(0, 0, 0, 5),
         }];
         let mut buf = Vec::new();
         flush_placements(&mut buf, &mut state, &placements).unwrap();
         assert!(String::from_utf8(buf).unwrap().is_empty());
+    }
+
+    /// Asserts that an id which is not a minted instance is skipped rather
+    /// than mounted or propagated as an error.
+    ///
+    /// Case: a caller passes a registration handle where the widget wants an
+    /// instance id.
+    #[test]
+    fn flush_skips_an_id_that_is_not_an_instance() {
+        let mut state = FlushState::default();
+        let placements = vec![Placement {
+            instance: "nf2k7q5w3x3m5a6b2c4d6e7f".into(),
+            area: rect(0, 0, 10, 5),
+        }];
+        let mut buf = Vec::new();
+        flush_placements(&mut buf, &mut state, &placements).unwrap();
+        assert!(String::from_utf8(buf).unwrap().is_empty());
+        assert!(state.last.is_empty());
     }
 
     #[test]
@@ -833,6 +942,10 @@ mod tests {
         }
     }
 
+    /// Asserts that a compositing push is buffered under the instance it
+    /// names, not the handle it also carries.
+    ///
+    /// Case: one of two placements of a registration starts painting.
     #[test]
     fn reader_thread_inserts_compositing_into_shared_map() {
         use std::os::unix::net::UnixListener;
@@ -864,7 +977,7 @@ mod tests {
         let mut server = server_conn;
         writeln!(
             server,
-            r#"{{"op":"compositing","handle":"h1","active":true}}"#
+            r#"{{"op":"compositing","handle":"h1","instance":"{INSTANCE_A}","active":true}}"#
         )
         .unwrap();
         server.flush().unwrap();
@@ -872,9 +985,13 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let map = pending_compositing.lock().unwrap();
-        assert_eq!(map.get("h1"), Some(&true));
+        assert_eq!(map.get(INSTANCE_A), Some(&true));
     }
 
+    /// Asserts that a later push for the same instance replaces the buffered
+    /// state rather than being ignored.
+    ///
+    /// Case: a placement is unmounted after having composited.
     #[test]
     fn reader_thread_updates_compositing_to_false() {
         use std::os::unix::net::UnixListener;
@@ -906,7 +1023,7 @@ mod tests {
         let mut server = server_conn;
         writeln!(
             server,
-            r#"{{"op":"compositing","handle":"h1","active":false}}"#
+            r#"{{"op":"compositing","handle":"h1","instance":"{INSTANCE_A}","active":false}}"#
         )
         .unwrap();
         server.flush().unwrap();
@@ -914,7 +1031,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let map = pending_compositing.lock().unwrap();
-        assert_eq!(map.get("h1"), Some(&false));
+        assert_eq!(map.get(INSTANCE_A), Some(&false));
     }
 
     #[test]

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -150,8 +150,12 @@ enum Pending {
     /// A `register`: the oneshot carries the minted `(handle, instance)` pair,
     /// and the handlers and event queues are installed under that handle
     /// before the caller is woken.
+    ///
+    /// The handle stays a [`HandleId`] across the channel. The two ids are
+    /// otherwise distinguished only by tuple position, and a consumer that
+    /// swapped them would mount a handle — which the host can never resolve.
     Register {
-        reply: Sender<OrzmaResult<(String, String)>>,
+        reply: Sender<OrzmaResult<(HandleId, String)>>,
         handlers: Arc<HashMap<String, BoxedHandler>>,
         events: Arc<EventQueues>,
     },
@@ -309,7 +313,7 @@ impl Orzma {
             &line,
         )?;
         let (handle, instance) = await_reply(&rx)?;
-        let handle_slot = Arc::new(Mutex::new(HandleId::from(handle)));
+        let handle_slot = Arc::new(Mutex::new(handle));
         let instance_slot = Arc::new(Mutex::new(instance));
         if let Ok(mut regs) = self.registrations.lock() {
             regs.push(Registration {
@@ -606,16 +610,16 @@ fn settle_reply(
         } => {
             let outcome = match (reply.ok, reply.handle, reply.instance) {
                 (true, Some(handle), Some(instance)) => {
-                    let handle = handle.to_string();
+                    let key = handle.to_string();
                     // NOTE: install on this thread, before the next line is
                     // read, so a `call` or `event` pipelined right behind the
                     // reply finds its handlers and queues rather than racing
                     // the registrant's thread.
                     if let Ok(mut map) = handlers.lock() {
-                        map.insert(handle.clone(), methods);
+                        map.insert(key.clone(), methods);
                     }
                     if let Ok(mut map) = events.lock() {
-                        map.insert(handle.clone(), queues);
+                        map.insert(key, queues);
                     }
                     Ok((handle, instance))
                 }
@@ -828,16 +832,17 @@ fn replay_registration(
         }
     };
     let old = reg.handle_id();
+    let key = new_handle.to_string();
     if let Ok(mut map) = handlers.lock() {
         map.remove(old.as_str());
-        map.insert(new_handle.clone(), reg.handlers.clone());
+        map.insert(key.clone(), reg.handlers.clone());
     }
     if let Ok(mut map) = events.lock() {
         map.remove(old.as_str());
-        map.insert(new_handle.clone(), reg.events.clone());
+        map.insert(key, reg.events.clone());
     }
     *reg.instance_slot.lock().unwrap_or_else(|e| e.into_inner()) = new_instance;
-    let handle_id = HandleId::from(new_handle);
+    let handle_id = new_handle;
     *reg.handle_slot.lock().unwrap_or_else(|e| e.into_inner()) = handle_id.clone();
 
     for slot in &reg.extra_instances {
@@ -967,7 +972,7 @@ mod tests {
 
         assert_eq!(
             reg_rx.recv().unwrap().unwrap(),
-            ("h".to_string(), "i1".to_string())
+            (HandleId::from("h".to_string()), "i1".to_string())
         );
         assert_eq!(inst_rx.recv().unwrap().unwrap(), "i2".to_string());
         assert!(pending.lock().unwrap().is_empty());

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -752,6 +752,14 @@ fn attempt_reconnect(
         tracing::debug!("reconnect: ORZMA_SOCK is unset, will retry on next signal");
         return;
     };
+    // NOTE: claim the registrations before dialing, and hold them through the
+    // replay. A mint holds the same lock across its own round trip, so taking
+    // it any later would let this swap the writer under a request the mint has
+    // already prepared for the old connection — which the new one answers with
+    // `unknown_handle`.
+    let Ok(regs) = registrations.lock() else {
+        return;
+    };
     let new_stream = match connect_sock(&sock) {
         Ok(s) => s,
         Err(e) => {
@@ -796,9 +804,6 @@ fn attempt_reconnect(
         events.clone(),
         disconnected.clone(),
     );
-    let Ok(regs) = registrations.lock() else {
-        return;
-    };
     for reg in regs.iter() {
         if !replay_registration(writer, handlers, pending, events, reg) {
             disconnected.store(true, Ordering::Relaxed);
@@ -903,6 +908,9 @@ mod tests {
 
     const INSTANCE_A: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
     const INSTANCE_B: &str = "81b4e77c05a3492fd6180e29ba735fc1";
+
+    /// Serializes the tests that write `$ORZMA_SOCK`, which is process-global.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
         Rect {
@@ -1224,6 +1232,78 @@ mod tests {
             handle.new_instance(),
             Err(OrzmaError::SessionClosed)
         ));
+    }
+
+    /// Asserts that a reconnect claims the saved registrations before it dials
+    /// the new socket, so a mint already holding them cannot have the writer
+    /// swapped out from under the request it is about to send.
+    ///
+    /// Case: orzma restarts in the moment an app is asking for a second
+    /// placement of a view it registered earlier.
+    #[test]
+    fn a_reconnect_waits_for_the_registrations_before_it_dials() {
+        use std::os::unix::net::UnixListener;
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("new.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        // SAFETY: ENV_LOCK is held, serializing every test in this module that
+        // writes the environment.
+        unsafe { std::env::set_var("ORZMA_SOCK", &sock_path) };
+
+        let (old_client, _old_server) = UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(old_client));
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
+        let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let registrations: Arc<Mutex<Vec<Registration>>> = Arc::new(Mutex::new(Vec::new()));
+        let disconnected = Arc::new(AtomicBool::new(true));
+        let generation = Arc::new(AtomicU64::new(0));
+
+        let held = registrations.lock().unwrap();
+        let reconnect = {
+            let (writer, pending, pending_compositing, handlers, events, registrations) = (
+                writer.clone(),
+                pending.clone(),
+                pending_compositing.clone(),
+                handlers.clone(),
+                events.clone(),
+                registrations.clone(),
+            );
+            let (disconnected, generation) = (disconnected.clone(), generation.clone());
+            thread::spawn(move || {
+                attempt_reconnect(
+                    &writer,
+                    &handlers,
+                    &pending,
+                    &pending_compositing,
+                    &disconnected,
+                    &generation,
+                    &registrations,
+                    &events,
+                    "tok",
+                );
+            })
+        };
+
+        thread::sleep(Duration::from_millis(250));
+        assert!(
+            matches!(listener.accept(), Err(e) if e.kind() == ErrorKind::WouldBlock),
+            "the reconnect dialed the new socket while the registrations were held"
+        );
+
+        drop(held);
+        listener.set_nonblocking(false).unwrap();
+        let (stream, _) = listener.accept().unwrap();
+        let mut line = String::new();
+        BufReader::new(stream).read_line(&mut line).unwrap();
+        assert!(
+            line.contains(r#""op":"hello""#),
+            "expected the handshake on the new socket, got {line:?}"
+        );
+        reconnect.join().unwrap();
     }
 
     /// Asserts that two instances of one registration recorded in the same

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -98,7 +98,7 @@ impl FlushState {
         socket: &SharedWriter,
         frame: &FramePlacements,
     ) -> OrzmaResult<()> {
-        flush_placements(out, self, &frame.placements)?;
+        self.emit_placements(out, frame)?;
         // NOTE: only take the writer lock (shared with the reader thread and
         // every WebviewHandle::emit) when focus actually changed; this runs every
         // render frame and the unchanged path must not contend the lock.
@@ -107,6 +107,20 @@ impl FlushState {
         }
         let mut w = socket.lock()?;
         flush_focus(&mut *w, &mut self.last_focused, &frame.focused)
+    }
+
+    /// Emits this frame's geometry to `out` alone, leaving the focus op unsent.
+    ///
+    /// This is the flush to use while the control socket is down. Geometry
+    /// rides the PTY, which outlives the socket, and there is nothing at the
+    /// other end of the socket to receive a focus op — attempting one would
+    /// only fail the whole draw.
+    pub fn emit_placements(
+        &mut self,
+        out: &mut impl Write,
+        frame: &FramePlacements,
+    ) -> OrzmaResult<()> {
+        flush_placements(out, self, &frame.placements)
     }
 
     pub fn reset(&mut self) {
@@ -119,6 +133,10 @@ type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandle
 type PendingReplies = Arc<Mutex<VecDeque<Pending>>>;
 
 /// One in-flight request awaiting its op-less reply.
+///
+/// An entry outlives its waiter's [`REPLY_TIMEOUT`] on purpose: a late reply
+/// still corresponds to this entry by position, so dropping the entry would
+/// hand that reply to the next waiter in line.
 enum Pending {
     /// A `register`: the oneshot carries the minted `(handle, instance)` pair,
     /// and the handlers and event queues are installed under that handle
@@ -900,26 +918,35 @@ mod tests {
         assert!(pending.lock().unwrap().is_empty());
     }
 
-    /// Asserts that a reply whose shape does not match the waiting request
-    /// still consumes that request's queue entry and fails its waiter.
+    /// Asserts that every reply a waiting request cannot be satisfied by — a
+    /// rejection, or a success missing the id it should carry — still consumes
+    /// that request's queue entry and fails only its own waiter.
     ///
-    /// Case: the host answers a `new_instance` with a rejection, and another
-    /// request is already queued behind it.
+    /// Case: the host rejects a `new_instance` for a handle this connection
+    /// does not own, then answers two more requests malformed, while a further
+    /// request waits behind them.
     #[test]
-    fn a_mismatched_reply_consumes_its_entry_rather_than_desyncing_the_queue() {
+    fn an_unusable_reply_consumes_its_entry_rather_than_desyncing_the_queue() {
         let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
         let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let (first_tx, first_rx) = bounded(1);
-        let (second_tx, second_rx) = bounded(1);
-        pending
-            .lock()
-            .unwrap()
-            .push_back(Pending::NewInstance { reply: first_tx });
-        pending
-            .lock()
-            .unwrap()
-            .push_back(Pending::NewInstance { reply: second_tx });
+        let (rejected_tx, rejected_rx) = bounded(1);
+        let (no_instance_tx, no_instance_rx) = bounded(1);
+        let (no_handle_tx, no_handle_rx) = bounded(1);
+        let (survivor_tx, survivor_rx) = bounded(1);
+        {
+            let mut q = pending.lock().unwrap();
+            q.push_back(Pending::NewInstance { reply: rejected_tx });
+            q.push_back(Pending::NewInstance {
+                reply: no_instance_tx,
+            });
+            q.push_back(Pending::Register {
+                reply: no_handle_tx,
+                handlers: Arc::new(HashMap::new()),
+                events: Arc::new(EventQueues::from_decls(&[])),
+            });
+            q.push_back(Pending::NewInstance { reply: survivor_tx });
+        }
 
         settle_reply(
             &pending,
@@ -927,18 +954,33 @@ mod tests {
             &events,
             r#"{"ok":false,"error":"not_owner"}"#,
         );
+        settle_reply(&pending, &handlers, &events, r#"{"ok":true}"#);
         settle_reply(
             &pending,
             &handlers,
             &events,
-            r#"{"ok":true,"instance":"i2"}"#,
+            r#"{"ok":true,"instance":"i3"}"#,
+        );
+        settle_reply(
+            &pending,
+            &handlers,
+            &events,
+            r#"{"ok":true,"instance":"i4"}"#,
         );
 
         assert!(matches!(
-            first_rx.recv().unwrap(),
+            rejected_rx.recv().unwrap(),
             Err(OrzmaError::Instance { .. })
         ));
-        assert_eq!(second_rx.recv().unwrap().unwrap(), "i2".to_string());
+        assert!(matches!(
+            no_instance_rx.recv().unwrap(),
+            Err(OrzmaError::Instance { .. })
+        ));
+        assert!(matches!(
+            no_handle_rx.recv().unwrap(),
+            Err(OrzmaError::Register { .. })
+        ));
+        assert_eq!(survivor_rx.recv().unwrap().unwrap(), "i4".to_string());
         assert!(pending.lock().unwrap().is_empty());
     }
 

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -167,7 +167,7 @@ type PendingCompositing = Arc<Mutex<HashMap<String, bool>>>;
 
 /// A saved webview registration for replay on reconnect, holding every id slot
 /// a reconnect has to refill: the handle, the default instance, and one slot
-/// per instance minted by [`Orzma::new_instance`].
+/// per instance minted by [`WebviewHandle::new_instance`].
 struct Registration {
     kind: RegisterKind,
     handle_slot: Arc<Mutex<HandleId>>,
@@ -194,15 +194,68 @@ pub(crate) struct ReconnectHandle {
     pub(crate) reconnect_tx: Sender<()>,
 }
 
+/// The request and replay plumbing a [`WebviewHandle`] needs in order to mint
+/// on its own registration: the pending-reply queue a request is tracked
+/// through, and the registrations a reconnect replays.
+///
+/// A handle reaches this through a [`std::sync::Weak`], so holding one never
+/// keeps a session alive. The fields stay behind their own `Arc`s because the
+/// reader and reconnect threads capture those directly — dropping the [`Orzma`]
+/// therefore drops this core (failing every later `upgrade`) while leaving the
+/// threads their own view of the same state.
+pub(crate) struct SessionCore {
+    pending: PendingReplies,
+    registrations: Arc<Mutex<Vec<Registration>>>,
+}
+
+impl SessionCore {
+    /// Mints an additional placement on `handle`, writing the request through
+    /// `writer` and blocking until the control plane answers it.
+    pub(crate) fn mint_instance(
+        &self,
+        writer: &SharedWriter,
+        handle: &WebviewHandle,
+    ) -> OrzmaResult<WebviewInstance> {
+        // NOTE: the saved registrations stay locked from before the request goes
+        // out until after the minted slot is recorded. A reconnect replays them
+        // under this same lock, so releasing it any earlier would let a replay
+        // complete in between and leave this slot holding an instance minted on
+        // the connection that just died — one the app can never mount.
+        let mut regs = self.registrations.lock().unwrap_or_else(|e| e.into_inner());
+        let handle_id = handle.handle_id();
+        let (tx, rx) = bounded(1);
+        let line = serde_json::to_string(&ClientMsg::NewInstance {
+            handle: handle_id.clone(),
+        })?;
+        send_request(
+            writer,
+            &self.pending,
+            Pending::NewInstance { reply: tx },
+            &line,
+        )?;
+        let slot = Arc::new(Mutex::new(await_reply(&rx)?));
+        match regs
+            .iter_mut()
+            .find(|r| handle.shares_handle_slot(&r.handle_slot))
+        {
+            Some(reg) => reg.extra_instances.push(slot.clone()),
+            None => tracing::debug!(
+                handle = %handle_id,
+                "minted an instance for a handle with no saved registration; it will not survive a reconnect"
+            ),
+        }
+        Ok(WebviewInstance::new_shared(slot, writer.clone()))
+    }
+}
+
 /// An orzma session: owns the control-socket connection and reader thread.
 pub struct Orzma {
     writer: SharedWriter,
-    pending: PendingReplies,
+    core: Arc<SessionCore>,
     frame: Arc<Mutex<FramePlacements>>,
     pending_compositing: PendingCompositing,
     disconnected: Arc<AtomicBool>,
     generation: Arc<AtomicU64>,
-    registrations: Arc<Mutex<Vec<Registration>>>,
     reconnect_tx: crossbeam_channel::Sender<()>,
 }
 
@@ -277,12 +330,14 @@ impl Orzma {
 
         Ok(Self {
             writer,
-            pending,
+            core: Arc::new(SessionCore {
+                pending,
+                registrations,
+            }),
             frame: Arc::new(Mutex::new(FramePlacements::default())),
             pending_compositing,
             disconnected,
             generation,
-            registrations,
             reconnect_tx,
         })
     }
@@ -304,7 +359,7 @@ impl Orzma {
         let line = serde_json::to_string(&ClientMsg::Register(kind.clone()))?;
         send_request(
             &self.writer,
-            &self.pending,
+            &self.core.pending,
             Pending::Register {
                 reply: tx,
                 handlers: handlers.clone(),
@@ -315,8 +370,14 @@ impl Orzma {
         let (handle, instance) = await_reply(&rx)?;
         let handle_slot = Arc::new(Mutex::new(handle));
         let instance_slot = Arc::new(Mutex::new(instance));
-        if let Ok(mut regs) = self.registrations.lock() {
-            regs.push(Registration {
+        // NOTE: save through a poisoned lock rather than skipping the push. A
+        // returned handle whose registration was never saved mints placements
+        // no reconnect can replay, and reports nothing when it does.
+        self.core
+            .registrations
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(Registration {
                 kind,
                 handle_slot: handle_slot.clone(),
                 instance_slot: instance_slot.clone(),
@@ -324,56 +385,13 @@ impl Orzma {
                 handlers: handlers.clone(),
                 events: events.clone(),
             });
-        }
         Ok(WebviewHandle::new_shared(
             handle_slot,
             instance_slot,
             events,
             self.writer.clone(),
+            Arc::downgrade(&self.core),
         ))
-    }
-
-    /// Mints an additional placement on `handle`, blocking until the control
-    /// plane replies.
-    ///
-    /// A registration always has one placement, addressed by
-    /// [`WebviewHandle::instance_id`]; every instance minted here is another
-    /// place the same content can be mounted, at the same time as the others.
-    /// The returned instance is replayed alongside its registration when the
-    /// session reconnects.
-    ///
-    /// Blocks on a control-socket round trip, so call it while setting the app
-    /// up — never from inside the draw loop.
-    pub fn new_instance(&self, handle: &WebviewHandle) -> OrzmaResult<WebviewInstance> {
-        // NOTE: the saved registrations stay locked from before the request goes
-        // out until after the minted slot is recorded. A reconnect replays them
-        // under this same lock, so releasing it any earlier would let a replay
-        // complete in between and leave this slot holding an instance minted on
-        // the connection that just died — one the app can never mount.
-        let mut regs = self.registrations.lock().unwrap_or_else(|e| e.into_inner());
-        let handle_id = handle.handle_id();
-        let (tx, rx) = bounded(1);
-        let line = serde_json::to_string(&ClientMsg::NewInstance {
-            handle: handle_id.clone(),
-        })?;
-        send_request(
-            &self.writer,
-            &self.pending,
-            Pending::NewInstance { reply: tx },
-            &line,
-        )?;
-        let slot = Arc::new(Mutex::new(await_reply(&rx)?));
-        match regs
-            .iter_mut()
-            .find(|r| handle.shares_handle_slot(&r.handle_slot))
-        {
-            Some(reg) => reg.extra_instances.push(slot.clone()),
-            None => tracing::debug!(
-                handle = %handle_id,
-                "minted an instance for a handle with no saved registration; it will not survive a reconnect"
-            ),
-        }
-        Ok(WebviewInstance::new_shared(slot, self.writer.clone()))
     }
 
     /// Locks and clears the per-frame placement collector for `render_stateful_widget`.
@@ -1057,13 +1075,8 @@ mod tests {
         let handle_slot = Arc::new(Mutex::new(HandleId::from("h-old".to_owned())));
         let instance_slot = Arc::new(Mutex::new(INSTANCE_A.to_owned()));
         let events = Arc::new(EventQueues::from_decls(&[]));
-        let orzma = Orzma {
-            writer: writer.clone(),
+        let core = Arc::new(SessionCore {
             pending: Arc::new(Mutex::new(VecDeque::new())),
-            frame: Arc::new(Mutex::new(FramePlacements::default())),
-            pending_compositing: Arc::new(Mutex::new(HashMap::new())),
-            disconnected: Arc::new(AtomicBool::new(false)),
-            generation: Arc::new(AtomicU64::new(0)),
             registrations: Arc::new(Mutex::new(vec![Registration {
                 kind: Webview::inline("x").kind,
                 handle_slot: handle_slot.clone(),
@@ -1072,9 +1085,23 @@ mod tests {
                 handlers: Arc::new(HashMap::new()),
                 events: events.clone(),
             }])),
+        });
+        let handle = WebviewHandle::new_shared(
+            handle_slot,
+            instance_slot,
+            events,
+            writer.clone(),
+            Arc::downgrade(&core),
+        );
+        let orzma = Orzma {
+            writer,
+            core,
+            frame: Arc::new(Mutex::new(FramePlacements::default())),
+            pending_compositing: Arc::new(Mutex::new(HashMap::new())),
+            disconnected: Arc::new(AtomicBool::new(false)),
+            generation: Arc::new(AtomicU64::new(0)),
             reconnect_tx: bounded::<()>(1).0,
         };
-        let handle = WebviewHandle::new_shared(handle_slot, instance_slot, events, writer);
         (orzma, handle, server)
     }
 
@@ -1086,8 +1113,10 @@ mod tests {
     #[test]
     fn a_mint_racing_a_reconnect_still_records_the_placement_for_replay() {
         let (orzma, handle, server) = session_with_one_registration();
-        let refilled = orzma.registrations.lock().unwrap()[0].handle_slot.clone();
-        let pending = orzma.pending.clone();
+        let refilled = orzma.core.registrations.lock().unwrap()[0]
+            .handle_slot
+            .clone();
+        let pending = orzma.core.pending.clone();
 
         let host = thread::spawn(move || {
             let mut line = String::new();
@@ -1101,12 +1130,14 @@ mod tests {
             );
         });
 
-        let extra = orzma.new_instance(&handle).unwrap();
+        let extra = handle.new_instance().unwrap();
         host.join().unwrap();
 
         assert_eq!(extra.id(), INSTANCE_B);
         assert_eq!(
-            orzma.registrations.lock().unwrap()[0].extra_instances.len(),
+            orzma.core.registrations.lock().unwrap()[0]
+                .extra_instances
+                .len(),
             1,
             "the minted placement must be recorded for replay"
         );
@@ -1121,8 +1152,8 @@ mod tests {
     #[test]
     fn a_reconnect_replay_cannot_interleave_with_a_mint_in_flight() {
         let (orzma, handle, server) = session_with_one_registration();
-        let pending = orzma.pending.clone();
-        let registrations = orzma.registrations.clone();
+        let pending = orzma.core.pending.clone();
+        let registrations = orzma.core.registrations.clone();
 
         let host = thread::spawn(move || {
             let mut line = String::new();
@@ -1137,12 +1168,62 @@ mod tests {
             held_while_in_flight
         });
 
-        orzma.new_instance(&handle).unwrap();
+        handle.new_instance().unwrap();
 
         assert!(
             host.join().unwrap(),
             "the request went out with the registrations unlocked, leaving a replay free to interleave"
         );
+    }
+
+    /// Asserts that a handle mints an extra placement of its own registration
+    /// and records it for replay, without the caller holding the session.
+    ///
+    /// Case: an app splits a pane and shows the view it is already drawing a
+    /// second time alongside the first.
+    #[test]
+    fn a_handle_mints_its_own_placement() {
+        let (orzma, handle, server) = session_with_one_registration();
+        let pending = orzma.core.pending.clone();
+
+        let host = thread::spawn(move || {
+            let mut line = String::new();
+            BufReader::new(server).read_line(&mut line).unwrap();
+            settle_reply(
+                &pending,
+                &Arc::new(Mutex::new(HashMap::new())),
+                &Arc::new(Mutex::new(HashMap::new())),
+                &format!(r#"{{"ok":true,"instance":"{INSTANCE_B}"}}"#),
+            );
+        });
+
+        let extra = handle.new_instance().unwrap();
+        host.join().unwrap();
+
+        assert_eq!(extra.id(), INSTANCE_B);
+        assert_eq!(
+            orzma.core.registrations.lock().unwrap()[0]
+                .extra_instances
+                .len(),
+            1,
+            "the minted placement must be recorded for replay"
+        );
+    }
+
+    /// Asserts that a handle whose session is gone reports the closed session
+    /// rather than writing a request nothing is left to track.
+    ///
+    /// Case: an app tears its session down while a widget still holds the
+    /// handle it was drawing.
+    #[test]
+    fn a_handle_outliving_its_session_cannot_mint() {
+        let (orzma, handle, _server) = session_with_one_registration();
+        drop(orzma);
+
+        assert!(matches!(
+            handle.new_instance(),
+            Err(OrzmaError::SessionClosed)
+        ));
     }
 
     /// Asserts that two instances of one registration recorded in the same

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -4,9 +4,11 @@ use crate::error::{OrzmaError, OrzmaResult};
 use crate::escape::{clamp_dims, cursor_to, mount, unmount, valid_instance};
 use crate::events::{EventQueues, EventRegistry};
 use crate::handler::BoxedHandler;
-use crate::protocol::{ClientMsg, IncomingCall, IncomingEvent, RegisterKind, RegisterReply};
-use crate::webview::{SharedWriter, Webview, WebviewHandle};
-use crossbeam_channel::{Sender, bounded};
+use crate::protocol::{
+    ClientMsg, HandleId, IncomingCall, IncomingEvent, RegisterKind, ServerReply,
+};
+use crate::webview::{SharedWriter, Webview, WebviewHandle, WebviewInstance};
+use crossbeam_channel::{Receiver, Sender, bounded};
 use ratatui::layout::Rect;
 use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, ErrorKind, Write};
@@ -14,6 +16,11 @@ use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
+use std::time::Duration;
+
+/// How long a blocking control-socket request waits for its reply before
+/// giving up on it.
+const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// One placement's requested position this frame.
 #[derive(Debug, Clone)]
@@ -109,25 +116,44 @@ impl FlushState {
 }
 
 type HandlerRegistry = Arc<Mutex<HashMap<String, Arc<HashMap<String, BoxedHandler>>>>>;
-type PendingRegisters = Arc<Mutex<VecDeque<PendingRegister>>>;
+type PendingReplies = Arc<Mutex<VecDeque<Pending>>>;
 
-/// One in-flight `register` awaiting its untagged reply: the oneshot to wake the
-/// caller, plus the handlers and event queues to install once the control plane
-/// mints the handle.
-struct PendingRegister {
-    reply: Sender<OrzmaResult<String>>,
-    handlers: Arc<HashMap<String, BoxedHandler>>,
-    events: Arc<EventQueues>,
+/// One in-flight request awaiting its op-less reply.
+enum Pending {
+    /// A `register`: the oneshot carries the minted `(handle, instance)` pair,
+    /// and the handlers and event queues are installed under that handle
+    /// before the caller is woken.
+    Register {
+        reply: Sender<OrzmaResult<(String, String)>>,
+        handlers: Arc<HashMap<String, BoxedHandler>>,
+        events: Arc<EventQueues>,
+    },
+    /// A `new_instance`: the oneshot carries the minted instance.
+    NewInstance { reply: Sender<OrzmaResult<String>> },
 }
 
 type PendingCompositing = Arc<Mutex<HashMap<String, bool>>>;
 
-/// A saved webview registration for replay on reconnect.
+/// A saved webview registration for replay on reconnect, holding every id slot
+/// a reconnect has to refill: the handle, the default instance, and one slot
+/// per instance minted by [`Orzma::new_instance`].
 struct Registration {
     kind: RegisterKind,
-    handle_slot: Arc<Mutex<String>>,
+    handle_slot: Arc<Mutex<HandleId>>,
+    instance_slot: Arc<Mutex<String>>,
+    extra_instances: Vec<Arc<Mutex<String>>>,
     handlers: Arc<HashMap<String, BoxedHandler>>,
     events: Arc<EventQueues>,
+}
+
+impl Registration {
+    /// The handle this registration currently answers to.
+    fn handle_id(&self) -> HandleId {
+        self.handle_slot
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
 }
 
 /// The minimal shared state passed to [`OrzmaBackend`] for reconnect signalling.
@@ -140,7 +166,7 @@ pub(crate) struct ReconnectHandle {
 /// An orzma session: owns the control-socket connection and reader thread.
 pub struct Orzma {
     writer: SharedWriter,
-    pending: PendingRegisters,
+    pending: PendingReplies,
     frame: Arc<Mutex<FramePlacements>>,
     pending_compositing: PendingCompositing,
     disconnected: Arc<AtomicBool>,
@@ -164,7 +190,7 @@ impl Orzma {
         let stream = connect_sock(&sock)?;
         let writer: SharedWriter = Arc::new(Mutex::new(stream.try_clone()?));
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
         let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
         let disconnected: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let generation: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
@@ -230,7 +256,11 @@ impl Orzma {
         })
     }
 
-    /// Registers a webview, blocking until the control plane mints its handle.
+    /// Registers a webview, blocking until the control plane mints its handle
+    /// and that registration's first placement instance.
+    ///
+    /// Blocks on a control-socket round trip, so call it while setting the app
+    /// up — never from inside the draw loop.
     pub fn register(&self, webview: Webview) -> OrzmaResult<WebviewHandle> {
         let Webview {
             kind,
@@ -241,43 +271,75 @@ impl Orzma {
         let events = Arc::new(EventQueues::from_decls(&event_decls));
         let (tx, rx) = bounded(1);
         let line = serde_json::to_string(&ClientMsg::Register(kind.clone()))?;
-        {
-            let mut w = self.writer.lock()?;
-            // NOTE: push the pending entry while holding the writer lock so the
-            // FIFO order matches the on-wire order — register replies are untagged,
-            // so concurrent registrants would otherwise mismatch their handles.
-            self.pending.lock()?.push_back(PendingRegister {
+        send_request(
+            &self.writer,
+            &self.pending,
+            Pending::Register {
                 reply: tx,
                 handlers: handlers.clone(),
                 events: events.clone(),
-            });
-            if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
-                // The register never went out, so no reply will arrive for this
-                // entry; drop it so it can't consume a later registrant's reply.
-                self.pending.lock()?.pop_back();
-                return Err(e.into());
-            }
-        }
-
-        // NOTE: the reader thread installs the event queues under the minted
-        // handle BEFORE sending this reply (mirroring the handler install), so an
-        // event pipelined right behind the register reply finds its queues rather
-        // than racing this main thread; do not move the install back here.
-        let handle = rx.recv().map_err(|_| OrzmaError::Disconnected)??;
-        let handle_slot = Arc::new(Mutex::new(handle));
+            },
+            &line,
+        )?;
+        let (handle, instance) = await_reply(&rx)?;
+        let handle_slot = Arc::new(Mutex::new(HandleId::from(handle)));
+        let instance_slot = Arc::new(Mutex::new(instance));
         if let Ok(mut regs) = self.registrations.lock() {
             regs.push(Registration {
                 kind,
                 handle_slot: handle_slot.clone(),
+                instance_slot: instance_slot.clone(),
+                extra_instances: Vec::new(),
                 handlers: handlers.clone(),
                 events: events.clone(),
             });
         }
         Ok(WebviewHandle::new_shared(
             handle_slot,
+            instance_slot,
             events,
             self.writer.clone(),
         ))
+    }
+
+    /// Mints an additional placement on `handle`, blocking until the control
+    /// plane replies.
+    ///
+    /// A registration always has one placement, addressed by
+    /// [`WebviewHandle::instance_id`]; every instance minted here is another
+    /// place the same content can be mounted, at the same time as the others.
+    /// The returned instance is replayed alongside its registration when the
+    /// session reconnects.
+    ///
+    /// Blocks on a control-socket round trip, so call it while setting the app
+    /// up — never from inside the draw loop.
+    pub fn new_instance(&self, handle: &WebviewHandle) -> OrzmaResult<WebviewInstance> {
+        let handle_id = handle.handle_id();
+        let (tx, rx) = bounded(1);
+        let line = serde_json::to_string(&ClientMsg::NewInstance {
+            handle: handle_id.clone(),
+        })?;
+        send_request(
+            &self.writer,
+            &self.pending,
+            Pending::NewInstance { reply: tx },
+            &line,
+        )?;
+        let slot = Arc::new(Mutex::new(await_reply(&rx)?));
+        let mut replayable = false;
+        if let Ok(mut regs) = self.registrations.lock()
+            && let Some(reg) = regs.iter_mut().find(|r| r.handle_id() == handle_id)
+        {
+            reg.extra_instances.push(slot.clone());
+            replayable = true;
+        }
+        if !replayable {
+            tracing::debug!(
+                handle = %handle_id,
+                "minted an instance for a handle with no saved registration; it will not survive a reconnect"
+            );
+        }
+        Ok(WebviewInstance::new_shared(slot, self.writer.clone()))
     }
 
     /// Locks and clears the per-frame placement collector for `render_stateful_widget`.
@@ -424,7 +486,7 @@ fn spawn_reader(
     stream: UnixStream,
     writer: SharedWriter,
     handlers: HandlerRegistry,
-    pending: PendingRegisters,
+    pending: PendingReplies,
     pending_compositing: PendingCompositing,
     events: EventRegistry,
     disconnected: Arc<AtomicBool>,
@@ -479,34 +541,8 @@ fn spawn_reader(
                         ),
                     }
                 }
-            } else if let Ok(reply) = serde_json::from_str::<RegisterReply>(trimmed)
-                && let Some(reg) = pending.lock().ok().and_then(|mut q| q.pop_front())
-            {
-                let outcome = if reply.ok {
-                    match reply.handle {
-                        // Install handlers under the minted handle on this thread,
-                        // before the next line is read, so a `call` pipelined right
-                        // after the reply finds its handlers rather than racing the
-                        // registrant's main thread.
-                        Some(h) => {
-                            if let Ok(mut map) = handlers.lock() {
-                                map.insert(h.clone(), reg.handlers);
-                            }
-                            if let Ok(mut map) = events.lock() {
-                                map.insert(h.clone(), reg.events);
-                            }
-                            Ok(h)
-                        }
-                        None => Err(OrzmaError::Register {
-                            reason: "missing handle".into(),
-                        }),
-                    }
-                } else {
-                    Err(OrzmaError::Register {
-                        reason: reply.error.unwrap_or_else(|| "unknown".into()),
-                    })
-                };
-                let _ = reg.reply.send(outcome);
+            } else if parsed.as_ref().is_some_and(|v| v.get("op").is_none()) {
+                settle_reply(&pending, &handlers, &events, trimmed);
             }
         }
         // The socket closed: drop every pending sender so any in-flight
@@ -519,7 +555,105 @@ fn spawn_reader(
     });
 }
 
+/// Settles the oldest outstanding request with one op-less reply line.
+fn settle_reply(
+    pending: &PendingReplies,
+    handlers: &HandlerRegistry,
+    events: &EventRegistry,
+    line: &str,
+) {
+    let Ok(reply) = serde_json::from_str::<ServerReply>(line) else {
+        return;
+    };
+    // NOTE: pop before validating. Leaving the entry on a shape mismatch would
+    // desync the queue permanently, since replies arrive strictly in request
+    // order.
+    let Some(entry) = pending.lock().ok().and_then(|mut q| q.pop_front()) else {
+        return;
+    };
+    match entry {
+        Pending::Register {
+            reply: waiter,
+            handlers: methods,
+            events: queues,
+        } => {
+            let outcome = match (reply.ok, reply.handle, reply.instance) {
+                (true, Some(handle), Some(instance)) => {
+                    let handle = handle.to_string();
+                    // NOTE: install on this thread, before the next line is
+                    // read, so a `call` or `event` pipelined right behind the
+                    // reply finds its handlers and queues rather than racing
+                    // the registrant's thread.
+                    if let Ok(mut map) = handlers.lock() {
+                        map.insert(handle.clone(), methods);
+                    }
+                    if let Ok(mut map) = events.lock() {
+                        map.insert(handle.clone(), queues);
+                    }
+                    Ok((handle, instance))
+                }
+                (true, _, _) => Err(OrzmaError::Register {
+                    reason: "register reply missing handle or instance".into(),
+                }),
+                (false, _, _) => Err(OrzmaError::Register {
+                    reason: reply.error.unwrap_or_else(|| "unknown".into()),
+                }),
+            };
+            let _ = waiter.send(outcome);
+        }
+        Pending::NewInstance { reply: waiter } => {
+            let outcome = match (reply.ok, reply.instance) {
+                (true, Some(instance)) => Ok(instance),
+                (true, None) => Err(OrzmaError::Instance {
+                    reason: "new_instance reply missing instance".into(),
+                }),
+                (false, _) => Err(OrzmaError::Instance {
+                    reason: reply.error.unwrap_or_else(|| "unknown".into()),
+                }),
+            };
+            let _ = waiter.send(outcome);
+        }
+    }
+}
+
+/// Queues `entry` and writes its request line, both under the writer lock.
+///
+/// # Invariants
+///
+/// The pending entry is pushed while the writer lock is held so the queue order
+/// matches the on-wire order; a reply carries no request id, so a concurrent
+/// requester would otherwise settle this caller's waiter. A failed write pops
+/// the entry back off, since no reply will ever arrive for a request that never
+/// went out.
+fn send_request(
+    writer: &SharedWriter,
+    pending: &PendingReplies,
+    entry: Pending,
+    line: &str,
+) -> OrzmaResult<()> {
+    let mut w = writer.lock()?;
+    pending.lock()?.push_back(entry);
+    if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
+        pending.lock()?.pop_back();
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+/// Blocks for one request's reply, reporting both a closed channel and an
+/// expired [`REPLY_TIMEOUT`] as [`OrzmaError::Disconnected`].
+fn await_reply<T>(rx: &Receiver<OrzmaResult<T>>) -> OrzmaResult<T> {
+    rx.recv_timeout(REPLY_TIMEOUT)
+        .unwrap_or(Err(OrzmaError::Disconnected))
+}
+
 fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: IncomingCall) {
+    tracing::debug!(
+        handle = call.handle,
+        instance = call.instance,
+        method = call.method,
+        "dispatching an inbound call"
+    );
     let handler = handlers
         .lock()
         .ok()
@@ -554,7 +688,7 @@ fn dispatch_call(writer: &SharedWriter, handlers: &HandlerRegistry, call: Incomi
 fn attempt_reconnect(
     writer: &SharedWriter,
     handlers: &HandlerRegistry,
-    pending: &PendingRegisters,
+    pending: &PendingReplies,
     pending_compositing: &PendingCompositing,
     disconnected: &Arc<AtomicBool>,
     generation: &Arc<AtomicU64>,
@@ -613,68 +747,96 @@ fn attempt_reconnect(
     let Ok(regs) = registrations.lock() else {
         return;
     };
-    let Ok(mut w) = writer.lock() else { return };
     for reg in regs.iter() {
-        let (tx, rx) = bounded::<OrzmaResult<String>>(1);
-        {
-            let Ok(mut pq) = pending.lock() else {
-                disconnected.store(true, Ordering::Relaxed);
-                return;
-            };
-            pq.push_back(PendingRegister {
-                reply: tx,
-                handlers: reg.handlers.clone(),
-                events: reg.events.clone(),
-            });
-        }
-        let line = match serde_json::to_string(&ClientMsg::Register(reg.kind.clone())) {
-            Ok(l) => l,
-            Err(e) => {
-                tracing::debug!("reconnect: serialize register failed: {e}");
-                disconnected.store(true, Ordering::Relaxed);
-                return;
-            }
-        };
-        if writeln!(w, "{line}").and_then(|()| w.flush()).is_err() {
-            tracing::debug!("reconnect: register write failed");
+        if !replay_registration(writer, handlers, pending, events, reg) {
             disconnected.store(true, Ordering::Relaxed);
             return;
         }
-        // NOTE: release writer lock while awaiting the reader-thread reply so
-        // the reader can write focus/emit responses without deadlocking.
-        drop(w);
-        let new_handle = match rx.recv().unwrap_or(Err(OrzmaError::Disconnected)) {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::debug!("reconnect: re-registration failed: {e}");
-                disconnected.store(true, Ordering::Relaxed);
-                return;
-            }
-        };
-        let old = reg
-            .handle_slot
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
-        if let Ok(mut map) = handlers.lock() {
-            map.remove(&old);
-            map.insert(new_handle.clone(), reg.handlers.clone());
-        }
-        if let Ok(mut map) = events.lock() {
-            map.remove(&old);
-            map.insert(new_handle.clone(), reg.events.clone());
-        }
-        if let Ok(mut slot) = reg.handle_slot.lock() {
-            *slot = new_handle;
-        }
-        w = match writer.lock() {
-            Ok(g) => g,
-            Err(_) => return,
-        };
     }
-    drop(w);
     generation.fetch_add(1, Ordering::Relaxed);
     tracing::debug!("reconnect: completed successfully");
+}
+
+/// Re-registers one saved registration on the fresh connection and refills
+/// every id slot it owns — the handle, the default instance, and one
+/// `new_instance` round trip per extra instance — returning whether the whole
+/// replay succeeded.
+///
+/// A partial replay leaves the slots it already refilled in place. The caller
+/// marks the session disconnected without bumping the generation, so the next
+/// attempt replays this registration from the start.
+fn replay_registration(
+    writer: &SharedWriter,
+    handlers: &HandlerRegistry,
+    pending: &PendingReplies,
+    events: &EventRegistry,
+    reg: &Registration,
+) -> bool {
+    let (tx, rx) = bounded(1);
+    let line = match serde_json::to_string(&ClientMsg::Register(reg.kind.clone())) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::debug!("reconnect: serialize register failed: {e}");
+            return false;
+        }
+    };
+    if let Err(e) = send_request(
+        writer,
+        pending,
+        Pending::Register {
+            reply: tx,
+            handlers: reg.handlers.clone(),
+            events: reg.events.clone(),
+        },
+        &line,
+    ) {
+        tracing::debug!("reconnect: register write failed: {e}");
+        return false;
+    }
+    let (new_handle, new_instance) = match await_reply(&rx) {
+        Ok(minted) => minted,
+        Err(e) => {
+            tracing::debug!("reconnect: re-registration failed: {e}");
+            return false;
+        }
+    };
+    let old = reg.handle_id();
+    if let Ok(mut map) = handlers.lock() {
+        map.remove(old.as_str());
+        map.insert(new_handle.clone(), reg.handlers.clone());
+    }
+    if let Ok(mut map) = events.lock() {
+        map.remove(old.as_str());
+        map.insert(new_handle.clone(), reg.events.clone());
+    }
+    *reg.instance_slot.lock().unwrap_or_else(|e| e.into_inner()) = new_instance;
+    let handle_id = HandleId::from(new_handle);
+    *reg.handle_slot.lock().unwrap_or_else(|e| e.into_inner()) = handle_id.clone();
+
+    for slot in &reg.extra_instances {
+        let (tx, rx) = bounded(1);
+        let line = match serde_json::to_string(&ClientMsg::NewInstance {
+            handle: handle_id.clone(),
+        }) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::debug!("reconnect: serialize new_instance failed: {e}");
+                return false;
+            }
+        };
+        if let Err(e) = send_request(writer, pending, Pending::NewInstance { reply: tx }, &line) {
+            tracing::debug!("reconnect: new_instance write failed: {e}");
+            return false;
+        }
+        match await_reply(&rx) {
+            Ok(instance) => *slot.lock().unwrap_or_else(|e| e.into_inner()) = instance,
+            Err(e) => {
+                tracing::debug!("reconnect: re-minting an instance failed: {e}");
+                return false;
+            }
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -692,6 +854,92 @@ mod tests {
             width: w,
             height: h,
         }
+    }
+
+    /// Asserts that a register waiter and a new-instance waiter each receive
+    /// their own reply when both are outstanding, so a mismatch cannot desync
+    /// the queue.
+    ///
+    /// Case: one thread registers a second view while another is already
+    /// asking for an extra placement.
+    #[test]
+    fn a_mixed_pending_queue_routes_each_reply_to_its_waiter() {
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (reg_tx, reg_rx) = bounded(1);
+        let (inst_tx, inst_rx) = bounded(1);
+        pending.lock().unwrap().push_back(Pending::Register {
+            reply: reg_tx,
+            handlers: Arc::new(HashMap::new()),
+            events: Arc::new(EventQueues::from_decls(&[])),
+        });
+        pending
+            .lock()
+            .unwrap()
+            .push_back(Pending::NewInstance { reply: inst_tx });
+
+        settle_reply(
+            &pending,
+            &handlers,
+            &events,
+            r#"{"ok":true,"handle":"h","instance":"i1"}"#,
+        );
+        settle_reply(
+            &pending,
+            &handlers,
+            &events,
+            r#"{"ok":true,"instance":"i2"}"#,
+        );
+
+        assert_eq!(
+            reg_rx.recv().unwrap().unwrap(),
+            ("h".to_string(), "i1".to_string())
+        );
+        assert_eq!(inst_rx.recv().unwrap().unwrap(), "i2".to_string());
+        assert!(pending.lock().unwrap().is_empty());
+    }
+
+    /// Asserts that a reply whose shape does not match the waiting request
+    /// still consumes that request's queue entry and fails its waiter.
+    ///
+    /// Case: the host answers a `new_instance` with a rejection, and another
+    /// request is already queued behind it.
+    #[test]
+    fn a_mismatched_reply_consumes_its_entry_rather_than_desyncing_the_queue() {
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
+        let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let events: EventRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (first_tx, first_rx) = bounded(1);
+        let (second_tx, second_rx) = bounded(1);
+        pending
+            .lock()
+            .unwrap()
+            .push_back(Pending::NewInstance { reply: first_tx });
+        pending
+            .lock()
+            .unwrap()
+            .push_back(Pending::NewInstance { reply: second_tx });
+
+        settle_reply(
+            &pending,
+            &handlers,
+            &events,
+            r#"{"ok":false,"error":"not_owner"}"#,
+        );
+        settle_reply(
+            &pending,
+            &handlers,
+            &events,
+            r#"{"ok":true,"instance":"i2"}"#,
+        );
+
+        assert!(matches!(
+            first_rx.recv().unwrap(),
+            Err(OrzmaError::Instance { .. })
+        ));
+        assert_eq!(second_rx.recv().unwrap().unwrap(), "i2".to_string());
+        assert!(pending.lock().unwrap().is_empty());
     }
 
     /// Asserts that two instances of one registration recorded in the same
@@ -861,33 +1109,42 @@ mod tests {
         assert!(state.last.is_empty());
     }
 
+    /// Asserts that a focus op names the newly-focused instance, and that a
+    /// frame focusing the same instance again writes nothing.
+    ///
+    /// Case: the user clicks into a webview pane and then keeps typing in it
+    /// across many frames.
     #[test]
     fn flush_focus_emits_on_change_and_skips_unchanged() {
         let mut last = None;
         let mut buf = Vec::new();
-        flush_focus(&mut buf, &mut last, &Some("v".to_string())).unwrap();
+        flush_focus(&mut buf, &mut last, &Some(INSTANCE_A.to_string())).unwrap();
         let v: serde_json::Value =
             serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
         assert_eq!(v["op"], "focus");
-        assert_eq!(v["handle"], "v");
+        assert_eq!(v["instance"], INSTANCE_A);
 
         let mut buf2 = Vec::new();
-        flush_focus(&mut buf2, &mut last, &Some("v".to_string())).unwrap();
+        flush_focus(&mut buf2, &mut last, &Some(INSTANCE_A.to_string())).unwrap();
         assert!(
             String::from_utf8(buf2).unwrap().is_empty(),
             "unchanged focus emits nothing"
         );
     }
 
+    /// Asserts that dropping focus emits a focus op with a null instance and
+    /// clears the remembered target.
+    ///
+    /// Case: the user moves focus from a webview pane back to a native widget.
     #[test]
     fn flush_focus_emits_blur_on_none() {
-        let mut last = Some("v".to_string());
+        let mut last = Some(INSTANCE_A.to_string());
         let mut buf = Vec::new();
         flush_focus(&mut buf, &mut last, &None).unwrap();
         let v: serde_json::Value =
             serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
         assert_eq!(v["op"], "focus");
-        assert_eq!(v["handle"], serde_json::Value::Null);
+        assert_eq!(v["instance"], serde_json::Value::Null);
         assert_eq!(last, None);
     }
 
@@ -957,7 +1214,7 @@ mod tests {
         let pending_compositing: Arc<Mutex<HashMap<String, bool>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
 
         let client = UnixStream::connect(&sock_path).unwrap();
         let writer: SharedWriter = Arc::new(Mutex::new(client.try_clone().unwrap()));
@@ -1003,7 +1260,7 @@ mod tests {
         let pending_compositing: Arc<Mutex<HashMap<String, bool>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
 
         let client = UnixStream::connect(&sock_path).unwrap();
         let writer: SharedWriter = Arc::new(Mutex::new(client.try_clone().unwrap()));
@@ -1058,7 +1315,7 @@ mod tests {
             .insert("h1".to_owned(), queues.clone());
 
         let handlers: HandlerRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let pending: PendingRegisters = Arc::new(Mutex::new(VecDeque::new()));
+        let pending: PendingReplies = Arc::new(Mutex::new(VecDeque::new()));
         let pending_compositing: PendingCompositing = Arc::new(Mutex::new(HashMap::new()));
 
         let client = UnixStream::connect(&sock_path).unwrap();

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -345,6 +345,12 @@ impl Orzma {
     /// Blocks on a control-socket round trip, so call it while setting the app
     /// up — never from inside the draw loop.
     pub fn new_instance(&self, handle: &WebviewHandle) -> OrzmaResult<WebviewInstance> {
+        // NOTE: the saved registrations stay locked from before the request goes
+        // out until after the minted slot is recorded. A reconnect replays them
+        // under this same lock, so releasing it any earlier would let a replay
+        // complete in between and leave this slot holding an instance minted on
+        // the connection that just died — one the app can never mount.
+        let mut regs = self.registrations.lock().unwrap_or_else(|e| e.into_inner());
         let handle_id = handle.handle_id();
         let (tx, rx) = bounded(1);
         let line = serde_json::to_string(&ClientMsg::NewInstance {
@@ -357,18 +363,15 @@ impl Orzma {
             &line,
         )?;
         let slot = Arc::new(Mutex::new(await_reply(&rx)?));
-        let mut replayable = false;
-        if let Ok(mut regs) = self.registrations.lock()
-            && let Some(reg) = regs.iter_mut().find(|r| r.handle_id() == handle_id)
+        match regs
+            .iter_mut()
+            .find(|r| handle.shares_handle_slot(&r.handle_slot))
         {
-            reg.extra_instances.push(slot.clone());
-            replayable = true;
-        }
-        if !replayable {
-            tracing::debug!(
+            Some(reg) => reg.extra_instances.push(slot.clone()),
+            None => tracing::debug!(
                 handle = %handle_id,
                 "minted an instance for a handle with no saved registration; it will not survive a reconnect"
-            );
+            ),
         }
         Ok(WebviewInstance::new_shared(slot, self.writer.clone()))
     }
@@ -1042,6 +1045,104 @@ mod tests {
         ));
         assert_eq!(survivor_rx.recv().unwrap().unwrap(), "i4".to_string());
         assert!(pending.lock().unwrap().is_empty());
+    }
+
+    /// A session holding one saved registration, returned with a handle over
+    /// that registration's id slots and the far end of its socket. No reader
+    /// thread runs, so a request the session writes waits until the test
+    /// settles it by hand.
+    fn session_with_one_registration() -> (Orzma, WebviewHandle, UnixStream) {
+        let (client, server) = UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(client));
+        let handle_slot = Arc::new(Mutex::new(HandleId::from("h-old".to_owned())));
+        let instance_slot = Arc::new(Mutex::new(INSTANCE_A.to_owned()));
+        let events = Arc::new(EventQueues::from_decls(&[]));
+        let orzma = Orzma {
+            writer: writer.clone(),
+            pending: Arc::new(Mutex::new(VecDeque::new())),
+            frame: Arc::new(Mutex::new(FramePlacements::default())),
+            pending_compositing: Arc::new(Mutex::new(HashMap::new())),
+            disconnected: Arc::new(AtomicBool::new(false)),
+            generation: Arc::new(AtomicU64::new(0)),
+            registrations: Arc::new(Mutex::new(vec![Registration {
+                kind: Webview::inline("x").kind,
+                handle_slot: handle_slot.clone(),
+                instance_slot: instance_slot.clone(),
+                extra_instances: Vec::new(),
+                handlers: Arc::new(HashMap::new()),
+                events: events.clone(),
+            }])),
+            reconnect_tx: bounded::<()>(1).0,
+        };
+        let handle = WebviewHandle::new_shared(handle_slot, instance_slot, events, writer);
+        (orzma, handle, server)
+    }
+
+    /// Asserts that an instance minted while a reconnect replaces the handle it
+    /// was requested under is still recorded for replay.
+    ///
+    /// Case: orzma restarts in the moment between the host answering an app's
+    /// request for a second placement and the app taking delivery of it.
+    #[test]
+    fn a_mint_racing_a_reconnect_still_records_the_placement_for_replay() {
+        let (orzma, handle, server) = session_with_one_registration();
+        let refilled = orzma.registrations.lock().unwrap()[0].handle_slot.clone();
+        let pending = orzma.pending.clone();
+
+        let host = thread::spawn(move || {
+            let mut line = String::new();
+            BufReader::new(server).read_line(&mut line).unwrap();
+            *refilled.lock().unwrap() = HandleId::from("h-new".to_owned());
+            settle_reply(
+                &pending,
+                &Arc::new(Mutex::new(HashMap::new())),
+                &Arc::new(Mutex::new(HashMap::new())),
+                &format!(r#"{{"ok":true,"instance":"{INSTANCE_B}"}}"#),
+            );
+        });
+
+        let extra = orzma.new_instance(&handle).unwrap();
+        host.join().unwrap();
+
+        assert_eq!(extra.id(), INSTANCE_B);
+        assert_eq!(
+            orzma.registrations.lock().unwrap()[0].extra_instances.len(),
+            1,
+            "the minted placement must be recorded for replay"
+        );
+    }
+
+    /// Asserts that a mint holds the saved registrations from before it sends
+    /// its request until after it records the placement, so a reconnect replay
+    /// can neither run between the two nor answer the request itself.
+    ///
+    /// Case: the socket dies while an app is asking for a second placement, and
+    /// the reconnect thread reaches the registrations it has to replay.
+    #[test]
+    fn a_reconnect_replay_cannot_interleave_with_a_mint_in_flight() {
+        let (orzma, handle, server) = session_with_one_registration();
+        let pending = orzma.pending.clone();
+        let registrations = orzma.registrations.clone();
+
+        let host = thread::spawn(move || {
+            let mut line = String::new();
+            BufReader::new(server).read_line(&mut line).unwrap();
+            let held_while_in_flight = registrations.try_lock().is_err();
+            settle_reply(
+                &pending,
+                &Arc::new(Mutex::new(HashMap::new())),
+                &Arc::new(Mutex::new(HashMap::new())),
+                &format!(r#"{{"ok":true,"instance":"{INSTANCE_B}"}}"#),
+            );
+            held_while_in_flight
+        });
+
+        orzma.new_instance(&handle).unwrap();
+
+        assert!(
+            host.join().unwrap(),
+            "the request went out with the registrations unlocked, leaving a replay free to interleave"
+        );
     }
 
     /// Asserts that two instances of one registration recorded in the same

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -123,6 +123,15 @@ impl FlushState {
         flush_placements(out, self, &frame.placements)
     }
 
+    /// Drops the record of what was last emitted, so the next flush re-asserts
+    /// this frame's geometry and focus from scratch.
+    ///
+    /// Called when the connection the record described has gone: the host
+    /// forgets every mount when the socket drops, so diffing against it would
+    /// be diffing against state that no longer exists anywhere. Re-registering
+    /// also mints fresh instance ids, which the diff already treats as new
+    /// placements; what clearing adds is that the vanished-instance pass then
+    /// emits no unmount for an id the host has already dropped.
     pub fn reset(&mut self) {
         self.last.clear();
         self.last_focused = None;

--- a/sdk/ratatui_orzma/src/session.rs
+++ b/sdk/ratatui_orzma/src/session.rs
@@ -870,6 +870,10 @@ fn replay_registration(
 mod tests {
     use super::*;
     use ratatui::layout::Rect;
+    use std::fmt::Debug;
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Level, Metadata, Subscriber};
 
     const INSTANCE_A: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
     const INSTANCE_B: &str = "81b4e77c05a3492fd6180e29ba735fc1";
@@ -880,6 +884,48 @@ mod tests {
             y,
             width: w,
             height: h,
+        }
+    }
+
+    /// A `tracing` subscriber that renders every DEBUG event's fields into a
+    /// shared buffer, so a test can assert on a diagnostic the code emits
+    /// instead of returns. Install it with `tracing::subscriber::with_default`,
+    /// which scopes it to the calling thread.
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<String>>>);
+
+    impl Subscriber for CapturedLogs {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            *metadata.level() == Level::DEBUG
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut rendered = String::new();
+            event.record(&mut FieldText(&mut rendered));
+            self.0
+                .lock()
+                .expect("the capture buffer is uncontended")
+                .push(rendered);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    struct FieldText<'a>(&'a mut String);
+
+    impl Visit for FieldText<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+            self.0.push_str(&format!("{}={value:?} ", field.name()));
         }
     }
 
@@ -1158,6 +1204,32 @@ mod tests {
         flush_placements(&mut buf, &mut state, &placements).unwrap();
         assert!(String::from_utf8(buf).unwrap().is_empty());
         assert!(state.last.is_empty());
+    }
+
+    /// Asserts that skipping a placement emits one debug event naming the
+    /// rejected id, so the skip leaves a trace the caller can find.
+    ///
+    /// Case: a caller passes a registration handle where the widget wants an
+    /// instance id, sees no webview, and turns on debug logging to find out
+    /// which id the flush refused.
+    #[test]
+    fn flush_logs_the_placement_it_skips() {
+        let logs = CapturedLogs::default();
+        let mut state = FlushState::default();
+        let placements = vec![Placement {
+            instance: "nf2k7q5w3x3m5a6b2c4d6e7f".into(),
+            area: rect(0, 0, 10, 5),
+        }];
+        let mut buf = Vec::new();
+
+        tracing::subscriber::with_default(logs.clone(), || {
+            flush_placements(&mut buf, &mut state, &placements).unwrap();
+        });
+
+        let captured = logs.0.lock().expect("the capture buffer is uncontended");
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].contains("nf2k7q5w3x3m5a6b2c4d6e7f"));
+        assert!(captured[0].contains("skipping a placement"));
     }
 
     /// Asserts that a focus op names the newly-focused instance, and that a

--- a/sdk/ratatui_orzma/src/webview.rs
+++ b/sdk/ratatui_orzma/src/webview.rs
@@ -4,7 +4,7 @@ use crate::error::OrzmaResult;
 use crate::events::{EventDecl, EventQueues};
 use crate::handler::{BoxedHandler, make_handler};
 use crate::keychord::KeyChord;
-use crate::protocol::{ClientMsg, NavAction, RegisterKind};
+use crate::protocol::{ClientMsg, HandleId, NavAction, RegisterKind};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::any::TypeId;
@@ -186,32 +186,58 @@ impl Webview {
     }
 }
 
-/// A registered webview handle: emit events to the page, read its id.
+/// A registered webview: emit events to its page(s), drive its default
+/// placement, and read the two ids it is addressed by.
+///
+/// A registration is addressed by a [`HandleId`], and each of its placements by
+/// an instance id. [`WebviewHandle::instance_id`] returns the default
+/// placement's; extra placements come from [`crate::Orzma::new_instance`].
 #[derive(Clone, Debug)]
 pub struct WebviewHandle {
-    id: Arc<Mutex<String>>,
+    handle: Arc<Mutex<HandleId>>,
+    instance: Arc<Mutex<String>>,
     events: Arc<EventQueues>,
     writer: SharedWriter,
 }
 
 impl PartialEq for WebviewHandle {
     fn eq(&self, other: &Self) -> bool {
-        self.id() == other.id()
+        self.handle_id() == other.handle_id()
     }
 }
 
 impl WebviewHandle {
-    /// Returns the opaque handle id minted by the control plane.
-    pub fn id(&self) -> String {
-        self.id.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    /// Returns the opaque handle the control plane minted for this
+    /// registration.
+    ///
+    /// This addresses the registration itself, which is what
+    /// [`crate::Orzma::new_instance`] mints from. It is not what a placement is
+    /// mounted or navigated by: pass [`WebviewHandle::instance_id`] to
+    /// [`crate::WebviewWidget::new`].
+    pub fn handle_id(&self) -> HandleId {
+        self.handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
-    /// Pushes an event to the currently-mounted page(s) of this handle.
+    /// Returns the id of this registration's default placement.
+    ///
+    /// This is the id [`crate::WebviewWidget::new`] mounts and the navigation
+    /// methods below drive.
+    pub fn instance_id(&self) -> String {
+        self.instance
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Pushes an event to every currently-mounted page of this registration.
     ///
     /// Mount-scoped: a no-op (still `Ok`) when nothing is mounted.
     pub fn emit<T: Serialize>(&self, event: &str, payload: &T) -> OrzmaResult<()> {
         let msg = ClientMsg::Emit {
-            handle: self.id(),
+            handle: self.handle_id(),
             event: event.to_owned(),
             payload: serde_json::to_value(payload)?,
         };
@@ -222,26 +248,29 @@ impl WebviewHandle {
         Ok(())
     }
 
-    /// Navigates this handle's mounted webview to `url` in place (no
+    /// Navigates this registration's default placement to `url` in place (no
     /// re-registration). Mount-scoped: a no-op (still `Ok`) when nothing is
-    /// mounted.
+    /// mounted under that instance. Other placements are left where they are.
     pub fn navigate(&self, url: impl Into<String>) -> OrzmaResult<()> {
-        self.send_nav(NavAction::To(url.into()))
+        send_nav(&self.writer, self.instance_id(), NavAction::To(url.into()))
     }
 
-    /// Goes back in the webview's native session history. Mount-scoped.
+    /// Goes back in the default placement's native session history.
+    /// Mount-scoped; other placements are unaffected.
     pub fn go_back(&self) -> OrzmaResult<()> {
-        self.send_nav(NavAction::Back)
+        send_nav(&self.writer, self.instance_id(), NavAction::Back)
     }
 
-    /// Goes forward in the webview's native session history. Mount-scoped.
+    /// Goes forward in the default placement's native session history.
+    /// Mount-scoped; other placements are unaffected.
     pub fn go_forward(&self) -> OrzmaResult<()> {
-        self.send_nav(NavAction::Forward)
+        send_nav(&self.writer, self.instance_id(), NavAction::Forward)
     }
 
-    /// Reloads the current page. Mount-scoped.
+    /// Reloads the default placement's page. Mount-scoped; other placements are
+    /// unaffected.
     pub fn reload(&self) -> OrzmaResult<()> {
-        self.send_nav(NavAction::Reload)
+        send_nav(&self.writer, self.instance_id(), NavAction::Reload)
     }
 
     /// Drains and returns every buffered event of type `T`, oldest first.
@@ -261,27 +290,81 @@ impl WebviewHandle {
             .collect()
     }
 
-    /// Creates a handle from a pre-existing shared ID slot for callers that need
-    /// to share the ID slot across threads.
+    /// Creates a handle over pre-existing shared id slots, which the reconnect
+    /// replay refills in place.
     pub(crate) fn new_shared(
-        id: Arc<Mutex<String>>,
+        handle: Arc<Mutex<HandleId>>,
+        instance: Arc<Mutex<String>>,
         events: Arc<EventQueues>,
         writer: SharedWriter,
     ) -> Self {
-        Self { id, events, writer }
+        Self {
+            handle,
+            instance,
+            events,
+            writer,
+        }
+    }
+}
+
+/// One extra placement of a registration, minted by
+/// [`crate::Orzma::new_instance`].
+///
+/// It can be mounted at the same time as the registration's default placement
+/// and as its other extra placements, each showing the same content
+/// independently.
+#[derive(Clone, Debug)]
+pub struct WebviewInstance {
+    instance: Arc<Mutex<String>>,
+    writer: SharedWriter,
+}
+
+impl WebviewInstance {
+    /// Returns the id of this placement, to pass to
+    /// [`crate::WebviewWidget::new`].
+    pub fn id(&self) -> String {
+        self.instance
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
-    fn send_nav(&self, action: NavAction) -> OrzmaResult<()> {
-        let msg = ClientMsg::Navigate {
-            handle: self.id(),
-            action,
-        };
-        let line = serde_json::to_string(&msg)?;
-        let mut w = self.writer.lock()?;
-        writeln!(w, "{line}")?;
-        w.flush()?;
-        Ok(())
+    /// Navigates this placement to `url` in place. Mount-scoped: a no-op (still
+    /// `Ok`) when nothing is mounted under this instance.
+    pub fn navigate(&self, url: impl Into<String>) -> OrzmaResult<()> {
+        send_nav(&self.writer, self.id(), NavAction::To(url.into()))
     }
+
+    /// Goes back in this placement's native session history. Mount-scoped.
+    pub fn go_back(&self) -> OrzmaResult<()> {
+        send_nav(&self.writer, self.id(), NavAction::Back)
+    }
+
+    /// Goes forward in this placement's native session history. Mount-scoped.
+    pub fn go_forward(&self) -> OrzmaResult<()> {
+        send_nav(&self.writer, self.id(), NavAction::Forward)
+    }
+
+    /// Reloads this placement's page. Mount-scoped.
+    pub fn reload(&self) -> OrzmaResult<()> {
+        send_nav(&self.writer, self.id(), NavAction::Reload)
+    }
+
+    /// Creates a placement over a pre-existing shared instance slot, which the
+    /// reconnect replay refills in place.
+    pub(crate) fn new_shared(instance: Arc<Mutex<String>>, writer: SharedWriter) -> Self {
+        Self { instance, writer }
+    }
+}
+
+/// Writes one `navigate` op addressed to `instance`.
+fn send_nav(writer: &SharedWriter, instance: String, action: NavAction) -> OrzmaResult<()> {
+    let msg = ClientMsg::Navigate { instance, action };
+    let line = serde_json::to_string(&msg)?;
+    let mut w = writer.lock()?;
+    writeln!(w, "{line}")?;
+    w.flush()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -440,19 +523,80 @@ mod tests {
         assert!(v.get("preload").is_none(), "empty preload must be skipped");
     }
 
+    /// Asserts that both ids a handle exposes are read through their shared
+    /// slots, so a refill is visible to a handle already in a caller's hands.
+    ///
+    /// Case: the session reconnects and re-registers, which mints a fresh
+    /// handle and instance for a view the app is still holding and drawing.
     #[test]
-    fn id_reflects_slot_update() {
-        let slot = Arc::new(Mutex::new("old-id".to_owned()));
+    fn both_ids_reflect_a_slot_update() {
+        let handle_slot = Arc::new(Mutex::new(HandleId::from("old-handle".to_owned())));
+        let instance_slot = Arc::new(Mutex::new("old-instance".to_owned()));
         let (a, _b) = std::os::unix::net::UnixStream::pair().unwrap();
         let writer: SharedWriter = Arc::new(Mutex::new(a));
         let handle = WebviewHandle::new_shared(
-            slot.clone(),
+            handle_slot.clone(),
+            instance_slot.clone(),
             Arc::new(crate::events::EventQueues::from_decls(&[])),
             writer,
         );
-        assert_eq!(handle.id(), "old-id");
-        *slot.lock().unwrap() = "new-id".to_owned();
-        assert_eq!(handle.id(), "new-id");
+        assert_eq!(handle.handle_id().to_string(), "old-handle");
+        assert_eq!(handle.instance_id(), "old-instance");
+
+        *handle_slot.lock().unwrap() = HandleId::from("new-handle".to_owned());
+        *instance_slot.lock().unwrap() = "new-instance".to_owned();
+        assert_eq!(handle.handle_id().to_string(), "new-handle");
+        assert_eq!(handle.instance_id(), "new-instance");
+    }
+
+    /// Asserts that a navigation names the placement it drives, so a handle
+    /// with several placements moves only its default one.
+    ///
+    /// Case: the app follows a link in the pane showing a view's default
+    /// placement while a second placement of that view stays where it is.
+    #[test]
+    fn a_handle_navigation_addresses_its_default_instance() {
+        use std::io::{BufRead, BufReader};
+        let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(client));
+        let handle = WebviewHandle::new_shared(
+            Arc::new(Mutex::new(HandleId::from("h".to_owned()))),
+            Arc::new(Mutex::new("i1".to_owned())),
+            Arc::new(crate::events::EventQueues::from_decls(&[])),
+            writer,
+        );
+
+        handle.navigate("https://example.com").unwrap();
+
+        let mut line = String::new();
+        BufReader::new(server).read_line(&mut line).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["op"], "navigate");
+        assert_eq!(v["instance"], "i1");
+        assert_eq!(v["action"]["to"], "https://example.com");
+    }
+
+    /// Asserts that a minted placement drives its own instance rather than the
+    /// registration's default one.
+    ///
+    /// Case: an app reloads the right-hand pane of a split showing one view
+    /// twice, leaving the left-hand pane untouched.
+    #[test]
+    fn an_extra_instance_navigates_itself() {
+        use std::io::{BufRead, BufReader};
+        let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+        let writer: SharedWriter = Arc::new(Mutex::new(client));
+        let instance = WebviewInstance::new_shared(Arc::new(Mutex::new("i2".to_owned())), writer);
+
+        assert_eq!(instance.id(), "i2");
+        instance.reload().unwrap();
+
+        let mut line = String::new();
+        BufReader::new(server).read_line(&mut line).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["op"], "navigate");
+        assert_eq!(v["instance"], "i2");
+        assert_eq!(v["action"], "reload");
     }
 
     #[test]
@@ -473,8 +617,12 @@ mod tests {
 
         let (sock, _b) = std::os::unix::net::UnixStream::pair().unwrap();
         let writer: SharedWriter = Arc::new(Mutex::new(sock));
-        let handle =
-            WebviewHandle::new_shared(Arc::new(Mutex::new("h".to_owned())), events, writer);
+        let handle = WebviewHandle::new_shared(
+            Arc::new(Mutex::new(HandleId::from("h".to_owned()))),
+            Arc::new(Mutex::new("i1".to_owned())),
+            events,
+            writer,
+        );
 
         let got = handle.read_events::<Hello>();
         assert_eq!(

--- a/sdk/ratatui_orzma/src/webview.rs
+++ b/sdk/ratatui_orzma/src/webview.rs
@@ -1,10 +1,11 @@
 //! Webview builder and registered handle.
 
-use crate::error::OrzmaResult;
+use crate::error::{OrzmaError, OrzmaResult};
 use crate::events::{EventDecl, EventQueues};
 use crate::handler::{BoxedHandler, make_handler};
 use crate::keychord::KeyChord;
 use crate::protocol::{ClientMsg, HandleId, NavAction, RegisterKind};
+use crate::session::SessionCore;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::any::TypeId;
@@ -12,7 +13,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 /// The shared write half of the control socket.
 pub(crate) type SharedWriter = Arc<Mutex<UnixStream>>;
@@ -187,17 +188,18 @@ impl Webview {
 }
 
 /// A registered webview: emit events to its page(s), drive its default
-/// placement, and read the two ids it is addressed by.
+/// placement, mint further placements, and read the two ids it is addressed by.
 ///
 /// A registration is addressed by a [`HandleId`], and each of its placements by
 /// an instance id. [`WebviewHandle::instance_id`] returns the default
-/// placement's; extra placements come from [`crate::Orzma::new_instance`].
+/// placement's; extra placements come from [`WebviewHandle::new_instance`].
 #[derive(Clone, Debug)]
 pub struct WebviewHandle {
     handle: Arc<Mutex<HandleId>>,
     instance: Arc<Mutex<String>>,
     events: Arc<EventQueues>,
     writer: SharedWriter,
+    session: Weak<SessionCore>,
 }
 
 impl PartialEq for WebviewHandle {
@@ -207,11 +209,38 @@ impl PartialEq for WebviewHandle {
 }
 
 impl WebviewHandle {
+    /// Mints an additional placement of this registration, blocking until the
+    /// control plane replies.
+    ///
+    /// A registration always has one placement, addressed by
+    /// [`WebviewHandle::instance_id`]; every instance minted here is another
+    /// place the same content can be mounted, at the same time as the others.
+    /// The returned instance is replayed alongside its registration when the
+    /// session reconnects.
+    ///
+    /// Blocks on a control-socket round trip, so call it while setting the app
+    /// up. Two places must never call it:
+    ///
+    /// - the draw loop, which the round trip would stall;
+    /// - an RPC handler registered with [`Webview::on`], which runs on the
+    ///   reader thread that would have to deliver this very reply — the call
+    ///   cannot be answered until it gives that thread back, so it blocks until
+    ///   the reply times out.
+    ///
+    /// Returns [`OrzmaError::SessionClosed`] once the [`crate::Orzma`] this
+    /// handle was registered through has been dropped. Minting is the only
+    /// thing a dropped session revokes: the methods above keep writing to the
+    /// control socket, which outlives the session object.
+    pub fn new_instance(&self) -> OrzmaResult<WebviewInstance> {
+        let core = self.session.upgrade().ok_or(OrzmaError::SessionClosed)?;
+        core.mint_instance(&self.writer, self)
+    }
+
     /// Returns the opaque handle the control plane minted for this
     /// registration.
     ///
     /// This addresses the registration itself, which is what
-    /// [`crate::Orzma::new_instance`] mints from. It is not what a placement is
+    /// [`WebviewHandle::new_instance`] mints from. It is not what a placement is
     /// mounted or navigated by: pass [`WebviewHandle::instance_id`] to
     /// [`crate::WebviewWidget::new`].
     pub fn handle_id(&self) -> HandleId {
@@ -307,18 +336,20 @@ impl WebviewHandle {
         instance: Arc<Mutex<String>>,
         events: Arc<EventQueues>,
         writer: SharedWriter,
+        session: Weak<SessionCore>,
     ) -> Self {
         Self {
             handle,
             instance,
             events,
             writer,
+            session,
         }
     }
 }
 
 /// One extra placement of a registration, minted by
-/// [`crate::Orzma::new_instance`].
+/// [`WebviewHandle::new_instance`].
 ///
 /// It can be mounted at the same time as the registration's default placement
 /// and as its other extra placements, each showing the same content
@@ -549,6 +580,7 @@ mod tests {
             instance_slot.clone(),
             Arc::new(crate::events::EventQueues::from_decls(&[])),
             writer,
+            Weak::new(),
         );
         assert_eq!(handle.handle_id().to_string(), "old-handle");
         assert_eq!(handle.instance_id(), "old-instance");
@@ -574,6 +606,7 @@ mod tests {
             Arc::new(Mutex::new("i1".to_owned())),
             Arc::new(crate::events::EventQueues::from_decls(&[])),
             writer,
+            Weak::new(),
         );
 
         handle.navigate("https://example.com").unwrap();
@@ -632,6 +665,7 @@ mod tests {
             Arc::new(Mutex::new("i1".to_owned())),
             events,
             writer,
+            Weak::new(),
         );
 
         let got = handle.read_events::<Hello>();

--- a/sdk/ratatui_orzma/src/webview.rs
+++ b/sdk/ratatui_orzma/src/webview.rs
@@ -290,6 +290,16 @@ impl WebviewHandle {
             .collect()
     }
 
+    /// Whether `slot` is the very slot this handle reads its handle id from.
+    ///
+    /// Registrations are matched against a handle by this identity rather than
+    /// by the id the slot currently holds: a reconnect refills the slot in
+    /// place, so an id read before a round trip can no longer be found by value
+    /// once the replay lands.
+    pub(crate) fn shares_handle_slot(&self, slot: &Arc<Mutex<HandleId>>) -> bool {
+        Arc::ptr_eq(&self.handle, slot)
+    }
+
     /// Creates a handle over pre-existing shared id slots, which the reconnect
     /// replay refills in place.
     pub(crate) fn new_shared(

--- a/sdk/ratatui_orzma/src/widget.rs
+++ b/sdk/ratatui_orzma/src/widget.rs
@@ -254,8 +254,8 @@ mod tests {
     /// compositing state, leaving another placement's buffered for the widget
     /// that renders it.
     ///
-    /// Case: an app shows one registration in two panes, and only the second
-    /// pane's page has started painting.
+    /// Case: one placement's page starts painting, and the next widget drawn
+    /// belongs to a different placement.
     #[test]
     fn on_compositing_change_ignores_another_instances_pending_state() {
         use std::cell::Cell;

--- a/sdk/ratatui_orzma/src/widget.rs
+++ b/sdk/ratatui_orzma/src/widget.rs
@@ -11,17 +11,22 @@ use ratatui::widgets::{Clear, StatefulWidget, Widget};
 /// into the frame the [`crate::OrzmaBackend`] emits on the next draw. Optionally
 /// paints a fallback under-layer (shown on non-macOS or before the page composites).
 pub struct WebviewWidget<W = WebviewDefaultPlaceholder> {
-    handle: String,
+    instance: String,
     fallback: W,
     focused: bool,
     on_compositing_change: Option<Box<dyn Fn(bool) + 'static>>,
 }
 
 impl WebviewWidget<WebviewDefaultPlaceholder> {
-    /// Creates a widget for the given webview handle id.
-    pub fn new(handle: impl Into<String>) -> Self {
+    /// Creates a widget for the given placement instance id, as returned by
+    /// [`crate::WebviewHandle::instance_id`] or [`crate::WebviewInstance::id`].
+    ///
+    /// A registration handle is not an instance id and will never mount; the
+    /// [`crate::HandleId`] that [`crate::WebviewHandle::handle_id`] returns is
+    /// deliberately not accepted here.
+    pub fn new(instance: impl Into<String>) -> Self {
         Self {
-            handle: handle.into(),
+            instance: instance.into(),
             fallback: WebviewDefaultPlaceholder,
             focused: false,
             on_compositing_change: None,
@@ -33,7 +38,7 @@ impl<W> WebviewWidget<W> {
     /// Sets a fallback widget painted into the cells under the webview.
     pub fn fallback<W2: Widget>(self, widget: W2) -> WebviewWidget<W2> {
         WebviewWidget {
-            handle: self.handle,
+            instance: self.instance,
             fallback: widget,
             focused: self.focused,
             on_compositing_change: self.on_compositing_change,
@@ -41,7 +46,7 @@ impl<W> WebviewWidget<W> {
     }
 
     /// Registers a callback invoked during [`StatefulWidget::render`] when a
-    /// compositing-state change for this handle is pending in the frame state.
+    /// compositing-state change for this instance is pending in the frame state.
     ///
     /// The callback receives `true` when the webview starts compositing (the
     /// page is live and painting) and `false` when it stops.
@@ -78,11 +83,11 @@ impl<W: Widget> StatefulWidget for WebviewWidget<W> {
         }
         Clear.render(area, buf);
         self.fallback.render(area, buf);
-        state.record(self.handle.clone(), area);
+        state.record(self.instance.clone(), area);
         if self.focused {
-            state.set_focused(self.handle.clone());
+            state.set_focused(self.instance.clone());
         }
-        if let Some(active) = state.take_compositing(&self.handle)
+        if let Some(active) = state.take_compositing(&self.instance)
             && let Some(cb) = &self.on_compositing_change
         {
             cb(active);
@@ -107,6 +112,9 @@ mod tests {
     use ratatui::text::Text;
     use ratatui::widgets::StatefulWidget;
 
+    const INSTANCE: &str = "3f5a9c02d1e84b7690ab3cde12f45678";
+    const OTHER_INSTANCE: &str = "81b4e77c05a3492fd6180e29ba735fc1";
+
     #[test]
     fn records_placement_and_blanks_cells() {
         let area = Rect {
@@ -118,10 +126,10 @@ mod tests {
         let mut buf = Buffer::filled(Rect::new(0, 0, 10, 5), ratatui::buffer::Cell::new("Z"));
         let mut state = FramePlacements::default();
 
-        WebviewWidget::new("view-x").render(area, &mut buf, &mut state);
+        WebviewWidget::new(INSTANCE).render(area, &mut buf, &mut state);
 
         assert_eq!(state.placements_for_test().len(), 1);
-        assert_eq!(state.placements_for_test()[0].handle, "view-x");
+        assert_eq!(state.placements_for_test()[0].instance, INSTANCE);
         assert_eq!(buf[(1, 1)].symbol(), " ");
     }
 
@@ -136,7 +144,7 @@ mod tests {
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
 
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .fallback(Text::raw("hi"))
             .render(area, &mut buf, &mut state);
 
@@ -153,7 +161,7 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .focused(true)
             .render(area, &mut buf, &mut state);
         assert_eq!(state.placements_for_test().len(), 1);
@@ -169,10 +177,10 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .focused(true)
             .render(area, &mut buf, &mut state);
-        assert_eq!(state.focused_for_test(), Some("v"));
+        assert_eq!(state.focused_for_test(), Some(INSTANCE));
     }
 
     #[test]
@@ -185,7 +193,7 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        WebviewWidget::new("v").render(area, &mut buf, &mut state);
+        WebviewWidget::new(INSTANCE).render(area, &mut buf, &mut state);
         assert_eq!(state.focused_for_test(), None);
     }
 
@@ -201,13 +209,13 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        state.pending_compositing.insert("v".into(), true);
+        state.pending_compositing.insert(INSTANCE.into(), true);
 
         let fired = Rc::new(Cell::new(false));
         let fired_val = Rc::new(Cell::new(false));
         let fired2 = fired.clone();
         let fired_val2 = fired_val.clone();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .on_compositing_change(move |active| {
                 fired2.set(true);
                 fired_val2.set(active);
@@ -232,13 +240,49 @@ mod tests {
 
         let fired = Rc::new(std::cell::Cell::new(false));
         let fired2 = fired.clone();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .on_compositing_change(move |_| fired2.set(true))
             .render(area, &mut buf, &mut state);
 
         assert!(
             !fired.get(),
             "callback must not fire when no pending compositing"
+        );
+    }
+
+    /// Asserts that a widget consumes only its own instance's pending
+    /// compositing state, leaving another placement's buffered for the widget
+    /// that renders it.
+    ///
+    /// Case: an app shows one registration in two panes, and only the second
+    /// pane's page has started painting.
+    #[test]
+    fn on_compositing_change_ignores_another_instances_pending_state() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 1,
+        };
+        let mut buf = Buffer::empty(area);
+        let mut state = FramePlacements::default();
+        state
+            .pending_compositing
+            .insert(OTHER_INSTANCE.into(), true);
+
+        let fired = Rc::new(Cell::new(false));
+        let fired2 = fired.clone();
+        WebviewWidget::new(INSTANCE)
+            .on_compositing_change(move |_| fired2.set(true))
+            .render(area, &mut buf, &mut state);
+
+        assert!(!fired.get(), "another placement's state must not fire here");
+        assert_eq!(
+            state.pending_compositing_for_test().get(OTHER_INSTANCE),
+            Some(&true),
+            "the other placement's state must stay buffered for its own widget"
         );
     }
 
@@ -254,11 +298,11 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        state.pending_compositing.insert("v".into(), false);
+        state.pending_compositing.insert(INSTANCE.into(), false);
 
         let fired_val = Rc::new(Cell::new(true));
         let fired_val2 = fired_val.clone();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .on_compositing_change(move |active| {
                 fired_val2.set(active);
             })
@@ -277,9 +321,9 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        state.pending_compositing.insert("v".into(), true);
+        state.pending_compositing.insert(INSTANCE.into(), true);
 
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .on_compositing_change(move |_| {})
             .render(area, &mut buf, &mut state);
 
@@ -302,11 +346,11 @@ mod tests {
         };
         let mut buf = Buffer::empty(area);
         let mut state = FramePlacements::default();
-        state.pending_compositing.insert("v".into(), true);
+        state.pending_compositing.insert(INSTANCE.into(), true);
 
         let fired = Rc::new(Cell::new(false));
         let fired2 = fired.clone();
-        WebviewWidget::new("v")
+        WebviewWidget::new(INSTANCE)
             .on_compositing_change(move |_| fired2.set(true))
             .fallback(Text::raw("x"))
             .render(area, &mut buf, &mut state);

--- a/sdk/ratatui_orzma/tests/integration.rs
+++ b/sdk/ratatui_orzma/tests/integration.rs
@@ -56,11 +56,9 @@ fn backend_draw_emits_mount_apc_and_focus_op() {
         {
             let mut scratch = Buffer::empty(Rect::new(0, 0, 80, 40));
             let mut frame = orzma.frame();
-            WebviewWidget::new(handle.id()).focused(true).render(
-                Rect::new(2, 3, 48, 12),
-                &mut scratch,
-                &mut *frame,
-            );
+            WebviewWidget::new(handle.instance_id())
+                .focused(true)
+                .render(Rect::new(2, 3, 48, 12), &mut scratch, &mut *frame);
         }
 
         // Terminal::flush calls Backend::draw once per frame; drive it directly.
@@ -68,14 +66,97 @@ fn backend_draw_emits_mount_apc_and_focus_op() {
         Backend::draw(&mut backend, no_cells.into_iter()).unwrap();
 
         let out = String::from_utf8(term_bytes.0.lock().unwrap().clone()).unwrap();
+        let instance = &server.instance;
         assert!(
-            out.contains("Omount;v=view-1,r=12,c=48"),
+            out.contains(&format!("Omount;n={instance},r=12,c=48")),
             "terminal output missing mount APC verb: {out:?}"
         );
 
         let msg = server.next_message();
         assert_eq!(msg["op"], "focus");
-        assert_eq!(msg["handle"], "view-1");
+        assert_eq!(msg["instance"], instance.as_str());
+    });
+}
+
+#[test]
+fn new_instance_mints_a_second_placement_that_mounts_on_its_own() {
+    let server = FakeServer::start("view-multi");
+    with_env(&server.sock_path.clone(), || {
+        let orzma = Orzma::connect().unwrap();
+        let handle = orzma.register(Webview::inline("x")).unwrap();
+        let extra = orzma.new_instance(&handle).unwrap();
+        assert_ne!(
+            extra.id(),
+            handle.instance_id(),
+            "an extra placement must not reuse the default instance"
+        );
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OrzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &orzma);
+        {
+            let mut scratch = Buffer::empty(Rect::new(0, 0, 80, 40));
+            let mut frame = orzma.frame();
+            WebviewWidget::new(handle.instance_id()).render(
+                Rect::new(0, 0, 10, 5),
+                &mut scratch,
+                &mut frame,
+            );
+            WebviewWidget::new(extra.id()).render(Rect::new(0, 6, 10, 5), &mut scratch, &mut frame);
+        }
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        let out = String::from_utf8(term_bytes.0.lock().unwrap().clone()).unwrap();
+        let default = handle.instance_id();
+        let second = extra.id();
+        assert!(
+            out.contains(&format!("Omount;n={default},")),
+            "the default placement did not mount: {out:?}"
+        );
+        assert!(
+            out.contains(&format!("Omount;n={second},")),
+            "the minted placement did not mount: {out:?}"
+        );
+    });
+}
+
+#[test]
+fn reconnect_remints_every_instance_of_a_registration() {
+    use std::time::Duration;
+    let pair = support::ReconnectPair::start("view-mi1", "view-mi2");
+    with_env(&pair.first.sock_path.clone(), || {
+        let orzma = Orzma::connect().unwrap();
+        let handle = orzma.register(Webview::inline("x")).unwrap();
+        let extra = orzma.new_instance(&handle).unwrap();
+        let before = extra.id();
+
+        let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));
+        let mut backend = OrzmaBackend::new(CrosstermBackend::new(term_bytes.clone()), &orzma);
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        drop(pair.first);
+        std::thread::sleep(Duration::from_millis(200));
+        // NOTE: ENV_LOCK is held by with_env, serializing env var access.
+        unsafe { std::env::set_var("ORZMA_SOCK", &pair.second.sock_path) };
+        Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while extra.id() == before {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the extra placement was never re-minted"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert_eq!(
+            handle.instance_id(),
+            pair.second.instance,
+            "the default placement must follow the re-registration"
+        );
+        assert_eq!(
+            extra.id(),
+            support::instance_for("view-mi2/1"),
+            "the extra placement must be re-minted on the new connection"
+        );
     });
 }
 
@@ -89,7 +170,8 @@ fn call_is_dispatched_and_replied() {
             .unwrap();
 
         server.send(json!({
-            "op": "call", "handle": "view-1", "reqId": "7", "method": "ping", "params": "hi"
+            "op": "call", "handle": "view-1", "instance": server.instance,
+            "reqId": "7", "method": "ping", "params": "hi"
         }));
 
         let reply = server.next_message();
@@ -107,7 +189,8 @@ fn unknown_method_replies_error() {
         let orzma = Orzma::connect().unwrap();
         let _h = orzma.register(Webview::inline("x")).unwrap();
         server.send(json!({
-            "op": "call", "handle": "view-2", "reqId": "1", "method": "nope", "params": null
+            "op": "call", "handle": "view-2", "instance": server.instance,
+            "reqId": "1", "method": "nope", "params": null
         }));
         let reply = server.next_message();
         assert_eq!(reply["ok"], false);
@@ -198,17 +281,19 @@ fn panicking_handler_does_not_kill_reader() {
 
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
-        server.send(
-            json!({ "op": "call", "handle": "view-5", "reqId": "1", "method": "boom", "params": null }),
-        );
+        server.send(json!({
+            "op": "call", "handle": "view-5", "instance": server.instance,
+            "reqId": "1", "method": "boom", "params": null
+        }));
         let boom = server.next_message();
         std::panic::set_hook(prev);
         assert_eq!(boom["reqId"], "1");
         assert_eq!(boom["ok"], false);
 
-        server.send(
-            json!({ "op": "call", "handle": "view-5", "reqId": "2", "method": "ping", "params": null }),
-        );
+        server.send(json!({
+            "op": "call", "handle": "view-5", "instance": server.instance,
+            "reqId": "2", "method": "ping", "params": null
+        }));
         let ping = server.next_message();
         assert_eq!(ping["reqId"], "2");
         assert_eq!(ping["ok"], true);
@@ -224,7 +309,7 @@ fn reconnect_updates_handle_id_and_reregisters() {
         let orzma = Orzma::connect().unwrap();
         let handle = orzma.register(Webview::inline("<h1>rc</h1>")).unwrap();
         assert_eq!(
-            handle.id(),
+            handle.handle_id().to_string(),
             "view-rc1",
             "initial registration must get first handle"
         );
@@ -243,7 +328,7 @@ fn reconnect_updates_handle_id_and_reregisters() {
         Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
 
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        while handle.id() == "view-rc1" {
+        while handle.handle_id().to_string() == "view-rc1" {
             assert!(
                 std::time::Instant::now() < deadline,
                 "reconnect did not complete within 5 seconds"
@@ -251,7 +336,7 @@ fn reconnect_updates_handle_id_and_reregisters() {
             std::thread::sleep(Duration::from_millis(50));
         }
         assert_eq!(
-            handle.id(),
+            handle.handle_id().to_string(),
             "view-rc2",
             "handle ID must update to second server's handle after reconnect"
         );
@@ -302,7 +387,7 @@ fn reconnect_preserves_inbound_events() {
         Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
 
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        while handle.id() == "view-ev1" {
+        while handle.handle_id().to_string() == "view-ev1" {
             assert!(
                 std::time::Instant::now() < deadline,
                 "reconnect did not complete"

--- a/sdk/ratatui_orzma/tests/integration.rs
+++ b/sdk/ratatui_orzma/tests/integration.rs
@@ -88,7 +88,7 @@ fn new_instance_mints_a_second_placement_that_mounts_on_its_own() {
     with_env(&server.sock_path.clone(), || {
         let orzma = Orzma::connect().unwrap();
         let handle = orzma.register(Webview::inline("x")).unwrap();
-        let extra = orzma.new_instance(&handle).unwrap();
+        let extra = handle.new_instance().unwrap();
         assert_ne!(
             extra.id(),
             handle.instance_id(),
@@ -134,7 +134,7 @@ fn reconnect_remints_every_instance_of_a_registration() {
     with_env(&pair.first.sock_path.clone(), || {
         let orzma = Orzma::connect().unwrap();
         let handle = orzma.register(Webview::inline("x")).unwrap();
-        let extra = orzma.new_instance(&handle).unwrap();
+        let extra = handle.new_instance().unwrap();
         let before = extra.id();
 
         let term_bytes = SharedBuf(Arc::new(Mutex::new(Vec::new())));

--- a/sdk/ratatui_orzma/tests/integration.rs
+++ b/sdk/ratatui_orzma/tests/integration.rs
@@ -78,6 +78,10 @@ fn backend_draw_emits_mount_apc_and_focus_op() {
     });
 }
 
+/// Asserts that an instance minted on an existing registration is distinct
+/// from its default one and mounts alongside it in the same frame.
+///
+/// Case: an app shows one view in a split, side by side.
 #[test]
 fn new_instance_mints_a_second_placement_that_mounts_on_its_own() {
     let server = FakeServer::start("view-multi");
@@ -119,6 +123,10 @@ fn new_instance_mints_a_second_placement_that_mounts_on_its_own() {
     });
 }
 
+/// Asserts that a reconnect re-mints a registration's extra placements, not
+/// just its default one, into the slots the app already holds.
+///
+/// Case: orzma restarts while an app is drawing the same view in two panes.
 #[test]
 fn reconnect_remints_every_instance_of_a_registration() {
     use std::time::Duration;
@@ -135,7 +143,7 @@ fn reconnect_remints_every_instance_of_a_registration() {
 
         drop(pair.first);
         std::thread::sleep(Duration::from_millis(200));
-        // NOTE: ENV_LOCK is held by with_env, serializing env var access.
+        // SAFETY: ENV_LOCK is held by with_env, serializing all env var access.
         unsafe { std::env::set_var("ORZMA_SOCK", &pair.second.sock_path) };
         Backend::draw(&mut backend, std::iter::empty::<(u16, u16, &Cell)>()).unwrap();
 

--- a/sdk/ratatui_orzma/tests/support/mod.rs
+++ b/sdk/ratatui_orzma/tests/support/mod.rs
@@ -5,9 +5,26 @@ use std::os::unix::net::UnixListener;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
+/// A deterministic 32-lowercase-hex instance id derived from `seed`, in the
+/// form the control plane mints and the APC verbs accept.
+pub fn instance_for(seed: &str) -> String {
+    format!(
+        "{:016x}{:016x}",
+        fnv1a(seed, 0xcbf2_9ce4_8422_2325),
+        fnv1a(seed, 0x8422_2325_cbf2_9ce4)
+    )
+}
+
+fn fnv1a(seed: &str, basis: u64) -> u64 {
+    seed.bytes().fold(basis, |h, b| {
+        (h ^ u64::from(b)).wrapping_mul(0x0000_0100_0000_01b3)
+    })
+}
+
 /// A fake control server: accepts one client, auto-replies to the first
-/// `register` with a fixed handle, forwards every client line over `received`,
-/// and pushes lines to the client via `to_client`.
+/// `register` with a fixed handle and its instance, mints a fresh instance for
+/// every `new_instance`, forwards every client line over `received`, and pushes
+/// lines to the client via `to_client`.
 ///
 /// `start` is non-blocking: it binds the socket and spawns the accept/reader and
 /// writer threads, then returns immediately so the client can connect afterward.
@@ -17,6 +34,9 @@ use std::thread;
 /// client's reader see EOF.
 pub struct FakeServer {
     pub sock_path: std::path::PathBuf,
+    /// The instance the auto-replied `register` mints, as the client will
+    /// address its default placement by.
+    pub instance: String,
     received: Receiver<Value>,
     to_client: Sender<Value>,
     _dir: tempfile::TempDir,
@@ -33,6 +53,8 @@ impl FakeServer {
         let (to_client, client_rx) = mpsc::channel::<Value>();
         let reply_tx = to_client.clone();
         let handle = handle.to_owned();
+        let instance = instance_for(&handle);
+        let reply_instance = instance.clone();
         let (close_tx, close_rx) = mpsc::sync_channel::<()>(0);
 
         thread::spawn(move || {
@@ -60,6 +82,7 @@ impl FakeServer {
             let mut reader = BufReader::new(stream);
             let mut line = String::new();
             let mut replied = false;
+            let mut minted = 0u32;
             loop {
                 line.clear();
                 if reader.read_line(&mut line).unwrap_or(0) == 0 {
@@ -68,7 +91,13 @@ impl FakeServer {
                 if let Ok(v) = serde_json::from_str::<Value>(line.trim()) {
                     if !replied && v["op"] == "register" {
                         replied = true;
-                        let _ = reply_tx.send(json!({ "ok": true, "handle": handle }));
+                        let _ = reply_tx.send(
+                            json!({ "ok": true, "handle": handle, "instance": reply_instance }),
+                        );
+                    } else if v["op"] == "new_instance" {
+                        minted += 1;
+                        let extra = instance_for(&format!("{handle}/{minted}"));
+                        let _ = reply_tx.send(json!({ "ok": true, "instance": extra }));
                     }
                     let _ = recv_tx.send(v);
                 }
@@ -77,6 +106,7 @@ impl FakeServer {
 
         Self {
             sock_path,
+            instance,
             received,
             to_client,
             _dir: dir,
@@ -114,6 +144,7 @@ impl FakeServer {
 
         Self {
             sock_path,
+            instance: instance_for("dropping"),
             received,
             to_client,
             _dir: dir,
@@ -126,11 +157,13 @@ impl FakeServer {
         self.to_client.send(v).unwrap();
     }
 
-    /// Blocks for the next post-handshake line the client sent (skips hello/register).
+    /// Blocks for the next post-handshake line the client sent, skipping the
+    /// requests this server auto-replies to (`hello`, `register`,
+    /// `new_instance`) so they cannot leak into a caller's assertion.
     pub fn next_message(&self) -> Value {
         loop {
             let v = self.received.recv().unwrap();
-            if v["op"] != "hello" && v["op"] != "register" {
+            if v["op"] != "hello" && v["op"] != "register" && v["op"] != "new_instance" {
                 return v;
             }
         }

--- a/src/input/focus.rs
+++ b/src/input/focus.rs
@@ -205,6 +205,7 @@ fn cursor_claims_webview(window: &Window, claim: &WebviewClaimParams) -> Option<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orzma_vt::prelude::InstanceId;
 
     #[test]
     fn focused_webview_follows_active_pane() {
@@ -287,9 +288,11 @@ mod tests {
             .spawn((
                 ChildOf(pane),
                 Webview {
-                    view_id: "v".into(),
-                    instance_id: None,
+                    handle: "v".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();
@@ -317,9 +320,11 @@ mod tests {
             .spawn((
                 ChildOf(pane),
                 Webview {
-                    view_id: "v".into(),
-                    instance_id: None,
+                    handle: "v".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();
@@ -354,9 +359,11 @@ mod tests {
             .spawn((
                 ChildOf(surface),
                 Webview {
-                    view_id: "h1".into(),
-                    instance_id: None,
+                    handle: "h1".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();
@@ -431,9 +438,11 @@ mod tests {
         app.world_mut().spawn((
             ChildOf(shell),
             Webview {
-                view_id: "w".into(),
-                instance_id: None,
+                handle: "w".into(),
+                instance: InstanceId(1),
                 slot: 0,
+                rows: 10,
+                cols: 40,
             },
         ));
         app.world_mut().spawn((

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -406,6 +406,7 @@ mod tests {
     use bevy::window::{Ime, Window, WindowResolution};
     use orzma_tty_renderer::CellMetrics;
     use orzma_tty_renderer::prelude::{Cursor, TerminalGrid};
+    use orzma_vt::prelude::InstanceId;
 
     #[test]
     fn try_new_returns_none_for_empty_text() {
@@ -726,9 +727,11 @@ mod tests {
             .spawn((
                 ChildOf(terminal),
                 Webview {
-                    view_id: "webview".into(),
-                    instance_id: None,
+                    handle: "webview".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();
@@ -771,9 +774,11 @@ mod tests {
             .spawn((
                 ChildOf(terminal_entity),
                 Webview {
-                    view_id: "webview".into(),
-                    instance_id: None,
+                    handle: "webview".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();

--- a/src/input/mouse/webview/router.rs
+++ b/src/input/mouse/webview/router.rs
@@ -245,6 +245,7 @@ mod tests {
     use bevy::window::WindowResolution;
     use bevy_cef::prelude::FocusedWebview;
     use orzma_tty_renderer::CellMetrics;
+    use orzma_vt::prelude::InstanceId;
 
     fn test_metrics() -> TerminalCellMetricsResource {
         TerminalCellMetricsResource {
@@ -292,9 +293,11 @@ mod tests {
             .spawn((
                 ChildOf(shell),
                 Webview {
-                    view_id: "webview".into(),
-                    instance_id: None,
+                    handle: "webview".into(),
+                    instance: InstanceId(1),
                     slot: 0,
+                    rows: 10,
+                    cols: 40,
                 },
             ))
             .id();


### PR DESCRIPTION
## Summary

A webview placement used to be addressed by three different identifiers, and which one you needed
depended on where you stood: `orzma_vt` minted a `PlacementId`, the control plane handed programs an
opaque `handle`, and the APC mount verb took a `view_id`. Nothing in the type system stopped you from
passing the wrong one — the failure mode was a webview that silently never appeared.

This collapses all three into one host-minted `InstanceId`: 32 lowercase hex digits, 128 CSPRNG bits,
minted by the control plane and handed to the registering program *before* it writes its mount. The VT
no longer mints anything; `orzma_vt` has no RNG dependency at all, which makes that structural rather
than a convention.

Because the id now arrives before the mount, one registration can hold several placements. That is what
the new `new_instance` control op is for, and it is why `focus`, `navigate`, `compositing` and `call`
became instance-scoped: with two placements of one handle live, a handle no longer identifies a target.

Design doc: `docs/todo/webview-instance-id.md`.

## The type gate

`HandleId` deliberately has no conversion to `String` — no `From`, no `Into`, no `AsRef` path. Passing a
handle where an instance belongs is now a compile error rather than a webview that never appears:

```
error[E0277]: the trait bound `String: From<HandleId>` is not satisfied
  ... required by a bound in `WebviewWidget::new`
```

This was verified by compiling a throwaway crate against the published SDK, not by inspection.

## Wire protocol

```
register     → {"ok":true,"handle":"<26-char base32>","instance":"<32 lowercase hex>"}
new_instance → {"op":"new_instance","handle":"…"}  ⇒  {"ok":true,"instance":"…"}
               errors: unknown_handle | not_owner
focus        → {"op":"focus","instance":"…"|null}
navigate     → {"op":"navigate","instance":"…","action":…}
compositing  ← {"op":"compositing","handle":"…","instance":"…","active":<bool>}
call         ← {"op":"call","handle":"…","instance":"…","reqId":"…","method":"…","params":…}

APC          → ESC _ Omount;n=<instance>,r=<rows>,c=<cols> ESC \
               ESC _ Ounmount[;n=<instance>] ESC \
```

A reply with no `op` field settles the **oldest outstanding request**, not the most recent `register` —
`register` and `new_instance` both return op-less replies, so the SDK routes them through a FIFO.

## Breaking changes

- `Omount;v=<handle>` and `Ounmount;v=<handle>` are gone. The old spelling is now rejected, and there are
  negative tests pinning that (`crates/orzma_vt/src/interpreter/apc.rs:173`, `:174`, `:213`).
- `focus` and `navigate` take `instance` instead of `handle`.
- `WebviewHandle::id()` is now `handle_id() -> HandleId`; `instance_id() -> String` is what
  `WebviewWidget::new` wants.
- `PlacementId` is gone from every public surface; `orzma_tty_renderer` re-exports `InstanceId` in its place.

## Notable fix found along the way

`sdk/ratatui_orzma/src/backend.rs` — a dead control socket could wedge the whole TUI permanently. The
disconnect reset cleared `last_focused`, so the next draw wrote a focus op to the dead socket; that write
returned `BrokenPipe` and short-circuited past the crate's only `reconnect_tx` sender, so reconnect never
fired again and every subsequent draw failed the same way. It needed a focused webview at disconnect time
to trigger. The control socket is an auxiliary channel now: losing it degrades webview features, and the
TUI keeps rendering to the still-live PTY.

## Testing

- `cargo test --workspace`: 1557 passed, 0 failed, 20 suites
- `cargo clippy --workspace --all-targets -- -D warnings`: clean, on a run forced past the incremental
  cache so every `#[expect]` is proven still firing
- `cargo fmt --check`: clean
- `pnpm -r test` 50 passed, `pnpm check-types`, `pnpm lint:ci`: clean (no TypeScript changes; regression check)

Two invariants that had no guard now have one: `Vt::remove_placements` visiting both screens without
short-circuiting, and the skip diagnostic on an unusable placement id. Both were confirmed to
discriminate by introducing the regression and watching them fail.

Not verified: `just run` plus a visual check that a webview actually appears — that needs a GUI session.

## Follow-ups (deliberately not in this PR)

- `call` carries an instance but `event` does not. The design doc's op table never ruled on `event`;
  it stays handle-scoped, matching the SDK's handle-keyed `read_events`.
- `bevy_orzma_tty` spells one `Vec<InstanceId>` `placements` and another `instances` on the same API.
  The spec set both names, so reconciling them is its own change.
- `FlushState::reset` is close to inert on the reconnect path — fresh ids make the keyed diff re-mount
  everything anyway. Its own doc records the reasoning.
- `pnpm check-types` needs `pnpm --filter @orzma/web build` first from a cold worktree. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ufv4BbEFBZ4MFCDPhu4C8P
