### PR TITLE
refactor(orzma_vt): ignore MC and HP memory lock on purpose rather than by fall-through

### DIFF
--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -198,6 +198,12 @@ impl VTActor for Executor<'_> {
             (b'\\', []) => {}
             // RIS
             (b'c', []) => self.reset_device(),
+            // HP memory lock / unlock
+            // NOTE: Memory lock is ignored rather than honored. It "locks
+            // memory above the cursor" (xterm-ctlseqs.pdf p.9), so honoring
+            // it would let a stray `ESC l` keep every row above the cursor
+            // from scrolling until an `ESC m` that may never come.
+            (b'l' | b'm', []) => {}
             // LS2
             (b'n', []) => self.invoke_character_set(GCode::G2),
             // LS3
@@ -273,6 +279,14 @@ impl VTActor for Executor<'_> {
             (None, b't') if params.value(0) == Some(22) => self.device.push_title(),
             // XTWINOPS 23
             (None, b't') if params.value(0) == Some(23) => self.pop_title(),
+            // MC
+            // NOTE: Every media copy is ignored rather than honored, printer
+            // controller mode included. That mode sends all later output to
+            // the printer "without displaying them on the screen" (vt510.pdf
+            // p.323), so honoring it with no printer attached would let a
+            // stray `CSI 5 i` hide everything up to a `CSI 4 i` that may
+            // never come.
+            (None | Some(b'?'), b'i') => {}
             // CUU
             (None, b'A') => self
                 .device

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -137,6 +137,8 @@ mod interpret_output;
 mod keypad;
 mod line_editing;
 mod line_movement;
+mod media_copy;
+mod memory_lock;
 mod modes;
 mod mouse;
 mod parser_limits;

--- a/crates/orzma_vt/src/interpreter/tests/media_copy.rs
+++ b/crates/orzma_vt/src/interpreter/tests/media_copy.rs
@@ -1,0 +1,44 @@
+//! Tests that the media copy family is ignored, so a printer request
+//! neither hides the output behind it nor answers.
+
+use super::*;
+
+/// Asserts that `CSI 5 i` leaves the terminal displaying what follows
+/// rather than entering printer controller mode and diverting it to a
+/// printer.
+///
+/// Case: a user `cat`s a binary file whose bytes happen to spell
+/// `CSI 5 i` and goes on reading the text printed behind it.
+#[test]
+fn printer_controller_mode_is_never_entered() {
+    let device = interpret(b"\x1b[5iab");
+    let row = device.active_screen().viewport_row(ViewportLine(0));
+    assert_eq!(row[0].c, 'a');
+    assert_eq!(row[1].c, 'b');
+}
+
+/// Asserts that every media copy is ignored rather than answered: none
+/// raises chunk liveness, a reply, or a signal.
+///
+/// Case: an application written for a terminal with a printer attached
+/// requests a screen print, toggles printer controller and autoprint
+/// modes, and asks for xterm's HTML and SVG screen dumps.
+#[test]
+fn every_media_copy_is_ignored() {
+    for request in [
+        &b"\x1b[i"[..],
+        b"\x1b[0i",
+        b"\x1b[4i",
+        b"\x1b[5i",
+        b"\x1b[10i",
+        b"\x1b[11i",
+        b"\x1b[?1i",
+        b"\x1b[?4i",
+        b"\x1b[?5i",
+    ] {
+        let output = interpret_fully(request).1;
+        assert!(!output.damaged, "{request:?} raises no liveness");
+        assert!(output.replies.is_empty(), "{request:?} sends no reply");
+        assert!(output.signals.is_empty(), "{request:?} raises no signal");
+    }
+}

