### PR TITLE
fix: implement IL, DL, SU and SD so Neovim's scrolling repaints

### DIFF
--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -307,6 +307,42 @@ impl VTActor for Executor<'_> {
                     self.stage(damage);
                 }
             }
+            // IL
+            (None, b'L') => {
+                let damage = self
+                    .device
+                    .active_screen_mut()
+                    .insert_lines(repeat_count(params.value(0)));
+                self.stage(damage);
+            }
+            // DL
+            (None, b'M') => {
+                let damage = self
+                    .device
+                    .active_screen_mut()
+                    .delete_lines(repeat_count(params.value(0)));
+                self.stage(damage);
+            }
+            // SU
+            (None, b'S') => {
+                let damage = self
+                    .device
+                    .active_screen_mut()
+                    .scroll_region_up(repeat_count(params.value(0)));
+                self.stage(damage);
+            }
+            // SD
+            // NOTE: xterm's highlight mouse tracking (`CSI Ps;Ps;Ps;Ps;Ps T`,
+            // XTHIMOUSE) shares this final byte with no private marker, so
+            // only the one-parameter spelling is a scroll down; without the
+            // guard a mouse-tracking request would scroll the screen.
+            (None, b'T') if params.values().count() <= 1 => {
+                let damage = self
+                    .device
+                    .active_screen_mut()
+                    .scroll_region_down(repeat_count(params.value(0)));
+                self.stage(damage);
+            }
             // CHT
             (None, b'I') => self
                 .device

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -56,7 +56,13 @@ struct Session(OrzmaVt);
 
 impl Session {
     fn new() -> Self {
-        Self(OrzmaVt::new(GridSize { cols: 4, rows: 3 }, 10))
+        Self::sized(GridSize { cols: 4, rows: 3 })
+    }
+
+    /// One terminal of the given size, for a capture whose scroll
+    /// region needs more rows than the default three.
+    fn sized(size: GridSize) -> Self {
+        Self(OrzmaVt::new(size, 10))
     }
 
     /// Interprets `chunk` and hands back what it alone produced.
@@ -123,6 +129,7 @@ mod device_status;
 mod erase;
 mod interpret_output;
 mod keypad;
+mod line_editing;
 mod line_movement;
 mod mouse;
 mod parser_limits;

--- a/crates/orzma_vt/src/interpreter/tests/line_editing.rs
+++ b/crates/orzma_vt/src/interpreter/tests/line_editing.rs
@@ -1,0 +1,151 @@
+//! Tests for the line-editing and region-scrolling CSI sequences:
+//! insert line, delete line, scroll up, and scroll down.
+
+use super::*;
+
+/// Asserts that `CSI L` opens one blank row at the cursor and homes
+/// the cursor to column zero.
+///
+/// Case: an editor scrolls its buffer back by one line with the
+/// terminfo `il1` capability.
+#[test]
+fn the_insert_line_sequence_opens_a_blank_row_at_the_cursor() {
+    let device = interpret(b"ab\x1b[L");
+    let screen = device.active_screen();
+    assert_eq!(screen.viewport_row(ViewportLine(0))[0].c, ' ');
+    assert_eq!(screen.viewport_row(ViewportLine(1))[0].c, 'a');
+    assert_eq!(screen.cursor_column(), GridColumn(0));
+}
+
+/// Asserts that `CSI Pn L` inserts `Pn` rows.
+///
+/// Case: an editor scrolls its buffer back by two lines with the
+/// terminfo `il` capability.
+#[test]
+fn the_insert_line_sequence_honors_its_count() {
+    let device = interpret(b"a\x1b[2L");
+    let screen = device.active_screen();
+    assert_eq!(screen.viewport_row(ViewportLine(0))[0].c, ' ');
+    assert_eq!(screen.viewport_row(ViewportLine(1))[0].c, ' ');
+    assert_eq!(screen.viewport_row(ViewportLine(2))[0].c, 'a');
+}
+
+/// Asserts that `CSI M` deletes the cursor row, moves the rows below
+/// it up, and homes the cursor to column zero.
+///
+/// Case: an editor scrolls its buffer forward by one line with the
+/// terminfo `dl1` capability.
+#[test]
+fn the_delete_line_sequence_removes_the_cursor_row() {
+    let device = interpret(b"ab\x1b[2;1Hc\x1b[1;2H\x1b[M");
+    let screen = device.active_screen();
+    assert_eq!(screen.viewport_row(ViewportLine(0))[0].c, 'c');
+    assert_eq!(screen.viewport_row(ViewportLine(1))[0].c, ' ');
+    assert_eq!(screen.cursor_column(), GridColumn(0));
+}
+
+/// Asserts that `CSI Pn M` deletes `Pn` rows and that a zero reads as
+/// the default of one.
+///
+/// Case: an editor scrolls its buffer forward by two lines with the
+/// terminfo `dl` capability.
+#[test]
+fn the_delete_line_sequence_honors_its_count() {
+    let device = interpret(b"a\x1b[2;1Hb\x1b[3;1Hc\x1b[1;1H\x1b[2M");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(0))[0].c,
+        'c'
+    );
+
+    let device = interpret(b"a\x1b[2;1Hb\x1b[1;1H\x1b[0M");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(0))[0].c,
+        'b'
+    );
+}
+
+/// Asserts that `CSI Pn S` scrolls the region up by `Pn` rows without
+/// moving the cursor.
+///
+/// Case: a program uses the terminfo `indn` capability to scroll a
+/// pane forward two lines at once.
+#[test]
+fn the_scroll_up_sequence_scrolls_the_region_without_moving_the_cursor() {
+    let device = interpret(b"\x1b[3;1Ha\x1b[1;2H\x1b[2S");
+    let screen = device.active_screen();
+    assert_eq!(screen.viewport_row(ViewportLine(0))[0].c, 'a');
+    assert_eq!(screen.cursor_column(), GridColumn(1));
+}
+
+/// Asserts that `CSI T` scrolls the region down by one row and that a
+/// lone zero reads as that same default.
+///
+/// Case: a program uses the terminfo `rin` capability to scroll a
+/// pane back one line.
+#[test]
+fn the_scroll_down_sequence_scrolls_the_region_down() {
+    let device = interpret(b"a\x1b[T");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(1))[0].c,
+        'a'
+    );
+
+    let device = interpret(b"a\x1b[0T");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(1))[0].c,
+        'a'
+    );
+}
+
+/// Asserts that a `CSI T` carrying more than one parameter is ignored
+/// rather than read as a scroll down.
+///
+/// Case: a program starts xterm highlight mouse tracking with
+/// `CSI 1;1;1;1;1 T` on a terminal that does not implement it.
+#[test]
+fn a_multi_parameter_scroll_down_sequence_is_ignored() {
+    let device = interpret(b"a\x1b[1;1;1;1;1T");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(0))[0].c,
+        'a'
+    );
+}
+
+/// Asserts that a delete line raises the chunk liveness.
+///
+/// Case: an editor's scroll arrives in a chunk that prints nothing.
+#[test]
+fn a_delete_line_reports_damage() {
+    assert!(damage_of(b"\x1b[M"));
+}
+
+/// Asserts that Neovim's scroll sequence moves the buffer rows up
+/// inside the DECSTBM region, blanks the row that opens at the bottom
+/// margin, leaves the tabline and statusline alone, and emits a frame
+/// carrying every viewport row.
+///
+/// Case: Neovim 0.12 on a 51-row window scrolls a file forward by one
+/// line with `CSI 3;50 r`, `CSI 3;1 H`, `CSI M`, `CSI r`, and a
+/// repaint of the newly exposed bottom row.
+#[test]
+fn the_neovim_scroll_capture_moves_the_region_and_repaints_every_row() {
+    let mut session = Session::sized(GridSize { cols: 4, rows: 51 });
+    session.feed(b"\x1b[1;1Ht\x1b[3;1Ha\x1b[4;1Hb\x1b[50;1Hy\x1b[51;1Hz");
+    session
+        .frame()
+        .expect("the setup emits the bootstrap frame");
+
+    let output = session.feed(b"\x1b[3;50r\x1b[3;1H\x1b[M");
+    assert!(output.damaged);
+    assert_eq!(session.char_at(49, 0), ' ');
+
+    session.feed(b"\x1b[r\x1b[50;1Hn");
+    let frame = session.frame().expect("the scroll emits a frame");
+    assert_eq!(frame.rows.len(), 51);
+    assert_eq!(session.char_at(0, 0), 't');
+    assert_eq!(session.char_at(2, 0), 'b');
+    assert_eq!(session.char_at(3, 0), ' ');
+    assert_eq!(session.char_at(48, 0), 'y');
+    assert_eq!(session.char_at(49, 0), 'n');
+    assert_eq!(session.char_at(50, 0), 'z');
+}

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -6,23 +6,6 @@
 //! motion returns nothing, because the per-chunk cursor diff reports
 //! it.
 
