### PR TITLE
test(orzma_tty): tolerate the exit sender outliving the status it sent

### DIFF
--- a/crates/orzma_tty/src/pty.rs
+++ b/crates/orzma_tty/src/pty.rs
@@ -49,9 +49,13 @@ pub enum ChunkPoll {
 pub enum ExitPoll {
     /// The child exited; `None` if the `wait` itself failed.
     Exited(Option<i32>),
-    /// The child is still running (or its status is not yet sent).
+    /// No status is queued while the thread that sends it is still alive.
+    ///
+    /// Besides a running child, this covers the moment after the status
+    /// has been received but before the sending thread has exited.
     Pending,
-    /// The reader thread is gone without ever sending a status.
+    /// The thread that sends the status is gone and no status remains
+    /// queued.
     Disconnected,
 }
 
@@ -624,9 +628,9 @@ mod tests {
     }
 
     /// Asserts that the child's exit is reported exactly once: the
-    /// first successful poll yields the exit code, and every later poll
-    /// finds the reader thread gone and reports `Disconnected` rather
-    /// than replaying the code.
+    /// first successful poll yields the exit code, and later polls report
+    /// `Pending` until the sending thread is gone and then `Disconnected`,
+    /// never replaying the code.
     ///
     /// Case: the shell process exits while the host keeps polling every
     /// frame for output and exit state.
@@ -651,12 +655,19 @@ mod tests {
             thread::sleep(Duration::from_millis(10));
         };
         assert_eq!(code, Some(0));
-        for _ in 0..3 {
-            assert_eq!(
-                pty.poll_exit(),
-                ExitPoll::Disconnected,
-                "the exit must not be re-reported"
-            );
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match pty.poll_exit() {
+                ExitPoll::Disconnected => break,
+                ExitPoll::Pending => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "the exit stream never disconnected"
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                }
+                ExitPoll::Exited(code) => panic!("the exit was re-reported with {code:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `exit_is_reported_once_after_the_child_terminates` failed on the Windows CI runner (run 34589834550, on #291, which does not touch `orzma_tty`) with `left: Pending, right: Disconnected`.
- The thread that sends the exit status keeps `exit_tx` alive until its closure returns. A poll that lands between the `send` and that drop gets `Empty`, which maps to `Pending`. The old test polled three times with no sleep right after receiving the code and required `Disconnected` each time, so it lost this race whenever the sender thread was preempted.
- The test now polls until `Disconnected` (10s deadline) and panics if `Exited` ever shows up again, so it still checks the exit-once contract.
- The `ExitPoll::Pending` / `Disconnected` docs now cover the window after the status has been received but before the sending thread has exited.

Production is unaffected: `OrzmaTty::latch_exit` stops polling once the exit is observed.

## Test plan

- [x] Adding a temporary `thread::sleep(50ms)` after `exit_tx.send` (Unix path) makes the old test fail the same way CI did (`left: Pending`), and the new test passes with it. The sleep is not part of this PR.
- [x] `cargo test -p orzma_tty`: 122 passed
- [x] `cargo clippy -p orzma_tty --all-targets` and `cargo fmt --check`: clean
- [ ] `test (windows-latest)` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159apPJkmDpCEbJjSqii5SR