### PR TITLE
test(orzma_tty_renderer): pin the shader's style constants to the Style bits

### DIFF
--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -485,10 +485,8 @@ pub enum FontFace {
 
 impl FontFace {
     pub fn from_style(style: u16) -> Self {
-        const BOLD: u16 = Style::BOLD.bits();
-        const ITALIC: u16 = Style::ITALIC.bits();
-        let bold = (style & BOLD) != 0;
-        let italic = (style & ITALIC) != 0;
+        let bold = (style & Style::BOLD.bits()) != 0;
+        let italic = (style & Style::ITALIC.bits()) != 0;
         match (bold, italic) {
             (false, false) => Self::Regular,
             (true, false) => Self::Bold,

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -484,6 +484,9 @@ pub enum FontFace {
 }
 
 impl FontFace {
+    /// Returns the face that a cell's raw `Style` bits select.
+    ///
+    /// Only `BOLD` and `ITALIC` take part; every other bit is ignored.
     pub fn from_style(style: u16) -> Self {
         let bold = (style & Style::BOLD.bits()) != 0;
         let italic = (style & Style::ITALIC.bits()) != 0;
@@ -828,5 +831,25 @@ mod tests {
             res.metrics.advance_phys,
             m12.advance_phys * 2.0,
         );
+    }
+
+    /// Asserts that `from_style` picks the face from the `BOLD` and
+    /// `ITALIC` bits alone, whatever other `Style` bits the cell carries.
+    ///
+    /// Case: a program prints bold, italic, and bold-italic text, some of
+    /// it also underlined or reversed.
+    #[test]
+    fn from_style_selects_the_face_from_the_bold_and_italic_bits() {
+        let other_bits = Style::all().difference(Style::BOLD | Style::ITALIC).bits();
+        let cases = [
+            (Style::empty(), FontFace::Regular),
+            (Style::BOLD, FontFace::Bold),
+            (Style::ITALIC, FontFace::Italic),
+            (Style::BOLD | Style::ITALIC, FontFace::BoldItalic),
+        ];
+        for (style, face) in cases {
+            assert_eq!(FontFace::from_style(style.bits()), face);
+            assert_eq!(FontFace::from_style(style.bits() | other_bits), face);
+        }
     }
 }

--- a/crates/orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/orzma_tty_renderer/src/glyph/font.rs
@@ -2,6 +2,7 @@ use crate::bundled::{
     BOLD, BOLD_ITALIC, FALLBACK_BOLD, FALLBACK_BOLD_ITALIC, FALLBACK_ITALIC, FALLBACK_REGULAR,
     ITALIC, REGULAR, SYMBOL_REGULAR,
 };
+use crate::schema::Style;
 use ab_glyph::{Font, FontArc, FontVec, ScaleFont};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
@@ -484,8 +485,8 @@ pub enum FontFace {
 
 impl FontFace {
     pub fn from_style(style: u16) -> Self {
-        const BOLD: u16 = 1;
-        const ITALIC: u16 = 2;
+        const BOLD: u16 = Style::BOLD.bits();
+        const ITALIC: u16 = Style::ITALIC.bits();
         let bold = (style & BOLD) != 0;
         let italic = (style & ITALIC) != 0;
         match (bold, italic) {

--- a/crates/orzma_tty_renderer/src/material.rs
+++ b/crates/orzma_tty_renderer/src/material.rs
@@ -559,8 +559,8 @@ struct GpuCell {
     fg_packed: u32,
     /// `0xAABBGGRR` packed background.
     bg_packed: u32,
-    /// The cell's `Style` bits from `orzma_vt`, plus the renderer-only
-    /// flags from bit 16 up.
+    /// The cell's `Style` bits ORed with the underline and strike bits its
+    /// combining marks promote, plus the renderer-only flags from bit 16 up.
     style_flags: u32,
     /// OSC 8 wire id of this cell, or `0` for "no link". Safe because
     /// `HyperlinkInterner` reserves `HyperlinkId(0)`.
@@ -572,12 +572,16 @@ struct GpuCell {
 /// origin. See `rebuild_cells` and `terminal_ui_material.wgsl`.
 ///
 /// Bit allocation in `GpuCell.style_flags` (a `u32`):
-/// - Bits 0-15: the cell's `Style` bits from `orzma_vt` (BOLD=1, ITALIC=2,
-///   UNDERLINE=4, STRIKE=8, REVERSE=16, DIM=32, HIDDEN=64; bits 7-15
-///   reserved).
+/// - Bits 0-15: `orzma_vt`'s `Style` flags at the bits `Style` assigns,
+///   from the cell's own `Style` and from `style_from_combining_marks`.
 /// - Bits 16+: renderer-only flags (this const), kept physically separate
 ///   from the `Style` range so a future `Style` flag cannot collide.
 const STYLE_WIDE_RIGHT_HALF: u32 = 0x1_0000;
+
+const _: () = assert!(
+    (STYLE_WIDE_RIGHT_HALF & Style::all().bits() as u32) == 0,
+    "a renderer-only style flag overlaps a `Style` bit",
+);
 
 impl Default for GpuCell {
     // NOTE: glyph_index defaults to u32::MAX (GLYPH_NONE) — the shader's
@@ -913,7 +917,7 @@ fn rebuild_cells(
             let glyph_index = resolve_glyph_index(cell, state, fonts, atlas, phys_font_size);
             let fg = packed_palette.cell_fg(cell.fg);
             let bg = packed_palette.cell_bg(cell.bg);
-            let style_flags = u32::from(cell.style) | style_bits_from_combining_marks(&cell.text);
+            let style_flags = u32::from(cell.style | style_from_combining_marks(&cell.text).bits());
 
             let target = (row_idx as u32 * cols + col) as usize;
             if let Some(slot) = state.cpu_cells.get_mut(target) {
@@ -953,40 +957,30 @@ fn rebuild_cells(
     }
 }
 
-/// TODO: 以下のようなスタイにも対応できるようにする
-///
-///  - U+0301 (鋭アクセント á)
-///  - U+0303 (チルダ ã)
-///  - U+0308 (ウムラウト ä)
-///  - U+20D7 (上向きベクトル a⃗)
-///
-///
-/// Promotes specific combining marks in a grapheme cluster to terminal-style
-/// underline/strike bits so the shader paints them, since `ab_glyph` cannot
-/// composite combining glyphs onto the base char in Tier 1.
+/// Promotes specific combining marks in a grapheme cluster to the `Style`
+/// underline and strike flags so the shader paints them, since `ab_glyph`
+/// cannot composite combining glyphs onto the base char in Tier 1.
 ///
 /// Maps U+0332 (combining low line), U+0333 (double low line), U+0331
 /// (combining macron below) to `Style::UNDERLINE`, and U+0336 (combining
 /// long stroke overlay) to `Style::STRIKE`. Other combining marks are
 /// ignored — the base glyph still renders.
-fn style_bits_from_combining_marks(text: &str) -> u32 {
-    // ASCII bytes (< 0x80) can never be combining marks (those live above
-    // U+0300, i.e. multi-byte UTF-8). is_ascii is SIMD-vectorized and skips
-    // the per-char decode for the dominant case in a typical terminal frame.
+fn style_from_combining_marks(text: &str) -> Style {
     if text.is_ascii() {
-        return 0;
+        return Style::empty();
     }
-    const UNDERLINE: u32 = Style::UNDERLINE.bits() as u32;
-    const STRIKE: u32 = Style::STRIKE.bits() as u32;
-    let mut bits = 0u32;
+    // TODO: Render other combining marks as well, such as U+0301
+    // (combining acute accent), U+0303 (combining tilde), U+0308
+    // (combining diaeresis), and U+20D7 (combining right arrow above).
+    let mut style = Style::empty();
     for c in text.chars() {
         match c {
-            '\u{0332}' | '\u{0333}' | '\u{0331}' => bits |= UNDERLINE,
-            '\u{0336}' => bits |= STRIKE,
+            '\u{0332}' | '\u{0333}' | '\u{0331}' => style |= Style::UNDERLINE,
+            '\u{0336}' => style |= Style::STRIKE,
             _ => {}
         }
     }
-    bits
+    style
 }
 
 fn resolve_glyph_index(
@@ -1056,7 +1050,7 @@ fn selection_uniforms(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
     use std::mem::size_of;
 
     #[test]
@@ -1279,38 +1273,56 @@ mod tests {
         }
     }
 
-    /// Asserts that the style constants the shader declares are exactly
-    /// the `Style` flags it paints, each carrying the bit `Style` assigns.
+    /// Asserts that the shader's style constants are exactly the `Style`
+    /// flags other than the font-selecting `BOLD` and `ITALIC`, plus the
+    /// renderer-only `WIDE_RIGHT_HALF`, each declared with the bit the Rust
+    /// side assigns.
     ///
-    /// Case: a new SGR attribute takes one of the reserved style bits and
-    /// the shader is updated in the same change.
+    /// Case: a program prints underlined, struck-through, reverse-video,
+    /// faint, and concealed text, and the shader paints each attribute from
+    /// the cell's raw `Style` bits.
     #[test]
     fn wgsl_style_constants_track_the_style_bits() {
-        const FONT_SELECTED: [&str; 2] = ["BOLD", "ITALIC"];
+        const FONT_SELECTED: Style = Style::BOLD.union(Style::ITALIC);
         let src = include_str!("shaders/terminal_ui_material.wgsl");
-        let declared: BTreeMap<&str, u32> = src
+        let declared: BTreeSet<String> = src
             .lines()
-            .filter_map(|line| line.trim().strip_prefix("const STYLE_"))
-            .map(|decl| {
-                let (name, literal) = decl
-                    .split_once(": u32 = ")
-                    .expect("a style constant is declared as `const STYLE_X: u32 = Nu;`");
-                let literal = literal.trim_end_matches("u;");
-                let value = match literal.strip_prefix("0x") {
-                    Some(hex) => u32::from_str_radix(hex, 16),
-                    None => literal.parse(),
-                }
-                .expect("a style constant carries an integer literal");
-                (name, value)
-            })
+            .map(str::trim)
+            .filter(|line| line.starts_with("const STYLE_"))
+            .map(str::to_owned)
             .collect();
-        let mut expected: BTreeMap<&str, u32> = Style::all()
+        let expected: BTreeSet<String> = Style::all()
+            .difference(FONT_SELECTED)
             .iter_names()
-            .filter(|(name, _)| !FONT_SELECTED.contains(name))
-            .map(|(name, flag)| (name, u32::from(flag.bits())))
+            .map(|(name, flag)| format!("const STYLE_{name}: u32 = {}u;", flag.bits()))
+            .chain([format!(
+                "const STYLE_WIDE_RIGHT_HALF: u32 = {STYLE_WIDE_RIGHT_HALF:#x}u;"
+            )])
             .collect();
-        expected.insert("WIDE_RIGHT_HALF", STYLE_WIDE_RIGHT_HALF);
         assert_eq!(declared, expected);
+    }
+
+    /// Asserts that the underline-like combining marks promote to
+    /// `Style::UNDERLINE`, the long stroke overlay to `Style::STRIKE`, and
+    /// any other text to no flags.
+    ///
+    /// Case: a program decorates text with combining low lines and stroke
+    /// overlays next to plain ASCII and accented text.
+    #[test]
+    fn combining_marks_promote_to_underline_and_strike() {
+        assert_eq!(style_from_combining_marks("a"), Style::empty());
+        assert_eq!(style_from_combining_marks("e\u{0301}"), Style::empty());
+        for mark in ['\u{0331}', '\u{0332}', '\u{0333}'] {
+            assert_eq!(
+                style_from_combining_marks(&format!("a{mark}")),
+                Style::UNDERLINE
+            );
+        }
+        assert_eq!(style_from_combining_marks("a\u{0336}"), Style::STRIKE);
+        assert_eq!(
+            style_from_combining_marks("a\u{0332}\u{0336}"),
+            Style::UNDERLINE | Style::STRIKE
+        );
     }
 
     /// Asserts that in-viewport selection endpoints map to their

--- a/crates/orzma_tty_renderer/src/material.rs
+++ b/crates/orzma_tty_renderer/src/material.rs
@@ -6,7 +6,7 @@ use crate::{
     material::state::TerminalMaterialState,
     schema::{
         Color as CellColor, GridCell, GridLine, HyperlinkHoverState, Palette, Rgb,
-        SelectionGeometry, SelectionRange, TerminalGrid,
+        SelectionGeometry, SelectionRange, Style, TerminalGrid,
     },
 };
 use bevy::{
@@ -965,8 +965,8 @@ fn rebuild_cells(
 /// composite combining glyphs onto the base char in Tier 1.
 ///
 /// Maps U+0332 (combining low line), U+0333 (double low line), U+0331
-/// (combining macron below) to `style::UNDERLINE`, and U+0336 (combining
-/// long stroke overlay) to `style::STRIKE`. Other combining marks are
+/// (combining macron below) to `Style::UNDERLINE`, and U+0336 (combining
+/// long stroke overlay) to `Style::STRIKE`. Other combining marks are
 /// ignored — the base glyph still renders.
 fn style_bits_from_combining_marks(text: &str) -> u32 {
     // ASCII bytes (< 0x80) can never be combining marks (those live above
@@ -975,8 +975,8 @@ fn style_bits_from_combining_marks(text: &str) -> u32 {
     if text.is_ascii() {
         return 0;
     }
-    const UNDERLINE: u32 = 4;
-    const STRIKE: u32 = 8;
+    const UNDERLINE: u32 = Style::UNDERLINE.bits() as u32;
+    const STRIKE: u32 = Style::STRIKE.bits() as u32;
     let mut bits = 0u32;
     for c in text.chars() {
         match c {

--- a/crates/orzma_tty_renderer/src/material.rs
+++ b/crates/orzma_tty_renderer/src/material.rs
@@ -559,7 +559,8 @@ struct GpuCell {
     fg_packed: u32,
     /// `0xAABBGGRR` packed background.
     bg_packed: u32,
-    /// Mirror of `orzma_terminal_protocol::style::*` bit flags.
+    /// The cell's `Style` bits from `orzma_vt`, plus the renderer-only
+    /// flags from bit 16 up.
     style_flags: u32,
     /// OSC 8 wire id of this cell, or `0` for "no link". Safe because
     /// `HyperlinkInterner` reserves `HyperlinkId(0)`.
@@ -571,9 +572,9 @@ struct GpuCell {
 /// origin. See `rebuild_cells` and `terminal_ui_material.wgsl`.
 ///
 /// Bit allocation in `GpuCell.style_flags` (a `u32`):
-/// - Bits 0-15: wire-protocol style mirrored from
-///   `orzma_terminal_protocol::style::*` (BOLD=1, ITALIC=2, UNDERLINE=4,
-///   STRIKE=8, REVERSE=16, DIM=32, HIDDEN=64; bits 7-15 reserved).
+/// - Bits 0-15: the cell's `Style` bits from `orzma_vt` (BOLD=1, ITALIC=2,
+///   UNDERLINE=4, STRIKE=8, REVERSE=16, DIM=32, HIDDEN=64; bits 7-15
+///   reserved).
 /// - Bits 16+: renderer-only flags (this const), kept physically separate
 ///   from the wire range so a future wire extension cannot collide.
 const STYLE_WIDE_RIGHT_HALF: u32 = 0x1_0000;
@@ -1055,6 +1056,7 @@ fn selection_uniforms(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use std::mem::size_of;
 
     #[test]
@@ -1275,6 +1277,40 @@ mod tests {
                 "slot {i} call must pair overlay_rects[{i}] with overlay{i}_tex"
             );
         }
+    }
+
+    /// Asserts that the style constants the shader declares are exactly
+    /// the `Style` flags it paints, each carrying the bit `Style` assigns.
+    ///
+    /// Case: a new SGR attribute takes one of the reserved style bits and
+    /// the shader is updated in the same change.
+    #[test]
+    fn wgsl_style_constants_track_the_style_bits() {
+        const FONT_SELECTED: [&str; 2] = ["BOLD", "ITALIC"];
+        let src = include_str!("shaders/terminal_ui_material.wgsl");
+        let declared: BTreeMap<&str, u32> = src
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("const STYLE_"))
+            .map(|decl| {
+                let (name, literal) = decl
+                    .split_once(": u32 = ")
+                    .expect("a style constant is declared as `const STYLE_X: u32 = Nu;`");
+                let literal = literal.trim_end_matches("u;");
+                let value = match literal.strip_prefix("0x") {
+                    Some(hex) => u32::from_str_radix(hex, 16),
+                    None => literal.parse(),
+                }
+                .expect("a style constant carries an integer literal");
+                (name, value)
+            })
+            .collect();
+        let mut expected: BTreeMap<&str, u32> = Style::all()
+            .iter_names()
+            .filter(|(name, _)| !FONT_SELECTED.contains(name))
+            .map(|(name, flag)| (name, u32::from(flag.bits())))
+            .collect();
+        expected.insert("WIDE_RIGHT_HALF", STYLE_WIDE_RIGHT_HALF);
+        assert_eq!(declared, expected);
     }
 
     /// Asserts that in-viewport selection endpoints map to their

--- a/crates/orzma_tty_renderer/src/material.rs
+++ b/crates/orzma_tty_renderer/src/material.rs
@@ -576,7 +576,7 @@ struct GpuCell {
 ///   UNDERLINE=4, STRIKE=8, REVERSE=16, DIM=32, HIDDEN=64; bits 7-15
 ///   reserved).
 /// - Bits 16+: renderer-only flags (this const), kept physically separate
-///   from the wire range so a future wire extension cannot collide.
+///   from the `Style` range so a future `Style` flag cannot collide.
 const STYLE_WIDE_RIGHT_HALF: u32 = 0x1_0000;
 
 impl Default for GpuCell {

--- a/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -80,13 +80,13 @@ struct CellColors {
 @group(1) @binding(16) var overlay10_tex: texture_2d<f32>;
 @group(1) @binding(17) var overlay11_tex: texture_2d<f32>;
 
-// NOTE: Must stay in sync with `orzma_terminal_protocol::style::*`. The
-//       Rust-side test `style_bits_match_protocol_constants` asserts the
-//       literal values here against the canonical Rust constants.
 // Hyperlink accent color when the activation modifier is held and the
 // cell shares the hovered link's id. Hardcoded for v1.
 const ACCENT_LINK_COLOR: vec4<f32> = vec4<f32>(0.4, 0.7, 1.0, 1.0);
 
+// NOTE: Each style constant must carry the bit `Style` in `orzma_vt`
+//       assigns. The test `wgsl_style_constants_track_the_style_bits` in
+//       material.rs fails when a value or the set of names drifts.
 const STYLE_UNDERLINE: u32 = 4u;
 const STYLE_STRIKE: u32 = 8u;
 const STYLE_REVERSE: u32 = 16u;

--- a/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -84,9 +84,10 @@ struct CellColors {
 // cell shares the hovered link's id. Hardcoded for v1.
 const ACCENT_LINK_COLOR: vec4<f32> = vec4<f32>(0.4, 0.7, 1.0, 1.0);
 
-// NOTE: Each style constant must carry the bit `Style` in `orzma_vt`
-//       assigns. The test `wgsl_style_constants_track_the_style_bits` in
-//       material.rs fails when a value or the set of names drifts.
+// NOTE: Each style constant must carry the bit that `orzma_vt`'s `Style`
+//       assigns to the same name. The test
+//       `wgsl_style_constants_track_the_style_bits` in material.rs fails
+//       when a value or the set of names drifts.
 const STYLE_UNDERLINE: u32 = 4u;
 const STYLE_STRIKE: u32 = 8u;
 const STYLE_REVERSE: u32 = 16u;

--- a/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
+++ b/crates/orzma_tty_renderer/src/shaders/terminal_ui_material.wgsl
@@ -84,10 +84,6 @@ struct CellColors {
 // cell shares the hovered link's id. Hardcoded for v1.
 const ACCENT_LINK_COLOR: vec4<f32> = vec4<f32>(0.4, 0.7, 1.0, 1.0);
 
-// NOTE: Each style constant must carry the bit that `orzma_vt`'s `Style`
-//       assigns to the same name. The test
-//       `wgsl_style_constants_track_the_style_bits` in material.rs fails
-//       when a value or the set of names drifts.
 const STYLE_UNDERLINE: u32 = 4u;
 const STYLE_STRIKE: u32 = 8u;
 const STYLE_REVERSE: u32 = 16u;

--- a/crates/orzma_vt/src/screen/cursor.rs
+++ b/crates/orzma_vt/src/screen/cursor.rs
@@ -4,9 +4,9 @@ use crate::screen::grid::coords::GridPoint;
 
 /// Bit 0 of the packed `cursor_style` u32 — set when the cursor
 /// should be drawn. The WGSL shader short-circuits when this bit is
-/// clear (see `terminal_ui_material.wgsl:337`). Exposed so app-level
-/// overrides (e.g., `TerminalGrid.suppress_cursor`) can mask it out
-/// without re-deriving the literal `1`.
+/// clear (see `paint_cursor` in `terminal_ui_material.wgsl`). Exposed
+/// so app-level overrides (e.g., `TerminalGrid.suppress_cursor`) can
+/// mask it out without re-deriving the literal `1`.
 pub const CURSOR_VISIBLE_BIT: u32 = 1;
 
 /// Cursor state at snapshot time.
@@ -27,7 +27,7 @@ impl Cursor {
     /// Packs the style into the u32 the WGSL shader decodes: bit 0 is
     /// [`CURSOR_VISIBLE_BIT`], bits 1-2 carry the shape (Block `0`,
     /// Underline `1`, Bar `2`), and bit 3 carries the blinking flag
-    /// (see `terminal_ui_material.wgsl:99-103`).
+    /// (see the `CURSOR_*` constants in `terminal_ui_material.wgsl`).
     pub fn pack_cursor_style(&self) -> u32 {
         let visible = if self.visible { CURSOR_VISIBLE_BIT } else { 0 };
         let shape = match self.shape {

--- a/crates/orzma_vt/src/screen/grid/run.rs
+++ b/crates/orzma_vt/src/screen/grid/run.rs
@@ -9,17 +9,6 @@ use bitflags::bitflags;
 
 bitflags! {
     /// The SGR attributes a cell or a run carries.
-    ///
-    /// # Invariants
-    ///
-    /// The renderer's shader reads the raw bits and mirrors every flag
-    /// except `BOLD` and `ITALIC` as a literal constant, so renumbering
-    /// one repaints cells with the wrong attribute. The renderer test
-    /// `wgsl_style_constants_track_the_style_bits` catches that drift
-    /// under `cargo test --workspace`; `cargo test -p orzma_vt` does not
-    /// run it. Bits 7-15 are reserved for the SGR attributes this
-    /// terminal parses but cannot yet paint — the underline variants
-    /// `4:2`-`4:5`, blink, and overline.
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
     pub struct Style: u16 {
         /// Bold weight.

--- a/crates/orzma_vt/src/screen/grid/run.rs
+++ b/crates/orzma_vt/src/screen/grid/run.rs
@@ -12,11 +12,14 @@ bitflags! {
     ///
     /// # Invariants
     ///
-    /// The bit values are pinned by the renderer's shader constants,
-    /// which read the raw bits: renumbering a flag silently repaints
-    /// every cell with the wrong attribute. Bits 7-15 are reserved for
-    /// the SGR attributes this terminal parses but cannot yet paint —
-    /// the underline variants `4:2`-`4:5`, blink, and overline.
+    /// The renderer's shader reads the raw bits and mirrors every flag
+    /// except `BOLD` and `ITALIC` as a literal constant, so renumbering
+    /// one repaints cells with the wrong attribute. The renderer test
+    /// `wgsl_style_constants_track_the_style_bits` catches that drift
+    /// under `cargo test --workspace`; `cargo test -p orzma_vt` does not
+    /// run it. Bits 7-15 are reserved for the SGR attributes this
+    /// terminal parses but cannot yet paint — the underline variants
+    /// `4:2`-`4:5`, blink, and overline.
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
     pub struct Style: u16 {
         /// Bold weight.


### PR DESCRIPTION
## Problem

The shader's `STYLE_*` constants are literal copies of `orzma_vt`'s `Style` bits, which the GPU reads raw. A `// NOTE:` above them claimed that a Rust test, `style_bits_match_protocol_constants`, kept them in sync with `orzma_terminal_protocol::style`. Neither that test nor that crate exists any more. `Style`'s own doc also declared its bits "pinned by the renderer's shader constants", and nothing checked that either.

The Rust side of the renderer held two more hand copies: `style_bits_from_combining_marks` (`UNDERLINE = 4`, `STRIKE = 8`) and `FontFace::from_style` (`BOLD = 1`, `ITALIC = 2`). Renumbering a `Style` flag would have painted cells with the wrong attribute, and no test would have failed.

## Solution

**Rendering is unchanged.** The affected code is `crates/orzma_tty_renderer` (`material.rs`, `glyph/font.rs`, `terminal_ui_material.wgsl`), plus two doc comments in `crates/orzma_vt`.

- `wgsl_style_constants_track_the_style_bits` reads the shader with `include_str!` and compares its `const STYLE_*` declaration lines, as a set, with lines built from every `Style` flag except the font-selecting `BOLD` / `ITALIC`, plus `STYLE_WIDE_RIGHT_HALF`. A changed value, a missing or extra name on either side, or a duplicate declaration fails it.
- A `const` assert keeps the renderer-only `STYLE_WIDE_RIGHT_HALF` off every `Style` bit.
- The combining-mark helper becomes `style_from_combining_marks` and returns `Style`, and `FontFace::from_style` masks with `Style::BOLD` / `Style::ITALIC` directly. Both mappings now have tests; neither had one before.
- Comments:
  - The stale shader NOTE is replaced and moved to sit directly above the constants.
  - `material.rs` docs stop naming the deleted crate and stop hand-copying bit values.
  - `Style`'s invariant names the guard, and says that `cargo test -p orzma_vt` alone does not run it.
  - `orzma_vt`'s `cursor.rs` cites `paint_cursor` and the `CURSOR_*` constants instead of shader line numbers, which the NOTE move had shifted.
  - The Japanese `/// TODO:` on the combining-mark helper becomes an English `// TODO:`.

### Commits

| | |
| --- | --- |
| `2c2ec9d` | renderer bit copies derived from `Style` |
| `93db54e` | shader sync test and the NOTE fix |
| `dcbb0db` | `from_style` masks through `Style` directly; wording fixes (from review) |
| `a735ef8` | line-set comparison, the `const` assert, tests for both mappings, doc fixes (from a follow-up code review) |

## Tests

`orzma_tty_renderer` goes from 70 to 73 tests: the shader sync test, `from_style_selects_the_face_from_the_bold_and_italic_bits`, and `combining_marks_promote_to_underline_and_strike`. `orzma_vt` stays at 801, since only doc comments changed there.

Each guard was checked by mutation:
- A changed shader value (`STYLE_DIM = 33u`), an extra `STYLE_BLINK` declaration, and a duplicate declaration each fail the sync test.
- A mask typo in `from_style` fails its test, and so do swapped combining-mark arms.
- An overlapping renderer-only bit fails at compile time.

`cargo test -p orzma_tty_renderer -p orzma_vt`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass.

## For the reviewer

- The label is `skip-changelog` because nothing a user sees changes.
- The `CURSOR_*` constants and the shape decode in the shader are hand copies of `Cursor::pack_cursor_style` of the same kind, still unguarded. They are latent until DECSCUSR lands, and left for that change.
- The code review of this branch also reported pre-existing rendering issues outside this diff, left untouched here:
  - `resolve_cell_colors` applies HIDDEN before REVERSE, so `SGR 7;8` loses the reversed block.
  - Reverse video hard-codes opaque black instead of the palette background.
  - Underline and strike still paint on HIDDEN cells.
  - An atlas overflow partway through `rebuild_cells` can leave stale glyph indices.
  - `paint_right_strip` paints a sliver of a last-column wide glyph into the padding.

  They seem worth follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