-// TODO: This attribute is file-level, so it silences dead_code across
-// the whole `screen/` subtree (12 files, ~5,400 lines), though only
-// about 8 items actually need it. Narrow it to item-level `#[expect]`s
-// once the executor's CSI handlers land and most of those items go
-// live.
-// NOTE: the `#[cfg(test)]` module below uses every item this lint
-// would flag, so an unconditional `#[expect(dead_code)]` is fulfilled
-// in a plain build but unfulfilled — and denied under `-D warnings` —
-// in a test build. Gating it to non-test builds keeps both clean.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the executor reaches these screen operations once its CSI handlers land"
-    )
-)]
-
 pub mod cell;
 pub mod character_sets;
 pub mod checkpoint;

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -413,6 +413,31 @@ impl Screen {
         None
     }
 
+    /// Inserts `count` blank rows at the cursor inside the scroll
+    /// region: the cursor row and the rows below it move down, the
+    /// rows pushed past the bottom margin are lost, and the pen's erase
+    /// cell fills the rows that open. The cursor is homed to column
+    /// zero and the deferred wrap is disarmed.
+    ///
+    /// A cursor outside the margins inserts nothing (VT510 "IL — Insert
+    /// Line"). The count is clamped to the rows from the cursor through
+    /// the bottom margin. An insert never feeds history: the rows it
+    /// discards leave from the bottom margin, not the top of the page.
+    /// The cursor homing follows xterm, kitty, and ECMA-48 § 8.3.67
+    /// rather than alacritty and wezterm, which leave the column alone.
+    ///
+    /// # Control Functions
+    ///
+    /// - `IL` (`CSI Pn L`)
+    pub fn insert_lines(&mut self, count: u16) -> Option<DamageSpan> {
+        if !self.scroll_region.scroll_span().contains(&self.state.line) {
+            return None;
+        }
+        let damage = self.shift_rows_down(self.state.line, count)?;
+        self.carriage_return();
+        Some(damage)
+    }
+
     /// Deletes `count` rows at the cursor inside the scroll region: the
     /// rows below move up and the pen's erase cell fills the rows that
     /// open at the bottom margin. The cursor is homed to column zero
