### PR TITLE
refactor(orzma_vt): ignore DECSET 1034 on purpose rather than by fall-through

### DIFF
--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -661,6 +661,13 @@ impl Executor<'_> {
                 1049 => self.set_alternate_screen_with_cursor(enabled),
                 // Bracketed paste
                 2004 => self.device.modes_mut().bracketed_paste = enabled,
+                // Interpret "meta" key
+                // NOTE: The eighth-bit meta encoding is ignored rather than
+                // honored. Alt always prefixes ESC, which is xterm's
+                // metaSendsEscape, and xterm gives that precedence over this
+                // mode; honoring it would let the `smm` readline sends at
+                // startup switch every Alt key away from the ESC prefix.
+                1034 => {}
                 _ => self.set_mouse_mode(mode, enabled),
             }
         }

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -652,6 +652,13 @@ impl Executor<'_> {
                 1004 => self.device.modes_mut().focus_in_out = enabled,
                 // Alternate scroll
                 1007 => self.device.modes_mut().alternate_scroll = enabled,
+                // Interpret "meta" key
+                // NOTE: The eighth-bit meta encoding is ignored rather than
+                // honored. Alt always prefixes ESC, which is xterm's
+                // metaSendsEscape, and xterm gives that precedence over this
+                // mode; honoring it would let the `smm` readline sends at
+                // startup switch every Alt key away from the ESC prefix.
+                1034 => {}
                 // Alternate screen, erased on exit
                 1047 => self.set_alternate_screen_erased_on_exit(enabled),
                 // DECSC / DECRC
@@ -661,13 +668,6 @@ impl Executor<'_> {
                 1049 => self.set_alternate_screen_with_cursor(enabled),
                 // Bracketed paste
                 2004 => self.device.modes_mut().bracketed_paste = enabled,
-                // Interpret "meta" key
-                // NOTE: The eighth-bit meta encoding is ignored rather than
-                // honored. Alt always prefixes ESC, which is xterm's
-                // metaSendsEscape, and xterm gives that precedence over this
-                // mode; honoring it would let the `smm` readline sends at
-                // startup switch every Alt key away from the ESC prefix.
-                1034 => {}
                 _ => self.set_mouse_mode(mode, enabled),
             }
         }

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -157,6 +157,7 @@ mod line_editing;
 mod line_movement;
 mod media_copy;
 mod memory_lock;
+mod meta_key;
 mod modes;
 mod mouse;
 mod parser_limits;

--- a/crates/orzma_vt/src/interpreter/tests/meta_key.rs
+++ b/crates/orzma_vt/src/interpreter/tests/meta_key.rs
@@ -1,0 +1,36 @@
+//! Tests that the eighth-bit meta mode is ignored, so the key encoder's
+//! ESC prefix stays the only Alt encoding.
+
+use super::*;
+use crate::device::modes::VtModes;
+
+/// Asserts that `CSI ? 1034 h` and `CSI ? 1034 l` leave every mode at
+/// its default rather than recording a meta encoding.
+///
+/// Case: bash starts readline on an `xterm-256color` terminal, and
+/// readline sends the terminfo `smm` string to turn the meta key on.
+#[test]
+fn the_meta_key_mode_changes_no_mode() {
+    for request in [&b"\x1b[?1034h"[..], b"\x1b[?1034l"] {
+        assert_eq!(
+            interpret(request).modes(),
+            VtModes::default(),
+            "{request:?} changes no mode"
+        );
+    }
+}
+
+/// Asserts that neither setting nor resetting the meta key mode raises
+/// chunk liveness, a reply, or a signal.
+///
+/// Case: a shell turns the meta key on as it starts a prompt and off
+/// again as it hands the terminal to a program.
+#[test]
+fn neither_setting_nor_resetting_the_meta_key_mode_raises_anything() {
+    for request in [&b"\x1b[?1034h"[..], b"\x1b[?1034l"] {
+        let output = interpret_fully(request).1;
+        assert!(!output.damaged, "{request:?} raises no liveness");
+        assert!(output.replies.is_empty(), "{request:?} sends no reply");
+        assert!(output.signals.is_empty(), "{request:?} raises no signal");
+    }
+}

