### PR TITLE
feat: add mouse selection to the Vt trait and wire copy and yank

### DIFF
--- a/crates/bevy_orzma_tty/src/requests/selection.rs
+++ b/crates/bevy_orzma_tty/src/requests/selection.rs
@@ -6,9 +6,11 @@
 //! it so the requests and their payload types travel together — each
 //! request carries exactly what the VT applies.
 //!
-//! The apply observers are stubs until a selection capability trait
-//! lands on the new `Vt` protocol.
+//! The start, update, and clear observers route to the targeted
+//! entity's handle; the vi-cursor start and the kind change stay stubs
+//! until vi mode lands in the VT.
 
+use crate::OrzmaTtyHandle;
 use bevy::prelude::*;
 pub use orzma_vt::prelude::{CellSide, GridPoint, SelectionKind};
 
@@ -81,12 +83,110 @@ impl Plugin for SelectionPlugin {
     }
 }
 
-fn start_selection(_e: On<RequestTtySelectionStart>) {}
+fn start_selection(e: On<RequestTtySelectionStart>, mut terms: Query<&mut OrzmaTtyHandle>) {
+    if let Ok(mut tty) = terms.get_mut(e.terminal) {
+        tty.start_selection(e.cell, e.side, e.kind);
+    }
+}
 
 fn start_selection_at_vi_cursor(_e: On<RequestTtySelectionStartAtViCursor>) {}
 
-fn update_selection(_e: On<RequestTtySelectionUpdate>) {}
+fn update_selection(e: On<RequestTtySelectionUpdate>, mut terms: Query<&mut OrzmaTtyHandle>) {
+    if let Ok(mut tty) = terms.get_mut(e.terminal) {
+        tty.extend_selection(e.cell, e.side);
+    }
+}
 
 fn change_selection_kind(_e: On<RequestTtySelectionKindChange>) {}
 