@@ -478,6 +503,23 @@ impl Screen {
             if first == ScreenLine(0) {
                 self.hold_scrolled_viewport();
             }
+        }
+        Some(DamageSpan::Full)
+    }
+
+    /// Shifts the rows from `first` through the bottom margin down by
+    /// `count` rows, filling the rows that open at `first` with the
+    /// pen's erase cell; `None` when the clamped count is zero.
+    ///
+    /// The rows pushed past the bottom margin are discarded. Nothing
+    /// reaches history on this path, because the rows that leave do so
+    /// at the bottom margin rather than at the top of the page.
+    fn shift_rows_down(&mut self, first: ScreenLine, count: u16) -> Option<DamageSpan> {
+        let bottom = self.scroll_region.bottom_margin();
+        let count = self.clamped_rows(first, count)?;
+        let fill = self.state.pen.erase_cell();
+        for _ in 0..count {
+            self.grid.scroll_down_one(first, bottom, fill);
         }
         Some(DamageSpan::Full)
     }

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -463,6 +463,37 @@ impl Screen {
         Some(damage)
     }
 
+    /// Scrolls the whole scroll region up by `count` rows: the rows at
+    /// the top margin leave and the pen's erase cell fills the rows that
+    /// open at the bottom margin. The cursor does not move.
+    ///
+    /// The count is clamped to the region height. A region whose top
+    /// margin is the first row of the page feeds the departing rows to
+    /// history, as a line feed there would, and it does so even when a
+    /// bottom margin pins content below the region.
+    ///
+    /// # Control Functions
+    ///
+    /// - `SU` (`CSI Pn S`)
+    pub fn scroll_region_up(&mut self, count: u16) -> Option<DamageSpan> {
+        self.shift_rows_up(self.scroll_region.top_margin(), count)
+    }
+
+    /// Scrolls the whole scroll region down by `count` rows: the pen's
+    /// erase cell fills the rows that open at the top margin and the
+    /// rows pushed past the bottom margin are lost. The cursor does not
+    /// move.
+    ///
+    /// The count is clamped to the region height. Nothing is fed to
+    /// history.
+    ///
+    /// # Control Functions
+    ///
+    /// - `SD` (`CSI Pn T`)
+    pub fn scroll_region_down(&mut self, count: u16) -> Option<DamageSpan> {
+        self.shift_rows_down(self.scroll_region.top_margin(), count)
+    }
+
     /// Follows a one-row scroll with the offset that keeps a scrolled
     /// viewport on the content it was showing.
     ///

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -354,16 +354,7 @@ impl Screen {
     /// - `NEL` (`0x85`, `ESC E`) — after the carriage return
     pub fn line_feed(&mut self) -> Option<DamageSpan> {
         if self.state.line == self.scroll_region.bottom_margin() {
-            let top = self.scroll_region.top_margin();
-            self.grid.scroll_up_one(
-                top,
-                self.scroll_region.bottom_margin(),
-                self.state.pen.erase_cell(),
-            );
-            if top == ScreenLine(0) {
-                self.hold_scrolled_viewport();
-            }
-            return Some(DamageSpan::Full);
+            return self.scroll_region_up(1);
         }
         if self.state.line.0 + 1 < self.grid.size().rows {
             self.state.line.0 += 1;
@@ -383,12 +374,7 @@ impl Screen {
     pub fn reverse_index(&mut self) -> Option<DamageSpan> {
         self.state.pending_wrap = false;
         if self.state.line == self.scroll_region.top_margin() {
-            self.grid.scroll_down_one(
-                self.scroll_region.top_margin(),
-                self.scroll_region.bottom_margin(),
-                self.state.pen.erase_cell(),
-            );
-            return Some(DamageSpan::Full);
+            return self.scroll_region_down(1);
         }
         if ScreenLine(0) < self.state.line {
             self.state.line.0 -= 1;
@@ -512,9 +498,10 @@ impl Screen {
         let bottom = self.scroll_region.bottom_margin();
         let count = self.clamped_rows(first, count)?;
         let fill = self.state.pen.erase_cell();
+        let feeds_history = first == ScreenLine(0);
         for _ in 0..count {
             self.grid.scroll_up_one(first, bottom, fill);
-            if first == ScreenLine(0) {
+            if feeds_history {
                 self.hold_scrolled_viewport();
             }
         }
@@ -542,20 +529,15 @@ impl Screen {
     /// clamped to the rows through the bottom margin, and `None` when
     /// that leaves nothing to do.
     ///
-    /// # Invariants
-    ///
-    /// `first` is at or above the bottom margin; the callers guarantee
-    /// it by checking the cursor against the margins or by passing the
-    /// top margin itself. The debug assertion catches a future caller
-    /// that does neither, which would otherwise underflow the
-    /// subtraction below.
+    /// A `first` below the bottom margin also yields `None`, because it
+    /// names no row the shift could move. The callers never produce one
+    /// — they check the cursor against the margins or pass the top
+    /// margin itself — so the guard exists to keep a future caller that
+    /// does neither from wrapping the subtraction into a count that
+    /// would walk the ring outside the region.
     fn clamped_rows(&self, first: ScreenLine, count: u16) -> Option<u16> {
         let bottom = self.scroll_region.bottom_margin();
-        debug_assert!(
-            first <= bottom,
-            "a row shift starts at or above the bottom margin"
-        );
-        let count = count.min(bottom.0 - first.0 + 1);
+        let count = count.min(bottom.0.checked_sub(first.0)? + 1);
         (count > 0).then_some(count)
     }
 

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -413,6 +413,31 @@ impl Screen {
         None
     }
 
+    /// Deletes `count` rows at the cursor inside the scroll region: the
+    /// rows below move up and the pen's erase cell fills the rows that
+    /// open at the bottom margin. The cursor is homed to column zero
+    /// and the deferred wrap is disarmed.
+    ///
+    /// A cursor outside the margins deletes nothing (VT510 "DL — Delete
+    /// Line"). The count is clamped to the rows from the cursor through
+    /// the bottom margin. A delete with the cursor on the first row of
+    /// the page feeds the deleted rows to history, as xterm, alacritty,
+    /// and wezterm do; the cursor homing follows xterm, kitty, and
+    /// ECMA-48 § 8.3.32 rather than alacritty and wezterm, which leave
+    /// the column alone.
+    ///
+    /// # Control Functions
+    ///
+    /// - `DL` (`CSI Pn M`)
+    pub fn delete_lines(&mut self, count: u16) -> Option<DamageSpan> {
+        if !self.scroll_region.scroll_span().contains(&self.state.line) {
+            return None;
+        }
+        let damage = self.shift_rows_up(self.state.line, count)?;
+        self.carriage_return();
+        Some(damage)
+    }
+
     /// Follows a one-row scroll with the offset that keeps a scrolled
     /// viewport on the content it was showing.
     ///
@@ -433,6 +458,49 @@ impl Screen {
         let history =
             u32::try_from(self.grid.history_len()).expect("scrollback never exceeds u32::MAX rows");
         self.viewport.offset = DisplayOffset(self.viewport.offset.0.saturating_add(1).min(history));
+    }
+
+    /// Shifts the rows from `first` through the bottom margin up by
+    /// `count` rows, filling the rows that open at the bottom margin
+    /// with the pen's erase cell; `None` when the clamped count is
+    /// zero.
+    ///
+    /// A shift that starts on the first row of the page feeds each
+    /// departing row to history and holds a scrolled-back viewport on
+    /// the row it was showing, one row at a time, the way
+    /// [`Self::line_feed`] does.
+    fn shift_rows_up(&mut self, first: ScreenLine, count: u16) -> Option<DamageSpan> {
+        let bottom = self.scroll_region.bottom_margin();
+        let count = self.clamped_rows(first, count)?;
+        let fill = self.state.pen.erase_cell();
+        for _ in 0..count {
+            self.grid.scroll_up_one(first, bottom, fill);
+            if first == ScreenLine(0) {
+                self.hold_scrolled_viewport();
+            }
+        }
+        Some(DamageSpan::Full)
+    }
+
+    /// The rows a shift starting at `first` may actually move: `count`
+    /// clamped to the rows through the bottom margin, and `None` when
+    /// that leaves nothing to do.
+    ///
+    /// # Invariants
+    ///
+    /// `first` is at or above the bottom margin; the callers guarantee
+    /// it by checking the cursor against the margins or by passing the
+    /// top margin itself. The debug assertion catches a future caller
+    /// that does neither, which would otherwise underflow the
+    /// subtraction below.
+    fn clamped_rows(&self, first: ScreenLine, count: u16) -> Option<u16> {
+        let bottom = self.scroll_region.bottom_margin();
+        debug_assert!(
+            first <= bottom,
+            "a row shift starts at or above the bottom margin"
+        );
+        let count = count.min(bottom.0 - first.0 + 1);
+        (count > 0).then_some(count)
     }
 
     /// Resolves a motion into the offset it aims at, before clamping.

--- a/crates/orzma_vt/src/screen/tests.rs
+++ b/crates/orzma_vt/src/screen/tests.rs
@@ -74,6 +74,8 @@ mod restore_checkpoint;
 mod reverse_index;
 mod save_checkpoint;
 mod scroll;
+mod scroll_region_down;
+mod scroll_region_up;
 mod seat_cursor;
 mod set_origin_mode;
 mod set_scroll_region;

--- a/crates/orzma_vt/src/screen/tests.rs
+++ b/crates/orzma_vt/src/screen/tests.rs
@@ -59,6 +59,7 @@ mod display_offset;
 mod erase_in_display;
 mod erase_in_line;
 mod fill_alignment_pattern;
+mod insert_lines;
 mod line_feed;
 mod move_backward_tabs;
 mod move_cursor_relative;

--- a/crates/orzma_vt/src/screen/tests.rs
+++ b/crates/orzma_vt/src/screen/tests.rs
@@ -36,9 +36,25 @@ fn dirty_screen() -> Screen {
     screen
 }
 
+/// Seeds one glyph into the first column of each leading row, so a
+/// shifted row can be told apart from an erased one.
+fn seed(screen: &mut Screen, glyphs: &[char]) {
+    for (line, glyph) in (0u16..).zip(glyphs) {
+        screen.grid[ScreenLine(line)][0].c = *glyph;
+    }
+}
+
+/// The first-column glyph of each of the leading `rows` screen rows.
+fn glyphs(screen: &Screen, rows: u16) -> Vec<char> {
+    (0..rows)
+        .map(|line| screen.grid[ScreenLine(line)][0].c)
+        .collect()
+}
+
 mod backspace;
 mod carriage_return;
 mod cursor;
+mod delete_lines;
 mod display_offset;
 mod erase_in_display;
 mod erase_in_line;

--- a/crates/orzma_vt/src/screen/tests/delete_lines.rs
+++ b/crates/orzma_vt/src/screen/tests/delete_lines.rs
@@ -1,0 +1,243 @@
+//! Tests for deleting lines at the cursor inside the scroll region.
+
+use super::*;
+
+/// Asserts that a delete moves the rows below the cursor up inside
+/// the region, blanks the bottom-margin row with the pen's erase cell,
+/// leaves rows outside the region alone, and feeds no history.
+///
+/// Case: Neovim, with its tabline pinned above the scroll region,
+/// scrolls the buffer forward by one line.
+#[test]
+fn a_delete_moves_the_rows_below_the_cursor_up_inside_the_region() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(1);
+    let blank = screen.state.pen.erase_cell().c;
+    let damage = screen.delete_lines(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', 'c', 'd', blank]);
+    assert_eq!(damage, Some(DamageSpan::Full));
+    assert_eq!(screen.grid.history_len(), 0);
+}
+
+/// Asserts that a delete with the cursor outside the scroll region
+/// moves nothing and reports nothing.
+///
+/// Case: an application leaves the cursor on a header row above the
+/// region it scrolls and sends a stray delete line.
+#[test]
+fn a_delete_outside_the_region_does_nothing() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(0);
+    screen.state.column = GridColumn(2);
+    let damage = screen.delete_lines(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', 'b', 'c', 'd']);
+    assert_eq!(damage, None);
+    assert_eq!(screen.state.column, GridColumn(2));
+}
+
+/// Asserts that a count larger than the rows left in the region
+/// deletes only those rows and leaves the rows below the bottom
+/// margin standing.
+///
+/// Case: an editor asks to delete more lines than fit between the
+/// cursor and the status line it keeps below the region.
+#[test]
+fn a_count_past_the_bottom_margin_deletes_only_the_remaining_rows() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(0),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(1);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.delete_lines(9);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, blank, 'd']);
+}
+
+/// Asserts that the rows a delete opens carry the pen's background
+/// rather than a default cell, so background-colour erase holds.
+///
+/// Case: a program paints a pane with a blue background and then
+/// deletes a line inside it.
+#[test]
+fn a_delete_fills_the_opened_rows_with_the_pen_background() {
+    let mut screen = screen();
+    screen.pen_mut().bg = Color::Indexed(4);
+    screen.state.line = ScreenLine(0);
+    screen.delete_lines(1);
+    let opened = &screen.grid[ScreenLine(2)];
+    assert_eq!(opened[0].c, ' ');
+    assert_eq!(opened[0].bg, Color::Indexed(4));
+}
+
+/// Asserts that a delete homes the cursor to column zero and disarms
+/// the deferred wrap, leaving the cursor row unchanged.
+///
+/// Case: a program fills the last column of a row and then deletes
+/// the line below instead of printing the character the wrap was
+/// waiting for.
+#[test]
+fn a_delete_homes_the_cursor_and_disarms_the_deferred_wrap() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(1);
+    screen.state.column = GridColumn(3);
+    screen.state.pending_wrap = true;
+    screen.delete_lines(1);
+    assert_eq!(screen.state.line, ScreenLine(1));
+    assert_eq!(screen.state.column, GridColumn(0));
+    assert!(!screen.state.pending_wrap);
+}
+
+/// Asserts that a zero count deletes nothing and leaves the cursor
+/// where it was.
+///
+/// Case: a caller forwards a count of zero straight through instead
+/// of applying the control function's default of one.
+#[test]
+fn a_zero_count_deletes_nothing() {
+    let mut screen = screen();
+    seed(&mut screen, &['a', 'b', 'c']);
+    screen.state.column = GridColumn(2);
+    let damage = screen.delete_lines(0);
+    assert_eq!(glyphs(&screen, 3), vec!['a', 'b', 'c']);
+    assert_eq!(damage, None);
+    assert_eq!(screen.state.column, GridColumn(2));
+}
+
+/// Asserts that a delete with the cursor on the first row of a
+/// full-page region feeds every deleted row to history and walks a
+/// scrolled-back viewport one row further per deleted row.
+///
+/// Case: the user is reading scrollback on the primary screen while
+/// a program deletes two lines from the top of the page.
+#[test]
+fn a_delete_on_the_first_row_feeds_history_and_holds_a_scrolled_viewport_per_row() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.line_feed();
+    screen.line_feed();
+    assert_eq!(screen.grid.history_len(), 2);
+    screen.set_display_offset(DisplayOffset(2));
+    seed(&mut screen, &['a', 'b', 'c']);
+    screen.state.line = ScreenLine(0);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.delete_lines(2);
+    assert_eq!(screen.grid.history_len(), 4);
+    assert_eq!(screen.grid.row(GridLine(-2))[0].c, 'a');
+    assert_eq!(screen.grid.row(GridLine(-1))[0].c, 'b');
+    assert_eq!(glyphs(&screen, 3), vec!['c', blank, blank]);
+    assert_eq!(screen.display_offset(), DisplayOffset(4));
+}
+
+/// Asserts that at history capacity a delete on the first row keeps
+/// the viewport offset clamped to the history that survives.
+///
+/// Case: the user is reading the oldest line of a small scrollback
+/// when a program deletes two lines from the top of the page.
+#[test]
+fn a_delete_at_history_capacity_clamps_the_viewport_to_surviving_history() {
+    let mut screen = Screen::new(GridSize { cols: 4, rows: 3 }, 1);
+    screen.state.line = ScreenLine(2);
+    screen.line_feed();
+    assert_eq!(screen.grid.history_len(), 1);
+    screen.set_display_offset(DisplayOffset(1));
+    screen.state.line = ScreenLine(0);
+    screen.delete_lines(2);
+    assert_eq!(screen.grid.history_len(), 1);
+    assert_eq!(screen.display_offset(), DisplayOffset(1));
+}
+
+/// Asserts that a viewport pinned to the live tail stays pinned when
+/// a delete on the first row feeds history.
+///
+/// Case: the user is watching live output when a program deletes a
+/// line from the top of the page.
+#[test]
+fn a_delete_on_the_first_row_leaves_a_pinned_viewport_pinned() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(0);
+    screen.delete_lines(1);
+    assert_eq!(screen.grid.history_len(), 1);
+    assert_eq!(screen.display_offset(), DisplayOffset(0));
+}
+
+/// Asserts that a placement anchored below the deleted rows follows
+/// its row up the screen.
+///
+/// Case: a webview sits under a line of output and the program
+/// deletes a line above it.
+#[test]
+fn a_placement_below_the_deleted_rows_follows_its_row() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.mount_placement(InstanceId(1), PlacementSize { rows: 1, cols: 1 });
+    screen.state.line = ScreenLine(1);
+    screen.delete_lines(1);
+    let projected = screen.project_placements();
+    assert_eq!(projected.len(), 1);
+    assert_eq!(projected[0].point.line, GridLine(1));
+    assert!(screen.evict_lost_anchors().is_empty());
+}
+
+/// Asserts that a placement anchored on a deleted row inside a region
+/// below a top margin is dropped by the projection and named by the
+/// sweep.
+///
+/// Case: a webview sits on a line inside an editor's scroll region and
+/// the editor deletes that line.
+#[test]
+fn a_placement_on_a_deleted_row_is_evicted() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    screen.state.line = ScreenLine(2);
+    screen.mount_placement(InstanceId(1), PlacementSize { rows: 1, cols: 1 });
+    screen.delete_lines(1);
+    assert!(screen.project_placements().is_empty());
+    assert_eq!(screen.evict_lost_anchors(), vec![InstanceId(1)]);
+}
+
+/// Asserts that a selection below the deleted rows follows its rows
+/// and one confined to a recycled row stops resolving.
+///
+/// Case: the user has text selected in an editor pane when the editor
+/// deletes lines above and on the selection.
+#[test]
+fn a_selection_follows_surviving_rows_and_unresolves_on_a_recycled_one() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    let point = |line: i32, column: u16| GridPoint {
+        line: GridLine(line),
+        column: GridColumn(column),
+    };
+    assert!(screen.start_selection(point(3, 0), CellSide::Left, SelectionKind::Simple));
+    assert!(screen.extend_selection(point(3, 2), CellSide::Right));
+    screen.state.line = ScreenLine(1);
+    screen.delete_lines(1);
+    let range = screen
+        .selection_range()
+        .expect("the selection followed its row");
+    assert_eq!(range.start.line, GridLine(2));
+    assert_eq!(range.end.line, GridLine(2));
+
+    assert!(screen.start_selection(point(1, 0), CellSide::Left, SelectionKind::Simple));
+    assert!(screen.extend_selection(point(1, 2), CellSide::Right));
+    screen.delete_lines(1);
+    assert_eq!(screen.selection_range(), None);
+}