--- a/crates/orzma_vt/src/interpreter/tests/memory_lock.rs
+++ b/crates/orzma_vt/src/interpreter/tests/memory_lock.rs
@@ -1,0 +1,33 @@
+//! Tests that HP memory lock is ignored, so no row is held out of
+//! scrolling.
+
+use super::*;
+
+/// Asserts that `ESC l` leaves the rows above the cursor free to scroll
+/// rather than locking them in place.
+///
+/// Case: a stray `ESC l` reaches the terminal while a shell is filling
+/// the screen, and the output goes on scrolling up past the top row.
+#[test]
+fn memory_lock_holds_no_row_out_of_scrolling() {
+    let device = interpret(b"a\r\nb\x1bl\n\n");
+    assert_eq!(
+        device.active_screen().viewport_row(ViewportLine(0))[0].c,
+        'b'
+    );
+}
+
+/// Asserts that neither `ESC l` nor `ESC m` raises chunk liveness, a
+/// reply, or a signal.
+///
+/// Case: a program written for an HP terminal locks the top of the
+/// screen as it starts and unlocks it again as it exits.
+#[test]
+fn neither_memory_lock_nor_unlock_raises_anything() {
+    for request in [&b"\x1bl"[..], b"\x1bm"] {
+        let output = interpret_fully(request).1;
+        assert!(!output.damaged, "{request:?} raises no liveness");
+        assert!(output.replies.is_empty(), "{request:?} sends no reply");
+        assert!(output.signals.is_empty(), "{request:?} raises no signal");
+    }
+}

--- a/docs/todo/vt-conformance-scope.md
+++ b/docs/todo/vt-conformance-scope.md
@@ -74,8 +74,11 @@ xterm-ctlseqs.pdf 全体の網羅は目標にしない。
 
 | シーケンス | 機能 | terminfo | 判断 |
 |---|---|---|---|
-| `CSI 0i` / `CSI 4i` / `CSI 5i` | MC プリンタ制御 | `mc0`/`mc4`/`mc5`/`mc5i` | **無視で可**。ただし「意図的に無視」とコメントを残す |
-| `ESC l` / `ESC m` | HP メモリロック | `meml`/`memu` | **無視で可**。同上 |
+| ~~`CSI 0i` / `CSI 4i` / `CSI 5i`~~ | ~~MC プリンタ制御~~ | `mc0`/`mc4`/`mc5`/`mc5i` | **✅ 意図的に無視と明示（2026-09-11）**。`csi_dispatch` に `(None \| Some(b'?'), b'i') => {}` を置き、xterm の 10/11（HTML/SVG ダンプ）と DEC private の `CSI ? Ps i`（autoprint 等）も同じ腕で塞いだ。理由は `// NOTE:` に記録: vt510 p.323 はプリンタコントローラモードを「画面に表示せずプリンタへ送る」と定めるので、忠実に実装するとプリンタ無しでは迷い込んだ `CSI 5 i` 1 つで `CSI 4 i` まで全出力が消える。**代償として `mc5i`（"printer won't echo on screen"）の広告とは食い違う**（`CSI 5 i` 以降も表示される）。alacritty も `CSI i` を持たず同じ挙動。テストは `interpreter/tests/media_copy.rs` |
+| ~~`ESC l` / `ESC m`~~ | ~~HP メモリロック~~ | `meml`/`memu` | **✅ 意図的に無視と明示（2026-09-11）**。`esc_dispatch` に `(b'l' \| b'm', []) => {}`。xterm-ctlseqs p.9 は "Locks memory above the cursor" と定めるので、実装すると迷い込んだ `ESC l` でカーソルより上の行がスクロールしなくなる。テストは `interpreter/tests/memory_lock.rs`（ロックを模した変異を入れると落ちることを確認済み） |
+
+> 1-C の 2 件はいずれも実装前から `_ => {}` に落ちて無視されていたので、**挙動は変わらない**。
+> 追加したテストは変更前から通る characterization テストで、将来仕様どおりに実装した変更を検出するためのもの。
 
 ## 2. Tier 2 — 推奨
 
