### PR TITLE
perf(orzma_vt): reserve at most eight runs per emitted row

### DIFF
--- a/crates/orzma_vt/src/screen/grid/row.rs
+++ b/crates/orzma_vt/src/screen/grid/row.rs
@@ -39,7 +39,7 @@ impl Row<Cell> {
     /// Adjacent cells sharing foreground, background, and style become
     /// one [`Run`], and the runs together span every column of the row.
     pub fn to_runs(&self) -> Row<Run> {
-        let mut runs: Vec<Run> = Vec::with_capacity(self.0.len());
+        let mut runs: Vec<Run> = Vec::with_capacity(self.0.len().min(RUNS_RESERVE));
         for cell in self.0.iter() {
             match runs.last_mut() {
                 Some(run) if run.fg == cell.fg && run.bg == cell.bg && run.style == cell.style => {
@@ -117,6 +117,12 @@ impl IndexMut<GridColumn> for Row<Cell> {
         &mut self.0[usize::from(column.0)]
     }
 }
+
+/// How many runs [`Row::to_runs`] reserves up front. A single-attribute
+/// row then carries capacity for a few runs instead of one per column,
+/// and geometric growth reaches a highlighted row's twenty to forty runs
+/// in one or two reallocations.
+const RUNS_RESERVE: usize = 8;
 
 #[cfg(test)]
 mod tests {
@@ -229,5 +235,22 @@ mod tests {
         let runs = row.to_runs();
         assert_eq!(runs.iter().map(|run| u32::from(run.cols)).sum::<u32>(), 8);
         assert_eq!(runs[0].text, "hi      ");
+    }
+
+    /// Asserts that a single-attribute row's run vector reserves at most
+    /// `RUNS_RESERVE` runs rather than one per column.
+    ///
+    /// Case: a frame carries a hundred unstyled blank lines of a wide
+    /// terminal, each of which coalesces into one run.
+    #[test]
+    fn a_single_attribute_row_reserves_at_most_the_run_reserve() {
+        let row = Row::filled(200, Cell::default());
+        let runs = row.to_runs();
+        assert_eq!(runs.len(), 1);
+        assert!(
+            runs.0.capacity() <= RUNS_RESERVE,
+            "capacity {} exceeds the reserve of {RUNS_RESERVE}",
+            runs.0.capacity()
+        );
     }
 }

--- a/crates/orzma_vt/src/screen/grid/row.rs
+++ b/crates/orzma_vt/src/screen/grid/row.rs
@@ -33,13 +33,19 @@ impl<T: Clone> Row<T> {
 }
 
 impl Row<Cell> {
+    /// How many runs [`Row::to_runs`] reserves up front. A single-attribute
+    /// row then carries capacity for a few runs instead of one per column,
+    /// and geometric growth reaches a highlighted row's twenty to forty runs
+    /// in one to three reallocations.
+    const RUNS_RESERVE: usize = 8;
+
     /// Coalesces the row's cells into the attribute runs a frame
     /// carries.
     ///
     /// Adjacent cells sharing foreground, background, and style become
     /// one [`Run`], and the runs together span every column of the row.
     pub fn to_runs(&self) -> Row<Run> {
-        let mut runs: Vec<Run> = Vec::with_capacity(self.0.len().min(RUNS_RESERVE));
+        let mut runs: Vec<Run> = Vec::with_capacity(self.0.len().min(Self::RUNS_RESERVE));
         for cell in self.0.iter() {
             match runs.last_mut() {
                 Some(run) if run.fg == cell.fg && run.bg == cell.bg && run.style == cell.style => {
@@ -117,12 +123,6 @@ impl IndexMut<GridColumn> for Row<Cell> {
         &mut self.0[usize::from(column.0)]
     }
 }
-
-/// How many runs [`Row::to_runs`] reserves up front. A single-attribute
-/// row then carries capacity for a few runs instead of one per column,
-/// and geometric growth reaches a highlighted row's twenty to forty runs
-/// in one to three reallocations.
-const RUNS_RESERVE: usize = 8;
 
 #[cfg(test)]
 mod tests {
@@ -248,9 +248,10 @@ mod tests {
         let runs = row.to_runs();
         assert_eq!(runs.len(), 1);
         assert!(
-            runs.0.capacity() <= RUNS_RESERVE,
-            "capacity {} exceeds the reserve of {RUNS_RESERVE}",
-            runs.0.capacity()
+            runs.0.capacity() <= Row::RUNS_RESERVE,
+            "capacity {} exceeds the reserve of {}",
+            runs.0.capacity(),
+            Row::RUNS_RESERVE
         );
     }
 }

--- a/crates/orzma_vt/src/screen/grid/row.rs
+++ b/crates/orzma_vt/src/screen/grid/row.rs
@@ -121,7 +121,7 @@ impl IndexMut<GridColumn> for Row<Cell> {
 /// How many runs [`Row::to_runs`] reserves up front. A single-attribute
 /// row then carries capacity for a few runs instead of one per column,
 /// and geometric growth reaches a highlighted row's twenty to forty runs
-/// in one or two reallocations.
+/// in one to three reallocations.
 const RUNS_RESERVE: usize = 8;
 
 #[cfg(test)]
@@ -240,8 +240,8 @@ mod tests {
     /// Asserts that a single-attribute row's run vector reserves at most
     /// `RUNS_RESERVE` runs rather than one per column.
     ///
-    /// Case: a frame carries a hundred unstyled blank lines of a wide
-    /// terminal, each of which coalesces into one run.
+    /// Case: a frame carries one unstyled blank line of a wide terminal,
+    /// which coalesces into a single run.
     #[test]
     fn a_single_attribute_row_reserves_at_most_the_run_reserve() {
         let row = Row::filled(200, Cell::default());


### PR DESCRIPTION
## Problem

`Row::to_runs` reserved one `Run` per column before coalescing, so every emitted row allocated for the worst case (every cell a different attribute) even though a typical row coalesces into a handful of runs. Under a frame backlog that allocation is paid once per row per queued frame. This is PR 3 of 4 from `docs/superpowers/specs/2026-09-09-orzmux-buffer-saturation-design.md` (§5) and is stacked on PR 2.

## Solution

- `Row::to_runs` reserves `min(columns, RUNS_RESERVE)` with `RUNS_RESERVE = 8`, and lets the `Vec` grow only for rows that genuinely carry more runs.
- A test pins that a single-attribute row reserves at most the run reserve.

Stacked on `fix-orzma-tty-bounded-chunk-channel`; this PR's base is that branch so the diff shows only its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKxWdmgiGa4MAtzGeEXQS7