--- a/crates/orzma_vt/src/screen/tests/insert_lines.rs
+++ b/crates/orzma_vt/src/screen/tests/insert_lines.rs
@@ -1,0 +1,128 @@
+//! Tests for inserting blank lines at the cursor inside the scroll
+//! region.
+
+use super::*;
+
+/// Asserts that an insert opens a blank row at the cursor, moves the
+/// rows below it down inside the region, discards the bottom-margin
+/// row, and leaves rows outside the region alone.
+///
+/// Case: Neovim, with its tabline pinned above the scroll region,
+/// scrolls the buffer backward by one line.
+#[test]
+fn an_insert_opens_a_blank_row_at_the_cursor_inside_the_region() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(1);
+    let blank = screen.state.pen.erase_cell().c;
+    let damage = screen.insert_lines(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, 'b', 'c']);
+    assert_eq!(damage, Some(DamageSpan::Full));
+}
+
+/// Asserts that an insert with the cursor outside the scroll region
+/// moves nothing and reports nothing.
+///
+/// Case: an application leaves the cursor on a status row below the
+/// region it scrolls and sends a stray insert line.
+#[test]
+fn an_insert_outside_the_region_does_nothing() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(0),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(3);
+    screen.state.column = GridColumn(2);
+    let damage = screen.insert_lines(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', 'b', 'c', 'd']);
+    assert_eq!(damage, None);
+    assert_eq!(screen.state.column, GridColumn(2));
+}
+
+/// Asserts that a count larger than the rows left in the region
+/// blanks only those rows and leaves the rows below the bottom margin
+/// standing.
+///
+/// Case: an editor asks to insert more lines than fit between the
+/// cursor and the status line it keeps below the region.
+#[test]
+fn a_count_past_the_bottom_margin_inserts_only_the_remaining_rows() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(0),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(1);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.insert_lines(9);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, blank, 'd']);
+}
+
+/// Asserts that an insert homes the cursor to column zero and disarms
+/// the deferred wrap, leaving the cursor row unchanged.
+///
+/// Case: a program fills the last column of a row and then inserts a
+/// line instead of printing the character the wrap was waiting for.
+#[test]
+fn an_insert_homes_the_cursor_and_disarms_the_deferred_wrap() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(1);
+    screen.state.column = GridColumn(3);
+    screen.state.pending_wrap = true;
+    screen.insert_lines(1);
+    assert_eq!(screen.state.line, ScreenLine(1));
+    assert_eq!(screen.state.column, GridColumn(0));
+    assert!(!screen.state.pending_wrap);
+}
+
+/// Asserts that an insert on the first row of the page feeds nothing
+/// to history, because the row it pushes off the bottom margin is
+/// discarded rather than scrolled past.
+///
+/// Case: a program inserts a line at the top of the primary screen
+/// while the user has scrollback to return to.
+#[test]
+fn an_insert_never_feeds_history() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.line_feed();
+    assert_eq!(screen.grid.history_len(), 1);
+    screen.set_display_offset(DisplayOffset(1));
+    screen.state.line = ScreenLine(0);
+    screen.insert_lines(1);
+    assert_eq!(screen.grid.history_len(), 1);
+    assert_eq!(screen.display_offset(), DisplayOffset(1));
+}
+
+/// Asserts that a placement below the cursor follows its row down and
+/// one on the bottom-margin row is dropped by the projection and
+/// named by the sweep.
+///
+/// Case: two webviews sit inside an editor's scroll region, one on
+/// its last row, when the editor inserts a line above them.
+#[test]
+fn placements_follow_their_rows_and_the_bottom_margin_row_is_evicted() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(0),
+        bottom: ScreenLine(2),
+    });
+    screen.state.line = ScreenLine(1);
+    screen.mount_placement(InstanceId(1), PlacementSize { rows: 1, cols: 1 });
+    screen.state.line = ScreenLine(2);
+    screen.mount_placement(InstanceId(2), PlacementSize { rows: 1, cols: 1 });
+    screen.state.line = ScreenLine(0);
+    screen.insert_lines(1);
+    let projected = screen.project_placements();
+    assert_eq!(projected.len(), 1);
+    assert_eq!(projected[0].id, InstanceId(1));
+    assert_eq!(projected[0].point.line, GridLine(2));
+    assert_eq!(screen.evict_lost_anchors(), vec![InstanceId(2)]);
+}