@@ -168,7 +171,8 @@ Tier 1/2 とは別軸。`csi_dispatch` ではなく `crates/orzma_tty/src/input/
 6. **OSC 4/10/11/12** とその問い合わせ・リセット。
 7. **DECRQM/DECRPM と 2026 同期出力**、**DECRQSS/XTGETTCAP**。
 8. **OSC 8 / OSC 52**、**DECLRMM/DECSLRM**、**1015**。
-9. **残りの厳密準拠**: SGR blink、DECSCNM、メモリロック、プリンタ制御。
+9. **残りの厳密準拠**: SGR blink、DECSCNM。~~メモリロック、プリンタ制御~~ は
+   **意図的に無視と明示して完了（2026-09-11、§1-C）**。
 
 ## 6. 検証方法
 


### PR DESCRIPTION
## Problem

orzma advertises `xterm-256color` when the inherited `TERM` is empty, so every capability that entry advertises is an implementation contract. Tier 1-C of [`docs/todo/vt-conformance-scope.md`](docs/todo/vt-conformance-scope.md) lists two legacy families the entry advertises but that have little practical value:

| Sequence | Function | terminfo | Decision in the ledger |
| --- | --- | --- | --- |
| `CSI 0i` / `CSI 4i` / `CSI 5i` | MC (printer control) | `mc0` / `mc4` / `mc5` / `mc5i` | Ignore, but record that the ignore is deliberate |
| `ESC l` / `ESC m` | HP memory lock / unlock | `meml` / `memu` | Same |

Both already reached the catch-all `_ => {}` in `csi_dispatch` / `esc_dispatch`, so they were ignored. The problem was that nothing in the code or tests told a future reader whether that was a decision or an oversight, and the conformance audit that found the other Tier 1 gaps could not tell the two apart.

Printer controller mode is the case where this matters most: honoring it the way the manuals define it would change what the user sees, as explained below.

## Solution

**Behavior is unchanged.** Both families get explicit no-op arms in `crates/orzma_vt/src/interpreter.rs`, each with a `// NOTE:` that records why honoring it would be harmful and cites the manual it comes from.

- **MC**: `(None | Some(b'?'), b'i') => {}`. vt510 p.323 and vt220 p.38 define printer controller mode (`CSI 5 i`) as sending all later output to the printer *"without displaying them on the screen"* until `CSI 4 i`. Honoring that with no printer attached means one stray `CSI 5 i` (say, from `cat`-ing a binary file) hides everything that follows. One arm covers the whole family: the advertised `0`/`4`/`5`, xterm's `10`/`11` (HTML/SVG screen dumps), and the DEC-private `CSI ? Ps i` (autoprint etc.). terminfo doesn't advertise the private form, but vt510 defines it as the same MC function ("VT mode").
- **HP memory lock**: `(b'l' | b'm', []) => {}`. xterm-ctlseqs p.9 defines `ESC l` as *"Locks memory above the cursor"*. Honoring it means one stray `ESC l` stops every row above the cursor from scrolling until an `ESC m` that may never come.

alacritty (`vte-0.15.0/src/ansi.rs`) has no arm for either family and drops them through `unhandled!()`, so this matches its behavior.

### Known gap, accepted on purpose

Because `CSI 5 i` is ignored, text after it still appears on screen. That contradicts the advertised `mc5i` capability ("printer won't echo on screen"). The ledger records this as a deliberate trade-off: the alternative is the hidden-output failure above.

### Commits

| | |
| --- | --- |
| `24dcfdc` | characterization tests, which pass against the pre-change fall-through |
| `6805b80` | the two explicit arms and their `// NOTE:`s (behavior-neutral) |
| `724e88c` | conformance ledger: Tier 1-C marked done, §5 item 9 trimmed |

## Tests

Four cases in two new modules, following the "one module per control function" layout:

- `interpreter/tests/media_copy.rs`
  - Text after `CSI 5 i` still displays, so printer controller mode is never entered.
  - None of `CSI i`, `0i`, `4i`, `5i`, `10i`, `11i`, `?1i`, `?4i`, `?5i` raises chunk liveness, a reply, or a signal.
- `interpreter/tests/memory_lock.rs`
  - After `ESC l`, the rows above the cursor still scroll off at the bottom margin.
  - Neither `ESC l` nor `ESC m` raises chunk liveness, a reply, or a signal.

These are **characterization tests**: all four pass before the explicit arms land, because the old fall-through already ignored these sequences. Their value is failing if a later change honors the manuals' behavior.

I checked the memory-lock scroll test with a mutation: making `ESC l` set the top margin at the cursor row (xterm's lock) made it fail, with row 0 keeping `a`. I did not run the same check for `CSI 5 i`.

`cargo clippy -p orzma_vt --all-targets -- -D warnings` is clean, and `cargo test -p orzma_vt` passes all 773 tests.

## For the reviewer

The label is `skip-changelog` rather than `enhancement` because no user-visible behavior changes. Relabel if you'd rather list it with the other conformance PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsV2Gno8vcfu5vChaVTUg6
