### PR TITLE
perf: resolve history row ids through an index instead of scanning the ring

### DIFF
--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -4,6 +4,7 @@ pub mod row;
 pub mod run;
 
 pub(crate) mod coords;
+mod history_index;
 
 use crate::screen::cell::Cell;
 use crate::screen::grid::coords::{GridLine, ScreenLine};
@@ -46,7 +47,7 @@ pub struct GridSize {
 /// The uniqueness is per grid, NOT per terminal: the primary and
 /// alternate screens own separate grids that both start at zero, so
 /// resolving an id against the wrong one silently names a different row.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LineId(u64);
 
 /// Storage-only grid: scrollback history plus the visible screen in

--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -8,6 +8,7 @@ mod history_index;
 
 use crate::screen::cell::Cell;
 use crate::screen::grid::coords::{GridLine, ScreenLine};
+use crate::screen::grid::history_index::HistoryIndex;
 use crate::screen::grid::row::Row;
 use std::collections::VecDeque;
 use std::ops::{Index, IndexMut, Range};
@@ -41,8 +42,9 @@ pub struct GridSize {
 /// into it like any other, so binary-searching the history segment alone
 /// is equally unsound. The front row is not necessarily the lowest id
 /// either, because on a grid built without history a reverse scroll
-/// inserts at ring index zero. The only sound constant-time rejection is
-/// `id >= next_line_id`, which no caller can produce.
+/// inserts at ring index zero. History is therefore resolved through an
+/// id-keyed index rather than by position, and only the visible rows are
+/// scanned.
 ///
 /// The uniqueness is per grid, NOT per terminal: the primary and
 /// alternate screens own separate grids that both start at zero, so
@@ -71,6 +73,8 @@ pub struct Grid {
     max_history: usize,
     /// The id the next row to enter the ring will carry.
     next_line_id: u64,
+    /// Constant-time lookup of a history row's ring index by its id.
+    history_index: HistoryIndex,
 }
 
 /// One stored row: its identity together with its cells.
@@ -99,6 +103,7 @@ impl Grid {
             size,
             max_history,
             next_line_id: u64::from(size.rows),
+            history_index: HistoryIndex::default(),
         }
     }
 
@@ -107,6 +112,7 @@ impl Grid {
     /// The grid keeps its size and its history cap.
     pub fn reset(&mut self) {
         self.rows.clear();
+        self.history_index = HistoryIndex::default();
         for _ in 0..self.size.rows {
             self.push_blank_row();
         }
@@ -158,6 +164,7 @@ impl Grid {
             return;
         }
         let grows_history = base < self.max_history;
+        let departing = self.rows[base].id;
         let entering = if grows_history {
             GridRow {
                 id,
@@ -168,10 +175,16 @@ impl Grid {
                 .rows
                 .pop_front()
                 .expect("the ring always holds the visible rows");
+            if self.max_history > 0 {
+                self.history_index.pop_oldest(recycled.id);
+            }
             recycled.id = id;
             recycled.cells.fill(fill);
             recycled
         };
+        if self.max_history > 0 {
+            self.history_index.enter(departing);
+        }
         // NOTE: Seating the entering row just past the bottom margin is
         // what hands the departing row to history: the ring grows by one,
         // so the window of visible rows slides off it while the rows
@@ -204,12 +217,22 @@ impl Grid {
 
     /// The active-grid line the row `id` now sits at; `None` once it has
     /// left the ring.
+    ///
+    /// A history row resolves in constant time through the history
+    /// index; a visible row is found by a scan bounded by the screen
+    /// height.
     pub fn grid_line(&self, id: LineId) -> Option<GridLine> {
-        let index = self.rows.iter().rposition(|row| row.id == id)?;
-        let line = index as i64 - self.history_len() as i64;
-        Some(GridLine(
-            i32::try_from(line).expect("a ring index minus its history fits in i32"),
-        ))
+        let history = self.history_len();
+        if let Some(index) = self.history_index.index_of(id) {
+            let line = index as i64 - history as i64;
+            return Some(GridLine(
+                i32::try_from(line).expect("a ring index minus its history fits in i32"),
+            ));
+        }
+        self.rows
+            .range(history..)
+            .position(|row| row.id == id)
+            .map(|line| GridLine(i32::try_from(line).expect("a screen line fits in i32")))
     }
 
     /// Borrows the row at an active-grid line; a negative line reaches
@@ -277,8 +300,12 @@ impl Grid {
             self.rows.truncate(self.rows.len() - dropped);
         } else if old < rows {
             let growth = usize::from(rows - old);
-            let appended = growth.saturating_sub(self.history_len());
-            for _ in 0..appended {
+            let history = self.history_len();
+            let reclaimed = growth.min(history);
+            for row in self.rows.range(history - reclaimed..history) {
+                self.history_index.reclaim_newest(row.id);
+            }
+            for _ in 0..growth - reclaimed {
                 self.push_blank_row();
             }
         }
@@ -313,6 +340,18 @@ impl Grid {
     #[inline]
     fn visible_index(&self, line: u16) -> usize {
         self.history_len() + usize::from(line)
+    }
+
+    /// Checks that the history index names exactly the history rows, each
+    /// at its ring index, and no visible row.
+    #[cfg(test)]
+    fn assert_history_index_matches_ring(&self) {
+        let history = self.history_len();
+        assert_eq!(self.history_index.len(), history);
+        for (index, row) in self.rows.iter().enumerate() {
+            let expected = (index < history).then_some(index);
+            assert_eq!(self.history_index.index_of(row.id), expected);
+        }
     }
 }
 
@@ -844,7 +883,7 @@ mod tests {
 
         /// Asserts that an anchor still resolves once the history holds
         /// ids that are no longer ascending, which is why the lookup
-        /// scans rather than binary-searches.
+        /// indexes history by id rather than binary-searching it.
         ///
         /// Case: a full-screen application scrolls backwards — minting a
         /// row with a high id above older rows — and then output pushes
@@ -908,6 +947,283 @@ mod tests {
             for id in &first {
                 assert_eq!(grid.grid_line(*id), None);
             }
+        }
+    }
+
+    mod history_index {
+        use super::*;
+
+        fn ids(grid: &Grid) -> Vec<LineId> {
+            (0..grid.size().rows)
+                .map(|line| grid.line_id(ScreenLine(line)))
+                .collect()
+        }
+
+        /// Asserts that a growth brings the newest history row back onto
+        /// the screen at line zero while the older ones stay in history.
+        ///
+        /// Case: two lines have scrolled into history and the user drags
+        /// the window one row taller.
+        #[test]
+        fn a_growth_reclaims_the_newest_history_row() {
+            let mut grid = grid(2, 10);
+            let [a, b] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert!(grid.resize(GridSize { cols: 4, rows: 3 }));
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that one growth reclaiming several rows resolves each
+        /// of them to consecutive screen lines.
+        ///
+        /// Case: three lines sit in history and the user drags the
+        /// window two rows taller in one motion.
+        #[test]
+        fn a_growth_reclaims_several_rows_in_order() {
+            let mut grid = grid(2, 10);
+            let [a, b] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            let c = grid.line_id(ScreenLine(1));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert_eq!(grid.history_len(), 3);
+            assert!(grid.resize(GridSize { cols: 4, rows: 4 }));
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            assert_eq!(grid.grid_line(c), Some(GridLine(1)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a growth larger than the history reclaims every
+        /// history row and appends fresh ones below.
+        ///
+        /// Case: one line sits in history and the user maximizes the
+        /// window, asking for far more rows than history can supply.
+        #[test]
+        fn a_growth_larger_than_the_history_reclaims_it_all() {
+            let mut grid = grid(2, 10);
+            let [a, b] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert!(grid.resize(GridSize { cols: 4, rows: 5 }));
+            assert_eq!(grid.history_len(), 0);
+            assert_eq!(grid.grid_line(a), Some(GridLine(0)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(1)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a row reclaimed after the cap has popped rows
+        /// re-enters history at the right line when output scrolls again.
+        ///
+        /// Case: on a terminal at its scrollback cap the user drags the
+        /// window taller and the shell then prints another line.
+        #[test]
+        fn a_reclaimed_row_re_enters_history_after_the_cap_has_popped() {
+            let mut grid = grid(3, 2);
+            let [a, b, c] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            for _ in 0..3 {
+                scroll_up_whole_screen(&mut grid, Cell::default());
+            }
+            assert_eq!(grid.grid_line(a), None);
+            assert!(grid.resize(GridSize { cols: 4, rows: 4 }));
+            assert_eq!(grid.grid_line(b), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(c), Some(GridLine(0)));
+            grid.assert_history_index_matches_ring();
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert_eq!(grid.grid_line(b), Some(GridLine(-2)));
+            assert_eq!(grid.grid_line(c), Some(GridLine(-1)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a shrink stops the dropped bottom rows from
+        /// resolving and leaves history where it was.
+        ///
+        /// Case: one line sits in history and the user drags the window
+        /// two rows shorter with the cursor near the top.
+        #[test]
+        fn a_shrink_drops_the_bottom_ids_and_keeps_history() {
+            let mut grid = grid(4, 10);
+            let a = grid.line_id(ScreenLine(0));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            let [b, c, d, e] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            assert!(grid.resize(GridSize { cols: 4, rows: 2 }));
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            assert_eq!(grid.grid_line(c), Some(GridLine(1)));
+            assert_eq!(grid.grid_line(d), None);
+            assert_eq!(grid.grid_line(e), None);
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a columns-only resize leaves every id where it was.
+        ///
+        /// Case: one line sits in history and the user drags the window
+        /// wider without changing its height.
+        #[test]
+        fn a_columns_only_resize_moves_no_id() {
+            let mut grid = grid(3, 10);
+            let a = grid.line_id(ScreenLine(0));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            let b = grid.line_id(ScreenLine(0));
+            assert!(grid.resize(GridSize { cols: 6, rows: 3 }));
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a scroll whose region starts at the top but ends
+        /// above the last line still hands the top row to history while
+        /// the rows below the region keep their lines.
+        ///
+        /// Case: an application pins a status line to the bottom row with
+        /// `DECSTBM` and the pane above it scrolls.
+        #[test]
+        fn a_top_anchored_region_scroll_hands_the_top_row_to_history() {
+            let mut grid = grid(4, 10);
+            let [a, b, _, d] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            grid.scroll_up_one(ScreenLine(0), ScreenLine(2), Cell::default());
+            assert_eq!(grid.history_len(), 1);
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            assert_eq!(grid.grid_line(d), Some(GridLine(3)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a scroll inside a region below the top discards
+        /// the region's top row without touching history.
+        ///
+        /// Case: a line has scrolled into history, then an application
+        /// sets a scroll region under a header line and scrolls it.
+        #[test]
+        fn a_region_scroll_below_the_top_discards_without_touching_history() {
+            let mut grid = grid(4, 10);
+            let a = grid.line_id(ScreenLine(0));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            let [b, c, d, e] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            grid.scroll_up_one(ScreenLine(1), ScreenLine(2), Cell::default());
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(0)));
+            assert_eq!(grid.grid_line(c), None);
+            assert_eq!(grid.grid_line(d), Some(GridLine(1)));
+            assert_eq!(grid.grid_line(e), Some(GridLine(3)));
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a reverse scroll after history exists discards the
+        /// bottom row without touching history.
+        ///
+        /// Case: a line has scrolled into history and an application then
+        /// scrolls the whole screen backwards.
+        #[test]
+        fn a_reverse_scroll_after_history_exists_leaves_history_alone() {
+            let mut grid = grid(3, 10);
+            let a = grid.line_id(ScreenLine(0));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            let [b, _, d] = ids(&grid)[..] else {
+                unreachable!()
+            };
+            grid.scroll_down_one(ScreenLine(0), ScreenLine(2), Cell::default());
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            assert_eq!(grid.grid_line(b), Some(GridLine(1)));
+            assert_eq!(grid.grid_line(d), None);
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that scrolling after a reset fills history afresh and
+        /// a second reset empties it again.
+        ///
+        /// Case: an application sends `RIS`, prints a screenful, and
+        /// sends `RIS` again.
+        #[test]
+        fn history_refills_between_repeated_resets() {
+            let mut grid = grid(3, 10);
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            grid.reset();
+            grid.assert_history_index_matches_ring();
+            let a = grid.line_id(ScreenLine(0));
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert_eq!(grid.grid_line(a), Some(GridLine(-1)));
+            grid.assert_history_index_matches_ring();
+            grid.reset();
+            assert_eq!(grid.grid_line(a), None);
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that a grid without history never indexes a row.
+        ///
+        /// Case: a full-screen application scrolls its alternate screen
+        /// forwards and backwards.
+        #[test]
+        fn a_grid_without_history_indexes_nothing() {
+            let mut grid = grid(3, 0);
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            grid.scroll_down_one(ScreenLine(0), ScreenLine(2), Cell::default());
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            assert_eq!(grid.history_len(), 0);
+            grid.assert_history_index_matches_ring();
+        }
+
+        /// Asserts that the index agrees with the ring after every step of
+        /// a session that mixes every ring mutation.
+        ///
+        /// Case: a long session scrolls to the cap, keeps scrolling, runs
+        /// a full-screen pager with region scrolls, resizes both ways,
+        /// resets, and scrolls again.
+        #[test]
+        fn the_index_agrees_with_the_ring_through_a_mixed_session() {
+            let mut grid = grid(4, 3);
+            let mut seen: Vec<LineId> = ids(&grid);
+            let mut step = |grid: &mut Grid| {
+                grid.assert_history_index_matches_ring();
+                for id in &seen {
+                    if let Some(line) = grid.grid_line(*id) {
+                        let index = usize::try_from(i64::from(line.0) + grid.history_len() as i64)
+                            .expect("a resolved line sits inside the ring");
+                        assert_eq!(grid.rows[index].id, *id);
+                    }
+                }
+                seen.extend(ids(grid));
+            };
+            for _ in 0..5 {
+                scroll_up_whole_screen(&mut grid, Cell::default());
+                step(&mut grid);
+            }
+            grid.scroll_up_one(ScreenLine(1), ScreenLine(2), Cell::default());
+            step(&mut grid);
+            grid.scroll_down_one(ScreenLine(0), ScreenLine(3), Cell::default());
+            step(&mut grid);
+            grid.scroll_up_one(ScreenLine(0), ScreenLine(2), Cell::default());
+            step(&mut grid);
+            assert!(grid.resize(GridSize { cols: 4, rows: 6 }));
+            step(&mut grid);
+            assert!(grid.resize(GridSize { cols: 6, rows: 6 }));
+            step(&mut grid);
+            assert!(grid.resize(GridSize { cols: 6, rows: 2 }));
+            step(&mut grid);
+            for _ in 0..4 {
+                scroll_up_whole_screen(&mut grid, Cell::default());
+                step(&mut grid);
+            }
+            grid.reset();
+            step(&mut grid);
+            scroll_up_whole_screen(&mut grid, Cell::default());
+            step(&mut grid);
         }
     }
 }

--- a/crates/orzma_vt/src/screen/grid/history_index.rs
+++ b/crates/orzma_vt/src/screen/grid/history_index.rs
@@ -52,6 +52,12 @@ impl HistoryIndex {
         self.seq_of.remove(&id);
     }
 
+    /// Number of history rows the index names.
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.seq_of.len()
+    }
+
     fn next_seq(&self) -> u64 {
         self.popped + self.seq_of.len() as u64
     }

--- a/crates/orzma_vt/src/screen/grid/history_index.rs
+++ b/crates/orzma_vt/src/screen/grid/history_index.rs
@@ -19,12 +19,11 @@ use std::collections::HashMap;
 /// # Invariants
 ///
 /// The live sequence numbers form the contiguous interval
-/// `[popped, next_seq)`, so `seq_of.len() == next_seq - popped`, and
-/// that length equals the grid's `history_len`.
+/// `[popped, popped + seq_of.len())`, whose length equals the grid's
+/// `history_len`.
 #[derive(Debug, Default)]
 pub(super) struct HistoryIndex {
     seq_of: HashMap<LineId, u64>,
-    next_seq: u64,
     popped: u64,
 }
 
@@ -33,50 +32,28 @@ impl HistoryIndex {
     /// history row.
     pub fn index_of(&self, id: LineId) -> Option<usize> {
         let seq = *self.seq_of.get(&id)?;
-        Some(
-            usize::try_from(seq - self.popped)
-                .expect("a live entry sits at or past the popped count"),
-        )
+        usize::try_from(seq - self.popped).ok()
     }
 
     /// Records that `id` became the newest history row.
     pub fn enter(&mut self, id: LineId) {
-        let replaced = self.seq_of.insert(id, self.next_seq);
-        self.next_seq += 1;
-        debug_assert!(replaced.is_none(), "a row enters history once");
-        self.debug_assert_contiguous();
+        self.seq_of.insert(id, self.next_seq());
     }
 
     /// Records that `id`, the oldest history row, left through the cap.
     pub fn pop_oldest(&mut self, id: LineId) {
-        let removed = self.seq_of.remove(&id);
+        self.seq_of.remove(&id);
         self.popped += 1;
-        debug_assert_eq!(
-            removed,
-            Some(self.popped - 1),
-            "the cap pops the oldest entry"
-        );
-        self.debug_assert_contiguous();
     }
 
     /// Records that `id`, the newest history row, went back to being
     /// visible.
     pub fn reclaim_newest(&mut self, id: LineId) {
-        let removed = self.seq_of.remove(&id);
-        self.next_seq -= 1;
-        debug_assert_eq!(
-            removed,
-            Some(self.next_seq),
-            "a growth reclaims the newest entry"
-        );
-        self.debug_assert_contiguous();
+        self.seq_of.remove(&id);
     }
 
-    fn debug_assert_contiguous(&self) {
-        debug_assert_eq!(
-            u64::try_from(self.seq_of.len()).expect("an entry count fits in u64"),
-            self.next_seq - self.popped
-        );
+    fn next_seq(&self) -> u64 {
+        self.popped + self.seq_of.len() as u64
     }
 }
 

--- a/crates/orzma_vt/src/screen/grid/history_index.rs
+++ b/crates/orzma_vt/src/screen/grid/history_index.rs
@@ -1,0 +1,183 @@
+//! Constant-time lookup of a history row's ring index by its `LineId`,
+//! kept in step with the ring as rows enter, pop, and get reclaimed.
+
+use crate::screen::grid::LineId;
+use std::collections::HashMap;
+
+/// Where each history row sits, by id, in constant time.
+///
+/// Only history is indexed: a row enters it at the newest end, leaves
+/// it from the oldest end (the cap) or the newest end (a growth
+/// reclaiming it), and is never recycled while inside. Each entry
+/// therefore gets a running sequence number, and its ring index is
+/// that number minus the count popped so far, so a pop moves nothing.
+///
+/// The visible rows stay unindexed: a region scroll recycles and
+/// reorders them freely, and a scan over them is bounded by the screen
+/// height rather than the history cap.
+///
+/// # Invariants
+///
+/// The live sequence numbers form the contiguous interval
+/// `[popped, next_seq)`, so `seq_of.len() == next_seq - popped`, and
+/// that length equals the grid's `history_len`.
+#[derive(Debug, Default)]
+pub(super) struct HistoryIndex {
+    seq_of: HashMap<LineId, u64>,
+    next_seq: u64,
+    popped: u64,
+}
+
+impl HistoryIndex {
+    /// The ring index of the history row `id`; `None` when `id` is not a
+    /// history row.
+    pub fn index_of(&self, id: LineId) -> Option<usize> {
+        let seq = *self.seq_of.get(&id)?;
+        Some(
+            usize::try_from(seq - self.popped)
+                .expect("a live entry sits at or past the popped count"),
+        )
+    }
+
+    /// Records that `id` became the newest history row.
+    pub fn enter(&mut self, id: LineId) {
+        let replaced = self.seq_of.insert(id, self.next_seq);
+        self.next_seq += 1;
+        debug_assert!(replaced.is_none(), "a row enters history once");
+        self.debug_assert_contiguous();
+    }
+
+    /// Records that `id`, the oldest history row, left through the cap.
+    pub fn pop_oldest(&mut self, id: LineId) {
+        let removed = self.seq_of.remove(&id);
+        self.popped += 1;
+        debug_assert_eq!(
+            removed,
+            Some(self.popped - 1),
+            "the cap pops the oldest entry"
+        );
+        self.debug_assert_contiguous();
+    }
+
+    /// Records that `id`, the newest history row, went back to being
+    /// visible.
+    pub fn reclaim_newest(&mut self, id: LineId) {
+        let removed = self.seq_of.remove(&id);
+        self.next_seq -= 1;
+        debug_assert_eq!(
+            removed,
+            Some(self.next_seq),
+            "a growth reclaims the newest entry"
+        );
+        self.debug_assert_contiguous();
+    }
+
+    fn debug_assert_contiguous(&self) {
+        debug_assert_eq!(
+            u64::try_from(self.seq_of.len()).expect("an entry count fits in u64"),
+            self.next_seq - self.popped
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts that an empty index resolves nothing.
+    ///
+    /// Case: a fresh terminal has printed less than one screenful, so no
+    /// row has entered history yet.
+    #[test]
+    fn an_empty_index_resolves_nothing() {
+        let index = HistoryIndex::default();
+        assert_eq!(index.index_of(LineId(0)), None);
+    }
+
+    /// Asserts that rows entering history take consecutive ring indices
+    /// in entry order.
+    ///
+    /// Case: the shell scrolls three lines of output into history on a
+    /// terminal that has not reached its scrollback cap.
+    #[test]
+    fn entering_rows_take_consecutive_indices() {
+        let mut index = HistoryIndex::default();
+        index.enter(LineId(10));
+        index.enter(LineId(11));
+        index.enter(LineId(12));
+        assert_eq!(index.index_of(LineId(10)), Some(0));
+        assert_eq!(index.index_of(LineId(11)), Some(1));
+        assert_eq!(index.index_of(LineId(12)), Some(2));
+    }
+
+    /// Asserts that popping the oldest row forgets it and shifts every
+    /// survivor down by one.
+    ///
+    /// Case: output keeps scrolling on a terminal whose scrollback is at
+    /// its cap, so each new history row pushes the oldest one out.
+    #[test]
+    fn popping_the_oldest_shifts_the_survivors_down() {
+        let mut index = HistoryIndex::default();
+        index.enter(LineId(10));
+        index.enter(LineId(11));
+        index.enter(LineId(12));
+        index.pop_oldest(LineId(10));
+        assert_eq!(index.index_of(LineId(10)), None);
+        assert_eq!(index.index_of(LineId(11)), Some(0));
+        assert_eq!(index.index_of(LineId(12)), Some(1));
+    }
+
+    /// Asserts that reclaiming the newest row forgets it and leaves the
+    /// older rows where they were.
+    ///
+    /// Case: the user drags the window taller, so the newest history row
+    /// comes back onto the screen.
+    #[test]
+    fn reclaiming_the_newest_leaves_the_older_rows_in_place() {
+        let mut index = HistoryIndex::default();
+        index.enter(LineId(10));
+        index.enter(LineId(11));
+        index.enter(LineId(12));
+        index.reclaim_newest(LineId(12));
+        assert_eq!(index.index_of(LineId(12)), None);
+        assert_eq!(index.index_of(LineId(10)), Some(0));
+        assert_eq!(index.index_of(LineId(11)), Some(1));
+    }
+
+    /// Asserts that a row entering after a reclaim takes the reclaimed
+    /// slot without the reclaimed row resolving there.
+    ///
+    /// Case: the user drags the window taller, then the shell prints
+    /// enough to scroll a new row into history.
+    #[test]
+    fn a_row_entering_after_a_reclaim_reuses_the_slot() {
+        let mut index = HistoryIndex::default();
+        index.enter(LineId(10));
+        index.enter(LineId(11));
+        index.reclaim_newest(LineId(11));
+        index.enter(LineId(20));
+        assert_eq!(index.index_of(LineId(20)), Some(1));
+        assert_eq!(index.index_of(LineId(11)), None);
+    }
+
+    /// Asserts that a pop, a reclaim, and an entry compose into the
+    /// positions the ring actually holds.
+    ///
+    /// Case: on a terminal at its scrollback cap, output pushes the
+    /// oldest row out, the user drags the window taller, and the shell
+    /// then scrolls another row into history.
+    #[test]
+    fn a_pop_a_reclaim_and_an_entry_compose() {
+        let mut index = HistoryIndex::default();
+        index.enter(LineId(10));
+        index.enter(LineId(11));
+        index.enter(LineId(12));
+        index.pop_oldest(LineId(10));
+        index.reclaim_newest(LineId(12));
+        index.enter(LineId(30));
+        assert_eq!(index.index_of(LineId(10)), None);
+        assert_eq!(index.index_of(LineId(12)), None);
+        assert_eq!(index.index_of(LineId(11)), Some(0));
+        assert_eq!(index.index_of(LineId(30)), Some(1));
+    }
+}

--- a/docs/todo/eviction-at-source.md
+++ b/docs/todo/eviction-at-source.md
@@ -1,0 +1,270 @@
+# 退避を発生源で報告する — `Vt::sweep_evictions` の削除
+
+webview placement の退避（`VtSignal::WebviewEvicted`）を、pump ごとの掃引で
+拾う形から、アンカーを失わせた操作自身が報告する形に改める設計書。
+スタック PR の 2 本目で、`docs/todo/grid-history-index.md`（`grid_line` の
+O(1) 化）の上に積む。前提 PR が無いと、チャンクごとの掃引が大量出力時に
+parse と同程度のコストを払う。
+
+## 現状: pump が掃引する
+
+`Vt::sweep_evictions`（`crates/orzma_vt/src/lib.rs:128`）は両画面の
+`evict_lost_anchors` を呼び、解決不能になったアンカーの placement を取り除いて
+`WebviewEvicted` にまとめる。呼び手は `OrzmaTty::pump`
+（`crates/orzma_tty/src/lib.rs:274`）だけで、次の順序不変条件を手で守っている。
+
+1. `drain_chunks` で全チャンクを解釈する。
+2. `sweep_evictions` を呼び、退避があれば coalescer を arm して
+   `pending_signals` に積む。
+3. `pending_signals` を取り出す（`ChildExit` は最後）。
+4. `frame()` を要求する。
+
+アンカーを失わせる経路と、現在の報告口は次のとおり。
+
+| 発生源 | `interpret` を通る | 現在の報告口 |
+| --- | --- | --- |
+| 出力で行が履歴上限から押し出される | 通る | 次の pump の掃引 |
+| `RIS`（`Executor::reset_device`） | 通る | 次の pump の掃引 |
+| alt → primary の flip（`Executor::switch_screen`） | 通る | そのチャンクの `InterpretOutput::signals`（掃引外。`docs/memo/decset.md:90`） |
+| `Vt::resize` による縮小 | 通らない | 次の pump の掃引 |
+| `Vt::scroll` | 通らない | 発生しない（viewport だけ動く） |
+| `Vt::remove_placements` | 通らない | 発生しない（呼び手が id を知っている） |
+
+### 何が問題か
+
+- トレイトに「owner は signal drain と frame の前に掃引を呼べ」という
+  手動の不変条件が乗っている。`OrzmaTty` 以外の呼び手や pump の順序変更が
+  破りうる誤用クラスである。
+- `switch_screen` は発生源で signal を出し、`reset_device` は `ResetTitle` は
+  発生源で出すのに取り残した placement は掃引に任せる、という非対称がある。
+- webview ありのアイドル時に毎 tick 掃引する。
+
+## 調査結果の要約
+
+Codex と Claude Code Agent の並列調査、および他ターミナル 8 実装
+（alacritty、wezterm、Ghostty、kitty、libvterm、foot、VTE、Windows Terminal）
+のソース調査の結論。
+
+- **signal と frame が同じ batch に乗る保証は今も無い。** `pump` は
+  `pending_signals` を毎回無条件に drain するが、frame は coalescer の期限
+  （3ms idle / 12ms cap）まで待つ。退避 signal は今日でも `frame == None` の
+  batch で先に届く。
+- **ホスト側の消費者はどちらの順でも正しく動く。** `on_webview_evicted`
+  （`bevy_orzma_webview/src/webview/mount.rs:456`）は id で despawn するだけ、
+  `project_webview_overlays`（同 `:563`）は「signal が先」「frame が先」の
+  両方を許容する。
+- **本番の resize 呼び出し元は observer ではない。** `src/session/layout.rs`
+  の `resize_to_window` system が `handle.resize()` を直接呼ぶ。resize から
+  同期的に signal を返す設計にすると、`bevy_orzma_tty/src/signals.rs` の
+  private な `VtSignal → Tty*Signal` 変換を root binary 側にも複製する
+  ことになる。
+- **signal 同士の順序は FIFO の `pending_signals` が保証している。**
+  `[Evicted{X}, Mount{X}]` の順序依存は `docs/todo/webview-instance-id.md`
+  §5 と `mount.rs` の回帰テストが固定している。
+- **他実装はすべて、stream 由来イベントを解析時点で同期的にホストへ渡し、
+  ホスト起点の resize をイベント源として扱わない。** 画像・placement の
+  喪失を明示イベントで知らせる実装は無く、dirty flag か再描画で気づかせる。
+  VTE だけがコア内で pending bits に積み `emit_pending_signals()` で
+  一括発行する。
+
+orzma の二層構造は、VT 層（`InterpretOutput` に同期で積む）が多数派の
+「同期 emitter」に、`OrzmaTty`（`pending_signals` と `pump`）が VTE 型の
+「処理ステップ末尾での一括発行」に対応する。この二層をそのまま保つ。
+
+## 設計
+
+### 方針
+
+- VT 層は操作ごとに結果を同期的に返す。`sweep_evictions` は削除する。
+- ホストへの配送口は `pump` 一本のまま。Bevy 層と `resize_to_window` は
+  変更しない。
+- 契約を明文化する: **退避は次の pump までに、かつその変更を反映する最初の
+  frame より前に届く。同じ `PumpOutput` に乗るとは限らない。**
+
+### `Vt` トレイト
+
+| メソッド | 現在 | 変更後 |
+| --- | --- | --- |
+| `sweep_evictions` | `-> Vec<VtSignal>` | 削除 |
+| `interpret` | 退避は掃引に任せる | チャンク末尾で両画面を掃引し `signals` に積む。退避があれば `damaged = true` |
+| `resize` | `-> bool` | `-> Option<ResizeChanged>` |
+| `scroll` | `-> bool` | 変更なし |
+| `remove_placements` | `-> bool` | 変更なし |
+
+```rust
+/// What a [`Vt::resize`] that changed the dimensions caused besides
+/// the grid change.
+///
+/// # Invariants
+///
+/// A resize to the size the grid already has changes nothing and
+/// strands nothing, so it returns `None`; this value exists only
+/// when the dimensions changed.
+pub struct ResizeChanged {
+    /// The placements whose anchor row the resize dropped out of
+    /// history; empty when every anchor survived.
+    pub evicted: Vec<InstanceId>,
+}
+```
+
+`Option<ResizeChanged>` が成立する根拠は `Screen::resize` の同サイズ早期
+return（`screen.rs` の `if old == size { return None; }`）で、寸法が変わらない
+resize は grid に触れず、何も取り残さない。`Screen::resize` と
+`DeviceState::resize` が既に `Option<DamageSpan>` で「変わったときだけ
+`Some`」を返しており、トレイト境界まで同じ語法が通る。
+
+### `OrzmaVt`
+
+```rust
+fn resize(&mut self, size: GridSize) -> Option<ResizeChanged> {
+    let damage = self.device.resize(size)?;
+    self.tracker.stage_if_changed(Some(damage));
+    Some(ResizeChanged {
+        evicted: self.device.evict_lost_anchors(),
+    })
+}
+```
+
+`interpret` は変更しない。掃引は `Interpreter::parse` の末尾に入る。
+
+### `Interpreter` / `Executor`
+
+`parse` の末尾には既に cursor 変化の liveness fold がある。その隣で
+一度だけ掃引する。
+
+```rust
+pub fn parse(&mut self, output: &mut InterpretOutput, device: &mut DeviceState,
+             tracker: &mut FrameTracker, chunk: &[u8]) {
+    let cursor_before = device.active_screen().cursor();
+    let mut executor = Executor { output, sync: &mut self.sync, device, tracker };
+    self.parser.parse(chunk, &mut executor);
+    executor.sweep_evictions();
+    executor.output.damaged |= cursor_before != executor.device.active_screen().cursor();
+}
+
+impl Executor<'_> {
+    /// Names the placements this chunk stranded — a reset, or rows the
+    /// output pushed past the history cap — and raises the chunk
+    /// liveness, because a shortened placement list is a frame-visible
+    /// section change even when no row was damaged.
+    ///
+    /// The sweep runs once, after the whole chunk, so a placement the
+    /// chunk strands and then re-mounts is updated in place rather
+    /// than evicted and re-created.
+    fn sweep_evictions(&mut self) {
+        let Some(evicted) = VtSignal::evicted(self.device.evict_lost_anchors()) else {
+            return;
+        };
+        self.signal(evicted);
+        self.output.damaged = true;
+    }
+}
+```
+
+チャンク末尾で一回にする理由:
+
+1. アンカーが失われるのは parse の中で、parse の前に掃引すると最後の
+   チャンクが取り残したものは次の出力まで報告されない。
+2. チャンク途中で掃引すると「取り残し → 同 id を再 mount」が退避 + 新規
+   mount になる。末尾なら再 mount がテーブル上の placement を更新し直して
+   から判定する。
+3. `signal()` と `output.damaged` の規約（byte 順、frame に関わる変化は
+   自分で liveness を立てる）を持つのは `Executor` であり、liveness を
+   立てる箇所を一つの型に保てる。
+
+`switch_screen` は `take_placements` でテーブルから外すので今のまま発生源で
+出す。`reset_device` は無変更で、`device.reset()` が解決不能にしたアンカーを
+末尾の掃引が拾う。
+
+退避 signal はチャンク内の他の signal の後ろに付く。順序が意味を持つのは
+同一 id の `[Evicted, Mount]` だけで、そのケースは末尾掃引なら退避自体が
+起きない。
+
+### `OrzmaTty`
+
+```rust
+pub fn resize(&mut self, cols: u16, rows: u16) -> OrzmaTtyResult {
+    // (degenerate-size gate and pty.resize unchanged)
+    if let Some(changed) = self.vt.resize(GridSize { cols, rows }) {
+        self.coalescer.arm_or_extend(Instant::now());
+        if let Some(evicted) = VtSignal::evicted(changed.evicted) {
+            self.pending_signals.push(TtySignal::Vt(evicted));
+        }
+    }
+    Ok(())
+}
+```
+
+- `feed_chunk` は無変更。`damaged` が arm を駆動し、signal は
+  `pending_signals` へ。
+- `pump` から掃引ブロックとその `NOTE` を削除する。`ChildExit` を最後に
+  する処理は残す。
+- `VtSignal::evicted` は現在 `pub(crate)`。`OrzmaTty` から使うため `pub`
+  にする（構築箇所を一つに保つ）。
+
+### 安全網
+
+掃引を消すと catch-all が無くなり、ホスト起点でアンカーを失わせる操作を
+将来追加したとき（現状は `resize` だけ）に報告を忘れると webview entity が
+黙って残る。`FrameTracker::emit`（`frame.rs:141`）が `project_placements` を
+呼ぶ箇所で「frame を出す時点で解決不能なアンカーが残っていない」ことを
+`debug_assert!` する。報告漏れがテストで即座に落ちる。
+
+この assert は「frame の前に必ず掃引か報告が済んでいる」を前提にするので、
+`orzma_vt` の単体テストで `device.reset()` などを直接呼んだ後に `frame()`
+を要求する書き方はできなくなる。退避を伴うテストは `interpret` か
+`resize` を経由する。
+
+### 挙動の差
+
+同じ pump 内の別チャンクで「アンカーを失う → 同 id を再 mount」が起きた
+場合、現在は pump 末尾の掃引前に更新されるので何も起きないが、変更後は
+`[Evicted X, Mount X]` が出て CEF ブラウザが despawn と respawn を経る。
+どちらも境界（pump かチャンクか）依存の挙動で、ホストはこの順序を回帰
+テストで扱い済み。10,000 行の履歴を越えたアンカーを同 id で再 mount する
+アプリは想定しづらく、正しさの問題ではなく respawn 確率のわずかな増加。
+
+## テスト
+
+### `orzma_vt/src/lib.rs`
+
+掃引テスト 4 本を置き換える。
+
+| 現在 | 変更後 |
+| --- | --- |
+| 何も失っていない掃引は signal を出さない | webview の無い端末に出力を流しても `WebviewEvicted` は出ない |
+| reset 後の掃引が名前を挙げる | `RIS` を含むチャンクの `InterpretOutput` が名前を挙げ、`damaged` が真 |
+| shrink 後の掃引が名前を挙げる | `resize` の `ResizeChanged::evicted` が名前を挙げる。同サイズは `None` |
+| 二度目の掃引は何も出さない | 退避を出した次のチャンクは何も出さない |
+
+追加: 空画面での `RIS`（row damage を積まない）でも `damaged` が真になる。
+
+### `orzma_tty/src/lib.rs`
+
+- `a_pump_reports_what_the_eviction_sweep_raised`（`:461`）:
+  「resize してから pump」で退避が `PumpOutput::signals` に乗る形に。
+- `an_eviction_arms_the_coalesce_window`（`:481`）: 「resize の退避が
+  arm する」と「退避を含む interpret（`damaged = true`）が arm する」の
+  2 本に分ける。
+- `FakeVt`（`test_support.rs:73`）: `sweeps` を消し、
+  `resize_outcomes: VecDeque<Option<ResizeChanged>>` を持たせる。
+
+## ドキュメントの追随
+
+| 箇所 | 変更 |
+| --- | --- |
+| `Vt::resize` の doc（`orzma_vt/src/lib.rs:151` 付近） | 「取り残しは次の `sweep_evictions` が名前を挙げる」を削除し、`ResizeChanged` を説明 |
+| `VtSignal` の doc（同 `:198` 付近） | 「`sweep_evictions` から返る」の一文を削除 |
+| `DeviceState::resize` の doc（`device.rs:93`） | 「次の `evict_lost_anchors` が名前を挙げる」を「`Vt::resize` が返す」に |
+| `Executor::switch_screen` の doc（`interpreter.rs`） | 「owner の掃引に任せない理由」を「チャンク末尾の掃引に任せない理由」に |
+| `docs/todo/webview-instance-id.md:199`、`:425`〜`:446` | `sweep_evictions` 前提の記述を更新 |
+| `docs/memo/decset.md:90` | 「pump の掃引では拾えない」を「チャンク末尾の掃引では拾えない」に |
+| `orzma_vt/src/lib.rs:279` | 参照先 `docs/orzma_vt_internal_design.md` はワークツリーに無い。今回の変更と独立だが、doc を触るついでに直す |
+
+## スコープ外
+
+- `grid_line` の性能は前提 PR で解決済み。「行が ring を離れたときだけ
+  掃引する」watermark gate は前提 PR で不要になったため入れない。
+- `Vt::scroll` と `Vt::remove_placements` の戻り値は広げない。
+- `OrzmaTty::resize` や `RequestTtyResize` observer から signal を同期的に
+  Bevy へ流す設計は採らない。

--- a/docs/todo/grid-history-index.md
+++ b/docs/todo/grid-history-index.md
@@ -1,0 +1,238 @@
+# `Grid::grid_line` を O(1) にする — 履歴索引
+
+webview placement のアンカー解決を、ring 全体の線形走査から履歴索引の
+定数時間参照に置き換える設計書。スタック PR の 1 本目で、後続の
+`docs/todo/eviction-at-source.md`（退避の発生源報告）がこれを前提にする。
+挙動は変えない純粋な最適化であり、変更は `crates/orzma_vt/src/screen/grid.rs`
+と、新設する `crates/orzma_vt/src/screen/grid/history_index.rs`（`grid.rs` が
+`mod history_index;` で宣言する）の 2 ファイルに閉じる。
+
+## 現状: アンカー解決が ring 長に比例する
+
+placement は `LineId` をアンカーとして持ち、`Grid::grid_line(id)` で現在の
+行位置に解決する（`crates/orzma_vt/src/screen/grid.rs:206`）。
+
+```rust
+pub fn grid_line(&self, id: LineId) -> Option<GridLine> {
+    let index = self.rows.iter().rposition(|row| row.id == id)?;
+    ...
+}
+```
+
+`rposition` は ring を末尾から走査するので、live tail 付近のアンカーは
+数ステップで見つかるが、履歴の奥にあるアンカーと、既に ring を離れた
+（つまり退避対象の）アンカーは ring 全長を払う。
+
+呼び出し元は 2 つで、どちらも placement 全件に対して `grid_line` を呼ぶ。
+
+| 呼び出し元 | 頻度 | 目的 |
+| --- | --- | --- |
+| `ScreenPlacements::evict_lost_anchors`（`screen/placements.rs:116`） | 現在は pump ごと。`eviction-at-source` 後はチャンクごと + resize ごと | 解決不能なアンカーを退避 |
+| `ScreenPlacements::project`（`screen/placements.rs:87`） | frame 発行ごと（`frame.rs:191`） | placement リストの投影 |
+
+本番値は履歴上限 10,000 行（`bevy_orzma_tty/src/lib.rs:32`）、placement 上限は
+overlay slot の 12（`orzma_tty_renderer/src/material.rs:308`）なので、最悪で
+一回あたり約 12 万回の id 比較になる。webview が無ければ
+`ScreenPlacements::is_empty` で即 return するため、通常のシェル利用では
+ゼロコストである。問題になるのは「webview あり + 大量出力」で、4096 バイトの
+チャンクごとに掃引するとチャンクの parse と同程度のコストを払いうる。
+
+## なぜ順序に頼れないか
+
+「id は単調増加だから行順とみなせる」「失われるのは古い側から」という
+前提で早期停止する案は成立しない。`LineId` の doc（`grid.rs:40` 付近）が
+既に「履歴区間だけの二分探索も不健全」と明記しており、コード上の根拠は
+次のとおり。
+
+| 経路 | 何が起きるか | 失われる id |
+| --- | --- | --- |
+| `scroll_up_one` で `top == 0`、履歴上限到達 | `pop_front` で最古の行を捨てる | 最小側 |
+| `scroll_up_one` で `top > 0`（DECSTBM の領域スクロール） | 領域先頭の行を取り除き、新 id で領域末尾に差し込む | 中間 |
+| `scroll_down_one`（RI など） | 領域末尾の行を取り除き、新 id で領域先頭に差し込む | 中間 |
+| `resize_rows` の縮小 | `truncate` で ring 末尾（カーソルより下）を落とす | 最大側 |
+| `reset` | 全行 | 全部 |
+
+さらに `ScreenPlacements::mount` は mount 順に `push` し、アンカーは
+`cursor_line_id()` なので、テーブル自体も id 順ではない。順序ではなく
+**索引**で解く。
+
+## 設計: 履歴区間だけを索引する
+
+ring は性質の違う 2 区間からできている。
+
+| 区間 | 長さ | 行の出入り | リサイクル |
+| --- | --- | --- | --- |
+| 履歴（先頭 `history_len` 行） | 最大 `max_history` | 新しい端に 1 行ずつ入り、古い端（上限溢れ）か新しい端（伸長時の回収）からしか出ない | されない |
+| 表示（末尾 `size.rows` 行） | 数十 | 領域スクロールで途中挿入・削除 | される |
+
+線形走査が高くつくのは履歴区間だけで、そこは「両端でしか出入りしない
+deque」である。各行に通し番号を振れば、`ring index = 通し番号 − これまで
+pop した数` で位置が出る。先頭が pop されても既存の要素は動かない。
+表示区間は並びが自由に変わるので索引せず、画面高さで有界な走査のままに
+する。
+
+### `HistoryIndex`
+
+`screen/grid/history_index.rs` に置き、`grid.rs` にだけ見せる。状態は
+`seq_of` と `popped` の 2 つだけで、次に振る通し番号は
+`popped + seq_of.len()` から導出する。区間の連続性は導出式で構造的に
+成り立つので、本番コードに `debug_assert!` は置かない。O(history) の
+突き合わせ（各エントリの index が ring 上のその行の id と一致し、件数が
+`history_len` と一致する）は `#[cfg(test)]` のヘルパに置き、`Grid` の
+テストから呼ぶ。
+
+```rust
+/// Where each history row sits, by id, in constant time.
+///
+/// Only history is indexed: a row enters it at the newest end, leaves
+/// it from the oldest end (the cap) or the newest end (a growth
+/// reclaiming it), and is never recycled while inside. Each entry
+/// therefore gets a running sequence number, and its ring index is
+/// that number minus the count popped so far, so a pop moves nothing.
+///
+/// The visible rows stay unindexed: a region scroll recycles and
+/// reorders them freely, and a scan over them is bounded by the screen
+/// height rather than the history cap.
+///
+/// # Invariants
+///
+/// The live sequence numbers form the contiguous interval
+/// `[popped, popped + seq_of.len())`, whose length equals the grid's
+/// `history_len`.
+#[derive(Debug, Default)]
+pub(super) struct HistoryIndex {
+    seq_of: HashMap<LineId, u64>,
+    popped: u64,
+}
+
+impl HistoryIndex {
+    pub(super) fn index_of(&self, id: LineId) -> Option<usize> {
+        let seq = *self.seq_of.get(&id)?;
+        Some(usize::try_from(seq - self.popped).expect("a live entry sits at or past the popped count"))
+    }
+
+    pub(super) fn enter(&mut self, id: LineId) {
+        self.seq_of.insert(id, self.next_seq());
+    }
+
+    pub(super) fn pop_oldest(&mut self, id: LineId) {
+        self.seq_of.remove(&id);
+        self.popped += 1;
+    }
+
+    pub(super) fn reclaim_newest(&mut self, id: LineId) {
+        self.seq_of.remove(&id);
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.popped + u64::try_from(self.seq_of.len()).expect("an entry count fits in u64")
+    }
+}
+```
+
+生きている通し番号は常に連続区間 `[popped, popped + len)` を成す。`enter` は
+区間の直後の番号を振り、`pop_oldest` は `popped` を外し、`reclaim_newest` は
+区間の末尾を外す。回収で空いた番号を後の `enter` が再利用しても、前の id は
+既に取り除かれているので古い対応は残らない。
+
+`Grid` にフィールド `history_index: HistoryIndex` を足す。
+
+### `grid_line`
+
+履歴は索引で、表示は走査で引く。id は grid 内で一意なので `rposition` と
+`position` の違いは結果に影響しない。
+
+```rust
+pub fn grid_line(&self, id: LineId) -> Option<GridLine> {
+    let history = self.history_len();
+    if let Some(index) = self.history_index.index_of(id) {
+        let line = index as i64 - history as i64;
+        return Some(GridLine(i32::try_from(line).expect("a ring index minus its history fits in i32")));
+    }
+    self.rows
+        .range(history..)
+        .position(|row| row.id == id)
+        .map(|line| GridLine(i32::try_from(line).expect("a screen line fits in i32")))
+}
+```
+
+### 索引を保守する箇所
+
+行が履歴区間の境界を跨ぐのは 4 箇所だけである。
+
+| 箇所 | 操作 |
+| --- | --- |
+| `scroll_up_one` の `top == 0` 分岐 | 表示 0 行目が履歴の新しい端に入る。`max_history > 0` のとき `enter(departing)`。上限に達していれば `pop_front` した行を先に `pop_oldest`。`max_history == 0`（alternate 画面）では pop される行が departing そのものなので何もしない |
+| `scroll_up_one` の `top > 0` 分岐、`scroll_down_one` | 表示区間内の入れ替えなので無変更 |
+| `resize_rows` の伸長 | 回収される `min(growth, history_len)` 行は履歴の新しい端。その id を `reclaim_newest` する。通し番号は `len` から導出するので、複数行を外す順序は結果に影響しない |
+| `resize_rows` の縮小 | 表示末尾の `truncate` なので無変更 |
+| `reset` | `HistoryIndex::default()` に戻す |
+
+`mint` と `push_blank_row` は表示区間に足すだけなので触らない。
+
+`Screen::resize` は `grid.resize` の前に `scroll_up_one` で必要行数を履歴へ
+押し出しており、その分は上の通常経路で索引に入る。`scroll_up_one` で
+`top == 0` かつ `bottom < size.rows - 1` の場合も、`below_bottom` が変わるだけで
+ring が 1 行伸びて境界が `base` から `base + 1` に動くので、表示 0 行目が履歴に
+入る点は同じである。縮小の `truncate` は `old_rows - new_rows` 行しか落とさず、
+これは旧表示区間を越えないので履歴には届かない。
+
+Codex による監査（2026-09-03）で、`Grid` の全 mutation と `Screen` の全
+呼び出し箇所（`line_feed`、`reverse_index`、`resize`、`reset`、print / erase /
+DECALN の cell 書き換え）について上の分類が確認されている。
+
+## 効果と代償
+
+- 掃引と投影の両方が `placements × (ハッシュ 1 回 + 画面高さ以下の比較)`
+  になる。12 件 × 50 行なら 600 回程度で、12 万回から二桁以上下がる。
+  履歴側の参照は `HashMap` なので厳密な最悪 O(1) ではなく期待 O(1) である。
+- 代償は履歴が伸びる行送りごとにハッシュ挿入 1 回、上限溢れ後は挿入と
+  削除で 2 回。cell 書き込みに埋もれる量だが、行送りという最頻経路に
+  乗ることは確かである。
+- メモリは 10,000 エントリで数百 KB。
+- 外部依存は増やさない。`std::collections::HashMap` の既定ハッシュで足り、
+  キーが `u64` なので必要になれば恒等ハッシュに差し替えられる。
+
+## テスト
+
+`grid.rs` の既存 `mod tests`（`grid.rs:336`）に足す。いずれも `grid_line` の
+結果を固定する。
+
+- 履歴上限溢れ後: 最古の id は `None`、生き残りは正しい負の行。
+- 伸長で履歴を回収した後: 回収された行の id が表示区間の正しい行に解決する。
+- 縮小後: 落ちた行の id は `None`、履歴側は無変更。
+- `reset` 後: 以前の id はすべて `None`、索引は空。
+- 領域スクロール（`top > 0`）と `scroll_down_one` 後: 取り除かれた id は
+  `None`、履歴側は無変更。
+- alternate 画面相当（`max_history == 0`）でのスクロール: 索引に何も入らない。
+
+Codex レビューで追加を求められたケース。
+
+- `top == 0` かつ `bottom < size.rows - 1`: 表示 0 行目は履歴に入り、margin より
+  下の行は表示に残る。
+- 上限溢れ → 伸長回収 → さらに行送り: `pop_oldest → reclaim_newest → enter` で
+  通し番号の再利用を通す。
+- 一度の伸長で複数行を回収: 新しい側から順に外れる。
+- 履歴より大きい伸長: 回収と新規追加が混ざる。
+- 履歴ありでの列だけの resize: 索引は無変更。
+- `Screen::resize` の縮小で複数回の事前スクロールが要る場合: 上限未満と上限到達の
+  両方。
+- スクロールバック中の resize: アンカー解決と回収分の offset 補正の両方。
+- 履歴ありでの領域スクロール（`top > 0`）と `scroll_down_one`、および
+  `max_history == 0` での `scroll_down_one`。
+- 履歴ありからの `reset` を繰り返し、各 reset 後に再度行送りする。
+- 決定的な混合操作テスト: 上限まで行送り、溢れを繰り返し、領域の上下スクロール、
+  伸長、縮小、reset、再行送りを順に行い、**各操作の後**に下の突き合わせヘルパを
+  呼ぶ。生存している全 id が正しい行に、退避・リサイクルされた全 id が `None` に
+  解決することも各ステップで確認する。
+
+`HistoryIndex` 自身の単体テスト（`history_index.rs`）は、`enter` / `pop_oldest` /
+`reclaim_newest` の通し番号算術と `index_of` を `Grid` 抜きで固定する。
+
+`#[cfg(test)]` 専用のヘルパは、`seq_of.len() == history_len` と、索引の各エントリが実際にその ring index の行 id と一致することを突き合わせる。
+
+## スコープ外
+
+- `ScreenPlacements` と `Screen` は無変更。
+- 退避 signal の配送経路の変更は `docs/todo/eviction-at-source.md`。
+- ハッシャの差し替えは計測で必要になってから。


### PR DESCRIPTION
## Summary

`Grid::grid_line` walked the whole ring for every lookup, so each webview placement sweep and projection cost `placements × (history + rows)` comparisons — up to ~120k with a full 10,000-row scrollback and the 12-slot placement cap.

History rows now resolve in constant time through a new `HistoryIndex` (`screen/grid/history_index.rs`), which keys each history row's running sequence number by `LineId`; the ring index is that number minus the count popped so far, so a cap pop moves nothing. Only the visible rows are still scanned, bounded by the screen height.

The index is maintained at the three places a row crosses the history/visible boundary:

- a whole-screen scroll (`enter`, plus `pop_oldest` at the cap),
- a growth reclaiming history rows (`reclaim_newest`),
- a reset.

Region scrolls, reverse scrolls, shrinks, and column resizes never touch history and leave the index alone. `LineId` gains `Hash`; behavior of `grid_line` is unchanged.

This is PR 1 of a two-PR stack. PR 2 (`docs/todo/eviction-at-source.md`) will delete `Vt::sweep_evictions` and sweep once per chunk, which is only affordable with this index in place.

Design: `docs/todo/grid-history-index.md` (reviewed by Codex; the audit of every `Grid` mutation and `Screen` call site is recorded there).

## Test plan

- [x] 6 `HistoryIndex` unit tests pin the sequence arithmetic without a `Grid`.
- [x] 12 new `grid_line` tests cover growth reclaim (single, multiple, larger than history), reclaim after the cap has popped, shrink, columns-only resize, top-anchored region scroll, region scroll below the top, reverse scroll after history exists, repeated resets, `max_history == 0`, and a mixed session that cross-checks the index against the ring after every step.
- [x] `cargo test --workspace --no-fail-fast`: every crate green (564 in `orzma_vt`); the only failures are the two known environment-dependent font tests in the root binary, unchanged by this PR.
- [x] `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7hHczMdMutg3pSqcnGohK