--- a/crates/orzma_vt/src/screen/tests/line_feed.rs
+++ b/crates/orzma_vt/src/screen/tests/line_feed.rs
@@ -171,3 +171,18 @@ fn a_linefeed_preserves_pending_wrap() {
     screen.line_feed();
     assert!(screen.state.pending_wrap);
 }
+
+/// Asserts that a linefeed preserves the deferred-wrap flag on the
+/// scrolling path as well as on the moving one.
+///
+/// Case: an application fills the last column of the bottom row of
+/// the screen and then emits a bare linefeed, so the screen scrolls
+/// instead of moving the cursor down.
+#[test]
+fn a_linefeed_that_scrolls_preserves_pending_wrap() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.state.pending_wrap = true;
+    assert_eq!(screen.line_feed(), Some(DamageSpan::Full));
+    assert!(screen.state.pending_wrap);
+}

--- a/crates/orzma_vt/src/screen/tests/scroll_region_down.rs
+++ b/crates/orzma_vt/src/screen/tests/scroll_region_down.rs
@@ -1,0 +1,65 @@
+//! Tests for scrolling the whole region down without moving the
+//! cursor.
+
+use super::*;
+
+/// Asserts that a scroll down rotates the whole region, blanks the
+/// top-margin row, discards the bottom-margin row, leaves rows outside
+/// the region alone, and leaves the cursor exactly where it was.
+///
+/// Case: a program with a pinned header scrolls the pane below it
+/// backward while its cursor rests mid-row on a line it is editing.
+#[test]
+fn a_scroll_down_rotates_the_region_and_leaves_the_cursor_alone() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(2);
+    screen.state.column = GridColumn(3);
+    screen.state.pending_wrap = true;
+    let blank = screen.state.pen.erase_cell().c;
+    let damage = screen.scroll_region_down(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, 'b', 'c']);
+    assert_eq!(damage, Some(DamageSpan::Full));
+    assert_eq!(screen.state.line, ScreenLine(2));
+    assert_eq!(screen.state.column, GridColumn(3));
+    assert!(screen.state.pending_wrap);
+}
+
+/// Asserts that a count larger than the region blanks the whole
+/// region and nothing more.
+///
+/// Case: an application asks to scroll back by more lines than its
+/// region holds.
+#[test]
+fn a_count_past_the_region_height_scrolls_only_the_region() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.scroll_region_down(9);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, blank, 'd']);
+}
+
+/// Asserts that a scroll down of the full page feeds nothing to
+/// history and leaves a scrolled-back viewport where it was.
+///
+/// Case: the user is reading scrollback while a program scrolls the
+/// full page down by one line.
+#[test]
+fn a_scroll_down_never_feeds_history() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.line_feed();
+    assert_eq!(screen.grid.history_len(), 1);
+    screen.set_display_offset(DisplayOffset(1));
+    screen.scroll_region_down(1);
+    assert_eq!(screen.grid.history_len(), 1);
+    assert_eq!(screen.display_offset(), DisplayOffset(1));
+}