-fn clear_selection(_e: On<RequestTtySelectionClear>) {}
+fn clear_selection(e: On<RequestTtySelectionClear>, mut terms: Query<&mut OrzmaTtyHandle>) {
+    if let Ok(mut tty) = terms.get_mut(e.terminal) {
+        tty.clear_selection();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OrzmaTtyHandle;
+    use orzma_vt::prelude::{GridColumn, GridLine, Vt};
+
+    fn app_with_terminal() -> (App, Entity) {
+        let mut app = App::new();
+        app.add_plugins(SelectionPlugin);
+        let (mut handle, _) = OrzmaTtyHandle::detached(4, 3);
+        handle.feed_bytes(b"abcd\r\nefgh\r\nijkl");
+        let terminal = app.world_mut().spawn(handle).id();
+        (app, terminal)
+    }
+
+    fn cell(line: i32, column: u16) -> GridPoint {
+        GridPoint {
+            line: GridLine(line),
+            column: GridColumn(column),
+        }
+    }
+
+    fn selection_text(app: &App, terminal: Entity) -> Option<String> {
+        app.world()
+            .get::<OrzmaTtyHandle>(terminal)
+            .expect("terminal entity must keep its handle")
+            .vt()
+            .selection_text()
+    }
+
+    /// Asserts that a start followed by an update reaches the VT as one
+    /// selection whose text the handle can read back.
+    ///
+    /// Case: the user presses on a cell and drags across two more.
+    #[test]
+    fn start_and_update_reach_the_vt() {
+        let (mut app, terminal) = app_with_terminal();
+        app.world_mut().trigger(RequestTtySelectionStart {
+            terminal,
+            cell: cell(0, 1),
+            side: CellSide::Left,
+            kind: SelectionKind::Simple,
+        });
+        app.world_mut().trigger(RequestTtySelectionUpdate {
+            terminal,
+            cell: cell(0, 2),
+            side: CellSide::Right,
+        });
+        assert_eq!(selection_text(&app, terminal).as_deref(), Some("bc"));
+    }
+
+    /// Asserts that a clear request drops the selection the VT holds.
+    ///
+    /// Case: the user clicks elsewhere after selecting a row.
+    #[test]
+    fn clear_reaches_the_vt() {
+        let (mut app, terminal) = app_with_terminal();
+        app.world_mut().trigger(RequestTtySelectionStart {
+            terminal,
+            cell: cell(0, 0),
+            side: CellSide::Left,
+            kind: SelectionKind::Lines,
+        });
+        assert!(selection_text(&app, terminal).is_some());
+        app.world_mut()
+            .trigger(RequestTtySelectionClear { terminal });
+        assert_eq!(selection_text(&app, terminal), None);
+    }
+
+    /// Asserts that a request aimed at an entity without a handle is
+    /// ignored rather than panicking.
+    ///
+    /// Case: a drag update is in flight while its pane is torn down.
+    #[test]
+    fn a_request_on_a_bare_entity_is_ignored() {
+        let mut app = App::new();
+        app.add_plugins(SelectionPlugin);
+        let terminal = app.world_mut().spawn_empty().id();
+        app.world_mut().trigger(RequestTtySelectionUpdate {
+            terminal,
+            cell: cell(0, 0),
+            side: CellSide::Left,
+        });
+    }
+}

--- a/crates/bevy_orzma_tty/src/requests/selection.rs
+++ b/crates/bevy_orzma_tty/src/requests/selection.rs
@@ -108,7 +108,6 @@ fn clear_selection(e: On<RequestTtySelectionClear>, mut terms: Query<&mut OrzmaT
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::OrzmaTtyHandle;
     use orzma_vt::prelude::{GridColumn, GridLine, Vt};
 
     fn app_with_terminal() -> (App, Entity) {

--- a/crates/orzma_tty/src/lib.rs
+++ b/crates/orzma_tty/src/lib.rs
@@ -167,6 +167,30 @@ impl<V: Vt> OrzmaTty<V> {
         }
     }
 
+    /// Anchors a selection, arming the coalescer only when the VT's
+    /// state changed so an unchanged frame is not woken.
+    pub fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) {
+        if self.vt.start_selection(cell, side, kind) {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+    }
+
+    /// Moves the selection's moving end, arming the coalescer only when
+    /// it moved.
+    pub fn extend_selection(&mut self, cell: GridPoint, side: CellSide) {
+        if self.vt.extend_selection(cell, side) {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+    }
+
+    /// Drops the selection, arming the coalescer only when there was
+    /// one.
+    pub fn clear_selection(&mut self) {
+        if self.vt.clear_selection() {
+            self.coalescer.arm_or_extend(Instant::now());
+        }
+    }
+
     /// Resizes both the PTY (kernel winsize) and the VT grid, then arms
     /// the coalescer so the new geometry repaints at the next deadline
     /// even on an otherwise idle terminal.
@@ -565,6 +589,29 @@ mod tests {
     fn resize_arms_the_coalescer() {
         let (mut term, _sink) = detached_term();
         term.resize(120, 40).expect("resize");
+        assert!(term.coalescer.is_armed());
+    }
+
+    /// Asserts that a selection operation the VT reports as a change arms
+    /// the coalescer, and one it reports as unchanged does not.
+    ///
+    /// Case: the user starts a selection on an idle shell, then the host
+    /// re-sends a request the VT treats as a no-op.
+    #[test]
+    fn selection_operations_arm_the_coalescer_only_on_a_change() {
+        let (mut term, _sink) = detached_term();
+        let cell = GridPoint {
+            line: GridLine(0),
+            column: GridColumn(0),
+        };
+        term.vt.selection_changes = false;
+        term.start_selection(cell, CellSide::Left, SelectionKind::Simple);
+        term.extend_selection(cell, CellSide::Right);
+        term.clear_selection();
+        assert!(!term.coalescer.is_armed());
+
+        term.vt.selection_changes = true;
+        term.start_selection(cell, CellSide::Left, SelectionKind::Simple);
         assert!(term.coalescer.is_armed());
     }
 

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -51,7 +51,9 @@ impl Write for CaptureSink {
 /// size did not change) and names the next scripted `evictions` entry
 /// when it did. `scroll` records the motion:
 /// `Scroll::Bottom` snaps `display_offset` to zero, every other motion
-/// returns the scripted `scroll_moves`.
+/// returns the scripted `scroll_moves`. The selection operations return
+/// the scripted `selection_changes` and `selection_text` is always
+/// `None`.
 pub struct FakeVt {
     /// Grid size reported and updated by `resize`.
     pub grid_size: GridSize,
@@ -61,6 +63,8 @@ pub struct FakeVt {
     pub modes: VtModes,
     /// Scripted return for non-`Bottom` scrolls.
     pub scroll_moves: bool,
+    /// Scripted return for the selection operations.
+    pub selection_changes: bool,
     /// Every chunk `interpret` received, in order.
     pub interpreted: Vec<Vec<u8>>,
     /// Every motion `scroll` received, in order.
@@ -86,6 +90,7 @@ impl FakeVt {
             display_offset: DisplayOffset(0),
             modes: VtModes::default(),
             scroll_moves: false,
+            selection_changes: false,
             interpreted: Vec::new(),
             scrolls: Vec::new(),
             resizes: Vec::new(),
@@ -138,15 +143,15 @@ impl Vt for FakeVt {
     }
 
     fn start_selection(&mut self, _cell: GridPoint, _side: CellSide, _kind: SelectionKind) -> bool {
-        false
+        self.selection_changes
     }
 
     fn extend_selection(&mut self, _cell: GridPoint, _side: CellSide) -> bool {
-        false
+        self.selection_changes
     }
 
     fn clear_selection(&mut self) -> bool {
-        false
+        self.selection_changes
     }
 
     fn selection_text(&self) -> Option<String> {

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -141,6 +141,10 @@ impl Vt for FakeVt {
         false
     }
 
+    fn clear_selection(&mut self) -> bool {
+        false
+    }
+
     fn grid_size(&self) -> GridSize {
         self.grid_size
     }

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -3,7 +3,8 @@
 //! the resize seam.
 
 use orzma_vt::prelude::{
-    DisplayOffset, Frame, GridSize, InstanceId, InterpretOutput, ResizeChanged, Scroll, Vt, VtModes,
+    CellSide, DisplayOffset, Frame, GridPoint, GridSize, InstanceId, InterpretOutput,
+    ResizeChanged, Scroll, SelectionKind, Vt, VtModes,
 };
 #[cfg(any(test, feature = "test-support"))]
 use portable_pty::{MasterPty, PtySize};
@@ -134,6 +135,10 @@ impl Vt for FakeVt {
         } else {
             self.scroll_moves
         }
+    }
+
+    fn start_selection(&mut self, _cell: GridPoint, _side: CellSide, _kind: SelectionKind) -> bool {
+        false
     }
 
     fn grid_size(&self) -> GridSize {

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -141,6 +141,10 @@ impl Vt for FakeVt {
         false
     }
 
+    fn extend_selection(&mut self, _cell: GridPoint, _side: CellSide) -> bool {
+        false
+    }
+
     fn clear_selection(&mut self) -> bool {
         false
     }

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -149,6 +149,10 @@ impl Vt for FakeVt {
         false
     }
 
+    fn selection_text(&self) -> Option<String> {
+        None
+    }
+
     fn grid_size(&self) -> GridSize {
         self.grid_size
     }

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -298,18 +298,21 @@ impl DeviceState {
         evicted
     }
 
-    /// Applies an alternate-screen flip, tearing down the placements the
-    /// abandoned alternate screen owned.
+    /// Applies an alternate-screen flip, tearing down the placements and
+    /// the selection the abandoned alternate screen owned.
     ///
-    /// Primary placements are hidden while the alternate screen is shown,
-    /// not destroyed. This operation stages no damage of its own: the
-    /// flip itself must stage `DamageSpan::Full`, which carries the
-    /// changed list.
+    /// Primary placements and the primary selection are hidden while the
+    /// alternate screen is shown, not destroyed. This operation stages no
+    /// damage of its own: the flip itself must stage `DamageSpan::Full`,
+    /// which carries the changed list.
     pub fn switch_screen(&mut self, to: ScreenKind) -> Vec<InstanceId> {
         self.modes.active_screen = to;
         match to {
             ScreenKind::Alternate => Vec::new(),
-            ScreenKind::Primary => self.screens.alternate.take_placements(),
+            ScreenKind::Primary => {
+                self.screens.alternate.clear_selection();
+                self.screens.alternate.take_placements()
+            }
         }
     }
 

--- a/crates/orzma_vt/src/frame.rs
+++ b/crates/orzma_vt/src/frame.rs
@@ -89,6 +89,8 @@ pub(crate) struct FrameTracker {
     placements: Vec<AnchoredPlacement>,
     /// The palette the last emitted frame carried.
     palette: Palette,
+    /// The selection the last emitted frame carried.
+    selection: Option<SelectionRange>,
 }
 
 impl FrameTracker {
@@ -107,6 +109,7 @@ impl FrameTracker {
             display_offset: DisplayOffset::default(),
             placements: Vec::new(),
             palette: Palette::default(),
+            selection: None,
         }
     }
 
@@ -142,12 +145,13 @@ impl FrameTracker {
         let screen = device.active_screen();
         let cursor = screen.cursor();
         let display_offset = screen.display_offset();
+        let selection = screen.selection_range();
         let placements = self.diff_placements(device);
         let palette = self.diff_palette(device.palette());
         if self.damage.is_clean()
             && placements.is_none()
             && palette.is_none()
-            && !self.cursor_or_offset_changed(&cursor, display_offset)
+            && !self.carried_changed(&cursor, display_offset, selection)
         {
             return None;
         }
@@ -164,7 +168,7 @@ impl FrameTracker {
             cursor,
             display_offset,
             vi_cursor: None,
-            selection: None,
+            selection,
             placements,
             palette,
             hyperlinks: Vec::new(),
@@ -172,16 +176,24 @@ impl FrameTracker {
         self.settle(
             frame.cursor,
             frame.display_offset,
+            frame.selection,
             frame.placements.as_ref(),
             frame.palette.as_ref(),
         );
         Some(frame)
     }
 
-    /// Returns whether the unconditionally-carried small fields differ
+    /// Returns whether the unconditionally-carried small sections differ
     /// from what the consumer last saw.
-    fn cursor_or_offset_changed(&self, cursor: &Cursor, display_offset: DisplayOffset) -> bool {
-        *cursor != self.cursor || display_offset != self.display_offset
+    fn carried_changed(
+        &self,
+        cursor: &Cursor,
+        display_offset: DisplayOffset,
+        selection: Option<SelectionRange>,
+    ) -> bool {
+        *cursor != self.cursor
+            || display_offset != self.display_offset
+            || selection != self.selection
     }
 
     /// Resolves the active screen's placements and reports the complete
@@ -210,11 +222,13 @@ impl FrameTracker {
         &mut self,
         cursor: Cursor,
         display_offset: DisplayOffset,
+        selection: Option<SelectionRange>,
         placements: Option<&Vec<AnchoredPlacement>>,
         palette: Option<&Palette>,
     ) {
         self.cursor = cursor;
         self.display_offset = display_offset;
+        self.selection = selection;
         if let Some(placements) = placements {
             self.placements.clone_from(placements);
         }
@@ -266,6 +280,7 @@ mod tests {
         assert_eq!(tracker.display_offset, device.display_offset());
         assert_eq!(&tracker.palette, device.palette());
         assert!(tracker.placements.is_empty());
+        assert_eq!(tracker.selection, None);
     }
 
     /// Asserts that an unchanged projection diffs to `None`, a mutated
@@ -287,6 +302,7 @@ mod tests {
         tracker.settle(
             device.active_screen().cursor(),
             device.display_offset(),
+            None,
             Some(&listed),
             None,
         );
@@ -307,7 +323,13 @@ mod tests {
         let changed = tracker
             .diff_palette(&palette)
             .expect("an override changes the table");
-        tracker.settle(Cursor::default(), DisplayOffset(0), None, Some(&changed));
+        tracker.settle(
+            Cursor::default(),
+            DisplayOffset(0),
+            None,
+            None,
+            Some(&changed),
+        );
         assert_eq!(tracker.diff_palette(&palette), None);
     }
 

--- a/crates/orzma_vt/src/frame.rs
+++ b/crates/orzma_vt/src/frame.rs
@@ -80,17 +80,13 @@ pub struct DirtyRow {
 pub(crate) struct FrameTracker {
     /// Damage staged for the next emit, from every source.
     damage: Damage,
-    /// The cursor the last emitted frame carried, compared against to
-    /// detect changes.
-    cursor: Cursor,
-    /// The display offset the last emitted frame carried.
-    display_offset: DisplayOffset,
+    /// The always-carried sections the last emitted frame carried,
+    /// compared against to detect changes.
+    carried: Carried,
     /// The placement list the last emitted frame carried.
     placements: Vec<AnchoredPlacement>,
     /// The palette the last emitted frame carried.
     palette: Palette,
-    /// The selection the last emitted frame carried.
-    selection: Option<SelectionRange>,
 }
 
 impl FrameTracker {
@@ -105,11 +101,9 @@ impl FrameTracker {
     pub fn new() -> Self {
         Self {
             damage: Damage::new(),
-            cursor: Cursor::default(),
-            display_offset: DisplayOffset::default(),
+            carried: Carried::default(),
             placements: Vec::new(),
             palette: Palette::default(),
-            selection: None,
         }
     }
 
@@ -143,15 +137,17 @@ impl FrameTracker {
     ///   retains nothing.
     pub fn emit(&mut self, device: &DeviceState) -> Option<Frame> {
         let screen = device.active_screen();
-        let cursor = screen.cursor();
-        let display_offset = screen.display_offset();
-        let selection = screen.selection_range();
+        let carried = Carried {
+            cursor: screen.cursor(),
+            display_offset: screen.display_offset(),
+            selection: screen.selection_range(),
+        };
         let placements = self.diff_placements(device);
         let palette = self.diff_palette(device.palette());
         if self.damage.is_clean()
             && placements.is_none()
             && palette.is_none()
-            && !self.carried_changed(&cursor, display_offset, selection)
+            && carried == self.carried
         {
             return None;
         }
@@ -165,35 +161,16 @@ impl FrameTracker {
         let frame = Frame {
             size,
             rows,
-            cursor,
-            display_offset,
+            cursor: carried.cursor,
+            display_offset: carried.display_offset,
             vi_cursor: None,
-            selection,
+            selection: carried.selection,
             placements,
             palette,
             hyperlinks: Vec::new(),
         };
-        self.settle(
-            frame.cursor,
-            frame.display_offset,
-            frame.selection,
-            frame.placements.as_ref(),
-            frame.palette.as_ref(),
-        );
+        self.settle(carried, frame.placements.as_ref(), frame.palette.as_ref());
         Some(frame)
-    }
-
-    /// Returns whether the unconditionally-carried small sections differ
-    /// from what the consumer last saw.
-    fn carried_changed(
-        &self,
-        cursor: &Cursor,
-        display_offset: DisplayOffset,
-        selection: Option<SelectionRange>,
-    ) -> bool {
-        *cursor != self.cursor
-            || display_offset != self.display_offset
-            || selection != self.selection
     }
 
     /// Resolves the active screen's placements and reports the complete
@@ -220,15 +197,11 @@ impl FrameTracker {
     /// same change again on the next attempt.
     fn settle(
         &mut self,
-        cursor: Cursor,
-        display_offset: DisplayOffset,
-        selection: Option<SelectionRange>,
+        carried: Carried,
         placements: Option<&Vec<AnchoredPlacement>>,
         palette: Option<&Palette>,
     ) {
-        self.cursor = cursor;
-        self.display_offset = display_offset;
-        self.selection = selection;
+        self.carried = carried;
         if let Some(placements) = placements {
             self.placements.clone_from(placements);
         }
@@ -236,6 +209,15 @@ impl FrameTracker {
             self.palette.clone_from(palette);
         }
     }
+}
+
+/// The sections every frame carries unconditionally, compared as one
+/// value so a change in any of them owes a frame.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Carried {
+    cursor: Cursor,
+    display_offset: DisplayOffset,
+    selection: Option<SelectionRange>,
 }
 
 #[cfg(test)]
@@ -277,10 +259,10 @@ mod tests {
     fn a_new_tracker_matches_a_fresh_device() {
         let tracker = FrameTracker::new();
         let device = DeviceState::new(GridSize { cols: 4, rows: 3 }, 10);
-        assert_eq!(tracker.display_offset, device.display_offset());
+        assert_eq!(tracker.carried.display_offset, device.display_offset());
         assert_eq!(&tracker.palette, device.palette());
         assert!(tracker.placements.is_empty());
-        assert_eq!(tracker.selection, None);
+        assert_eq!(tracker.carried.selection, None);
     }
 
     /// Asserts that an unchanged projection diffs to `None`, a mutated
@@ -300,9 +282,11 @@ mod tests {
             .expect("a mount changes the projection");
         assert_eq!(listed.len(), 1);
         tracker.settle(
-            device.active_screen().cursor(),
-            device.display_offset(),
-            None,
+            Carried {
+                cursor: device.active_screen().cursor(),
+                display_offset: device.display_offset(),
+                selection: None,
+            },
             Some(&listed),
             None,
         );
@@ -323,13 +307,7 @@ mod tests {
         let changed = tracker
             .diff_palette(&palette)
             .expect("an override changes the table");
-        tracker.settle(
-            Cursor::default(),
-            DisplayOffset(0),
-            None,
-            None,
-            Some(&changed),
-        );
+        tracker.settle(Carried::default(), None, Some(&changed));
         assert_eq!(tracker.diff_palette(&palette), None);
     }
 

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -1063,4 +1063,69 @@ mod tests {
             "a second removal names nothing"
         );
     }
+
+    /// Asserts that a primary-screen selection is hidden while the alternate
+    /// screen is shown and comes back unchanged on return.
+    ///
+    /// Case: the user selects a shell line, opens a full-screen editor, and
+    /// quits it.
+    #[test]
+    fn a_primary_selection_hides_behind_the_alternate_screen() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\x1b[?1049h");
+        assert_eq!(projected(&vt), None);
+        vt.interpret(b"\x1b[?1049l");
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (0, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a selection made on the alternate screen is dropped when
+    /// the terminal returns to the primary screen, so a later alternate
+    /// session does not inherit it.
+    ///
+    /// Case: the user selects a line inside a pager, quits it, and opens
+    /// another full-screen program.
+    #[test]
+    fn an_alternate_selection_is_discarded_on_return() {
+        let mut vt = filled();
+        vt.interpret(b"\x1b[?1049h");
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\x1b[?1049l");
+        assert_eq!(projected(&vt), None);
+        vt.interpret(b"\x1b[?1049h");
+        assert_eq!(projected(&vt), None);
+    }
+
+    /// Asserts that a reset on an otherwise blank grid still marks the chunk
+    /// damaged and emits a frame without the selection.
+    ///
+    /// Case: a blank terminal has a line selected when a program issues RIS.
+    #[test]
+    fn a_reset_clears_the_selection_and_reports_it() {
+        let mut vt = vt();
+        vt.frame();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.frame();
+        let output = vt.interpret(b"\x1bc");
+        assert!(output.damaged);
+        assert_eq!(vt.frame().expect("the reset emits").selection, None);
+    }
+
+    /// Asserts that a selection whose row has left the ring still counts as
+    /// present for `clear_selection`, even though it no longer projects.
+    ///
+    /// Case: on a terminal with no scrollback the user selects the top row,
+    /// the shell scrolls it away, and the user clicks to dismiss.
+    #[test]
+    fn a_clear_of_a_dead_selection_still_reports_true() {
+        let mut vt = OrzmaVt::new(GridSize { cols: 4, rows: 3 }, 0);
+        vt.interpret(b"abcd\r\nefgh\r\nijkl");
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\r\n");
+        assert_eq!(projected(&vt), None);
+        assert!(vt.clear_selection());
+    }
 }

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -180,6 +180,12 @@ pub trait Vt {
     /// emit-time diff decides on its own whether a frame is owed.
     fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) -> bool;
 
+    /// Drops the active selection; returns whether there was one.
+    ///
+    /// A selection whose rows have left the ring still counts: it holds
+    /// state even though it projects nothing.
+    fn clear_selection(&mut self) -> bool;
+
     /// Grid dimensions in cells.
     fn grid_size(&self) -> GridSize;
 
@@ -370,6 +376,10 @@ impl Vt for OrzmaVt {
             .start_selection(cell, side, kind)
     }
 
+    fn clear_selection(&mut self) -> bool {
+        self.device.active_screen_mut().clear_selection()
+    }
+
     fn grid_size(&self) -> GridSize {
         self.device.grid_size()
     }
@@ -512,6 +522,62 @@ mod tests {
         assert!(vt.start_selection(cell(0, 1), CellSide::Left, SelectionKind::Simple));
         assert_eq!(projected(&vt), None);
         assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that clearing when nothing is selected reports no change and
+    /// owes no frame.
+    ///
+    /// Case: the user clicks in the terminal with no selection active, and
+    /// the host sends its usual clear.
+    #[test]
+    fn a_clear_without_a_selection_is_a_no_op() {
+        let mut vt = filled();
+        assert!(!vt.clear_selection());
+        assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that clearing on an idle terminal emits a frame that drops
+    /// the selection and repaints no rows.
+    ///
+    /// Case: the user clicks elsewhere to dismiss a selection while the
+    /// shell is quiet.
+    #[test]
+    fn an_idle_clear_emits_a_frame_without_the_selection() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.frame();
+        assert!(vt.clear_selection());
+        let frame = vt.frame().expect("an idle clear emits");
+        assert!(frame.rows.is_empty());
+        assert_eq!(frame.selection, None);
+    }
+
+    /// Asserts that a second clear finds nothing to drop.
+    ///
+    /// Case: the host sends a clear on every click, and the user clicks
+    /// twice after dismissing a selection.
+    #[test]
+    fn a_repeated_clear_is_a_no_op() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        assert!(vt.clear_selection());
+        assert!(!vt.clear_selection());
+    }
+
+    /// Asserts that a Lines start on an idle terminal emits a frame that
+    /// carries the new range and repaints no rows.
+    ///
+    /// Case: the user triple-clicks a row while the shell is quiet.
+    #[test]
+    fn an_idle_start_emits_a_rowless_frame_carrying_the_selection() {
+        let mut vt = filled();
+        assert!(vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines));
+        let frame = vt.frame().expect("an idle start emits");
+        assert!(frame.rows.is_empty());
+        assert_eq!(
+            frame.selection,
+            Some(range((0, 0), (0, 3), SelectionGeometry::Lines))
+        );
     }
 
     /// Asserts that a resize to the size the grid already has returns

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -180,6 +180,14 @@ pub trait Vt {
     /// emit-time diff decides on its own whether a frame is owed.
     fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) -> bool;
 
+    /// Moves the active selection's moving end to `cell`; returns
+    /// whether the moving end changed. A no-op returning `false` when
+    /// there is no active selection or `cell` is outside the grid.
+    ///
+    /// Two cells naming the same boundary — the right half of one and
+    /// the left half of the next — are the same moving end.
+    fn extend_selection(&mut self, cell: GridPoint, side: CellSide) -> bool;
+
     /// Drops the active selection; returns whether there was one.
     ///
     /// A selection whose rows have left the ring still counts: it holds
@@ -374,6 +382,10 @@ impl Vt for OrzmaVt {
         self.device
             .active_screen_mut()
             .start_selection(cell, side, kind)
+    }
+
+    fn extend_selection(&mut self, cell: GridPoint, side: CellSide) -> bool {
+        self.device.active_screen_mut().extend_selection(cell, side)
     }
 
     fn clear_selection(&mut self) -> bool {
@@ -578,6 +590,284 @@ mod tests {
             frame.selection,
             Some(range((0, 0), (0, 3), SelectionGeometry::Lines))
         );
+    }
+
+    /// Asserts that a start while a selection is active replaces it rather
+    /// than extending or keeping it.
+    ///
+    /// Case: with two rows selected, the user triple-clicks a different row.
+    #[test]
+    fn a_start_replaces_the_active_selection() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.extend_selection(cell(1, 0), CellSide::Left);
+        assert!(vt.start_selection(cell(2, 1), CellSide::Left, SelectionKind::Lines));
+        assert_eq!(
+            projected(&vt),
+            Some(range((2, 0), (2, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that an anchor on the right half of a cell starts the
+    /// selection on the following cell.
+    ///
+    /// Case: the user presses on the right half of column 1 and drags to
+    /// the left half of column 3.
+    #[test]
+    fn a_right_side_anchor_starts_on_the_next_boundary() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 1), CellSide::Right, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(0, 3), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 2), (0, 2), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that an extend with no active selection reports no change
+    /// and creates nothing.
+    ///
+    /// Case: a drag update arrives after a click elsewhere already cleared
+    /// the selection.
+    #[test]
+    fn an_extend_without_a_selection_is_a_no_op() {
+        let mut vt = filled();
+        assert!(!vt.extend_selection(cell(0, 2), CellSide::Right));
+        assert_eq!(projected(&vt), None);
+        assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that dragging the moving end to the right projects the cells
+    /// from the anchor through the cell under the pointer.
+    ///
+    /// Case: the user presses on the first cell of a row and drags across
+    /// two more.
+    #[test]
+    fn a_forward_extend_projects_the_span() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(0, 2), CellSide::Right));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (0, 2), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that extending an idle terminal's selection emits a frame
+    /// that carries the new range and repaints no rows.
+    ///
+    /// Case: the shell is quiet while the user keeps dragging.
+    #[test]
+    fn an_idle_extend_emits_a_rowless_frame() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(0, 2), CellSide::Right);
+        vt.frame();
+        assert!(vt.extend_selection(cell(0, 3), CellSide::Right));
+        let frame = vt.frame().expect("an idle extend emits");
+        assert!(frame.rows.is_empty());
+        assert_eq!(
+            frame.selection,
+            Some(range((0, 0), (0, 3), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that dragging above and left of the anchor swaps the ends so
+    /// the projected range still reads top-left to bottom-right.
+    ///
+    /// Case: the user presses in the middle of the second row and drags up
+    /// into the first.
+    #[test]
+    fn a_backward_drag_normalizes_the_endpoints() {
+        let mut vt = filled();
+        vt.start_selection(cell(1, 2), CellSide::Left, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(0, 1), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 1), (1, 1), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that an extend to the same cell boundary the moving end already
+    /// occupies reports no change, even when the column and side differ.
+    ///
+    /// Case: the pointer crosses from the right half of one cell into the
+    /// left half of the next without moving the boundary.
+    #[test]
+    fn an_extend_to_the_same_boundary_is_a_no_op() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 1), CellSide::Right, SelectionKind::Simple);
+        vt.frame();
+        assert!(!vt.extend_selection(cell(0, 2), CellSide::Left));
+        assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that an anchor on the right edge of a row begins the range on
+    /// the first cell of the row below.
+    ///
+    /// Case: the user presses on the right half of the last column and drags
+    /// down into the next row.
+    #[test]
+    fn a_right_edge_anchor_wraps_to_the_next_row() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 3), CellSide::Right, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(1, 1), CellSide::Right));
+        assert_eq!(
+            projected(&vt),
+            Some(range((1, 0), (1, 1), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that a moving end on the left edge of a row ends the range on
+    /// the last cell of the row above.
+    ///
+    /// Case: the user drags down and lands on the left half of the first
+    /// column of the next row.
+    #[test]
+    fn a_left_edge_end_wraps_to_the_previous_row() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 1), CellSide::Left, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(1, 0), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 1), (0, 3), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that a range whose ends wrap past each other projects nothing.
+    ///
+    /// Case: the user presses on the right half of the last column and drags
+    /// onto the left half of the first column of the next row.
+    #[test]
+    fn a_wrap_that_crosses_itself_is_empty() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 3), CellSide::Right, SelectionKind::Simple);
+        assert!(vt.extend_selection(cell(1, 0), CellSide::Left));
+        assert_eq!(projected(&vt), None);
+    }
+
+    /// Asserts that a Lines drag spans whole rows from the anchor's row to
+    /// the pointer's row regardless of the columns involved.
+    ///
+    /// Case: the user triple-clicks a row and drags two rows down.
+    #[test]
+    fn a_lines_extend_takes_whole_rows() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 2), CellSide::Left, SelectionKind::Lines);
+        assert!(vt.extend_selection(cell(2, 1), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (2, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that moving the end of a Lines selection within its row
+    /// changes the state but owes no frame.
+    ///
+    /// Case: the user drags sideways inside the triple-clicked row.
+    #[test]
+    fn a_column_only_move_under_lines_changes_no_projection() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 2), CellSide::Left, SelectionKind::Lines);
+        vt.frame();
+        assert!(vt.extend_selection(cell(0, 3), CellSide::Right));
+        assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that an extend to a line the ring does not hold is rejected
+    /// and leaves the moving end where it was.
+    ///
+    /// Case: the drag reaches above the viewport on a terminal with no
+    /// scrollback yet.
+    #[test]
+    fn an_extend_to_a_line_outside_the_ring_is_rejected() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(0, 2), CellSide::Right);
+        assert!(!vt.extend_selection(cell(-1, 0), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (0, 2), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that an extend whose column is past the grid width is
+    /// rejected rather than folded onto the row's right edge.
+    ///
+    /// Case: a shrink resize lands between the host's hit test and the drag
+    /// update reaching the terminal.
+    #[test]
+    fn an_extend_past_the_last_column_is_rejected() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(0, 2), CellSide::Right);
+        assert!(!vt.extend_selection(cell(0, 4), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (0, 2), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that a drag into scrollback the ring still holds extends the
+    /// selection there.
+    ///
+    /// Case: the user triple-clicks the top live row and drags up into the
+    /// history the terminal has retained.
+    #[test]
+    fn an_extend_into_history_is_accepted() {
+        let mut vt = filled();
+        vt.interpret(b"\r\n\r\n");
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        assert!(vt.extend_selection(cell(-2, 0), CellSide::Left));
+        assert_eq!(
+            projected(&vt),
+            Some(range((-2, 0), (0, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a selection stays on the rows it was made on when output
+    /// pushes those rows into history.
+    ///
+    /// Case: the user has two lines selected when the shell prints two more.
+    #[test]
+    fn a_selection_follows_its_rows_into_history() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.extend_selection(cell(1, 0), CellSide::Left);
+        vt.interpret(b"\r\n\r\n");
+        assert_eq!(
+            projected(&vt),
+            Some(range((-2, 0), (-1, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a selection whose end lies past a shrunken width projects
+    /// onto the new last column instead of past the grid.
+    ///
+    /// Case: the user has a full row selected and narrows the window.
+    #[test]
+    fn a_width_shrink_clamps_the_projected_column() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(0, 3), CellSide::Right);
+        assert!(vt.resize(GridSize { cols: 2, rows: 3 }).is_some());
+        assert_eq!(
+            projected(&vt),
+            Some(range((0, 0), (0, 1), SelectionGeometry::Linear))
+        );
+    }
+
+    /// Asserts that a drag update after a clear has no selection to extend.
+    ///
+    /// Case: a stale drag update arrives after the click that cleared the
+    /// selection.
+    #[test]
+    fn an_extend_after_a_clear_is_a_no_op() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.clear_selection();
+        assert!(!vt.extend_selection(cell(1, 0), CellSide::Left));
+        assert_eq!(projected(&vt), None);
     }
 
     /// Asserts that a resize to the size the grid already has returns

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -56,14 +56,13 @@ pub mod prelude {
 /// the grid and scrollback, tracks damage, and builds frames. The
 /// trait has no constructor — a concrete VT is built with its own
 /// configuration and injected; spawn geometry arrives via
-/// [`Vt::resize`]. Selection and vi mode arrive later as separate
-/// capability traits.
+/// [`Vt::resize`]. Vi mode arrives later.
 ///
-/// The read surface is deliberately frame-granular: cell-level host
-/// features (e.g. hyperlink hover) resolve against the emitted
-/// [`crate::prelude::Row`] / [`crate::prelude::Run`] data, so the
-/// trait exposes no per-cell read seam and the VT's storage cell
-/// never leaves the crate.
+/// The read surface exposes no per-cell seam: cell-level host features
+/// (e.g. hyperlink hover) resolve against the emitted
+/// [`crate::prelude::Row`] / [`crate::prelude::Run`] data, and the only
+/// text read, [`Vt::selection_text`], is a derived value, so the VT's
+/// storage cell never leaves the crate.
 ///
 /// # Invariants
 ///

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -11,6 +11,8 @@ use crate::{
     interpreter::Interpreter,
     placement::{InstanceId, PlacementSize},
     screen::grid::GridSize,
+    screen::grid::coords::GridPoint,
+    screen::selection::{CellSide, SelectionKind},
     screen::viewport::{DisplayOffset, Scroll},
 };
 use std::path::PathBuf;
@@ -167,6 +169,16 @@ pub trait Vt {
     /// Applies the viewport motion; returns whether the viewport
     /// moved. Only a real move stages (full) damage.
     fn scroll(&mut self, scroll: Scroll) -> bool;
+
+    /// Anchors a new selection at `cell`, replacing any active one;
+    /// returns whether the selection state changed. A cell outside the
+    /// grid (a line already evicted from history, or a column past the
+    /// width) is rejected, leaving the current selection untouched.
+    ///
+    /// The return value reports the stored state, not the projection:
+    /// a start whose projection is empty still returns `true`, and the
+    /// emit-time diff decides on its own whether a frame is owed.
+    fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) -> bool;
 
     /// Grid dimensions in cells.
     fn grid_size(&self) -> GridSize;
@@ -352,6 +364,12 @@ impl Vt for OrzmaVt {
         self.tracker.stage_if_changed(self.device.scroll(scroll))
     }
 
+    fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) -> bool {
+        self.device
+            .active_screen_mut()
+            .start_selection(cell, side, kind)
+    }
+
     fn grid_size(&self) -> GridSize {
         self.device.grid_size()
     }
@@ -369,11 +387,131 @@ impl Vt for OrzmaVt {
 mod tests {
     use super::*;
     use crate::placement::{InstanceId, PlacementSize};
-    use crate::screen::grid::coords::GridLine;
+    use crate::screen::grid::coords::{GridColumn, GridLine};
+    use crate::screen::selection::{SelectionGeometry, SelectionRange};
     use crate::screen::viewport::ViewportLine;
 
     fn vt() -> OrzmaVt {
         OrzmaVt::new(GridSize { cols: 4, rows: 3 }, 10)
+    }
+
+    /// A 4×3 terminal whose rows read `abcd` / `efgh` / `ijkl`, with the
+    /// bootstrap frame already drained.
+    fn filled() -> OrzmaVt {
+        let mut vt = vt();
+        vt.interpret(b"abcd\r\nefgh\r\nijkl");
+        vt.frame();
+        vt
+    }
+
+    fn cell(line: i32, column: u16) -> GridPoint {
+        GridPoint {
+            line: GridLine(line),
+            column: GridColumn(column),
+        }
+    }
+
+    /// The selection the active screen projects right now, read without
+    /// consuming a frame.
+    fn projected(vt: &OrzmaVt) -> Option<SelectionRange> {
+        vt.device.active_screen().selection_range()
+    }
+
+    fn range(start: (i32, u16), end: (i32, u16), geometry: SelectionGeometry) -> SelectionRange {
+        SelectionRange {
+            start: cell(start.0, start.1),
+            end: cell(end.0, end.1),
+            geometry,
+        }
+    }
+
+    /// Asserts that a Lines start projects the anchored row from its first
+    /// to its last column.
+    ///
+    /// Case: the user triple-clicks the middle row of the terminal.
+    #[test]
+    fn a_lines_start_projects_the_whole_row() {
+        let mut vt = filled();
+        assert!(vt.start_selection(cell(1, 2), CellSide::Left, SelectionKind::Lines));
+        assert_eq!(
+            projected(&vt),
+            Some(range((1, 0), (1, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a start identical to the active selection reports no
+    /// change and owes no frame.
+    ///
+    /// Case: the host re-fires the same start request for a repeated
+    /// triple-click on the row that is already selected.
+    #[test]
+    fn an_identical_start_is_a_no_op() {
+        let mut vt = filled();
+        vt.start_selection(cell(1, 0), CellSide::Left, SelectionKind::Lines);
+        vt.frame();
+        assert!(!vt.start_selection(cell(1, 0), CellSide::Left, SelectionKind::Lines));
+        assert!(vt.frame().is_none());
+    }
+
+    /// Asserts that a start on a line the ring does not hold is rejected and
+    /// leaves the active selection untouched.
+    ///
+    /// Case: the press was hit-tested against a frame that still showed a
+    /// history row, which the terminal has since trimmed away.
+    #[test]
+    fn a_start_on_a_line_outside_the_ring_is_rejected() {
+        let mut vt = filled();
+        vt.start_selection(cell(1, 0), CellSide::Left, SelectionKind::Lines);
+        assert!(!vt.start_selection(cell(-1, 0), CellSide::Left, SelectionKind::Lines));
+        assert_eq!(
+            projected(&vt),
+            Some(range((1, 0), (1, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a start whose column is past the grid width is rejected
+    /// even for a Lines selection that would ignore the column.
+    ///
+    /// Case: a shrink resize lands between the host's hit test and the
+    /// request reaching the terminal.
+    #[test]
+    fn a_start_past_the_last_column_is_rejected() {
+        let mut vt = filled();
+        vt.start_selection(cell(1, 0), CellSide::Left, SelectionKind::Lines);
+        assert!(!vt.start_selection(cell(0, 4), CellSide::Left, SelectionKind::Lines));
+        assert_eq!(
+            projected(&vt),
+            Some(range((1, 0), (1, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a start on a history line the ring still holds is
+    /// accepted and projects there.
+    ///
+    /// Case: the user scrolls back and triple-clicks a row that has already
+    /// left the live screen.
+    #[test]
+    fn a_start_on_a_history_line_is_accepted() {
+        let mut vt = filled();
+        vt.interpret(b"\r\n\r\n");
+        assert!(vt.start_selection(cell(-1, 0), CellSide::Left, SelectionKind::Lines));
+        assert_eq!(
+            projected(&vt),
+            Some(range((-1, 0), (-1, 3), SelectionGeometry::Lines))
+        );
+    }
+
+    /// Asserts that a fresh Simple start returns `true` even though its
+    /// empty projection leaves `frame()` with nothing to emit.
+    ///
+    /// Case: the user presses the mouse button on a cell and the host
+    /// anchors a selection before the pointer has moved.
+    #[test]
+    fn a_fresh_simple_start_changes_state_but_projects_nothing() {
+        let mut vt = filled();
+        assert!(vt.start_selection(cell(0, 1), CellSide::Left, SelectionKind::Simple));
+        assert_eq!(projected(&vt), None);
+        assert!(vt.frame().is_none());
     }
 
     /// Asserts that a resize to the size the grid already has returns

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -194,6 +194,11 @@ pub trait Vt {
     /// state even though it projects nothing.
     fn clear_selection(&mut self) -> bool;
 
+    /// The text the active selection covers; `None` exactly when
+    /// [`Frame::selection`] would be `None` — no selection, an empty
+    /// span, or an endpoint whose line has left the ring.
+    fn selection_text(&self) -> Option<String>;
+
     /// Grid dimensions in cells.
     fn grid_size(&self) -> GridSize;
 
@@ -390,6 +395,10 @@ impl Vt for OrzmaVt {
 
     fn clear_selection(&mut self) -> bool {
         self.device.active_screen_mut().clear_selection()
+    }
+
+    fn selection_text(&self) -> Option<String> {
+        self.device.active_screen().selection_text()
     }
 
     fn grid_size(&self) -> GridSize {
@@ -1127,5 +1136,122 @@ mod tests {
         vt.interpret(b"\r\n");
         assert_eq!(projected(&vt), None);
         assert!(vt.clear_selection());
+    }
+
+    /// Asserts that a terminal with no selection has no text to copy.
+    ///
+    /// Case: the user presses the copy shortcut without having selected
+    /// anything.
+    #[test]
+    fn no_selection_yields_no_text() {
+        let vt = filled();
+        assert_eq!(vt.selection_text(), None);
+    }
+
+    /// Asserts that a single-row Simple selection reads exactly the cells
+    /// between its two boundaries.
+    ///
+    /// Case: the user drags across the middle two characters of a word.
+    #[test]
+    fn a_simple_span_reads_the_cells_between_its_ends() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 1), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(0, 2), CellSide::Right);
+        assert_eq!(vt.selection_text().as_deref(), Some("bc"));
+    }
+
+    /// Asserts that a Simple selection spanning three rows takes the tail of
+    /// the first, the whole middle row, and the head of the last, joined by
+    /// newlines with none at the end.
+    ///
+    /// Case: the user drags from the middle of one line down into the
+    /// middle of the line two below it.
+    #[test]
+    fn a_multi_row_span_joins_rows_with_newlines() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 2), CellSide::Left, SelectionKind::Simple);
+        vt.extend_selection(cell(2, 1), CellSide::Right);
+        assert_eq!(vt.selection_text().as_deref(), Some("cd\nefgh\nij"));
+    }
+
+    /// Asserts that the blank cells past a row's last printed character are
+    /// not copied.
+    ///
+    /// Case: the user selects two short lines on a wide terminal.
+    #[test]
+    fn trailing_blanks_are_trimmed_per_row() {
+        let mut vt = vt();
+        vt.interpret(b"ab\r\ncd");
+        vt.frame();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.extend_selection(cell(1, 0), CellSide::Left);
+        assert_eq!(vt.selection_text().as_deref(), Some("ab\ncd"));
+    }
+
+    /// Asserts that a Lines selection copies whole rows regardless of the
+    /// columns the drag touched.
+    ///
+    /// Case: the user triple-clicks a line and drags into the next.
+    #[test]
+    fn a_lines_selection_reads_whole_rows() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 2), CellSide::Left, SelectionKind::Lines);
+        vt.extend_selection(cell(1, 1), CellSide::Left);
+        assert_eq!(vt.selection_text().as_deref(), Some("abcd\nefgh"));
+    }
+
+    /// Asserts that a selection whose two ends sit on the same boundary
+    /// yields no text, matching the frame that paints nothing.
+    ///
+    /// Case: the user presses the mouse button and releases it without
+    /// crossing a cell.
+    #[test]
+    fn an_empty_simple_selection_yields_no_text() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 1), CellSide::Left, SelectionKind::Simple);
+        assert_eq!(vt.selection_text(), None);
+    }
+
+    /// Asserts that a selection whose row has been recycled out of the ring
+    /// yields no text rather than the row now in its place.
+    ///
+    /// Case: on a terminal with no scrollback the user selects the top row
+    /// and the shell scrolls it away before the copy.
+    #[test]
+    fn a_selection_whose_line_left_the_ring_yields_no_text() {
+        let mut vt = OrzmaVt::new(GridSize { cols: 4, rows: 3 }, 0);
+        vt.interpret(b"abcd\r\nefgh\r\nijkl");
+        vt.frame();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\r\n");
+        assert_eq!(vt.selection_text(), None);
+    }
+
+    /// Asserts that the copied text is the row the user selected, not the
+    /// row that has since scrolled into its screen position.
+    ///
+    /// Case: the user selects a line and the shell prints two more before
+    /// the copy shortcut lands.
+    #[test]
+    fn the_text_follows_the_rows_after_a_scroll() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\r\n\r\n");
+        assert_eq!(vt.selection_text().as_deref(), Some("abcd"));
+    }
+
+    /// Asserts that a primary-screen selection yields no text while the
+    /// alternate screen is shown and its text again once it is back.
+    ///
+    /// Case: the user selects a shell line, opens a pager, presses copy
+    /// inside it, quits, and presses copy again.
+    #[test]
+    fn a_hidden_primary_selection_yields_no_text() {
+        let mut vt = filled();
+        vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
+        vt.interpret(b"\x1b[?1049h");
+        assert_eq!(vt.selection_text(), None);
+        vt.interpret(b"\x1b[?1049l");
+        assert_eq!(vt.selection_text().as_deref(), Some("abcd"));
     }
 }

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -447,6 +447,14 @@ mod tests {
         vt.device.active_screen().selection_range()
     }
 
+    /// Asserts that the next frame repaints no rows and carries
+    /// `selection`, which is what an idle selection change owes.
+    fn assert_rowless_frame(vt: &mut OrzmaVt, selection: Option<SelectionRange>) {
+        let frame = vt.frame().expect("an idle selection change emits");
+        assert!(frame.rows.is_empty());
+        assert_eq!(frame.selection, selection);
+    }
+
     fn range(start: (i32, u16), end: (i32, u16), geometry: SelectionGeometry) -> SelectionRange {
         SelectionRange {
             start: cell(start.0, start.1),
@@ -567,9 +575,7 @@ mod tests {
         vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines);
         vt.frame();
         assert!(vt.clear_selection());
-        let frame = vt.frame().expect("an idle clear emits");
-        assert!(frame.rows.is_empty());
-        assert_eq!(frame.selection, None);
+        assert_rowless_frame(&mut vt, None);
     }
 
     /// Asserts that a second clear finds nothing to drop.
@@ -592,11 +598,9 @@ mod tests {
     fn an_idle_start_emits_a_rowless_frame_carrying_the_selection() {
         let mut vt = filled();
         assert!(vt.start_selection(cell(0, 0), CellSide::Left, SelectionKind::Lines));
-        let frame = vt.frame().expect("an idle start emits");
-        assert!(frame.rows.is_empty());
-        assert_eq!(
-            frame.selection,
-            Some(range((0, 0), (0, 3), SelectionGeometry::Lines))
+        assert_rowless_frame(
+            &mut vt,
+            Some(range((0, 0), (0, 3), SelectionGeometry::Lines)),
         );
     }
 
@@ -672,11 +676,9 @@ mod tests {
         vt.extend_selection(cell(0, 2), CellSide::Right);
         vt.frame();
         assert!(vt.extend_selection(cell(0, 3), CellSide::Right));
-        let frame = vt.frame().expect("an idle extend emits");
-        assert!(frame.rows.is_empty());
-        assert_eq!(
-            frame.selection,
-            Some(range((0, 0), (0, 3), SelectionGeometry::Linear))
+        assert_rowless_frame(
+            &mut vt,
+            Some(range((0, 0), (0, 3), SelectionGeometry::Linear)),
         );
     }
 

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -891,7 +891,9 @@ impl Screen {
     /// Reports [`DamageSpan::Full`], or nothing when the grid was
     /// already blank and carried no history; the cursor homes either
     /// way, because cursor motion reaches the renderer through the
-    /// per-chunk cursor diff rather than through damage.
+    /// per-chunk cursor diff rather than through damage. A selection the
+    /// reset drops also reports `Full`, so the frame that no longer
+    /// carries it is owed even on a blank grid.
     ///
     /// # Invariants
     ///
@@ -911,7 +913,8 @@ impl Screen {
     ///
     /// - `RIS` (`ESC c`) — its screen-scoped actions
     pub fn reset(&mut self) -> Option<DamageSpan> {
-        let dirty = !self.grid.is_blank();
+        let cleared = self.selection.clear();
+        let dirty = !self.grid.is_blank() || cleared;
         self.grid.reset();
         self.viewport = Viewport::default();
         self.scroll_region = ScrollRegion::new(self.grid.size().rows);

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -1130,6 +1130,16 @@ impl Screen {
         self.selection.start(end, kind)
     }
 
+    /// Moves the active selection's moving end to `cell`; returns
+    /// whether it moved. A no-op without an active selection or for a
+    /// cell outside the grid.
+    pub fn extend_selection(&mut self, cell: GridPoint, side: CellSide) -> bool {
+        let Some(end) = self.selection_end(cell, side) else {
+            return false;
+        };
+        self.selection.extend(end)
+    }
+
     /// Drops the active selection; returns whether there was one, even
     /// one whose rows have already left the ring.
     pub fn clear_selection(&mut self) -> bool {

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -53,7 +53,8 @@ use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};
 use crate::screen::margins::{Margins, OriginMode, ScrollRegion};
 use crate::screen::placements::ScreenPlacements;
 use crate::screen::selection::{
-    CellSide, Resolved, ScreenSelection, SelectionEnd, SelectionKind, SelectionRange,
+    CellSide, Resolved, ScreenSelection, SelectionEnd, SelectionGeometry, SelectionKind,
+    SelectionRange,
 };
 use crate::screen::state::ScreenState;
 use crate::screen::tabs::{CharacterTabEdit, TabStops};
@@ -1147,6 +1148,48 @@ impl Screen {
     /// one whose rows have already left the ring.
     pub fn clear_selection(&mut self) -> bool {
         self.selection.clear()
+    }
+
+    /// The text the active selection covers, row by row; `None` exactly
+    /// when [`Self::selection_range`] is `None`.
+    ///
+    /// Each row's span is the same one the range describes — a Linear
+    /// range takes the columns between its ends on the first and last
+    /// rows and whole rows between, a Lines range whole rows throughout —
+    /// with trailing blanks trimmed. Rows are joined by `\n` with none
+    /// after the last.
+    // TODO: Join soft-wrapped rows without a newline once `Row` records
+    // the wrap.
+    pub fn selection_text(&self) -> Option<String> {
+        let range = self.selection_range()?;
+        let last_column = self.grid.size().cols - 1;
+        let mut text = String::new();
+        for line in range.start.line.0..=range.end.line.0 {
+            let (first, last) = match range.geometry {
+                SelectionGeometry::Lines => (0, last_column),
+                SelectionGeometry::Linear | SelectionGeometry::Block => (
+                    if line == range.start.line.0 {
+                        range.start.column.0
+                    } else {
+                        0
+                    },
+                    if line == range.end.line.0 {
+                        range.end.column.0
+                    } else {
+                        last_column
+                    },
+                ),
+            };
+            let row = self.grid.row(GridLine(line));
+            let row_text: String = (first..=last)
+                .map(|column| row[GridColumn(column)].c)
+                .collect();
+            if line != range.start.line.0 {
+                text.push('\n');
+            }
+            text.push_str(row_text.trim_end());
+        }
+        Some(text)
     }
 
     /// The endpoint a host cell stands for; `None` when the cell is

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -1130,6 +1130,12 @@ impl Screen {
         self.selection.start(end, kind)
     }
 
+    /// Drops the active selection; returns whether there was one, even
+    /// one whose rows have already left the ring.
+    pub fn clear_selection(&mut self) -> bool {
+        self.selection.clear()
+    }
+
     /// The endpoint a host cell stands for; `None` when the cell is
     /// outside the ring or past the width.
     fn selection_end(&self, cell: GridPoint, side: CellSide) -> Option<SelectionEnd> {

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -52,6 +52,9 @@ use crate::screen::grid::GridSize;
 use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};
 use crate::screen::margins::{Margins, OriginMode, ScrollRegion};
 use crate::screen::placements::ScreenPlacements;
+use crate::screen::selection::{
+    CellSide, Resolved, ScreenSelection, SelectionEnd, SelectionKind, SelectionRange,
+};
 use crate::screen::state::ScreenState;
 use crate::screen::tabs::{CharacterTabEdit, TabStops};
 use crate::screen::viewport::{DisplayOffset, Scroll, Viewport, ViewportLine};
@@ -73,6 +76,7 @@ pub struct Screen {
     character_set_mapping: CharacterSetMapping,
     checkpoint: Checkpoint,
     placements: ScreenPlacements,
+    selection: ScreenSelection,
 }
 
 /// Span selector for [`Screen::erase_in_line`] (`CSI K`).
@@ -140,6 +144,7 @@ impl Screen {
             character_set_mapping: CharacterSetMapping::default(),
             checkpoint: Checkpoint::default(),
             placements: ScreenPlacements::new(),
+            selection: ScreenSelection::new(),
         }
     }
 }
@@ -785,6 +790,20 @@ impl Screen {
         }
     }
 
+    /// The selection as an emitted frame carries it: normalized,
+    /// cell-side trimmed, in active-grid coordinates; `None` when there
+    /// is no selection, its span is empty, or an endpoint's row has
+    /// left the ring.
+    pub fn selection_range(&self) -> Option<SelectionRange> {
+        match self
+            .selection
+            .resolve(|id| self.grid.grid_line(id), self.grid.size().cols)
+        {
+            Resolved::Range(range) => Some(range),
+            Resolved::None | Resolved::Empty => None,
+        }
+    }
+
     /// The id of the row the cursor sits on — the anchor a mount samples.
     pub fn cursor_line_id(&self) -> LineId {
         self.grid.line_id(self.state.line)
@@ -1087,6 +1106,38 @@ impl Screen {
     pub fn evict_lost_anchors(&mut self) -> Vec<InstanceId> {
         self.placements
             .evict_lost_anchors(|anchor| self.grid.grid_line(anchor))
+    }
+}
+
+/// The selection this screen owns.
+///
+/// The endpoints are resolved through the same expression
+/// [`Self::project_placements`] passes for anchors, so a selection can
+/// only ever be resolved against the grid that minted its rows.
+impl Screen {
+    /// Anchors a new selection at `cell`, replacing any active one;
+    /// returns whether the state changed. A cell outside the grid is
+    /// rejected and leaves the current selection untouched.
+    pub fn start_selection(
+        &mut self,
+        cell: GridPoint,
+        side: CellSide,
+        kind: SelectionKind,
+    ) -> bool {
+        let Some(end) = self.selection_end(cell, side) else {
+            return false;
+        };
+        self.selection.start(end, kind)
+    }
+
+    /// The endpoint a host cell stands for; `None` when the cell is
+    /// outside the ring or past the width.
+    fn selection_end(&self, cell: GridPoint, side: CellSide) -> Option<SelectionEnd> {
+        if cell.column.0 >= self.grid.size().cols {
+            return None;
+        }
+        let line = self.grid.line_id_at(cell.line)?;
+        Some(SelectionEnd::at(line, cell.column, side))
     }
 }
 

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -53,8 +53,7 @@ use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};
 use crate::screen::margins::{Margins, OriginMode, ScrollRegion};
 use crate::screen::placements::ScreenPlacements;
 use crate::screen::selection::{
-    CellSide, Resolved, ScreenSelection, SelectionEnd, SelectionGeometry, SelectionKind,
-    SelectionRange,
+    CellSide, Resolved, ScreenSelection, SelectionEnd, SelectionKind, SelectionRange,
 };
 use crate::screen::state::ScreenState;
 use crate::screen::tabs::{CharacterTabEdit, TabStops};
@@ -1153,7 +1152,7 @@ impl Screen {
     /// The text the active selection covers, row by row; `None` exactly
     /// when [`Self::selection_range`] is `None`.
     ///
-    /// Each row's span comes from [`Self::selection_span_on`], with
+    /// Each row's span comes from [`SelectionRange::span_on`], with
     /// trailing blanks trimmed. Rows are joined by `\n` with none after
     /// the last.
     // TODO: Join soft-wrapped rows without a newline once `Row` records
@@ -1163,7 +1162,7 @@ impl Screen {
         let last_column = self.grid.size().cols - 1;
         let mut text = String::new();
         for line in range.start.line.0..=range.end.line.0 {
-            let (first, last) = Self::selection_span_on(&range, line, last_column);
+            let (first, last) = range.span_on(line, last_column);
             let row = self.grid.row(GridLine(line));
             let row_text: String = (first..=last)
                 .map(|column| row[GridColumn(column)].c)
@@ -1179,32 +1178,8 @@ impl Screen {
     /// The endpoint a host cell stands for; `None` when the cell is
     /// outside the ring or past the width.
     fn selection_end(&self, cell: GridPoint, side: CellSide) -> Option<SelectionEnd> {
-        if cell.column.0 >= self.grid.size().cols {
-            return None;
-        }
-        let line = self.grid.line_id_at(cell.line)?;
+        let line = self.grid.line_id_at_point(cell)?;
         Some(SelectionEnd::at(line, cell.column, side))
-    }
-
-    /// The inclusive column span the selection covers on `line`: the
-    /// same expression the renderer's shader evaluates, so the copied
-    /// text and the painted highlight always agree.
-    fn selection_span_on(range: &SelectionRange, line: i32, last_column: u16) -> (u16, u16) {
-        match range.geometry {
-            SelectionGeometry::Lines => (0, last_column),
-            SelectionGeometry::Linear | SelectionGeometry::Block => (
-                if line == range.start.line.0 {
-                    range.start.column.0
-                } else {
-                    0
-                },
-                if line == range.end.line.0 {
-                    range.end.column.0
-                } else {
-                    last_column
-                },
-            ),
-        }
     }
 }
 

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -1153,11 +1153,9 @@ impl Screen {
     /// The text the active selection covers, row by row; `None` exactly
     /// when [`Self::selection_range`] is `None`.
     ///
-    /// Each row's span is the same one the range describes — a Linear
-    /// range takes the columns between its ends on the first and last
-    /// rows and whole rows between, a Lines range whole rows throughout —
-    /// with trailing blanks trimmed. Rows are joined by `\n` with none
-    /// after the last.
+    /// Each row's span comes from [`Self::selection_span_on`], with
+    /// trailing blanks trimmed. Rows are joined by `\n` with none after
+    /// the last.
     // TODO: Join soft-wrapped rows without a newline once `Row` records
     // the wrap.
     pub fn selection_text(&self) -> Option<String> {
@@ -1165,21 +1163,7 @@ impl Screen {
         let last_column = self.grid.size().cols - 1;
         let mut text = String::new();
         for line in range.start.line.0..=range.end.line.0 {
-            let (first, last) = match range.geometry {
-                SelectionGeometry::Lines => (0, last_column),
-                SelectionGeometry::Linear | SelectionGeometry::Block => (
-                    if line == range.start.line.0 {
-                        range.start.column.0
-                    } else {
-                        0
-                    },
-                    if line == range.end.line.0 {
-                        range.end.column.0
-                    } else {
-                        last_column
-                    },
-                ),
-            };
+            let (first, last) = Self::selection_span_on(&range, line, last_column);
             let row = self.grid.row(GridLine(line));
             let row_text: String = (first..=last)
                 .map(|column| row[GridColumn(column)].c)
@@ -1200,6 +1184,27 @@ impl Screen {
         }
         let line = self.grid.line_id_at(cell.line)?;
         Some(SelectionEnd::at(line, cell.column, side))
+    }
+
+    /// The inclusive column span the selection covers on `line`: the
+    /// same expression the renderer's shader evaluates, so the copied
+    /// text and the painted highlight always agree.
+    fn selection_span_on(range: &SelectionRange, line: i32, last_column: u16) -> (u16, u16) {
+        match range.geometry {
+            SelectionGeometry::Lines => (0, last_column),
+            SelectionGeometry::Linear | SelectionGeometry::Block => (
+                if line == range.start.line.0 {
+                    range.start.column.0
+                } else {
+                    0
+                },
+                if line == range.end.line.0 {
+                    range.end.column.0
+                } else {
+                    last_column
+                },
+            ),
+        }
     }
 }
 

--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -7,7 +7,7 @@ pub(crate) mod coords;
 mod history_index;
 
 use crate::screen::cell::Cell;
-use crate::screen::grid::coords::{GridLine, ScreenLine};
+use crate::screen::grid::coords::{GridLine, GridPoint, ScreenLine};
 use crate::screen::grid::history_index::HistoryIndex;
 use crate::screen::grid::row::Row;
 use std::collections::VecDeque;
@@ -219,6 +219,15 @@ impl Grid {
     /// is outside the ring.
     pub fn line_id_at(&self, line: GridLine) -> Option<LineId> {
         self.ring_index(line).map(|index| self.rows[index].id)
+    }
+
+    /// The id of the row a cell sits on; `None` when the cell's line is
+    /// outside the ring or its column is past the width.
+    pub fn line_id_at_point(&self, point: GridPoint) -> Option<LineId> {
+        if point.column.0 >= self.size.cols {
+            return None;
+        }
+        self.line_id_at(point.line)
     }
 
     /// The active-grid line the row `id` now sits at; `None` once it has

--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -215,6 +215,12 @@ impl Grid {
         self.rows[self.visible_index(line.0)].id
     }
 
+    /// The id of the row at an active-grid line; `None` when the line
+    /// is outside the ring.
+    pub fn line_id_at(&self, line: GridLine) -> Option<LineId> {
+        self.ring_index(line).map(|index| self.rows[index].id)
+    }
+
     /// The active-grid line the row `id` now sits at; `None` once it has
     /// left the ring.
     ///
@@ -244,8 +250,9 @@ impl Grid {
     /// and `line < rows`. [`crate::screen::Screen`] guarantees that by
     /// clamping the viewport to the history it actually has.
     pub fn row(&self, line: GridLine) -> &Row<Cell> {
-        let index = i64::from(self.history_len() as u32) + i64::from(line.0);
-        let index = usize::try_from(index).expect("the line resolves inside the ring");
+        let index = self
+            .ring_index(line)
+            .expect("the line resolves inside the ring");
         &self.rows[index].cells
     }
 
@@ -342,6 +349,13 @@ impl Grid {
         self.history_len() + usize::from(line)
     }
 
+    /// The ring index of an active-grid line; `None` outside the ring.
+    fn ring_index(&self, line: GridLine) -> Option<usize> {
+        let index = i64::from(self.history_len() as u32) + i64::from(line.0);
+        let index = usize::try_from(index).ok()?;
+        (index < self.rows.len()).then_some(index)
+    }
+
     /// Checks that the history index names exactly the history rows, each
     /// at its ring index, and no visible row.
     #[cfg(test)]
@@ -381,11 +395,45 @@ mod tests {
         Grid::new(GridSize { cols: 4, rows }, max_history)
     }
 
+    fn grid_with_history(history_rows: usize) -> Grid {
+        let mut grid = Grid::new(GridSize { cols: 4, rows: 3 }, 10);
+        for _ in 0..history_rows {
+            grid.scroll_up_one(ScreenLine(0), ScreenLine(2), Cell::default());
+        }
+        grid
+    }
+
     /// Scrolls with the margins a screen carries before any `DECSTBM`,
     /// which is the region every history assertion below is about.
     fn scroll_up_whole_screen(grid: &mut Grid, fill: Cell) {
         let bottom = ScreenLine(grid.size().rows - 1);
         grid.scroll_up_one(ScreenLine(0), bottom, fill);
+    }
+
+    /// Asserts that a screen line and a history line both resolve to the
+    /// id `grid_line` maps back to the same line.
+    ///
+    /// Case: the host names a cell by its active-grid line and the VT
+    /// needs the row identity behind it, on the live screen and in
+    /// scrollback alike.
+    #[test]
+    fn line_id_at_round_trips_through_grid_line() {
+        let grid = grid_with_history(2);
+        for line in [-2, -1, 0, 2] {
+            let id = grid.line_id_at(GridLine(line)).expect("inside the ring");
+            assert_eq!(grid.grid_line(id), Some(GridLine(line)));
+        }
+    }
+
+    /// Asserts that a line above the retained history or below the
+    /// screen resolves to `None`.
+    ///
+    /// Case: a request names a row the terminal has since trimmed.
+    #[test]
+    fn line_id_at_rejects_lines_outside_the_ring() {
+        let grid = grid_with_history(2);
+        assert_eq!(grid.line_id_at(GridLine(-3)), None);
+        assert_eq!(grid.line_id_at(GridLine(3)), None);
     }
 
     /// Asserts that a resize to the size the grid already has reports

--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -410,8 +410,8 @@ mod tests {
         grid.scroll_up_one(ScreenLine(0), bottom, fill);
     }
 
-    /// Asserts that a screen line and a history line both resolve to the
-    /// id `grid_line` maps back to the same line.
+    /// Asserts that a screen line and a history line both resolve to an
+    /// id that `grid_line` maps back to the same line.
     ///
     /// Case: the host names a cell by its active-grid line and the VT
     /// needs the row identity behind it, on the live screen and in

--- a/crates/orzma_vt/src/screen/selection.rs
+++ b/crates/orzma_vt/src/screen/selection.rs
@@ -1,7 +1,9 @@
-//! Selection vocabulary: the span a selection covers, how it is shaped,
-//! and which side of a cell an endpoint sits on.
+//! Selection vocabulary — the span a selection covers, how it is shaped,
+//! and which side of a cell an endpoint sits on — plus the selection one
+//! screen owns and its projection into that vocabulary.
 
-use crate::screen::grid::coords::GridPoint;
+use crate::screen::grid::LineId;
+use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint};
 
 /// A renderable selection: normalized active-grid endpoints plus the
 /// shape they span.
@@ -69,4 +71,384 @@ pub enum CellSide {
     Left,
     /// Right half.
     Right,
+}
+
+/// The selection one screen owns: two endpoints on that screen's rows
+/// plus the granularity between them.
+///
+/// Endpoints are stored as a row identity and a cell boundary, so the
+/// selection follows its rows when output scrolls them into history and
+/// does not depend on the projection the frame carries.
+#[derive(Debug)]
+pub(crate) struct ScreenSelection {
+    state: Option<SelectionState>,
+}
+
+/// One endpoint of a screen selection.
+///
+/// `boundary` is a cell boundary in `0..=cols`: the left side of column
+/// `c` is boundary `c`, its right side is `c + 1`, so `cols` is the
+/// right edge of the row. Two `(column, side)` pairs that name the same
+/// boundary compare equal here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SelectionEnd {
+    pub line: LineId,
+    pub boundary: u16,
+}
+
+/// What a selection resolves to at one instant.
+///
+/// `None` and `Empty` both project nothing; they differ in whether any
+/// state exists, which `clear` reports and the projection does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Resolved {
+    /// No selection, or an endpoint whose row has left the ring.
+    None,
+    /// A selection whose two ends enclose no cell.
+    Empty,
+    /// The cells the selection covers, normalized for the frame.
+    Range(SelectionRange),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SelectionState {
+    anchor: SelectionEnd,
+    moving: SelectionEnd,
+    kind: SelectionKind,
+}
+
+impl SelectionEnd {
+    /// The boundary a host-reported cell half stands for.
+    pub fn at(line: LineId, column: GridColumn, side: CellSide) -> Self {
+        let boundary = match side {
+            CellSide::Left => column.0,
+            CellSide::Right => column.0 + 1,
+        };
+        Self { line, boundary }
+    }
+}
+
+impl ScreenSelection {
+    /// Builds a screen with nothing selected.
+    pub fn new() -> Self {
+        Self { state: None }
+    }
+
+    /// Anchors a new selection with both ends on `end`, replacing any
+    /// active one; returns whether the state changed.
+    pub fn start(&mut self, end: SelectionEnd, kind: SelectionKind) -> bool {
+        let next = SelectionState {
+            anchor: end,
+            moving: end,
+            kind,
+        };
+        if self.state == Some(next) {
+            return false;
+        }
+        self.state = Some(next);
+        true
+    }
+
+    /// Moves the active selection's moving end; returns whether it
+    /// moved. A no-op without an active selection.
+    pub fn extend(&mut self, end: SelectionEnd) -> bool {
+        let Some(state) = &mut self.state else {
+            return false;
+        };
+        if state.moving == end {
+            return false;
+        }
+        state.moving = end;
+        true
+    }
+
+    /// Drops the selection; returns whether there was one.
+    pub fn clear(&mut self) -> bool {
+        self.state.take().is_some()
+    }
+
+    /// Resolves the endpoints through `line_of` into the range a frame
+    /// carries.
+    ///
+    /// Boundaries past `cols` are clamped to it. A Simple selection is
+    /// normalized by `(line, boundary)`, then each boundary becomes an
+    /// inclusive cell: a start on a row's right edge moves to the next
+    /// row's first cell and an end on a row's left edge moves to the
+    /// previous row's last cell; ends that cross after that enclose no
+    /// cell. A Lines selection spans whole rows between the two
+    /// endpoints' rows and never wraps.
+    ///
+    /// # Invariants
+    ///
+    /// Endpoints are ordered only after resolving to [`GridLine`];
+    /// nothing orders the ring by [`LineId`].
+    pub fn resolve(
+        &self,
+        mut line_of: impl FnMut(LineId) -> Option<GridLine>,
+        cols: u16,
+    ) -> Resolved {
+        debug_assert!(cols > 0, "a screen never has zero columns");
+        let Some(state) = self.state else {
+            return Resolved::None;
+        };
+        let (Some(anchor_line), Some(moving_line)) =
+            (line_of(state.anchor.line), line_of(state.moving.line))
+        else {
+            return Resolved::None;
+        };
+        let anchor = (anchor_line.0, state.anchor.boundary.min(cols));
+        let moving = (moving_line.0, state.moving.boundary.min(cols));
+        let (start, end) = if anchor <= moving {
+            (anchor, moving)
+        } else {
+            (moving, anchor)
+        };
+        let last_column = cols - 1;
+        let (start, end) = match state.kind {
+            SelectionKind::Lines => ((start.0, 0), (end.0, last_column)),
+            SelectionKind::Simple => {
+                if start == end {
+                    return Resolved::Empty;
+                }
+                let start = if start.1 == cols {
+                    (start.0 + 1, 0)
+                } else {
+                    start
+                };
+                let end = if end.1 == 0 {
+                    (end.0 - 1, last_column)
+                } else {
+                    (end.0, end.1 - 1)
+                };
+                if start > end {
+                    return Resolved::Empty;
+                }
+                (start, end)
+            }
+        };
+        Resolved::Range(SelectionRange {
+            start: GridPoint {
+                line: GridLine(start.0),
+                column: GridColumn(start.1),
+            },
+            end: GridPoint {
+                line: GridLine(end.0),
+                column: GridColumn(end.1),
+            },
+            geometry: SelectionGeometry::from(state.kind),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::screen::grid::coords::ScreenLine;
+    use crate::screen::grid::{Grid, GridSize, LineId};
+
+    const COLS: u16 = 4;
+
+    fn grid() -> Grid {
+        Grid::new(
+            GridSize {
+                cols: COLS,
+                rows: 3,
+            },
+            10,
+        )
+    }
+
+    fn id(grid: &Grid, line: u16) -> LineId {
+        grid.line_id(ScreenLine(line))
+    }
+
+    fn end(grid: &Grid, line: u16, column: u16, side: CellSide) -> SelectionEnd {
+        SelectionEnd::at(id(grid, line), GridColumn(column), side)
+    }
+
+    fn point(line: i32, column: u16) -> GridPoint {
+        GridPoint {
+            line: GridLine(line),
+            column: GridColumn(column),
+        }
+    }
+
+    fn resolve(selection: &ScreenSelection, grid: &Grid) -> Resolved {
+        selection.resolve(|id| grid.grid_line(id), COLS)
+    }
+
+    fn range_of(resolved: Resolved) -> SelectionRange {
+        match resolved {
+            Resolved::Range(range) => range,
+            other => panic!("expected a range, got {other:?}"),
+        }
+    }
+
+    /// Asserts that a cell's left side maps to the boundary before it
+    /// and its right side to the boundary after it.
+    ///
+    /// Case: the host reports the half of the cell the pointer landed
+    /// on, and the VT needs the cell boundary that half stands for.
+    #[test]
+    fn a_side_converts_to_the_adjacent_boundary() {
+        let grid = grid();
+        assert_eq!(end(&grid, 0, 1, CellSide::Left).boundary, 1);
+        assert_eq!(end(&grid, 0, 1, CellSide::Right).boundary, 2);
+    }
+
+    /// Asserts that an empty table resolves to `Resolved::None`.
+    ///
+    /// Case: a frame is emitted on a terminal nothing has been selected
+    /// on.
+    #[test]
+    fn no_state_resolves_to_none() {
+        let grid = grid();
+        let selection = ScreenSelection::new();
+        assert!(matches!(resolve(&selection, &grid), Resolved::None));
+    }
+
+    /// Asserts that a Simple selection whose two ends share a boundary
+    /// resolves to `Resolved::Empty`, and that a start which changes
+    /// nothing reports `false`.
+    ///
+    /// Case: the user presses the mouse button and has not moved yet,
+    /// then the host re-sends the same press.
+    #[test]
+    fn a_simple_start_alone_is_empty_and_idempotent() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        let anchor = end(&grid, 0, 1, CellSide::Left);
+        assert!(selection.start(anchor, SelectionKind::Simple));
+        assert!(matches!(resolve(&selection, &grid), Resolved::Empty));
+        assert!(!selection.start(anchor, SelectionKind::Simple));
+    }
+
+    /// Asserts that a forward extend on one row resolves to the cells
+    /// between the two boundaries, inclusive of the cell before the end
+    /// boundary.
+    ///
+    /// Case: the user drags from the first cell across two more.
+    #[test]
+    fn a_forward_extend_resolves_to_the_span() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 0, CellSide::Left), SelectionKind::Simple);
+        assert!(selection.extend(end(&grid, 0, 2, CellSide::Right)));
+        let range = range_of(resolve(&selection, &grid));
+        assert_eq!(range.start, point(0, 0));
+        assert_eq!(range.end, point(0, 2));
+        assert_eq!(range.geometry, SelectionGeometry::Linear);
+    }
+
+    /// Asserts that an extend to the boundary the moving end already
+    /// occupies reports no change, even via a different cell and side.
+    ///
+    /// Case: the pointer crosses from the right half of one cell into
+    /// the left half of the next.
+    #[test]
+    fn an_extend_to_the_same_boundary_reports_no_change() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 1, CellSide::Right), SelectionKind::Simple);
+        assert!(!selection.extend(end(&grid, 0, 2, CellSide::Left)));
+    }
+
+    /// Asserts that a moving end above and left of the anchor is
+    /// normalized so the range reads top-left to bottom-right.
+    ///
+    /// Case: the user drags upward from the middle of the second row.
+    #[test]
+    fn a_backward_drag_is_normalized() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 1, 2, CellSide::Left), SelectionKind::Simple);
+        selection.extend(end(&grid, 0, 1, CellSide::Left));
+        let range = range_of(resolve(&selection, &grid));
+        assert_eq!(range.start, point(0, 1));
+        assert_eq!(range.end, point(1, 1));
+    }
+
+    /// Asserts that a start boundary on the right edge of a row begins
+    /// the range on the first cell of the next row, and an end boundary
+    /// on the left edge of a row ends it on the last cell of the row
+    /// above.
+    ///
+    /// Case: drags that begin on the right half of the last column or
+    /// land on the left half of the first column.
+    #[test]
+    fn edge_boundaries_wrap_to_the_adjacent_row() {
+        let grid = grid();
+        let mut from_right_edge = ScreenSelection::new();
+        from_right_edge.start(end(&grid, 0, 3, CellSide::Right), SelectionKind::Simple);
+        from_right_edge.extend(end(&grid, 1, 1, CellSide::Right));
+        let range = range_of(resolve(&from_right_edge, &grid));
+        assert_eq!((range.start, range.end), (point(1, 0), point(1, 1)));
+
+        let mut to_left_edge = ScreenSelection::new();
+        to_left_edge.start(end(&grid, 0, 1, CellSide::Left), SelectionKind::Simple);
+        to_left_edge.extend(end(&grid, 1, 0, CellSide::Left));
+        let range = range_of(resolve(&to_left_edge, &grid));
+        assert_eq!((range.start, range.end), (point(0, 1), point(0, 3)));
+    }
+
+    /// Asserts that a range whose wrapped ends cross resolves to
+    /// `Resolved::Empty`.
+    ///
+    /// Case: the user presses on the right half of the last column and
+    /// releases on the left half of the first column of the next row.
+    #[test]
+    fn a_wrap_that_crosses_itself_is_empty() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 3, CellSide::Right), SelectionKind::Simple);
+        selection.extend(end(&grid, 1, 0, CellSide::Left));
+        assert!(matches!(resolve(&selection, &grid), Resolved::Empty));
+    }
+
+    /// Asserts that a Lines selection spans whole rows from the
+    /// anchor's row to the moving end's row without any boundary wrap,
+    /// so an anchor on a row's right edge still selects that row.
+    ///
+    /// Case: the user triple-clicks the right half of a row's last
+    /// column and drags one row down.
+    #[test]
+    fn lines_take_whole_rows_without_wrapping() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 3, CellSide::Right), SelectionKind::Lines);
+        selection.extend(end(&grid, 1, 1, CellSide::Left));
+        let range = range_of(resolve(&selection, &grid));
+        assert_eq!((range.start, range.end), (point(0, 0), point(1, 3)));
+        assert_eq!(range.geometry, SelectionGeometry::Lines);
+    }
+
+    /// Asserts that an end whose row the resolver cannot place makes
+    /// the whole selection resolve to `Resolved::None`, while the state
+    /// still counts as present for `clear`.
+    ///
+    /// Case: output scrolled the anchor's row out of the ring before the
+    /// next frame.
+    #[test]
+    fn a_lost_row_resolves_to_none_but_keeps_the_state() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 0, CellSide::Left), SelectionKind::Lines);
+        assert!(matches!(selection.resolve(|_| None, COLS), Resolved::None));
+        assert!(selection.clear());
+        assert!(!selection.clear());
+    }
+
+    /// Asserts that a boundary past the width is clamped to the width
+    /// at resolution time.
+    ///
+    /// Case: the grid shrank after the selection was made.
+    #[test]
+    fn a_boundary_past_the_width_is_clamped() {
+        let grid = grid();
+        let mut selection = ScreenSelection::new();
+        selection.start(end(&grid, 0, 0, CellSide::Left), SelectionKind::Simple);
+        selection.extend(end(&grid, 0, 3, CellSide::Right));
+        let range = range_of(selection.resolve(|id| grid.grid_line(id), 2));
+        assert_eq!((range.start, range.end), (point(0, 0), point(0, 1)));
+    }
 }

--- a/crates/orzma_vt/src/screen/selection.rs
+++ b/crates/orzma_vt/src/screen/selection.rs
@@ -51,7 +51,7 @@ impl From<SelectionKind> for SelectionGeometry {
 
 /// Selection granularity.
 // TODO: Add the `Block` (rectangular column) and `Semantic` (snapped to
-// word boundaries) kinds once the selection capability trait lands.
+// word boundaries) kinds once vi mode and semantic selection land.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectionKind {
     /// Cell-by-cell, wrapping at the end of each line.

--- a/crates/orzma_vt/src/screen/selection.rs
+++ b/crates/orzma_vt/src/screen/selection.rs
@@ -98,8 +98,9 @@ pub(crate) struct SelectionEnd {
 
 /// What a selection resolves to at one instant.
 ///
-/// `None` and `Empty` both project nothing; they differ in whether any
-/// state exists, which `clear` reports and the projection does not.
+/// `None` and `Empty` both project nothing; `Empty` records that a
+/// selection exists whose ends enclose no cell, so a caller can tell an
+/// empty selection from no selection at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Resolved {
     /// No selection, or an endpoint whose row has left the ring.

--- a/crates/orzma_vt/src/screen/selection.rs
+++ b/crates/orzma_vt/src/screen/selection.rs
@@ -24,6 +24,29 @@ pub struct SelectionRange {
     pub geometry: SelectionGeometry,
 }
 
+impl SelectionRange {
+    /// The inclusive column span the selection covers on `line`: the
+    /// same expression the renderer's shader evaluates, so the copied
+    /// text and the painted highlight always agree.
+    pub(crate) fn span_on(&self, line: i32, last_column: u16) -> (u16, u16) {
+        match self.geometry {
+            SelectionGeometry::Lines => (0, last_column),
+            SelectionGeometry::Linear | SelectionGeometry::Block => (
+                if line == self.start.line.0 {
+                    self.start.column.0
+                } else {
+                    0
+                },
+                if line == self.end.line.0 {
+                    self.end.column.0
+                } else {
+                    last_column
+                },
+            ),
+        }
+    }
+}
+
 /// The shape a [`SelectionRange`] spans between its endpoints.
 ///
 /// Wider than [`SelectionKind`]: the two current selection kinds only
@@ -175,9 +198,9 @@ impl ScreenSelection {
     /// normalized by `(line, boundary)`, then each boundary becomes an
     /// inclusive cell: a start on a row's right edge moves to the next
     /// row's first cell and an end on a row's left edge moves to the
-    /// previous row's last cell; ends that cross after that enclose no
-    /// cell. A Lines selection spans whole rows between the two
-    /// endpoints' rows and never wraps.
+    /// previous row's last cell; ends that coincide or cross after that
+    /// enclose no cell. A Lines selection spans whole rows between the
+    /// two endpoints' rows and never wraps.
     ///
     /// # Invariants
     ///
@@ -208,9 +231,6 @@ impl ScreenSelection {
         let (start, end) = match state.kind {
             SelectionKind::Lines => ((start.0, 0), (end.0, last_column)),
             SelectionKind::Simple => {
-                if start == end {
-                    return Resolved::Empty;
-                }
                 let start = if start.1 == cols {
                     (start.0 + 1, 0)
                 } else {

--- a/src/action/terminal.rs
+++ b/src/action/terminal.rs
@@ -14,7 +14,7 @@ use bevy::prelude::*;
 pub(crate) use open_uri::TerminalOpenUri;
 pub(crate) use selection::{
     TerminalSelectionClear, TerminalSelectionCopy, TerminalSelectionStart, TerminalSelectionUpdate,
-    trigger_selection_copy,
+    copy_selection_of, trigger_selection_copy,
 };
 pub(crate) use viewport_scroll::TerminalViewportScroll;
 

--- a/src/action/terminal.rs
+++ b/src/action/terminal.rs
@@ -12,6 +12,8 @@ use crate::action::terminal::{
 use bevy::prelude::*;
 
 pub(crate) use open_uri::TerminalOpenUri;
+#[cfg(test)]
+pub(crate) use selection::test_support;
 pub(crate) use selection::{
     TerminalSelectionClear, TerminalSelectionCopy, TerminalSelectionStart, TerminalSelectionUpdate,
     copy_selection_of, trigger_selection_copy,

--- a/src/action/terminal/selection.rs
+++ b/src/action/terminal/selection.rs
@@ -1,13 +1,15 @@
 //! Local-selection actions: start / update / clear a selection on a terminal
 //! surface, and copy the current selection to the clipboard.
 
+use crate::action::clipboard::CopyAction;
+use crate::surface::OrzmaTerminal;
 use bevy::prelude::*;
 use bevy_orzma_tty::prelude::{
-    CellSide, GridPoint, RequestTtySelectionClear, RequestTtySelectionStart,
+    CellSide, GridPoint, OrzmaTtyHandle, RequestTtySelectionClear, RequestTtySelectionStart,
     RequestTtySelectionUpdate, SelectionKind,
 };
 use orzma_tty_renderer::schema::TerminalGrid;
-use orzma_vt::prelude::{DisplayOffset, ViewportLine};
+use orzma_vt::prelude::{DisplayOffset, ViewportLine, Vt};
 
 /// Starts a new local selection on `entity` at `point`.
 #[derive(EntityEvent, Debug, Clone)]
@@ -58,6 +60,18 @@ pub(crate) struct TerminalSelectionCopy {
 pub(crate) fn trigger_selection_copy(commands: &mut Commands, focused: Option<Entity>) {
     if let Some(entity) = focused {
         commands.trigger(TerminalSelectionCopy { entity });
+    }
+}
+
+/// Triggers a `CopyAction` carrying `handle`'s selected text, or nothing
+/// when there is no selection or the selection covers only blanks, so the
+/// clipboard is never overwritten with an empty string. Shared by the
+/// mouse copy and the vi yank.
+pub(crate) fn copy_selection_of(commands: &mut Commands, handle: &OrzmaTtyHandle) {
+    if let Some(text) = handle.vt().selection_text()
+        && !text.is_empty()
+    {
+        commands.trigger(CopyAction { text });
     }
 }
 
@@ -119,11 +133,17 @@ fn on_terminal_selection_clear(ev: On<TerminalSelectionClear>, mut commands: Com
 }
 
 /// Applies a `TerminalSelectionCopy`: writes the selection text (if any) to
-/// the clipboard.
-// TODO: `bevy_orzma_tty` exposes no selection-reading capability yet
-// (docs/todo/migrate-to-new-vt.md item 11), so a copy request currently
-// finds nothing to copy.
-fn on_terminal_selection_copy(_ev: On<TerminalSelectionCopy>) {}
+/// the clipboard. Needs only read access to the handle.
+fn on_terminal_selection_copy(
+    ev: On<TerminalSelectionCopy>,
+    mut commands: Commands,
+    terminals: Query<&OrzmaTtyHandle, With<OrzmaTerminal>>,
+) {
+    let Ok(handle) = terminals.get(ev.entity) else {
+        return;
+    };
+    copy_selection_of(&mut commands, handle);
+}
 
 /// Converts a viewport-relative point (`mouse.rs`'s contract: line `0` is
 /// the top of the displayed viewport) into the active-grid coordinates
@@ -142,6 +162,9 @@ fn to_grid_point(viewport_point: GridPoint, offset: DisplayOffset) -> GridPoint 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
+    use crate::surface::OrzmaTerminal;
+    use bevy_orzma_tty::prelude::OrzmaTtyHandle;
     use orzma_vt::prelude::{GridColumn, GridLine};
 
     #[derive(Resource, Default)]
@@ -291,5 +314,75 @@ mod tests {
         app.update();
 
         assert_eq!(app.world().resource::<SeenClears>().0, vec![entity]);
+    }
+
+    fn app_capturing_copies() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_observer(on_terminal_selection_copy);
+        capture_copy_actions(&mut app);
+        app
+    }
+
+    /// Spawns a terminal showing `rows`, with row 0 selected as Lines when
+    /// `select` is set.
+    fn spawn_terminal(app: &mut App, rows: &[u8], select: bool) -> Entity {
+        let (mut handle, _sink) = OrzmaTtyHandle::detached(4, 3);
+        handle.feed_bytes(rows);
+        if select {
+            handle.start_selection(
+                GridPoint {
+                    line: GridLine(0),
+                    column: GridColumn(0),
+                },
+                CellSide::Left,
+                SelectionKind::Lines,
+            );
+        }
+        app.world_mut().spawn((handle, OrzmaTerminal)).id()
+    }
+
+    fn captured(app: &App) -> &[String] {
+        &app.world().resource::<CapturedCopyActions>().0
+    }
+
+    /// Asserts that a copy request writes the terminal's selected text
+    /// through `CopyAction`.
+    ///
+    /// Case: the user selects a row and presses the copy shortcut.
+    #[test]
+    fn selection_copy_writes_the_selected_text() {
+        let mut app = app_capturing_copies();
+        let entity = spawn_terminal(&mut app, b"abcd\r\nefgh\r\nijkl", true);
+        app.world_mut().trigger(TerminalSelectionCopy { entity });
+        app.update();
+        assert_eq!(captured(&app), ["abcd".to_string()]);
+    }
+
+    /// Asserts that a copy request with no selection triggers nothing, so
+    /// the clipboard keeps its previous contents.
+    ///
+    /// Case: the user presses the copy shortcut without selecting.
+    #[test]
+    fn selection_copy_without_a_selection_triggers_nothing() {
+        let mut app = app_capturing_copies();
+        let entity = spawn_terminal(&mut app, b"abcd\r\nefgh\r\nijkl", false);
+        app.world_mut().trigger(TerminalSelectionCopy { entity });
+        app.update();
+        assert!(captured(&app).is_empty());
+    }
+
+    /// Asserts that a selection covering only blank cells triggers nothing,
+    /// so an empty string never overwrites the clipboard.
+    ///
+    /// Case: the user triple-clicks an empty line and presses the copy
+    /// shortcut.
+    #[test]
+    fn selection_copy_of_a_blank_row_triggers_nothing() {
+        let mut app = app_capturing_copies();
+        let entity = spawn_terminal(&mut app, b"\r\nefgh", true);
+        app.world_mut().trigger(TerminalSelectionCopy { entity });
+        app.update();
+        assert!(captured(&app).is_empty());
     }
 }

--- a/src/action/terminal/selection.rs
+++ b/src/action/terminal/selection.rs
@@ -163,8 +163,6 @@ fn to_grid_point(viewport_point: GridPoint, offset: DisplayOffset) -> GridPoint 
 mod tests {
     use super::*;
     use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
-    use crate::surface::OrzmaTerminal;
-    use bevy_orzma_tty::prelude::OrzmaTtyHandle;
     use orzma_vt::prelude::{GridColumn, GridLine};
 
     #[derive(Resource, Default)]

--- a/src/action/terminal/selection.rs
+++ b/src/action/terminal/selection.rs
@@ -160,9 +160,35 @@ fn to_grid_point(viewport_point: GridPoint, offset: DisplayOffset) -> GridPoint 
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use orzma_vt::prelude::{GridColumn, GridLine};
+
+    /// Spawns a detached terminal showing `rows` as an `OrzmaTerminal`,
+    /// with row 0 selected as Lines when `select` is set, so copy and
+    /// yank observers can be exercised against real selected text.
+    pub(crate) fn spawn_terminal(app: &mut App, rows: &[u8], select: bool) -> Entity {
+        let (mut handle, _sink) = OrzmaTtyHandle::detached(4, 3);
+        handle.feed_bytes(rows);
+        if select {
+            handle.start_selection(
+                GridPoint {
+                    line: GridLine(0),
+                    column: GridColumn(0),
+                },
+                CellSide::Left,
+                SelectionKind::Lines,
+            );
+        }
+        app.world_mut().spawn((handle, OrzmaTerminal)).id()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
+    use crate::action::terminal::selection::test_support::spawn_terminal;
     use orzma_vt::prelude::{GridColumn, GridLine};
 
     #[derive(Resource, Default)]
@@ -320,24 +346,6 @@ mod tests {
             .add_observer(on_terminal_selection_copy);
         capture_copy_actions(&mut app);
         app
-    }
-
-    /// Spawns a terminal showing `rows`, with row 0 selected as Lines when
-    /// `select` is set.
-    fn spawn_terminal(app: &mut App, rows: &[u8], select: bool) -> Entity {
-        let (mut handle, _sink) = OrzmaTtyHandle::detached(4, 3);
-        handle.feed_bytes(rows);
-        if select {
-            handle.start_selection(
-                GridPoint {
-                    line: GridLine(0),
-                    column: GridColumn(0),
-                },
-                CellSide::Left,
-                SelectionKind::Lines,
-            );
-        }
-        app.world_mut().spawn((handle, OrzmaTerminal)).id()
     }
 
     fn captured(app: &App) -> &[String] {

--- a/src/action/vi/applier.rs
+++ b/src/action/vi/applier.rs
@@ -2,14 +2,15 @@
 //! `bevy_orzma_tty` request `EntityEvent`, and to the vi-mode exit event
 //! `mode.rs` owns for selection toggling, yank, and exit.
 
-use crate::action::clipboard::CopyAction;
+use crate::action::terminal::copy_selection_of;
 use crate::action::vi::mode::ExitViMode;
 use crate::action::vi::{
     ViExitRequest, ViMotionRequest, ViScrollRequest, ViSelectionToggleRequest, ViYankRequest,
 };
+use crate::surface::OrzmaTerminal;
 use bevy::prelude::*;
 use bevy_orzma_tty::prelude::{
-    RequestTtyScroll, RequestTtySelectionClear, RequestTtySelectionKindChange,
+    OrzmaTtyHandle, RequestTtyScroll, RequestTtySelectionClear, RequestTtySelectionKindChange,
     RequestTtySelectionStartAtViCursor, RequestTtyViMotion, SelectionKind,
 };
 use orzma_configs::vi_mode::ViModeScroll;
@@ -68,11 +69,14 @@ fn on_vi_selection_toggle(ev: On<ViSelectionToggleRequest>, mut commands: Comman
     }
 }
 
-/// Copies the current selection (currently stubbed to nothing) and always
-/// leaves vi mode.
-fn on_vi_yank(ev: On<ViYankRequest>, mut commands: Commands) {
-    if let Some(text) = selection_to_string() {
-        commands.trigger(CopyAction { text });
+/// Copies the current selection and always leaves vi mode.
+fn on_vi_yank(
+    ev: On<ViYankRequest>,
+    mut commands: Commands,
+    terminals: Query<&OrzmaTtyHandle, With<OrzmaTerminal>>,
+) {
+    if let Ok(handle) = terminals.get(ev.entity) {
+        copy_selection_of(&mut commands, handle);
     }
     commands.trigger(ExitViMode { entity: ev.entity });
 }
@@ -116,17 +120,9 @@ impl SelectionOp {
     }
 }
 
-// TODO: read the live selection kind from the VT once a selection
-// capability exists (docs/todo/migrate-to-new-vt.md item 11); until then
-// every toggle resolves to `SelectionOp::Start`.
+// TODO: Read the live selection kind from the VT once vi mode lands there;
+// until then every toggle resolves to `SelectionOp::Start`.
 fn selection_type() -> Option<SelectionKind> {
-    None
-}
-
-// TODO: read the live selection text from the VT once a selection
-// capability exists (docs/todo/migrate-to-new-vt.md item 11); until then
-// yank never has anything to copy.
-fn selection_to_string() -> Option<String> {
     None
 }
 
@@ -269,15 +265,12 @@ mod tests {
     #[derive(Resource, Default)]
     struct SeenExits(Vec<Entity>);
 
-    /// Asserts that yank always exits vi mode and — since
-    /// `selection_to_string` is stubbed to `None` until a selection-reading
-    /// capability lands (docs/todo/migrate-to-new-vt.md item 11) — never
-    /// emits a `CopyAction`.
+    /// Asserts that a yank on an entity without a terminal handle still
+    /// exits vi mode and copies nothing.
     ///
-    /// Case: the user presses the yank key in vi mode, with or without an
-    /// active selection.
+    /// Case: the yank key lands while the focused pane is being torn down.
     #[test]
-    fn yank_exits_vi_mode_and_currently_never_copies() {
+    fn yank_without_a_handle_exits_vi_mode_and_copies_nothing() {
         use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
 
         let mut app = app_with_applier();
@@ -294,6 +287,46 @@ mod tests {
 
         assert_eq!(app.world().resource::<SeenExits>().0, vec![entity]);
         assert!(app.world().resource::<CapturedCopyActions>().0.is_empty());
+    }
+
+    /// Asserts that a yank copies the terminal's selected text and then
+    /// exits vi mode.
+    ///
+    /// Case: the user selects a line in vi mode and presses the yank key.
+    #[test]
+    fn yank_copies_the_selection_and_exits_vi_mode() {
+        use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
+        use crate::surface::OrzmaTerminal;
+        use bevy_orzma_tty::prelude::OrzmaTtyHandle;
+        use orzma_vt::prelude::{CellSide, GridColumn, GridLine, GridPoint};
+
+        let mut app = app_with_applier();
+        app.init_resource::<SeenExits>().add_observer(
+            |ev: On<ExitViMode>, mut seen: ResMut<SeenExits>| {
+                seen.0.push(ev.entity);
+            },
+        );
+        capture_copy_actions(&mut app);
+        let (mut handle, _sink) = OrzmaTtyHandle::detached(4, 3);
+        handle.feed_bytes(b"abcd\r\nefgh\r\nijkl");
+        handle.start_selection(
+            GridPoint {
+                line: GridLine(0),
+                column: GridColumn(0),
+            },
+            CellSide::Left,
+            SelectionKind::Lines,
+        );
+        let entity = app.world_mut().spawn((handle, OrzmaTerminal)).id();
+
+        app.world_mut().trigger(ViYankRequest { entity });
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<CapturedCopyActions>().0,
+            vec!["abcd".to_string()]
+        );
+        assert_eq!(app.world().resource::<SeenExits>().0, vec![entity]);
     }
 
     /// Asserts that a `ViExitRequest` always triggers `ExitViMode`, even for

--- a/src/action/vi/applier.rs
+++ b/src/action/vi/applier.rs
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn yank_copies_the_selection_and_exits_vi_mode() {
         use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
-        use orzma_vt::prelude::{CellSide, GridColumn, GridLine, GridPoint};
+        use crate::action::terminal::test_support::spawn_terminal;
 
         let mut app = app_with_applier();
         app.init_resource::<SeenExits>().add_observer(
@@ -305,17 +305,7 @@ mod tests {
             },
         );
         capture_copy_actions(&mut app);
-        let (mut handle, _sink) = OrzmaTtyHandle::detached(4, 3);
-        handle.feed_bytes(b"abcd\r\nefgh\r\nijkl");
-        handle.start_selection(
-            GridPoint {
-                line: GridLine(0),
-                column: GridColumn(0),
-            },
-            CellSide::Left,
-            SelectionKind::Lines,
-        );
-        let entity = app.world_mut().spawn((handle, OrzmaTerminal)).id();
+        let entity = spawn_terminal(&mut app, b"abcd\r\nefgh\r\nijkl", true);
 
         app.world_mut().trigger(ViYankRequest { entity });
         app.update();

--- a/src/action/vi/applier.rs
+++ b/src/action/vi/applier.rs
@@ -296,8 +296,6 @@ mod tests {
     #[test]
     fn yank_copies_the_selection_and_exits_vi_mode() {
         use crate::action::clipboard::test_support::{CapturedCopyActions, capture_copy_actions};
-        use crate::surface::OrzmaTerminal;
-        use bevy_orzma_tty::prelude::OrzmaTtyHandle;
         use orzma_vt::prelude::{CellSide, GridColumn, GridLine, GridPoint};
 
         let mut app = app_with_applier();


### PR DESCRIPTION
## Summary

Adds mouse selection to the `Vt` trait and wires it end to end, from the Bevy request observers to the clipboard.

- **`orzma_vt`**: `Vt::{start_selection, extend_selection, clear_selection, selection_text}`. The selection is owned per `Screen` as `LineId` + cell-boundary endpoints (`ScreenSelection`), so it follows its rows into history; it is projected at emit time into `Frame::selection`, which `FrameTracker` now carries and diffs like the cursor and display offset (an idle start / extend / clear emits a rowless frame). Alternate-screen flips hide the primary selection and discard the alternate one on return; `RIS` clears it and reports `damaged` even on a blank grid. `selection_text` derives its per-row span from the same expression the shader paints, so the copied text always matches the highlight.
- **`orzma_tty`**: forwards the three operations and arms the coalescer only when the VT reports a change.
- **`bevy_orzma_tty`**: the start / update / clear request observers now reach the handle (the vi-cursor start and kind change stay stubs until vi mode lands).
- **`orzma`**: the mouse copy and the vi yank read the selection through one shared helper that never overwrites the clipboard with an empty string.

Design: `docs/superpowers/specs/2026-09-05-vt-selection-design.md` (git-ignored; decisions D1–D13). The 40 approved test cases for the four methods live in `docs/todo/tdd-lib-*.md` (untracked in this PR) and are transcribed into `crates/orzma_vt/src/lib.rs`.

## Test plan

- [x] `cargo test --workspace` (1645 passed, 0 failed)
- [x] `cargo clippy --workspace --all-targets` (no warnings)
- [x] `cargo fmt --all -- --check`
- [ ] Manual (`cargo run`): drag-select in the shell paints a highlight; `Cmd+C` copies it; the highlight follows the lines as output scrolls; it disappears inside `less` and returns on quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2JFJZvPVeDUf6VACBCvZZ
