### PR TITLE
refactor(bevy_orzmux): remove the connection on disconnect instead of tracking DisconnectReported

### DIFF
--- a/crates/bevy_orzmux/src/drain.rs
+++ b/crates/bevy_orzmux/src/drain.rs
@@ -31,30 +31,34 @@ impl Plugin for DrainPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PaneRegistry>()
             .init_resource::<CurrentLayout>()
-            .init_resource::<DisconnectReported>()
-            .add_systems(Update, drain_orzmux_events.in_set(OrzmuxSystems::Drain));
+            .add_systems(
+                Update,
+                drain_orzmux_events
+                    .run_if(resource_exists::<OrzmuxConnection>)
+                    .in_set(OrzmuxSystems::Drain),
+            );
     }
 }
 
-/// Whether `OrzmuxSessionEnded` was already triggered for a disconnect.
-#[derive(Resource, Default)]
-struct DisconnectReported(bool);
-
-/// Drains every queued event in order. Not gated on change detection:
-/// channel arrivals are invisible to it.
+/// Drains every queued event in order, then ends the session and removes
+/// `OrzmuxConnection` once the backend is gone.
+///
+/// Runs only while `OrzmuxConnection` exists, so after it removes the
+/// connection it never runs again and the session ends exactly once. It is
+/// not gated on change detection because channel arrivals are invisible to
+/// it.
 fn drain_orzmux_events(
     mut commands: Commands,
     mut registry: ResMut<PaneRegistry>,
     mut current: ResMut<CurrentLayout>,
-    mut reported: ResMut<DisconnectReported>,
     connection: Res<OrzmuxConnection>,
 ) {
     for event in connection.0.try_iter() {
         apply_event(&mut commands, &mut registry, &mut current, event);
     }
-    if connection.0.is_disconnected() && !reported.0 {
-        reported.0 = true;
+    if connection.0.is_disconnected() {
         commands.trigger(OrzmuxSessionEnded);
+        commands.remove_resource::<OrzmuxConnection>();
     }
 }
 
@@ -335,7 +339,8 @@ mod tests {
         assert_eq!(app.world().resource::<Seen>().texts, vec![None]);
     }
 
-    /// Asserts that a vanished backend ends the session once.
+    /// Asserts that a vanished backend ends the session once and that the
+    /// drain removes the connection in the frame that detects it.
     ///
     /// Case: the backend thread panicked.
     #[test]
@@ -343,6 +348,8 @@ mod tests {
         let (mut app, events) = app();
         drop(events);
         app.update();
+        assert!(!app.world().contains_resource::<OrzmuxConnection>());
+        assert_eq!(app.world().resource::<Seen>().ended, 1);
         app.update();
         assert_eq!(app.world().resource::<Seen>().ended, 1);
     }

--- a/crates/bevy_orzmux/src/drain.rs
+++ b/crates/bevy_orzmux/src/drain.rs
@@ -44,9 +44,9 @@ impl Plugin for DrainPlugin {
 /// `OrzmuxConnection` once the backend is gone.
 ///
 /// Runs only while `OrzmuxConnection` exists, so after it removes the
-/// connection it never runs again and the session ends exactly once. It is
-/// not gated on change detection because channel arrivals are invisible to
-/// it.
+/// connection it never runs again and a disconnect ends the session
+/// exactly once. It is not gated on change detection because channel
+/// arrivals are invisible to it.
 fn drain_orzmux_events(
     mut commands: Commands,
     mut registry: ResMut<PaneRegistry>,

--- a/crates/bevy_orzmux/src/lib.rs
+++ b/crates/bevy_orzmux/src/lib.rs
@@ -34,6 +34,13 @@ pub mod prelude {
 }
 
 /// The GUI's connection to the multiplexer backend.
+///
+/// # Invariants
+///
+/// The resource exists only until the drain detects that the backend is
+/// gone; the drain then removes it. Every system and observer that reads it
+/// is therefore gated with `run_if(resource_exists::<OrzmuxConnection>)`,
+/// because a missing `Res` panics under Bevy's default error handler.
 #[derive(Resource)]
 pub struct OrzmuxConnection(pub OrzmuxClient);
 

--- a/crates/bevy_orzmux/src/requests.rs
+++ b/crates/bevy_orzmux/src/requests.rs
@@ -65,6 +65,9 @@ impl Plugin for OrzmaEventRequestPlugin {
 /// Sends a pane-addressed command for a terminal entity: the one place
 /// that maps an entity to its `PaneId` and drops requests aimed at an
 /// entity that is not (or no longer) a pane.
+///
+/// It reads `OrzmuxConnection`, so every observer that takes it must be
+/// registered with `run_if(resource_exists::<OrzmuxConnection>)`.
 #[derive(SystemParam)]
 pub(crate) struct PaneSender<'w, 's> {
     connection: Res<'w, OrzmuxConnection>,

--- a/crates/bevy_orzmux/src/requests.rs
+++ b/crates/bevy_orzmux/src/requests.rs
@@ -137,3 +137,95 @@ pub(crate) mod test_support {
         commands.try_iter().map(|(_, c)| c).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::requests::test_support::{app_with_connection, spawn_pane};
+    use orzma_tty::prelude::{
+        CellCoord, KeyText, MouseButton, MouseReport, MouseReportKind, ProtocolModifiers,
+        TerminalKey, TerminalModifiers,
+    };
+    use orzma_vt::prelude::{GridColumn, GridLine, InstanceId, PlacementSize, ScreenLine, Scroll};
+    use orzmux::prelude::PaneId;
+
+    /// Asserts that no request observer runs once the connection is
+    /// removed, so none of them panics.
+    ///
+    /// Case: the backend thread has died, and the user keeps typing,
+    /// clicking, and pasting before `AppExit` takes effect.
+    #[test]
+    fn no_request_observer_runs_without_a_connection() {
+        let (mut app, _commands) = app_with_connection(OrzmaEventRequestPlugin);
+        let pane = spawn_pane(&mut app, PaneId(1));
+        app.world_mut().remove_resource::<OrzmuxConnection>();
+        let key = TerminalKey::Character(KeyText::new("x").unwrap());
+        let cell = GridPoint {
+            line: GridLine(0),
+            column: GridColumn(0),
+        };
+        let instance: InstanceId = "3f5a9c02d1e84b7690ab3cde12f45678"
+            .parse()
+            .expect("valid id");
+
+        let world = app.world_mut();
+        world.trigger(RequestTtyKeyInput {
+            terminal: pane,
+            key: key.clone(),
+            modifiers: TerminalModifiers::default(),
+        });
+        world.trigger(RequestActiveKeyInput {
+            key,
+            modifiers: TerminalModifiers::default(),
+        });
+        world.trigger(RequestTtyPaste {
+            terminal: pane,
+            text: "x".into(),
+        });
+        world.trigger(RequestActivePaste { text: "x".into() });
+        world.trigger(RequestTtyCopySelection { terminal: pane });
+        world.trigger(RequestTtyMouseInput {
+            terminal: pane,
+            mouse: MouseReport {
+                button: MouseButton::Left,
+                kind: MouseReportKind::Press,
+                cell: CellCoord { col: 1, row: 1 },
+                mods: ProtocolModifiers::default(),
+            },
+        });
+        world.trigger(RequestTtyScroll {
+            terminal: pane,
+            scroll: Scroll::Delta(1),
+        });
+        world.trigger(RequestTtySelectionStart {
+            terminal: pane,
+            cell,
+            side: CellSide::Left,
+            kind: SelectionKind::Simple,
+        });
+        world.trigger(RequestTtySelectionUpdate {
+            terminal: pane,
+            cell,
+            side: CellSide::Right,
+        });
+        world.trigger(RequestTtySelectionClear { terminal: pane });
+        world.trigger(RequestTtyWebviewMount {
+            terminal: pane,
+            instance,
+            row: ScreenLine(0),
+            column: GridColumn(0),
+            size: PlacementSize { rows: 1, cols: 1 },
+        });
+        world.trigger(RequestTtyWebviewRemove {
+            terminal: pane,
+            instances: vec![instance],
+        });
+        world.trigger(RequestPaneAction {
+            action: PaneAction::Kill,
+        });
+        world.trigger(RequestPaneAction {
+            action: PaneAction::Select(pane),
+        });
+        app.update();
+    }
+}

--- a/crates/bevy_orzmux/src/requests/copy.rs
+++ b/crates/bevy_orzmux/src/requests/copy.rs
@@ -1,6 +1,7 @@
 //! `RequestTtyCopySelection`: asks the backend for a pane's selected
 //! text; the answer arrives as `TtySelectionTextSignal`.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 use orzmux::prelude::{OrzmuxCommand, PaneTarget};
@@ -16,7 +17,7 @@ pub(super) struct CopyPlugin;
 
 impl Plugin for CopyPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_copy_selection);
+        app.add_observer(apply_copy_selection.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/key_input.rs
+++ b/crates/bevy_orzmux/src/requests/key_input.rs
@@ -34,8 +34,8 @@ pub(super) struct KeyInputPlugin;
 
 impl Plugin for KeyInputPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_key_input)
-            .add_observer(apply_active_key_input);
+        app.add_observer(apply_key_input.run_if(resource_exists::<OrzmuxConnection>))
+            .add_observer(apply_active_key_input.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/mouse_input.rs
+++ b/crates/bevy_orzmux/src/requests/mouse_input.rs
@@ -1,6 +1,7 @@
 //! `RequestTtyMouseInput`: a mouse-protocol report the host UI asks a
 //! terminal entity to receive, sent as `OrzmuxCommand::MouseInput`.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 use orzma_tty::prelude::MouseReport;
@@ -22,7 +23,7 @@ pub(super) struct MouseInputPlugin;
 
 impl Plugin for MouseInputPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_mouse_input);
+        app.add_observer(apply_mouse_input.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/pane.rs
+++ b/crates/bevy_orzmux/src/requests/pane.rs
@@ -31,7 +31,7 @@ pub(super) struct PaneActionPlugin;
 
 impl Plugin for PaneActionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_pane_action);
+        app.add_observer(apply_pane_action.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/paste.rs
+++ b/crates/bevy_orzmux/src/requests/paste.rs
@@ -33,8 +33,8 @@ pub(super) struct PastePlugin;
 
 impl Plugin for PastePlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_paste)
-            .add_observer(apply_active_paste);
+        app.add_observer(apply_paste.run_if(resource_exists::<OrzmuxConnection>))
+            .add_observer(apply_active_paste.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/scroll.rs
+++ b/crates/bevy_orzmux/src/requests/scroll.rs
@@ -1,6 +1,7 @@
 //! `RequestTtyScroll`: the viewport movement the host UI asks a terminal
 //! entity to perform, sent as `OrzmuxCommand::Scroll`.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 use orzma_vt::prelude::Scroll;
@@ -25,7 +26,7 @@ pub(super) struct ScrollPlugin;
 
 impl Plugin for ScrollPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_scroll);
+        app.add_observer(apply_scroll.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/selection.rs
+++ b/crates/bevy_orzmux/src/requests/selection.rs
@@ -10,6 +10,7 @@
 //! `OrzmuxCommand`; the vi-cursor start and the kind change stay stubs
 //! until vi mode lands in the backend.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 pub use orzma_vt::prelude::{CellSide, GridPoint, SelectionKind};
@@ -76,11 +77,11 @@ pub(super) struct SelectionPlugin;
 
 impl Plugin for SelectionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(start_selection)
+        app.add_observer(start_selection.run_if(resource_exists::<OrzmuxConnection>))
             .add_observer(start_selection_at_vi_cursor)
-            .add_observer(update_selection)
+            .add_observer(update_selection.run_if(resource_exists::<OrzmuxConnection>))
             .add_observer(change_selection_kind)
-            .add_observer(clear_selection);
+            .add_observer(clear_selection.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/webview_mount.rs
+++ b/crates/bevy_orzmux/src/requests/webview_mount.rs
@@ -2,6 +2,7 @@
 //! a terminal entity to register when a program mounts over the socket
 //! rather than the PTY, sent as `OrzmuxCommand::MountPlacement`.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 use orzma_vt::prelude::{GridColumn, InstanceId, PlacementSize, ScreenLine};
@@ -28,7 +29,7 @@ pub(super) struct WebviewMountPlugin;
 
 impl Plugin for WebviewMountPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_webview_mount);
+        app.add_observer(apply_webview_mount.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/crates/bevy_orzmux/src/requests/webview_remove.rs
+++ b/crates/bevy_orzmux/src/requests/webview_remove.rs
@@ -2,6 +2,7 @@
 //! terminal entity to drop when a registration is released, sent as
 //! `OrzmuxCommand::RemovePlacements`.
 
+use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
 use bevy::prelude::*;
 use orzma_vt::prelude::InstanceId;
@@ -25,7 +26,7 @@ pub(super) struct WebviewRemovePlugin;
 
 impl Plugin for WebviewRemovePlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(apply_webview_remove);
+        app.add_observer(apply_webview_remove.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 

--- a/docs/todo/remove-disconnect-reported.md
+++ b/docs/todo/remove-disconnect-reported.md
@@ -1,1 +1,0 @@
-Investigate whether DisconnectReported can be removed by revisiting the structure of OrzmuxConnection.

--- a/src/session/layout.rs
+++ b/src/session/layout.rs
@@ -22,6 +22,7 @@ impl Plugin for LayoutPlugin {
                 Update,
                 send_window_geometry
                     .run_if(resource_exists::<TerminalCellMetricsResource>)
+                    .run_if(resource_exists::<OrzmuxConnection>)
                     .run_if(
                         not(resource_exists::<PaneGeometry>)
                             .or_else(resource_exists_and_changed::<TerminalCellMetricsResource>)
@@ -166,5 +167,28 @@ mod tests {
                 ..
             }]
         ));
+    }
+
+    /// Asserts that the geometry sender does not run without a
+    /// connection, leaving `PaneGeometry` unset rather than panicking.
+    ///
+    /// Case: the backend thread dies before the first geometry is sent,
+    /// while the font metrics and the primary window already exist.
+    #[test]
+    fn geometry_is_not_sent_without_a_connection() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(LayoutPlugin)
+            .insert_resource(metrics(8.0, 16.0));
+        app.world_mut().spawn((
+            Window {
+                resolution: WindowResolution::new(800, 600),
+                ..default()
+            },
+            PrimaryWindow,
+        ));
+        app.update();
+
+        assert!(!app.world().contains_resource::<PaneGeometry>());
     }
 }

--- a/src/session/spawn.rs
+++ b/src/session/spawn.rs
@@ -20,7 +20,7 @@ pub(super) struct SpawnPlugin;
 
 impl Plugin for SpawnPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(on_pane_spawn_request);
+        app.add_observer(on_pane_spawn_request.run_if(resource_exists::<OrzmuxConnection>));
     }
 }
 
@@ -121,5 +121,34 @@ mod tests {
         };
         assert_eq!(*sent_request, request);
         assert!(env.contains(&("ORZMA_TOKEN".to_string(), token)));
+    }
+
+    /// Asserts that a spawn request without a connection spawns no
+    /// entity and records no pending spawn, rather than panicking.
+    ///
+    /// Case: the backend thread has died, and a split shortcut fires
+    /// before `AppExit` takes effect.
+    #[test]
+    fn a_spawn_request_without_a_connection_does_nothing() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(SpawnPlugin)
+            .init_resource::<PaneRegistry>();
+        app.world_mut().spawn((Node::default(), ShellSurfaceUi));
+        app.world_mut().trigger(PaneSpawnRequest {
+            at: NewPaneAt::Root,
+        });
+        app.update();
+
+        assert!(
+            app.world()
+                .resource::<PaneRegistry>()
+                .pending_spawns
+                .is_empty()
+        );
+        let mut terminals = app
+            .world_mut()
+            .query_filtered::<Entity, With<OrzmaTerminal>>();
+        assert_eq!(terminals.iter(app.world()).count(), 0);
     }
 }