--- a/crates/orzma_vt/src/screen/tests/scroll_region_up.rs
+++ b/crates/orzma_vt/src/screen/tests/scroll_region_up.rs
@@ -1,0 +1,92 @@
+//! Tests for scrolling the whole region up without moving the cursor.
+
+use super::*;
+
+/// Asserts that a scroll up rotates the whole region, blanks the
+/// bottom-margin row, leaves rows outside the region alone, and leaves
+/// the cursor exactly where it was.
+///
+/// Case: a program with a pinned header scrolls the pane below it
+/// forward while its cursor rests mid-row on a line it is editing.
+#[test]
+fn a_scroll_up_rotates_the_region_and_leaves_the_cursor_alone() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(3),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(2);
+    screen.state.column = GridColumn(3);
+    screen.state.pending_wrap = true;
+    let blank = screen.state.pen.erase_cell().c;
+    let damage = screen.scroll_region_up(1);
+    assert_eq!(glyphs(&screen, 4), vec!['a', 'c', 'd', blank]);
+    assert_eq!(damage, Some(DamageSpan::Full));
+    assert_eq!(screen.state.line, ScreenLine(2));
+    assert_eq!(screen.state.column, GridColumn(3));
+    assert!(screen.state.pending_wrap);
+    assert_eq!(screen.grid.history_len(), 0);
+}
+
+/// Asserts that a scroll up moves the region even when the cursor
+/// sits outside it, and that a top margin on the first row feeds the
+/// departing row to history even though a bottom margin pins content
+/// below the region.
+///
+/// Case: a program parks its cursor on a status row below the region
+/// and scrolls the region from there.
+#[test]
+fn a_scroll_up_ignores_where_the_cursor_is() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(0),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    screen.state.line = ScreenLine(3);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.scroll_region_up(1);
+    assert_eq!(glyphs(&screen, 4), vec!['b', 'c', blank, 'd']);
+    assert_eq!(screen.grid.history_len(), 1);
+    assert_eq!(screen.grid.row(GridLine(-1))[0].c, 'a');
+}
+
+/// Asserts that a count larger than the region blanks the whole
+/// region and nothing more.
+///
+/// Case: an application asks to scroll by more lines than its region
+/// holds.
+#[test]
+fn a_count_past_the_region_height_scrolls_only_the_region() {
+    let mut screen = tall_screen();
+    screen.scroll_region.set_margins(Margins {
+        top: ScreenLine(1),
+        bottom: ScreenLine(2),
+    });
+    seed(&mut screen, &['a', 'b', 'c', 'd']);
+    let blank = screen.state.pen.erase_cell().c;
+    screen.scroll_region_up(9);
+    assert_eq!(glyphs(&screen, 4), vec!['a', blank, blank, 'd']);
+}
+
+/// Asserts that a scroll up of a region whose top margin is the first
+/// row feeds every departing row to history and walks a scrolled-back
+/// viewport one row further per departing row.
+///
+/// Case: the user is reading scrollback while a program scrolls the
+/// full page up by two lines.
+#[test]
+fn a_scroll_up_from_the_first_row_feeds_history_and_holds_the_viewport_per_row() {
+    let mut screen = screen();
+    screen.state.line = ScreenLine(2);
+    screen.line_feed();
+    assert_eq!(screen.grid.history_len(), 1);
+    screen.set_display_offset(DisplayOffset(1));
+    seed(&mut screen, &['a', 'b', 'c']);
+    screen.scroll_region_up(2);
+    assert_eq!(screen.grid.history_len(), 3);
+    assert_eq!(screen.grid.row(GridLine(-2))[0].c, 'a');
+    assert_eq!(screen.grid.row(GridLine(-1))[0].c, 'b');
+    assert_eq!(screen.display_offset(), DisplayOffset(3));
+}