--- a/docs/todo/vt-conformance-scope.md
+++ b/docs/todo/vt-conformance-scope.md
@@ -62,7 +62,7 @@ xterm-ctlseqs.pdf 全体の網羅は目標にしない。
 | `CSI ! p` | DECSTR ソフトリセット | `is2`, `rs2` | `INTER∅` | **terminfo 経由の初期化列の先頭**。毎回無視されモードが残留する。`CharacterSetMapping::reset()` は DECSTR 待ちで `#[expect(dead_code)]` のまま（`character_sets.rs:220`）。**DECTCEM 実装後、優先度が上がった**: vt510 p.277 Table 5-9 は DECSTR 後の DECTCEM を "Cursor enabled." と定めており、`is2`/`rs2` の先頭が `\E[!p` なので **`tput init` が隠れたカーソルを回復できない**。RIS (`\Ec`) は `VtModes::default()` で回復するが、DECSTR は名指しした一部だけを戻すので `text_cursor_enable = Shown` を明示的に含める必要がある。**DECAWM も同じ Table 5-9 に載っている**（"Autowrap / DECAWM / No autowrap."、IRM の "Replace mode." も同様）。IRM は `InsertReplaceMode::default()` が既に `Replace` なので一致するが、`AutoWrap::default()` は `Enabled` なので **DECAWM だけ default が表の値と逆**であり、値そのものが要判断（`am` を広告する端末で本当に off に落とすか）。含める場合は `modes_mut` への直書きではなく `DeviceState::set_auto_wrap` を通すこと — reset 方向は両画面の LCF 解除を伴う（§4 の LCF 一覧を参照） |
 | `CSI ?12 h/l` | カーソル点滅 | `cnorm`, `cvvis` | `MODE∅`。`blinking: false` 固定 | 点滅指定が効かない |
 | `CSI ?3 l` | DECCOLM リセット | `is2`, `rs2` の一部 | `MODE∅` | 初期化列に含まれる |
-| `CSI ?1034 h/l` | 8bit Meta | `smm`/`rmm`, `km` | `MODE∅` | Meta キーのバイト表現が食い違う |
+| ~~`CSI ?1034 h/l`~~ | ~~8bit Meta~~ | `smm`/`rmm`, `km` | **✅ 意図的に無視と明示（2026-09-11）**。`set_private_modes` に `1034 => {}`。Alt は常に ESC 前置（xterm の metaSendsEscape 相当）で、xterm と foot は 1036 を 1034 より優先するので、この設定では 8 ビット符号化に到達しない。bash / readline が起動時に送る `smm` は変更前から無視されており、挙動は変わらない。テストは `interpreter/tests/meta_key.rs` | ~~Meta キーのバイト表現が食い違う~~ |
 | `CSI ?5 h/l` | DECSCNM 反転 | `flash` | `MODE∅` | ビジュアルベルが無反応 |
 | `CSI 5 m` | SGR blink | `blink`, `sgr` | **意図的に no-op**（`sgr.rs:112` の `5 \| 6 \| 25 \| ... => {}`） | 点滅が普通の文字になる。`Style` へのビット追加＋レンダラ対応が要る |
 | `OSC 4;n;rgb:…` | インデックス色変更 | `initc`, `ccc` | `OSC∅` | パレット変更が効かない |


### PR DESCRIPTION
## Problem

Tier 1-B of [`docs/todo/vt-conformance-scope.md`](docs/todo/vt-conformance-scope.md) lists `CSI ? 1034 h/l` ("Interpret meta key", xterm-ctlseqs p.20), which `xterm-256color` advertises through `smm` / `rmm` and `km`. It fell through `set_private_modes` into `set_mouse_mode`, which ignores numbers it does not know. So it was ignored, but nothing in the code or tests told a reader whether that was a decision or an oversight.

The sequence does arrive in practice: bash's readline sends `smm` (`\E[?1034h`) at startup on `xterm-256color`.

## Solution

**Behavior is unchanged.** `set_private_modes` gets an explicit `1034 => {}` arm, placed in numeric order between 1007 and 1047, with a `// NOTE:` recording why honoring the mode would be harmful:

- orzma's key encoder always prefixes Alt with ESC. That is xterm's `metaSendsEscape` (DECSET 1036) permanently on, and both xterm (`input.c`) and foot (`input.c`) give 1036 precedence over 1034. The eighth-bit encoding 1034 selects is therefore never reached in that configuration.
- Honoring 1034 anyway would let readline's startup `smm` switch every Alt key away from the ESC prefix.

alacritty, kitty, ghostty and wezterm have no handler for 1034 either. This is the same shape as #288.

### Commits

| | |
| --- | --- |
| `eaf320d` | characterization tests, which pass against the pre-change fall-through |
| `235b8cf` | the explicit arm and its `// NOTE:` (behavior-neutral) |
| `5503f26` | scope doc: the §1-B row marked as explicitly ignored |
| `8a63b8d` | the arm moved into numeric order (from review) |

## Tests

`interpreter/tests/meta_key.rs` adds two cases, taking `orzma_vt` from 801 to 803 tests:

- `?1034h` and `?1034l` both leave every mode at its default.
- Neither raises chunk liveness, a reply, or a signal.

These are characterization tests: both pass before the arm lands, because the old fall-through already ignored the mode. I checked the first with a mutation: making the arm set `app_cursor` made it fail.

`cargo test -p orzma_vt`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass.

## For the reviewer

The label is `skip-changelog` rather than `enhancement` because no user-visible behavior changes, as with #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