### PR DESCRIPTION
## Problem

`drain_orzmux_events` kept a private `DisconnectReported(bool)` resource so that `OrzmuxSessionEnded` fired only once after the backend went away. The flag existed only because `OrzmuxConnection` outlived the backend: after a disconnect the resource stayed in the world, so every later drain still saw `is_disconnected()` and needed something to remember it had already reported.

This resolves the `docs/todo/remove-disconnect-reported.md` note added in #279, which this PR deletes.

## Solution

`OrzmuxConnection` now exists only until the drain detects that the backend is gone. Its presence is the GUI's view of the connection, so the flag is no longer needed.

- **Drain.** `drain_orzmux_events` runs only while the resource exists (`run_if(resource_exists::<OrzmuxConnection>)`). On disconnect it queues `trigger(OrzmuxSessionEnded)` and then `remove_resource::<OrzmuxConnection>()`. Once the resource is gone the drain never runs again, so a disconnect ends the session exactly once. Because the removal is queued last, the signals the same drain triggered, and anything their observers queue, still apply while the connection exists (Bevy 0.19 flushes world commands after each command).
- **Readers.** A missing `Res<T>` panics under Bevy's default error handler, so every reader is gated with the same condition:
  - the 13 request observers in `bevy_orzmux`, using Bevy 0.19's observer `run_if`;
  - `on_pane_spawn_request` in `src/session/spawn.rs`;
  - `send_window_geometry` in `src/session/layout.rs`.

  The four stub observers (`apply_vi_mode`, `apply_vi_motion`, `start_selection_at_vi_cursor`, `change_selection_kind`) do not read the connection and stay ungated.