### PR DESCRIPTION
## Problem

Scrolling a file in Neovim inside orzma repainted only the rows at the scroll
edge. The rows above kept showing stale content, and they picked up scattered
one-cell corruption on top of it.

`orzma_vt` implemented neither insert line (IL, `CSI Pn L`) nor delete line
(DL, `CSI Pn M`). Neovim's TUI scrolls a window with exactly those two
sequences, wrapped in a DECSTBM region:

```
CSI 3;50 r      set the scroll region
CSI 3;1 H       cursor to the top-left of the region
CSI M           delete one line
CSI r           reset the region
CSI 50;1 H ...  repaint only the newly exposed row
```

`csi_dispatch` had no arm for either final byte, so every scroll fell through
to `_ => {}` and the grid never moved. The one-cell corruption was the same
bug, not a second one: once the grid diverged from Neovim's model, Neovim's
ordinary single-cell incremental writes landed on the wrong rows.

`src/main.rs` forces `TERM=xterm-256color`, whose terminfo advertises `dl`,
`dl1`, `il`, `il1` and `csr`, so Neovim had no reason to fall back to a full
redraw.

## Solution

Adds the four region-editing control functions and wires them to their
sequences. Everything is confined to `orzma_vt`.

**`Screen`** gains `insert_lines`, `delete_lines`, `scroll_region_up` and
`scroll_region_down`, resting on two private helpers that loop the existing
one-row primitives `Grid::scroll_up_one` / `Grid::scroll_down_one` over a span
from a first line to the bottom margin, sharing one count clamp.