- **The gates are required, not defensive.** Requests can arrive after the removal and before `AppExit` takes effect: the input systems in `OrzmaSystems::Input` run after the drain in the same frame, and the control plane's `apply_control_events` is not ordered against the drain at all.
- **Docs.** `OrzmuxConnection` gains an `# Invariants` section that states this. `PaneSender`'s doc now says every observer that takes it needs the gate, because its ten users never name the connection in their signatures.
- `OrzmuxClient` (`crates/orzmux`) is unchanged. `is_disconnected()` is still how the drain learns about the disconnect.

**Why not `resource_removed`.** I considered a separate notifier gated on `resource_removed::<OrzmuxConnection>`. That condition samples presence through a `Local<bool>`, so it never fires when the resource is removed before the condition has seen it exist. That happens when the backend dies before the first update, which is exactly what the existing disconnect test simulates. Triggering right next to the removal avoids the problem.

**Behavior change.** A request that arrives after the removal is now dropped silently. Before, `OrzmuxClient::send` dropped it with `warn!("mux backend is gone; command dropped")`. The app is already exiting at that point.

### Commits

| | |
| --- | --- |
| `73a9e910` | gate the 13 request observers, with a no-panic test |
| `0584d3a5` | gate the spawn observer and the geometry sender, with a test for each |
| `32123385` | the drain removes the connection on disconnect; `DisconnectReported` deleted; `# Invariants` doc |
| `23503e13` | `PaneSender` doc note, tighter drain doc wording, and the shipped `docs/todo` note removed (from review) |

## Tests

- `requests::tests::no_request_observer_runs_without_a_connection` removes the connection and triggers all 13 request events. It passes when nothing panics. Without the gates, the first trigger panics with `Resource does not exist`, which the RED run showed.
- `session::spawn::tests::a_spawn_request_without_a_connection_does_nothing` and `session::layout::tests::geometry_is_not_sent_without_a_connection` satisfy every precondition except the connection, so only the new gate decides the outcome. Both panicked in the RED run, and a reviewer confirmed that the layout test fails again once its gate is removed.
- `drain::tests::a_disconnected_backend_ends_the_session_once` now asserts, right after the first `update()`, that the connection is gone and the session ended once. After a second `update()` it asserts the count is still one. This catches a removal that lands a frame late as well as a second notification.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass.

## For the reviewer

The label is `skip-changelog` because no user-visible behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019V1npbREABtUU6GUrLLqYw