- Insert and delete start at the cursor and are no-ops outside the DECSTBM
  margins, per VT510. On success they home the cursor to column zero and clear
  the deferred wrap, following xterm, kitty and ECMA-48 §8.3.32/§8.3.67. This
  is a deliberate divergence from alacritty and wezterm, which touch neither,
  and it matches the split `reverse_index` already takes for the wrap flag.
- The two region scrolls start at the top margin and leave the cursor alone.
- Passing the shift's first line as the primitive's `top` gives the scrollback
  behaviour for free: rows feed history only when the shift starts at screen
  row 0, and the scrolled-back viewport is held once per scrolled row.
- The scroll-region names avoid `scroll_up` / `scroll_down`, because
  `Screen::scroll(Scroll)` already means moving the viewport over scrollback.

**`csi_dispatch`** gains four arms. The scroll-down arm accepts at most one
parameter: xterm's highlight mouse tracking (`CSI Ps;Ps;Ps;Ps;Ps T`,
XTHIMOUSE) shares that final byte and carries no private marker, so an
unguarded arm would scroll the screen on a mouse-tracking request. xterm and
kitty gate the same way.

Two pieces of cleanup came out of review and are included here:

- `line_feed` and `reverse_index` each carried their own copy of the
  region-scroll rule, down to the viewport hold. They now delegate to
  `scroll_region_up(1)` / `scroll_region_down(1)`, so a later change to the
  history-feed or viewport-hold policy cannot leave those two paths behind.
- The screen module's file-level dead-code allowance is removed. Its own TODO
  asked for exactly this once the CSI handlers landed, and `#[expect]` fails
  the build once its lint stops firing.

### Testing

35 new tests. The crate suite goes from 635 to 670, and the workspace suite
passes at 1,762. `cargo clippy --workspace --all-targets -- -D warnings` and
`cargo fmt --check` are clean.

Coverage includes each operation inside and outside the region, count clamping
at the margin, the cursor and wrap-flag contract, the scrollback push and the
per-row viewport hold both below and at history capacity, webview placements
that follow their row versus ones evicted with a deleted row, a selection
endpoint lost to a deleted row, the multi-parameter `CSI T` being ignored, and
an end-to-end replay of the captured Neovim sequence on a 51-row grid that
asserts the shifted rows, the erased row, the untouched rows outside the
region, and that the emitted frame carries every row.

### Not included

Three gaps found during investigation are left as follow-ups, since none is
needed for this bug: DECRQM is never answered because any CSI carrying an
intermediate byte is dropped; DECTCEM is unimplemented; and the VT advances one
column per scalar while the renderer advances by display width.

The fix is verified by the emulator's own tests. A manual check in a real
window is still worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCt3WAeruFvbpiLucR9Hcu
