### PR TITLE
docs: limit Rust doc comments to the contract a reader relies on, and sweep them

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -45,13 +45,15 @@ relies on, an invariant a later mutation must preserve. If overlooking
 the comment causes no real failure, do not write it — rename an
 identifier so the code carries the meaning, or delete it.
 
-Note: `///` and `//!` are **doc comments**, not "line comments" for this rule — see the next section.
+Note: `///` and `//!` are **doc comments**, not "line comments" for this rule — see "Doc comments" and "Doc comment content — only what the reader needs" below.
 
 ## Comment references — cite `docs/references/`, nothing else under `docs/`
 
 Comments and doc comments may cite a file under `docs/references/` — the
-VT, ECMA-48 and xterm manuals. **No other path under `docs/` may be cited
-from code**, doc comments included.
+VT, ECMA-48 and xterm manuals — including a section of one
+(`ECMA-48 § 8.3.67`). **No other document under `docs/` may be cited from
+code**, doc comments included — not by path, and not by section number or
+decision ID (`spec §7`, `D17a of the engine-swap design`).
 
 Everything else in `docs/` is short-lived by design. `docs/todo/` holds
 per-task working notes that are deleted once the task ships, and
@@ -62,7 +64,8 @@ broken code path, nothing fails to compile when it does.
 | Pattern                                          | Example                                    | Instead                                                          |
 | ------------------------------------------------ | ------------------------------------------ | ---------------------------------------------------------------- |
 | Citing a working note                            | `// TODO: … (docs/todo/migrate.md item 11)` | State the blocker in the comment itself and drop the path        |
-| Citing a tracking table                          | `// NOTE: see docs/todo/vt-conformance-scope.md` | Write the decision the table records, not a pointer to it   |
+| Citing a tracking table                          | `// NOTE: see docs/todo/vt-conformance-scope.md` | Write the decision the table records (in a doc comment, only as the contract it implies), not a pointer to it |
+| Citing a design doc by section or decision ID    | `/// … (spec §7)` / `// … (D16)`           | Drop the pointer; state the contract (doc) or the caveat (`// NOTE:`) itself |
 | Citing a manual                                  | `/// vt510.pdf p.319 — "Default: Replace."` | **Allowed** — `docs/references/` is permanent                    |
 
 The rule is one-directional: Markdown under `docs/`, PR descriptions and
@@ -70,7 +73,10 @@ commit messages may link wherever they like. It binds only what ships
 inside a `.rs` file.
 
 When a working note holds reasoning a future reader will want, copy the
-**conclusion** into the comment rather than linking the note. A citation
+**conclusion** into the comment rather than linking the note. In a doc
+comment the conclusion is copied only as the contract it implies; the
+rationale behind it is not copied (see "Doc comment content — only what
+the reader needs"). A citation
 that carries its own quote and page — `vt510.pdf p.316, "Text between the
 cursor and right margin moves to the right."` — stays checkable after
 every surrounding file is gone.
@@ -107,6 +113,84 @@ Forbidden:
 | Externally `pub` item with no doc           | Public API owes the reader an explanation |
 | Placeholder doc like `/// TODO: write this` | Don't ship empty docs                     |
 
+## Doc comment content — only what the reader needs
+
+A doc comment (`///`, `//!`, or the equivalent `#[doc = "…"]`) states the
+contract a reader relies on to use the item, and nothing else. Content
+outside the allowed list below is deleted — not moved to a `//` comment, a
+`# Notes` section, or another item's doc — except as the `NOTE:` boundary
+case below allows. This applies to every doc comment under `src/` and
+`crates/`, whatever the item's visibility.
+
+Allowed:
+
+| Content | Example |
+| ------- | ------- |
+| The one-line summary | `/// Returns the active pane.` |
+| Observable behavior, and what the return value means — including `None`, `false`, and sentinel values | `` Reports [`DamageSpan::Full`], or `None` when the grid was already blank. `` |
+| Meaning of an input that its type does not state: unit, coordinate space, base, valid range | `` A one-based line; `None` stands for an omitted parameter. `` |
+| Side effects and state changes the caller can observe | `The cursor does not move.` |
+| Preconditions and caller obligations, including an ordering constraint whose violation breaks behavior | `Must run before any thread is spawned.` |
+| Edge cases and boundary values | `A zero count moves one column.` |
+| `# Panics`, `# Errors`, `# Safety` | |
+| `# Invariants` — the guarantee itself | `Line ids are never reused within one grid.` |
+| Limitations and unsupported cases the caller can observe, stated in the present tense | `UTF-8 mouse encoding (1005) is sent with X10 framing.` |
+| Spec mapping: `# Control Functions`, `# References`, and citations of normative specifications and manuals (the `docs/references/` manuals, DEC STD-070) | `vt510.pdf p.319 — "Default: Replace."` |
+| For a `#[test]` fn: the asserted contract and the `Case:` scenario (see "Test doc comments") | |
+| `# Examples` | |
+| `TODO: <text>` | `TODO: support the UTF-8 mouse encoding (1005).` |
+
+Forbidden (representative — the allowed list above is authoritative):
+
+| Category | Example |
+| -------- | ------- |
+| Implementation steps — how the body does its work | `History is therefore resolved through an id-keyed index rather than by position.` |
+| Design rationale and rejected alternatives, including why an item is named or placed as it is | `we use the name Checkpoint instead because …` |
+| External history and comparisons with other implementations: other terminals' behavior, issues, commits, dependency source lines | `kitty commit 668f6fa and Alacritty issue #800` / `the trade alacritty makes too` |
+| Hypothetical breakage, and deferral to another item's doc | `A rewrite that renumbers from zero would silently …` / `` [`Screen::resize`] records why `` |
+| Time-bound wording, and pointers to design documents the reader cannot follow | `Vi mode arrives later.` / `for now` / `until Phase 3` / `(spec §7)` / `D17a of the engine-swap design` |
+| Echo of the code: the name, signature, or item kind restated; ECS registration, schedule, or `run_if` recited; another item's doc copied | `Bevy Resource wrapping …` / `Runs in PostUpdate before …` |
+| Callers and tests, in a non-test item's doc: who calls the item, how testable it is, what the tests cover | `Used by the UI-font path.` / `Kept pure so unit tests can cover every branch.` |
+| Absence inventory: what the item does not hold or know, when no caller would expect it to | `The grid knows nothing about cursors.` |
+| A `NOTE:` tag inside a doc comment | `/// NOTE: …` |
+
+Boundary cases:
+
+- An intra-doc link that names a type or item the contract uses is allowed;
+  a link that hands the explanation to another item is not.
+- "Preconditions and caller obligations" covers what a caller must do;
+  "Callers and tests" covers who the callers are. Only the first is allowed.
+- An `# Invariants` entry states the guarantee; what would break without it
+  is not written.
+- A contrast that states what the item does against a behavior a caller
+  could expect ("truncating rather than reflowing", "ignored rather than
+  clamped") is observable behavior and is allowed; an alternative the
+  designers considered and rejected is not.
+- Citing what a specification or manual says ("xterm's ctlseqs documents
+  …") is spec mapping; describing what another implementation does ("xterm
+  homes the cursor …") is a comparison.
+- Schedule and ordering information is allowed on an item an outside system
+  must order against (a `SystemSet`, for instance); reciting where the item
+  itself is registered or scheduled is not.
+- Each item states its own contract, even when it matches a delegate's;
+  "another item's doc copied" means text that describes a different item.
+- A sentence that mixes allowed and forbidden content is split: the allowed
+  part stays, and a consequence of misuse is restated as the precondition or
+  `# Panics` entry it implies.
+- Future work is written only as a `TODO:`, whose text the time-bound ban
+  does not cover. Untagged future-design prose becomes a `TODO:` when it
+  names pending work and is deleted otherwise.
+- A heading outside the allowed list (`# Notes`, `# Layout`, …) grants no
+  allowance: each sentence under it is judged by the rows above.
+- A module doc (`//!`) states the module's purpose in 1–3 lines; it does not
+  list the module's items, files, or callers.
+- A field or variant doc does not repeat its parent's doc or a sibling's.
+- A `NOTE:` found in a doc comment is rewritten as allowed doc content when
+  it states a contract, becomes a body `// NOTE:` when it meets the bar in
+  "Comments", and is deleted otherwise.
+- Test doc comments keep the two-part structure in "Test doc comments"; the
+  forbidden list applies to them as well.
+
 ## Comment prose — write complete English sentences
 
 English prose in comment and doc bodies — doc-comment paragraphs
@@ -136,7 +220,7 @@ Not fragments for this rule (still fine):
   deliberately makes it a noun phrase or third-person singular verb
   phrase (`/// Returns the active pane.`).
 - Standard parallel ellipsis sharing an auxiliary or subject
-  (`are pinned by its tests, not re-asserted here`).
+  (`are clamped to the grid, not wrapped`).
 - Em-dashes, semicolons, and colons joining clauses that are each
   complete on their own.
 - Table cells, section headings, and list labels inside doc bodies.
@@ -146,8 +230,8 @@ Complete does not mean long — keep comments concise:
 - Say it once: one to three short sentences per paragraph; a doc body
   that can be one sentence stays one sentence.
 - Cut filler and repetition: do not restate the first line in the
-  body, and do not add background the reader does not need in order
-  to use the item.
+  body. What a doc comment may contain at all is set by "Doc comment
+  content — only what the reader needs".
 - When trimming, drop whole sentences rather than degrading the
   survivors into fragments — the complete-sentences rule above still
   applies to what remains.
@@ -168,18 +252,17 @@ asserted contract AND the concrete case the test envisions:
   already say.
 - A test doc holds exactly those two parts — no policy paragraph in
   between. When a test pins a decided policy (e.g. "a zero-axis resize
-  is ignored"), fold the decision — including the rejected alternative
-  when it fits — into the first line ("Asserts that a request with a
-  zero axis is ignored rather than clamped."); the rationale behind
-  the decision lives in the production item's doc comment or the
-  design doc, not in the test.
+  is ignored"), fold the decision — including the behavior a reader
+  might expect instead, when it fits — into the first line ("Asserts
+  that a request with a zero axis is ignored rather than clamped.");
+  the rationale behind the decision is not written in any doc comment.
 - Keep the `Case:` paragraph to the scenario and stop — 1–3 sentences.
   The scenario is the paragraph's ONLY content; in particular:
   - Do not restate what the test itself pins — the first line already
     says it.
   - Do not state policies, design decisions, or their rationale in the
     `Case:` paragraph — fold the decision into the first line and
-    leave the rationale to the production doc.
+    leave the rationale out.
   - Do not speculate about how a hypothetical broken implementation
     would misbehave ("a forward that drops the operation would paint no
     highlight") — that is the test's justification, not the case.
@@ -200,8 +283,9 @@ fn a_degenerate_resize_is_ignored() { ... }
 Not required:
 
 - Test helpers, fixtures, and mocks inside `#[cfg(test)]` — keep their
-  names descriptive instead (a doc comment is still welcome when the
-  helper hides a non-obvious recipe, e.g. scrollback seeding math).
+  names descriptive instead (a doc comment is still welcome when it
+  states a non-obvious contract of the helper, e.g. how many history
+  rows the seeded scrollback holds).
 
 ## Imports
 
@@ -396,7 +480,7 @@ Required:
   the resource is absent.
 - After moving the guard into a `run_if`, delete the in-body early
   return — leaving both is redundant and misleads the reader about when
-  the system runs. Note the gating in the system's doc comment instead.
+  the system runs.
 - Keep any test that registers the same system in sync: add the matching
   `run_if` so the test exercises the real scheduling behavior.
 
@@ -622,7 +706,8 @@ Not tool-enforced — review-time check required. The following rules cannot cur
 
 - `mod.rs` ban
 - Comment taxonomy — only `// TODO:` / `// NOTE:` / `// SAFETY:`
-- Comment references — code cites `docs/references/` only; no other path under `docs/` appears in a comment or doc comment (see "Comment references")
+- Comment references — code cites `docs/references/` only; no other document under `docs/` appears in a comment or doc comment, by path, section number, or decision ID (see "Comment references")
+- Doc comment content — doc comments carry only the allowed content; forbidden content is deleted, not relocated (see "Doc comment content — only what the reader needs")
 - Comment prose — English prose in comment/doc bodies is written as complete, natural sentences, not telegraphic fragments, and kept concise (see "Comment prose — write complete English sentences")
 - File-level module `//!` requirement
 - Test doc comments — every `#[test]` fn documents its asserted contract plus a scenario-only `Case:` paragraph, and nothing else; pinned policies fold into the first line, never a paragraph of their own (see "Test doc comments")

--- a/crates/bevy_orzma_tty_renderer/src/bundled.rs
+++ b/crates/bevy_orzma_tty_renderer/src/bundled.rs
@@ -1,12 +1,6 @@
-//! Static byte slices of the bundled JetBrains Mono Nerd Font Mono TTFs.
+//! Static byte slices of the font TTFs `TerminalFonts::default()` loads.
 //!
-//! Exposing these as `pub` constants lets downstream crates (the Bevy
-//! app's `FontBridgePlugin`) reference the same `include_bytes!`-embedded
-//! bytes the renderer's `TerminalFonts::default()` uses, instead of
-//! re-embedding identical copies. Without this single source of truth,
-//! each `include_bytes!` site in a separate crate produces a distinct
-//! static slot (the linker cannot dedup across crate boundaries without
-//! LTO), and the binary carries ~10 MB × N copies.
+//! A crate that needs the same fonts references these constants.
 
 /// Regular-weight JetBrains Mono Nerd Font Mono bytes.
 pub const REGULAR: &[u8] =
@@ -41,9 +35,8 @@ pub const FALLBACK_BOLD_ITALIC: &[u8] =
 
 /// Noto Sans Symbols 2 bytes (symbol/dingbat fallback).
 ///
-/// Covers Miscellaneous Symbols, Dingbats, and Geometric Shapes blocks
-/// (e.g. ☐ ☑ ☒ ✔) that neither the primary nor the CJK fallback carries —
-/// the marks interactive TUIs draw for checkbox/selection state. Symbols
-/// have no weight/style variants, so a single regular face serves all faces.
+/// Covers the Miscellaneous Symbols, Dingbats, and Geometric Shapes
+/// blocks (e.g. ☐ ☑ ☒ ✔) that neither the primary nor the CJK fallback
+/// carries. This single regular face serves all faces.
 pub const SYMBOL_REGULAR: &[u8] =
     include_bytes!("../assets/fonts/notosanssymbols2/NotoSansSymbols2-Regular.ttf");

--- a/crates/bevy_orzma_tty_renderer/src/glyph.rs
+++ b/crates/bevy_orzma_tty_renderer/src/glyph.rs
@@ -32,13 +32,13 @@ impl Plugin for TerminalGlyphPlugin {
     }
 }
 
-/// Handle to the GPU-side mirror of the `GlyphAtlas`, plus the last
-/// observed atlas generation so the sync system only re-uploads on change.
+/// Handle to the GPU-side mirror of the `GlyphAtlas`, plus the atlas
+/// generation that mirror was built from.
 #[derive(Resource)]
 pub struct AtlasImage {
     /// Bevy `Image` asset whose pixel buffer mirrors `GlyphAtlas.pixels`.
     pub handle: Handle<Image>,
-    /// Last `GlyphAtlas.generation` seen by `sync_atlas_image`.
+    /// Last `GlyphAtlas.generation` the image was synced to.
     pub last_generation: u64,
 }
 

--- a/crates/bevy_orzma_tty_renderer/src/glyph/atlas.rs
+++ b/crates/bevy_orzma_tty_renderer/src/glyph/atlas.rs
@@ -31,25 +31,22 @@ pub struct GlyphRect {
 
 /// CPU-side R8Unorm atlas for rasterized glyphs.
 ///
-/// Packs glyphs using shelf packing (rows of uniform height per shelf).
-/// When the atlas is full, clears and restarts from the top-left — Tier 1
-/// keeps this simple because realistic monospaced workloads (a few hundred
-/// ASCII + CJK characters) never fill a 1024×1024 atlas during normal use.
+/// When the atlas is full, it clears every packed glyph and restarts from
+/// the top-left.
 #[derive(Resource)]
 pub struct GlyphAtlas {
     /// One byte of alpha coverage per pixel, row-major.
     pub pixels: Vec<u8>,
     /// All glyphs currently packed into the atlas.
     pub glyphs: HashMap<GlyphKey, GlyphRect>,
-    /// Bumped on every rasterization and on `clear`. The render plugin
-    /// re-uploads the GPU texture when this value changes.
+    /// Bumped on every rasterization, including one that clears a full
+    /// atlas first. The GPU texture picks up `pixels` only when this
+    /// value changes.
     pub generation: u64,
     shelves: Shelves,
 }
 
-/// Which face in the fallback chain a glyph resolved through. Tells
-/// `get_or_insert` which em-matched `PxScale` to rasterize at, so every face
-/// renders its em-square at the same physical pixel size.
+/// Which face in the fallback chain a glyph resolved through.
 #[derive(Clone, Copy)]
 enum GlyphTier {
     Primary,
@@ -63,17 +60,11 @@ enum GlyphTier {
 /// (notdef).
 ///
 /// Returns `(font, glyph_id, tier)` for the resolved face, or `None` when no
-/// face in the chain contains the glyph. The symbol tier carries Miscellaneous
-/// Symbols / Dingbats marks (e.g. ☐ ☑ ☒ ✔) that neither the primary nor the
-/// CJK fallback ships.
+/// face in the chain contains the glyph.
 ///
-/// `glyph_id` lookup is scale-independent, so this resolves before any scale is
-/// chosen.
-///
-/// NOTE: retries on `glyph_id == 0` only — NOT on degenerate outline
-/// (`w == 0 || h == 0`), which `get_or_insert` still short-circuits after
-/// outlining. PUA Nerd Font icons (U+E000–U+F8FF) resolve non-zero on the
-/// primary, so they never reach the fallbacks.
+/// A face whose glyph outlines to zero extent still resolves there. PUA
+/// Nerd Font icons (U+E000–U+F8FF) resolve non-zero on the primary, so
+/// they never reach the fallbacks.
 fn resolve_glyph<'a>(
     fonts: &'a TerminalFonts,
     face: &FontFace,
@@ -100,12 +91,6 @@ fn resolve_glyph<'a>(
 /// Shrinks a symbol-tier glyph so its rasterized width fits the monospace cell
 /// advance, returning the original outline when it already fits or when
 /// re-outlining at the reduced scale fails.
-///
-/// Symbol-fallback glyphs come from a proportional font (Noto Sans Symbols 2)
-/// and routinely outline wider than the narrow primary cell pitch. Left
-/// unshrunk, a width-1 symbol (e.g. ☑) overflows its cell and the shader's
-/// `paint_left_overdraw` stage paints that overflow on top of the neighbouring
-/// cell — so a `[✔]` checkbox would bleed the mark over the `]`.
 fn fit_symbol_to_cell(
     font: &FontArc,
     glyph_id: ab_glyph::GlyphId,
@@ -146,9 +131,9 @@ impl GlyphAtlas {
     /// Returns the rect for the keyed glyph, rasterizing and packing it on
     /// first use.
     ///
-    /// Returns `None` when `face` is out of range, the codepoint is not a
-    /// valid Unicode scalar, or the glyph has zero extent (e.g. ASCII space,
-    /// combining marks, or glyphs the font does not carry).
+    /// Returns `None` when the codepoint is not a valid Unicode scalar, no
+    /// face in the fallback chain carries it, or the glyph has zero extent
+    /// (e.g. ASCII space or a combining mark).
     pub fn get_or_insert(&mut self, key: GlyphKey, fonts: &TerminalFonts) -> Option<GlyphRect> {
         if let Some(r) = self.glyphs.get(&key) {
             return Some(*r);

--- a/crates/bevy_orzma_tty_renderer/src/glyph/font.rs
+++ b/crates/bevy_orzma_tty_renderer/src/glyph/font.rs
@@ -8,13 +8,11 @@ use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use ttf_parser::Face as TtfFace;
 
-/// Error returned by `TerminalFonts::from_faces` (the actual producer;
-/// `from_bytes` delegates to it) when a face's bytes fail to parse — primary
-/// faces via `ab_glyph::FontVec::try_from_vec_and_index`, fallback faces via
-/// `FontArc::try_from_vec`.
+/// Error returned by `TerminalFonts::from_faces` and
+/// `TerminalFonts::from_bytes` when a face's bytes fail to parse.
 #[derive(Debug, thiserror::Error)]
 pub enum FontLoadError {
-    /// `FontArc::try_from_vec` rejected the bytes for this face.
+    /// `ab_glyph` rejected the bytes for this face.
     #[error("ab_glyph rejected {face:?} face: {source}")]
     ParseFailed {
         /// Which face's bytes were invalid.
@@ -31,8 +29,7 @@ const FONT_SIZE_PX: f32 = 12.0;
 /// PrimaryWindow's `scale_factor` to obtain the physical pixel size fed to
 /// `cell_metrics_px` and the glyph atlas.
 ///
-/// Defaults to 12.0 (`FONT_SIZE_PX`); the app's `FontBridgePlugin` overwrites it
-/// from `config.font.size` at Startup, before cell metrics are computed.
+/// Defaults to 12.0.
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct TerminalFontSize(pub f32);
 
@@ -42,15 +39,14 @@ impl Default for TerminalFontSize {
     }
 }
 
-/// Public `SystemSet` label used to order systems against the renderer's
-/// cell-metrics initialization. App-level plugins that need to mutate
-/// `TerminalFonts` before metrics are computed should run their Startup
-/// systems `.before(TerminalFontInitSet::InitCellMetrics)`.
+/// Label to order systems against the renderer's cell-metrics
+/// initialization. A plugin that mutates `TerminalFonts` before metrics
+/// are computed must run its Startup systems
+/// `.before(TerminalFontInitSet::InitCellMetrics)`.
 #[derive(SystemSet, Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TerminalFontInitSet {
-    /// `init_cell_metrics_from_primary_window` lives in this set. With
-    /// `bridge_font_config` (or any other override) running `.before` it,
-    /// the metrics are computed from the final `TerminalFonts`.
+    /// Holds the Startup system that computes the initial cell metrics
+    /// from `TerminalFonts`.
     InitCellMetrics,
 }
 
@@ -69,18 +65,12 @@ impl Plugin for TerminalFontPlugin {
     }
 }
 
-/// Inserts `TerminalCellMetricsResource` at Startup based on the
-/// PrimaryWindow's current scale_factor. Bevy 0.19's winit runner writes
-/// the OS-reported scale_factor into the Window during `create_windows()`
-/// (in `resumed()`), which runs before the first `App::update()` — so this
-/// Startup system sees the correct DPR on its very first invocation,
-/// eliminating the 1-frame Retina jitter where the resource would
-/// otherwise hold DPR=1.0 values.
+/// Inserts `TerminalCellMetricsResource` from the PrimaryWindow's
+/// scale_factor and `TerminalFontSize`. The very first metrics already
+/// carry the OS-reported scale factor, not a DPR of 1.0.
 ///
-/// `Single<&Window, With<PrimaryWindow>>` refuses to run the system unless
-/// exactly one matching entity exists; under `MinimalPlugins` (no Window)
-/// the system is silently skipped, and consumers' test helpers continue
-/// to insert `TerminalCellMetricsResource` manually.
+/// The system runs only while exactly one primary window exists; without
+/// one (under `MinimalPlugins`, say) it is skipped.
 fn init_cell_metrics_from_primary_window(
     mut commands: Commands,
     fonts: Res<TerminalFonts>,
@@ -97,21 +87,9 @@ fn init_cell_metrics_from_primary_window(
 }
 
 /// Pixel metrics for the regular face at the given physical pixel size.
-///
-/// Data sources differ by field because no single library exposes all
-/// the OpenType metrics we need:
-/// - `advance_phys` / `ascent_phys` / `descent_phys` come from
-///   `ab_glyph::ScaleFont`.
-/// - `line_height_phys` comes from the `hhea` table via `ttf-parser`
-///   (`ab_glyph::PxScale` maps the em-square exactly to the requested
-///   pixel size, so its `line_gap()` is always 0 — using it would
-///   collapse rows to the em-height and lose the typographic gap).
-/// - `underline_position_phys` / `underline_thickness_phys` come from the
-///   OpenType `post` table via `ttf-parser` (`ab_glyph` exposes no
-///   underline API).
 #[derive(Clone, Copy, Debug)]
 pub struct CellMetrics {
-    /// Horizontal advance of glyph `'0'` in physical pixels (Alacritty parity).
+    /// Horizontal advance of glyph `'0'` in physical pixels.
     pub advance_phys: f32,
     /// Ascent + |descent| + line_gap in physical pixels.
     pub line_height_phys: f32,
@@ -128,20 +106,16 @@ pub struct CellMetrics {
     /// Worst-case rightward overflow in physical px across all four faces
     /// (Regular/Italic/Bold/BoldItalic) over ASCII printable codepoints,
     /// measured as `max(0, outline_glyph(...).px_bounds().max.x - cell_w_phys_floor)`.
-    /// Used by the shader to paint the rightmost column's overflow pixels
-    /// inside the bg_padding strip; used by `resize_terminals_to_node` to
-    /// reserve that strip from the available node width.
+    /// A host laying out a terminal node must reserve this much width past
+    /// the grid rectangle.
     pub max_overflow_phys: f32,
 }
 
-/// Cross-crate public Resource exposing the current `CellMetrics` for
-/// `orzma::resize_terminals_to_node` and any other consumer that needs
-/// the canonical cell pitch / advance values.
+/// The canonical cell pitch and advance values.
 ///
-/// Inserted at `Startup` by `init_cell_metrics_from_primary_window` based
-/// on the OS-reported scale_factor of the PrimaryWindow; subsequently
-/// rewritten by `update_terminal_material` whenever DPR or font size
-/// changes (e.g. window moved to a different-DPR display).
+/// It is inserted at startup from the PrimaryWindow's scale_factor and
+/// rewritten whenever the DPR or the font size changes (e.g. the window
+/// moves to a different-DPR display).
 #[derive(Resource, Clone, Copy, Debug)]
 pub struct TerminalCellMetricsResource {
     /// Current cell pitch and typographic measurements in physical pixels.
@@ -169,20 +143,18 @@ pub struct TerminalFonts {
     /// Fallback bold weight, italic style.
     pub fallback_bold_italic: FontArc,
     /// Symbol/dingbat fallback (e.g. checkbox marks ☐ ☑ ☒ ✔), tried after
-    /// both the primary and CJK fallback miss. Face-independent: symbols have
-    /// no weight/style variants, so one face serves every `FontFace`. Always
-    /// the bundled Noto Sans Symbols 2 — never user-overridable.
+    /// both the primary and CJK fallback miss. One face serves every
+    /// `FontFace`, and it is always the bundled Noto Sans Symbols 2: no
+    /// constructor takes a symbol face.
     pub symbol: FontArc,
     /// `.ttc` face index of the regular face. Every ttf-parser reparse of the
-    /// regular face (cell metrics, em-scale) MUST use this index — parsing a
-    /// collection face at index 0 reads a different face and yields wrong metrics.
+    /// regular face (cell metrics, em-scale) MUST use this index.
     regular_index: u32,
 }
 
 /// Computes the worst-case rightward overflow (in physical px) over ASCII
-/// printable codepoints for a single scaled face. Uses the same
-/// `outline_glyph(...).px_bounds()` path as the atlas rasterizer, so the
-/// value matches what the shader actually samples.
+/// printable codepoints for a single scaled face. The value matches the
+/// bitmap extent the atlas rasterizes and the shader samples.
 ///
 /// `cell_w_phys_floor` is the floored advance the renderer uses as cell
 /// pitch. The overflow is how far past that floor the rasterized bitmap
@@ -220,9 +192,7 @@ fn em_scale_of(font: &FontArc, index: u32) -> f32 {
     (asc - desc) as f32 / upem
 }
 
-/// Loads the bundled symbol/dingbat fallback face (Noto Sans Symbols 2). It is
-/// never user-overridable, so both [`TerminalFonts::from_bytes`] and
-/// [`TerminalFonts::default`] build it from the same embedded bytes.
+/// Loads the bundled symbol/dingbat fallback face (Noto Sans Symbols 2).
 fn bundled_symbol_face() -> FontArc {
     FontArc::try_from_slice(SYMBOL_REGULAR).expect("bundled NotoSansSymbols2-Regular load")
 }
@@ -243,10 +213,11 @@ fn fallback_face(bytes: Vec<u8>, face: FontFace) -> Result<FontArc, FontLoadErro
 
 impl TerminalFonts {
     /// Constructs a `TerminalFonts` from four primary `(bytes, .ttc index)`
-    /// pairs plus four fallback byte buffers. Each primary face is loaded at its
-    /// own collection index; fallback + symbol faces are always index 0. Stores
-    /// the regular face's index for later metric reparses. On per-face parse
-    /// failure returns `FontLoadError::ParseFailed` naming the face.
+    /// pairs plus four fallback byte buffers. Each primary face is loaded at
+    /// its own collection index; fallback and symbol faces are always index 0.
+    ///
+    /// Returns `FontLoadError::ParseFailed` naming the face whose bytes
+    /// failed to parse.
     pub fn from_faces(
         regular: (Vec<u8>, u32),
         bold: (Vec<u8>, u32),
@@ -282,19 +253,14 @@ impl TerminalFonts {
     }
 
     /// Constructs a `TerminalFonts` from eight owned TTF byte buffers, one
-    /// per face (four primary + four fallback). `Vec<u8>` is required by
-    /// `ab_glyph::FontArc::try_from_vec`; callers responsible for runtime
-    /// font loading (e.g., the Bevy font-bridge plugin) read bytes from disk,
-    /// build `Vec<u8>`, and call this. On per-face parse failure, returns
-    /// `FontLoadError::ParseFailed` naming the offending face — callers may
-    /// then substitute bundled bytes for that face and retry.
+    /// per face (four primary + four fallback), loading every primary face
+    /// at collection index 0.
     ///
-    /// The symbol fallback face is loaded internally from the bundled
-    /// Noto Sans Symbols 2 — it is not user-overridable, so callers do not
-    /// supply it.
+    /// Returns `FontLoadError::ParseFailed` naming the face whose bytes
+    /// failed to parse.
     ///
-    /// Delegates to [`Self::from_faces`] with face index 0 for all four
-    /// primary faces.
+    /// The symbol fallback face is always the bundled Noto Sans Symbols 2,
+    /// so callers do not supply it.
     pub fn from_bytes(
         regular: Vec<u8>,
         bold: Vec<u8>,
@@ -327,13 +293,9 @@ impl TerminalFonts {
         }
     }
 
-    /// Returns the fallback face matching `face`. Used by
-    /// `atlas::get_or_insert` when the primary face does not contain a
-    /// glyph for the requested codepoint.
+    /// Returns the fallback face matching `face`.
     ///
-    /// NOTE: this is the GLYPH-lookup path. `cell_metrics_px` and
-    /// `max_overflow_phys` still read only the 4 primary faces — fallback
-    /// metrics never participate in cell layout.
+    /// The fallback faces serve glyph lookup alone.
     pub fn fallback_choice(&self, face: &FontFace) -> &FontArc {
         match face {
             FontFace::Regular => &self.fallback_regular,
@@ -344,7 +306,7 @@ impl TerminalFonts {
     }
 
     /// Returns full pixel metrics for the regular face at the requested
-    /// physical pixel size. See [`CellMetrics`] for individual field semantics.
+    /// physical pixel size.
     pub fn cell_metrics_px(&self, phys_size_px: u16) -> CellMetrics {
         let face = TtfFace::parse(self.regular.font_data(), self.regular_index)
             .expect(
@@ -408,31 +370,27 @@ impl TerminalFonts {
         }
     }
 
-    /// Returns the `ab_glyph::PxScale` value for the primary regular face at the
-    /// given physical pixel size. Used by `cell_metrics_px` and `glyph/atlas.rs`.
+    /// Returns the `ab_glyph::PxScale` value for the primary regular face at
+    /// the given physical pixel size.
     pub(crate) fn px_scale_value(&self, phys_size_px: u16) -> f32 {
         f32::from(phys_size_px) * em_scale_of(&self.regular, self.regular_index)
     }
 
     /// Returns the `PxScale` value for the CJK fallback face so its em-square
-    /// renders at the same physical pixel size as the primary's, preventing the
-    /// fallback from rasterizing larger than the grid expects. Mirrors
-    /// [`Self::px_scale_value`] but reads `self.fallback_regular`'s metrics.
+    /// renders at the same physical pixel size as the primary's.
     pub(crate) fn fallback_px_scale_value(&self, phys_size_px: u16) -> f32 {
         f32::from(phys_size_px) * em_scale_of(&self.fallback_regular, 0)
     }
 
     /// Returns the `PxScale` value for the symbol fallback face so its
     /// em-square renders at the same physical pixel size as the primary's.
-    /// Mirrors [`Self::px_scale_value`] but reads `self.symbol`'s metrics.
     pub(crate) fn symbol_px_scale_value(&self, phys_size_px: u16) -> f32 {
         f32::from(phys_size_px) * em_scale_of(&self.symbol, 0)
     }
 
     /// Returns the primary regular face's `'0'` advance in physical pixels —
     /// the monospace cell pitch the grid lays out at, matching the
-    /// `advance_phys` field of [`Self::cell_metrics_px`]. Used by the atlas to
-    /// shrink over-wide symbol-fallback glyphs to their cell.
+    /// `advance_phys` field of [`Self::cell_metrics_px`].
     pub(crate) fn cell_advance_px(&self, phys_size_px: u16) -> f32 {
         let scaled = self
             .regular
@@ -545,10 +503,12 @@ mod tests {
         assert_eq!(TerminalFonts::default().regular_index, 0);
     }
 
-    /// `cell_metrics_px(12)` returns sensible values for JetBrains Mono
-    /// Nerd Font Mono Regular at 12px. Empirical ranges were measured
-    /// against the bundled TTF; structural invariants (positive ascent,
-    /// negative underline position) are the load-bearing assertions.
+    /// Asserts that `cell_metrics_px(12)` lands in the ranges measured for
+    /// the bundled JetBrains Mono Nerd Font Mono Regular, with the
+    /// underline below the baseline and at least one pixel thick.
+    ///
+    /// Case: the terminal lays out its grid with the bundled font at the
+    /// default 12 px size.
     #[test]
     fn jetbrains_mono_12px_metrics_are_sensible() {
         let fonts = TerminalFonts::default();
@@ -588,8 +548,11 @@ mod tests {
         );
     }
 
-    /// JBM Mono at 12 px must report a non-zero `max_overflow_phys`
-    /// because glyphs like `W` rasterize past the floored advance.
+    /// Asserts that the bundled font at 12 px reports a non-zero
+    /// `max_overflow_phys`.
+    ///
+    /// Case: the terminal lays out the bundled font at 12 px, where a
+    /// glyph like `W` rasterizes past the floored advance.
     #[test]
     fn cell_metrics_px_reports_nonzero_max_overflow() {
         let fonts = TerminalFonts::default();
@@ -601,10 +564,11 @@ mod tests {
         );
     }
 
-    /// `max_overflow_phys` must cover the worst face — independently
-    /// measure each of the 4 faces and verify each is ≤ the reported
-    /// `max_overflow_phys`. Catches a regression where the fold drops
-    /// any face from the per-face max computation.
+    /// Asserts that `max_overflow_phys` is at least the overflow each of
+    /// the four primary faces reaches on its own.
+    ///
+    /// Case: a program prints bold and italic text, whose glyphs can
+    /// reach further past the cell than the regular face's.
     #[test]
     fn cell_metrics_px_max_overflow_covers_all_faces() {
         let fonts = TerminalFonts::default();
@@ -633,7 +597,9 @@ mod tests {
         }
     }
 
-    /// 24 px metrics are approximately double the 12 px ones.
+    /// Asserts that 24 px metrics are approximately double the 12 px ones.
+    ///
+    /// Case: the user doubles the font size from 12 px to 24 px.
     #[test]
     fn metrics_scale_linearly_with_size() {
         let fonts = TerminalFonts::default();
@@ -643,11 +609,11 @@ mod tests {
         assert!((m24.line_height_phys - m12.line_height_phys * 2.0).abs() < 0.5);
     }
 
-    /// `cell_metrics_px` and `glyph/atlas.rs` must rasterize at the SAME
-    /// PxScale, otherwise atlas glyphs are physically smaller (or larger)
-    /// than the cell pitch and either leave blank gutters on the right
-    /// (atlas < cell) or overflow without coverage (atlas > cell).
-    /// This test guards against accidental divergence.
+    /// Asserts that `cell_metrics_px` measures its advance at the same
+    /// `PxScale` that `px_scale_value` hands the atlas.
+    ///
+    /// Case: the renderer measures the cell pitch and rasterizes the
+    /// bundled font's glyphs at 12 px.
     #[test]
     fn px_scale_value_matches_cell_metrics_internal_use() {
         let fonts = TerminalFonts::default();
@@ -666,11 +632,11 @@ mod tests {
         );
     }
 
-    /// `TerminalFontPlugin::build` must not overwrite an already-present
-    /// `TerminalFonts` resource. Apps pre-insert a custom `TerminalFonts`
-    /// (e.g., from a runtime config-driven font override) BEFORE adding
-    /// `TerminalFontPlugin`; if the plugin overwrote it, the override
-    /// would be lost.
+    /// Asserts that `TerminalFontPlugin::build` keeps an already-present
+    /// `TerminalFonts` resource rather than overwriting it.
+    ///
+    /// Case: the app inserts a config-driven font override before adding
+    /// `TerminalFontPlugin`.
     #[test]
     fn terminal_font_plugin_preserves_pre_inserted_terminal_fonts() {
         use bevy::window::{PrimaryWindow, Window, WindowResolution};
@@ -780,12 +746,12 @@ mod tests {
         assert_ne!(b_ptr, i_ptr, "Bold and Italic fallback share bytes");
     }
 
-    /// `init_cell_metrics_from_primary_window` reads the PrimaryWindow's
-    /// scale_factor and inserts a DPR-aware `TerminalCellMetricsResource`.
-    /// Verifies BOTH (a) `phys_font_size` reflects the scale_factor and
-    /// (b) the derived metrics (advance_phys) are also DPR-scaled —
-    /// catches a regression where phys_font_size is correct but a wrong
-    /// size (e.g. FONT_SIZE_PX as u16) is fed to cell_metrics_px.
+    /// Asserts that the inserted `TerminalCellMetricsResource` scales both
+    /// `phys_font_size` and the metrics derived from it by the
+    /// PrimaryWindow's scale_factor.
+    ///
+    /// Case: the app starts on a Retina display reporting a scale factor
+    /// of 2.
     #[test]
     fn init_cell_metrics_from_primary_window_uses_window_scale_factor() {
         use bevy::window::{PrimaryWindow, Window, WindowResolution};

--- a/crates/bevy_orzma_tty_renderer/src/grid.rs
+++ b/crates/bevy_orzma_tty_renderer/src/grid.rs
@@ -1,20 +1,15 @@
-//! `TerminalGridPlugin` — applies each `TtyFrameSignal`'s frame to the
-//! per-entity `TerminalGrid` component through one `EntityEvent`
-//! observer.
+//! Applies each `TtyFrameSignal`'s frame to the per-entity
+//! `TerminalGrid` component.
 
 use crate::schema::TerminalGrid;
 use bevy::prelude::*;
 use bevy_orzmux::prelude::{OrzmuxPane, TtyFrameSignal};
 
-/// Registers the `apply_frame` observer and makes every pane entity
-/// carry a `TerminalGrid`.
+/// Applies each signalled frame to its terminal's grid, and makes every
+/// pane entity carry a `TerminalGrid`.
 ///
-/// The grid is a required component of [`OrzmuxPane`] because the backend
-/// emits its bootstrap repaint exactly once: a frame delivered to a
-/// pane entity without a grid would be dropped, and the backend offers
-/// no repaint request to recover it. Bevy registers a requirement only
-/// before the first entity carrying `OrzmuxPane` exists, so the plugin
-/// must be added before any pane is promoted.
+/// The grid is a required component of [`OrzmuxPane`]. The plugin must be
+/// added before any pane is promoted.
 #[derive(Default)]
 pub struct TerminalGridPlugin;
 
@@ -28,19 +23,11 @@ impl Plugin for TerminalGridPlugin {
 /// Applies the signalled frame to its terminal's grid, touching the
 /// component mutably only when the frame changes something.
 ///
-/// `orzma_tty` emits at most one frame per coalesce window, and
-/// `FrameTracker::emit` already returns `None` when nothing changed, so
-/// a signalled frame is usually real damage. The gate here is what
-/// keeps the mirror honest on the frames that are not: a frame naming
-/// only rows outside the mirror's range, only hyperlink ids the mirror
-/// already knows, or sections that already equal the mirror's own.
-/// `update_terminal_material` reads a changed grid as a reason to
-/// rebuild the GPU buffers, so a spurious write here would rebuild
-/// them for nothing.
+/// A frame naming only rows outside the mirror's range, only hyperlink
+/// ids the mirror already knows, or sections that already equal the
+/// mirror's own leaves the component untouched.
 ///
-/// A frame addressed to an entity without a grid is ignored; with the
-/// plugin registered that is only an entity that never carried a
-/// handle.
+/// A frame addressed to an entity without a grid is ignored.
 fn apply_frame(signal: On<TtyFrameSignal>, mut terminals: Query<&mut TerminalGrid>) {
     let Ok(grid) = terminals.get_mut(signal.terminal) else {
         return;
@@ -86,8 +73,7 @@ mod tests {
     /// Asserts that a frame carrying nothing new leaves the grid
     /// component unchanged.
     ///
-    /// Case: a synthetic frame repeats what the mirror already holds, a
-    /// shape the VT's emit gate never produces on its own.
+    /// Case: a frame repeats what the mirror already holds.
     #[test]
     fn a_frame_with_nothing_new_leaves_the_grid_unchanged() {
         let (mut app, terminal) = app_with_grid();
@@ -102,9 +88,8 @@ mod tests {
     /// Asserts that a frame whose metadata moved does mark the grid
     /// changed.
     ///
-    /// Case: a synthetic offset-only frame reaches a settled mirror, a
-    /// shape the VT itself never emits because a scroll repaints every
-    /// row.
+    /// Case: a frame that only moves the display offset reaches a settled
+    /// mirror.
     #[test]
     fn a_frame_that_moves_the_viewport_marks_the_grid_changed() {
         let (mut app, terminal) = app_with_grid();

--- a/crates/bevy_orzma_tty_renderer/src/material.rs
+++ b/crates/bevy_orzma_tty_renderer/src/material.rs
@@ -31,15 +31,10 @@ use bevy::{
 
 mod state;
 
-/// Render-side public SystemSet anchor for `update_terminal_material`.
+/// Ordering anchor for the system that writes each terminal's material.
 ///
-/// `sync_atlas_image` in `glyph.rs` is ordered with
-/// `.after(TerminalMaterialSystems::UpdateMaterial)` so that any glyphs
-/// rasterized this frame are mirrored into the `Image` asset before the
-/// next ExtractSchedule, keeping atlas pixels and material params in
-/// lock-step with the bind group rebuild. Exposed `pub` so consumers
-/// (e.g., orzma's `resize_terminals_to_node`) can sequence
-/// layout-driven grid resizes `.before(Self::UpdateMaterial)`.
+/// A system that resizes a terminal's grid from the layout must run
+/// `.before(Self::UpdateMaterial)`.
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub enum TerminalMaterialSystems {
     UpdateMaterial,
@@ -263,9 +258,7 @@ impl TerminalUiMaterial {
 /// `tint` (rgb = target color in LINEAR space, `a` = blend amount) and a
 /// brightness `dim`. The shader blends each background source toward `tint.rgb`
 /// by `tint.a` before glyphs/overlays paint (background only), then multiplies
-/// the final color by `dim`. The consumer (e.g. orzma) sets this on a
-/// terminal host from its active-pane state; `update_terminal_material` bakes
-/// both into the uniform each frame. An absent component is treated as
+/// the final color by `dim`. An absent component is treated as
 /// `{ dim: 1.0, tint: ZERO }` (full-bright, untinted / active).
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
 pub struct PaneInactiveStyle {
@@ -294,9 +287,8 @@ impl Default for PaneInactiveStyle {
 }
 
 /// Padding colour used for the area outside a terminal grid (and the whole
-/// quad while a grid is unpainted) when the terminal has no OSC 11 default
-/// background. Defaults to black (the prior behaviour); the binary sets it to
-/// the theme background so a momentarily-unpainted pane is not pure black.
+/// quad while a grid is unpainted) when the terminal's default background
+/// is black. Defaults to black.
 #[derive(Resource, Default)]
 pub struct TerminalPaddingFallback(pub [u8; 3]);
 
@@ -304,24 +296,20 @@ pub struct TerminalPaddingFallback(pub [u8; 3]);
 ///
 /// Slot index = array index into `overlays` / `overlay_rects`; the WGSL
 /// texture binding is `OVERLAY_TEX_BINDING_BASE + i`. Hard upper bound per
-/// terminal surface (spec §6.1).
+/// terminal surface.
 pub const OVERLAY_SLOTS: usize = 12;
 
-/// Per-terminal overlay placements + textures, derived every frame by the
-/// consumer (e.g. orzma's webview projection) and consumed by
-/// `update_terminal_material` — the only material mutation site. The renderer
-/// knows nothing about what the textures contain.
+/// Per-terminal overlay placements and textures.
 ///
-/// # Invariants
+/// `rects[i]` is `(row, col, rows, cols)` in CELL coordinates; `row` may be
+/// negative when the rect starts above the viewport. `rows == 0` is the
+/// inactive-slot sentinel: the shader skips the slot, while the renderer
+/// binds `textures[i]` regardless, so consumers should set freed slots to
+/// `None`.
 ///
-/// - `rects[i]` is `(row, col, rows, cols)` in CELL coordinates; `row` may be
-///   negative (rect partially above the viewport). `rows == 0` is the
-///   inactive-slot sentinel — the shader skips the slot; the renderer binds
-///   `textures[i]` regardless, so consumers should set freed slots to `None`
-///   (the rebuild-every-frame contract below does this naturally).
-/// - Consumers must rebuild this component from live state every frame
-///   (all-sentinel start), so stale texture handles cannot outlive their
-///   producers (spec §5).
+/// Consumers must rebuild this component from live state every frame
+/// (all-sentinel start), so stale texture handles cannot outlive their
+/// producers.
 #[derive(Component, Clone, Debug)]
 pub struct TerminalOverlays {
     /// Placement rects, slot-indexed: `(row, col, rows, cols)` in cells.
@@ -341,32 +329,8 @@ impl Default for TerminalOverlays {
 
 /// Uniform block uploaded once per frame alongside the storage buffers.
 ///
-/// # Invariants
-///
-/// - All `_phys` fields are PHYSICAL pixels (no DPR division). The shader
-///   computes everything in physical-px space; `dpr` is provided for
-///   diagnostic purposes only (currently unused in shader after Tier 1
-///   `dpr_inv` removal).
-/// - `bg_padding_color` is the color the shader paints OUTSIDE the
-///   `grid_size * cell_size_px` rectangle (where the gui-side
-///   `resize_terminals_to_node` left padding).
-/// - "No cursor" is encoded by clearing the `CURSOR_VISIBLE` bit in
-///   `cursor_style` (and leaving `cursor_pos` at any value). The shader
-///   short-circuits on `cursor_visible == 0u`, so we deliberately keep
-///   `cursor_pos` as `UVec2` rather than introducing a signed sentinel —
-///   the existing visibility bit already does that job. A cursor (vi or
-///   live) whose grid line projects outside the viewport takes the same
-///   path: `cursor_visible = 0`.
-///
-/// # Layout (std140, encase derive)
-///
-/// Field offsets in bytes. `max_overflow_phys` fills the 4-byte padding slot
-/// at offset 76 that encase would otherwise insert before `bg_padding_color`
-/// (Vec4 needs 16-byte alignment, lands at offset 80). `inactive_tint` is also
-/// a Vec4 (16-byte alignment), so encase pads the 4 bytes after `dim` and lands
-/// it at offset 112; `overlay_rects` (`array<vec4<i32>, 12>`) follows at offset
-/// 128. The trailing `overlay_dim` / `overlay_desaturate` scalars sit at 320/324
-/// and the struct rounds up to its 16-byte alignment (total 336 bytes):
+/// The WGSL `TerminalParams` declaration must match this std140 layout,
+/// whose field offsets are in bytes and whose total size is 336 bytes:
 ///
 /// | Offset | Field                       |
 /// |--------|-----------------------------|
@@ -394,6 +358,18 @@ impl Default for TerminalOverlays {
 /// | 128    | `overlay_rects`             |
 /// | 320    | `overlay_dim`               |
 /// | 324    | `overlay_desaturate`        |
+///
+/// # Invariants
+///
+/// - All `_phys` fields are PHYSICAL pixels (no DPR division). The shader
+///   computes everything in physical-px space and never reads `dpr`.
+/// - `bg_padding_color` is the color the shader paints OUTSIDE the
+///   `grid_size * cell_size_px` rectangle.
+/// - "No cursor" is encoded by clearing the `CURSOR_VISIBLE` bit in
+///   `cursor_style` (and leaving `cursor_pos` at any value); the shader
+///   short-circuits on `cursor_visible == 0u`. A cursor (vi or live)
+///   whose grid line projects outside the viewport takes the same path:
+///   `cursor_visible = 0`.
 #[derive(Clone, Copy, ShaderType, Debug)]
 struct TerminalParams {
     grid_size: UVec2,
@@ -405,20 +381,20 @@ struct TerminalParams {
     /// Packed: bit0=visible, bits1-2=shape (0=block / 1=underline / 2=bar), bit3=blinking.
     cursor_style: u32,
     time_seconds: f32,
-    /// Selection start row in viewport coords; `i32` because endpoints in
-    /// scrollback clamp to `-1` (above) or `rows` (below).
+    /// Selection start row in viewport coords; an endpoint in scrollback
+    /// clamps to `-1` (above) or `rows` (below).
     sel_start_row: i32,
     sel_start_col: u32,
     sel_end_row: i32,
     sel_end_col: u32,
-    /// 0 = none, 1 = char, 2 = line. See `SelectionGeometry`.
+    /// 0 = none, 1 = char, 2 = line.
     sel_kind: u32,
     underline_position_phys: f32,
     underline_thickness_phys: f32,
     /// Worst-case ASCII rightward bbox overflow (physical px) across all four
     /// faces. The shader uses this to extend its "rightmost column glyph"
     /// evaluation past `grid_size.x * cell_size_px.x` into the bg_padding
-    /// strip; the host reserves the same amount from the node width.
+    /// strip; the host must reserve the same amount from the node width.
     max_overflow_phys: f32,
     bg_padding_color: Vec4,
     /// Wire id of the hovered link (across all panes); `0` = nothing
@@ -429,15 +405,12 @@ struct TerminalParams {
     /// path in the shader.
     hover_active: u32,
     /// Pane brightness multiplier applied to the final fragment RGB.
-    /// `1.0` = active / full-bright; `< 1.0` dims an inactive pane. The
-    /// hand-written `Default` below sets this to `1.0` so an un-updated
-    /// material never renders dark (a derived `Default` would give `0.0`).
+    /// `1.0` = active / full-bright; `< 1.0` dims an inactive pane.
     dim: f32,
     /// Per-pane background tint: `rgb` = target color (LINEAR), `a` = blend
     /// amount in `0.0..=1.0`. The shader blends each background source toward
     /// `rgb` by `a` BEFORE glyphs/overlays paint (background only). `a == 0`
-    /// (active / no-op) leaves the background untouched; `Default` (below) sets
-    /// this to `Vec4::ZERO`. A Vec4, so encase pads the 4 bytes after `dim`.
+    /// (active / no-op) leaves the background untouched.
     inactive_tint: Vec4,
     /// Slot-indexed inline-overlay rects `(row, col, rows, cols)` in cell
     /// coords; `row` may be negative; `rows == 0` = inactive slot sentinel.
@@ -494,8 +467,8 @@ impl TerminalParams {
     /// - A live (non-vi) cursor carries the application's DECTCEM state, so
     ///   `cursor_visible` is `0` while the terminal has seen `CSI ? 25 l`,
     ///   and `grid.suppress_cursor` clears the bit on top of either source.
-    /// - When `grid.selection` is `None`, `sel_kind == 0` and the shader's
-    ///   `is_in_selection_uniform` short-circuits to `false`.
+    /// - When `grid.selection` is `None`, `sel_kind == 0` and the shader
+    ///   paints no selection.
     fn new(
         grid: &TerminalGrid,
         cell_size_px: Vec2,
@@ -562,20 +535,16 @@ struct GpuCell {
     /// The cell's `Style` bits ORed with the underline and strike bits its
     /// combining marks promote, plus the renderer-only flags from bit 16 up.
     style_flags: u32,
-    /// OSC 8 wire id of this cell, or `0` for "no link". Safe because
-    /// `HyperlinkInterner` reserves `HyperlinkId(0)`.
+    /// OSC 8 wire id of this cell, or `0` for "no link".
     hyperlink_id: u32,
 }
 
 /// Set on the right-half cell of a width=2 (CJK / wide) grapheme so the
-/// shader knows to render its glyph anchored to the left-half cell's
-/// origin. See `rebuild_cells` and `terminal_ui_material.wgsl`.
+/// shader renders its glyph anchored to the left-half cell's origin.
 ///
 /// Bit allocation in `GpuCell.style_flags` (a `u32`):
-/// - Bits 0-15: `orzma_vt`'s `Style` flags at the bits `Style` assigns,
-///   from the cell's own `Style` and from `style_from_combining_marks`.
-/// - Bits 16+: renderer-only flags (this const), kept physically separate
-///   from the `Style` range so a future `Style` flag cannot collide.
+/// - Bits 0-15: `Style` flags at the bits `Style` assigns.
+/// - Bits 16+: renderer-only flags such as this one.
 const STYLE_WIDE_RIGHT_HALF: u32 = 0x1_0000;
 
 const _: () = assert!(
@@ -599,7 +568,7 @@ impl Default for GpuCell {
     }
 }
 
-/// Per-glyph atlas record used by the fragment shader.
+/// Per-glyph atlas record in the glyph storage buffer.
 #[derive(Clone, Copy, ShaderType, Default, Debug)]
 struct GpuGlyph {
     /// Top-left of the glyph rect in atlas physical px.
@@ -613,8 +582,8 @@ struct GpuGlyph {
 }
 
 impl GpuGlyph {
-    /// Builds a `GpuGlyph` from an atlas rect. All offsets and sizes are in
-    /// physical pixels — the shader handles all DPR-aware geometry.
+    /// Builds a `GpuGlyph` from an atlas rect, with all offsets and sizes
+    /// in physical pixels.
     fn new(rect: GlyphRect) -> Self {
         Self {
             uv_min: Vec2::new(rect.u as f32, rect.v as f32),
@@ -639,9 +608,7 @@ fn padding_color(default_bg: Rgb, fallback: [u8; 3]) -> Vec4 {
 /// treats as "terminal default background".
 const TRANSPARENT_BG: u32 = 0;
 
-/// The grid palette pre-packed to the shader's linear `u32` encoding,
-/// built once per cell rebuild so symbolic colors resolve by table
-/// lookup instead of a per-cell sRGB-to-linear conversion.
+/// The grid palette pre-packed to the shader's linear `u32` encoding.
 struct PackedPalette {
     indexed: [u32; 256],
     foreground: u32,
@@ -679,13 +646,8 @@ impl PackedPalette {
     /// # Invariants
     ///
     /// `DefaultBackground` packs [`TRANSPARENT_BG`], never the opaque
-    /// palette background: the shader keys on `bg.a == 0` to composite
-    /// webview overlays and the padding base through the cell and to
-    /// resolve reverse video (`resolve_cell_colors` / `tint_bg` in
-    /// `terminal_ui_material.wgsl`), and the sentinel is what keeps an
-    /// equal explicit RGB background distinguishable per the
-    /// `schema::Color` invariant. An opaque pack here occludes every
-    /// webview rect.
+    /// palette background, so an explicit RGB equal to that background
+    /// stays distinguishable from the default.
     fn cell_bg(&self, color: CellColor) -> u32 {
         match color {
             CellColor::DefaultBackground => TRANSPARENT_BG,
@@ -731,7 +693,7 @@ fn update_terminal_material(
     // cost is bounded by `needs_rebuild` below. The same every-frame Modified
     // is also the overlay-texture rebind lifeline: a bevy_cef headless target
     // re-creates its GPU texture on resize, and only this rebuild repoints
-    // the bind group at it (spec §4).
+    // the bind group at it.
     // NOTE: Skip the per-entity work when PrimaryWindow is transiently
     // absent (display hotplug, brief winit reconnect). Trade-off: the
     // `mat.params = ...` write below would fire AssetEvent::Modified
@@ -958,8 +920,7 @@ fn rebuild_cells(
 }
 
 /// Promotes specific combining marks in a grapheme cluster to the `Style`
-/// underline and strike flags so the shader paints them, since `ab_glyph`
-/// cannot composite combining glyphs onto the base char in Tier 1.
+/// underline and strike flags so the shader paints them.
 ///
 /// Maps U+0332 (combining low line), U+0333 (double low line), U+0331
 /// (combining macron below) to `Style::UNDERLINE`, and U+0336 (combining
@@ -1016,10 +977,9 @@ fn resolve_glyph_index(
 }
 
 /// Projects a grid-space selection into the clamped viewport-space
-/// uniform tuple the shader consumes. Rows widen to i64 before adding
-/// the display offset (a signed line plus an unsigned offset must not
-/// wrap) and clamp to the -1 (above) / `rows` (below) sentinels so a
-/// partially visible selection still paints its on-screen span.
+/// uniform tuple the shader consumes. Rows clamp to the -1 (above) /
+/// `rows` (below) sentinels, so a partially visible selection still
+/// paints its on-screen span.
 fn selection_uniforms(
     selection: Option<&SelectionRange>,
     display_offset: u32,
@@ -1083,9 +1043,7 @@ mod tests {
     /// Asserts that a linked cell's wire id reaches its GPU slot while
     /// an unlinked cell's slot keeps the 0 sentinel.
     ///
-    /// Case: a row mixes OSC 8 linked text with plain text, and the
-    /// shader needs the per-cell id to underline only the hovered
-    /// link.
+    /// Case: a row mixes OSC 8 linked text with plain text.
     #[test]
     fn rebuild_cells_writes_hyperlink_id_when_present() {
         use bevy::platform::collections::HashMap;
@@ -1374,13 +1332,6 @@ mod tests {
     /// Asserts that fg and bg packing resolve symbolic colors through
     /// the live palette, and that the default background packs the
     /// transparent sentinel instead of the palette value.
-    ///
-    /// The sentinel policy rejects packing the opaque palette
-    /// background for `DefaultBackground`: the shader keys on
-    /// `bg.a == 0` to composite webview overlays and the padding base
-    /// through default-background cells, so an opaque pack would
-    /// occlude both and erase the explicit-vs-default distinction the
-    /// `schema::Color` invariant requires.
     ///
     /// Case: OSC 4 recolors an indexed slot and OSC 10 the default
     /// foreground while a webview overlay is mounted behind

--- a/crates/bevy_orzma_tty_renderer/src/material.rs
+++ b/crates/bevy_orzma_tty_renderer/src/material.rs
@@ -1333,9 +1333,9 @@ mod tests {
     /// the live palette, and that the default background packs the
     /// transparent sentinel instead of the palette value.
     ///
-    /// Case: OSC 4 recolors an indexed slot and OSC 10 the default
-    /// foreground while a webview overlay is mounted behind
-    /// default-background cells.
+    /// Case: a palette whose default foreground and indexed slot 1
+    /// already hold custom colors packs cells for a webview overlay
+    /// mounted behind default-background cells.
     #[test]
     fn cell_packing_resolves_through_the_live_palette() {
         use crate::schema::{Color as CellColor, Palette, Rgb};

--- a/crates/bevy_orzma_tty_renderer/src/material/state.rs
+++ b/crates/bevy_orzma_tty_renderer/src/material/state.rs
@@ -12,7 +12,7 @@ use bevy::{
     render::storage::ShaderBuffer,
 };
 
-/// Registers a `MaterialNode<TerminalUiMaterial>` on-add hook that seeds the SSBO buffers, attaches the glyph atlas image, and inserts the per-entity [`TerminalMaterialState`] cache.
+/// Seeds the SSBO buffers, attaches the glyph atlas image, and inserts the per-entity [`TerminalMaterialState`] cache whenever a `MaterialNode<TerminalUiMaterial>` is added.
 pub struct TerminalMaterialStatePlugin;
 
 impl Plugin for TerminalMaterialStatePlugin {
@@ -24,45 +24,33 @@ impl Plugin for TerminalMaterialStatePlugin {
 }
 
 /// CPU-side cache mirroring what the GPU sees this frame.
-///
-/// SSBO handles and the atlas texture live on [`TerminalUiMaterial`]; this
-/// component stores only the cached LUT and per-frame bookkeeping.
 #[derive(Component)]
 pub(crate) struct TerminalMaterialState {
     pub glyph_index_map: HashMap<GlyphKey, u32>,
     pub cpu_cells: Vec<GpuCell>,
     pub cpu_glyphs: Vec<GpuGlyph>,
     pub last_atlas_generation: u64,
-    /// Set from `TerminalGrid`'s change detection and cleared only
-    /// once the rebuild actually uploads. It has to latch: Bevy
-    /// clears the change signal as soon as the system runs, so a
-    /// grid written on a frame whose rebuild bails out would never
-    /// reach the GPU.
+    /// Set from `TerminalGrid`'s change detection and cleared only once
+    /// the rebuild actually uploads, so it stays set across a frame whose
+    /// rebuild bails out.
     pub grid_dirty: bool,
     pub last_grid_dims: (u16, u16),
-    /// Last physical font size used for glyph rasterization. Reset to 0 in
-    /// `on_add_material_node` so the first `update_terminal_material` for
-    /// the entity sees `phys_size_changed == true` and triggers
-    /// `invalidate_all()`.
+    /// Last physical font size used for glyph rasterization; `0` before
+    /// the entity's first rebuild.
     pub last_phys_font_size: u16,
-    /// Cached output of `TerminalFonts::cell_metrics_px(last_phys_font_size)`
-    /// to avoid re-parsing the `post` table on every frame.
+    /// Cached output of `TerminalFonts::cell_metrics_px(last_phys_font_size)`.
     pub cached_metrics: Option<CellMetrics>,
     pub initialized: bool,
 }
 
 impl TerminalMaterialState {
-    /// Resets all glyph-cache state so the next `update_terminal_material`
-    /// invocation fully reuploads the atlas LUT, glyph rects, and atlas
-    /// generation marker. Called on DPR change (`phys_font_size` changed).
+    /// Resets all glyph-cache state and marks the grid dirty, so the next
+    /// `update_terminal_material` invocation fully reuploads the atlas
+    /// LUT, glyph rects, and atlas generation marker.
     ///
-    /// Deliberately does NOT touch:
-    /// - `last_phys_font_size` — the caller writes it after invalidation
-    ///   so the next frame's diff detection still works.
-    /// - `cpu_cells` — re-populated wholesale by `rebuild_cells` on the
-    ///   next rebuild (forced here by `grid_dirty = true`).
-    /// - `initialized` — stays `true`; the rebuild path is re-entered via
-    ///   `grid_changed`, not via `!initialized`.
+    /// It leaves `last_phys_font_size`, `cpu_cells`, and `initialized`
+    /// untouched; the caller writes `last_phys_font_size` itself after
+    /// invalidating.
     pub(crate) fn invalidate_all(&mut self) {
         self.glyph_index_map.clear();
         self.cpu_glyphs.clear();

--- a/crates/bevy_orzma_tty_renderer/src/schema.rs
+++ b/crates/bevy_orzma_tty_renderer/src/schema.rs
@@ -1,6 +1,5 @@
-//! Renderer-facing schema: the `TerminalGrid` component and hover
-//! state, plus the shared terminal vocabulary re-exported flat from
-//! [`orzma_vt::prelude`].
+//! Renderer-facing schema: the grid and hover state the renderer draws
+//! from, in the terminal vocabulary of [`orzma_vt::prelude`].
 
 mod grid;
 mod hover;

--- a/crates/bevy_orzma_tty_renderer/src/schema/grid.rs
+++ b/crates/bevy_orzma_tty_renderer/src/schema/grid.rs
@@ -500,8 +500,8 @@ mod tests {
     /// Asserts that suppression clears only the visible bit while the
     /// vi cursor's projected position is still reported.
     ///
-    /// Case: the user composes IME text while vi mode is active, so the
-    /// app hides the caret without discarding where it sits.
+    /// Case: an IME composition hides the caret while a projected
+    /// cursor position is already recorded on the mirror.
     #[test]
     fn suppress_cursor_does_not_affect_vi_cursor_position() {
         let grid = TerminalGrid {
@@ -959,8 +959,8 @@ mod tests {
 
     /// Asserts that a palette replaces the mirror and `None` keeps it.
     ///
-    /// Case: OSC 11 recolors the background once, and every later frame
-    /// carries no palette.
+    /// Case: one frame recolors the background once, and every later
+    /// frame carries no palette.
     #[test]
     fn a_palette_replaces_the_mirror_and_none_keeps_it() {
         let mut grid = TerminalGrid::settled();

--- a/crates/bevy_orzma_tty_renderer/src/schema/grid.rs
+++ b/crates/bevy_orzma_tty_renderer/src/schema/grid.rs
@@ -1,6 +1,5 @@
-//! The renderer's CPU-side mirror of one terminal: the `TerminalGrid`
-//! component, the cells it materializes from a frame's runs, and the
-//! cursor and hover queries the host reads off it.
+//! The renderer's CPU-side mirror of one terminal, materialized into
+//! cells from the frames applied to it.
 
 use crate::schema::{
     AnchoredPlacement, CURSOR_VISIBLE_BIT, Color, Cursor, CursorShape, DisplayOffset, GridColumn,
@@ -16,10 +15,6 @@ use unicode_width::UnicodeWidthStr;
 
 /// One materialized cell of the renderer's CPU-side grid, expanded
 /// from the frame's [`crate::schema::Run`]s.
-///
-/// This is renderer vocabulary, not part of the VT contract: the VT
-/// emits attribute runs, and the renderer materializes them into cells
-/// for glyph resolution and hover hit-testing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GridCell {
     /// The grapheme cluster text for this cell.
@@ -41,16 +36,13 @@ pub struct GridCell {
 impl GridCell {
     /// Whether this cell paints no glyph: a zero-width cell (combining mark /
     /// wide-char spacer) or one whose text is empty or all whitespace.
-    ///
-    /// Shared by the renderer's glyph resolution and the host paint-rescue's
-    /// blank-grid test so the two notions of "renders nothing" cannot drift.
     #[inline]
     pub fn is_blank(&self) -> bool {
         self.width == 0 || self.text.trim().is_empty()
     }
 }
 
-/// A structure represents the layout structure of the terminal grid.
+/// The layout structure of the terminal grid.
 /// Each terminal entity owns this component.
 #[derive(Component, Default)]
 pub struct TerminalGrid {
@@ -64,23 +56,20 @@ pub struct TerminalGrid {
     pub cursor: Option<Cursor>,
     /// Lines scrolled back from the live tail; 0 = at live tail.
     pub display_offset: u32,
-    /// Vi-mode cursor when the server is in vi mode; `None` otherwise.
-    /// `ViModePlugin` reads this every frame to drive `ViModeState::active`.
+    /// Vi-mode cursor from the last applied frame; `None` when that frame
+    /// carries none.
     pub vi_cursor: Option<ViCursor>,
-    /// Active selection range emitted alongside `vi_cursor`. Independent of
-    /// `vi_cursor` — survives motion without selection.
+    /// Active selection range from the last applied frame, independent of
+    /// `vi_cursor`.
     pub selection: Option<SelectionRange>,
     /// App-level cursor visibility override. When `true`,
     /// `current_cursor_pos_and_style()` clears [`CURSOR_VISIBLE_BIT`]
-    /// before returning. Independent of `Cursor.visible` (which mirrors
-    /// DECTCEM from the wire) — this field is for the UI layer (e.g.,
-    /// IME composition) to non-destructively hide the cursor without
-    /// clobbering terminal-controlled state.
+    /// before returning. It is independent of `Cursor.visible`, so it
+    /// hides the cursor without clobbering terminal-controlled state.
     pub suppress_cursor: bool,
     /// OSC 8 hyperlinks indexed by id. Every applied frame merges its
     /// `hyperlinks` into this table, and a known id is never
-    /// overwritten. The lookup is a linear scan, which suits the few
-    /// distinct hyperlinks a session carries.
+    /// overwritten.
     pub hyperlinks: Vec<(HyperlinkId, HyperlinkUri)>,
     /// The live palette set by the last frame that carried one;
     /// symbolic cell colors resolve against it.
@@ -135,11 +124,10 @@ impl TerminalGrid {
         Some((cursor.point.column.0, row.0))
     }
 
-    /// Projects the cursor like [`Self::cursor_viewport_cell`], but never
-    /// yields `None`: a cursor whose line is scrolled out of the visible
-    /// rows keeps its column on row `0`, and a missing cursor maps to the
-    /// origin, so IME anchoring stays at the cursor's column while the
-    /// user is scrolled back.
+    /// Projects the cursor into viewport cells as `(column, row)`, but
+    /// never yields `None`: a cursor whose line is scrolled out of the
+    /// visible rows keeps its column on row `0`, and a missing cursor maps
+    /// to the origin.
     pub fn cursor_viewport_cell_or_top(&self) -> (u16, u16) {
         let Some(cursor) = self.cursor.as_ref() else {
             return (0, 0);
@@ -187,22 +175,16 @@ impl TerminalGrid {
 
     /// Whether applying `frame` would change this grid.
     ///
-    /// A frame is self-describing about change — an absent row and a
-    /// `None` section mean "unchanged" — so this reads only what
-    /// [`Self::apply`] would write: a row inside the frame's own size,
-    /// a size the grid does not hold yet, a moved cursor or viewport, a
-    /// listed section that differs, or a hyperlink id the table lacks.
+    /// An absent row and a `None` section mean "unchanged", so this counts
+    /// only a row inside the frame's own size, a size the grid does not
+    /// hold yet, a cursor, vi cursor, selection or viewport that differs,
+    /// a listed section that differs, or a hyperlink id the table lacks.
     /// Rows beyond the frame's size and known hyperlink ids do not
     /// count.
     ///
     /// # Invariants
     ///
     /// Returns `true` exactly when [`Self::apply`] mutates something.
-    /// The observer derefs the component mutably only on `true`, so a
-    /// spurious `true` here rebuilds the GPU buffers for nothing and a
-    /// spurious `false` drops a repaint. Both methods destructure the
-    /// frame exhaustively, so a field added to [`Frame`] fails to
-    /// compile until each has decided what to do with it.
     pub fn differs_from(&self, frame: &Frame) -> bool {
         let Frame {
             size,
@@ -234,18 +216,16 @@ impl TerminalGrid {
 
     /// Applies `frame` to this grid.
     ///
-    /// The size is settled first so every row the frame carries has a
-    /// slot, the hyperlink table is merged before rows are materialized
-    /// so they resolve against it, and the `None` sections are left
-    /// alone. Row damage is not diffed against the cells already there:
-    /// a row's presence is the VT's statement that it changed.
+    /// Every row the frame carries inside its size replaces the cells at
+    /// that line, resolving its hyperlink ids against the table, into
+    /// which this frame's own definitions are merged first; the `None`
+    /// sections are left alone.
     ///
     /// # Invariants
     ///
     /// After `apply` returns, `self.cells.len() == self.rows as usize`,
-    /// whatever length the grid was built with. Every field written here
-    /// has a matching predicate in [`Self::differs_from`]; a change to
-    /// how one field is applied must change how it is compared.
+    /// whatever length the grid was built with. It mutates the grid
+    /// exactly when [`Self::differs_from`] reports `true`.
     pub fn apply(&mut self, frame: &Frame) {
         let Frame {
             size,
@@ -504,8 +484,7 @@ mod tests {
     /// Asserts that suppression clears the visible bit of the packed
     /// style.
     ///
-    /// Case: IME composition temporarily hides the caret without
-    /// touching terminal-controlled cursor state.
+    /// Case: an IME composition temporarily hides the caret.
     #[test]
     fn current_cursor_pos_and_style_clears_visible_bit_when_suppressed() {
         let grid = TerminalGrid {
@@ -542,10 +521,8 @@ mod tests {
     }
 
     /// Asserts that a cursor whose line projects outside the viewport
-    /// paints nothing.
-    ///
-    /// The decided policy is to omit the caret rather than clamp it to
-    /// an edge cell it does not occupy.
+    /// paints nothing rather than being clamped to an edge cell it does
+    /// not occupy.
     ///
     /// Case: the user scrolls back through history while the shell
     /// keeps its caret on the live prompt line below the viewport.
@@ -705,8 +682,7 @@ mod tests {
     /// that advances by display width.
     ///
     /// Case: a row mixes a wide CJK grapheme with ASCII text on a
-    /// scrolled-back history line, so the ASCII cell's point must land
-    /// after both columns of the wide character.
+    /// scrolled-back history line.
     #[test]
     fn runs_to_cells_assigns_points_by_display_width() {
         let cells = runs_to_cells(&[run_with_link("あb", None)], GridLine(-3), &[]);
@@ -735,8 +711,7 @@ mod tests {
 
     /// Asserts that a frame carrying nothing new reports no difference.
     ///
-    /// Case: a synthetic frame repeats what the mirror already holds, a
-    /// shape the VT's emit gate never produces on its own.
+    /// Case: a frame repeats what the mirror already holds.
     #[test]
     fn a_quiet_frame_does_not_differ() {
         assert!(!TerminalGrid::settled().differs_from(&quiet_frame()));
@@ -770,9 +745,8 @@ mod tests {
     /// and that applying the frame settles the grid so the offset
     /// round-trips to a matching state.
     ///
-    /// Case: a synthetic offset-only frame reaches a settled mirror, a
-    /// shape the VT itself never emits because a scroll repaints every
-    /// row.
+    /// Case: a frame that only moves the display offset reaches a settled
+    /// mirror.
     #[test]
     fn a_moved_viewport_differs() {
         let mut grid = TerminalGrid::settled();
@@ -789,9 +763,7 @@ mod tests {
     /// applying the frame resizes the cell rows to match even though
     /// the frame carries no rows of its own.
     ///
-    /// Case: a synthetic size-only frame reaches a settled mirror, a
-    /// shape the VT itself never emits because its resize repaints
-    /// every row.
+    /// Case: a frame that only changes the size reaches a settled mirror.
     #[test]
     fn a_new_size_alone_differs() {
         let mut grid = TerminalGrid::settled();

--- a/crates/bevy_orzma_tty_renderer/src/schema/hover.rs
+++ b/crates/bevy_orzma_tty_renderer/src/schema/hover.rs
@@ -1,26 +1,20 @@
-//! Global hover state shared between the orzma input layer (writer) and
-//! the renderer's `update_terminal_material` (reader). Lives in the
-//! renderer crate so the renderer does not depend on the application
-//! crate.
+//! Global hover state for the hyperlink under the pointer.
 
 use crate::schema::HyperlinkId;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::resource::Resource;
 
-/// Pointer hover state used to drive the hyperlink underline-accent and
-/// the OS cursor icon. Exactly one cell can be hovered at a time across
-/// all panes, so this is a global Resource rather than per-pane
-/// component.
+/// Pointer hover state that drives the hyperlink underline accent.
+/// Exactly one cell can be hovered at a time across all panes.
 #[derive(Resource, Default, Debug, Clone)]
 pub struct HyperlinkHoverState {
-    /// Surface-host entity the cursor is currently over, or `None`
-    /// when the cursor is outside every pane.
+    /// Surface-host entity the cursor is over, or `None` when the cursor
+    /// is outside every pane.
     pub entity: Option<Entity>,
-    /// Hovered wire id; meaningful only when `entity` is `Some`. `None`
-    /// when the cursor is over an unlinked cell.
+    /// Hovered wire id, or `None` when the cursor is over an unlinked
+    /// cell; meaningful only when `entity` is `Some`.
     pub hyperlink_id: Option<HyperlinkId>,
-    /// Activation modifier (Cmd on macOS, Ctrl elsewhere) is currently
-    /// held. Drives both the cursor icon flip and the shader's
-    /// `hover_active` uniform.
+    /// Whether the activation modifier (Cmd on macOS, Ctrl elsewhere) is
+    /// held. It drives the shader's `hover_active` uniform.
     pub modifier_held: bool,
 }

--- a/crates/bevy_orzma_webview/src/control_plane.rs
+++ b/crates/bevy_orzma_webview/src/control_plane.rs
@@ -1,7 +1,6 @@
 //! Native orzma control plane: a local Unix-socket listener that accepts
-//! authenticated dynamic webview registrations (Tier 1) from local programs,
-//! mints opaque handles into the `OrzmaRegistry`, and tears them down on
-//! disconnect or surface despawn. Uses a Tokio-free reader/writer thread model.
+//! authenticated Tier 1 webview registrations from local programs, mints
+//! opaque handles, and tears them down on disconnect or surface despawn.
 
 use crate::control_plane::listener::{ControlEvent, spawn_listener};
 use crate::control_plane::protocol::{HostKeyChord, NavAction, RegisterKind, ServerMsg};
@@ -32,8 +31,7 @@ mod protocol;
 pub(crate) use protocol::PushMsg;
 
 /// A forward-key chord normalized to host input types: a bevy `KeyCode` plus
-/// modifier booleans. Used to suppress CEF double-delivery and to match keys
-/// for PTY forwarding (design spec §E type normalization).
+/// modifier booleans.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NormalizedChord {
     /// The base key as a bevy `KeyCode`.
@@ -56,9 +54,7 @@ pub(crate) enum OrzmaSource {
     /// A single inline HTML document, registered into `WebviewAssetRegistry` and
     /// served under `orzma://<handle>/`.
     Inline(String),
-    /// A remote `http(s)` URL loaded directly by CEF (no `orzma://` origin,
-    /// no `WebviewAssetRegistry` entry). `bridge` records whether the registering
-    /// program opted into the `window.orzma` back-channel.
+    /// A remote `http(s)` URL loaded directly by CEF.
     Url {
         /// The validated `http(s)` URL.
         url: String,
@@ -85,8 +81,7 @@ impl OrzmaSource {
 }
 
 /// A Tier 1 dynamic registration: its content source, entry, input policy, and
-/// the terminal surface + control-plane connection that own it (for scoped
-/// mount-gating and teardown).
+/// the terminal surface + control-plane connection that own it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OrzmaView {
     /// The content source.
@@ -96,24 +91,20 @@ pub(crate) struct OrzmaView {
     /// Whether the mounted webview accepts pointer/keyboard input.
     pub interactive: bool,
     /// The terminal surface an `Omount;n=<instance>` for this registration
-    /// must originate from. The registering program's PTY env token resolved
-    /// to this surface, so only that surface may mount an instance that
-    /// resolves to this handle (tighter than the spec's pane wording).
+    /// must originate from.
     pub owner_surface: Entity,
     /// The control-plane connection that registered it.
     pub connection_id: u64,
     /// The normalized forward-key chords for this view, derived from the
-    /// `register` wire payload. Copied onto the mounted webview entity as
-    /// `ForwardKeys` so Phase-4 systems can read them off the focused child.
+    /// `register` wire payload and copied onto the mounted webview entity as
+    /// `ForwardKeys`.
     pub forward_keys: Vec<NormalizedChord>,
     /// User-supplied preload scripts, copied verbatim from the register wire
     /// and injected onto the mounted webview's `PreloadScripts` after the host
-    /// bridge/hints. No size cap or validation (the registering program is
-    /// local and trusted).
+    /// bridge. They carry no size cap and no validation.
     pub preload: Vec<String>,
-    /// Every instance minted for this registration, in mint order. The
-    /// registry keeps this list and its `by_instance` reverse index in
-    /// lockstep, so releasing the handle releases exactly these ids.
+    /// Every instance minted for this registration, in mint order. Releasing
+    /// the handle releases exactly these ids.
     pub instances: Vec<InstanceId>,
 }
 
@@ -122,9 +113,9 @@ pub(crate) struct OrzmaView {
 /// and the instance the mount was addressed by.
 #[derive(Component, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WebviewOwner {
-    /// The owning connection (push `call` frames here).
+    /// The connection this webview's back-channel frames are routed to.
     pub connection_id: u64,
-    /// The registration handle (for `emit` fan-out + ownership checks).
+    /// The registration handle this webview's content came from.
     pub handle: HandleId,
     /// The placement this webview was mounted under, so a back-channel
     /// frame names which of a handle's placements it came from.
@@ -136,13 +127,6 @@ pub(crate) struct WebviewOwner {
 /// It is the host of that registration's `orzma://<handle>/` origin, the
 /// routing key for its back-channel, and the ownership unit `unregister`
 /// and connection teardown act on.
-///
-/// # Invariants
-///
-/// There is deliberately no `From<HandleId> for String`. That absence is
-/// what stops a handle from flowing into an `impl Into<String>` parameter
-/// that wants an instance id; adding the conversion for convenience
-/// silently reopens that path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct HandleId(String);
@@ -179,14 +163,9 @@ impl fmt::Display for HandleId {
 /// Maps an opaque `handle` to its dynamic registration, and every minted
 /// instance back to the handle it belongs to.
 ///
-/// The single Bevy-side registry for Tier 1 (the CEF scheme handler reads
-/// the thin `WebviewAssetRegistry` separately). Carries scoped removal for
-/// teardown.
-///
 /// # Invariants
 ///
-/// The two maps are only ever touched through `&mut self` methods on this
-/// type, so an instance is in `by_instance` exactly while its handle's
+/// An instance resolves here exactly while its handle's
 /// `OrzmaView.instances` lists it.
 #[derive(Resource, Default)]
 pub(crate) struct OrzmaRegistry {
@@ -247,10 +226,8 @@ impl OrzmaRegistry {
     /// Inserts a registration with no instances yet.
     ///
     /// The caller mints its first instance with [`Self::mint_instance`]
-    /// immediately afterwards, so every id — the first one included —
-    /// comes from the one minting path. Inserting over an existing `handle`
-    /// first purges that handle's previous instances from `by_instance`, so
-    /// the two maps stay in lockstep even when a caller reuses a handle.
+    /// immediately afterwards. Inserting over an existing `handle` first
+    /// drops that handle's previous instances, so they no longer resolve.
     pub fn insert(&mut self, handle: HandleId, view: OrzmaView) {
         if let Some(previous) = self.by_handle.insert(handle, view) {
             for id in previous.instances {
@@ -262,11 +239,7 @@ impl OrzmaRegistry {
     /// Mints an instance for `handle`; `None` only when the handle is
     /// unknown.
     ///
-    /// This is the ONLY path that produces an [`InstanceId`], so every
-    /// allocated instance is a fresh 128-bit CSPRNG draw. Registry-wide
-    /// uniqueness rests on that draw rather than on a structural check: the
-    /// `debug_assert!` below is a tripwire for a broken CSPRNG, and it
-    /// compiles out in release.
+    /// Every minted instance is a fresh 128-bit CSPRNG draw.
     pub fn mint_instance(&mut self, handle: &HandleId) -> Option<InstanceId> {
         if !self.by_handle.contains_key(handle) {
             return None;
@@ -361,13 +334,6 @@ impl OrzmaRpc {
     /// Removes and returns the in-flight call for `global_id`, but ONLY when it
     /// was registered by `connection_id`. A mismatching connection leaves the
     /// entry intact and returns `None`.
-    ///
-    /// # Invariants
-    /// The match-before-remove order is load-bearing: global reqIds are a
-    /// monotonic counter shared across all connections, so they are guessable. A
-    /// foreign program replaying another connection's reqId must NOT be able to
-    /// consume (and thereby drop) that connection's pending call — checking
-    /// ownership only AFTER removing would orphan the page Promise.
     pub(crate) fn take_for_connection(
         &mut self,
         global_id: &str,
@@ -403,9 +369,8 @@ impl OrzmaRpc {
 }
 
 /// A shared `token → surface` map: the env-injected `$ORZMA_TOKEN` of each PTY
-/// resolves to the surface that owns it. Read by the listener thread on `hello`,
-/// written when a terminal surface is spawned. `Entity` is stored directly; it
-/// is only meaningful inside the same `World` generation.
+/// resolves to the surface that owns it. `Entity` is stored directly, so a
+/// binding is only meaningful inside the same `World` generation.
 #[derive(Resource, Clone, Default)]
 pub struct TokenRegistry(Arc<RwLock<HashMap<String, Entity>>>);
 
@@ -420,16 +385,17 @@ impl TokenRegistry {
         self.0.write().unwrap().insert(token.into(), surface);
     }
 
-    /// Drops every binding that resolves to `surface`. Called when a surface
-    /// despawns so a recycled `Entity` id cannot resolve a stale key.
+    /// Drops every binding that resolves to `surface`. Call it when a surface
+    /// despawns, so a recycled `Entity` id cannot resolve a stale key.
     pub fn remove_entity(&self, surface: Entity) {
         self.0.write().unwrap().retain(|_, bound| *bound != surface);
     }
 }
 
 /// A shared `connection_id → outbound-line sender` table. Each live control
-/// connection owns a writer thread draining a `Sender<String>`; ECS pushes
-/// server-initiated `{op:"call",…}` lines here to reach a specific program.
+/// connection owns a writer thread draining a `Sender<String>`;
+/// server-initiated `{op:"call",…}` lines are queued here to reach a specific
+/// program.
 #[derive(Resource, Clone, Default)]
 pub(crate) struct ConnectionWriters(Arc<RwLock<HashMap<u64, Sender<String>>>>);
 
@@ -456,14 +422,11 @@ impl ConnectionWriters {
 }
 
 /// Mints an opaque 128-bit [`HandleId`] (CSPRNG), base32-encoded (unpadded)
-/// and lowercased. The alphabet `a-z2-7` keeps a minted handle spellable in
-/// a URL host, which is where it is used.
+/// and lowercased. The alphabet is `a-z2-7`, so a minted handle is spellable
+/// verbatim as a URL host.
 ///
 /// # Invariants
-/// The output MUST be lowercase. A handle is used as the host of the
-/// `orzma://<handle>/` URL, and Chromium canonicalizes (lowercases) the host
-/// of a STANDARD-scheme URL before it reaches the scheme handler; an uppercase
-/// handle would then miss the case-sensitive `WebviewAssetRegistry` lookup → 404.
+/// The output is always lowercase.
 fn mint_handle_id() -> HandleId {
     let mut bytes = [0u8; 16];
     getrandom::getrandom(&mut bytes).expect("OS CSPRNG is available");
@@ -474,13 +437,13 @@ fn mint_handle_id() -> HandleId {
 #[derive(Resource)]
 pub(crate) struct ControlEvents(pub(crate) Receiver<ControlEvent>);
 
-/// The CEF-facing `WebviewAssetRegistry`, held as a resource so the apply system and
-/// teardown can populate/purge `Dir` handles the scheme handler reads.
+/// The CEF-facing `WebviewAssetRegistry`, shared with the `orzma://` scheme
+/// handler.
 #[derive(Resource, Clone)]
 pub(crate) struct WebviewAssetRegistryRes(pub(crate) WebviewAssetRegistry);
 
-/// The bound control-socket path + token registry, surfaced so terminal-surface
-/// setup can mint per-surface tokens and inject `$ORZMA_SOCK` / `$ORZMA_TOKEN`.
+/// The bound control-socket path and token registry, used to mint per-surface
+/// tokens and inject `$ORZMA_SOCK` / `$ORZMA_TOKEN`.
 #[derive(Resource, Clone)]
 pub struct ControlPlaneHandle {
     /// The bound listener socket path (`$ORZMA_SOCK`).
@@ -492,9 +455,8 @@ pub struct ControlPlaneHandle {
 impl ControlPlaneHandle {
     /// Returns the `ORZMA_SOCK` / `ORZMA_TOKEN` env pairs to inject into `surface`'s
     /// PTY so a program running in it can reach the control plane and resolve to
-    /// `surface`. Pure: derives the token but does NOT register it — call
-    /// [`bind_surface`](Self::bind_surface) after the PTY actually spawns, so a
-    /// failed spawn leaks no binding.
+    /// `surface`. Pure: it derives the token but does NOT register it — call
+    /// [`bind_surface`](Self::bind_surface) after the PTY actually spawns.
     pub fn surface_env(&self, surface: Entity) -> [(String, String); 2] {
         [
             (
@@ -513,14 +475,13 @@ impl ControlPlaneHandle {
 }
 
 /// Derives the per-surface token (`orzma:<entity-bits>`) from a surface entity.
-/// Single-sources the format so [`ControlPlaneHandle::surface_env`] and
-/// [`ControlPlaneHandle::bind_surface`] always agree.
 fn surface_token(surface: Entity) -> String {
     format!("orzma:{}", surface.to_bits())
 }
 
-/// Wires the control-plane listener, the event-apply system, and the teardown
-/// observer. Takes the `WebviewAssetRegistry` shared with the `orzma` scheme handler.
+/// Wires the control-plane listener, the event-apply system, and the
+/// despawned-surface GC. Takes the `WebviewAssetRegistry` shared with the
+/// `orzma` scheme handler.
 pub(crate) struct ControlPlanePlugin {
     orzma_assets: WebviewAssetRegistry,
 }
@@ -562,11 +523,8 @@ impl Plugin for ControlPlanePlugin {
 /// `RemovedComponents<OrzmuxPane>` so it fires for every pane entity the
 /// multiplexer backend closes.
 ///
-/// # Invariants
-/// Must stay ungated and run every frame: `RemovedComponents` buffers clear at
-/// end of frame, so a skipped frame leaks registrations + assets. The purge
-/// also runs when `ControlPlaneHandle` is absent (token unbinding is then a
-/// no-op) — gating it behind the handle would leak in that case.
+/// Must stay ungated and run every frame, including when
+/// `ControlPlaneHandle` is absent (token unbinding is then a no-op).
 fn gc_despawned_surfaces(
     mut registry: ResMut<OrzmaRegistry>,
     mut closed: RemovedComponents<OrzmuxPane>,
@@ -594,16 +552,13 @@ struct ControlRuntime(
     RuntimeRoot,
 );
 
-/// Drains queued `ControlEvent`s: mints handles for `register` and populates the
-/// `OrzmaRegistry` (+ `WebviewAssetRegistry` for `Dir`), releases on `unregister`,
-/// and purges a connection's handles on `Disconnect`.
+/// Drains queued `ControlEvent`s: mints handles for `register` and populates
+/// the `OrzmaRegistry` (+ `WebviewAssetRegistry` for `Dir` and `Inline`),
+/// releases on `unregister`, and purges a connection's handles on `Disconnect`.
 ///
 /// `Register` and `NewInstance` are refused with `owner_gone` when the owning
-/// entity is no longer alive, so a connection that outlives its pane's
-/// despawn (and the GC that follows) cannot recreate registrations for it.
-/// Liveness, not the `OrzmuxPane` marker, gates the refusal: a fast shell can
-/// register before the GUI has drained the backend's `PaneOpened` and
-/// inserted `OrzmuxPane`, and that pending owner must still be accepted.
+/// entity is no longer alive. An owner that is alive but does not yet carry
+/// `OrzmuxPane` is still accepted.
 fn apply_control_events(
     mut commands: Commands,
     mut registry: ResMut<OrzmaRegistry>,
@@ -1058,8 +1013,8 @@ fn on_navigate(
 /// Applies a socket `mount`: registers a placement for `instance` at the
 /// visible cell `(row, col)` of `owner_surface` when `connection_id` owns
 /// the instance and `(rows, cols)` lies within the VT's bounds. The VT's
-/// verdict arrives as the same `TtyWebviewMountSignal` /
-/// `TtyWebviewMountRejectedSignal` an APC mount produces.
+/// verdict arrives as a `TtyWebviewMountSignal` or a
+/// `TtyWebviewMountRejectedSignal`.
 fn on_mount(
     commands: &mut Commands,
     registry: &OrzmaRegistry,
@@ -1088,9 +1043,8 @@ fn on_mount(
 }
 
 /// Applies a socket `unmount`: despawns the webview mounted for `instance`
-/// under `owner_surface` and hands its reservation back to the VT, the two
-/// steps a registration release performs, when `connection_id` owns the
-/// instance.
+/// under `owner_surface` and hands its reservation back to the VT, when
+/// `connection_id` owns the instance.
 fn on_unmount(
     commands: &mut Commands,
     registry: &OrzmaRegistry,
@@ -1117,10 +1071,6 @@ fn on_unmount(
 /// Tears down the registrations `removed` released: despawns their mounted
 /// webviews and hands the reservations back to the VT on the surface that
 /// owned them.
-///
-/// The VT cannot learn that a registration is gone — that fact lives on the
-/// control socket — so without the second step each released placement keeps
-/// a per-terminal cap slot until its anchor scrolls out of history.
 fn release_registrations(
     commands: &mut Commands,
     webviews: &Query<(Entity, &Webview)>,
@@ -1218,7 +1168,7 @@ fn build_view(
 }
 
 /// True when `entry` is a non-empty relative path of normal components only
-/// (no `..`, `.`, or leading `/`). Same shape as `asset::is_safe_rel_path`.
+/// (no `..`, `.`, or leading `/`).
 fn is_safe_entry(entry: &str) -> bool {
     let p = std::path::Path::new(entry);
     !p.as_os_str().is_empty()
@@ -1227,12 +1177,9 @@ fn is_safe_entry(entry: &str) -> bool {
 }
 
 /// Validates a `url` register source: parses it, requires an `http`/`https`
-/// scheme, then a non-empty host. The scheme check precedes the host check on
-/// purpose — `url::Url::parse("javascript:…")` succeeds with no host, so a
-/// host-first order would mis-report `javascript:` as `invalid_url` instead of
-/// `unsupported_scheme`.
-/// Returns the parser-normalized URL (not the raw input) so the validated and
-/// loaded forms are identical.
+/// scheme, then a non-empty host. A non-`http(s)` scheme reports
+/// `unsupported_scheme` even when the URL also has no host.
+/// Returns the parser-normalized URL, not the raw input.
 fn validate_url_source(url: &str) -> Result<String, &'static str> {
     let parsed = Url::parse(url).map_err(|_| "invalid_url")?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -1566,9 +1513,8 @@ mod registry_tests {
     }
 
     /// Asserts that inserting over an existing handle purges that handle's
-    /// stale instances from the reverse `by_instance` index, so a released
-    /// registration's instances never keep resolving after a new one takes
-    /// its handle.
+    /// stale instances, so a released registration's instances never keep
+    /// resolving after a new one takes its handle.
     ///
     /// Case: a handle is reused for a fresh registration before its previous
     /// one was explicitly removed.
@@ -1626,7 +1572,7 @@ mod apply_tests {
     }
 
     /// Asserts that a `register` from a connection whose owner surface is
-    /// gone is refused, so GC cannot be undone by a late registration.
+    /// gone is refused.
     ///
     /// Case: a program keeps its control connection open after its pane
     /// was killed and sends another `register`.
@@ -1658,8 +1604,7 @@ mod apply_tests {
     }
 
     /// Asserts that a `register` from a live but still-pending owner (no
-    /// `OrzmuxPane` yet) is accepted, since the liveness gate must not
-    /// reintroduce the race the token pre-binding was designed to avoid.
+    /// `OrzmuxPane` yet) is accepted.
     ///
     /// Case: the new pane's shell connects and registers before the GUI has
     /// drained the backend's `PaneOpened`.
@@ -1698,8 +1643,7 @@ mod apply_tests {
     }
 
     /// Asserts that a `new_instance` for a handle whose owner surface has
-    /// despawned is refused with `owner_gone`, mirroring the `register`
-    /// refusal.
+    /// despawned is refused with `owner_gone`.
     ///
     /// Case: a program's pane was killed while its control connection
     /// stayed open, and it asks for another placement of a handle it
@@ -1744,9 +1688,8 @@ mod apply_tests {
         assert!(matches!(reply, ServerMsg::Err { ref error, .. } if error == "owner_gone"));
     }
 
-    /// Asserts that a `new_instance` naming an unknown handle still
-    /// replies `unknown_handle`, unaffected by the owner-liveness gate
-    /// added for the `owner_gone` refusal.
+    /// Asserts that a `new_instance` naming an unknown handle replies
+    /// `unknown_handle` rather than `owner_gone`.
     ///
     /// Case: a program sends `new_instance` for a handle nobody
     /// registered, such as a stale id left over from an earlier session.
@@ -2057,8 +2000,7 @@ mod apply_tests {
     /// back to the VT on the surface that owned them.
     ///
     /// Case: a program unregisters a view whose placements the terminal
-    /// still holds, so their cap slots must be freed without waiting for
-    /// the anchors to scroll out of history.
+    /// still holds.
     #[test]
     fn unregister_reclaims_the_released_placements_from_the_vt() {
         #[derive(Resource, Default)]

--- a/crates/bevy_orzma_webview/src/control_plane/listener.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/listener.rs
@@ -1,12 +1,6 @@
 //! Tokio-free control-plane listener: an accept loop thread plus one reader
-//! thread and one writer thread per connection. Each connection must come
-//! from orzma's own user (checked by peer UID on Unix, and enforced by the
-//! socket directory's DACL on Windows), must `hello` with a valid token
-//! (resolved via `TokenRegistry` to its surface), then its
-//! `register`/`unregister` lines and its disconnect are emitted as
-//! `ControlEvent`s. A bounded reply channel per request carries the minted
-//! handle back from the ECS apply system; the reply is relayed through the
-//! per-connection writer thread so all writes go through a single owner.
+//! thread and one writer thread per connection, turning each client line into
+//! a `ControlEvent` for the ECS apply system.
 
 use crate::control_plane::ConnectionWriters;
 use crate::control_plane::HandleId;
@@ -23,10 +17,10 @@ use std::os::fd::AsRawFd;
 
 /// An event the listener emits to the ECS apply system.
 pub(crate) enum ControlEvent {
-    /// A `register` from a hello'd connection; the apply system mints a handle,
-    /// populates the registries, and sends the reply back on `reply`.
+    /// A `register` from a hello'd connection; the minted handle comes back
+    /// on `reply`.
     Register {
-        /// Connection id (for scoped teardown).
+        /// The connection the minted registration is owned by.
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
@@ -37,15 +31,15 @@ pub(crate) enum ControlEvent {
     },
     /// An `unregister` from a connection.
     Unregister {
-        /// Connection id (ownership check).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The handle to release.
         handle: HandleId,
     },
-    /// A `new_instance` from a hello'd connection; the apply system mints an
-    /// instance on a handle this connection owns and replies on `reply`.
+    /// A `new_instance` naming a handle; the minted instance comes back on
+    /// `reply`.
     NewInstance {
-        /// Connection id (ownership check).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The handle to mint an additional instance for.
         handle: HandleId,
@@ -67,12 +61,12 @@ pub(crate) enum ControlEvent {
         value: Value,
         /// The error message when `ok` is false.
         error: Option<String>,
-        /// The connection that sent the reply (for in-flight ownership).
+        /// The connection that sent the reply. Ownership is not checked here.
         connection_id: u64,
     },
-    /// A program-initiated push to its handle's webviews.
+    /// A program-initiated push to a handle's webviews.
     Emit {
-        /// The connection that sent the emit (ownership is checked in apply).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The target handle.
         handle: HandleId,
@@ -83,7 +77,7 @@ pub(crate) enum ControlEvent {
     },
     /// An app-owned focus set/clear for the connection's surface.
     SetFocus {
-        /// Connection id (ownership check in apply).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
@@ -92,7 +86,7 @@ pub(crate) enum ControlEvent {
     },
     /// An app-initiated in-place navigation of one mounted placement.
     Navigate {
-        /// Connection id (ownership check in apply).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
@@ -101,9 +95,9 @@ pub(crate) enum ControlEvent {
         /// What to do.
         action: NavAction,
     },
-    /// A socket `mount` for one of the connection's instances.
+    /// A socket `mount` naming an instance.
     Mount {
-        /// Connection id (ownership check in apply).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
@@ -118,9 +112,9 @@ pub(crate) enum ControlEvent {
         /// Rect width in cells.
         cols: u16,
     },
-    /// A socket `unmount` for one of the connection's instances.
+    /// A socket `unmount` naming an instance.
     Unmount {
-        /// Connection id (ownership check in apply).
+        /// The connection that sent it. Ownership is not checked here.
         connection_id: u64,
         /// The surface the connection's token resolved to.
         owner_surface: Entity,
@@ -163,11 +157,8 @@ pub(crate) fn spawn_listener(
 
 /// Whether a freshly accepted connection may proceed to the handshake.
 ///
-/// Unix: the peer's UID must equal orzma's own. Windows: always true —
-/// the socket directory's current-user DACL (see
-/// `bevy_orzma_webview_host::restrict_to_current_user`) already keeps other
-/// users from connecting, and AF_UNIX on Windows offers no peer
-/// credentials to double-check.
+/// On Unix the peer's UID must equal orzma's own. On Windows it is always
+/// true.
 #[cfg(unix)]
 fn accepts(stream: &UnixStream) -> bool {
     // SAFETY: `getuid` has no preconditions and cannot fail.
@@ -181,8 +172,7 @@ fn accepts(_stream: &UnixStream) -> bool {
 }
 
 /// Returns the connecting peer's UID via `getpeereid` (Apple/BSD), or `None` on
-/// error. The `libc` crate exposes `getpeereid` only on these targets; Linux
-/// uses the `SO_PEERCRED` variant below.
+/// error.
 #[cfg(any(
     target_os = "macos",
     target_os = "ios",
@@ -224,9 +214,9 @@ fn peer_uid(stream: &UnixStream) -> Option<u32> {
     (rc == 0).then_some(cred.uid)
 }
 
-/// Reads one connection: requires a valid `hello`, spawns a writer thread for
-/// all outbound lines (register replies + future server-push), registers the
-/// writer in `writers`, then forwards each `register`/`unregister`, then emits
+/// Reads one connection: it requires a valid `hello`, spawns a writer thread
+/// for all outbound lines (replies and server pushes) and registers it in
+/// `writers`, forwards each request line as a `ControlEvent`, then emits
 /// `Disconnect` and removes the writer on EOF.
 fn serve_connection(
     stream: UnixStream,
@@ -308,9 +298,8 @@ fn read_hello(lines: &mut BufReader<UnixStream>, tokens: &TokenRegistry) -> Opti
     tokens.resolve(&token)
 }
 
-/// Dispatches one parsed `ClientMsg`; relays the register reply through `out_tx`
-/// so all writes go through the single writer thread. Returns `Break` when the
-/// connection should be torn down.
+/// Dispatches one parsed `ClientMsg`, relaying the register reply through
+/// `out_tx`. Returns `Break` when the connection should be torn down.
 fn handle_client_msg(
     msg: ClientMsg,
     connection_id: u64,
@@ -756,8 +745,8 @@ mod tests {
     /// Asserts that the bound socket file inherits the runtime
     /// directory's current-user restriction.
     ///
-    /// Case: orzma binds its control socket under `%TEMP%` on Windows,
-    /// where the endpoint ACL is the only thing keeping other users out.
+    /// Case: orzma binds its control socket in its runtime directory under
+    /// `%TEMP%` on Windows.
     #[cfg(windows)]
     #[test]
     fn the_bound_socket_file_is_private_to_the_current_user() {

--- a/crates/bevy_orzma_webview/src/control_plane/protocol.rs
+++ b/crates/bevy_orzma_webview/src/control_plane/protocol.rs
@@ -1,7 +1,6 @@
 //! NDJSON wire types for the control plane, internally tagged on `op`. The
 //! listener parses one `ClientMsg` per line and replies with one `ServerMsg`
-//! per request line. Unknown `op` values fail to parse (strict, matching the
-//! OSC parser ethos).
+//! per request line; an unknown `op` fails to parse.
 
 use crate::control_plane::HandleId;
 use orzma_vt::prelude::InstanceId;
@@ -196,10 +195,8 @@ pub(crate) enum ServerMsg {
 }
 
 impl ServerMsg {
-    /// A `register` reply carrying the minted handle and its first instance.
-    ///
-    /// Both id slots are typed, so neither can take the other's value: the
-    /// wire spelling is produced here rather than at the call site.
+    /// A `register` reply carrying the minted handle and its first instance
+    /// in its wire spelling.
     pub fn registered(handle: impl Into<HandleId>, instance: InstanceId) -> Self {
         Self::Registered {
             ok: true,
@@ -487,8 +484,8 @@ mod tests {
         );
     }
 
-    /// Asserts that each of the three reply shapes serializes to the exact
-    /// line the SDK's position-matched FIFO reads back.
+    /// Asserts that each of the three reply shapes serializes to its exact
+    /// wire line.
     ///
     /// Case: one connection registers a view, asks for a second placement,
     /// then sends a request the host rejects.

--- a/crates/bevy_orzma_webview/src/lib.rs
+++ b/crates/bevy_orzma_webview/src/lib.rs
@@ -1,8 +1,6 @@
-//! Standalone terminal webview layer: CEF render wiring, the `window.orzma`
-//! Tier 1 back-channel, APC mount/unmount of webviews anchored to terminal
-//! cells, and the control socket that mints Tier 1 handles. Decoupled from any
-//! multiplexer; the host maps its surfaces onto `OrzmaTerminal` entities and
-//! drives `KeyboardFocused`.
+//! Terminal webview layer: CEF render wiring, the `window.orzma` Tier 1
+//! back-channel, APC mount and unmount of webviews anchored to terminal cells,
+//! and the control socket that mints Tier 1 handles.
 
 mod control_plane;
 #[cfg(test)]
@@ -23,8 +21,8 @@ use webview::paint::PaintPlugin;
 use webview::render::RenderPlugin;
 pub use webview::render::cef_plugin;
 
-/// Bevy plugin: the in-process webview subsystem — CEF render wiring + the
-/// `window.orzma` back-channel, APC mount/unmount, and the control socket.
+/// The in-process webview subsystem: CEF render wiring, the `window.orzma`
+/// back-channel, APC mount and unmount, and the control socket.
 ///
 /// The host supplies the `WebviewAssetRegistry` shared with the `orzma://`
 /// scheme handler (built via [`cef_plugin`]).

--- a/crates/bevy_orzma_webview/src/test_support.rs
+++ b/crates/bevy_orzma_webview/src/test_support.rs
@@ -1,8 +1,5 @@
 //! Test-only capture of `log` records, so a test can assert that a code path
-//! raised no warning. Bevy's built-in command error handlers (the one behind
-//! `EntityCommands::despawn`, for instance) report through `log::warn!`, not
-//! through the app's fallback error handler, so this is the only way to see
-//! them from a test.
+//! raised no warning.
 
 use log::{Level, Log, Metadata, Record};
 use std::sync::{Mutex, OnceLock};
@@ -32,8 +29,8 @@ impl Log for CapturingLogger {
 /// Installs the capturing logger once per test process and returns every
 /// warning-or-worse message captured so far whose text contains `needle`.
 ///
-/// Tests run concurrently in one process, so a caller compares the count
-/// before and after the code under test rather than asserting emptiness.
+/// The capture is process-wide, so a caller compares the count before and
+/// after the code under test rather than asserting emptiness.
 pub(crate) fn warnings_containing(needle: &str) -> Vec<String> {
     INSTALL.get_or_init(|| {
         if log::set_logger(&CapturingLogger).is_ok() {

--- a/crates/bevy_orzma_webview/src/webview.rs
+++ b/crates/bevy_orzma_webview/src/webview.rs
@@ -1,6 +1,6 @@
-//! In-process webview: CEF render wiring + window.orzma back-channel (render),
-//! APC mount/unmount (apc), webviews rendered into the terminal flow (mount),
-//! and the CPU paint bridge for platforms without a GPU paint path (paint).
+//! In-process webviews anchored to terminal cells: CEF render wiring, the
+//! `window.orzma` back-channel, APC mount and unmount, placement in the
+//! terminal flow, and the CPU paint bridge.
 
 pub(crate) mod apc;
 pub(crate) mod mount;

--- a/crates/bevy_orzma_webview/src/webview/apc.rs
+++ b/crates/bevy_orzma_webview/src/webview/apc.rs
@@ -43,9 +43,7 @@ pub(crate) fn on_webview_mount(
     );
 }
 
-/// Reports a mount the VT refused. The placement cap rejected it, so
-/// there is nothing to spawn — without this line a webview that never
-/// appears would leave no trace at all.
+/// Reports a mount the VT refused, spawning nothing.
 pub(crate) fn on_webview_mount_rejected(ev: On<TtyWebviewMountRejectedSignal>) {
     let req = ev.event();
     tracing::debug!(

--- a/crates/bevy_orzma_webview/src/webview/mount.rs
+++ b/crates/bevy_orzma_webview/src/webview/mount.rs
@@ -1,9 +1,6 @@
-//! Webview mount module: `ChildOf` children of a terminal surface that render a
-//! registered view into the terminal's text flow. This module owns the
-//! components, the mount/unmount policy executed by the `Mount` /
-//! `Unmount` observers in `apc`, and the
-//! `WebviewPlugin` runtime systems that keep `WebviewSize` in
-//! sync with cell metrics and project placements into `TerminalOverlays`.
+//! Webview mounting: `ChildOf` children of a terminal surface that render a
+//! registered view into the terminal's text flow, keep their size in step with
+//! the cell metrics, and project their placements into `TerminalOverlays`.
 
 use super::apc::NonInteractive;
 use super::render::preload::build_preload;
@@ -27,24 +24,19 @@ use bevy_orzmux::prelude::{RequestTtyWebviewRemove, TtyWebviewEvictedSignal};
 use orzma_vt::prelude::InstanceId;
 
 /// The normalized forward-key chords for a mounted webview, copied from
-/// its registration. Read by the focused-key filter-fill and PTY-forward
-/// systems (Phase 4) off the focused child entity.
+/// its registration.
 #[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
 pub struct ForwardKeys(pub Vec<NormalizedChord>);
 
 /// Marks a webview entity and records its identity: the instance it was
 /// mounted under, the registration handle it came from, the overlay
 /// texture slot it occupies on its parent terminal, and the rectangle it
-/// reserved. The owning terminal surface is NOT duplicated here — it is
-/// the `ChildOf` parent, per the "no typed back-references" convention.
-/// Each child's `slot` is the single source of truth for slot allocation
-/// (no separate allocation table).
+/// reserved. The owning terminal surface is the `ChildOf` parent.
 ///
 /// # Invariants
 ///
-/// `AnchoredPlacement.size` for this instance always equals `rows` /
-/// `cols` here — the VT treats a size change as a remount, so a drift
-/// between the CEF surface size and the painted rect cannot arise.
+/// `AnchoredPlacement.size` for this instance always equals `rows` and
+/// `cols` here.
 #[derive(Component, Debug, Clone, PartialEq, Eq)]
 pub struct Webview {
     /// The registration this webview's content came from.
@@ -67,18 +59,11 @@ pub struct Webview {
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CompositeNotified;
 
-/// Registers the webview runtime systems: the `WebviewSize` size sync
-/// (`Update`), the per-frame projection that derives `TerminalOverlays` from
-/// the frame-carried placement list (spec §5), and the render-world ordering
-/// edge that keeps webview GPU texture injection ahead of the terminal
-/// material's bind-group rebuild.
-///
-/// The projection is scheduled in `PostUpdate` before
-/// `TerminalMaterialSystems::UpdateMaterial`: grid state settles during
-/// `Update` (`bevy_orzmux`'s pump emits `TtyFrameSignal` there and the
-/// renderer's `apply_frame` observer mirrors it into `TerminalGrid`), so
-/// projecting just before the material rebuild hands the same frame's
-/// overlays to the shader.
+/// Registers the webview runtime systems: the `WebviewSize` size sync, the
+/// per-frame projection that derives `TerminalOverlays` from the
+/// frame-carried placement list, and the render-world ordering edge that
+/// keeps webview GPU texture injection ahead of the terminal material's
+/// bind-group rebuild.
 pub(crate) struct WebviewPlugin;
 
 impl Plugin for WebviewPlugin {
@@ -112,16 +97,15 @@ pub(crate) struct WebviewMountContext {
     /// The requesting terminal surface — the `ChildOf` parent of the mount.
     pub terminal_surface: Entity,
     /// The instance the mount registered. A mount the VT refused never
-    /// reaches here — it arrives as `TtyWebviewMountRejectedSignal`.
+    /// reaches here.
     pub instance: InstanceId,
-    /// Rect height in terminal cells (validated 1..=200 by `orzma_vt`).
+    /// Rect height in terminal cells, validated to `1..=200`.
     pub rows: u16,
-    /// Rect width in terminal cells (validated 1..=400 by `orzma_vt`).
+    /// Rect width in terminal cells, validated to `1..=400`.
     pub cols: u16,
 }
 
-/// The system params `mount` / `unmount` need, bundled so the
-/// `on_webview_mount` observer gains a single extra parameter.
+/// The system params `mount` and `unmount` need.
 #[derive(SystemParam)]
 pub(crate) struct WebviewParams<'w, 's> {
     commands: Commands<'w, 's>,
@@ -146,12 +130,10 @@ pub(crate) struct ResolvedWebviewMount {
     pub interactive: bool,
     /// `(connection_id, handle)` of the registering program, used to stamp
     /// `WebviewOwner` for `window.orzma` back-channel routing. `Some` only when
-    /// the registration is bridged; a display-only `Url` view leaves it `None`,
-    /// which is the gate that also withholds the preload at mount.
+    /// the registration is bridged; a display-only `Url` view leaves it `None`.
     pub owner: Option<(u64, HandleId)>,
     /// The normalized forward-key chords copied from the registration, stamped
-    /// as a `ForwardKeys` component so the focused-key systems read them off
-    /// the webview entity without a registry lookup (design spec §C).
+    /// as a `ForwardKeys` component.
     pub forward_keys: Vec<NormalizedChord>,
     /// User-supplied preload scripts, injected after the host bridge (and as
     /// the only scripts for a display-only view).
@@ -159,13 +141,13 @@ pub(crate) struct ResolvedWebviewMount {
 }
 
 /// Resolves a handle (already looked up from an `Omount;n=<instance>`'s
-/// instance) against the `OrzmaRegistry` (Tier 1). `Dir`/`Inline` handles
-/// resolve to an `orzma://<handle>/…` URL (one origin per handle); a `Url`
-/// handle resolves to its verbatim remote URL. A handle resolves ONLY when
-/// `requesting_surface` is its `owner_surface` — the scoping gate that stops
-/// one surface from mounting another's handle. `owner` is populated only for
-/// a bridged registration (a display-only `Url` view leaves it `None`).
-/// Returns `None` for an unregistered or unowned handle.
+/// instance) against the `OrzmaRegistry` (Tier 1). Returns `None` for an
+/// unregistered or unowned handle.
+///
+/// `Dir` and `Inline` handles resolve to an `orzma://<handle>/…` URL (one
+/// origin per handle); a `Url` handle resolves to its verbatim remote URL. A
+/// handle resolves ONLY when `requesting_surface` is its `owner_surface`, and
+/// `owner` is populated only for a bridged registration.
 pub(crate) fn resolve_mount(
     id: &HandleId,
     requesting_surface: Entity,
@@ -200,18 +182,11 @@ pub(crate) fn resolve_mount(
 /// requesting surface does not own, and overlay-slot exhaustion are each a
 /// `tracing::debug!` plus a reclaim of the VT-side reservation.
 ///
-/// The parent (`ctx.terminal_surface`, the `TtyWebviewMountSignal` target) is
-/// the owning pane entity: both `OrzmuxPane` (whose drained signals include the
-/// APC mount) and the required `TerminalGrid` component live on that one
-/// entity, so the `ChildOf` parent is also the entity `project_webview_overlays`
-/// reads grid state from.
-///
-/// `WebviewSize` is seeded here because `bevy_cef` builds the CEF browser
-/// from it at creation. The seed is `(cols × cell_w, rows × cell_h) /
-/// scale_factor` in logical px from `TerminalCellMetricsResource` and the
-/// primary window; when neither exists yet (headless tests, pre-first-render)
-/// a placeholder cell of 8×16 physical px at scale 1.0 is used —
-/// `sync_webview_size` corrects it once real metrics arrive.
+/// `WebviewSize` is seeded to `(cols × cell_w, rows × cell_h) / scale_factor`
+/// in logical px from `TerminalCellMetricsResource` and the primary window.
+/// When neither exists yet (headless tests, pre-first-render) a placeholder
+/// cell of 8×16 physical px at scale 1.0 is used, and the size is corrected
+/// once real metrics arrive.
 pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: WebviewMountContext) {
     let live = live_webview_children(&params.children, &params.views, ctx.terminal_surface);
     if let Some(existing) = live.iter().find(|live| live.instance == ctx.instance) {
@@ -262,8 +237,7 @@ pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: We
     // MaterialNode (even for debug visualization). bevy_cef's mesh/sprite
     // input paths and display-size allocators key on `With<WebviewSource>`
     // plus exactly those components; adding one double-attaches input
-    // forwarding and display allocation on top of orzma's inline routing
-    // (design spec §4 invariant).
+    // forwarding and display allocation on top of orzma's inline routing.
     params.commands.entity(webview).insert((
         ChildOf(ctx.terminal_surface),
         source,
@@ -316,11 +290,8 @@ pub(crate) fn mount(params: &mut WebviewParams, dynamic: &OrzmaRegistry, ctx: We
 }
 
 /// Despawns the webview child(ren) of `terminal_surface` matching the
-/// scope: `Some(id)` removes that one instance; `None` removes every
-/// webview child, the shape a client-issued unmount-all takes. VT-side
-/// evictions (history trim, reset, alternate-screen teardown, resize)
-/// arrive separately as `TtyWebviewEvictedSignal` handled by
-/// `on_webview_evicted`.
+/// scope: `Some(id)` removes that one instance, and `None` removes every
+/// webview child.
 pub(crate) fn unmount(
     params: &mut WebviewParams,
     terminal_surface: Entity,
@@ -339,9 +310,7 @@ pub(crate) fn unmount(
 
 /// Returns the webview entity that currently holds keyboard focus on
 /// `active_surface`: `Some(e)` iff `FocusedWebview` points at `e`, `e` carries
-/// `Webview`, and its `ChildOf` parent is the active surface. The input
-/// dispatcher uses this to hoist the release-chord check, restrict the Escape
-/// scroll-to-bottom pre-handler, and suppress PTY key forwarding (spec §7).
+/// `Webview`, and its `ChildOf` parent is the active surface.
 pub fn focused_webview_of(
     focused: Option<&FocusedWebview>,
     webview_parents: &Query<&ChildOf, With<Webview>>,
@@ -364,17 +333,13 @@ pub struct WebviewHit {
 }
 
 /// Hit-tests a terminal-local physical-pixel point against the terminal's
-/// ACTIVE inline overlay rects (the same `TerminalOverlays` projection the
-/// shader composites, spec §7's single coordinate source) and returns the
-/// interactive child whose rect contains it.
+/// ACTIVE inline overlay rects and returns the interactive child whose rect
+/// contains it.
 ///
-/// Cell coordinates are 0-indexed (`row = floor(local_phys.y / cell_h)`,
-/// column analog) — NOT the 1-indexed `cell_at_local` convention the terminal
-/// click pipeline uses. `rows == 0` sentinel slots never match; a
+/// Cell coordinates are 0-indexed (`row = floor(local_phys.y / cell_h)`, and
+/// the column analog). `rows == 0` sentinel slots never match, and a
 /// partially-scrolled rect with a negative `row` origin still hits in its
-/// visible cells (its DIP origin lies above the viewport, so `local_dip.y`
-/// lands past the clipped rows). `NonInteractive` children are invisible to
-/// the hit-test, so their rects pass through as plain terminal input.
+/// visible cells. `NonInteractive` children are invisible to the hit-test.
 pub fn webview_hit_at(
     children: &Query<&Children>,
     webviews: &Query<(&Webview, Has<NonInteractive>)>,
@@ -417,9 +382,8 @@ pub fn webview_hit_at(
 }
 
 /// Converts a terminal-local physical-pixel point to webview-local DIP
-/// relative to a slot's active overlay rect, WITHOUT containment checking —
-/// the release leg of an in-flight inline press uses this so a pointer that
-/// drifted off the rect still produces a (possibly out-of-view) release
+/// relative to a slot's active overlay rect, WITHOUT containment checking, so
+/// a point that lies off the rect still produces a (possibly out-of-view)
 /// position. Returns `None` for an out-of-range slot or a `rows == 0`
 /// sentinel rect.
 pub fn webview_local_dip(
@@ -442,11 +406,6 @@ const FALLBACK_CELL_W_PHYS: f32 = 8.0;
 const FALLBACK_CELL_H_PHYS: f32 = 16.0;
 
 /// Drops the reservation a refused mount left in the VT.
-///
-/// The VT cannot tell a minted instance from a fabricated one, so it
-/// registers a placement for any syntactically valid `n=`. Without this a
-/// client can exhaust the per-terminal cap with mounts the host will never
-/// place.
 fn reclaim(params: &mut WebviewParams, terminal: Entity, instance: InstanceId) {
     params.commands.trigger(RequestTtyWebviewRemove {
         terminal,
@@ -510,9 +469,9 @@ fn smallest_free_slot(live: &[LiveWebview]) -> Option<u8> {
     (0..OVERLAY_SLOTS as u8).find(|slot| live.iter().all(|live| live.slot != *slot))
 }
 
-/// Physical cell pitch from the metrics resource (the same floor/max the
-/// terminal resize path applies), or the 8×16 placeholder when no terminal
-/// has rendered yet.
+/// Physical cell pitch from the metrics resource, floored to whole physical
+/// pixels and at least 1, or the 8×16 placeholder when no terminal has
+/// rendered yet.
 fn cell_size_phys(metrics: Option<&TerminalCellMetricsResource>) -> (f32, f32) {
     metrics
         .map(|m| {
@@ -538,12 +497,8 @@ fn seed_logical_size(
 }
 
 /// Recomputes every webview's `WebviewSize` from the current cell
-/// metrics and primary-window scale factor (spec §6.5), writing only when the
-/// value differs — `bevy_cef` commits sizes to CEF on `Changed<WebviewSize>`,
-/// so a spurious write each frame would re-commit (and re-create the
-/// IOSurface) every frame. Exact equality suffices: the inputs are identical
-/// frame-to-frame unless metrics/scale actually changed, and this math is
-/// deterministic.
+/// metrics and primary-window scale factor, writing only when the value
+/// differs.
 fn sync_webview_size(
     mut sizes: Query<(&mut WebviewSize, &Webview)>,
     metrics: Option<Res<TerminalCellMetricsResource>>,
@@ -564,13 +519,11 @@ fn sync_webview_size(
 /// Derives each terminal's `TerminalOverlays` from the frame-carried
 /// placement list, every frame, starting from the all-sentinel default.
 ///
-/// The list is authoritative and declarative: an id with no matching
-/// child is ignored (its mount signal has not landed yet), a mounted
-/// child whose id is absent paints nothing (hidden, not unmounted), and
-/// a rect whose top sits above the viewport passes through with a
-/// negative row for the shader to clip. Each point is projected with the
-/// grid's display offset; rects fully outside the viewport and columns
-/// at or past the right edge are culled here.
+/// An id with no matching child is ignored, a mounted child whose id is
+/// absent paints nothing (hidden, not unmounted), and a rect whose top
+/// sits above the viewport passes through with a negative row. Each point
+/// is projected with the grid's display offset; rects fully outside the
+/// viewport and columns at or past the right edge are culled here.
 ///
 /// The component is (re)inserted for every terminal that has inline
 /// children OR already carries `TerminalOverlays`, so a terminal whose
@@ -801,9 +754,7 @@ mod tests {
     }
 
     /// Queues every op from ONE system and applies the deferred commands
-    /// once, the batch shape a single VT pump produces. Triggering each op
-    /// through `World::trigger` instead would flush between them and would
-    /// not exercise the interleaving these signals really arrive in.
+    /// once, the batch shape a single VT pump produces.
     fn batch(app: &mut App, terminal: Entity, ops: Vec<Op>) {
         app.world_mut()
             .run_system_once(move |mut commands: Commands| {
@@ -1206,9 +1157,7 @@ mod tests {
     }
 
     /// Asserts that an eviction followed by a re-mount of the same
-    /// instance in one signal batch leaves exactly one live webview,
-    /// pinning the per-command flush `bevy_ecs` performs between queued
-    /// triggers.
+    /// instance in one signal batch leaves exactly one live webview.
     ///
     /// Case: a program leaves the alternate screen — tearing down the
     /// placements it held there — and immediately re-mounts the same view
@@ -1498,7 +1447,7 @@ mod tests {
     /// overlay slot verbatim, including a negative row.
     ///
     /// Case: a mounted webview's rect sticks partway above the viewport
-    /// after the user scrolls, and the shader clips the negative rows.
+    /// after the user scrolls.
     #[test]
     fn projection_passes_the_placement_rect_through() {
         let (mut app, terminal, instance) = app_with_registration();

--- a/crates/bevy_orzma_webview/src/webview/paint.rs
+++ b/crates/bevy_orzma_webview/src/webview/paint.rs
@@ -1,7 +1,5 @@
 //! Copies the CPU paint frames CEF produces on Windows and Linux into the
 //! headless `WebviewTextureTarget` image each mounted webview renders through.
-//! `bevy_cef` only writes that image on macOS (its GPU path), so without this
-//! bridge the terminal overlay samples the placeholder and the pane stays white.
 
 #[cfg(not(target_os = "macos"))]
 use bevy::asset::RenderAssetUsages;
@@ -15,8 +13,7 @@ use bevy_cef_core::prelude::{RenderPaintElementType, RenderTextureMessage};
 
 /// Registers the paint bridge on the platforms where CEF paints on the CPU.
 ///
-/// On macOS `bevy_cef` writes the target through its GPU path and never emits
-/// a paint message, so the plugin registers nothing there.
+/// On macOS it registers nothing.
 pub(crate) struct PaintPlugin;
 
 impl Plugin for PaintPlugin {

--- a/crates/bevy_orzma_webview/src/webview/render.rs
+++ b/crates/bevy_orzma_webview/src/webview/render.rs
@@ -13,27 +13,25 @@ use std::path::Path;
 pub(crate) mod preload;
 
 /// One frame emitted by the page bridge (`orzma_bridge.js`) via
-/// `cef.emit({ kind: '…', … })`, inspected by the per-kind observers.
+/// `cef.emit({ kind: '…', … })`.
 ///
-/// `#[serde(transparent)]` makes it deserialize from the bare emitted object
-/// (`{kind, reqId, …}`), not from a `{"0": …}` wrapper — `bevy_cef`'s
-/// `cef.emit(frame)` serializes only its first argument into one global
-/// `Receive<OrzmaFrame>`.
+/// It deserializes from the bare emitted object (`{kind, reqId, …}`), not
+/// from a `{"0": …}` wrapper.
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(transparent)]
 struct OrzmaFrame(serde_json::Value);
 
 /// The `kind` discriminator routing a `Receive<OrzmaFrame>` to the Tier 1
-/// back-channel (`on_orzma_call_frame`). The page side emits it in `orzma_bridge.js`.
+/// back-channel. The page bridge emits it in `orzma_bridge.js`.
 const ORZMA_CALL_KIND: &str = "orzma.call";
 
 /// The `kind` discriminator routing a `Receive<OrzmaFrame>` to the one-way
-/// inbound-event forwarder (`on_orzma_emit_frame`). Emitted by `orzma_bridge.js`.
+/// inbound-event forwarder. The page bridge emits it in `orzma_bridge.js`.
 const ORZMA_EMIT_KIND: &str = "orzma.emit";
 
 /// Builds the `CefPlugin` with the `orzma://` (dynamic, Tier 1) scheme bound
-/// to its shared `WebviewAssetRegistry`, using `root_cache_path` as this process's
-/// unique CEF profile directory (one Chromium singleton lock per instance).
+/// to its shared `WebviewAssetRegistry`, using `root_cache_path` as this
+/// process's unique CEF profile directory.
 pub fn cef_plugin(orzma_registry: WebviewAssetRegistry, root_cache_path: &Path) -> CefPlugin {
     CefPlugin {
         custom_schemes: vec![custom_orzma_scheme(orzma_registry)],
@@ -45,20 +43,13 @@ pub fn cef_plugin(orzma_registry: WebviewAssetRegistry, root_cache_path: &Path) 
 
 /// CEF command-line switches for the embedded webview.
 ///
-/// On macOS we always append `use-mock-keychain` so CEF's OSCrypt layer derives
-/// its cookie / Local State encryption key from a mock keychain rather than the
-/// real login keychain. Without it, release / bundled builds pop the "orzma
-/// wants to use … Chromium Safe Storage" keychain prompt on launch:
-/// `bevy_cef_core`'s `CommandLineConfig::default()` only carries this switch under
-/// `debug_assertions`, so it is absent from the `dist` profile. orzma's CEF
-/// profile is an ephemeral per-process temp dir (see `cef_profile`), so a mock
-/// key costs no real persistence. `effective_command_line_config` de-duplicates,
-/// so re-adding it on debug builds is harmless.
+/// On macOS the config always carries `use-mock-keychain`, so CEF's OSCrypt
+/// layer derives its cookie and Local State encryption key from a mock
+/// keychain rather than the real login keychain.
 ///
-/// The `debug` feature additionally exposes `remote-debugging-port` — a local
+/// The `debug` feature additionally exposes `remote-debugging-port`, a local
 /// Chromium DevTools (CDP) endpoint on `127.0.0.1:9222` for inspecting the
-/// embedded webview — and is off by default so that endpoint is never exposed in
-/// normal builds.
+/// embedded webview. It is off by default.
 fn cef_command_line_config() -> CommandLineConfig {
     let config = CommandLineConfig::default();
     #[cfg(target_os = "macos")]
@@ -68,9 +59,9 @@ fn cef_command_line_config() -> CommandLineConfig {
     config
 }
 
-/// Wires the `window.orzma` Tier 1 back-channel: the `orzma.call` frame
-/// observer, the webview-load loggers, and the focus sync that keeps
-/// `bevy_cef`'s `FocusedWebview` in step with the active pane.
+/// Wires the `window.orzma` Tier 1 back-channel: the `orzma.call` and
+/// `orzma.emit` frame observers, the `urlChanged` forwarder, the in-flight
+/// prune on webview despawn, and the webview-load loggers.
 pub(crate) struct RenderPlugin;
 
 impl Plugin for RenderPlugin {
@@ -87,15 +78,13 @@ impl Plugin for RenderPlugin {
 }
 
 /// Inbound (Tier 1 back-channel): a `window.orzma.call` arrives as a
-/// `Receive<OrzmaFrame>` with `kind:"orzma.call"`. The trusted caller is
-/// `frame.webview` (bound per-webview by `bevy_cef`, never the JS payload); its
-/// `WebviewOwner` names the registering connection. The call is forwarded over
-/// that connection's writer under a Rust-minted global reqId; a missing
-/// owner/connection rejects the page Promise directly.
+/// `Receive<OrzmaFrame>` with `kind:"orzma.call"`; any other `kind` is
+/// ignored.
 ///
-/// Registered as an observer on the shared `Receive<OrzmaFrame>` event (NOT a
-/// second `JsEmitEventPlugin`): the event carries all frames; non-`orzma.call`
-/// frames are ignored via the early return on `ORZMA_CALL_KIND`.
+/// The trusted caller is `frame.webview`, never the JS payload; its
+/// `WebviewOwner` names the registering connection. The call is forwarded over
+/// that connection's writer under a Rust-minted global reqId, and a missing
+/// owner or connection rejects the page Promise directly.
 fn on_orzma_call_frame(
     frame: On<Receive<OrzmaFrame>>,
     mut commands: Commands,
@@ -147,14 +136,13 @@ fn reject_orzma_call(commands: &mut Commands, webview: Entity, req_id: &str, err
 }
 
 /// Inbound (one-way): a `window.orzma.emit` arrives as a `Receive<OrzmaFrame>`
-/// with `kind:"orzma.emit"`. The trusted caller is `frame.webview` (bound per
-/// webview by `bevy_cef`); its `WebviewOwner` names the registering connection.
-/// The event is forwarded as a fire-and-forget `{op:"event"}` line — no reqId,
-/// no reply, no `OrzmaRpc` tracking. A missing owner or unavailable connection
-/// drops the event (debug-logged); there is no page Promise to settle.
+/// with `kind:"orzma.emit"`; any other `kind` is ignored.
 ///
-/// Registered on the shared `Receive<OrzmaFrame>` event (not a second
-/// `JsEmitEventPlugin`); frames whose `kind` is not `orzma.emit` are ignored.
+/// The trusted caller is `frame.webview`; its `WebviewOwner` names the
+/// registering connection. The event is forwarded as a fire-and-forget
+/// `{op:"event"}` line with no reqId, no reply, and no `OrzmaRpc` tracking.
+/// A missing owner or unavailable connection drops the event, and there is no
+/// page Promise to settle.
 fn on_orzma_emit_frame(
     frame: On<Receive<OrzmaFrame>>,
     writers: Res<ConnectionWriters>,
@@ -191,13 +179,12 @@ fn on_orzma_emit_frame(
 }
 
 /// Outbound (Tier 1 back-channel): when a webview's top-level URL changes (CEF
-/// `OnAddressChange` — link clicks, hint activations, redirects, hash/pushState),
-/// forwards a `urlChanged` call to the registering program so it can track
-/// page-driven navigation (e.g. orzbrowser's history + URL bar). Scoped to remote
-/// `http(s)` webviews; `orzma://` dir/inline views (which register no
-/// `urlChanged` handler) are skipped. Fire-and-forget: the minted reqId is not
-/// recorded, so the program's reply finds no in-flight entry and is dropped by
-/// `OrzmaRpc::take_for_connection`.
+/// `OnAddressChange` — link clicks, redirects, hash and pushState navigation),
+/// forwards a `urlChanged` call to the registering program.
+///
+/// The call is sent only for remote `http(s)` webviews; `orzma://` dir and
+/// inline views are skipped. It is fire-and-forget: the minted reqId is not
+/// recorded, so the program's reply is dropped.
 fn on_webview_address_changed(
     addr: On<AddressChanged>,
     mut rpc: ResMut<OrzmaRpc>,
@@ -233,14 +220,14 @@ fn drop_orzma_inflight_on_webview_despawn(
     rpc.drain_webview(remove.entity);
 }
 
-/// Logs the start of a webview page load. Debug-level diagnostics: these
-/// observers fire for every `bevy_cef` webview, not only orzma webviews.
+/// Logs the start of a webview page load at debug level.
+///
+/// It fires for every `bevy_cef` webview, not only orzma webviews.
 fn log_webview_load_started(load: On<LoadStarted>) {
     tracing::debug!(webview = ?load.webview, "webview load started");
 }
 
-/// Logs a finished page load + its HTTP status. A `LoadFinished` with no
-/// visible content points at a render/size issue rather than a load failure.
+/// Logs a finished page load and its HTTP status.
 fn log_webview_load_finished(load: On<LoadFinished>) {
     tracing::debug!(
         webview = ?load.webview,
@@ -249,9 +236,7 @@ fn log_webview_load_finished(load: On<LoadFinished>) {
     );
 }
 
-/// Logs a page load failure (CEF `OnLoadError`) — the signal that the scheme
-/// fetch / navigation failed (e.g. a mis-classified MIME or 5xx). Kept at
-/// `warn` because, unlike start/finish, it always indicates a real fault.
+/// Logs a page load failure (CEF `OnLoadError`) at `warn` level.
 fn log_webview_load_error(load: On<LoadError>) {
     tracing::warn!(
         webview = ?load.webview,

--- a/crates/bevy_orzma_webview/src/webview/render/preload.rs
+++ b/crates/bevy_orzma_webview/src/webview/render/preload.rs
@@ -4,15 +4,14 @@
 
 use bevy_cef::prelude::PreloadScripts;
 
-/// JS defining the unified `window.orzma` back-channel bridge (`.call` / `.on`),
-/// injected per Tier 1 bridged webview as a `PreloadScripts` entry. Frozen onto
-/// `window` so a page cannot shadow it.
+/// JS defining the `window.orzma` back-channel bridge (`.call` / `.on`),
+/// injected per Tier 1 bridged webview as a `PreloadScripts` entry. It is
+/// frozen onto `window`, so a page cannot shadow it.
 pub(super) const ORZMA_BRIDGE_JS: &str = include_str!("orzma_bridge.js");
 
 /// Builds the preload for a bridged Tier 1 webview: the `window.orzma`
 /// back-channel bridge, followed by the registering program's user scripts.
-/// No capability grant — the bridge routes to the registering program, not the
-/// host.
+/// The bridge routes to the registering program, not the host.
 pub(crate) fn build_preload(user: &[String]) -> PreloadScripts {
     let mut scripts = vec![ORZMA_BRIDGE_JS.to_string()];
     scripts.extend(user.iter().cloned());

--- a/crates/bevy_orzma_webview_host/src/asset.rs
+++ b/crates/bevy_orzma_webview_host/src/asset.rs
@@ -1,7 +1,6 @@
-//! Static-asset resolution for the in-process custom-scheme asset path
-//! (`orzma://`): percent-decode a webview-supplied request path, reject
-//! traversal, read the file under the registered asset root, and infer a bare
-//! MIME type. Pure (no `cef` dependency) so it is unit-testable on its own.
+//! Static-asset resolution for the `orzma://` custom scheme: percent-decode a
+//! webview-supplied request path, reject traversal, read the file under the
+//! registered asset root, and infer a bare MIME type.
 
 use std::path::Path;
 
@@ -26,11 +25,10 @@ pub enum AssetOutcome {
 /// Resolves `raw_path` (a percent-encoded, slash-separated relative URL path)
 /// under `root` and reads the file, returning a bare MIME type.
 ///
-/// `raw_path` is webview-controlled, so it is decoded exactly once and then
-/// rejected unless every component is a normal path segment — `..`, `.`, an
-/// absolute path, or a non-UTF-8 / malformed percent escape all yield
-/// [`AssetOutcome::Forbidden`]. This is the trust boundary that keeps a mounted
-/// page from reading files outside its webview directory.
+/// `raw_path` is decoded exactly once and then rejected unless every component
+/// is a normal path segment: `..`, `.`, an absolute path, or a non-UTF-8 or
+/// malformed percent escape all yield [`AssetOutcome::Forbidden`], so no
+/// request reads outside `root`.
 pub fn serve_static_asset(root: &Path, raw_path: &str) -> AssetOutcome {
     let Some(decoded) = percent_decode(raw_path) else {
         return AssetOutcome::Forbidden;
@@ -59,8 +57,7 @@ pub fn serve_static_asset(root: &Path, raw_path: &str) -> AssetOutcome {
     }
 }
 
-/// Upper bound on a single static asset (64 MiB): a larger file would buffer
-/// wholesale into the render process.
+/// Upper bound on a single static asset (64 MiB).
 const MAX_ASSET_LEN: u64 = 64 * 1024 * 1024;
 
 fn exceeds_limit(len: u64) -> bool {
@@ -68,8 +65,7 @@ fn exceeds_limit(len: u64) -> bool {
 }
 
 /// Decodes `%XX` escapes once. Returns `None` on a truncated/invalid escape or
-/// when the decoded bytes are not valid UTF-8. Does not treat `+` as space
-/// (that is a query-string rule, not a path rule).
+/// when the decoded bytes are not valid UTF-8. `+` is not treated as a space.
 fn percent_decode(s: &str) -> Option<String> {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
@@ -100,8 +96,8 @@ pub fn is_safe_rel_path(p: &Path) -> bool {
             .all(|c| matches!(c, std::path::Component::Normal(_)))
 }
 
-/// Maps a file extension to a bare MIME type for the asset set a Phase 1
-/// webview ships. Unknown extensions fall back to `application/octet-stream`.
+/// Maps a file extension to a bare MIME type. Unknown extensions fall back to
+/// `application/octet-stream`.
 fn mime_for_path(path: &Path) -> &'static str {
     let ext = path
         .extension()

--- a/crates/bevy_orzma_webview_host/src/host.rs
+++ b/crates/bevy_orzma_webview_host/src/host.rs
@@ -1,5 +1,5 @@
-//! Tokio-free host runtime: a per-handle runtime root used to mint the
-//! user-private socket directory tree for the webview control plane.
+//! Host runtime: a per-handle runtime root used to mint the user-private
+//! socket directory tree for the webview control plane.
 
 use crate::private_dir::restrict_to_current_user;
 use std::path::{Path, PathBuf};
@@ -156,8 +156,7 @@ mod tests {
     /// Asserts that the command-shim directory is private to the current
     /// user.
     ///
-    /// Case: a pane's `PATH` gains the shim directory; nobody else may
-    /// plant executables there.
+    /// Case: a pane's `PATH` gains the shim directory.
     #[test]
     fn runtime_root_creates_bin_dir_private() {
         let parent = tempfile::tempdir().unwrap();
@@ -223,11 +222,10 @@ mod tests {
     }
 
     /// Asserts that a socket path of exactly `SUN_PATH_MAX` bytes does not
-    /// fit while one byte shorter does, since the kernel needs one byte
-    /// for the NUL terminator.
+    /// fit while one byte shorter does.
     ///
-    /// Case: a temp directory whose length puts the longest socket path
-    /// right at the limit.
+    /// Case: a temp directory's length puts the longest socket path right at
+    /// the limit.
     #[test]
     fn a_socket_path_of_exactly_sun_path_max_bytes_does_not_fit() {
         let name = "n".repeat((SUN_PATH_MAX - 26) / 2);

--- a/crates/bevy_orzma_webview_host/src/lib.rs
+++ b/crates/bevy_orzma_webview_host/src/lib.rs
@@ -1,7 +1,6 @@
-//! Tokio-free host integration for orzma: a per-handle runtime root for the
-//! webview control plane and (behind the `cef` feature) serving
-//! dynamically-registered Tier 1 webview assets through an `orzma://`
-//! custom scheme via `WebviewAssetRegistry`.
+//! Host integration for orzma: a per-handle runtime root for the webview
+//! control plane and, behind the `cef` feature, an `orzma://` custom scheme
+//! serving dynamically-registered Tier 1 webview assets.
 
 pub mod asset;
 pub mod host;

--- a/crates/bevy_orzma_webview_host/src/orzma_scheme.rs
+++ b/crates/bevy_orzma_webview_host/src/orzma_scheme.rs
@@ -1,7 +1,6 @@
 //! `orzma://<handle>/<path>` custom-scheme handler for Tier 1 dynamic
-//! webviews. Resolves `<handle>` to a registered asset (`Dir` root or inline
-//! HTML bytes) via a shared `WebviewAssetRegistry` and serves files through
-//! `serve_static_asset` or directly from memory. Behind the `cef` feature.
+//! webviews: `<handle>` resolves through a shared `WebviewAssetRegistry` to a
+//! directory root or to inline HTML bytes. Behind the `cef` feature.
 
 #[cfg(feature = "cef")]
 use crate::asset::{AssetOutcome, serve_static_asset};
@@ -24,8 +23,7 @@ pub enum WebviewAsset {
 }
 
 /// A shared, interior-mutable map of dynamic `handle → WebviewAsset` for
-/// Tier 1 dynamic webview registrations. The CEF scheme handler is constructed
-/// at `CefPlugin::build()` and reads handles registered after its construction.
+/// Tier 1 dynamic webview registrations. Every clone sees the same handles.
 #[derive(Clone, Default)]
 pub struct WebviewAssetRegistry(Arc<RwLock<HashMap<String, WebviewAsset>>>);
 
@@ -106,12 +104,8 @@ fn resolve_request<'a>(
 }
 
 /// Returns the bare media type (drops any `;`-delimited parameters) for CEF's
-/// `mime_type` field, flooring an empty/blank input to `application/octet-stream`.
-/// CEF expects a bare type (e.g. `text/html`); a full `Content-Type` value with
-/// parameters (`text/html; charset=utf-8`) is not recognized, so Chromium fails
-/// to classify the document and renders blank. An empty `mime_type` triggers the
-/// same blank render, so it is floored to `application/octet-stream` (matching
-/// the SDK file handler's default) rather than passed through empty.
+/// `mime_type` field, flooring an empty or blank input to
+/// `application/octet-stream`.
 #[cfg(feature = "cef")]
 fn bare_mime(content_type: &str) -> String {
     let bare = content_type.split(';').next().unwrap_or("").trim();
@@ -122,8 +116,7 @@ fn bare_mime(content_type: &str) -> String {
     }
 }
 
-/// A minimal text `CefSchemeResponse` for error statuses (bevy_cef provides only
-/// `not_found()` / `bytes()`).
+/// A minimal text `CefSchemeResponse` for error statuses.
 #[cfg(feature = "cef")]
 fn status_text(status: u16, msg: &str) -> CefSchemeResponse {
     CefSchemeResponse {

--- a/crates/bevy_orzma_webview_host/src/private_dir.rs
+++ b/crates/bevy_orzma_webview_host/src/private_dir.rs
@@ -126,8 +126,7 @@ pub fn current_user_sid() -> io::Result<String> {
     Ok(unsafe { wide_to_string(owned.0.cast()) })
 }
 
-/// The DACL of `path` rendered as an SDDL string (`D:…`), for tests and
-/// diagnostics.
+/// The DACL of `path` rendered as an SDDL string (`D:…`).
 #[cfg(windows)]
 pub fn security_descriptor_sddl(path: &Path) -> io::Result<String> {
     let path = wide_path(path);
@@ -177,10 +176,9 @@ pub fn security_descriptor_sddl(path: &Path) -> io::Result<String> {
     Ok(unsafe { wide_to_string(owned.0.cast()) })
 }
 
-/// Normalizes an SDDL string the way Windows renders it: the descriptor is
-/// parsed and rendered back, so well-known SIDs come out as their two-letter
-/// aliases (for example `LA` for the built-in Administrator) exactly as
-/// [`security_descriptor_sddl`] would report them.
+/// Normalizes an SDDL string the way Windows renders it, so well-known SIDs
+/// come out as their two-letter aliases (for example `LA` for the built-in
+/// Administrator) exactly as [`security_descriptor_sddl`] reports them.
 #[cfg(windows)]
 pub fn canonical_sddl(sddl: &str) -> io::Result<String> {
     let wide_sddl = wide(sddl);

--- a/crates/bevy_orzma_webview_host/src/uds.rs
+++ b/crates/bevy_orzma_webview_host/src/uds.rs
@@ -1,7 +1,6 @@
 //! The control-plane socket types under one name: `std`'s Unix-domain
-//! sockets on Unix and the `uds_windows` crate's AF_UNIX sockets on
-//! Windows (Windows 10 1809+). Both expose the same `bind` / `connect` /
-//! `incoming` / `try_clone` / `shutdown` surface.
+//! sockets on Unix and `uds_windows`' AF_UNIX sockets on Windows
+//! (Windows 10 1809+), which expose the same surface.
 
 #[cfg(unix)]
 pub use std::os::unix::net::{UnixListener, UnixStream};

--- a/crates/bevy_orzmux/src/drain.rs
+++ b/crates/bevy_orzmux/src/drain.rs
@@ -1,6 +1,5 @@
-//! `drain_orzmux_events`: empties the backend's event channel every frame
-//! and turns each event into entity state or an `EntityEvent` the host
-//! observes.
+//! Empties the backend's event channel every frame and turns each event
+//! into entity state or an `EntityEvent` the host observes.
 
 use crate::layout::CurrentLayout;
 use crate::registry::PaneRegistry;
@@ -24,7 +23,7 @@ pub struct OrzmuxPaneSpawnFailed {
     pub error: String,
 }
 
-/// Registers the drain.
+/// Turns the backend's queued events into entity state and signals.
 pub(crate) struct DrainPlugin;
 
 impl Plugin for DrainPlugin {
@@ -43,10 +42,8 @@ impl Plugin for DrainPlugin {
 /// Drains every queued event in order, then ends the session and removes
 /// `OrzmuxConnection` once the backend is gone.
 ///
-/// Runs only while `OrzmuxConnection` exists, so after it removes the
-/// connection it never runs again and a disconnect ends the session
-/// exactly once. It is not gated on change detection because channel
-/// arrivals are invisible to it.
+/// A disconnect ends the session exactly once: removing the connection
+/// leaves nothing for a later call to drain.
 fn drain_orzmux_events(
     mut commands: Commands,
     mut registry: ResMut<PaneRegistry>,
@@ -62,9 +59,8 @@ fn drain_orzmux_events(
     }
 }
 
-/// `current` stays a `ResMut` so the write goes through `set_if_neq`:
-/// dereferencing it mutably on every drain would mark the resource
-/// changed on every frame and defeat `apply_layout`'s run condition.
+/// Applies one event. `current` is marked changed only when the layout
+/// differs.
 fn apply_event(
     commands: &mut Commands,
     registry: &mut PaneRegistry,
@@ -359,8 +355,7 @@ mod tests {
     /// changed.
     ///
     /// Case: a running pane repaints every frame without the layout
-    /// ever moving, so a system gated on `Changed<CurrentLayout>` must
-    /// not re-run on every repaint.
+    /// ever moving.
     #[test]
     fn a_frame_only_drain_does_not_change_the_layout() {
         let (mut app, events) = app();

--- a/crates/bevy_orzmux/src/layout.rs
+++ b/crates/bevy_orzmux/src/layout.rs
@@ -1,5 +1,5 @@
-//! The latest layout snapshot the drain received, and the system that
-//! applies it to pane nodes.
+//! The latest layout snapshot the drain received, applied to the pane
+//! and separator nodes.
 
 use crate::registry::PaneRegistry;
 use crate::{OrzmuxPane, OrzmuxSystems};
@@ -7,8 +7,7 @@ use bevy::prelude::*;
 use orzma_tty::CellPixels;
 use orzmux::prelude::{Layout, PaneRect, Separator, SplitOrientation};
 
-/// The latest layout snapshot. Written by the drain only when it
-/// differs; the non-empty → empty transition is detected there.
+/// The latest layout snapshot, marked changed only when it differs.
 #[derive(Resource, Default, Debug, PartialEq)]
 pub(crate) struct CurrentLayout(pub Layout);
 
@@ -31,10 +30,9 @@ pub struct OrzmuxPaneContainer;
 #[derive(Component, Debug)]
 pub(crate) struct OrzmuxSeparator;
 
-/// The GUI accepted a new active pane from a `Layout`. `previous` is
-/// the last accepted active's entity; it may already be despawned (a
-/// `PaneClosed` in the same drain), in which case it resolves to
-/// `None`.
+/// The GUI accepted a new active pane from a `Layout`. `previous`
+/// resolves to `None` when that entity was already despawned by a
+/// `PaneClosed` in the same drain.
 #[derive(Event, Debug, Clone, Copy)]
 pub struct OrzmuxActivePaneChanged {
     /// The entity that was the applied active before this change.
@@ -55,7 +53,8 @@ pub fn absolute_px_node(left: f32, top: f32, width: f32, height: f32) -> Node {
     }
 }
 
-/// Registers `apply_layout`, gated on a changed layout or geometry.
+/// Positions pane nodes and separators from the backend's latest
+/// layout.
 pub(crate) struct LayoutPlugin;
 
 impl Plugin for LayoutPlugin {
@@ -72,14 +71,15 @@ impl Plugin for LayoutPlugin {
     }
 }
 
-/// Separator colour until it is configurable.
+/// Separator colour.
+///
+/// TODO: make the colour configurable.
 const SEPARATOR_COLOR: Color = Color::srgb(0.35, 0.35, 0.40);
 
 /// Logical-px thickness of the line painted inside a reserved separator
 /// cell, before rounding to whole physical px (never below one).
 const SEPARATOR_THICKNESS_LOGICAL_PX: f32 = 1.0;
 
-/// Runs when `CurrentLayout` or `PaneGeometry` changed (see the plugin).
 fn apply_layout(
     mut commands: Commands,
     mut registry: ResMut<PaneRegistry>,
@@ -140,10 +140,8 @@ fn reconcile_separators(
 /// (`cells × cell_px`), divided by the scale factor for `Val::Px`.
 ///
 /// A right or bottom edge that stops short of the layout size grows into
-/// the reserved separator cell by everything but the line, so the pane's
-/// own background, which the renderer paints over the whole node, runs
-/// up to the line and only the line's thickness separates two panes on
-/// either axis.
+/// the reserved separator cell by everything but the line, so only the
+/// line's thickness separates two panes on either axis.
 fn pane_node(rect: &PaneRect, layout: &Layout, geometry: &PaneGeometry) -> Node {
     let scale = geometry.scale_factor;
     let (cell_w, cell_h) = cell_pitch_phys(geometry);
@@ -165,9 +163,8 @@ fn pane_node(rect: &PaneRect, layout: &Layout, geometry: &PaneGeometry) -> Node 
 ///
 /// A separator that stops short of the layout size ends inside the cell
 /// reserved for a crossing line, so its far end is extended across that
-/// cell to meet the crossing line. All offsets are whole physical px so
-/// the UI layout, which rounds node edges to physical px, cannot collapse
-/// the line to nothing; the division by the scale factor happens last.
+/// cell to meet the crossing line. All offsets are whole physical px, so
+/// the line never rounds away to nothing.
 fn separator_node(separator: &Separator, layout: &Layout, geometry: &PaneGeometry) -> Node {
     let scale = geometry.scale_factor;
     let (cell_w, cell_h) = cell_pitch_phys(geometry);
@@ -210,8 +207,7 @@ fn separator_node(separator: &Separator, layout: &Layout, geometry: &PaneGeometr
 /// that follows it: the reserved cell minus the line when the extent
 /// stops short of `limit`, zero when it reaches the layout edge. The
 /// split tree tiles the layout size, so every edge short of it is
-/// followed by exactly one separator cell; panes grow into that gap and
-/// separators extend across it to meet a crossing line.
+/// followed by exactly one separator cell.
 fn gap_before_line(start: u16, extent: u16, limit: u16, cell: f32, thickness: f32) -> f32 {
     if start + extent < limit {
         (cell - thickness).max(0.0)
@@ -238,9 +234,7 @@ fn line_thickness_phys(geometry: &PaneGeometry) -> f32 {
 /// Accepts `layout.active` unless it predates the GUI's last
 /// `SelectPane` while the applied active pane is still open, and
 /// reports a change against the applied active. A stale layout is
-/// accepted once the applied pane is gone, since the select in flight
-/// can no longer confirm it and focus would otherwise sit on nothing
-/// until the backend answers.
+/// accepted once the applied pane is gone.
 fn apply_active(commands: &mut Commands, registry: &mut PaneRegistry, layout: &Layout) {
     let stale = registry.last_select.is_some_and(|sent| layout.seq < sent);
     let applied_open = registry
@@ -628,8 +622,7 @@ mod tests {
     }
 
     /// Asserts that reapplying a layout whose pane rectangles are
-    /// unchanged leaves every pane `Node` unflagged, so a system gated
-    /// on `Changed<Node>` does not re-run on a no-op layout update.
+    /// unchanged leaves every pane `Node` unflagged.
     ///
     /// Case: the backend resends the same layout as part of an
     /// unrelated event batch, such as a `Layout` carrying only a fresh

--- a/crates/bevy_orzmux/src/lib.rs
+++ b/crates/bevy_orzmux/src/lib.rs
@@ -1,8 +1,6 @@
-//! Bevy integration for the multiplexer backend: the `OrzmuxPane` component
-//! every pane entity carries, the title component, inbound request
-//! observers, and the outbound signal types the drain triggers.
-//! `OrzmuxConnection`, `OrzmuxPane`, and the `drain` module bridge the same
-//! world to the multiplexer backend thread.
+//! Bevy integration for the multiplexer backend: mirrors its panes and
+//! layout into the world, forwards the host's requests to it, and turns
+//! its events into ECS signals.
 
 use crate::{
     drain::DrainPlugin,
@@ -50,18 +48,18 @@ pub struct OrzmuxConnection(pub OrzmuxClient);
 #[require(TtyTitle)]
 pub struct OrzmuxPane(pub PaneId);
 
-/// Ordering slots for the bridge's `Update` systems. The host chains
-/// `Drain → ApplyLayout → its input phases`.
+/// Ordering slots for the bridge's `Update` systems: `Drain` runs before
+/// `ApplyLayout`, and a host orders its input phases after both.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum OrzmuxSystems {
-    /// `drain_orzmux_events`.
+    /// Draining the backend's events into the world.
     Drain,
-    /// `apply_layout`.
+    /// Applying the latest layout to the pane nodes.
     ApplyLayout,
 }
 
-/// Registers the drain, the layout applier, the request observers, and
-/// the title component's observers.
+/// Mirrors the backend's panes, layout, and titles into the app, and
+/// forwards the host's requests to the backend.
 pub struct OrzmuxPlugin;
 
 impl Plugin for OrzmuxPlugin {

--- a/crates/bevy_orzmux/src/registry.rs
+++ b/crates/bevy_orzmux/src/registry.rs
@@ -10,7 +10,8 @@ use std::collections::HashMap;
 #[derive(Resource, Default, Debug)]
 pub struct PaneRegistry {
     /// Lookup cache, filled on `PaneOpened` and emptied on `PaneClosed`.
-    /// Never the source of session-end detection (see `drain_orzmux_events`).
+    /// An empty map does not mean the session ended; it is also empty
+    /// before the first pane opens.
     pub panes: HashMap<PaneId, Entity>,
     /// Entities pre-spawned for a `NewPane` whose answer is pending.
     pub pending_spawns: HashMap<RequestId, Entity>,

--- a/crates/bevy_orzmux/src/requests.rs
+++ b/crates/bevy_orzmux/src/requests.rs
@@ -1,7 +1,5 @@
-//! Inbound request `EntityEvent`s and `Event`s: commands the host UI
-//! fires at a terminal entity or at the backend's active pane, as
-//! opposed to the outbound `Tty*Signal`s in `signals.rs` that are
-//! drained FROM the backend.
+//! Inbound requests: the commands the host UI fires at a terminal entity
+//! or at the backend's active pane.
 
 use crate::requests::{
     copy::CopyPlugin, key_input::KeyInputPlugin, mouse_input::MouseInputPlugin,
@@ -62,9 +60,9 @@ impl Plugin for OrzmaEventRequestPlugin {
     }
 }
 
-/// Sends a pane-addressed command for a terminal entity: the one place
-/// that maps an entity to its `PaneId` and drops requests aimed at an
-/// entity that is not (or no longer) a pane.
+/// Sends a pane-addressed command for a terminal entity, mapping the
+/// entity to its `PaneId` and dropping requests aimed at an entity that
+/// is not (or no longer) a pane.
 ///
 /// It reads `OrzmuxConnection`, so every observer that takes it must be
 /// registered with `run_if(resource_exists::<OrzmuxConnection>)`.
@@ -88,9 +86,7 @@ impl PaneSender<'_, '_> {
     }
 }
 
-/// Test-only fixtures shared by this crate's tests: a detached
-/// [`OrzmuxClient`]-backed app plus helpers to spawn a mirrored pane entity
-/// and drain what an observer sent.
+/// Test-only fixtures shared by this crate's tests.
 #[cfg(test)]
 pub(crate) mod test_support {
     use crate::{OrzmuxConnection, OrzmuxPane, layout::CurrentLayout, registry::PaneRegistry};

--- a/crates/bevy_orzmux/src/requests/copy.rs
+++ b/crates/bevy_orzmux/src/requests/copy.rs
@@ -1,5 +1,5 @@
-//! `RequestTtyCopySelection`: asks the backend for a pane's selected
-//! text; the answer arrives as `TtySelectionTextSignal`.
+//! Asks the backend for a pane's selected text; the answer arrives as
+//! `TtySelectionTextSignal`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;

--- a/crates/bevy_orzmux/src/requests/key_input.rs
+++ b/crates/bevy_orzmux/src/requests/key_input.rs
@@ -1,5 +1,5 @@
-//! `RequestTtyKeyInput` (a specific pane) and `RequestActiveKeyInput`
-//! (the backend's active pane): both become `OrzmuxCommand::KeyInput`.
+//! Key input for a specific pane or for the backend's active pane; both
+//! become `OrzmuxCommand::KeyInput`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -7,17 +7,15 @@ use bevy::prelude::*;
 use orzma_tty::prelude::{TerminalKey, TerminalModifiers};
 use orzmux::prelude::{OrzmuxCommand, PaneTarget};
 
-/// A key for one specific pane entity (webview forwards and other
-/// entity-addressed paths). Keyboard and IME input use
-/// [`RequestActiveKeyInput`] instead so it resolves against the
-/// backend's active pane in command order.
+/// A key for one specific pane entity. Keyboard and IME input use
+/// [`RequestActiveKeyInput`] instead.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyKeyInput {
     #[event_target]
     pub terminal: Entity,
     /// The logical key pressed (character or named key, pre-encoding).
     pub key: TerminalKey,
-    /// Modifier state at press time; feeds the encoder, not a raw HID state.
+    /// Modifier state at press time, not a raw HID state.
     pub modifiers: TerminalModifiers,
 }
 
@@ -26,7 +24,7 @@ pub struct RequestTtyKeyInput {
 pub struct RequestActiveKeyInput {
     /// The logical key pressed (character or named key, pre-encoding).
     pub key: TerminalKey,
-    /// Modifier state at press time; feeds the encoder, not a raw HID state.
+    /// Modifier state at press time, not a raw HID state.
     pub modifiers: TerminalModifiers,
 }
 

--- a/crates/bevy_orzmux/src/requests/mouse_input.rs
+++ b/crates/bevy_orzmux/src/requests/mouse_input.rs
@@ -1,5 +1,5 @@
-//! `RequestTtyMouseInput`: a mouse-protocol report the host UI asks a
-//! terminal entity to receive, sent as `OrzmuxCommand::MouseInput`.
+//! A mouse-protocol report the host UI asks a terminal entity to
+//! receive, sent as `OrzmuxCommand::MouseInput`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -18,7 +18,7 @@ pub struct RequestTtyMouseInput {
     pub mouse: MouseReport,
 }
 
-/// Registers the [`RequestTtyMouseInput`] apply observer.
+/// Forwards [`RequestTtyMouseInput`] to the addressed pane.
 pub(super) struct MouseInputPlugin;
 
 impl Plugin for MouseInputPlugin {

--- a/crates/bevy_orzmux/src/requests/pane.rs
+++ b/crates/bevy_orzmux/src/requests/pane.rs
@@ -1,5 +1,5 @@
-//! `RequestPaneAction`: pane management the host asks for (directional
-//! selection, kill, click-to-focus), sent as the matching `OrzmuxCommand`.
+//! Pane management the host asks for (directional selection, kill,
+//! click-to-focus), sent as the matching `OrzmuxCommand`.
 
 use crate::layout::{CurrentLayout, OrzmuxActivePaneChanged};
 use crate::registry::PaneRegistry;

--- a/crates/bevy_orzmux/src/requests/paste.rs
+++ b/crates/bevy_orzmux/src/requests/paste.rs
@@ -1,5 +1,5 @@
-//! `RequestTtyPaste` (a specific pane) and `RequestActivePaste` (the
-//! backend's active pane): both become `OrzmuxCommand::Paste`.
+//! Paste for a specific pane or for the backend's active pane; both
+//! become `OrzmuxCommand::Paste`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -8,9 +8,9 @@ use orzmux::prelude::{OrzmuxCommand, PaneTarget};
 
 /// Fired by the host UI to paste text into a specific terminal entity.
 ///
-/// Carries the clipboard text verbatim.
-/// Bracketed-paste framing, marker stripping, and line-ending normalization all depend on terminal modes the
-/// host cannot see, so they belong to the apply observer — the host reads the clipboard and nothing more.
+/// The host sends the clipboard text and nothing more; bracketed-paste
+/// framing, marker stripping, and line-ending normalization happen when
+/// the paste is applied.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyPaste {
     #[event_target]
@@ -27,8 +27,8 @@ pub struct RequestActivePaste {
     pub text: String,
 }
 
-/// Registers the [`RequestTtyPaste`] and [`RequestActivePaste`] apply
-/// observers.
+/// Forwards [`RequestTtyPaste`] and [`RequestActivePaste`] to the
+/// backend.
 pub(super) struct PastePlugin;
 
 impl Plugin for PastePlugin {

--- a/crates/bevy_orzmux/src/requests/scroll.rs
+++ b/crates/bevy_orzmux/src/requests/scroll.rs
@@ -1,5 +1,5 @@
-//! `RequestTtyScroll`: the viewport movement the host UI asks a terminal
-//! entity to perform, sent as `OrzmuxCommand::Scroll`.
+//! The viewport movement the host UI asks a terminal entity to perform,
+//! sent as `OrzmuxCommand::Scroll`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -8,12 +8,7 @@ use orzma_vt::prelude::Scroll;
 use orzmux::prelude::OrzmuxCommand;
 
 /// Fired by the host UI to move a specific terminal entity's viewport.
-///
-/// The motion vocabulary is [`Scroll`] itself — the request carries
-/// exactly what the backend applies, and the observer's only job is
-/// routing it to the targeted entity's pane. Clamping at both ends of
-/// history and page-size resolution live in `orzma_vt` and are pinned
-/// by its tests, not re-asserted here.
+/// The request carries exactly the motion the backend applies.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyScroll {
     #[event_target]

--- a/crates/bevy_orzmux/src/requests/selection.rs
+++ b/crates/bevy_orzmux/src/requests/selection.rs
@@ -1,14 +1,8 @@
 //! Per-operation selection request events the host UI fires at a
 //! terminal entity.
 //!
-//! The payload vocabulary ([`SelectionKind`], [`CellSide`],
-//! [`GridPoint`]) is owned by the VT layer; this module re-exports
-//! it so the requests and their payload types travel together — each
-//! request carries exactly what the backend applies.
-//!
-//! The start, update, and clear observers send the matching
-//! `OrzmuxCommand`; the vi-cursor start and the kind change stay stubs
-//! until vi mode lands in the backend.
+//! TODO: apply the vi-cursor start and the kind change once vi mode
+//! lands in the backend.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -33,7 +27,8 @@ pub struct RequestTtySelectionStart {
 }
 
 /// Fired by the host UI to anchor a new selection at the vi cursor
-/// (vi-mode `v` / `V`), whose position only the VT knows.
+/// (vi-mode `v` / `V`). The backend has no vi mode, so applying it does
+/// nothing.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtySelectionStartAtViCursor {
     #[event_target]
@@ -57,7 +52,8 @@ pub struct RequestTtySelectionUpdate {
 }
 
 /// Fired by the host UI to switch selection granularity while keeping
-/// the anchor (vi-mode `v` while `V` is active, and the reverse).
+/// the anchor (vi-mode `v` while `V` is active, and the reverse). The
+/// backend has no vi mode, so applying it does nothing.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtySelectionKindChange {
     #[event_target]

--- a/crates/bevy_orzmux/src/requests/vi_mode.rs
+++ b/crates/bevy_orzmux/src/requests/vi_mode.rs
@@ -1,11 +1,10 @@
-//! `RequestTtyViMode`: the vi-mode switch the host UI asks a terminal
-//! entity to perform.
+//! The vi-mode switch the host UI asks a terminal entity to perform.
 
 use bevy::prelude::*;
 pub use orzma_vt::prelude::ViModeSwitch;
 
 /// Fired by the host UI to enter or leave vi mode on a specific terminal
-/// entity.
+/// entity. The backend has no vi mode, so applying it does nothing.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyViMode {
     #[event_target]
@@ -40,10 +39,8 @@ mod tests {
     /// Asserts that both switch directions reach an observer with their target
     /// intact, in the order they were fired.
     ///
-    /// Case: the enter/exit round trip a user performs constantly (`Ctrl-Shift-Space`
-    /// in, `Esc` out). Order matters because the two are not idempotent
-    /// against each other — a swallowed or reordered `Exit` would leave the
-    /// terminal accepting motions while the user believes they are typing.
+    /// Case: the enter/exit round trip a user performs constantly
+    /// (`Ctrl-Shift-Space` in, `Esc` out).
     #[test]
     fn trigger_delivers_both_switch_directions_in_order() {
         let mut app = App::new();
@@ -67,9 +64,7 @@ mod tests {
     /// Asserts that a repeated switch is delivered every time rather than
     /// deduplicated.
     ///
-    /// Case: `Enter` fired while already in vi mode. Idempotence is the apply
-    /// observer's call — it holds the current state, the event does not — so
-    /// the second request must still arrive for the observer to decide.
+    /// Case: `Enter` fired while already in vi mode.
     #[test]
     fn a_repeated_switch_is_not_deduplicated() {
         let mut app = App::new();

--- a/crates/bevy_orzmux/src/requests/vi_motion.rs
+++ b/crates/bevy_orzmux/src/requests/vi_motion.rs
@@ -1,16 +1,11 @@
-//! `RequestTtyViMotion`: the vi-cursor motion the host UI asks a terminal
-//! entity to perform.
+//! The vi-cursor motion the host UI asks a terminal entity to perform.
 //!
-//! [`ViMotion`] mirrors the motion vocabulary one-for-one. Its final home is
-//! the VT layer; it is defined here until that crate owns the type, at which
-//! point this becomes a re-export.
+//! TODO: move [`ViMotion`] to the VT layer and re-export it here.
 
 use bevy::prelude::*;
 
 /// Fired by the host UI to move a specific terminal entity's vi cursor.
-///
-/// Has no effect outside vi mode; the apply observer holds that state, so the
-/// host may fire without checking first.
+/// The backend has no vi mode, so applying it does nothing.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyViMotion {
     #[event_target]
@@ -138,11 +133,9 @@ mod tests {
 
     /// Asserts that every motion survives the trigger unchanged, in order.
     ///
-    /// Case: a held key repeating, and the near-miss pairs the vocabulary is
-    /// full of — `SemanticLeft` vs. `SemanticLeftEnd`, `WordRight` vs.
-    /// `WordRightEnd`. Those differ by one cell in the resulting cursor
-    /// position, so a mis-ordered or collapsed variant is invisible in a
-    /// single-motion test but wrong on screen.
+    /// Case: a held key repeating, and the near-miss pairs the
+    /// vocabulary is full of — `SemanticLeft` vs. `SemanticLeftEnd`,
+    /// `WordRight` vs. `WordRightEnd`.
     #[test]
     fn every_motion_round_trips_in_order() {
         let mut app = App::new();
@@ -166,10 +159,8 @@ mod tests {
 
     /// Asserts that no two motions compare equal.
     ///
-    /// Case: the guard for the `ALL` fixture above and for the enum itself. A
-    /// duplicated variant (easy to introduce when adding a motion by copying a
-    /// neighbouring line) would let `every_motion_round_trips_in_order` pass
-    /// while two distinct keybindings silently share one behaviour.
+    /// Case: a motion is added to the enum by copying a neighbouring
+    /// variant.
     #[test]
     fn all_motions_are_distinct() {
         for (i, a) in ALL.iter().enumerate() {

--- a/crates/bevy_orzmux/src/requests/webview_mount.rs
+++ b/crates/bevy_orzmux/src/requests/webview_mount.rs
@@ -1,6 +1,6 @@
-//! `RequestTtyWebviewMount`: the host-driven mount the control plane asks
-//! a terminal entity to register when a program mounts over the socket
-//! rather than the PTY, sent as `OrzmuxCommand::MountPlacement`.
+//! The host-driven mount the control plane asks a terminal entity to
+//! register when a program mounts over the socket rather than the PTY,
+//! sent as `OrzmuxCommand::MountPlacement`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;

--- a/crates/bevy_orzmux/src/requests/webview_remove.rs
+++ b/crates/bevy_orzmux/src/requests/webview_remove.rs
@@ -1,6 +1,5 @@
-//! `RequestTtyWebviewRemove`: the placements the control plane asks a
-//! terminal entity to drop when a registration is released, sent as
-//! `OrzmuxCommand::RemovePlacements`.
+//! The placements the control plane asks a terminal entity to drop when
+//! a registration is released, sent as `OrzmuxCommand::RemovePlacements`.
 
 use crate::OrzmuxConnection;
 use crate::requests::PaneSender;
@@ -11,9 +10,8 @@ use orzmux::prelude::OrzmuxCommand;
 /// Fired by the control plane to drop placements a terminal still holds
 /// for registrations that are gone.
 ///
-/// The backend cannot know that a registration was released — that
-/// fact lives on the control socket — so without this the placements
-/// keep a cap slot until their anchor scrolls out of history.
+/// The backend cannot know that a registration was released — that fact
+/// lives on the control socket.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct RequestTtyWebviewRemove {
     #[event_target]

--- a/crates/bevy_orzmux/src/signals.rs
+++ b/crates/bevy_orzmux/src/signals.rs
@@ -1,14 +1,6 @@
-//! Outbound signal types the drain triggers (`TtyBellSignal`,
-//! `TtyTitleChangedSignal`, `TtyTitleResetSignal`, `TtyClipboardStoreSignal`,
-//! `TtyCwdChangedSignal`, `TtyWebviewMountSignal`,
-//! `TtyWebviewMountRejectedSignal`, `TtyWebviewUnmountSignal`,
-//! `TtyWebviewEvictedSignal`, `TtyModeChangedSignal`, `TtyChildExitSignal`,
-//! `TtyFrameSignal`), plus `trigger_vt_signal`, the helper that turns one
-//! drained `VtSignal` into its matching `EntityEvent`.
-//! `TtySelectionTextSignal` answers a mux `CopySelection` request instead
-//! of draining from a VT, so it is a plain `Event` rather than an
-//! `EntityEvent`. Inbound requests fired by the host UI live in
-//! `requests.rs`.
+//! The outbound signals the drain turns the backend's events into: one
+//! `EntityEvent` per drained `VtSignal`, plus the backend's answer to a
+//! copy request.
 
 use bevy::ecs::entity::Entity;
 use bevy::ecs::event::EntityEvent;
@@ -16,8 +8,9 @@ use bevy::prelude::*;
 use orzma_vt::prelude::*;
 use std::path::PathBuf;
 
-/// Fired when alacritty raises `Event::Bell`.
-/// Best-effort — no back-pressure observability (control channel is unbounded).
+/// Fired when a terminal requests an audible bell. Delivery is
+/// best-effort: a consumer never back-pressures the terminal that rang
+/// it.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct TtyBellSignal {
     #[event_target]
@@ -39,8 +32,8 @@ pub struct TtyTitleResetSignal {
     pub terminal: Entity,
 }
 
-/// Fired when tracked `TermMode` flags transition between coalescer
-/// emit cycles.
+/// Fired for the mode flags that transitioned since the previous drain,
+/// as mode names (e.g. "alt-screen"). [`OrzmaVt`] never raises it.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct TtyModeChangedSignal {
     #[event_target]
@@ -49,7 +42,8 @@ pub struct TtyModeChangedSignal {
     pub removed: Vec<String>,
 }
 
-/// Fired when alacritty raises `Event::ClipboardStore`.
+/// Fired when the application copies data to the system clipboard via
+/// OSC 52. [`OrzmaVt`] never raises it.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct TtyClipboardStoreSignal {
     #[event_target]
@@ -57,8 +51,9 @@ pub struct TtyClipboardStoreSignal {
     pub content: String,
 }
 
-/// Fired exactly once when the child shell process exits.
-/// `code` is `None` if the `wait` itself failed.
+/// Fired exactly once when a pane closes. `code` is the shell's exit
+/// code, and `None` when the GUI killed the pane or the `wait` itself
+/// failed.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct TtyChildExitSignal {
     #[event_target]
@@ -66,8 +61,8 @@ pub struct TtyChildExitSignal {
     pub code: Option<i32>,
 }
 
-/// Fired when a terminal reports a new current working directory via OSC 7.
-/// Targets the terminal host entity; carries the validated absolute path.
+/// Fired when a terminal reports a new current working directory via
+/// OSC 7, carrying the absolute path parsed from the URI.
 #[derive(EntityEvent, Debug, Clone)]
 pub struct TtyCwdChangedSignal {
     #[event_target]
@@ -112,8 +107,8 @@ pub struct TtyWebviewUnmountSignal {
 pub struct TtyWebviewEvictedSignal {
     #[event_target]
     pub terminal: Entity,
-    /// The instances the VT evicted. It has already dropped them, so a
-    /// consumer despawns its own side without asking for a second removal.
+    /// The instances the VT evicted. It has already dropped them, so no
+    /// removal needs to be sent back.
     pub placements: Vec<InstanceId>,
 }
 
@@ -129,8 +124,7 @@ pub struct TtyFrameSignal {
 }
 
 /// The backend's answer to a `RequestTtyCopySelection`: the selected
-/// text (`None` when the pane was gone or the selection empty). A plain
-/// `Event` because the requesting pane may already be gone.
+/// text (`None` when the pane was gone or the selection empty).
 #[derive(Event, Debug, Clone)]
 pub struct TtySelectionTextSignal {
     pub text: Option<String>,

--- a/crates/bevy_orzmux/src/title.rs
+++ b/crates/bevy_orzmux/src/title.rs
@@ -1,5 +1,5 @@
-//! The `TtyTitle` component: the window title a terminal's application
-//! last set, kept in step with the VT's title signals.
+//! The window title a terminal's application last set, kept in step with
+//! the VT's title signals.
 
 use crate::signals::{TtyTitleChangedSignal, TtyTitleResetSignal};
 use bevy::prelude::*;
@@ -8,15 +8,14 @@ use bevy::prelude::*;
 /// OSC 2; `None` until it sets one, and again after the VT reports the
 /// title's return to the host's default.
 ///
-/// The string arrives already sanitized by the VT's OSC parser, so
-/// hosts can show it as is. A signal that repeats the state already
-/// held leaves the component untouched, so a host gated on
-/// `Changed<TtyTitle>` re-runs only when the title really moves.
+/// The string arrives already sanitized, so hosts can show it as is. A
+/// signal that repeats the state already held leaves the component
+/// untouched, so a host gated on `Changed<TtyTitle>` re-runs only when
+/// the title really moves.
 #[derive(Component, Debug, Clone, Default, PartialEq, Eq)]
 pub struct TtyTitle(pub Option<String>);
 
-/// Registers the observers that write [`TtyTitle`] from the title
-/// signals.
+/// Keeps [`TtyTitle`] in step with a terminal's title signals.
 pub(crate) struct TtyTitlePlugin;
 
 impl Plugin for TtyTitlePlugin {

--- a/crates/orzma_configs/src/error.rs
+++ b/crates/orzma_configs/src/error.rs
@@ -4,7 +4,7 @@ use crate::shortcuts::{DuplicateChord, KeyChord};
 use crate::vi_mode::DuplicateViModeKey;
 use std::path::PathBuf;
 
-/// Result alias used throughout the `orzma_configs` crate.
+/// Result alias for the config loader.
 pub type OrzmaConfigsResult<T = ()> = Result<T, OrzmaConfigsError>;
 
 /// Errors that can occur while resolving, reading, or parsing the config file.
@@ -30,13 +30,13 @@ pub enum OrzmaConfigsError {
         source: toml::de::Error,
     },
 
-    /// One or more KeyChord collisions among direct `[shortcuts]` bindings.
-    /// Collected in a single pass; reported all-at-once to avoid whack-a-mole.
+    /// One or more `KeyChord` collisions among direct `[shortcuts]` bindings.
+    /// Every collision is reported, not just the first.
     #[error("duplicate chord(s) among direct [shortcuts] bindings: {}", format_dupes(.0))]
     DuplicateChords(Vec<DuplicateChord>),
 
-    /// One or more KeyChord collisions among leader-scoped (`<Leader>`)
-    /// bindings. Collected in a single pass; reported all-at-once.
+    /// One or more `KeyChord` collisions among leader-scoped (`<Leader>`)
+    /// bindings. Every collision is reported, not just the first.
     #[error("duplicate chord(s) among <Leader> bindings: {}", format_dupes(.0))]
     DuplicatePrefixChords(Vec<DuplicateChord>),
 
@@ -45,8 +45,7 @@ pub enum OrzmaConfigsError {
     DuplicateViModeKeys(Vec<DuplicateViModeKey>),
 
     /// The configured leader chord duplicates a direct `[shortcuts]` binding's
-    /// chord. The leader is matched first, so that direct binding would be
-    /// unreachable.
+    /// chord, which would leave that binding unreachable.
     #[error("leader chord {chord} shadows the direct binding for {action}")]
     LeaderShadowsDirectBinding {
         /// The colliding chord (the leader).
@@ -72,8 +71,7 @@ pub enum OrzmaConfigsError {
         size: f32,
     },
 
-    /// A `[font].<face>.style` string (face ∈ normal / bold / italic /
-    /// bold_italic / ui) did not parse to a known weight + slant.
+    /// A `[font].<face>.style` string did not parse to a known weight + slant.
     #[error("invalid font style {value:?} for the {face} face")]
     InvalidFontStyle {
         /// The face label (`normal` / `bold` / `italic` / `bold_italic` / `ui`).

--- a/crates/orzma_configs/src/font.rs
+++ b/crates/orzma_configs/src/font.rs
@@ -9,23 +9,24 @@ const DEFAULT_SIZE: f32 = 11.25;
 
 /// One face's font configuration: a family name and a style string, both
 /// optional. Omitted `family` inherits `normal`'s; omitted `style` uses the
-/// face's canonical default (applied in `src/font`).
+/// face's canonical default.
 #[derive(Deserialize, Clone, Debug, PartialEq, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct FontFaceConfig {
     /// Font-family name resolved against the system font database.
     pub family: Option<String>,
-    /// Alacritty-style style string (e.g. `"Bold"`, `"SemiBold Italic"`).
+    /// Style string naming a weight and a slant (e.g. `"Bold"`,
+    /// `"SemiBold Italic"`).
     pub style: Option<String>,
 }
 
-/// The `[font]` section: a size plus the four terminal faces.
+/// The `[font]` section: a size, the four terminal faces, and the UI face.
 #[derive(Deserialize, Clone, Debug, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct FontConfig {
     /// Terminal font size in logical (CSS) pixels, scaled by the display's
-    /// `scale_factor` to device pixels — Alacritty's model (not literal
-    /// typographic points; no 96/72 conversion is applied).
+    /// `scale_factor` to device pixels. The unit is not the typographic
+    /// point; no 96/72 conversion is applied.
     pub size: f32,
     /// The regular face; its `family` is the base every other face inherits.
     pub normal: FontFaceConfig,
@@ -36,8 +37,8 @@ pub struct FontConfig {
     /// The bold-italic face; `family`/`style` default from `normal` / Bold Italic.
     pub bold_italic: FontFaceConfig,
     /// The UI-chrome face (window bar, prompts, indicators). `family` and
-    /// `style` each inherit from `normal` when omitted (not from this face's
-    /// own defaults); resolution and rendering live in `src/font`.
+    /// `style` each inherit from `normal` when omitted, not from this face's
+    /// own defaults.
     pub ui: FontFaceConfig,
 }
 
@@ -55,9 +56,8 @@ impl Default for FontConfig {
 }
 
 impl FontConfig {
-    /// Face labels whose `style` is set but whose effective family (own or
-    /// inherited from `normal`) is absent — so the bundled default is used and
-    /// `style` is silently ignored (D5/D9). Used to emit a load-time warning.
+    /// Face labels whose `style` is set while their effective family (own or
+    /// inherited from `normal`) is absent, so the style has no effect.
     pub fn faces_with_ignored_style(&self) -> Vec<&'static str> {
         let base_present = self.normal.family.is_some();
         self.faces()
@@ -67,15 +67,14 @@ impl FontConfig {
             .collect()
     }
 
-    /// Whether no face configures a font family — every face's `family` is
-    /// absent, so the bundled default font is used.
+    /// Whether none of the four terminal faces sets `family`.
     #[inline]
     pub fn has_no_configured_family(&self) -> bool {
         self.faces().iter().all(|(_, c)| c.family.is_none())
     }
 
     /// The four terminal faces paired with their `[font]` key labels, in fixed
-    /// order — the single source of truth for the face set.
+    /// order.
     pub const fn faces(&self) -> [(&'static str, &FontFaceConfig); 4] {
         [
             ("normal", &self.normal),

--- a/crates/orzma_configs/src/font/style.rs
+++ b/crates/orzma_configs/src/font/style.rs
@@ -1,4 +1,4 @@
-//! Parser for Alacritty-style `style` strings into a font weight + slant.
+//! Parser turning a `style` string into a font weight + slant.
 
 use std::str::FromStr;
 

--- a/crates/orzma_configs/src/inactive_pane.rs
+++ b/crates/orzma_configs/src/inactive_pane.rs
@@ -1,13 +1,10 @@
-//! Inactive-pane treatment configuration: a per-pane background tint toward a
-//! configurable grey (`tint_color` at strength `tint`) plus an optional
-//! brightness `dim`, applied by the terminal renderer to every pane that is
-//! not its workspace's active pane.
+//! Inactive-pane treatment configuration: the `[inactive_pane]` section's
+//! background tint and brightness dim for every pane that is not its
+//! workspace's active pane.
 
 use serde::{Deserialize, Serialize};
 
-/// Fully-resolved `[inactive_pane]` config block. The terminal renderer blends
-/// each inactive pane's background toward `tint_color` by `tint`, and multiplies
-/// brightness by `dim`.
+/// Fully-resolved `[inactive_pane]` config block.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(default)]
 pub struct InactivePaneConfig {
@@ -25,8 +22,7 @@ pub struct InactivePaneConfig {
     /// and overlays are untouched.
     pub tint: f32,
     /// Inactive-webview brightness multiplier in `0.0..=1.0` (lower = darker);
-    /// `1.0` leaves brightness untouched. Applied to webview overlays
-    /// only, so the background tint can stay background-only.
+    /// `1.0` leaves brightness untouched. It applies to webview overlays only.
     pub webview_dim: f32,
     /// Inactive-webview desaturation in `0.0..=1.0`: `0.0` keeps full color,
     /// `1.0` is fully grey. Applied to webview overlays alongside

--- a/crates/orzma_configs/src/keyboard.rs
+++ b/crates/orzma_configs/src/keyboard.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 
 /// Which Option/Alt key(s) macOS treats as Meta (Alt) instead of composing
-/// into special characters. Mirrors winit's `OptionAsAlt`; has no effect on
-/// non-macOS platforms, where Alt is always Meta.
+/// into special characters. It has no effect on non-macOS platforms, where
+/// Alt is always Meta.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum OptionAsAlt {

--- a/crates/orzma_configs/src/lib.rs
+++ b/crates/orzma_configs/src/lib.rs
@@ -31,7 +31,7 @@ pub mod vi_mode;
 pub struct OrzmaConfigs {
     /// Shortcut configuration.
     pub shortcuts: Shortcuts,
-    /// `[vi-mode]` table: vi-mode key bindings shared by both modes.
+    /// `[vi-mode]` table: vi-mode key bindings.
     #[serde(rename = "vi-mode")]
     pub vi_mode: ViModeConfig,
     /// Font configuration.

--- a/crates/orzma_configs/src/mouse.rs
+++ b/crates/orzma_configs/src/mouse.rs
@@ -1,36 +1,25 @@
-//! Mouse-input configuration (currently: wheel scroll behavior).
+//! Mouse-input configuration: the `[mouse]` section's wheel, click, drag,
+//! and autoscroll settings.
 
 use serde::{Deserialize, Serialize};
 
 /// Which modifier triggers "fine" scrolling (1 line per notch instead
-/// of `lines_per_notch`).
-///
-/// Default is `Alt`. Shift is deliberately not the default because
-/// macOS converts Shift+wheel into a horizontal-scroll event at the
-/// system level (vertical y becomes x), so Shift+wheel reaches the
-/// app as `ev.y == 0` and the fine path never fires. Alt+wheel passes
-/// through unchanged on macOS, Linux, and Windows.
+/// of `lines_per_notch`). The default is `Alt`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum FineModifier {
-    /// Shift key activates fine scrolling. **Broken on macOS** —
-    /// system converts Shift+wheel to horizontal scroll.
+    /// Shift key activates fine scrolling. It never fires on macOS.
     Shift,
-    /// Ctrl key activates fine scrolling. May collide with future
-    /// font-zoom shortcuts (kitty / Windows Terminal convention).
+    /// Ctrl key activates fine scrolling.
     Ctrl,
-    /// Alt key activates fine scrolling. Default.
+    /// Alt key activates fine scrolling.
     #[default]
     Alt,
     /// No modifier required; fine scrolling is always active.
     None,
 }
 
-/// Fully-resolved `[mouse]` config block. Consumed by the Bevy
-/// mouse-wheel and mouse-button input systems; the wheel-relevant
-/// subset is mapped to the root binary's `WheelConfig`, and the
-/// button-relevant subset to its `ButtonConfig` (both defined in
-/// `src/input/bindings.rs`, per D18).
+/// Fully-resolved `[mouse]` config block.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(default)]
 pub struct MouseConfig {
@@ -40,40 +29,30 @@ pub struct MouseConfig {
     pub fine_modifier: FineModifier,
     /// Lines scrolled per notch when the fine modifier is held.
     pub fine_lines: u32,
-    /// Upper bound on mouse-protocol events emitted per frame —
-    /// protects the PTY from input bursts when the user spins the
-    /// wheel rapidly while an app has SGR mouse tracking enabled.
+    /// Upper bound on mouse-protocol events emitted per frame.
     pub max_protocol_events_per_frame: u32,
     /// Wheel-input accumulation threshold expressed in cells of input
-    /// per emitted "notch". Lower = more responsive (each small wheel
-    /// movement fires a notch sooner).
-    ///
-    /// Default `0.5` works well for macOS smooth-scroll devices
-    /// (Magic Mouse, high-resolution wheels, trackpads) which emit
-    /// fractional line deltas; raise to `1.0` for a traditional
-    /// discrete-notch wheel that already emits `y = 1.0` per click.
+    /// per emitted "notch". A lower value is more responsive, firing a
+    /// notch after a smaller wheel movement. The default is `0.5`.
     pub cells_per_notch: f32,
     /// Dominant-axis lock strength for trackpad scrolling. The horizontal
     /// component of a swipe is emitted only when it dominates the gesture
-    /// (`|x| / hypot(x, y) >= axis_lock_ratio`); otherwise it is dropped so
-    /// jitter during a vertical scroll cannot leak a horizontal notch.
-    /// Clamped to `0.0..=1.0`; higher = stricter (more biased to vertical).
-    /// Default `0.9` matches Alacritty. `1.0` allows horizontal only for a
-    /// pure-horizontal gesture; `0.0` disables the lock.
+    /// (`|x| / hypot(x, y) >= axis_lock_ratio`), and is dropped otherwise.
+    /// Clamped to `0.0..=1.0`, where a higher value is stricter: `1.0`
+    /// allows horizontal motion only for a pure-horizontal gesture, and
+    /// `0.0` disables the lock. The default is `0.9`.
     pub axis_lock_ratio: f32,
     /// Max gap (ms) between consecutive clicks counted as a double /
-    /// triple click. Default mirrors macOS HIG.
+    /// triple click.
     pub double_click_timeout_ms: u32,
     /// Max cursor drift (logical px) between clicks counted as the
-    /// same chord. Default sized for Retina (4 logical = 8 physical
-    /// at DPR 2.0).
+    /// same chord.
     pub click_drift_px: f32,
     /// Drag-scroll tick rate (ms) at the pane edge. Decreased linearly
     /// by `autoscroll_step_ms` per cell past the edge, floored at
     /// `autoscroll_min_period_ms`.
     pub autoscroll_base_period_ms: u32,
-    /// Hard floor (ms) on the drag-scroll rate. Caps CPU during
-    /// sustained edge drag.
+    /// Hard floor (ms) on the drag-scroll rate.
     pub autoscroll_min_period_ms: u32,
     /// Linear decrement (ms per cell past the edge) applied to
     /// `autoscroll_base_period_ms`.
@@ -87,9 +66,8 @@ pub struct MouseConfig {
 }
 
 impl MouseConfig {
-    /// Clamps `axis_lock_ratio` to `0.0..=1.0` (NaN falls back to the default),
-    /// so an out-of-range or non-finite config value cannot silently disable
-    /// horizontal scrolling.
+    /// Clamps `axis_lock_ratio` to `0.0..=1.0`; a non-finite value falls back
+    /// to the default.
     pub(crate) fn normalize(&mut self) {
         let default = Self::default().axis_lock_ratio;
         self.axis_lock_ratio = if self.axis_lock_ratio.is_finite() {

--- a/crates/orzma_configs/src/path.rs
+++ b/crates/orzma_configs/src/path.rs
@@ -1,6 +1,5 @@
-//! Resolves which file `OrzmaConfigs::load` should read. Wraps env access
-//! behind a trait so tests can substitute a deterministic implementation
-//! without mutating process-wide environment variables.
+//! Config-path resolution: which file `OrzmaConfigs::load` should read, and
+//! `~` expansion for user-supplied paths.
 
 use crate::OrzmaConfigsError;
 use crate::OrzmaConfigsResult;
@@ -11,15 +10,10 @@ pub(crate) const ENV_XDG_CONFIG_HOME: &str = "XDG_CONFIG_HOME";
 const CONFIG_REL_PATH: &str = "orzma/config.toml";
 const HOME_CONFIG_DIR: &str = ".config";
 
-/// Abstraction over environment lookups used to resolve user-specified
-/// paths. Lets callers (notably `expand_user_path`) substitute the
-/// process environment in tests with deterministic fakes.
+/// Abstraction over the environment lookups used to resolve user-specified
+/// paths.
 ///
-/// External callers should construct or pass `SystemEnv` for production
-/// use; the trait's `var` / `home_dir` surface is intentionally narrow
-/// so test implementations stay simple. The crate-internal
-/// `resolve_config_path` is the other consumer but is `pub(crate)` and
-/// not part of the external API.
+/// Production callers pass [`SystemEnv`].
 pub trait Env {
     /// Returns the value of `key`, treating an empty string as unset.
     fn var(&self, key: &str) -> Option<String>;
@@ -27,7 +21,8 @@ pub trait Env {
     fn home_dir(&self) -> Option<PathBuf>;
 }
 
-/// Production `Env` implementation that delegates to `std::env` and `dirs`.
+/// [`Env`] implementation backed by the process environment and the user's
+/// real home directory.
 pub struct SystemEnv;
 
 impl Env for SystemEnv {

--- a/crates/orzma_configs/src/shortcuts.rs
+++ b/crates/orzma_configs/src/shortcuts.rs
@@ -1,11 +1,11 @@
-//! Shortcut domain types: keys, modifiers, chords, bindings, actions.
+//! The `[shortcuts]` section: the chord grammar and the actions it binds.
 
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 
-/// Logical key. v0 covers ASCII characters and a small set of named keys.
+/// Logical key: a single character or one of the named keys below.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
 pub enum Key {
     /// Single character key (`Key::Char('b')` for `"b"`).
@@ -28,9 +28,9 @@ pub enum Key {
     ArrowLeft,
     /// `ArrowRight`.
     ArrowRight,
-    /// `+` literal key (named to disambiguate from the `+` separator in `"Cmd+Plus"`).
+    /// The literal `+` key, written `Plus` in a chord string (`"Cmd+Plus"`).
     Plus,
-    /// Forward-compatibility variant for unknown logical key names.
+    /// An unrecognized logical key name, kept verbatim.
     Other(String),
 }
 
@@ -40,12 +40,10 @@ impl Key {
     ///
     /// # Invariants
     ///
-    /// The accepted domain MUST mirror `key_to_keycode` in
-    /// `src/input/shortcuts.rs` exactly: an ASCII-alphanumeric `Char` and the
-    /// named keys below map; `Plus`, `Other`, and any non-alphanumeric `Char`
-    /// do not. A divergence would let an unmappable leader pass config
-    /// validation yet resolve to no `KeyCode`, silently disabling the whole
-    /// prefix table.
+    /// The accepted domain is exactly the keys that map to a physical
+    /// `KeyCode`: an ASCII-alphanumeric `Char`, `Char('[')`, `Char(']')`, and
+    /// every named key below. `Plus`, `Other`, and any other character do not
+    /// map.
     pub fn maps_to_physical_key(&self) -> bool {
         // NOTE: keep this domain in lockstep with `key_to_keycode`
         // (src/input/shortcuts.rs); a divergence silently disables the prefix
@@ -174,8 +172,7 @@ impl fmt::Display for KeyChord {
     }
 }
 
-/// Reason a `parse_key_chord` invocation failed. Surfaced via
-/// `D::Error::custom` from serde's `deserialize_with`.
+/// Reason a `parse_key_chord` call failed.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum KeyChordParseError {
     /// Consecutive `+` or trailing `+` produced an empty token between separators.
@@ -203,8 +200,7 @@ pub enum KeyChordParseError {
 /// Modifier names are case-insensitive. Aliases: `Cmd` / `Command` / `Meta` /
 /// `Super` all set `meta`; `Alt` / `Opt` / `Option` all set `alt`. ASCII letter
 /// keys are normalized to lowercase (Shift is held in `Modifiers`, never in
-/// key case). Empty string is NOT accepted here; the field-level
-/// `deser_binding_or_unbind` handles the unbind case before calling this.
+/// key case). An empty string is not accepted.
 pub fn parse_key_chord(s: &str) -> Result<KeyChord, KeyChordParseError> {
     if s.is_empty() {
         return Err(KeyChordParseError::EmptyToken);
@@ -254,8 +250,7 @@ pub fn parse_key_chord(s: &str) -> Result<KeyChord, KeyChordParseError> {
     })
 }
 
-/// One chord-collision entry. Carried inside
-/// `OrzmaConfigsError::DuplicateChords` (defined in `error.rs`).
+/// One chord-collision entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DuplicateChord {
     /// The chord that has multiple bindings.
@@ -264,8 +259,7 @@ pub struct DuplicateChord {
     pub actions: Vec<&'static str>,
 }
 
-/// A bare modifier that can act as a tap leader. `Shift` is intentionally
-/// excluded (too noisy as a tap).
+/// A bare modifier that can act as a tap leader. `Shift` is not accepted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TapModifier {
     /// `Cmd` / `Command` / `Meta` / `Super`.
@@ -288,10 +282,6 @@ pub enum Leader {
 /// A resolved shortcut binding: a direct chord, or a leader-scoped chord
 /// reached after the configured `leader`. The `<Leader>` token in a config
 /// value selects the `Leader` variant.
-///
-/// serde derive is intentionally absent: the string grammar `"Cmd+V"` /
-/// `"<Leader>s"` is (de)serialized by the field functions above (a derived
-/// enum would emit externally-tagged output, not the string form).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Binding {
     /// Fires when the chord is pressed directly.
@@ -319,16 +309,13 @@ impl Binding {
 
 /// User-facing shortcut configuration: the leader chord plus one flat binding
 /// per action. Each value is a chord string (`"Cmd+V"`), a leader-scoped chord
-/// (`"<Leader>s"`), or `""` (unbind). The `kebab-case` rename maps each TOML
-/// key to its field; struct-level `#[serde(default)]` + `impl Default` seed
-/// omitted actions from their active defaults; `deny_unknown_fields` rejects
-/// typos (and the retired `[shortcuts.bindings]` / `[shortcuts.prefix_bindings]`
-/// tables and the old `prefix` key) at load time.
+/// (`"<Leader>s"`), or `""` (unbind). An omitted action keeps its default, and
+/// an unknown key is rejected at load time.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Shortcuts {
     /// The leader for `<Leader>`-scoped bindings: a chord (`Ctrl+A`) or a bare
-    /// modifier tap (`Cmd`). Empty/absent = disabled.
+    /// modifier tap (`Cmd`). An empty or absent value disables it.
     #[serde(deserialize_with = "deser_leader", serialize_with = "ser_leader")]
     pub leader: Option<Leader>,
     /// Paste the system clipboard into the active terminal.
@@ -355,7 +342,7 @@ pub struct Shortcuts {
         serialize_with = "ser_binding_or_unbind"
     )]
     pub quit: Option<Binding>,
-    /// Enter vi mode: Alacritty vi mode on the focused terminal.
+    /// Enter vi mode on the focused terminal.
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
@@ -403,121 +390,121 @@ pub struct Shortcuts {
         serialize_with = "ser_binding_or_unbind"
     )]
     pub kill_pane: Option<Binding>,
-    /// Toggle zoom on the active pane (no effect until the built-in multiplexer lands).
+    /// Toggle zoom on the active pane (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub zoom_pane: Option<Binding>,
-    /// Resize the active pane's border left by 5 cells, repeatable (no effect until the built-in multiplexer lands).
+    /// Resize the active pane's border left by 5 cells, repeatable (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub resize_left_pane: Option<Binding>,
-    /// Resize the active pane's border down by 5 cells, repeatable (no effect until the built-in multiplexer lands).
+    /// Resize the active pane's border down by 5 cells, repeatable (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub resize_down_pane: Option<Binding>,
-    /// Resize the active pane's border up by 5 cells, repeatable (no effect until the built-in multiplexer lands).
+    /// Resize the active pane's border up by 5 cells, repeatable (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub resize_up_pane: Option<Binding>,
-    /// Resize the active pane's border right by 5 cells, repeatable (no effect until the built-in multiplexer lands).
+    /// Resize the active pane's border right by 5 cells, repeatable (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub resize_right_pane: Option<Binding>,
-    /// Open a new window (no effect until the built-in multiplexer lands).
+    /// Open a new window (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub new_window: Option<Binding>,
-    /// Kill the active window, after a confirm prompt (no effect until the built-in multiplexer lands).
+    /// Kill the active window, after a confirm prompt (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub kill_window: Option<Binding>,
-    /// Switch to the next window (no effect until the built-in multiplexer lands).
+    /// Switch to the next window (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub next_window: Option<Binding>,
-    /// Switch to the previous window (no effect until the built-in multiplexer lands).
+    /// Switch to the previous window (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub previous_window: Option<Binding>,
-    /// Switch to the window at index0 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index0 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_0: Option<Binding>,
-    /// Switch to the window at index1 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index1 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_1: Option<Binding>,
-    /// Switch to the window at index2 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index2 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_2: Option<Binding>,
-    /// Switch to the window at index3 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index3 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_3: Option<Binding>,
-    /// Switch to the window at index4 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index4 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_4: Option<Binding>,
-    /// Switch to the window at index5 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index5 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_5: Option<Binding>,
-    /// Switch to the window at index6 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index6 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_6: Option<Binding>,
-    /// Switch to the window at index7 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index7 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_7: Option<Binding>,
-    /// Switch to the window at index8 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index8 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_8: Option<Binding>,
-    /// Switch to the window at index9 (no effect until the built-in multiplexer lands).
+    /// Switch to the window at index9 (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
     )]
     pub select_window_9: Option<Binding>,
-    /// Open the rename prompt for the active window (no effect until the built-in multiplexer lands).
+    /// Open the rename prompt for the active window (no effect).
     #[serde(
         deserialize_with = "deser_binding_or_unbind",
         serialize_with = "ser_binding_or_unbind"
@@ -531,8 +518,7 @@ pub struct Shortcuts {
     /// fires, pressing a repeat-marked key again within this window re-fires
     /// it without the leader; each fire re-arms the window. Default 500.
     ///
-    /// 0 disables repeat entirely and is NOT normalized away, unlike
-    /// `leader_tap_timeout_ms`.
+    /// 0 disables repeat entirely and is not normalized away.
     pub repeat_time_ms: u64,
 }
 
@@ -580,7 +566,6 @@ impl Default for Shortcuts {
 
 impl Shortcuts {
     /// `(label, &Option<Binding>, action)` for every action, in stable order.
-    /// The single source of truth for the action schema.
     pub fn bindings_iter(
         &self,
     ) -> impl Iterator<Item = (&'static str, &Option<Binding>, Shortcut)> + '_ {
@@ -742,8 +727,8 @@ impl Shortcuts {
         )
     }
 
-    /// Normalizes numeric fields: a `leader_tap_timeout_ms` of 0 is meaningless
-    /// (a tap would never fit), so it reverts to the 300 default.
+    /// Normalizes numeric fields: a `leader_tap_timeout_ms` of 0 reverts to the
+    /// 300 default.
     pub(crate) fn normalize(&mut self) {
         if self.leader_tap_timeout_ms == 0 {
             self.leader_tap_timeout_ms = 300;
@@ -764,7 +749,7 @@ pub enum PaneDirection {
     Right,
 }
 
-/// Which way a split divides the pane, named after the DIVIDER the user sees.
+/// Which way a split divides the pane.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SplitOrientation {
     /// A vertical divider: panes end up side by side.
@@ -773,10 +758,7 @@ pub enum SplitOrientation {
     Horizontal,
 }
 
-/// Shortcut actions. GUI-local actions, the multiplexer's pane operations
-/// (`SelectPane`, `SplitPane`, `KillPane`), and the remaining pane/window
-/// operations that still have no effect until the built-in multiplexer
-/// grows zoom, resize, and window support.
+/// Shortcut actions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Shortcut {
     /// Paste the system clipboard into the active terminal.
@@ -787,7 +769,7 @@ pub enum Shortcut {
     ReleaseWebviewFocus,
     /// Quits the orzma application.
     Quit,
-    /// Enters vi mode: Alacritty vi mode on the focused terminal.
+    /// Enters vi mode on the focused terminal.
     EnterViMode,
     /// Focuses the neighbor pane in the given direction.
     SelectPane(PaneDirection),
@@ -795,21 +777,21 @@ pub enum Shortcut {
     SplitPane(SplitOrientation),
     /// Kills the active pane.
     KillPane,
-    /// Toggles zoom on the active pane (no effect until the built-in multiplexer lands).
+    /// Toggles zoom on the active pane (no effect).
     ZoomPane,
-    /// Resizes the active pane's border in the given direction (no effect until the built-in multiplexer lands).
+    /// Resizes the active pane's border in the given direction (no effect).
     ResizePane(PaneDirection),
-    /// Opens a new window in the current session (no effect until the built-in multiplexer lands).
+    /// Opens a new window in the current session (no effect).
     NewWindow,
-    /// Kills the active window after a confirm prompt (no effect until the built-in multiplexer lands).
+    /// Kills the active window after a confirm prompt (no effect).
     KillWindow,
-    /// Switches to the next window (no effect until the built-in multiplexer lands).
+    /// Switches to the next window (no effect).
     NextWindow,
-    /// Switches to the previous window (no effect until the built-in multiplexer lands).
+    /// Switches to the previous window (no effect).
     PreviousWindow,
-    /// Switches to the window with this display index (no effect until the built-in multiplexer lands).
+    /// Switches to the window with this display index (no effect).
     SelectWindow(u8),
-    /// Opens the rename prompt for the active window (no effect until the built-in multiplexer lands).
+    /// Opens the rename prompt for the active window (no effect).
     RenameWindow,
 }
 
@@ -989,8 +971,8 @@ fn parse_default_binding(s: &str) -> Binding {
     parse_binding(s).unwrap_or_else(|e| panic!("invalid default binding {s:?}: {e}"))
 }
 
-/// Detects chord collisions across a table's bound entries. Returns a `Vec`
-/// sorted by chord (BTreeMap key order) for deterministic error output.
+/// Detects chord collisions across a table's bound entries. The returned `Vec`
+/// is sorted by chord.
 fn conflicts<'a>(
     entries: impl Iterator<Item = (&'static str, &'a KeyChord, Shortcut)>,
 ) -> Result<(), Vec<DuplicateChord>> {

--- a/crates/orzma_configs/src/vi_mode.rs
+++ b/crates/orzma_configs/src/vi_mode.rs
@@ -1,7 +1,6 @@
-//! `[vi-mode]` table: shared vi-mode key bindings. Keys are LOGICAL
+//! `[vi-mode]` table: vi-mode key bindings. Keys are logical
 //! (case-sensitive characters, symbols allowed) with an optional `Ctrl+`
-//! prefix — a different grammar from `[shortcuts]` chords, matching how
-//! vi-mode keys are actually decided at runtime.
+//! prefix, a different grammar from `[shortcuts]` chords.
 
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
@@ -77,8 +76,7 @@ pub enum ViModeBaseKey {
 /// # Invariants
 ///
 /// When `ctrl` is true the key MUST be `Char` of one ASCII-alphanumeric
-/// character (stored lowercase) or `Named` — `Ctrl+` entries are matched on
-/// the physical `KeyCode` at runtime, which only exists for that domain.
+/// character (stored lowercase) or `Named`.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ViModeKey {
     /// `Ctrl` is part of the binding.
@@ -185,8 +183,7 @@ pub fn parse_vi_mode_key(s: &str) -> Result<ViModeKey, ViModeKeyParseError> {
     })
 }
 
-/// A cursor motion, in engine-neutral vocabulary. The binary maps this to
-/// the terminal engine's `ViMotion`.
+/// A cursor motion.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ViModeMotion {
     /// One cell left.
@@ -287,7 +284,7 @@ pub enum ViModeSearchStep {
     Previous,
 }
 
-/// One vi-mode action, in config-crate (engine-free) vocabulary.
+/// One vi-mode action.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ViModeAction {
     /// Move the copy cursor.
@@ -300,16 +297,15 @@ pub enum ViModeAction {
     Yank,
     /// Leave vi mode.
     Exit,
-    /// Open a search / jump prompt (currently has no effect — local vi-mode
-    /// search is a future feature).
+    /// Open a search / jump prompt (no effect: vi-mode search is not
+    /// implemented).
     Prompt(ViModePromptDir),
-    /// Repeat the previous search (currently has no effect — local vi-mode
-    /// search is a future feature).
+    /// Repeat the previous search (no effect: vi-mode search is not
+    /// implemented).
     SearchStep(ViModeSearchStep),
 }
 
-/// One key with multiple bindings. Carried inside
-/// `OrzmaConfigsError::DuplicateViModeKeys`.
+/// One key with multiple bindings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DuplicateViModeKey {
     /// The key bound more than once.
@@ -346,7 +342,6 @@ macro_rules! vi_mode_fields {
 
         impl ViModeConfig {
             /// `(label, &keys, action)` for every action, in stable order.
-            /// The single source of truth for the `[vi-mode]` schema.
             pub fn bindings_iter(
                 &self,
             ) -> impl Iterator<Item = (&'static str, &Vec<ViModeKey>, ViModeAction)> + '_ {
@@ -424,35 +419,35 @@ vi_mode_fields! {
     yank => "yank", ViModeAction::Yank, ["y", "Enter"];
     /// Leave vi mode.
     exit => "exit", ViModeAction::Exit, ["q", "Escape", "Ctrl+C"];
-    /// Open the search-down prompt (currently has no effect — local vi-mode
-    /// search is a future feature).
+    /// Open the search-down prompt (no effect: vi-mode search is not
+    /// implemented).
     search_forward => "search-forward", ViModeAction::Prompt(ViModePromptDir::SearchForward), ["/"];
-    /// Open the search-up prompt (currently has no effect — local vi-mode
-    /// search is a future feature).
+    /// Open the search-up prompt (no effect: vi-mode search is not
+    /// implemented).
     search_backward => "search-backward", ViModeAction::Prompt(ViModePromptDir::SearchBackward), ["?"];
-    /// Repeat the previous search (currently has no effect — local vi-mode
-    /// search is a future feature).
+    /// Repeat the previous search (no effect: vi-mode search is not
+    /// implemented).
     search_next => "search-next", ViModeAction::SearchStep(ViModeSearchStep::Next), ["n"];
-    /// Repeat the previous search, reversed (currently has no effect — local
-    /// vi-mode search is a future feature).
+    /// Repeat the previous search, reversed (no effect: vi-mode search is not
+    /// implemented).
     search_previous => "search-previous", ViModeAction::SearchStep(ViModeSearchStep::Previous), ["N"];
-    /// Open the jump-to-char-forward prompt (currently has no effect — local
-    /// vi-mode search is a future feature).
+    /// Open the jump-to-char-forward prompt (no effect: vi-mode search is not
+    /// implemented).
     jump_forward => "jump-forward", ViModeAction::Prompt(ViModePromptDir::JumpForward), ["f"];
-    /// Open the jump-to-char-backward prompt (currently has no effect —
-    /// local vi-mode search is a future feature).
+    /// Open the jump-to-char-backward prompt (no effect: vi-mode search is
+    /// not implemented).
     jump_backward => "jump-backward", ViModeAction::Prompt(ViModePromptDir::JumpBackward), ["F"];
-    /// Open the jump-till-char-forward prompt (currently has no effect —
-    /// local vi-mode search is a future feature).
+    /// Open the jump-till-char-forward prompt (no effect: vi-mode search is
+    /// not implemented).
     jump_to_forward => "jump-to-forward", ViModeAction::Prompt(ViModePromptDir::JumpToForward), ["t"];
-    /// Open the jump-till-char-backward prompt (currently has no effect —
-    /// local vi-mode search is a future feature).
+    /// Open the jump-till-char-backward prompt (no effect: vi-mode search is
+    /// not implemented).
     jump_to_backward => "jump-to-backward", ViModeAction::Prompt(ViModePromptDir::JumpToBackward), ["T"];
 }
 
 impl ViModeConfig {
-    /// Detects keys bound to more than one action. Deterministic order via
-    /// `BTreeMap`.
+    /// Detects keys bound to more than one action. The reported entries are in
+    /// a deterministic order.
     pub(crate) fn validate_no_duplicate_keys(&self) -> Result<(), Vec<DuplicateViModeKey>> {
         let mut by_key: BTreeMap<ViModeKey, Vec<&'static str>> = BTreeMap::new();
         for (label, keys, _action) in self.bindings_iter() {

--- a/crates/orzma_tty/src/cell_pixels.rs
+++ b/crates/orzma_tty/src/cell_pixels.rs
@@ -3,8 +3,8 @@
 
 /// Physical pixels per terminal cell, as the host measures its font.
 ///
-/// `Default` is `0 × 0`, which projects to a zero-pixel winsize (the
-/// pre-multiplexer behaviour) for callers that have no metrics yet.
+/// `Default` is `0 × 0`, which projects to a zero-pixel winsize for a
+/// caller that has no metrics yet.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct CellPixels {
     /// Horizontal cell pitch in physical pixels.
@@ -17,9 +17,8 @@ impl CellPixels {
     /// Total window pixels for a `cols × rows` grid, saturating at
     /// `u16::MAX` per axis.
     ///
-    /// The result is what `ws_xpixel` / `ws_ypixel` expect: tmux writes
-    /// `xpixel * cols`, and portable-pty forwards `pixel_width` verbatim
-    /// into `ws_xpixel` despite documenting it as a per-cell width.
+    /// The result is what the winsize `ws_xpixel` / `ws_ypixel` fields
+    /// expect.
     pub fn window_pixels(self, cols: u16, rows: u16) -> (u16, u16) {
         if self.width.checked_mul(cols).is_none() || self.height.checked_mul(rows).is_none() {
             tracing::debug!(cols, rows, ?self, "pixel winsize saturated at u16::MAX");
@@ -52,8 +51,8 @@ mod tests {
     /// Asserts that a product beyond `u16::MAX` saturates instead of
     /// wrapping.
     ///
-    /// Case: a 4096-column grid at a 32 px cell pitch on a very wide
-    /// display.
+    /// Case: the layout gives a pane 4096 columns at a 32 px cell pitch
+    /// on a very wide display.
     #[test]
     fn window_pixels_saturate_instead_of_wrapping() {
         let px = CellPixels {

--- a/crates/orzma_tty/src/coalescer.rs
+++ b/crates/orzma_tty/src/coalescer.rs
@@ -1,9 +1,6 @@
-//! Per-terminal frame-emit coalescer.
-//!
-//! Owns the deadline state machine plus the flush flag that decides
-//! when the owning terminal emits accumulated damage: the coalesce
-//! window (idle debounce and hard cap) and the bootstrap flag behind
-//! the initial snapshot.
+//! Per-terminal frame-emit coalescer: the coalesce window (idle debounce
+//! and hard cap) and the bootstrap flag that decide when the owning
+//! terminal emits accumulated damage.
 
 use std::cmp::min;
 use std::time::{Duration, Instant};
@@ -12,14 +9,12 @@ use std::time::{Duration, Instant};
 #[derive(Debug)]
 pub struct Coalescer {
     /// Arrival time of the first chunk that opened the current coalesce
-    /// window. Anchors the `MAX_CAP` hard-flush deadline. Set only by the
-    /// first `arm_or_extend` call; subsequent chunks in the same window do
-    /// not move it. Cleared back to `None` by `disarm`.
+    /// window, anchoring the `MAX_CAP` hard-flush deadline; `None` while
+    /// disarmed. Later chunks in the same window do not move it.
     armed_at: Option<Instant>,
-    /// Arrival time of the most recent chunk in the current window. Anchors
-    /// the `IDLE` debounce deadline. Updated on every `arm_or_extend` call so
-    /// the idle timer resets whenever new input arrives. Cleared back to
-    /// `None` by `disarm`.
+    /// Arrival time of the most recent chunk in the current window,
+    /// anchoring the `IDLE` debounce deadline; `None` while disarmed.
+    /// Every chunk moves it, so the idle timer resets on new input.
     last_chunk_at: Option<Instant>,
     /// True until the first emit settles. The owner emits the initial
     /// snapshot without waiting for a deadline while this holds.
@@ -76,19 +71,14 @@ impl Coalescer {
     /// Settles a completed emit: closes the window and marks the bootstrap
     /// paint done.
     ///
-    /// # Invariants
-    ///
-    /// Call only after a frame was actually produced — settling on a
-    /// decision alone would spend the bootstrap debt with nothing painted.
+    /// Call it only after a frame was actually produced.
     pub fn settle_emit(&mut self) {
         self.disarm();
         self.bootstrap = false;
     }
 
-    /// Resets the window. Serves non-consuming resets (an emit settles
-    /// through [`Self::settle_emit`] instead): the bootstrap debt
-    /// survives, so a resize/scroll/selection repaint that paints
-    /// outside the coalesce path does not skip the initial snapshot.
+    /// Resets the window without touching the bootstrap debt; a completed
+    /// emit settles through [`Self::settle_emit`] instead.
     #[inline]
     pub fn disarm(&mut self) {
         self.armed_at = None;
@@ -140,8 +130,7 @@ mod tests {
     /// Asserts that each chunk inside the window moves the idle
     /// deadline to `last_chunk + IDLE` while under the cap.
     ///
-    /// Case: output keeps trickling in faster than the debounce, so
-    /// the flush keeps waiting for the stream to go quiet.
+    /// Case: output keeps trickling in faster than the debounce.
     #[test]
     fn each_chunk_extends_the_idle_deadline() {
         let mut coalescer = Coalescer::default();
@@ -158,8 +147,7 @@ mod tests {
     /// though the most recent chunk keeps the idle deadline in the
     /// future.
     ///
-    /// Case: continuous spam (`yes`) extends the debounce forever; the
-    /// screen must still update by the cap.
+    /// Case: continuous output from `yes` keeps extending the debounce.
     #[test]
     fn the_hard_cap_bounds_a_busy_window() {
         let mut coalescer = Coalescer::default();
@@ -171,7 +159,7 @@ mod tests {
 
     /// Asserts that a disarmed coalescer is never due, at any time.
     ///
-    /// Case: an idle terminal pumped every frame.
+    /// Case: the host pumps an idle terminal every frame.
     #[test]
     fn a_disarmed_coalescer_is_never_due() {
         let mut coalescer = Coalescer::default();
@@ -185,8 +173,7 @@ mod tests {
     /// Asserts that the window becomes due exactly once the idle
     /// debounce elapses after the last chunk.
     ///
-    /// Case: output stops, and the repaint fires when the stream has
-    /// been quiet for the debounce.
+    /// Case: a program prints one chunk of output and then goes quiet.
     #[test]
     fn the_window_is_due_once_idle_elapses() {
         let mut coalescer = Coalescer::default();
@@ -199,11 +186,7 @@ mod tests {
     /// Asserts that a default-built coalescer still owes the bootstrap
     /// emit and starts disarmed.
     ///
-    /// `Default` is hand-written for this; rederiving
-    /// `#[derive(Default)]` would silently start `bootstrap` at
-    /// `false` and the initial snapshot would never emit.
-    ///
-    /// Case: a freshly spawned terminal before its first pump.
+    /// Case: a terminal has just spawned and has not been pumped yet.
     #[test]
     fn a_fresh_coalescer_needs_bootstrap() {
         let coalescer = Coalescer::default();
@@ -214,8 +197,7 @@ mod tests {
     /// Asserts that settling a completed emit closes the coalesce window
     /// and clears the bootstrap debt.
     ///
-    /// Case: the terminal paints its initial snapshot, after which later
-    /// frames wait for the debounce deadline like any other output.
+    /// Case: the terminal paints its initial snapshot.
     #[test]
     fn settle_emit_closes_the_window_and_clears_the_bootstrap_debt() {
         let t0 = base();
@@ -231,10 +213,6 @@ mod tests {
 
     /// Asserts that disarming closes the window without clearing the
     /// bootstrap debt.
-    ///
-    /// `disarm` serves resets that painted nothing, so it must not spend a
-    /// debt only a real emit can settle; `settle_emit` is the consuming
-    /// path.
     ///
     /// Case: a resize discards the staged damage before the initial
     /// snapshot has ever been painted.

--- a/crates/orzma_tty/src/error.rs
+++ b/crates/orzma_tty/src/error.rs
@@ -15,7 +15,7 @@ pub enum OrzmaTtyError {
     /// Cloning the reader / taking the writer from the PTY master failed.
     #[error("PTY pipe setup failed")]
     PtyPipe(#[source] anyhow::Error),
-    /// Write a pty input buffer to the PTY master failed.
+    /// Writing an input buffer to the PTY master failed.
     #[error("PTY write failed")]
     PtyWrite(#[source] std::io::Error),
     /// Resizing the PTY master (`TIOCSWINSZ`) failed.

--- a/crates/orzma_tty/src/input.rs
+++ b/crates/orzma_tty/src/input.rs
@@ -61,17 +61,15 @@ impl PtyInput {
     ///
     /// - `bracketed = true`: strips every embedded occurrence of the four
     ///   bracketed-paste marker forms (7-bit `ESC [ 200~` / `ESC [ 201~` and
-    ///   C1 `U+009B 200~` / `U+009B 201~`) in a fixed-point loop, then wraps
-    ///   the sanitized body in `ESC [ 200 ~` ... `ESC [ 201 ~`; the body is
-    ///   otherwise passed through byte-for-byte. Closes the paste-injection
-    ///   class documented in kitty commit 668f6fa and Alacritty issue #800.
+    ///   C1 `U+009B 200~` / `U+009B 201~`), including those an earlier
+    ///   removal re-exposes, so no marker survives; then wraps the sanitized
+    ///   body in `ESC [ 200 ~` ... `ESC [ 201 ~`. The body is otherwise
+    ///   passed through byte-for-byte.
     /// - `bracketed = false`: normalizes line endings (`\r\n` and lone `\n`
-    ///   become `\r`) and filters nothing else — an unbracketed paste has
-    ///   the same authority as typed input.
+    ///   become `\r`) and filters nothing else.
     ///
-    /// The input domain is UTF-8 `&str`: the C1 markers match the codepoint
-    /// `U+009B` (UTF-8 `C2 9B`); a raw `9B` byte is not representable and
-    /// out of scope.
+    /// The C1 markers match the codepoint `U+009B` (UTF-8 `C2 9B`); a raw
+    /// `9B` byte is not representable in the `&str` input.
     ///
     /// # References
     ///

--- a/crates/orzma_tty/src/input/keyboard.rs
+++ b/crates/orzma_tty/src/input/keyboard.rs
@@ -1,6 +1,5 @@
-//! Pure VT-encoder for key input. Translates a logical key + modifiers
-//! into the byte sequence the PTY expects. No I/O, no Bevy types — kept
-//! pure so unit tests can cover every branch without an `App`.
+//! Pure VT-encoder for key input: translates a logical key and its
+//! modifiers into the byte sequence the PTY expects.
 
 mod keypad;
 
@@ -8,16 +7,11 @@ pub use keypad::KeypadKey;
 use orzma_vt::prelude::KeypadMode;
 
 /// Non-empty UTF-8 text carried by [`TerminalKey::Character`].
-///
-/// The non-empty invariant is what makes `encode_key` total: empty text has
-/// no PTY representation, so it is rejected once at construction instead of
-/// being reported on every encode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyText(String);
 
 impl KeyText {
-    /// Wraps `text`, returning `None` when it is empty — there is nothing to
-    /// send to the PTY in that case.
+    /// Wraps `text`, returning `None` when it is empty.
     pub fn new(text: impl Into<String>) -> Option<Self> {
         let text = text.into();
         (!text.is_empty()).then_some(Self(text))
@@ -29,8 +23,7 @@ impl KeyText {
     }
 }
 
-/// Subset of keys the terminal input codec understands. Keeps the public
-/// surface stable and tells callers exactly which keys are wired.
+/// Subset of keys the terminal input codec understands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalKey {
     /// UTF-8 text (single char or multi-codepoint composition).
@@ -54,8 +47,12 @@ pub enum TerminalKey {
 }
 
 /// Modifier flags carried alongside `TerminalKey`.
-/// `ctrl` / `alt` / `meta` affect `Character` encoding, and `shift` alone turns `Tab` into a
-/// back tab; its other uses wait for CSI u / modifyOtherKeys support.
+///
+/// `ctrl` / `alt` / `meta` affect `Character` encoding, and `shift`
+/// alone turns `Tab` into a back tab.
+///
+/// TODO: encode the other uses of `shift` once CSI u / modifyOtherKeys is
+/// supported.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TerminalModifiers {
     pub ctrl: bool,
@@ -66,14 +63,13 @@ pub struct TerminalModifiers {
 
 /// Translates a logical key + modifiers into the bytes the PTY expects.
 ///
-/// Total — every `TerminalKey` has a representation, because `Character`
-/// cannot carry an empty string.
+/// The encoding is total: every `TerminalKey` has a representation.
 ///
-/// The cursor keys — arrows plus Home and End, which xterm also classifies as
-/// cursor keys — honour `app_cursor_keys` (DECCKM): `ESC [ A/B/C/D/H/F` in
-/// normal mode, `ESC O A/B/C/D/H/F` in application mode. The VT220 editing
-/// keypad (Insert, Delete, PageUp, PageDown) is unaffected by DECCKM and maps to fixed
-/// sequences; `Character` is encoded by `encode_character`.
+/// The cursor keys — the arrows plus Home and End — honour
+/// `app_cursor_keys` (DECCKM): `ESC [ A/B/C/D/H/F` in normal mode,
+/// `ESC O A/B/C/D/H/F` in application mode. The VT220 editing keypad
+/// (Insert, Delete, PageUp, PageDown) is unaffected by DECCKM and maps to
+/// fixed sequences.
 ///
 /// Tab sends HT, and CBT (`CSI Z`, the terminfo `kcbt` string) when Shift
 /// is the only modifier held; other modifiers leave Tab as HT.

--- a/crates/orzma_tty/src/input/keyboard/keypad.rs
+++ b/crates/orzma_tty/src/input/keyboard/keypad.rs
@@ -1,16 +1,14 @@
 //! The numeric keypad's key vocabulary and its VT encoder. Which bytes a
 //! keypad key sends depends on `DECKPAM` / `DECKPNM` rather than on the
-//! modifiers the rest of the keyboard reads, so the encoding lives here
-//! beside the vocabulary it indexes.
+//! modifiers the rest of the keyboard reads.
 
 use orzma_vt::prelude::KeypadMode;
 
 /// A key on the PC-layout numeric keypad.
 ///
 /// [`Self::Comma`] and [`Self::Decimal`] name the character a key types
-/// rather than the station it sits at, which is how xterm keys its keypad
-/// table. A layout whose decimal separator is a comma therefore reaches this
-/// vocabulary as [`Self::Comma`].
+/// rather than the station it sits at, so a layout whose decimal separator
+/// is a comma reaches this vocabulary as [`Self::Comma`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeypadKey {
     Divide,
@@ -40,18 +38,11 @@ pub enum KeypadKey {
 impl KeypadKey {
     /// Encodes the keypad key input to the PTY bytes.
     ///
-    /// The neighbouring [PC-Style Function Keys] table is not this function's
-    /// specification. Its application column lists the editing sequences a
-    /// station emits when NumLock is off, which reach a terminal as separate
-    /// keys rather than as a keypad mode, so deriving from it turns keypad
-    /// digits into cursor keys.
-    ///
     /// # References
     ///
     /// - [VT220-Style Function Keys] — the keypad table this follows.
     ///
     /// [VT220-Style Function Keys]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-VT220-Style-Function-Keys
-    /// [PC-Style Function Keys]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-PC-Style-Function-Keys
     pub(super) fn encode(&self, mode: KeypadMode) -> &'static [u8] {
         macro_rules! ss3 {
             ($numeric:literal) => {

--- a/crates/orzma_tty/src/input/mouse.rs
+++ b/crates/orzma_tty/src/input/mouse.rs
@@ -1,6 +1,5 @@
-//! Pure VT-encoder for mouse-protocol reports. Translates a logical
-//! mouse report into the byte sequence the PTY expects. No I/O, no
-//! Bevy types — kept pure so unit tests can cover every branch.
+//! Pure VT-encoder for mouse-protocol reports: translates a logical
+//! mouse report into the byte sequence the PTY expects.
 
 use orzma_vt::prelude::MouseEncoding;
 
@@ -23,8 +22,8 @@ pub enum WheelDir {
 /// Mouse-protocol modifier set, mapped onto the report's `cb` bits
 /// (shift=4, alt/meta=8, ctrl=16).
 ///
-/// OS-level Alt (Option on macOS) is xterm's "meta" bit: `alt` and
-/// `meta` merge into the single +8 bit and never double-count.
+/// OS-level Alt (Option on macOS) reaches the report as the meta bit:
+/// `alt` and `meta` merge into the single +8 bit and never double-count.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ProtocolModifiers {
     pub shift: bool,
@@ -35,9 +34,9 @@ pub struct ProtocolModifiers {
 
 /// Button identity carried by a mouse report.
 ///
-/// Wheel variants are press-shaped: xterm reports them with button
-/// codes 64..=67 and never emits a release or sets the motion bit
-/// for them, so wheel reports use [`MouseReportKind::Press`].
+/// Wheel variants are press-shaped: they carry button codes 64..=67,
+/// and a wheel report uses [`MouseReportKind::Press`], never a release
+/// or a drag.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MouseButton {
     Left,
@@ -84,8 +83,8 @@ pub struct MouseReport {
 
 impl MouseReport {
     /// Encodes this report in the given mouse encoding. UTF-8 (1005)
-    /// is not implemented and intentionally falls back to X10 framing
-    /// (byte-identical for coordinates <= 95).
+    /// is not implemented and falls back to X10 framing (byte-identical
+    /// for coordinates <= 95).
     pub fn encode(&self, encoding: MouseEncoding) -> Vec<u8> {
         match encoding {
             MouseEncoding::Sgr => self.encode_sgr(),

--- a/crates/orzma_tty/src/input/paste.rs
+++ b/crates/orzma_tty/src/input/paste.rs
@@ -1,7 +1,6 @@
-//! Pure VT-encoder for paste input. Translates clipboard text into the
+//! Pure VT-encoder for paste input: translates clipboard text into the
 //! byte sequence the PTY expects, honouring bracketed-paste mode
-//! (DECSET 2004). No I/O, no Bevy types — kept pure so unit tests can
-//! cover every branch without an `App`.
+//! (DECSET 2004).
 
 /// 7-bit bracketed-paste start marker (`ESC [ 200 ~`).
 const START_7BIT: &str = "\x1b[200~";
@@ -24,16 +23,12 @@ pub(super) fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
 
 /// Strips every embedded occurrence of the four bracketed-paste marker
 /// forms — 7-bit `ESC [ 200~` / `ESC [ 201~` and C1 `U+009B 200~` /
-/// `U+009B 201~` — in a fixed-point loop, then wraps the sanitized body
-/// in `ESC [ 200 ~` ... `ESC [ 201 ~`. The body is otherwise passed
-/// through byte-for-byte.
+/// `U+009B 201~` — then wraps the sanitized body in `ESC [ 200 ~` ...
+/// `ESC [ 201 ~`. The body is otherwise passed through byte-for-byte.
 ///
-/// The loop is required because removing one marker can re-expose
-/// another (`ESC [ ESC [ 201 ~ 201 ~` → `ESC [ 201 ~`). It terminates
-/// because every iteration that continues removes at least one marker
-/// (six chars or more), bounding the iteration count by
-/// `text.len() / 6 + 1`. Closes the paste-injection class documented in
-/// kitty commit 668f6fa and Alacritty issue #800.
+/// A marker that an earlier removal re-exposes is stripped too
+/// (`ESC [ ESC [ 201 ~ 201 ~` leaves nothing), so no marker survives
+/// into the body.
 fn encode_bracketed(text: &str) -> Vec<u8> {
     let mut body = text.to_owned();
     loop {
@@ -56,8 +51,8 @@ fn encode_bracketed(text: &str) -> Vec<u8> {
 
 /// Normalizes line endings so shells receive one `\r` per line: `\r\n`
 /// collapses to `\r`, a lone `\n` becomes `\r`, and existing `\r` bytes
-/// pass through. Nothing else is filtered — an unbracketed paste has the
-/// same authority as typed input, so control bytes reach the PTY as-is.
+/// pass through. Nothing else is filtered, so control bytes reach the PTY
+/// as-is.
 fn normalize_newlines(text: &str) -> Vec<u8> {
     let mut out = Vec::with_capacity(text.len());
     let bytes = text.as_bytes();
@@ -109,7 +104,7 @@ mod tests {
 
     /// Adversarial inputs shared by the invariant sweep: every marker
     /// form embedded and doubled, adjacency, a cross-form mix, and the
-    /// re-exposure nests the fixed-point loop exists for.
+    /// nests where removing one marker re-exposes another.
     fn adversarial_inputs() -> Vec<String> {
         let mut inputs: Vec<String> = vec![
             "\x1b[\x1b[201~201~".into(),
@@ -128,8 +123,8 @@ mod tests {
 
     /// Asserts that clean text is framed by the 7-bit start/end markers.
     ///
-    /// Case: the ordinary paste — an app enabled DECSET 2004 and expects
-    /// the body delivered between `ESC[200~` and `ESC[201~`.
+    /// Case: the user pastes plain text into an app that enabled
+    /// DECSET 2004.
     #[test]
     fn bracketed_wraps_clean_body() {
         assert_eq!(encode_paste("hello", true), b"\x1b[200~hello\x1b[201~");
@@ -138,11 +133,8 @@ mod tests {
     /// Asserts that each of the four marker spellings is stripped from
     /// the body individually.
     ///
-    /// Case: hostile clipboard content embedding one marker to terminate
-    /// the paste frame early and have the remainder run as typed input —
-    /// the kitty 668f6fa / Alacritty #800 injection class. All four
-    /// spellings (7-bit and C1, start and end) must be covered because
-    /// any single surviving form re-opens the hole.
+    /// Case: hostile clipboard content embeds one marker to terminate the
+    /// paste frame early and have the remainder run as typed input.
     #[test]
     fn bracketed_strips_each_marker_form() {
         for marker in ALL_MARKERS {
@@ -156,9 +148,8 @@ mod tests {
 
     /// Asserts that repeated and adjacent markers are all removed.
     ///
-    /// Case: payloads that repeat a marker or butt two markers together,
-    /// probing a stripper that only removes the first occurrence or
-    /// mis-steps over adjacent matches.
+    /// Case: hostile clipboard content repeats a marker or butts two
+    /// markers together.
     #[test]
     fn bracketed_strips_repeated_and_adjacent_markers() {
         assert_eq!(
@@ -176,8 +167,8 @@ mod tests {
     /// Asserts that 7-bit and C1 spellings mixed in one body are both
     /// stripped.
     ///
-    /// Case: a payload alternating marker forms to slip past a stripper
-    /// that handles the forms in separate, non-composing passes.
+    /// Case: hostile clipboard content alternates the 7-bit and C1 marker
+    /// forms within one body.
     #[test]
     fn bracketed_strips_mixed_marker_forms() {
         assert_eq!(encode_paste("a\x1b[201~b\u{9b}200~c", true), wrapped("abc"));
@@ -187,10 +178,9 @@ mod tests {
     /// stripped, for start, end, and cross-form (7-bit removal exposing
     /// a C1 marker) nests.
     ///
-    /// Case: the reason the loop must run to a fixed point — one replace
-    /// pass over `ESC [ ESC [ 201 ~ 201 ~` leaves a freshly-assembled
-    /// `ESC [ 201 ~` behind, which a single-pass stripper would emit
-    /// into the frame.
+    /// Case: hostile clipboard content nests one marker inside another,
+    /// as in `ESC [ ESC [ 201 ~ 201 ~`, so removing the inner marker
+    /// assembles a fresh one from the leftovers.
     #[test]
     fn bracketed_fixed_point_strips_reexposed_markers() {
         for input in [
@@ -209,10 +199,9 @@ mod tests {
     /// Asserts that sequences resembling — but not equal to — the
     /// markers survive into the body.
     ///
-    /// Case: legitimate pasted content such as other CSI sequences
-    /// (`ESC[202~`), a truncated marker, or the bare digits `200~`. An
-    /// over-eager stripper that matches prefixes or ignores the final
-    /// byte would corrupt ordinary text.
+    /// Case: the user pastes legitimate content that holds another CSI
+    /// sequence (`ESC[202~`), a truncated marker, or the bare digits
+    /// `200~`.
     #[test]
     fn bracketed_preserves_similar_sequences() {
         for body in ["\x1b[202~", "\x1b[200", "200~", "\x1b]200~"] {
@@ -227,11 +216,8 @@ mod tests {
     /// Asserts that empty text still yields a complete, well-formed
     /// frame.
     ///
-    /// Case: the API's totality. The host layer never fires an empty
-    /// paste (its clipboard read filters empty text) and
-    /// `OrzmaTty::send_paste` early-returns on it, so this input is
-    /// reachable only by calling the encoder directly — but a caller
-    /// that does must still get a frame, not a bare marker fragment.
+    /// Case: a caller hands the encoder an empty clipboard read directly
+    /// while bracketed-paste mode is on.
     #[test]
     fn bracketed_empty_text_emits_well_formed_brackets() {
         assert_eq!(encode_paste("", true), b"\x1b[200~\x1b[201~");
@@ -240,10 +226,8 @@ mod tests {
     /// Asserts that newlines and multi-byte text cross the bracketed
     /// path byte-for-byte.
     ///
-    /// Case: the point of bracketed paste — the receiving app asked to
-    /// see the body verbatim and applies its own newline handling, so
-    /// the `\r`/`\n` normalization of the unbracketed path must NOT leak
-    /// in here, and non-ASCII content must not be re-encoded.
+    /// Case: the user pastes a multi-line, non-ASCII snippet into an app
+    /// that enabled DECSET 2004 and applies its own newline handling.
     #[test]
     fn bracketed_newlines_and_multibyte_pass_through() {
         assert_eq!(encode_paste("a\r\nb\nc\rd", true), wrapped("a\r\nb\nc\rd"));
@@ -253,11 +237,8 @@ mod tests {
     /// Asserts, over the whole adversarial fixture set, that no marker
     /// spelling ever survives into the emitted body.
     ///
-    /// Case: the invariant behind every example test above, checked as a
-    /// property so a future fixture (or a stripping bug the examples
-    /// happen to miss) is still caught: whatever the input, the frame
-    /// must be terminable only by the final `ESC[201~` the encoder
-    /// itself appends.
+    /// Case: each adversarial payload is pasted in turn into an app that
+    /// enabled DECSET 2004.
     #[test]
     fn bracketed_body_never_contains_any_marker() {
         for input in adversarial_inputs() {
@@ -274,9 +255,8 @@ mod tests {
     /// Asserts that a large marker-only payload (16k markers, ~96 KiB)
     /// terminates and strips to an empty body.
     ///
-    /// Case: resource-exhaustion regression for the fixed-point loop —
-    /// each iteration reallocates the body, so a pathological input must
-    /// not push the loop into quadratic blowup that stalls the UI.
+    /// Case: the user pastes a clipboard payload of about 96 KiB made of
+    /// nothing but end markers.
     #[test]
     fn bracketed_large_adversarial_input_terminates() {
         let input = END_7BIT.repeat(16_000);
@@ -287,9 +267,8 @@ mod tests {
     /// a lone `\n` becomes `\r`, existing `\r` passes through, and a
     /// `\r\n\n` run yields exactly two `\r`.
     ///
-    /// Case: a multi-line paste from an editor into a plain shell — the
-    /// line discipline expects one `\r` per line, and double-converting
-    /// `\r\n` would submit an empty extra line per paste.
+    /// Case: the user pastes a multi-line snippet from an editor into a
+    /// plain shell, whose line discipline expects one `\r` per line.
     #[test]
     fn unbracketed_normalizes_newlines() {
         for (input, expected) in [
@@ -305,10 +284,8 @@ mod tests {
     /// Asserts that paste markers are NOT stripped on the unbracketed
     /// path while newlines in the same input still normalize.
     ///
-    /// Case: with DECSET 2004 off there is no frame to break out of, so
-    /// the markers are ordinary bytes; the composite input pins that the
-    /// two rules (keep markers, normalize newlines) apply independently
-    /// to one text.
+    /// Case: the user pastes text that holds a paste marker and a newline
+    /// into a shell that left DECSET 2004 off.
     #[test]
     fn unbracketed_does_not_strip_paste_markers() {
         assert_eq!(
@@ -319,8 +296,8 @@ mod tests {
 
     /// Asserts that empty text encodes to zero bytes.
     ///
-    /// Case: nothing to paste means nothing on the wire — unlike the
-    /// bracketed path there is no frame that must stay well-formed.
+    /// Case: a caller hands the encoder an empty clipboard read directly
+    /// while bracketed-paste mode is off.
     #[test]
     fn unbracketed_empty_text_emits_nothing() {
         assert_eq!(encode_paste("", false), b"");
@@ -329,11 +306,8 @@ mod tests {
     /// Asserts that control characters pass through the unbracketed path
     /// unfiltered: TAB, BEL, ESC, ETX, and NUL.
     ///
-    /// Case: characterization of the current policy — an unbracketed
-    /// paste carries the same authority as typed input, so the encoder
-    /// filters nothing beyond newline normalization. A C0/ESC filtering
-    /// policy (and any multi-line paste confirmation) is a separate,
-    /// host-level security concern, deliberately NOT smuggled in here.
+    /// Case: the user pastes snippets holding a tab, a bell, or an escape
+    /// byte into a shell that left DECSET 2004 off.
     #[test]
     fn unbracketed_control_chars_pass_through() {
         for input in ["a\tb", "a\x07b", "a\x1bb", "a\x03b", "a\0b"] {

--- a/crates/orzma_tty/src/lib.rs
+++ b/crates/orzma_tty/src/lib.rs
@@ -1,4 +1,4 @@
-//! PTY-backed terminal core: spawns the login shell under a PTY and
+//! PTY-backed terminal core: spawns a shell under a PTY and
 //! drives an injected [`Vt`] implementor behind a frame coalescer.
 
 use crate::{
@@ -56,11 +56,11 @@ pub struct EnvValue(pub String);
 
 /// Everything one [`OrzmaTty::pump`] call produced.
 ///
-/// This is the pump's batch, not the VT's: [`orzma_vt::InterpretOutput`]
-/// is what a single chunk produced, and one pump folds several of those
-/// into at most one frame plus the signals they raised.
+/// One pump folds several interpreted chunks into at most one frame plus
+/// the signals they raised.
 pub struct PumpOutput {
-    /// The frame to draw, present only when the coalesce window came due.
+    /// The frame to draw, present only when the coalesce window came due or
+    /// the bootstrap snapshot was still owed.
     pub frame: Option<Frame>,
     /// Signals raised since the previous pump, in order, with
     /// `ChildExit` last.
@@ -70,15 +70,13 @@ pub struct PumpOutput {
     pub more_pending: bool,
 }
 
-/// The receivers a multiplexer registers in a `Select` to learn when a
-/// terminal has work: its output stream, and its exit stream until the
-/// exit has been observed.
+/// The receivers to wait on to learn when a terminal has work: its output
+/// stream, and its exit stream until the exit has been observed.
 pub struct Readiness<'a> {
     /// The PTY output stream.
     pub chunks: &'a Receiver<Vec<u8>>,
     /// The child-exit stream, or `None` once [`OrzmaTty::pump`] latched
-    /// the exit (a disconnected receiver is permanently ready, so it
-    /// must leave the `Select`).
+    /// the exit, at which point it must leave the wait set.
     pub exit: Option<&'a Receiver<Option<i32>>>,
 }
 
@@ -109,27 +107,22 @@ pub struct OrzmaTty<V: Vt> {
 }
 
 impl<V: Vt> OrzmaTty<V> {
-    /// Upper bound on chunks one [`Self::pump`] interprets (64 × the 4 KiB
-    /// reader buffer ≈ 256 KiB), so a flooding terminal cannot monopolize
-    /// its owner's loop.
+    /// Upper bound on chunks one [`Self::pump`] interprets: 64 reads of up
+    /// to 4 KiB each, so at most about 256 KiB.
     pub const MAX_CHUNKS_PER_PUMP: usize = 64;
 
     /// Upper bound for a resize's column count; requests beyond it are
     /// ignored by [`Self::resize`].
-    ///
-    /// 4096 columns is beyond any real display (8K at a tiny font is
-    /// ~2000), while capping the VT grid allocation a degenerate or
-    /// hostile request could otherwise trigger.
     const MAX_COLS: u16 = 4096;
     /// Upper bound for a resize's row count; requests beyond it are
-    /// ignored by [`Self::resize`]. Same rationale as [`Self::MAX_COLS`].
+    /// ignored by [`Self::resize`].
     const MAX_ROWS: u16 = 4096;
 
-    /// Spawns the login shell under a new PTY and sizes the injected VT
+    /// Spawns `options.shell` under a new PTY and sizes the injected VT
     /// to the spawn geometry.
     ///
-    /// The initial sizing reports the placements it strands exactly as
-    /// [`Self::resize`] does.
+    /// The placements the initial sizing strands reach the next pump as a
+    /// [`VtSignal::WebviewEvicted`] signal.
     pub fn spawn(vt: V, options: SpawnOptions) -> OrzmaTtyResult<Self> {
         let mut tty = Self::wired(vt, Pty::spawn(&options)?);
         tty.resize_vt(GridSize {
@@ -145,7 +138,7 @@ impl<V: Vt> OrzmaTty<V> {
     /// # Panics
     ///
     /// Panics when the ioctl fails, which means the master fd is no
-    /// longer valid and the terminal is unusable anyway.
+    /// longer valid.
     #[inline]
     pub fn pty_size(&self) -> PtySize {
         self.pty.size()
@@ -161,18 +154,16 @@ impl<V: Vt> OrzmaTty<V> {
     /// Builds a terminal around a fake PTY master instead of a spawned
     /// shell, so writes land on `writer` and no real PTY is opened.
     ///
-    /// The master is a `test_support::RecordingMaster`, so resize
-    /// calls still round-trip through `pty_size()`; no child process or
-    /// reader thread is started, so everything the input methods emit
-    /// can be observed on `writer` — typically a
+    /// Resize calls still round-trip through [`Self::pty_size`], and no
+    /// child process or reader thread is started, so everything the input
+    /// methods emit can be observed on `writer` — typically a
     /// [`test_support::CaptureSink`].
     ///
-    /// The initial sizing reports the placements it strands exactly as
-    /// [`Self::resize`] does.
+    /// The placements the initial sizing strands reach the next pump as a
+    /// [`VtSignal::WebviewEvicted`] signal.
     ///
-    /// The constructor is compiled for tests only: in-crate under
-    /// `cfg(test)`, and for downstream crates through the `test-support`
-    /// feature.
+    /// Available only under `cfg(test)` in this crate and through the
+    /// `test-support` feature downstream.
     #[cfg(any(test, feature = "test-support"))]
     pub fn detached(
         vt: V,
@@ -187,8 +178,8 @@ impl<V: Vt> OrzmaTty<V> {
     }
 
     /// Like [`Self::detached`], but with the chunk and exit streams fed by
-    /// the given receivers, so a test can queue output, exhaust the pump
-    /// budget, and report or withhold the child's exit.
+    /// the given receivers, so the caller controls the queued output and
+    /// whether the child's exit is reported.
     #[cfg(any(test, feature = "test-support"))]
     pub fn detached_with_channels(
         vt: V,
@@ -212,17 +203,15 @@ impl<V: Vt> OrzmaTty<V> {
     /// Feeds bytes through the same seam [`Self::pump`] runs PTY chunks
     /// through, arming the coalescer exactly as live output would.
     ///
-    /// Available to tests only: in-crate under `cfg(test)`, downstream
-    /// via the `test-support` feature.
+    /// Available only under `cfg(test)` in this crate and through the
+    /// `test-support` feature downstream.
     #[cfg(any(test, feature = "test-support"))]
     pub fn feed_bytes(&mut self, bytes: &[u8]) {
         self.feed_chunk(bytes);
     }
 
     /// Scrolls the grid, arming the coalescer only when the viewport
-    /// actually moved — a clamped or zero motion reports no damage, and
-    /// arming for it would open an emit window for a repaint that never
-    /// comes.
+    /// actually moved; a clamped or zero motion reports no damage.
     pub fn scroll(&mut self, scroll: Scroll) {
         if self.vt.scroll(scroll) {
             self.coalescer.arm_or_extend(Instant::now());
@@ -230,7 +219,7 @@ impl<V: Vt> OrzmaTty<V> {
     }
 
     /// Anchors a selection, arming the coalescer only when the VT's
-    /// state changed so an unchanged frame is not woken.
+    /// state changed.
     pub fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) {
         if self.vt.start_selection(cell, side, kind) {
             self.coalescer.arm_or_extend(Instant::now());
@@ -262,11 +251,10 @@ impl<V: Vt> OrzmaTty<V> {
     /// `Self::MAX_ROWS`, is ignored with `Ok` — neither clamped nor
     /// an error. When the PTY resize fails the call returns
     /// `OrzmaTtyError::PtyResize` and leaves the VT grid and
-    /// coalescer untouched (PTY first; nothing changes on failure).
+    /// coalescer untouched.
     ///
     /// A request for the grid size the VT already has changes nothing
-    /// and reports no damage, so it arms nothing either — the same gate
-    /// [`Self::scroll`] applies to a clamped motion.
+    /// and reports no damage, so it arms nothing either.
     ///
     /// The placements the new geometry strands reach the next pump as a
     /// [`VtSignal::WebviewEvicted`] signal; no PTY output is needed to
@@ -281,7 +269,7 @@ impl<V: Vt> OrzmaTty<V> {
     }
 
     /// Removes the placements the host names, arming the coalescer only
-    /// when one actually went so an unchanged frame is not woken.
+    /// when one actually went.
     pub fn remove_placements(&mut self, instances: &[InstanceId]) {
         if self.vt.remove_placements(instances) {
             self.coalescer.arm_or_extend(Instant::now());
@@ -289,9 +277,9 @@ impl<V: Vt> OrzmaTty<V> {
     }
 
     /// Registers a host-driven mount at the visible cell (`row`, `column`)
-    /// and queues the VT's verdict as the signal the mux forwards: an
-    /// accepted mount arms the coalescer and queues `WebviewMount`, a
-    /// rejected one queues `WebviewMountRejected` without arming.
+    /// and queues the VT's verdict as a signal: an accepted mount arms
+    /// the coalescer and queues `WebviewMount`, a rejected one queues
+    /// `WebviewMountRejected` without arming.
     pub fn mount_placement_at(
         &mut self,
         instance: InstanceId,
@@ -311,7 +299,7 @@ impl<V: Vt> OrzmaTty<V> {
     /// Encodes a key press and writes it to the PTY.
     ///
     /// Snaps a scrolled-back viewport to the live tail first
-    /// (scroll-on-input policy) so the echo is visible.
+    /// (scroll-on-input policy).
     pub fn send_key(&mut self, key: &TerminalKey, mods: &TerminalModifiers) -> OrzmaTtyResult {
         let modes = self.vt.modes();
         self.snap_to_live_tail();
@@ -322,24 +310,21 @@ impl<V: Vt> OrzmaTty<V> {
     /// Encodes one mouse report in the terminal's active mouse encoding
     /// and writes it to the PTY.
     ///
-    /// Deliberately does NOT snap a scrolled-back viewport: the
-    /// report's cell coordinates were computed by the host against the
-    /// viewport the user is looking at, so yanking the view to the live
-    /// tail on every report would make the screen jump under the
-    /// pointer.
+    /// Does not snap a scrolled-back viewport: the report's cell
+    /// coordinates are the ones the host computed against the viewport on
+    /// screen.
     pub fn send_mouse(&mut self, report: MouseReport) -> OrzmaTtyResult {
         let sequence = report.encode(self.vt.modes().mouse_encoding);
         self.pty.write_all(&sequence)
     }
 
     /// Writes a paste of clipboard text to the PTY, honouring
-    /// bracketed-paste mode (DECSET 2004) via [`PtyInput::encode_paste`].
+    /// bracketed-paste mode (DECSET 2004).
     ///
     /// Empty text is a no-op: nothing reaches the PTY. Otherwise a
     /// scrolled-back viewport snaps to the live tail first
     /// (scroll-on-input policy), and the whole frame goes out in a
-    /// single write — a partially-written frame would leave the
-    /// receiving app inside an unterminated paste.
+    /// single write.
     pub fn send_paste(&mut self, text: &str) -> OrzmaTtyResult {
         if text.is_empty() {
             return Ok(());
@@ -382,8 +367,7 @@ impl<V: Vt> OrzmaTty<V> {
     /// Emits the pending signals and an immediate frame without reading
     /// the PTY or waiting for the coalesce window.
     ///
-    /// Used after a resize so the repaint travels with the new layout.
-    /// Never reports `ChildExit`; that stays with [`Self::pump`].
+    /// Never reports `ChildExit`.
     pub fn flush_now(&mut self) -> PumpOutput {
         let signals = mem::take(&mut self.pending_signals);
         let frame = self.emit_frame();
@@ -452,10 +436,6 @@ impl<V: Vt> OrzmaTty<V> {
     /// Sizes the VT grid, arming the coalescer when the grid changed
     /// and queuing the placements the change stranded for the next
     /// pump.
-    ///
-    /// Both constructors and [`Self::resize`] size the VT through this
-    /// one path, so a VT handed in with placements mounted reports what
-    /// the initial sizing strands exactly as a later resize would.
     fn resize_vt(&mut self, size: GridSize) {
         let Some(changed) = self.vt.resize(size) else {
             return;
@@ -467,8 +447,7 @@ impl<V: Vt> OrzmaTty<V> {
     }
 
     /// Snaps a scrolled-back viewport to the live tail (scroll-on-input
-    /// policy), gated on [`Vt::is_at_live_tail`] so a no-op call stages
-    /// no damage.
+    /// policy); a viewport already at the live tail stages no damage.
     fn snap_to_live_tail(&mut self) {
         if !self.vt.is_at_live_tail() {
             self.scroll(Scroll::Bottom);
@@ -684,8 +663,8 @@ mod tests {
     /// Asserts that `flush_now` returns the pending signals and an
     /// immediate frame without reading the PTY.
     ///
-    /// Case: the backend resized a pane and wants the repaint in the same
-    /// batch as the new layout, before the coalescer window closes.
+    /// Case: the backend resizes a pane and sends its repaint in the same
+    /// batch as the new layout.
     #[test]
     fn flush_now_returns_pending_signals_and_an_immediate_frame() {
         let (mut tty, chunk_tx, _exit_tx) = channelled_term();
@@ -709,9 +688,8 @@ mod tests {
         );
     }
 
-    /// A minimal frame for scripting `FakeVt::frames`; the values are
-    /// arbitrary placeholders, since these tests only care whether a
-    /// frame came back, not its contents.
+    /// A minimal frame for scripting `FakeVt::frames`; its values are
+    /// arbitrary placeholders.
     fn a_frame() -> Frame {
         Frame {
             size: GridSize { cols: 80, rows: 24 },
@@ -766,8 +744,7 @@ mod tests {
     /// exactly one frame, not two.
     ///
     /// Case: the shell prints its prompt before the host's first pump
-    /// call after spawn, so the bootstrap debt and a real armed window
-    /// are both live at once.
+    /// call after spawn.
     #[test]
     fn a_pre_pump_chunk_does_not_double_emit_the_bootstrap_frame() {
         let (mut tty, _sink) = detached_term();
@@ -783,9 +760,8 @@ mod tests {
     /// Asserts that a detached terminal's resize round-trips through the
     /// fake master and that pumping it never reports a child exit.
     ///
-    /// Case: a `src/` fixture builds a terminal the same way dozens of
-    /// unit tests in this workspace do, resizes it to the test window,
-    /// and pumps it for a few frames.
+    /// Case: a fixture builds a detached terminal, resizes it to the test
+    /// window, and pumps it for a few frames.
     #[test]
     fn detached_resizes_through_the_fake_master_and_never_exits() {
         let sink = CaptureSink::default();
@@ -824,7 +800,7 @@ mod tests {
     /// arms nothing.
     ///
     /// Case: the host pumps a quiet terminal that has no webviews
-    /// mounted, which is every pump on a plain shell session.
+    /// mounted.
     #[test]
     fn a_pump_with_nothing_evicted_raises_nothing() {
         let (mut tty, _sink) = detached_term();
@@ -875,11 +851,8 @@ mod tests {
         );
     }
 
-    /// Asserts that a resize never writes through the PTY writer.
-    ///
-    /// The size change reaches the child as a kernel ioctl, so the
-    /// decided policy is that nothing at all enters the byte stream —
-    /// not even an XTWINOPS report.
+    /// Asserts that a resize never writes through the PTY writer, not
+    /// even an XTWINOPS report.
     ///
     /// Case: the user resizes the window while a program is reading
     /// stdin.
@@ -924,11 +897,8 @@ mod tests {
         assert!(term.coalescer.is_armed());
     }
 
-    /// Asserts that a zero-axis request touches neither the PTY size
-    /// nor the VT.
-    ///
-    /// The agreed policy is to ignore such a request outright rather
-    /// than clamp it.
+    /// Asserts that a zero-axis request is ignored rather than clamped,
+    /// touching neither the PTY size nor the VT.
     ///
     /// Case: a minimized window, or a frame before cell metrics load,
     /// computes 0 for an axis.
@@ -950,7 +920,7 @@ mod tests {
     }
 
     /// Asserts the per-axis cap: requests beyond `MAX_COLS` /
-    /// `MAX_ROWS` are ignored, the boundary value is applied.
+    /// `MAX_ROWS` are ignored, while the boundary value is applied.
     ///
     /// Case: a degenerate or hostile window geometry asks for a grid
     /// far larger than any real display.
@@ -1031,8 +1001,8 @@ mod tests {
     /// ioctl fails, the call returns `PtyResize` and the VT and
     /// coalescer are untouched.
     ///
-    /// Case: the kernel refuses the winsize ioctl, and the renderer
-    /// must keep drawing the size the child still has.
+    /// Case: the kernel refuses the winsize ioctl while the user resizes
+    /// the window.
     #[test]
     fn a_failing_pty_resize_leaves_the_vt_untouched() {
         let mut term = failing_term();
@@ -1086,11 +1056,8 @@ mod tests {
         assert_eq!(term.coalescer.next_deadline(), deadline);
     }
 
-    /// Asserts that scrolling writes nothing through the PTY writer.
-    ///
-    /// Viewport motion is host-side state, so the decided policy is
-    /// that no bytes reach the child — neither a CSI S/T pair nor
-    /// arrow keys.
+    /// Asserts that scrolling writes nothing through the PTY writer,
+    /// neither a CSI S/T pair nor arrow keys.
     ///
     /// Case: the user scrolls through history while a program is
     /// reading stdin.
@@ -1107,8 +1074,7 @@ mod tests {
     /// scrolled back snaps the viewport to the live tail AND schedules
     /// the repaint of that snap.
     ///
-    /// Case: the user scrolls into history and then pastes, expecting
-    /// the view to jump back to the prompt where the echo lands.
+    /// Case: the user scrolls into history and then pastes at the prompt.
     #[test]
     fn paste_while_scrolled_back_snaps_and_arms() {
         let (mut term, _sink) = detached_term();
@@ -1127,8 +1093,8 @@ mod tests {
 
     /// Asserts that key encoding consults the VT-reported DECCKM state.
     ///
-    /// Case: an arrow key pressed in a full-screen app that enabled
-    /// application cursor keys, then again at a plain prompt.
+    /// Case: the user presses an arrow key in a full-screen app that
+    /// enabled application cursor keys, then again at a plain prompt.
     #[test]
     fn send_key_honours_the_vt_reported_cursor_mode() {
         let (mut term, sink) = detached_term();
@@ -1146,8 +1112,8 @@ mod tests {
     /// Asserts that paste encoding consults the VT-reported bracketed
     /// paste mode.
     ///
-    /// Case: pasting into an app that enabled DECSET 2004 (vim, fzf,
-    /// modern shells).
+    /// Case: the user pastes into an app that enabled DECSET 2004, such
+    /// as vim, fzf, or a modern shell.
     #[test]
     fn send_paste_honours_the_vt_reported_bracketed_mode() {
         let (mut term, sink) = detached_term();
@@ -1169,11 +1135,8 @@ mod tests {
         assert_eq!(sink.contents(), b"hi");
     }
 
-    /// Asserts that `send_paste("")` writes nothing at all.
-    ///
-    /// The decided policy is to write nothing rather than an empty
-    /// bracketed-paste frame, which would still wake the receiving
-    /// program.
+    /// Asserts that `send_paste("")` writes nothing at all, rather than an
+    /// empty bracketed-paste frame.
     ///
     /// Case: the user pastes with an empty clipboard.
     #[test]
@@ -1237,9 +1200,9 @@ mod tests {
     /// Asserts that a `pump` which reports `ChildExit` has already
     /// interpreted every pending output chunk.
     ///
-    /// Case: `echo bye` — the reader thread delivers the final output
-    /// chunk and then the exit report, and the host pumps once after
-    /// both arrived.
+    /// Case: the child runs `echo bye`, so the reader thread delivers the
+    /// final output chunk and then the exit report, and the host pumps
+    /// once after both arrived.
     #[test]
     fn the_final_output_is_interpreted_when_the_exit_is_reported() {
         let (mut term, chunk_tx, exit_tx) = channelled_term();
@@ -1252,8 +1215,7 @@ mod tests {
     /// Asserts that VT signals from interpreted chunks surface as
     /// `TtySignal::Vt`, ahead of a `ChildExit` in the same batch.
     ///
-    /// Case: the shell rings the bell in its final output and exits;
-    /// the host must observe the bell before acting on the exit.
+    /// Case: the shell rings the bell in its final output and exits.
     #[test]
     fn vt_signals_are_forwarded_before_child_exit() {
         let (mut term, chunk_tx, exit_tx) = channelled_term();
@@ -1315,10 +1277,6 @@ mod tests {
     /// Asserts that a chunk which stages no damage leaves the coalesce
     /// window closed.
     ///
-    /// Arming on every non-empty chunk would wake the emit path for
-    /// output that changes nothing on screen, which is what the old
-    /// `verdict.is_some()` check did.
-    ///
     /// Case: a program queries the cursor position, so the VT answers
     /// with reply bytes and touches no cell.
     #[test]
@@ -1334,8 +1292,7 @@ mod tests {
     }
 
     /// Asserts that a host-driven removal arms the coalescer only when a
-    /// placement actually went, so a removal naming nothing does not wake
-    /// the owner for an unchanged frame.
+    /// placement actually went.
     ///
     /// Case: two connections drop in the same tick and the host issues a
     /// removal for each, but only the first names a live placement.
@@ -1374,7 +1331,7 @@ mod tests {
     }
 
     /// Asserts that an accepted host-driven mount queues `WebviewMount`
-    /// for the next pump and arms the coalescer so a frame follows.
+    /// for the next pump and arms the coalescer.
     ///
     /// Case: the control plane relays a socket `mount` from orzmd running
     /// in a Windows pane.

--- a/crates/orzma_tty/src/pty.rs
+++ b/crates/orzma_tty/src/pty.rs
@@ -1,4 +1,5 @@
-//! `Pty` — owns the PTY master, writer, child killer, and the
+//! `Pty` — owns the PTY master, writer, child killer, and the output and
+//! exit streams its OS threads feed.
 
 use crate::{
     CellPixels, SpawnOptions,
@@ -21,10 +22,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 /// PTY ownership for one spawned shell.
-///
-/// `Mutex` is required because `dyn MasterPty + Send` and `dyn Write +
-/// Send` are `!Sync`, while downstream wrappers (`bevy_orzmux`'s
-/// `Component`) need the owning `OrzmaTty` to be `Send + Sync`.
 pub struct Pty {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
@@ -61,17 +58,16 @@ pub enum ExitPoll {
 
 impl Pty {
     /// How many reader chunks may wait unparsed before the reader thread
-    /// parks: 256 × 4 KiB = 1 MiB per pane, matching Alacritty's ceiling.
+    /// parks: 256 × 4 KiB = 1 MiB per pane.
     pub const CHUNK_QUEUE_CAPACITY: usize = 256;
 
     /// Opens a PTY at the given grid size, spawns `options.shell` under
-    /// it as a login shell, and starts the blocking reader/wait OS
-    /// thread.
+    /// it (as a login shell on macOS), and starts the blocking OS thread
+    /// (two on Windows) that reads its output and waits for the child.
     ///
     /// On Windows, ConPTY writes `CSI 6 n` before it starts the child and
     /// holds the child until a cursor-position report arrives; the owner
-    /// must write that reply through [`Self::write_all`]. `OrzmaTty` does
-    /// so with the VT's replies (see `Screen::cursor_position_report`).
+    /// must write that reply through [`Self::write_all`].
     pub fn spawn(options: &SpawnOptions) -> OrzmaTtyResult<Self> {
         let (pixel_width, pixel_height) = options.cell_px.window_pixels(options.cols, options.rows);
         let pty_pair = native_pty_system()
@@ -145,13 +141,13 @@ impl Pty {
         !self.chunk_rx.is_empty()
     }
 
-    /// The output stream, for a `Select` that waits on many terminals.
+    /// The PTY output stream.
     #[inline]
     pub fn chunk_receiver(&self) -> &Receiver<Vec<u8>> {
         &self.chunk_rx
     }
 
-    /// The exit stream, for a `Select` that waits on many terminals.
+    /// The child-exit stream.
     #[inline]
     pub fn exit_receiver(&self) -> &Receiver<Option<i32>> {
         &self.exit_rx
@@ -171,9 +167,8 @@ impl Pty {
     /// with the pixel fields set to the total window pixels
     /// `cell_px × cells` (see [`CellPixels::window_pixels`]).
     ///
-    /// A no-policy wrapper: forwards the cell counts verbatim (validation
-    /// is `OrzmaTty::resize`'s job) and maps the master's error to
-    /// [`OrzmaTtyError::PtyResize`].
+    /// Forwards the cell counts verbatim, without validating them, and
+    /// maps the master's error to [`OrzmaTtyError::PtyResize`].
     pub fn resize(&mut self, cols: u16, rows: u16, cell_px: CellPixels) -> OrzmaTtyResult {
         let (pixel_width, pixel_height) = cell_px.window_pixels(cols, rows);
         self.master
@@ -191,8 +186,8 @@ impl Pty {
     /// Reads the master's current size back from the kernel
     /// (`TIOCGWINSZ`).
     ///
-    /// Panics on ioctl failure — the master fd is no longer valid at
-    /// that point (see `OrzmaTty::pty_size`).
+    /// Panics on ioctl failure, which means the master fd is no longer
+    /// valid.
     pub fn size(&self) -> PtySize {
         self.master
             .lock()
@@ -204,11 +199,6 @@ impl Pty {
     /// Opens a real PTY at the given grid size but routes writes to
     /// `writer` instead of the master, spawning no child process and no
     /// reader thread.
-    ///
-    /// `orzma_tty`'s own `#[cfg(test)]` tests are the only remaining
-    /// caller — `OrzmaTty::detached` builds around
-    /// [`crate::test_support::RecordingMaster`] instead so that
-    /// downstream test fixtures never open a real PTY.
     #[cfg(test)]
     pub fn detached(cols: u16, rows: u16, writer: Box<dyn Write + Send>) -> OrzmaTtyResult<Self> {
         let pty_pair = native_pty_system()
@@ -223,8 +213,7 @@ impl Pty {
     }
 
     /// Builds a `Pty` around an arbitrary master and writer, with no
-    /// child process and no reader thread — lets tests inject a fake
-    /// master (e.g. one whose `resize` fails).
+    /// child process and no reader thread.
     #[cfg(any(test, feature = "test-support"))]
     pub fn with_master(master: Box<dyn MasterPty + Send>, writer: Box<dyn Write + Send>) -> Self {
         let (chunk_tx, chunk_rx) = unbounded::<Vec<u8>>();
@@ -240,8 +229,8 @@ impl Pty {
     }
 
     /// Builds a `Pty` like [`Self::with_master`], but with the chunk
-    /// and exit streams fed by the given receivers — lets tests inject
-    /// PTY output and child-exit reports.
+    /// and exit streams fed by the given receivers, so the caller
+    /// supplies the PTY output and the child-exit reports.
     #[cfg(any(test, feature = "test-support"))]
     pub fn with_master_and_channels(
         master: Box<dyn MasterPty + Send>,
@@ -267,9 +256,8 @@ impl Drop for Pty {
 
 /// Builds the shell `CommandBuilder`: on macOS the shell is wrapped in
 /// `/usr/bin/login` so it runs as a login shell and sources
-/// `/etc/zprofile` (`path_helper`) and `~/.zprofile` — without that, an
-/// app launched from Finder runs under launchd's minimal `PATH`. Every
-/// other platform spawns the shell directly.
+/// `/etc/zprofile` (`path_helper`) and `~/.zprofile`. Every other
+/// platform spawns the shell directly.
 fn build_shell_command(shell: &str) -> CommandBuilder {
     #[cfg(target_os = "macos")]
     {
@@ -313,8 +301,7 @@ fn master_pipes(
     Ok((master.try_clone_reader()?, master.take_writer()?))
 }
 
-/// What the reader thread reports about its progress, shared with
-/// whoever needs to know whether output is still flowing.
+/// What the reader thread reports about its progress.
 struct ReaderProgress {
     /// When the reader last completed a read or a send.
     last_activity: Mutex<Instant>,
@@ -355,16 +342,13 @@ impl ReaderProgress {
 ///
 /// `progress` is stamped after every completed read and again after a
 /// blocking `send` returns, and its parked flag holds from the moment
-/// `try_send` finds the queue full until the blocking `send` returns, so
-/// a watcher can tell a reader parked on a full queue from one whose
-/// child went quiet.
+/// `try_send` finds the queue full until the blocking `send` returns.
 ///
 /// # Invariants
 ///
 /// The stamp after a blocking `send` is written before the parked flag
-/// clears. A watcher that observes the flag clear therefore also sees
-/// the fresh stamp, so it cannot pair "not parked" with the stale read
-/// stamp and report the exit early.
+/// clears, so a watcher that observes the flag clear also sees the fresh
+/// stamp.
 fn forward_chunks(reader: &mut dyn Read, chunk_tx: &Sender<Vec<u8>>, progress: &ReaderProgress) {
     let mut buf = [0u8; 4096];
     loop {
@@ -393,9 +377,6 @@ fn forward_chunks(reader: &mut dyn Read, chunk_tx: &Sender<Vec<u8>>, progress: &
 /// Spawns a dedicated OS thread that drains PTY output into `chunk_tx`
 /// and sends a single `exit_tx` message (`Some(code)` on graceful exit,
 /// `None` on wait failure) once the reader returns 0 or errors out.
-///
-/// The OS thread (vs. an async task) is required because the PTY read
-/// syscall is blocking.
 #[cfg(unix)]
 fn spawn_reader_thread(
     mut reader: Box<dyn Read + Send>,
@@ -421,15 +402,11 @@ fn spawn_reader_thread(
 /// second thread that waits for the child and sends the single `exit_tx`
 /// message once the output has gone quiet.
 ///
-/// ConPTY keeps the output pipe open after the child exits until the
-/// pseudoconsole is closed, so the reader cannot learn about the exit from
-/// EOF the way the Unix reader does. The watcher waits [`OUTPUT_QUIESCENCE`]
-/// after the reader's last completed read or send, as reported through its
-/// [`ReaderProgress`], and only while the reader is not parked on a full
-/// queue, so the child's final output is queued before the exit is
-/// reported; `OrzmaTty::pump` then reports `ChildExit` only once
-/// the queue is drained. The reader ends when the master is dropped by the
-/// pane teardown the exit triggers.
+/// The watcher waits [`OUTPUT_QUIESCENCE`] after the reader's last completed
+/// read or send, and only while the reader is not parked on a full queue,
+/// so the child's final output is queued before the exit is reported.
+/// The reader sees no EOF at the child's exit and ends when the master is
+/// dropped or a send finds the receiver gone.
 #[cfg(windows)]
 fn spawn_reader_thread(
     mut reader: Box<dyn Read + Send>,
@@ -453,8 +430,7 @@ fn spawn_reader_thread(
 const OUTPUT_QUIESCENCE: Duration = Duration::from_millis(50);
 
 /// The longest the watcher lets an unparked reader stream after the
-/// child exits, so a pseudoconsole that keeps streaming cannot delay
-/// the exit forever.
+/// child exits.
 #[cfg(windows)]
 const OUTPUT_QUIESCENCE_CAP: Duration = Duration::from_secs(2);
 
@@ -466,18 +442,14 @@ const QUIESCENCE_POLL_FLOOR: Duration = Duration::from_millis(10);
 /// completed for `quiescence`, or until the reader has spent `cap` in
 /// total not parked.
 ///
-/// A parked reader is not streaming, so time spent parked counts
-/// toward neither the idle window nor the cap: the exit is not reported
-/// while the child's output still waits in the pipe behind a full
-/// queue. The send stamp restarts the idle window on unpark, so a send
-/// that parked longer than the window cannot make the watcher fire
-/// before the next read completes.
+/// Time spent parked counts toward neither the idle window nor the cap,
+/// so the call does not return while the child's output still waits in
+/// the pipe behind a full queue. An unpark restarts the idle window from
+/// the send stamp.
 ///
-/// An interval counts toward the cap only when both of its polls find
-/// the reader unparked; a park that spans a poll is never charged,
-/// while one that fits inside a single interval still is. With the
-/// production poll rate that over-count is bounded by one interval per
-/// park.
+/// The unparked total is measured per poll interval: a park that spans
+/// a poll is never charged to the cap, while one that fits inside a
+/// single interval still is.
 #[cfg(any(windows, test))]
 fn wait_for_output_quiescence(progress: &ReaderProgress, quiescence: Duration, cap: Duration) {
     let mut unparked = Duration::ZERO;
@@ -550,10 +522,8 @@ mod tests {
     /// Asserts that a resize round-trips through the kernel: the size
     /// read back via `TIOCGWINSZ` is the size just applied.
     ///
-    /// Case: the wrapper's one real side effect. The non-square 120x40
-    /// pins the argument-to-field mapping — the method takes
-    /// `(cols, rows)` while `PtySize` declares `rows` first, so a
-    /// transposition compiles silently and swaps every grid dimension.
+    /// Case: the host applies a non-square 120x40 geometry to a pane's
+    /// PTY, and a program reads the size back with `TIOCGWINSZ`.
     #[test]
     fn resize_applies_the_size_to_the_kernel() {
         let mut pty = Pty::detached(80, 24, Box::new(sink())).expect("Pty::detached");
@@ -566,7 +536,7 @@ mod tests {
     /// pixel fields, not the per-cell pitch.
     ///
     /// Case: the host reports an 8×16 px cell and resizes the pane to
-    /// 100×40; a program reading `TIOCGWINSZ` must see 800×640.
+    /// 100×40 while a program reads `TIOCGWINSZ`.
     #[test]
     fn resize_writes_the_total_window_pixels() {
         let (master, calls) = RecordingMaster::at(80, 24);
@@ -585,14 +555,11 @@ mod tests {
         assert_eq!((last.pixel_width, last.pixel_height), (800, 640));
     }
 
-    /// Asserts that degenerate sizes are forwarded verbatim, one master
-    /// call per request.
+    /// Asserts that degenerate sizes are forwarded verbatim rather than
+    /// validated, one master call per request.
     ///
-    /// Case: the layering pin. The zero-axis / oversize policy lives
-    /// only in `OrzmaTty::resize`; this wrapper must not validate. A
-    /// guard sneaking in here would duplicate the policy and let the
-    /// two layers drift (one clamping while the other ignores) without
-    /// any layered test noticing.
+    /// Case: a caller hands the PTY a zero-axis geometry, such as the one
+    /// a minimized window computes.
     #[test]
     fn resize_forwards_degenerate_sizes_verbatim() {
         let (master, calls) = RecordingMaster::at(80, 24);
@@ -613,10 +580,8 @@ mod tests {
     /// Asserts that a master resize failure surfaces as
     /// `OrzmaTtyError::PtyResize`.
     ///
-    /// Case: the error-taxonomy pin, mirroring `write_all` →
-    /// `PtyWrite`. `OrzmaTty::resize`'s failure-atomicity branch and
-    /// the bevy layer's `error!` log both identify the failing
-    /// subsystem by this variant.
+    /// Case: the kernel refuses the winsize ioctl when the host resizes a
+    /// pane.
     #[test]
     fn a_failing_master_maps_to_pty_resize_error() {
         let mut pty = Pty::with_master(Box::new(FailingMaster), Box::new(sink()));
@@ -713,8 +678,7 @@ mod tests {
     /// Asserts that the child's last output is delivered before its
     /// exit is reported.
     ///
-    /// Case: a Windows shell prints a farewell line and exits; the pane
-    /// must show the line before it closes.
+    /// Case: a Windows shell prints a farewell line and exits.
     #[cfg(windows)]
     #[test]
     fn the_final_output_precedes_the_exit_report() {

--- a/crates/orzma_tty/src/signal.rs
+++ b/crates/orzma_tty/src/signal.rs
@@ -1,5 +1,5 @@
-//! Terminal-level signals: the VT-stream signals plus process
-//! lifecycle events the VT cannot observe.
+//! Terminal-level signals: the signals the VT stream raises plus the
+//! child process's lifecycle events.
 
 use orzma_vt::prelude::VtSignal;
 
@@ -7,7 +7,7 @@ use orzma_vt::prelude::VtSignal;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TtySignal {
     /// The child shell exited; `code` is `None` if the `wait` itself
-    /// failed. Fired exactly once per terminal.
+    /// failed. Fired at most once per terminal.
     ChildExit { code: Option<i32> },
     /// A signal the VT raised — one an interpreted chunk produced, or the
     /// eviction a resize reported.

--- a/crates/orzma_tty/src/test_support.rs
+++ b/crates/orzma_tty/src/test_support.rs
@@ -1,6 +1,5 @@
-//! Test-support seam: an in-memory sink observing the PTY write path,
-//! a scriptable [`Vt`] fake, plus crate-internal `MasterPty` fakes for
-//! the resize seam.
+//! Test-support seam: fakes that drive [`crate::OrzmaTty`] without a real
+//! PTY, child process, or VT emulator.
 
 use orzma_vt::prelude::{
     CellSide, DisplayOffset, Frame, GridColumn, GridPoint, GridSize, InstanceId, InterpretOutput,
@@ -18,8 +17,8 @@ use std::sync::{Arc, Mutex};
 
 /// Cloneable in-memory `Write` sink capturing every byte written to it.
 ///
-/// Clones share one buffer: hand one clone to `crate::OrzmaTty::detached`
-/// as the PTY writer and keep another to assert on [`CaptureSink::contents`].
+/// Clones share one buffer, so a clone handed out as the PTY writer and a
+/// clone kept for [`CaptureSink::contents`] see the same bytes.
 #[derive(Clone, Default)]
 pub struct CaptureSink(Arc<Mutex<Vec<u8>>>);
 
@@ -45,15 +44,14 @@ impl Write for CaptureSink {
 /// emulator.
 ///
 /// `interpret` records each chunk and pops the next scripted update; an
-/// empty script yields an update with `damaged: true`, matching the
-/// window-arming behavior of a real interpreted chunk when no test
-/// script overrides it. `resize` applies honestly (`None` when the
-/// size did not change) and names the next scripted `evictions` entry
-/// when it did. `scroll` records the motion:
-/// `Scroll::Bottom` snaps `display_offset` to zero, every other motion
-/// returns the scripted `scroll_moves`. The selection operations return
-/// the scripted `selection_changes` and `selection_text` is always
-/// `None`.
+/// empty script yields an update with `damaged: true`. `resize` applies
+/// honestly (`None` when the size did not change) and names the next
+/// scripted `evictions` entry when it did.
+///
+/// `scroll` records the motion: `Scroll::Bottom` snaps `display_offset`
+/// to zero, and every other motion returns the scripted `scroll_moves`.
+/// The selection operations return the scripted `selection_changes`, and
+/// `selection_text` is always `None`.
 pub struct FakeVt {
     /// Grid size reported and updated by `resize`.
     pub grid_size: GridSize,
@@ -61,10 +59,9 @@ pub struct FakeVt {
     pub display_offset: DisplayOffset,
     /// Device-wide terminal modes the host reads back.
     ///
-    /// This fake pops its frames from a scripted queue, so a mode that a
-    /// real [`crate::OrzmaTty`] would fold into the frame — DECTCEM's
-    /// cursor visibility, for one — is not honored here. Script the
-    /// frame to match, rather than expecting this field to drive it.
+    /// A mode that would show up in a frame — DECTCEM's cursor
+    /// visibility, for one — does not reach the scripted frames; script
+    /// the frame to match instead.
     pub modes: VtModes,
     /// Scripted return for non-`Bottom` scrolls.
     pub scroll_moves: bool,
@@ -193,8 +190,7 @@ impl Vt for FakeVt {
     }
 }
 
-/// `MasterPty` whose `resize` always fails, for pinning failure paths
-/// (`Pty::resize` error mapping, `OrzmaTty::resize` atomicity).
+/// `MasterPty` whose `resize` always fails.
 #[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct FailingMaster;
@@ -233,9 +229,8 @@ impl MasterPty for FailingMaster {
     }
 }
 
-/// `MasterPty` recording every `PtySize` handed to `resize`, so tests
-/// can assert the exact struct the caller forwarded (field mapping and
-/// pixel-zero policy are unobservable through kernel readback alone).
+/// `MasterPty` recording every `PtySize` handed to `resize`, so a caller
+/// can assert the exact struct that was forwarded.
 ///
 /// It also answers `get_size` with whatever it was last resized to, so
 /// a caller that writes a size and reads it back sees what a real

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -1,10 +1,4 @@
 //! The character-terminal device this VT emulates.
-//!
-//! [`DeviceState`] is the device model, not a layer of its own: the
-//! screens with their write cursors, the DECSET modes, the tab stops,
-//! the color table, and the title stack. `OrzmaTty` one crate up is
-//! the live terminal — a VT wired to a PTY — so the device the VT
-//! emulates deliberately does not borrow that name.
 
 pub(crate) mod color;
 pub(crate) mod modes;
@@ -22,12 +16,6 @@ use std::collections::VecDeque;
 
 /// The emulated terminal device: screens, modes, tabs, colors, title,
 /// and the terminal-scoped placement invariants.
-///
-/// It owns no parser, damage, or emission state — those are the VT's own
-/// machinery and sit beside it in [`crate::OrzmaVt`]. The placement
-/// table itself belongs to each [`Screen`]; what lives here is only what
-/// one screen cannot decide alone: the cap across the pair, and a live
-/// id's uniqueness across it.
 pub(crate) struct DeviceState {
     screens: Screens,
     modes: VtModes,
@@ -38,9 +26,8 @@ pub(crate) struct DeviceState {
 impl DeviceState {
     /// Builds a blank device with the primary screen active.
     ///
-    /// The alternate screen is built without scrollback: a full-screen
-    /// application has nothing to scroll back to, and its viewport stays
-    /// pinned to the live tail.
+    /// The alternate screen is built without scrollback, so its viewport
+    /// stays pinned to the live tail.
     pub fn new(size: GridSize, max_history: usize) -> Self {
         Self::assert_nonzero_size(size);
         Self {
@@ -75,30 +62,18 @@ impl DeviceState {
     /// Resizes both screens, truncating rather than reflowing; `None`
     /// when the dimensions already matched.
     ///
+    /// The caller must reject a size with a zero axis before it reaches
+    /// this method.
+    ///
+    /// Placements this strands are not named here: their anchors stop
+    /// resolving, and the next [`Self::evict_lost_anchors`] names them.
+    ///
     /// # Invariants
     ///
-    /// A resize that changes the dimensions must report
-    /// [`DamageSpan::Full`]: every emitted frame carries the new size but
-    /// nothing diffs it, so partial row damage would hand the renderer
-    /// new dimensions with stale rows behind them.
+    /// A resize that changes the dimensions reports [`DamageSpan::Full`].
     ///
-    /// Both axes are nonzero. A zero row count underflows
-    /// `Margins::new`, which [`Self::new`] already reaches through
-    /// `Screen::new`, so construction asserts the same precondition
-    /// before this method is ever called.
-    ///
-    /// Both screens are always the same size, so they always agree on
-    /// whether the dimensions changed; the primary's answer stands for
-    /// the pair, whichever one is on show.
-    ///
-    /// Placements this strands are not named here. The anchors simply
-    /// stop resolving, and [`crate::Vt::resize`] names them through
-    /// [`Self::evict_lost_anchors`] — the same contract
-    /// [`Screen::reset`] relies on.
-    ///
-    /// Reflow would land in `Grid`, on a wrap flag `Screen::print` sets
-    /// where it defers a wrap; the placement table would then need each
-    /// anchor re-pointed at the row its content survived on.
+    /// Both grid axes are nonzero, and both screens are always the same
+    /// size.
     pub fn resize(&mut self, size: GridSize) -> Option<DamageSpan> {
         Self::assert_nonzero_size(size);
         let primary = self.screens.primary.resize(size);
@@ -118,10 +93,7 @@ impl DeviceState {
     ///
     /// # Invariants
     ///
-    /// A motion that moves the viewport must report [`DamageSpan::Full`]:
-    /// the emit-time offset diff only guarantees that a frame is
-    /// emitted, not that it carries rows, so anything less would
-    /// repaint stale content at the new offset.
+    /// A motion that moves the viewport reports [`DamageSpan::Full`].
     pub fn scroll(&mut self, scroll: Scroll) -> Option<DamageSpan> {
         self.active_screen_mut().scroll(scroll)
     }
@@ -129,19 +101,13 @@ impl DeviceState {
     /// Returns both screens and every mode to their power-up state;
     /// `None` when the frame that follows needs no repaint.
     ///
-    /// # Invariants
-    ///
     /// Only the screen left active by the mode reset reaches a frame, so
     /// the alternate screen's damage is dropped rather than folded in.
     /// A reset that arrives while the alternate screen is shown always
-    /// repaints, because the implicit return to the primary screen
-    /// replaces the whole viewport.
+    /// repaints.
     ///
-    /// The title is cleared too: `self.title` returns to
-    /// [`TitleState::default`], dropping both the current title and the
-    /// whole save stack. This is a deliberate departure from alacritty,
-    /// which clears its title silently and leaves the host showing a
-    /// stale one.
+    /// The title is cleared too, dropping both the current title and the
+    /// whole save stack.
     ///
     /// # Control Functions
     ///
@@ -182,9 +148,8 @@ impl DeviceState {
     /// # Control Functions
     ///
     /// - `XTWINOPS` (`CSI 22 t`); the icon/window selector and the
-    ///   direct slot number xterm accepts after it are both ignored,
-    ///   because this terminal carries one title and no addressable
-    ///   slots, so a slot store arrives here as an ordinary push.
+    ///   direct slot number xterm accepts after it are both ignored, so
+    ///   a slot store arrives here as an ordinary push.
     pub fn push_title(&mut self) {
         if self.title.stack.len() == MAX_TITLE_DEPTH {
             self.title.stack.pop_front();
@@ -201,9 +166,9 @@ impl DeviceState {
     ///
     /// # Control Functions
     ///
-    /// - `XTWINOPS` (`CSI 23 t`); its sub-parameters are ignored on the
-    ///   same terms as [`DeviceState::push_title`]'s, so a slot fetch
-    ///   arrives here as an ordinary pop.
+    /// - `XTWINOPS` (`CSI 23 t`); the icon/window selector and the
+    ///   direct slot number xterm accepts after it are both ignored, so
+    ///   a slot fetch arrives here as an ordinary pop.
     pub fn pop_title(&mut self) -> Option<Option<String>> {
         self.title.stack.pop_back()
     }
@@ -221,10 +186,8 @@ impl DeviceState {
     /// The cursor an emitted frame carries: the active screen's write
     /// position with this device's DECTCEM state folded in.
     ///
-    /// Every caller that needs a frame-ready cursor goes through here.
-    /// Reading the screen and the mode separately is what lets a caller
-    /// pair a fresh screen with a stale mode, which silently drops a
-    /// `CSI ? 25 l` from the chunk-liveness diff.
+    /// A frame-ready cursor must be read through here rather than by
+    /// pairing a screen read with a separately-read mode.
     pub fn cursor(&self) -> Cursor {
         self.active_screen().cursor(self.modes.text_cursor_enable)
     }
@@ -234,7 +197,7 @@ impl DeviceState {
         self.modes
     }
 
-    /// Returns the mutable reference of [VtModes].
+    /// Mutably borrows the modes the device owns.
     pub fn modes_mut(&mut self) -> &mut VtModes {
         &mut self.modes
     }
@@ -247,11 +210,8 @@ impl DeviceState {
     /// STD-070 lists only the reset direction among the operations that
     /// clear the last-column flag.
     ///
-    /// The disarm is load-bearing, not a convenience. Without it a
-    /// reset followed by a set with no print in between would leave a
-    /// stale flag for the next character to cash in as a wrap. It does
-    /// not reach a checkpoint, so a reset that restores one (`DECRC`,
-    /// 1048, 1049) puts the saved flag back.
+    /// The disarm does not reach a checkpoint, so a later restore
+    /// (`DECRC`, 1048, 1049) puts the saved flag back.
     ///
     /// # Control Functions
     ///
@@ -270,11 +230,6 @@ impl DeviceState {
     }
 
     /// Switches the active screen without a flip's side effects.
-    ///
-    /// The production path is [`Self::switch_screen`], driven by the
-    /// interpreter's alternate-screen modes, which tears down the
-    /// abandoned alternate screen's placements; the placement tests use
-    /// this to reach the other screen while leaving every table intact.
     #[cfg(test)]
     pub(crate) fn set_active_screen_for_test(&mut self, kind: ScreenKind) {
         self.modes.active_screen = kind;
@@ -283,17 +238,16 @@ impl DeviceState {
 
 /// Webview placements.
 ///
-/// These terminal-scoped invariants live here because neither screen can
-/// satisfy them alone: the cap counts both screens, and a live id is
-/// unique across the pair.
+/// The cap counts both screens, and a live id is unique across the
+/// pair.
 impl DeviceState {
     /// Registers a mount at the active screen's cursor under the id the
     /// host minted; `false` when the cap rejects it.
     ///
     /// # Invariants
     ///
-    /// Supersession runs before the cap check: a re-mount frees the slot
-    /// it takes, so it must succeed even at the limit.
+    /// A re-mount of a live id frees the slot it takes, so it succeeds
+    /// even at the cap.
     pub fn mount_placement(&mut self, size: PlacementSize, id: InstanceId) -> bool {
         self.supersede_placement(id);
         if MAX_PLACEMENTS <= self.placement_count() {
@@ -309,8 +263,8 @@ impl DeviceState {
     ///
     /// # Invariants
     ///
-    /// Supersession runs before the cap check, as for
-    /// [`Self::mount_placement`].
+    /// A re-mount of a live id frees the slot it takes, so it succeeds
+    /// even at the cap.
     pub fn mount_placement_at(
         &mut self,
         row: ScreenLine,
@@ -338,13 +292,7 @@ impl DeviceState {
     /// Removes the placement a client `unmount` addresses on either
     /// screen; returns whether anything went.
     ///
-    /// # Invariants
-    ///
-    /// Every screen is visited — the accumulation must not short-circuit.
-    /// An unmount-all matches on both screens, and the host despawns every
-    /// matching child across the terminal in one pass, so a VT that stopped
-    /// at the first match would keep a placement holding a cap slot whose
-    /// host child is already gone.
+    /// An unmount-all removes the matching placements on both screens.
     pub fn unmount_placement(&mut self, id: Option<InstanceId>) -> bool {
         let primary = self.screens.primary.unmount_placement(id);
         let alternate = self.screens.alternate.unmount_placement(id);
@@ -352,8 +300,7 @@ impl DeviceState {
     }
 
     /// Removes the placements the host names on either screen; returns
-    /// whether anything went. Visits both screens without short-circuiting,
-    /// for the same reason [`Self::unmount_placement`] does.
+    /// whether anything went.
     pub fn remove_placements(&mut self, ids: &[InstanceId]) -> bool {
         let primary = self.screens.primary.remove_placements(ids);
         let alternate = self.screens.alternate.remove_placements(ids);
@@ -365,9 +312,7 @@ impl DeviceState {
     ///
     /// # Invariants
     ///
-    /// The primary screen's ids come first. The order is observable —
-    /// the host acts on the returned list in sequence — and this is the
-    /// only operation that exposes it, so it is fixed here.
+    /// The primary screen's ids come first.
     pub fn evict_lost_anchors(&mut self) -> Vec<InstanceId> {
         let mut evicted = self.screens.primary.evict_lost_anchors();
         evicted.extend(self.screens.alternate.evict_lost_anchors());
@@ -379,8 +324,8 @@ impl DeviceState {
     ///
     /// Primary placements and the primary selection are hidden while the
     /// alternate screen is shown, not destroyed. This operation stages no
-    /// damage of its own: the flip itself must stage `DamageSpan::Full`,
-    /// which carries the changed list.
+    /// damage of its own: the caller must stage `DamageSpan::Full` for
+    /// the flip.
     pub fn switch_screen(&mut self, to: ScreenKind) -> Vec<InstanceId> {
         self.modes.active_screen = to;
         match to {
@@ -404,15 +349,12 @@ impl DeviceState {
 }
 
 /// The primary / alternate pair.
-///
-/// Pure storage: which of the two is shown lives in
-/// [`VtModes::active_screen`], so this struct cannot contradict it.
 struct Screens {
     primary: Screen,
     alternate: Screen,
 }
 
-/// The base palette and its dynamic overrides.
+/// The base palette.
 // TODO: Apply the OSC 4 / 10 / 11 / 12 overrides to the carried
 // palette once their handlers land.
 struct ColorTable {
@@ -428,10 +370,8 @@ struct TitleState {
 
 /// Titles `CSI 22 t` may stack before the oldest is dropped.
 ///
-/// alacritty's 4096 is not spec-derived, and at the title length cap it
-/// would let one program retain about a megabyte of attacker-controlled
-/// text per terminal until the next reset. xterm documents direct stack
-/// access over slots 1 through 10, which this bound covers.
+/// xterm documents direct stack access over slots 1 through 10, which
+/// this bound covers.
 const MAX_TITLE_DEPTH: usize = 16;
 
 #[cfg(test)]
@@ -469,8 +409,7 @@ mod tests {
         assert_eq!(device.display_offset(), DisplayOffset(0));
     }
 
-    /// Asserts that a scroll on the alternate screen reports nothing,
-    /// because that screen keeps no history to move over.
+    /// Asserts that a scroll on the alternate screen reports nothing.
     ///
     /// Case: the user rolls the wheel while a full-screen editor is
     /// showing and alternate-scroll translation is off.
@@ -535,14 +474,8 @@ mod tests {
         assert_eq!(device.evict_lost_anchors(), vec![id]);
     }
 
-    /// Asserts that a stop set on one screen is absent from the other.
-    ///
-    /// The agreed policy gives each screen its own table, so a
-    /// full-screen application cannot disturb the tab positions the
-    /// shell left on the primary screen. xterm, VTE, alacritty,
-    /// wezterm, and Windows Terminal share one table across both
-    /// screens instead; ECMA-48 settles nothing here, because it
-    /// has no alternate screen at all.
+    /// Asserts that a stop set on one screen is absent from the other,
+    /// each screen keeping its own tab stop table rather than sharing one.
     ///
     /// Case: a shell installs its own tab positions, then a full-screen
     /// editor takes over the alternate screen and emits a tab.
@@ -567,14 +500,9 @@ mod tests {
     }
 
     /// Asserts that a checkpoint saved on one screen is unreachable from
-    /// the other.
-    ///
-    /// The agreed policy gives each screen its own checkpoint, so a
-    /// restore on the alternate screen returns its own power-up state
-    /// instead of consuming the save the shell left on the primary.
-    /// VT510 documents a separate `DECSC` buffer only for the main
-    /// display and the status line, so the alternate screen is this
-    /// terminal's own decision.
+    /// the other, so a restore on the alternate screen returns its own
+    /// power-up state instead of consuming the save the shell left on the
+    /// primary.
     ///
     /// Case: a shell saves its cursor, a full-screen editor takes over
     /// the alternate screen and emits a restore of its own, and the
@@ -803,8 +731,7 @@ mod tests {
         assert_eq!(device.placement_count(), 0);
     }
 
-    /// Asserts that a re-mount of a live id is accepted at the cap,
-    /// because supersession frees the slot it takes before the check.
+    /// Asserts that a re-mount of a live id is accepted at the cap.
     ///
     /// Case: a program holding the terminal's last placement slot
     /// re-renders that same view.
@@ -822,8 +749,8 @@ mod tests {
     /// placements the abandoned alternate screen owned and leaves the
     /// primary's alone.
     ///
-    /// Case: a full-screen application that mounted a webview exits, and
-    /// the shell's own webview from before it must survive.
+    /// Case: a full-screen application that mounted a webview exits while
+    /// the shell's own webview from before it is still mounted.
     #[test]
     fn a_flip_to_primary_tears_down_only_the_alternate_placements() {
         let mut device = device();
@@ -886,8 +813,7 @@ mod tests {
     /// Asserts that a full stack drops its oldest entry rather than
     /// refusing the newest, and holds exactly its cap.
     ///
-    /// Case: a runaway program pushes titles in a loop, and the device
-    /// must neither grow without bound nor lose the title just saved.
+    /// Case: a runaway program pushes titles in a loop.
     #[test]
     fn a_full_stack_drops_its_oldest_entry() {
         let mut device = device();
@@ -928,10 +854,6 @@ mod tests {
     }
 
     /// The glyph at `column` of the active screen's `line`th visible row.
-    ///
-    /// `column` is `u16` because `Row<Cell>` implements only
-    /// `Index<u16>` and `Index<GridColumn>`; a `usize` does not fall
-    /// through to the slice impl.
     fn glyph_at(device: &DeviceState, line: u16, column: u16) -> char {
         device.active_screen().viewport_row(ViewportLine(line))[column].c
     }

--- a/crates/orzma_vt/src/device/color.rs
+++ b/crates/orzma_vt/src/device/color.rs
@@ -3,25 +3,18 @@
 
 /// A cell color, carrying its source rather than a resolved value.
 ///
-/// # Invariants
-///
 /// A resolver MUST consult the live [`Palette`] before falling back to a
-/// built-in table. OSC 4 and OSC 104 overwrite palette entries in place,
-/// so resolving [`Color::Indexed`] against a fixed table silently
-/// discards them.
+/// built-in table.
 ///
 /// [`Color::DefaultBackground`] MUST NOT be resolved to the same value as
-/// an equal [`Color::Rgb`]: the default background renders transparent so
-/// webview overlays composite through it, while an explicitly-set
-/// background occludes them.
+/// an equal [`Color::Rgb`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Color {
-    /// The terminal default foreground (`SGR 39`, recolored by OSC 10).
+    /// The terminal default foreground (`SGR 39`).
     DefaultForeground,
-    /// The terminal default background (`SGR 49`, recolored by OSC 11).
+    /// The terminal default background (`SGR 49`).
     DefaultBackground,
-    /// An xterm-256 palette slot (`SGR 38;5` / `SGR 48;5`, recolored by
-    /// OSC 4 and reset by OSC 104).
+    /// An xterm-256 palette slot (`SGR 38;5` / `SGR 48;5`).
     Indexed(u8),
     /// A direct color (`SGR 38;2` / `SGR 48;2`).
     Rgb(Rgb),
@@ -32,12 +25,7 @@ impl Color {
     /// spell; `None` when the selector is not one this terminal answers
     /// or a component does not fit a byte.
     ///
-    /// # Invariants
-    ///
-    /// A component is rejected rather than clamped. Saturating a
-    /// palette index would turn `SGR 38;5;99999` into slot 255 — a
-    /// colour the application never asked for, rather than one it does
-    /// not get.
+    /// A component is rejected rather than clamped.
     pub fn from_sgr(selector: u16, operands: &[u16]) -> Option<Self> {
         match (selector, operands) {
             (5, [index]) => Some(Self::Indexed(u8::try_from(*index).ok()?)),
@@ -53,13 +41,11 @@ impl Color {
     /// The colour one `SGR` selector group's own `:` subparameters
     /// spell, everything after the `38` / `48` / `58` itself.
     ///
-    /// # Invariants
-    ///
-    /// The colour-space slot is optional. `2:Pi:r:g:b` is the spelling
-    /// the standard gives, but many programs omit `Pi` entirely and
-    /// every emulator checked accepts `2:r:g:b`, so the components are
-    /// located by the group's length. Subparameters after blue are the
-    /// tolerance tail the standard permits and are ignored.
+    /// The colour-space slot is optional: a group of five or more
+    /// subparameters reads as `2:Pi:r:g:b`, the spelling the standard
+    /// gives, and a four-element group reads as `2:r:g:b`. Subparameters
+    /// after blue are the tolerance tail the standard permits and are
+    /// ignored.
     pub fn from_sgr_group(subs: &[Option<u16>]) -> Option<Self> {
         let selector = subs.first().copied().flatten()?;
         let mut operands = [0u16; 3];
@@ -103,19 +89,17 @@ pub struct Rgb {
 
 /// The live color table symbolic [`Color`]s resolve against.
 ///
-/// Each slot is pre-resolved: the backend folds OSC 4 / OSC 104
-/// overrides over its built-in xterm table before publishing, so a
-/// consumer indexes this table directly instead of layering override
-/// lookups over a fallback of its own.
+/// Each slot is pre-resolved, so a consumer indexes this table directly
+/// instead of layering override lookups over a fallback of its own.
+///
+/// The table holds the built-in defaults.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Palette {
     /// The 256 xterm palette slots [`Color::Indexed`] addresses.
     pub indexed: Box<[Rgb; 256]>,
-    /// The default foreground [`Color::DefaultForeground`] resolves
-    /// to (recolored by OSC 10).
+    /// The default foreground [`Color::DefaultForeground`] resolves to.
     pub foreground: Rgb,
-    /// The default background [`Color::DefaultBackground`] resolves
-    /// to (recolored by OSC 11).
+    /// The default background [`Color::DefaultBackground`] resolves to.
     pub background: Rgb,
 }
 
@@ -135,8 +119,7 @@ impl Palette {
     /// [`Color::DefaultBackground`] resolves to [`Palette::background`]
     /// like any other slot. A consumer that must keep the transparent
     /// default background distinguishable from an equal explicit RGB
-    /// (see the invariant on [`Color`]) branches on the variant before
-    /// calling this.
+    /// branches on the variant before calling this.
     pub fn resolve(&self, color: Color) -> Rgb {
         match color {
             Color::DefaultForeground => self.foreground,
@@ -147,16 +130,14 @@ impl Palette {
     }
 }
 
-/// The default foreground [`Palette`] carries before any OSC 10
-/// override.
+/// The default foreground [`Palette`] carries.
 const DEFAULT_FOREGROUND: Rgb = Rgb {
     r: 255,
     g: 255,
     b: 255,
 };
 
-/// The default background [`Palette`] carries before any OSC 11
-/// override.
+/// The default background [`Palette`] carries.
 const DEFAULT_BACKGROUND: Rgb = Rgb { r: 0, g: 0, b: 0 };
 
 /// Channel ramp for the 6x6x6 cube portion of the xterm table.
@@ -223,9 +204,9 @@ const ANSI_16: [Rgb; 16] = [
     },
 ];
 
-/// The full 256-slot xterm table [`Color::Indexed`] resolves to before
-/// any OSC 4 override: [`ANSI_16`], the 6x6x6 cube on [`CUBE_RAMP`],
-/// and the grayscale ramp from 8 to 238 in steps of 10.
+/// The full 256-slot xterm table [`Color::Indexed`] resolves to:
+/// [`ANSI_16`], the 6x6x6 cube on [`CUBE_RAMP`], and the grayscale ramp
+/// from 8 to 238 in steps of 10.
 const XTERM_INDEXED: [Rgb; 256] = build_xterm_indexed();
 
 const fn build_xterm_indexed() -> [Rgb; 256] {
@@ -294,8 +275,7 @@ mod tests {
     /// with the xterm defaults.
     ///
     /// Case: a fresh terminal renders `ls --color` output before any
-    /// OSC 4 override arrives, so indexed cells must resolve against
-    /// the stock xterm colors.
+    /// OSC 4 override arrives.
     #[test]
     fn the_default_palette_seeds_the_ansi_base_slots() {
         let palette = Palette::default();
@@ -314,9 +294,7 @@ mod tests {
     /// Asserts that the default palette builds slots 16..=231 from the
     /// 6x6x6 cube with the xterm channel ramp.
     ///
-    /// Case: a TUI picks `SGR 38;5;196` for an error marker and the
-    /// renderer must show the canonical cube red, not an interpolated
-    /// approximation.
+    /// Case: a TUI picks `SGR 38;5;196` for an error marker.
     #[test]
     fn the_default_palette_builds_the_color_cube_from_the_channel_ramp() {
         let palette = Palette::default();
@@ -336,7 +314,7 @@ mod tests {
     /// grayscale ramp from 8 to 238.
     ///
     /// Case: a diff pager shades context lines with high grayscale
-    /// slots, which must land on the xterm gray steps.
+    /// slots.
     #[test]
     fn the_default_palette_ends_with_the_grayscale_ramp() {
         let palette = Palette::default();
@@ -355,9 +333,8 @@ mod tests {
     /// and that distinct colors hash differently.
     ///
     /// Case: a row of terminal output repeats the same indexed color
-    /// across adjacent cells for run coalescing to merge, while a
-    /// separate row switches between the default foreground and
-    /// background for the row-content hash to key on.
+    /// across adjacent cells, while a separate row switches between the
+    /// default foreground and background.
     #[test]
     fn equal_colors_hash_equally() {
         fn digest(c: Color) -> u64 {

--- a/crates/orzma_vt/src/device/color.rs
+++ b/crates/orzma_vt/src/device/color.rs
@@ -247,9 +247,9 @@ mod tests {
     /// it currently resolves to, so equality tracks the palette slot
     /// rather than the resolved pixel.
     ///
-    /// Case: an application selects palette slot 1 with SGR 38;5;1,
-    /// which currently resolves to the default xterm red, and the user
-    /// later issues an OSC 4 override that recolors that slot.
+    /// Case: one escape sequence selects palette slot 1 with SGR
+    /// 38;5;1, and another explicitly requests the same red that slot
+    /// currently resolves to with SGR 38;2;205;0;0.
     #[test]
     fn indexed_stays_distinct_from_the_rgb_it_would_resolve_to() {
         assert_ne!(Color::Indexed(1), Color::Rgb(Rgb { r: 205, g: 0, b: 0 }));
@@ -274,8 +274,8 @@ mod tests {
     /// Asserts that the default palette seeds the 16 ANSI base slots
     /// with the xterm defaults.
     ///
-    /// Case: a fresh terminal renders `ls --color` output before any
-    /// OSC 4 override arrives.
+    /// Case: a fresh terminal renders `ls --color` output, which picks
+    /// its colors from the 16 ANSI base slots.
     #[test]
     fn the_default_palette_seeds_the_ansi_base_slots() {
         let palette = Palette::default();
@@ -353,8 +353,9 @@ mod tests {
     /// Asserts that each color variant resolves against its designated
     /// palette slot.
     ///
-    /// Case: a renderer packs cell colors for the GPU while OSC 4 / 10
-    /// / 11 overrides are active.
+    /// Case: a renderer packs cell colors for the GPU from a palette
+    /// whose foreground, background, and indexed slot 42 already hold
+    /// colors distinct from the defaults.
     #[test]
     fn resolve_follows_the_live_table() {
         let mut palette = Palette {

--- a/crates/orzma_vt/src/device/modes.rs
+++ b/crates/orzma_vt/src/device/modes.rs
@@ -4,9 +4,9 @@
 /// Snapshot of the modes the device owns, as opposed to those a screen
 /// owns.
 ///
-/// A mode belongs here when both screens share it. The ones a screen
-/// owns — the cursor origin, the tab stops, the character set mapping —
-/// live on the screen itself instead.
+/// Both screens share every mode here. The ones a screen owns — the
+/// cursor origin, the tab stops, the character set mapping — live on the
+/// screen itself instead.
 ///
 /// # References
 ///
@@ -20,10 +20,6 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct VtModes {
     /// DECSET 1049/47: which of the two screens the device shows.
-    ///
-    /// This is the only record of the active screen — the screen pair
-    /// itself is pure storage and keeps no such flag, so the two
-    /// cannot disagree.
     pub active_screen: ScreenKind,
     /// IRM (`SM 4`): whether a printed character inserts or replaces.
     pub insert_replace: InsertReplaceMode,
@@ -38,18 +34,16 @@ pub struct VtModes {
     pub bracketed_paste: bool,
     /// DECSET 1007: enables alternate-scroll translation.
     ///
-    /// This stores the mode itself, which is not actionable on its own
-    /// — it takes effect only while [`Self::active_screen`] is
-    /// [`ScreenKind::Alternate`]. Read it through
-    /// [`Self::alternate_scroll_active`] rather than on its own.
+    /// It takes effect only while [`Self::active_screen`] is
+    /// [`ScreenKind::Alternate`], so a reader must go through
+    /// [`Self::alternate_scroll_active`] rather than read it on its own.
     pub alternate_scroll: bool,
     /// DECSET 1004: the app wants `CSI I` / `CSI O` focus reports.
     pub focus_in_out: bool,
     /// DECTCEM (DECSET 25): whether the text cursor is drawn.
     ///
-    /// The device carries this rather than either screen, so a switch to
-    /// the alternate screen keeps the state the application set.
-    /// DECSC does not save it either — the VT510 saved-item list does not name cursor visibility.
+    /// A switch to the alternate screen keeps the state the application
+    /// set, and DECSC does not save it either.
     pub text_cursor_enable: TextCursorEnable,
     /// Coordinate encoding for mouse reports.
     pub mouse_encoding: MouseEncoding,
@@ -61,9 +55,9 @@ impl VtModes {
     /// Whether alternate-scroll translation is in effect: DECSET 1007
     /// set *and* the alternate screen shown.
     ///
-    /// This is not "the wheel sends arrow keys" — an active mouse
-    /// tracking mode outranks alternate scroll, and resolving that
-    /// order is the host's wheel routing, not this snapshot's.
+    /// This is not "the wheel sends arrow keys": an active mouse
+    /// tracking mode outranks alternate scroll, and the caller must
+    /// resolve that order itself.
     pub const fn alternate_scroll_active(&self) -> bool {
         matches!(self.active_screen, ScreenKind::Alternate) && self.alternate_scroll
     }
@@ -73,8 +67,7 @@ impl VtModes {
 /// the rest of the row right.
 ///
 /// Both screens share one value, so an alternate-screen flip shows the
-/// mode it left, and `DECSC` does not carry it either — the saved-cursor
-/// state records why.
+/// mode it left, and `DECSC` does not carry it either.
 ///
 /// # Control Functions
 ///
@@ -99,11 +92,10 @@ impl InsertReplaceMode {
 /// Whether a graphic character received at the right border wraps to
 /// the next line or replaces the character already in the last column.
 ///
-/// Both screens share one value, and `DECSC` does not carry it; the
-/// saved-cursor state records what it carries instead.
+/// Both screens share one value, and `DECSC` does not carry it.
 ///
 /// The default is [`Self::Enabled`], the set rather than the reset
-/// state, because `xterm-256color` advertises `am`.
+/// state.
 ///
 /// # Control Functions
 ///
@@ -139,15 +131,14 @@ impl AutoWrap {
 /// Whether the text cursor is drawn.
 ///
 /// Both screens share one value, so an alternate-screen flip shows the
-/// mode it left, and `DECSC` does not carry it either — the saved-cursor
-/// state records why.
+/// mode it left, and `DECSC` does not carry it either.
 ///
 /// # Control Functions
 ///
 /// - `DECTCEM` (`CSI ? 25 h` / `CSI ? 25 l`)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TextCursorEnable {
-    /// The cursor is drawn. The power-up default.
+    /// The cursor is drawn; this is the power-up default.
     #[default]
     Shown,
     /// The cursor is not drawn.
@@ -203,8 +194,7 @@ impl ScreenKind {
 
 /// Mouse-report coordinate encoding.
 ///
-/// The encodings are mutually exclusive: xterm keeps DECSET 1005/1006
-/// as separate numbers, but setting one replaces the other.
+/// The encodings are mutually exclusive. DECSET 1005 is not answered.
 ///
 /// # References
 ///
@@ -229,9 +219,7 @@ impl MouseEncoding {
     /// when the number names no encoding this terminal answers.
     ///
     /// A `DECRST` returns to [`Self::X10`] only when the number names
-    /// the encoding currently in force. The variants and the numbers
-    /// correspond one to one, so an application that resets an encoding
-    /// it never set would otherwise disable the one it did.
+    /// the encoding currently in force.
     // TODO: Answer DECSET 1005 here once `MouseReport::encode` really
     // implements the UTF-8 coordinate extension. Selecting `Utf8` while
     // the encoder falls back to X10 would advertise a protocol whose
@@ -284,8 +272,7 @@ impl MouseTracking {
     /// when the number names no tracking level.
     ///
     /// A `DECSET` replaces the level outright. A `DECRST` clears it only
-    /// when the number names the level currently in force, for the same
-    /// reason [`MouseEncoding::with_decset`] records.
+    /// when the number names the level currently in force.
     pub fn with_decset(self, mode: u16, enabled: bool) -> Option<Self> {
         let level = match mode {
             1000 => Self::Clicks,
@@ -309,8 +296,7 @@ mod tests {
     /// autowrap enabled, which is the set rather than the reset state.
     ///
     /// Case: a terminal is spawned and the shell echoes a command line
-    /// longer than the window is wide, which has to continue on the
-    /// next row.
+    /// longer than the window is wide.
     #[test]
     fn autowrap_starts_enabled() {
         assert_eq!(VtModes::default().auto_wrap, AutoWrap::Enabled);

--- a/crates/orzma_vt/src/frame.rs
+++ b/crates/orzma_vt/src/frame.rs
@@ -279,8 +279,9 @@ mod tests {
     /// Asserts that the palette diff reports the change until the
     /// emitted table is settled.
     ///
-    /// Case: an OSC palette override arrives, one frame carries the new
-    /// table, and the next frame omits it again.
+    /// Case: the palette's foreground is changed to match its
+    /// background, one frame carries the updated table, and the next
+    /// frame, once that table is settled, omits it again.
     #[test]
     fn diff_palette_reports_the_change_until_settled() {
         let mut tracker = FrameTracker::new();

--- a/crates/orzma_vt/src/frame.rs
+++ b/crates/orzma_vt/src/frame.rs
@@ -1,12 +1,5 @@
 //! Frame assembly: turning device state into what one emit hands the
 //! renderer.
-//!
-//! A frame is one flat struct: a full repaint simply carries every
-//! viewport row, and the changed-only sections (`placements`,
-//! `palette`) are `Some` exactly when the emit-time diff against the
-//! [`FrameTracker`]'s retained values found them genuinely different.
-//! The pieces are read through one shared borrow of the device, so a
-//! frame describes a single instant.
 
 pub mod damage;
 
@@ -30,9 +23,7 @@ use crate::vi::ViCursor;
 /// emitted frame, and for placements `Some(vec![])` = none visible —
 /// a distinct state), while `vi_cursor` and `selection` are absent
 /// state (`None` = not in vi mode / no selection, carried on every
-/// frame). `rows` and `hyperlinks` need no `Option` — an absent row
-/// is unchanged, so a plain `Vec` with empty as its zero is the
-/// tighter type.
+/// frame).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Frame {
     /// Grid dimensions; always carried, doubling as the resize signal.
@@ -44,9 +35,10 @@ pub struct Frame {
     pub cursor: Cursor,
     /// Lines scrolled back from the live tail; always carried.
     pub display_offset: DisplayOffset,
-    /// Vi-mode cursor (active only in vi mode). Absent in normal mode.
+    /// Vi-mode cursor. It is always `None`, because this terminal does
+    /// not implement vi mode.
     pub vi_cursor: Option<ViCursor>,
-    /// Active selection range. Independent of vi cursor — survives motion.
+    /// Active selection range.
     pub selection: Option<SelectionRange>,
     /// Webview placements in active-grid coordinates: `None` when
     /// unchanged since the last emitted frame, otherwise the complete
@@ -55,15 +47,18 @@ pub struct Frame {
     /// `display_offset` and culls what falls outside the viewport.
     pub placements: Option<Vec<AnchoredPlacement>>,
     /// The live palette symbolic colors resolve against: `None` when
-    /// unchanged. A palette override owes a staged full repaint — the
-    /// emit-time diff guarantees only that a frame is emitted, not
-    /// that it carries rows — an obligation on the future
-    /// OSC 4 / 10 / 11 / 12 handler.
+    /// unchanged.
+    ///
+    /// TODO: stage a full repaint when an OSC 4 / 10 / 11 / 12 handler
+    /// overrides the palette.
     pub palette: Option<Palette>,
     /// Definitions for hyperlink ids referenced by `rows`, merged into
-    /// the consumer's retained table. Reserved: empty until the
-    /// hyperlink interner is ported, which is safe while
-    /// [`crate::prelude::Run::hyperlink_id`] is always `None`.
+    /// the consumer's retained table.
+    ///
+    /// It is always empty, and [`crate::prelude::Run::hyperlink_id`] is
+    /// always `None`.
+    ///
+    /// TODO: fill it once OSC 8 handling reaches the hyperlink interner.
     pub hyperlinks: Vec<Hyperlink>,
 }
 
@@ -92,13 +87,6 @@ pub(crate) struct FrameTracker {
 impl FrameTracker {
     /// Builds a tracker whose damage is seeded with the bootstrap full
     /// repaint, so the first emitted frame carries every viewport row.
-    ///
-    /// The retained [`Carried::default`] disagrees with a fresh device
-    /// on one field: its cursor is not visible, while
-    /// [`DeviceState::cursor`] folds in the `DECTCEM` default, which is.
-    /// The seeded damage is what makes that sound, because it forces the
-    /// first frame out regardless of any diff and that emit settles the
-    /// real cursor before the diffs are ever load-bearing.
     pub fn new() -> Self {
         Self {
             damage: Damage::new(),
@@ -130,12 +118,10 @@ impl FrameTracker {
     ///
     /// # Invariants
     ///
-    /// - The rows, the cursor, the offset, and the projection all come
-    ///   from one borrow of `device`, so a frame describes one instant.
-    /// - The tracker never retains a value the consumer does not see:
-    ///   the section diffs only compare, and the emitted frame is
-    ///   settled after the gate, so an attempt that returns `None`
-    ///   retains nothing.
+    /// - The rows, the cursor, the offset, and the projection describe
+    ///   one instant of `device`.
+    /// - The tracker never retains a value the consumer does not see, so
+    ///   an attempt that returns `None` retains nothing.
     pub fn emit(&mut self, device: &DeviceState) -> Option<Frame> {
         let screen = device.active_screen();
         let carried = Carried {
@@ -191,11 +177,7 @@ impl FrameTracker {
     /// Records what an emitted frame carried, so later diffs compare
     /// against what the consumer last saw.
     ///
-    /// # Invariants
-    ///
-    /// Every emitted frame settles here exactly once: a diff result
-    /// that reaches a frame without being settled would report the
-    /// same change again on the next attempt.
+    /// Every emitted frame must settle here exactly once.
     fn settle(
         &mut self,
         carried: Carried,
@@ -252,8 +234,7 @@ mod tests {
     }
 
     /// Asserts that a new tracker's retained values match a fresh
-    /// device for the diffed sections, so a fresh consumer and a fresh
-    /// VT agree without a completeness flag.
+    /// device for the diffed sections.
     ///
     /// Case: a terminal spawns and its very first frame omits the
     /// palette and placement sections.
@@ -316,8 +297,7 @@ mod tests {
     /// Asserts that `stage_if_changed` reports whether it staged
     /// anything.
     ///
-    /// Case: a scroll request is clamped to a no-op and its caller must
-    /// learn the viewport did not move.
+    /// Case: a scroll request is clamped to a no-op.
     #[test]
     fn stage_if_changed_reports_whether_anything_was_staged() {
         let mut rig = drained_rig();
@@ -395,8 +375,8 @@ mod tests {
     /// Asserts that a cursor-only change emits a frame with no rows,
     /// and that the next attempt emits nothing.
     ///
-    /// Case: the user presses an arrow key and the caret must move
-    /// without any row changing.
+    /// Case: the user presses an arrow key, moving the caret without
+    /// changing any row.
     #[test]
     fn a_cursor_only_change_emits_an_empty_rows_frame_once() {
         let mut rig = drained_rig();
@@ -411,7 +391,7 @@ mod tests {
     }
 
     /// Asserts that an emit attempt with nothing changed returns
-    /// `None` — the lean contract.
+    /// `None`.
     ///
     /// Case: a chunk changes only the pen, which no frame field
     /// carries.
@@ -423,8 +403,7 @@ mod tests {
     }
 
     /// Asserts that a display-offset change alone emits a frame
-    /// carrying the new offset once — the mechanical backstop for the
-    /// offset-stages-Full convention.
+    /// carrying the new offset once.
     ///
     /// Case: the viewport scrolls back while no cell content changes.
     #[test]

--- a/crates/orzma_vt/src/frame/damage.rs
+++ b/crates/orzma_vt/src/frame/damage.rs
@@ -1,25 +1,9 @@
-//! Damage vocabulary: the span one operation reports and the
-//! accumulator that merges spans toward the next emit.
-//!
-//! [`DamageSpan`] is the allocation-free value a single screen
-//! operation reports: a `Copy` span rather than a `Vec`, because this
-//! value crosses the per-printed-character path where a `Vec` per
-//! character would dominate the interpreter's cost.
-//!
-//! [`Damage`] accumulates what interpretation, scrolling, and resizing
-//! each report per call and hands the merged rows to the frame emitter.
-//! Staging merges rather than replaces: a source reports only what its
-//! own call produced, so an overwritten value would drop a repaint no
-//! later call re-reports.
+//! Damage tracking: which viewport rows the next frame must repaint.
 
 use crate::screen::viewport::ViewportLine;
 use std::iter;
 
 /// Viewport rows one operation damaged.
-///
-/// `Copy` and allocation-free: this value crosses the per-character path
-/// between a screen operation and the accumulator, where a `Vec` per
-/// printed character would dominate the interpreter's cost.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DamageSpan {
     /// Entire viewport is dirty (resize, clear, alt-screen swap, reset).
@@ -36,10 +20,7 @@ pub(crate) enum DamageSpan {
 impl DamageSpan {
     /// Builds an inclusive row span.
     ///
-    /// # Invariants
-    ///
-    /// `first <= last`; the accumulator's span writer sets wrong bits
-    /// without panicking on a reversed pair.
+    /// The caller must pass `first <= last`.
     pub fn rows(first: ViewportLine, last: ViewportLine) -> Self {
         debug_assert!(first <= last, "a damage span runs top to bottom");
         Self::Rows { first, last }
@@ -48,18 +29,19 @@ impl DamageSpan {
 
 /// Damage accumulated toward the next frame emit.
 ///
+/// Staging merges rather than replaces. A span staged under a pending
+/// `Full` is discarded.
+///
 /// # Invariants
 ///
-/// While `full` is set the row bits are empty: staging `Full` clears
-/// them and a span staged under a pending `Full` is discarded, which is
-/// what lets [`Self::dirty_rows`] chain both sources unconditionally.
+/// While `full` is set the row bits are empty.
 pub(crate) struct Damage {
-    /// Whether the entire viewport is dirty. Height-independent: the
-    /// flag expands against the emit-time viewport height, so a resize
-    /// between staging and emitting cannot under- or over-cover.
+    /// Whether the entire viewport is dirty. The flag is
+    /// height-independent: it expands against the emit-time viewport
+    /// height, so a resize between staging and emitting cannot under- or
+    /// over-cover.
     full: bool,
-    /// Dirty-row bits, reused across frames so staging never allocates
-    /// on the per-character path.
+    /// Dirty-row bits, reused across frames.
     rows: RowBits,
 }
 
@@ -68,9 +50,8 @@ impl Damage {
     ///
     /// # Invariants
     ///
-    /// Its seeded full damage is what makes the first emitted frame
-    /// carry every viewport row; an accumulator that starts clean
-    /// paints nothing until the first PTY output arrives.
+    /// Its seeded full damage makes the first emitted frame carry every
+    /// viewport row.
     pub fn new() -> Self {
         Self {
             full: true,
@@ -94,8 +75,7 @@ impl Damage {
         }
     }
 
-    /// Returns whether nothing is staged, so the emit gate can treat
-    /// the accumulator like the other unchanged sections.
+    /// Returns whether nothing is staged.
     pub fn is_clean(&self) -> bool {
         !self.full && self.rows.is_empty()
     }
@@ -104,9 +84,8 @@ impl Damage {
     /// and without duplicates: every row below `height` when full,
     /// otherwise the set bits.
     ///
-    /// The clip on the bit path is release-build defense; staged bits
-    /// at or above the emit-time height are unreachable while every
-    /// basis change stages `Full`.
+    /// Every staged row must lie below `height`; a release build drops
+    /// any that do not.
     pub fn dirty_rows(&self, height: u16) -> impl Iterator<Item = ViewportLine> + '_ {
         debug_assert!(
             self.rows.rows().all(|line| line.0 < height),
@@ -129,24 +108,15 @@ impl Damage {
 /// A reusable set of dirty viewport rows, one bit per row.
 ///
 /// Bit `b` of element `w` is viewport row `w * 64 + b`, with `b` counted
-/// from the least significant bit. Walking elements in order and bits by
-/// `trailing_zeros` therefore yields rows ascending, which is what lets
-/// the emitter build dirty rows without sorting.
-///
-/// The accumulator keeps one for the terminal's lifetime: staging a
-/// span sets bits and an emit turns them back into rows, so nothing is
-/// allocated once the buffer has grown to the viewport's height.
+/// from the least significant bit.
 #[derive(Debug, Default)]
 struct RowBits(Vec<u64>);
 
 impl RowBits {
     /// Sets every row in the inclusive span.
     ///
-    /// # Invariants
-    ///
-    /// `first <= last`. The `debug_assert!` catches a reversed span in a
-    /// debug build; in release the masks and the buffer sizing both
-    /// assume the ordering, so the result is meaningless.
+    /// The caller must pass `first <= last`; a debug build panics on a
+    /// reversed span.
     fn set_span(&mut self, first: ViewportLine, last: ViewportLine) {
         debug_assert!(first <= last, "a damage span runs top to bottom");
         let (first, last) = (usize::from(first.0), usize::from(last.0));
@@ -268,10 +238,6 @@ mod tests {
         /// Asserts that a full repaint clears the bits it supersedes, so a
         /// later shrink cannot surface a row past the new viewport.
         ///
-        /// The property is kept inside the accumulator rather than resting
-        /// on `Vt::resize` always staging `Full`, so a later change to the
-        /// resize path cannot silently break it.
-        ///
         /// Case: the window shrinks after output damaged a row that the
         /// smaller viewport no longer has.
         #[test]
@@ -301,11 +267,6 @@ mod tests {
 
         /// Asserts that every span endpoint around a 64-row word boundary
         /// sets exactly the rows it names.
-        ///
-        /// The boundary cases are the reason the last-word mask is written
-        /// as `u64::MAX >> (63 - last % 64)`: the arithmetically natural
-        /// `!(u64::MAX << (last % 64 + 1))` shifts by 64 exactly when
-        /// `last % 64 == 63`, which panics in a debug build.
         ///
         /// Case: a viewport whose height is a multiple of 64 erases from the
         /// cursor to the last row.
@@ -344,12 +305,9 @@ mod tests {
             assert_eq!(rows_of(&bits), [0, 20]);
         }
 
-        /// Asserts that clearing drops every set row, so a later span yields
-        /// exactly its own rows and none of the ones it replaced.
-        ///
-        /// The buffer itself is deliberately kept: `clear` is `fill(0)`, not
-        /// `Vec::clear`, so the element for every row ever staged stays
-        /// allocated and the length remains the high-water mark.
+        /// Asserts that clearing drops every set row without shortening the
+        /// buffer, so a later span yields exactly its own rows and none of
+        /// the ones it replaced.
         ///
         /// Case: a frame is emitted and the next chunk starts staging into
         /// the same terminal's accumulator.

--- a/crates/orzma_vt/src/hyperlink.rs
+++ b/crates/orzma_vt/src/hyperlink.rs
@@ -1,9 +1,4 @@
 //! OSC 8 hyperlink vocabulary and the id interner that dedupes it.
-//!
-//! [`HyperlinkInterner`] maps each `(source id, uri)` pair to a single
-//! [`HyperlinkId`], minting a fresh id the first time a pair is seen
-//! and returning the id already on file on repeats; it is where this
-//! crate mints hyperlink ids.
 // NOTE: the `#[cfg(test)]` module below uses every item this lint
 // would flag, so an unconditional `#[expect(dead_code)]` is fulfilled
 // in a plain build but unfulfilled — and denied under `-D warnings` —
@@ -31,11 +26,8 @@ pub struct Hyperlink {
 
 /// Monotonic hyperlink id.
 ///
-/// # Invariants
-///
 /// Callers outside the interner MUST NOT construct `HyperlinkId(0)`;
-/// it is the universal "no hyperlink" sentinel the renderer's
-/// `hyperlink_id != 0u` branch depends on.
+/// it is the universal "no hyperlink" sentinel.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct HyperlinkId(pub u32);
 
@@ -55,7 +47,7 @@ impl HyperlinkUri {
     }
 }
 
-/// Returns `true` when `uri` carries a scheme on the v1 allowlist
+/// Returns `true` when `uri` carries a scheme on the allowlist
 /// (`http`, `https`, `mailto`, `ftp`), case-insensitive.
 pub fn is_allowed(uri: &str) -> bool {
     scheme_of(uri)
@@ -78,6 +70,9 @@ pub(crate) struct SourceHyperlink {
     pub uri: HyperlinkUri,
 }
 
+/// Maps each `(source id, uri)` pair to a single [`HyperlinkId`],
+/// minting a fresh id the first time a pair is seen and returning the id
+/// already on file on repeats.
 pub(crate) struct HyperlinkInterner {
     id: u32,
     id_to_uri: HashMap<HyperlinkId, HyperlinkUri>,
@@ -88,8 +83,7 @@ impl HyperlinkInterner {
     /// Constructs an empty interner.
     ///
     /// The first id handed out is `HyperlinkId(1)`. `HyperlinkId(0)` is
-    /// reserved as the "no hyperlink" sentinel across the wire, the CPU
-    /// grid, and GPU storage.
+    /// reserved as the "no hyperlink" sentinel.
     pub(crate) fn new() -> Self {
         Self {
             id: 1,
@@ -124,8 +118,9 @@ impl Default for HyperlinkInterner {
 
 const ALLOWED_SCHEMES: &[&str] = &["http", "https", "mailto", "ftp"];
 
-/// Parses an RFC 3986 scheme: first byte ALPHA, continuation
-/// ALPHA / DIGIT / `+` / `-` / `.`. Returns `None` for malformed input.
+/// Parses an RFC 3986 scheme. The first byte is ALPHA, and each later
+/// byte is ALPHA, DIGIT, `+`, `-`, or `.`. Returns `None` for malformed
+/// input.
 fn scheme_of(uri: &str) -> Option<&str> {
     let (scheme, _) = uri.split_once(':')?;
     let mut bytes = scheme.bytes();
@@ -154,9 +149,7 @@ mod tests {
     /// Asserts that interning an equal key twice returns the same id.
     ///
     /// Case: one OSC 8 link spans many cells of a row, and the frame
-    /// builder builds a fresh key for every cell it walks. Two keys
-    /// constructed separately from the same source id and uri must
-    /// therefore resolve to one wire id.
+    /// builder builds a fresh key for every cell it walks.
     #[test]
     fn repeated_key_returns_the_same_id() {
         let mut interner = HyperlinkInterner::new();
@@ -169,8 +162,7 @@ mod tests {
     ///
     /// Case: a program prints two OSC 8 links to the same URL without an
     /// explicit `id=`, so alacritty auto-numbers them `0_alacritty` and
-    /// `1_alacritty`. They are two separate links on screen, and
-    /// hovering one must not underline the other.
+    /// `1_alacritty`.
     #[test]
     fn auto_generated_source_ids_keep_identical_uris_distinct() {
         let mut interner = HyperlinkInterner::new();
@@ -182,9 +174,6 @@ mod tests {
     /// Asserts that one source id reused across two uris yields distinct ids.
     ///
     /// Case: an application reuses `id=1` for a second, unrelated URL.
-    /// OSC 8 requires that cells pointing at different URIs are never
-    /// underlined together, and collapsing the two would also make a
-    /// click open the wrong address.
     #[test]
     fn reused_source_id_with_different_uri_yields_distinct_ids() {
         let mut interner = HyperlinkInterner::new();
@@ -197,7 +186,7 @@ mod tests {
     ///
     /// Case: a long URL wraps at the terminal edge, so the frame builder
     /// coalesces each row independently and interns the same link once
-    /// per row. Every wrapped fragment must join one hover group.
+    /// per row.
     #[test]
     fn wrapped_link_reinterned_per_row_keeps_one_id() {
         let mut interner = HyperlinkInterner::new();
@@ -210,8 +199,6 @@ mod tests {
     /// Asserts that many distinct keys all receive unique non-zero ids.
     ///
     /// Case: `ls --hyperlink=auto` fills a screen with one link per file.
-    /// Hovering a file name must not underline its neighbours, so no two
-    /// keys may collapse onto one wire id.
     #[test]
     fn distinct_keys_never_share_an_id() {
         let mut interner = HyperlinkInterner::new();
@@ -227,12 +214,11 @@ mod tests {
         assert!(!ids.contains(&HyperlinkId(0)));
     }
 
-    /// Asserts that source ids are compared byte for byte.
+    /// Asserts that source ids are compared byte for byte rather than
+    /// trimmed or canonicalized.
     ///
     /// Case: a program emits `id=42`, `id=042`, and `id=42 ` for three
-    /// links. Interpreting OSC 8 parameters belongs to the VT layer, so
-    /// the interner treats what it is handed as opaque bytes instead of
-    /// trimming or canonicalizing it.
+    /// links.
     #[test]
     fn source_id_is_compared_exactly() {
         let mut interner = HyperlinkInterner::new();
@@ -245,9 +231,7 @@ mod tests {
 
     /// Asserts that no key is ever assigned the reserved zero id.
     ///
-    /// Case: the GPU cell attribute stores `0` to mean "this cell carries
-    /// no link". Handing out `0` for a real link would paint the hover
-    /// underline across unlinked cells.
+    /// Case: a program prints sixteen links in one session.
     #[test]
     fn intern_never_returns_the_zero_sentinel() {
         let mut interner = HyperlinkInterner::new();
@@ -259,9 +243,7 @@ mod tests {
 
     /// Asserts that fresh keys are numbered from one upwards.
     ///
-    /// Case: the first link a session prints must not land on the zero
-    /// sentinel, and a replayed sequence of links must reproduce the same
-    /// wire ids.
+    /// Case: a fresh session prints its first three links.
     #[test]
     fn new_keys_receive_monotonic_ids_starting_at_one() {
         let mut interner = HyperlinkInterner::new();
@@ -282,9 +264,7 @@ mod tests {
     /// Asserts that re-interning a known key leaves the next id untouched.
     ///
     /// Case: a single link covers dozens of cells in a row, so the frame
-    /// builder interns it once per cell. Advancing the counter per cell
-    /// would burn the id space within one screen and fill the wire table
-    /// with duplicates.
+    /// builder interns it once per cell.
     #[test]
     fn reinterning_an_existing_key_does_not_advance_the_counter() {
         let mut interner = HyperlinkInterner::new();
@@ -297,9 +277,7 @@ mod tests {
     /// Asserts that an assigned id never changes as more keys arrive.
     ///
     /// Case: links keep accumulating across frames while earlier cells
-    /// are already on screen holding their ids. Renumbering an existing
-    /// entry would silently desynchronize hover grouping from the wire
-    /// table the renderer already stored.
+    /// are already on screen holding their ids.
     #[test]
     fn existing_ids_are_stable_across_later_interning() {
         let mut interner = HyperlinkInterner::new();
@@ -331,11 +309,11 @@ mod tests {
         );
     }
 
-    /// Asserts that extracting an unassigned id yields None.
+    /// Asserts that extracting an unassigned id yields None rather than
+    /// an unrelated uri or a panic.
     ///
     /// Case: an id from evicted scrollback or another terminal reaches
-    /// the lookup. Resolving it to some unrelated uri, or panicking, are
-    /// both worse than reporting that the link is gone.
+    /// the lookup.
     #[test]
     fn extract_returns_none_for_an_unknown_id() {
         let mut interner = HyperlinkInterner::new();
@@ -346,8 +324,7 @@ mod tests {
     /// Asserts that the reserved zero id resolves to nothing.
     ///
     /// Case: a caller forwards an unlinked cell's `0` straight into the
-    /// lookup. If the sentinel resolved to a uri, cells carrying no link
-    /// at all would become clickable.
+    /// lookup.
     #[test]
     fn extract_returns_none_for_the_zero_sentinel() {
         let mut interner = HyperlinkInterner::new();
@@ -358,8 +335,7 @@ mod tests {
     /// Asserts that two ids sharing a uri both resolve back to it.
     ///
     /// Case: the same URL appears twice on screen as two independent
-    /// links. They highlight separately on hover, yet clicking either one
-    /// must open the same address.
+    /// links.
     #[test]
     fn distinct_ids_for_one_uri_both_resolve_to_it() {
         let mut interner = HyperlinkInterner::new();
@@ -371,13 +347,10 @@ mod tests {
         assert_eq!(interner.extract(&second), Some(&expected));
     }
 
-    /// Asserts that an empty uri is interned like any other value.
+    /// Asserts that an empty uri is interned like any other value rather
+    /// than rejected or folded onto the zero sentinel.
     ///
-    /// Case: the alacritty backend never produces one, because
-    /// `OSC 8 ; ; ST` terminates a link and yields no hyperlink at all.
-    /// Another backend may hand one over, and the agreed policy is that
-    /// judging a uri belongs to the VT layer, so the interner stores it
-    /// rather than rejecting it or folding it onto the zero sentinel.
+    /// Case: a VT backend hands the interner an empty uri.
     #[test]
     fn empty_uri_is_interned_without_special_casing() {
         let mut interner = HyperlinkInterner::new();
@@ -392,9 +365,7 @@ mod tests {
     /// Asserts that a long uri round-trips whole and stays distinct from its prefix.
     ///
     /// Case: an application prints a generated URL carrying a
-    /// multi-kilobyte query string. Truncating it, or matching two such
-    /// URLs on a shared prefix, would send a click to the wrong address.
-    /// Any length ceiling belongs to the VT layer, not to the interner.
+    /// multi-kilobyte query string.
     #[test]
     fn long_uri_is_stored_without_truncation() {
         let mut interner = HyperlinkInterner::new();
@@ -407,12 +378,12 @@ mod tests {
         assert_eq!(interner.extract(&second), Some(&HyperlinkUri::new(longer)));
     }
 
-    /// Asserts that uris differing only in encoding or case stay distinct.
+    /// Asserts that uris differing only in encoding or case stay distinct
+    /// rather than being percent-decoded or case-folded.
     ///
-    /// Case: a terminal carries the bytes an application printed. Percent
-    /// decoding or case folding here would merge `https://例.jp/%E3%81%82`
-    /// with `https://例.jp/あ`, which the interner has no authority to
-    /// treat as one resource.
+    /// Case: an application prints links that differ only in
+    /// percent-encoding or letter case, such as `https://例.jp/%E3%81%82`
+    /// and `https://例.jp/あ`.
     #[test]
     fn uri_bytes_are_preserved_without_normalization() {
         let mut interner = HyperlinkInterner::new();

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -1,10 +1,5 @@
 //! Byte-stream decoding: the vtparse parser and the synchronized-update
 //! buffer.
-//!
-//! [`Interpreter`] turns PTY bytes into parser actions. It changes no
-//! device state itself — the executor it dispatches to does that —
-//! and it owns the CSI ?2026 buffer, so a synchronized update holds its
-//! bytes here until the application closes it.
 
 pub(crate) mod apc;
 
@@ -27,7 +22,7 @@ use crate::{
 };
 use vtparse::{CsiParam, VTActor, VTParser};
 
-/// The parser plus the bytes a synchronized update is holding back.
+/// The parser plus the synchronized-update buffer.
 pub(crate) struct Interpreter {
     parser: VTParser,
     sync: SyncBuffer,
@@ -35,20 +30,14 @@ pub(crate) struct Interpreter {
 
 impl Interpreter {
     /// Decodes one chunk, applying each action to the borrowed
-    /// components through an [`Executor`] and collecting everything the
-    /// chunk produced into `output`.
-    ///
-    /// The executor is built here rather than passed in because it
-    /// borrows [`SyncBuffer`], which `&mut self` already holds.
+    /// components and collecting everything the chunk produced into
+    /// `output`.
     ///
     /// # Invariants
     ///
-    /// Every run of the parser ends with [`Executor::sweep_evictions`],
-    /// after the chunk's last action: [`crate::Vt::interpret`] promises
-    /// that a chunk names the placements it strands in its own
-    /// [`InterpretOutput::signals`]. A run without the sweep would leave
-    /// them unnamed until a later chunk sweeps, while every frame in
-    /// between already omits them.
+    /// The placements the chunk strands are named in its own
+    /// [`InterpretOutput::signals`], after every signal the chunk's
+    /// actions raised.
     pub fn parse(
         &mut self,
         output: &mut InterpretOutput,
@@ -78,18 +67,13 @@ impl Default for Interpreter {
     }
 }
 
-/// Bytes held back while a synchronized update (CSI ?2026) is open.
+/// The buffer for a synchronized update (CSI ?2026).
+///
+/// TODO: hold back the bytes of an open synchronized update.
 #[derive(Default)]
 struct SyncBuffer {}
 
 /// The temporary view a parser callback applies its action through.
-///
-/// `output` borrows the caller's per-call local in
-/// [`crate::OrzmaVt`]'s [`crate::Vt::interpret`].
-/// The other fields borrow state that outlives the call — `device` and
-/// `tracker` are components `OrzmaVt` owns, and `sync` reborrows
-/// [`Interpreter::sync`], which persists across chunks. The view itself
-/// still carries nothing between chunks: it is rebuilt fresh each call.
 struct Executor<'a> {
     output: &'a mut InterpretOutput,
     #[expect(
@@ -501,8 +485,8 @@ impl VTActor for Executor<'_> {
     }
 }
 
-/// The control functions an eight-bit C1 byte and its seven-bit `ESC`
-/// form both request, so the two spellings cannot drift apart.
+/// The control-function steps the parser callbacks delegate to, and the
+/// helpers that record what a chunk produced.
 impl Executor<'_> {
     /// Moves the cursor down a row, scrolling at the bottom margin (IND,
     /// and the LF family that shares its effect).
@@ -560,8 +544,7 @@ impl Executor<'_> {
 
     /// Queues reply bytes for the owner to write back to the PTY.
     ///
-    /// A reply changes nothing the renderer draws, so it deliberately
-    /// leaves the chunk liveness alone.
+    /// A reply leaves the chunk liveness alone.
     fn reply(&mut self, bytes: &[u8]) {
         self.output.replies.extend_from_slice(bytes);
     }
@@ -586,8 +569,7 @@ impl Executor<'_> {
     /// Returns every screen and mode to its power-up state (RIS),
     /// reporting the title's return to the host's default.
     ///
-    /// A reset that finds no title reports nothing, so a terminal that
-    /// was never titled does not wake the host.
+    /// A reset that finds no title reports nothing.
     fn reset_device(&mut self) {
         let had_title = self.device.title().is_some();
         let damage = self.device.reset();
@@ -598,18 +580,17 @@ impl Executor<'_> {
     }
 
     /// Names the placements this chunk stranded and raises the chunk
-    /// liveness, because a shortened placement list is a frame-visible
-    /// section change even when no row was damaged.
+    /// liveness.
     ///
     /// A chunk strands a placement when its anchor row leaves the grid:
-    /// a reset mints every row afresh, and a scroll that recycles a row
-    /// rather than keeping it in history — past the cap, inside a scroll
-    /// region, downward at the top margin, or on a screen without
-    /// scrollback — re-mints it under an id no anchor holds.
+    /// a reset drops every row, and a scroll drops a row when it recycles
+    /// the row rather than keeping it in history — past the cap, inside a
+    /// scroll region, downward at the top margin, or on a screen without
+    /// scrollback.
     ///
-    /// The sweep runs once, after the whole chunk, so a placement the
-    /// chunk strands and then re-mounts is updated in place rather than
-    /// evicted and re-created.
+    /// It must run once per chunk, after the chunk's last action, so
+    /// that a placement the chunk strands and then re-mounts is updated
+    /// in place rather than evicted and re-created.
     fn sweep_evictions(&mut self) {
         let Some(evicted) = VtSignal::evicted(self.device.evict_lost_anchors()) else {
             return;
@@ -624,11 +605,6 @@ impl Executor<'_> {
 impl Executor<'_> {
     /// Applies every ANSI mode this terminal implements out of one `SM`
     /// or `RM` sequence, ignoring the numbers it does not.
-    ///
-    /// The private-marker form is a different number space, so `CSI 4 h`
-    /// (IRM) and `CSI ? 4 h` (DECSCLM) never reach the same arm.
-    /// [`Self::set_private_modes`] records why an unimplemented number
-    /// must not hide an implemented one later in the list.
     fn set_modes(&mut self, params: &CsiParams<'_>, enabled: bool) {
         for mode in params.values().flatten() {
             // IRM
@@ -640,9 +616,6 @@ impl Executor<'_> {
 
     /// Applies every private mode this terminal implements out of one
     /// `DECSET` or `DECRST` sequence, ignoring the numbers it does not.
-    ///
-    /// A sequence may carry several modes at once, and an unimplemented
-    /// one must not hide an implemented one later in the list.
     fn set_private_modes(&mut self, params: &CsiParams<'_>, enabled: bool) {
         for mode in params.values().flatten() {
             match mode {
@@ -691,10 +664,6 @@ impl Executor<'_> {
 
     /// Applies a mouse tracking level or report encoding; a number
     /// neither answers is ignored.
-    ///
-    /// The numbers live on the two enums rather than here, so the
-    /// tracking levels and the encodings each keep their mapping beside
-    /// the type that models them.
     fn set_mouse_mode(&mut self, mode: u16, enabled: bool) {
         let modes = self.device.modes_mut();
         if let Some(tracking) = modes.mouse_tracking.with_decset(mode, enabled) {
@@ -711,12 +680,8 @@ impl Executor<'_> {
     /// Each direction runs only from the other screen, so a set already
     /// on the alternate screen cannot overwrite that screen's own DECSC
     /// slot, and a stray reset on the primary screen leaves the cursor
-    /// alone. The save precedes the flip because `active_screen_mut` is
-    /// the only way to a screen; the erase follows it for the same
-    /// reason, and fills with the pen the alternate screen kept from
-    /// its previous use rather than the primary screen's — each screen
-    /// owns its pen — which is a known departure from xterm's shared
-    /// pen.
+    /// alone. The erase fills with the pen the alternate screen kept
+    /// from its previous use rather than the primary screen's.
     fn set_alternate_screen_with_cursor(&mut self, enabled: bool) {
         match (enabled, self.device.modes().active_screen) {
             (true, ScreenKind::Primary) => {
@@ -735,12 +700,6 @@ impl Executor<'_> {
     /// Applies `DECSET 1047` / `DECRST 1047`: a set is a bare flip; a
     /// reset erases the alternate screen, when it is the one shown, and
     /// then flips back.
-    ///
-    /// The erase precedes the flip because it must reach the alternate
-    /// screen, and it runs only while that screen is shown so a stray
-    /// reset on the primary screen erases nothing. The `Full` it stages
-    /// is redundant with the flip's own, and the damage ledger records
-    /// no screen.
     fn set_alternate_screen_erased_on_exit(&mut self, enabled: bool) {
         if !enabled && self.device.modes().active_screen == ScreenKind::Alternate {
             self.erase_in_display(EraseScreenMode::All);
@@ -749,18 +708,13 @@ impl Executor<'_> {
     }
 
     /// Shows `to`, naming the placements a return to the primary screen
-    /// tears down. Already showing `to` is a no-op: no repaint, no
-    /// signal.
-    ///
-    /// The eviction is raised here rather than left to the chunk-end
-    /// sweep because [`DeviceState::switch_screen`] takes the placements
-    /// out of the table, so the sweep could not find them.
+    /// tears down. Already showing `to` is a no-op that stages nothing
+    /// and signals nothing.
     ///
     /// # Invariants
     ///
-    /// The flip and the staged `Full` are never separated by an early
-    /// return: a frame after a screen flip must carry every viewport
-    /// row, and [`DeviceState::switch_screen`] stages nothing itself.
+    /// Every flip stages [`DamageSpan::Full`], so the frame after it
+    /// carries every viewport row.
     fn switch_screen(&mut self, to: ScreenKind) {
         if self.device.modes().active_screen == to {
             return;
@@ -775,11 +729,7 @@ impl Executor<'_> {
 
 /// A repeat count parameter, where an omitted or zero value means one.
 ///
-/// ECMA-48 gives the default to an *empty* parameter only (§ 5.4.2 e);
-/// an explicit zero selecting the default is ZERO DEFAULT MODE, which
-/// its annex F deprecates. DEC spells the rule out per function instead
-/// — VT220 states "a parameter of 0 or 1" for these counts — and that
-/// is what applications expect, so a zero resolves to one here.
+/// VT220 states "a parameter of 0 or 1" for these counts.
 fn repeat_count(value: Option<u16>) -> u16 {
     match value {
         None | Some(0) => 1,
@@ -787,9 +737,8 @@ fn repeat_count(value: Option<u16>) -> u16 {
     }
 }
 
-/// The DA1 response: a VT102 with no extensions, the class alacritty
-/// reports. A higher class would advertise features — Sixel, DRCS,
-/// selective erase — this terminal does not implement.
+/// The DA1 response: a VT102 with no extensions. This terminal does not
+/// implement Sixel, DRCS, or selective erase.
 const PRIMARY_ATTRIBUTES: &[u8] = b"\x1b[?6c";
 
 /// The DSR 5 response: the terminal is operating normally.
@@ -797,11 +746,8 @@ const DEVICE_OK: &[u8] = b"\x1b[0n";
 
 /// Builds the DA2 response.
 ///
-/// The terminal type is 0: xterm's table has no VT102 entry, and 0
-/// ("VT100") is the only code that claims no VT220-and-up feature set.
-/// The cartridge number is 1 rather than the zero xterm documents,
-/// because this response follows alacritty byte for byte; real
-/// terminals deviate here freely and readers ignore the field.
+/// The terminal type is 0 ("VT100"), and the cartridge number is 1
+/// rather than the zero xterm documents.
 fn secondary_attributes() -> Vec<u8> {
     format!("\x1b[>0;{};1c", firmware_version()).into_bytes()
 }
@@ -825,9 +771,7 @@ fn firmware_version() -> u32 {
 /// Packs a version into the single number DA2's firmware field carries,
 /// one hundred per component.
 ///
-/// The encoding assumes every component stays below one hundred, which
-/// this crate's versioning holds to; a minor or patch that reached it
-/// would collide with the next component up.
+/// Every component must stay below one hundred.
 fn pack_version(major: u32, minor: u32, patch: u32) -> u32 {
     major * 10_000 + minor * 100 + patch
 }

--- a/crates/orzma_vt/src/interpreter/apc.rs
+++ b/crates/orzma_vt/src/interpreter/apc.rs
@@ -1,10 +1,4 @@
 //! The orzma APC webview request and its wire parser.
-//!
-//! `Executor::apc_dispatch` hands raw APC payloads here. What comes
-//! back is what the byte stream asked for, before the VT has decided
-//! anything: resolving a mount into a placement — and so into a
-//! `VtSignal::WebviewMount` or `VtSignal::WebviewMountRejected` — is the
-//! dispatcher's job, which is why this module needs no device state.
 
 use crate::placement::{InstanceId, MAX_COLS, MAX_ROWS, PlacementSize};
 use std::str;

--- a/crates/orzma_vt/src/interpreter/csi.rs
+++ b/crates/orzma_vt/src/interpreter/csi.rs
@@ -1,8 +1,4 @@
-//! The parameter view `csi_dispatch` reads its sequences through.
-//!
-//! `vtparse` delivers one flat slice that mixes the private marker, the
-//! `;`-separated values, and the trailing intermediates. This module is
-//! the one place that knows how to tell them apart.
+//! The parameter view a CSI sequence is read through.
 
 use vtparse::CsiParam;
 
@@ -39,11 +35,6 @@ impl<'a> CsiParams<'a> {
     }
 
     /// Whether any intermediate byte trails the values.
-    ///
-    /// This is the guard that separates control functions sharing a
-    /// final byte: `vtparse` promotes intermediates into the parameter
-    /// slice, so `CSI 1 ; 2 $ r` and `CSI 1 ; 2 r` reach the dispatcher
-    /// with the same final byte and differ only here.
     pub(crate) fn has_intermediates(&self) -> bool {
         !self.intermediates.is_empty()
     }
@@ -51,13 +42,8 @@ impl<'a> CsiParams<'a> {
     /// The `;`-separated groups, each carrying its own `:`
     /// subparameters and their separators.
     ///
-    /// # Invariants
-    ///
-    /// An empty sequence yields ONE empty group, not none: a bare
-    /// `CSI m` is `SGR 0`, and an empty group is every control
-    /// function's own default. [`Self::values`] deliberately reports no
-    /// slots for that same input, because a bare `CSI H` listed no
-    /// parameters at all — the two views answer different questions.
+    /// An empty sequence yields ONE empty group, not none.
+    /// [`Self::values`] reports no slots for the same input.
     pub(crate) fn groups(&self) -> impl Iterator<Item = &'a [CsiParam]> {
         self.values
             .split(|param| matches!(param, CsiParam::P(b';')))
@@ -66,14 +52,13 @@ impl<'a> CsiParams<'a> {
     /// The first value of the `index`-th separated slot; `None` when the
     /// slot was omitted or does not exist.
     ///
-    /// A zero reads as `Some(0)`: whether a zero means the default is
-    /// each control function's own rule.
+    /// A zero reads as `Some(0)`; the caller decides whether it means
+    /// the default.
     pub(crate) fn value(&self, index: usize) -> Option<u16> {
         self.values().nth(index).flatten()
     }
 
-    /// Every separated slot in order, which is what `SM` and `RM` need
-    /// to find the modes they implement among the ones they do not.
+    /// Every separated slot in order.
     pub(crate) fn values(&self) -> impl Iterator<Item = Option<u16>> + '_ {
         let listed = (!self.values.is_empty()).then(|| self.groups());
         listed.into_iter().flatten().map(Self::first_value)
@@ -81,14 +66,6 @@ impl<'a> CsiParams<'a> {
 
     /// The saturating `u16` a slot's first integer reads as; `None` for
     /// a slot that carries none.
-    ///
-    /// # Invariants
-    ///
-    /// Saturation is right for a slot count or a mode number, where an
-    /// oversized value is out of range whichever way it is clamped. A
-    /// slot also collapses to one integer here, which loses the `:`
-    /// structure a direct colour is spelled with, so `SGR` walks
-    /// [`Self::groups`] itself rather than reading them through here.
     fn first_value(group: &[CsiParam]) -> Option<u16> {
         group.iter().find_map(|param| match param {
             CsiParam::Integer(value) => Some(u16::try_from(*value).unwrap_or(u16::MAX)),
@@ -116,10 +93,6 @@ mod tests {
     /// Asserts that a leading separator is read as an omitted first
     /// value rather than as a private marker.
     ///
-    /// The agreed policy recognises a marker only in 0x3C..=0x3F. A
-    /// looser rule that took whatever punctuation came first would drop
-    /// the whole sequence, and `CSI ; Pb r` is a legal DECSTBM spelling.
-    ///
     /// Case: an application sets only a bottom margin with `CSI ; 3 r`.
     #[test]
     fn a_leading_separator_is_not_a_private_marker() {
@@ -133,11 +106,6 @@ mod tests {
     /// Asserts that a zero survives as a value instead of reading as an
     /// omitted parameter.
     ///
-    /// The agreed policy leaves "a zero means the default" to each
-    /// control function rather than folding it here, because the rule is
-    /// not shared: CUP reads a zero line as line 1, while SGR's zero
-    /// means "reset every attribute".
-    ///
     /// Case: an application resets its attributes with `CSI 0 m`.
     #[test]
     fn a_zero_is_a_value_and_not_an_omission() {
@@ -146,12 +114,8 @@ mod tests {
         assert_eq!(params.value(0), Some(0));
     }
 
-    /// Asserts that a value too large for the parameter type saturates.
-    ///
-    /// The agreed policy saturates rather than reporting the parameter
-    /// as omitted: an omission means "use the default", which would hand
-    /// a program asking for an enormous row the ordinary behaviour
-    /// instead of the clamped extreme it asked for.
+    /// Asserts that a value too large for the parameter type saturates
+    /// rather than reading as omitted.
     ///
     /// Case: a fuzzer or a buggy program sends a line number far past
     /// any screen size.
@@ -217,8 +181,7 @@ mod tests {
         assert_eq!(params.values().collect::<Vec<_>>(), vec![Some(1), Some(6)]);
     }
 
-    /// Asserts that an empty sequence yields one empty group, which is
-    /// how a bare `CSI m` reads as `SGR 0`.
+    /// Asserts that an empty sequence yields one empty group.
     ///
     /// Case: an application resets every attribute with the shortest
     /// spelling the standard allows.

--- a/crates/orzma_vt/src/interpreter/osc.rs
+++ b/crates/orzma_vt/src/interpreter/osc.rs
@@ -1,8 +1,6 @@
 //! The operating system commands this terminal implements.
 //!
-//! The window title (OSC 0 and OSC 2) and the working directory (OSC 7)
-//! are implemented; the palette, hyperlinks, and the clipboard land
-//! later.
+//! TODO: implement the palette, hyperlinks, and the clipboard.
 
 use percent_encoding::percent_decode;
 use std::path::PathBuf;
@@ -12,12 +10,9 @@ use std::path::PathBuf;
 ///
 /// Only the `file` scheme is accepted, and only a URI that carries an
 /// absolute path after its authority. The host — `localhost`, a real
-/// hostname, or the empty host of `file:///…` — is ignored, because
-/// every one of them names the local machine as far as a
-/// working-directory report is concerned. Percent-encoded octets in the
-/// path (`%20` for a space, the UTF-8 octets of a non-ASCII name) are
-/// decoded, since every shell integration escapes them and the path is
-/// handed to the next spawned shell as its working directory.
+/// hostname, or the empty host of `file:///…` — is ignored.
+/// Percent-encoded octets in the path (`%20` for a space, the UTF-8
+/// octets of a non-ASCII name) are decoded.
 pub(crate) fn current_dir(params: &[&[u8]]) -> Option<PathBuf> {
     let [b"7", parts @ ..] = params else {
         return None;
@@ -34,13 +29,8 @@ pub(crate) fn current_dir(params: &[&[u8]]) -> Option<PathBuf> {
 /// carries no text at all also returns `None`, rather than emptying the
 /// title.
 ///
-/// The parser splits an operating system command on every `;`, so a
-/// title carrying one arrives in pieces and the tail is rejoined before
-/// anything else runs.
-///
-/// The title is sanitized before it leaves this function because
-/// `OSC 0` and `OSC 2` content is fully attacker-controlled, and
-/// [`crate::VtSignal::Title`] carries it across the crate boundary.
+/// The command arrives split on every `;`, and the pieces after the
+/// number are rejoined, so a title keeps its semicolons.
 pub(crate) fn window_title(params: &[&[u8]]) -> Option<String> {
     let [b"0" | b"2", text @ ..] = params else {
         return None;
@@ -56,17 +46,14 @@ const MAX_LEN: usize = 256;
 
 /// Returns a display-safe copy of an operating system command's title.
 ///
-/// Stripping runs before trimming: removing a zero-width character can
-/// expose fresh edge whitespace, and trimming first would leave a title
-/// that indents itself in the tab bar. A truncation trims once more
-/// before appending the ellipsis, because the cut can land inside the
-/// padding the first trim was too early to see.
+/// Edge whitespace is trimmed after stripping, including whitespace a
+/// stripped character exposed, and a truncation drops the whitespace it
+/// cuts against before appending the ellipsis.
 ///
-/// Filtering and truncation are deliberately not grapheme-aware. The
-/// stripped set includes U+200D ZERO WIDTH JOINER, so an emoji sequence
-/// loses its joins, and a truncation can fall between a base character
-/// and its combining marks. Both are accepted: the alternative is a
-/// segmentation dependency this crate does not carry.
+/// Filtering and truncation are not grapheme-aware. The stripped set
+/// includes U+200D ZERO WIDTH JOINER, so an emoji sequence loses its
+/// joins, and a truncation can fall between a base character and its
+/// combining marks.
 fn sanitize(raw: &str) -> String {
     let stripped: String = raw.chars().filter(|c| !is_disallowed(*c)).collect();
     let trimmed = stripped.trim();
@@ -85,17 +72,12 @@ fn sanitize(raw: &str) -> String {
 
 /// Whether a character must not reach a window title.
 ///
-/// Three groups are refused. The control characters are refused because
-/// a title is rendered as text and must not steer the surface drawing
-/// it, and U+2028 and U+2029 are refused beside them because they break
-/// a line without being control characters. The whole `Bidi_Control`
-/// property — U+061C, U+200E..U+200F, U+202A..U+202E, and
-/// U+2066..U+2069 — is refused because a title that reorders itself can
-/// impersonate another program. And the characters that occupy no space
-/// — U+00AD, U+180E, U+200B..U+200D, U+2060..U+2064, U+FEFF,
-/// U+FFF9..U+FFFB, and the U+E0000..U+E007F tag block — are refused
-/// because text the reader cannot see can hide inside a title that
-/// looks benign.
+/// Three groups are refused: the control characters, together with
+/// U+2028 and U+2029; the whole `Bidi_Control` property (U+061C,
+/// U+200E..U+200F, U+202A..U+202E, and U+2066..U+2069); and the
+/// characters that occupy no space (U+00AD, U+180E, U+200B..U+200D,
+/// U+2060..U+2064, U+FEFF, U+FFF9..U+FFFB, and the U+E0000..U+E007F tag
+/// block).
 fn is_disallowed(c: char) -> bool {
     // NOTE: the arms are grouped to match the three groups the doc
     // above names, so the two can be checked against each other line by
@@ -202,7 +184,7 @@ mod tests {
     /// Asserts that an icon name request sets no window title.
     ///
     /// Case: oh-my-zsh sends `OSC 1` for the tab and `OSC 2` for the
-    /// window, and this terminal carries only one title.
+    /// window.
     #[test]
     fn an_icon_name_sets_no_title() {
         assert!(window_title(&[b"1", b"hi"]).is_none());

--- a/crates/orzma_vt/src/interpreter/sgr.rs
+++ b/crates/orzma_vt/src/interpreter/sgr.rs
@@ -1,8 +1,4 @@
 //! The `SGR` half of [`Pen`].
-//!
-//! `Pen` itself lives in `screen::cell`, which knows nothing about
-//! `vtparse`. Applying a control sequence to it is interpretation, so
-//! the `impl` sits here and the screen layer stays free of the parser.
 
 use crate::device::color::Color;
 use crate::interpreter::csi::CsiParams;
@@ -21,24 +17,17 @@ const MAX_SUBPARAMS: usize = 9;
 impl Pen {
     /// The pen this one becomes after `params`, applied left to right.
     ///
-    /// # Invariants
-    ///
-    /// The attributes this terminal cannot paint are dropped in pairs —
+    /// The attributes this terminal cannot paint are dropped in pairs:
     /// blink (`5`, `6`, `25`), overline (`53`, `55`), and the underline
-    /// colour's reset (`59`) — because implementing a set without its
-    /// cancellation leaves an attribute no sequence can clear.
+    /// colour's reset (`59`).
     ///
     /// The underline variants `4:1` through `4:5` all become the one
     /// underline this terminal draws; `4:0` cancels it.
     ///
-    /// # Notes
-    ///
-    /// `vtparse` truncates a parameter list at `MAX_PARAMS = 32`, and
-    /// separators occupy slots, so roughly sixteen values survive. The
-    /// truncation is not detectable here: `csi_dispatch` receives
-    /// `ignored_excess_intermediates` as its `parameters_truncated`
-    /// argument, never `params_full`. A long enough sequence loses its
-    /// tail silently, and a cut can land inside a direct colour.
+    /// `vtparse` keeps only the first 32 slots of a parameter list,
+    /// separators included, so roughly sixteen values survive. A long
+    /// enough sequence loses its tail silently, and a cut can land
+    /// inside a direct colour.
     pub(crate) fn applied(self, params: &CsiParams<'_>) -> Self {
         let mut pen = self;
         let mut groups = params.groups();
@@ -146,15 +135,6 @@ impl Pen {
 
     /// The next group's first value, an omitted or malformed one
     /// reading as zero; `None` only when the list has ended.
-    ///
-    /// # Invariants
-    ///
-    /// A group that is present but carries no value MUST still be
-    /// counted, because the caller consumes a fixed number of operands
-    /// and reads `None` as the end of the list. Reporting an omitted
-    /// operand as absent would leave the remaining operands of
-    /// `38;2;;0;0` to read as ordinary attributes, and the two zeroes
-    /// there reset the whole pen.
     fn next_value<'a>(groups: &mut impl Iterator<Item = &'a [CsiParam]>) -> Option<u16> {
         let tokens = groups.next()?;
         let value = Group::decode(tokens)
@@ -186,12 +166,8 @@ impl Group {
     /// that is neither an integer nor a subparameter separator, or more
     /// subparameters than any answered form.
     ///
-    /// # Invariants
-    ///
     /// A group longer than [`MAX_SUBPARAMS`] is discarded whole rather
-    /// than truncated. The longest form this terminal answers is nine
-    /// subparameters, so a longer one is malformed rather than a
-    /// tolerance tail to ignore.
+    /// than truncated.
     fn decode(tokens: &[CsiParam]) -> Option<Self> {
         let mut subs = [None; MAX_SUBPARAMS];
         let mut len = 0;
@@ -521,8 +497,7 @@ mod tests {
         );
     }
 
-    /// Asserts that subparameters after the blue channel are ignored,
-    /// which is what the tolerance tail the standard permits needs.
+    /// Asserts that subparameters after the blue channel are ignored.
     ///
     /// Case: an application spells its colour with the full T.416 form,
     /// whose three fields after blue are the unused slot, the tolerance,
@@ -596,7 +571,7 @@ mod tests {
     }
 
     /// Asserts that the walk continues past a malformed colour in the
-    /// colon spelling, whose group boundary is unambiguous.
+    /// colon spelling.
     ///
     /// Case: an application emits a truncated colon colour followed by
     /// an attribute it still expects to take effect.
@@ -608,9 +583,8 @@ mod tests {
         assert!(applied(&tokens).style.contains(Style::BOLD));
     }
 
-    /// Asserts that an unknown colour selector abandons the rest of the
-    /// sequence, because the semicolon spelling gives no point to
-    /// resynchronise on.
+    /// Asserts that an unknown colour selector in the semicolon spelling
+    /// abandons the rest of the sequence.
     ///
     /// Case: an application asks for a colour space this terminal does
     /// not answer, then spells an attribute after it.

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the interpreter, one module per control function.
+//! Unit tests for the interpreter.
 
 use super::*;
 use crate::device::color::{Color, Rgb};
@@ -53,15 +53,11 @@ fn first_row_glyphs(device: &DeviceState) -> Vec<char> {
 }
 
 /// The glyph at `column` of the device's `line`th visible row.
-///
-/// `column` is `u16` because `Row<Cell>` implements only `Index<u16>`
-/// and `Index<GridColumn>`; a `usize` does not reach the slice impl.
 fn glyph_at(device: &DeviceState, line: u16, column: u16) -> char {
     device.active_screen().viewport_row(ViewportLine(line))[column].c
 }
 
-/// Reports the reply bytes `chunk` produced, through the public
-/// entry point rather than the crate-internal interpreter.
+/// Reports the reply bytes `chunk` produced.
 fn replies_of(chunk: &[u8]) -> Vec<u8> {
     let mut vt = OrzmaVt::new(GridSize { cols: 4, rows: 3 }, 10);
     vt.interpret(chunk).replies
@@ -69,7 +65,7 @@ fn replies_of(chunk: &[u8]) -> Vec<u8> {
 
 /// One terminal kept across chunks, so a test can build up state
 /// with one chunk and then observe what a later chunk alone
-/// produced, through the same entry points the owner uses.
+/// produced.
 struct Session(OrzmaVt);
 
 impl Session {
@@ -77,8 +73,7 @@ impl Session {
         Self::sized(GridSize { cols: 4, rows: 3 })
     }
 
-    /// One terminal of the given size, for a capture whose scroll
-    /// region needs more rows than the default three.
+    /// One terminal of the given size.
     fn sized(size: GridSize) -> Self {
         Self(OrzmaVt::new(size, 10))
     }

--- a/crates/orzma_vt/src/interpreter/tests/alignment.rs
+++ b/crates/orzma_vt/src/interpreter/tests/alignment.rs
@@ -17,11 +17,10 @@ fn the_alignment_pattern_fills_every_visible_row() {
 }
 
 /// Asserts that the repaint `ESC # 8` calls for reaches the chunk
-/// liveness rather than being dropped by the handler.
+/// liveness.
 ///
-/// Case: the technician sends the alignment pattern, and the owner
-/// must open its coalesce window for the frame that repaints the
-/// screen.
+/// Case: a service technician sends the alignment pattern to a
+/// screen an earlier command already printed on.
 #[test]
 fn the_alignment_pattern_marks_its_own_chunk_damaged() {
     assert!(liveness_after(b"a", b"\x1b#8"));

--- a/crates/orzma_vt/src/interpreter/tests/alternate_screen.rs
+++ b/crates/orzma_vt/src/interpreter/tests/alternate_screen.rs
@@ -26,8 +26,8 @@ fn decset_47_shows_the_alternate_screen() {
 /// contents intact, repaints the whole viewport, and raises no
 /// eviction when the alternate screen held no placements.
 ///
-/// Case: the program exits and the shell's prompt from before it
-/// must reappear.
+/// Case: the program exits back to the shell whose prompt was on
+/// the primary screen.
 #[test]
 fn decrst_47_returns_to_the_primary_screen() {
     let mut session = Session::new();
@@ -68,8 +68,8 @@ fn a_redundant_alternate_screen_switch_does_nothing() {
 /// in the chunk's own signals and leaves the primary screen's
 /// placement in the next frame.
 ///
-/// Case: a full-screen program that mounted a webview exits, and
-/// the shell's own webview from before it must survive.
+/// Case: a full-screen program that mounted a webview exits while
+/// the shell's own webview from before it is still mounted.
 #[test]
 fn leaving_the_alternate_screen_evicts_only_its_placements() {
     let mut session = Session::new();

--- a/crates/orzma_vt/src/interpreter/tests/auto_wrap.rs
+++ b/crates/orzma_vt/src/interpreter/tests/auto_wrap.rs
@@ -90,7 +90,7 @@ fn an_erase_to_end_runs_after_a_restore_while_autowrap_is_reset() {
 ///
 /// Case: the same application saves and restores the cursor around a
 /// reset of autowrap, then clears the character under the cursor with
-/// `ECH` instead of clearing to the end of the line.
+/// `ECH`.
 #[test]
 fn an_erase_of_characters_runs_after_a_restore_while_autowrap_is_reset() {
     let device = interpret(b"abcd\x1b7\x1b[?7l\x1b8\x1b[X");
@@ -118,7 +118,7 @@ fn an_erase_to_end_runs_after_a_bare_alternate_screen_round_trip() {
 /// saved cursor and with it the saved deferred wrap.
 ///
 /// Case: the same application makes the round trip through mode 1049
-/// rather than mode 47, so the return restores the saved cursor.
+/// rather than mode 47.
 #[test]
 fn an_erase_to_end_runs_after_a_mode_1049_round_trip() {
     let device = interpret(b"abcd\x1b[?1049h\x1b[?7l\x1b[?1049l\x1b[K");

--- a/crates/orzma_vt/src/interpreter/tests/character_editing.rs
+++ b/crates/orzma_vt/src/interpreter/tests/character_editing.rs
@@ -95,8 +95,7 @@ fn a_zero_parameter_delete_character_sequence_deletes_one_cell() {
     assert_eq!(row[3].c, ' ');
 }
 
-/// Asserts that an insert character raises the chunk liveness, so the
-/// shifted row reaches a frame.
+/// Asserts that an insert character raises the chunk liveness.
 ///
 /// Case: a shell's line editor inserts a character in a chunk that
 /// prints nothing of its own and moves the cursor nowhere.
@@ -105,8 +104,7 @@ fn an_insert_character_reports_damage() {
     assert!(liveness_after(b"abcd\x1b[1;2H", b"\x1b[@"));
 }
 
-/// Asserts that a delete character raises the chunk liveness, so the
-/// closed-up row reaches a frame.
+/// Asserts that a delete character raises the chunk liveness.
 ///
 /// Case: a shell's line editor deletes a character in a chunk that
 /// prints nothing of its own and moves the cursor nowhere.

--- a/crates/orzma_vt/src/interpreter/tests/character_set.rs
+++ b/crates/orzma_vt/src/interpreter/tests/character_set.rs
@@ -19,8 +19,8 @@ fn a_set_designated_into_g0_maps_what_follows() {
 
 /// Asserts that designating ASCII over a G code restores letters.
 ///
-/// Case: a program finishes a box and emits `ESC ( B` so the next
-/// `q` prints as a letter again.
+/// Case: a program finishes a box and emits `ESC ( B` before
+/// printing more text.
 #[test]
 fn redesignating_ascii_restores_letters() {
     let device = interpret(b"\x1b(0\x1b(Bq");
@@ -33,10 +33,6 @@ fn redesignating_ascii_restores_letters() {
 /// Asserts that a final with no set behind it designates ASCII
 /// rather than leaving the previous set in force.
 ///
-/// The agreed policy is to fall back rather than drop the sequence:
-/// leaving DEC Special Graphics designated would print the
-/// application's text as line segments.
-///
 /// Case: a program draws a box, then designates the Finnish
 /// national replacement set with `ESC ( C` before writing a label.
 #[test]
@@ -48,8 +44,8 @@ fn an_unsupported_designation_falls_back_to_ascii() {
     );
 }
 
-/// Asserts that a designation whose final takes two bytes reaches
-/// the same ASCII fallback a one-byte final does.
+/// Asserts that a designation whose final takes two bytes falls
+/// back to ASCII just as a one-byte final does.
 ///
 /// Case: a program draws a box with line drawing, then designates
 /// the Greek supplemental set with `ESC ( " >` before writing a
@@ -66,8 +62,7 @@ fn a_two_byte_final_designation_falls_back_to_ascii() {
 /// Asserts that `SO` invokes G1 into GL and `SI` returns G0 to it.
 ///
 /// Case: a program designates line drawing into G1 once, then
-/// brackets each run of box characters with `SO` and `SI` instead of
-/// redesignating G0 every time.
+/// brackets each run of box characters with `SO` and `SI`.
 #[test]
 fn the_shift_out_and_shift_in_pair_swaps_the_invoked_set() {
     let device = interpret(b"\x1b)0\x0eq\x0fq");
@@ -121,7 +116,7 @@ fn the_locking_shift_three_invokes_g3() {
 /// stops applying.
 ///
 /// Case: a program prints one box character mid-sentence with
-/// `ESC N` rather than shifting GL and shifting it back.
+/// `ESC N`.
 #[test]
 fn the_seven_bit_single_shift_two_lasts_one_character() {
     let device = interpret(b"\x1b*0\x1bNqq");
@@ -135,7 +130,7 @@ fn the_seven_bit_single_shift_two_lasts_one_character() {
     );
 }
 
-/// Asserts that the raw C1 byte for SS2 reaches the same arm.
+/// Asserts that the raw C1 byte for SS2 single-shifts too.
 ///
 /// Case: a program emits an eight-bit single shift on a terminal not
 /// running in UTF-8 mode.
@@ -152,7 +147,7 @@ fn the_raw_c1_byte_single_shifts() {
     );
 }
 
-/// Asserts that the UTF-8 encoding of U+008E reaches the same arm.
+/// Asserts that the UTF-8 encoding of U+008E single-shifts too.
 ///
 /// Case: a program running on a UTF-8 stream emits the single shift.
 #[test]

--- a/crates/orzma_vt/src/interpreter/tests/cursor.rs
+++ b/crates/orzma_vt/src/interpreter/tests/cursor.rs
@@ -29,8 +29,8 @@ fn the_cursor_forward_and_back_sequences_move_by_columns() {
     assert_eq!(screen.viewport_row(ViewportLine(0))[1].c, 'y');
 }
 
-/// Asserts that an omitted count moves one row, the default DEC
-/// gives every `Pn`.
+/// Asserts that an omitted count moves one row, which is the
+/// default DEC gives every `Pn`.
 ///
 /// Case: a program emits the bare `CSI B` spelling to step down a
 /// single row.
@@ -44,7 +44,7 @@ fn an_omitted_cursor_motion_count_moves_one_row() {
 }
 
 /// Asserts that `CSI E` moves down and returns to the first
-/// column, without scrolling the way `NEL` would.
+/// column.
 ///
 /// Case: a program starts the next record of a listing at the left
 /// edge two rows down.
@@ -71,8 +71,7 @@ fn the_preceding_line_sequence_moves_up_and_returns_to_column_one() {
 /// Asserts that `CSI E` at the bottom margin stays put rather than
 /// scrolling the region.
 ///
-/// Case: a program emits a next-line at the foot of its pane, where
-/// `NEL` would have scrolled but `CNL` must not.
+/// Case: a program emits a next-line at the foot of its pane.
 #[test]
 fn the_next_line_sequence_does_not_scroll_at_the_bottom() {
     let device = interpret(b"a\x1b[3;1Hb\x1b[Ex");
@@ -136,7 +135,7 @@ fn resetting_origin_mode_seats_the_cursor_at_the_corner() {
     );
 }
 
-/// Asserts that `CSI Pn G` reaches the column-addressing method.
+/// Asserts that `CSI Pn G` addresses the column its parameter names.
 ///
 /// Case: a full-screen application jumps to column 6 of the row it is
 /// already writing and prints there.
@@ -149,8 +148,8 @@ fn the_cursor_character_absolute_sequence_addresses_a_column() {
     );
 }
 
-/// Asserts that the `HPA` spelling reaches the same column-addressing
-/// method as `CHA`.
+/// Asserts that the `HPA` spelling addresses a column just as `CHA`
+/// does.
 ///
 /// Case: an application emits the character-position spelling of the
 /// same move and prints there.
@@ -163,8 +162,8 @@ fn the_character_position_absolute_sequence_addresses_a_column() {
     );
 }
 
-/// Asserts that `CSI Pn a` reaches the column-relative motion CUF uses,
-/// moving the cursor right by the parameter.
+/// Asserts that `CSI Pn a` moves the cursor right by the parameter,
+/// just as `CUF` does.
 ///
 /// Case: an application steps two columns right with the
 /// character-position-relative spelling and prints there.
@@ -191,8 +190,8 @@ fn the_character_position_relative_sequence_stops_at_the_last_column() {
     );
 }
 
-/// Asserts that `CSI Pn d` reaches the line-addressing method rather
-/// than moving the cursor down by the parameter.
+/// Asserts that `CSI Pn d` addresses the line its parameter names
+/// rather than moving the cursor down by the parameter.
 ///
 /// Case: an application jumps to row 2 from the home position and
 /// prints there.

--- a/crates/orzma_vt/src/interpreter/tests/device_attributes.rs
+++ b/crates/orzma_vt/src/interpreter/tests/device_attributes.rs
@@ -51,7 +51,8 @@ fn the_raw_c1_identify_reports_the_primary_class() {
     assert_eq!(replies_of(b"\x9a"), b"\x1b[?6c");
 }
 
-/// Asserts that the UTF-8 encoding of U+009A reaches the same arm.
+/// Asserts that the UTF-8 encoding of U+009A reports the primary
+/// class too.
 ///
 /// Case: a program running on a UTF-8 stream emits the identify.
 #[test]
@@ -108,8 +109,8 @@ fn a_tertiary_attributes_request_is_ignored() {
 
 /// Asserts that a version packs one hundred per component.
 ///
-/// Case: a release bumps the minor version and the firmware level
-/// DA2 reports has to move with it.
+/// Case: a release bumps the minor version that DA2's firmware level
+/// encodes.
 #[test]
 fn a_version_packs_one_hundred_per_component() {
     assert_eq!(pack_version(1, 2, 3), 10_203);

--- a/crates/orzma_vt/src/interpreter/tests/erase.rs
+++ b/crates/orzma_vt/src/interpreter/tests/erase.rs
@@ -31,8 +31,8 @@ fn the_erase_in_display_sequence_clears_the_whole_screen() {
 /// Asserts that an `ED` parameter this terminal does not answer
 /// leaves the screen alone rather than erasing something.
 ///
-/// Case: an application asks for `ED 3` to drop the scrollback,
-/// which this terminal does not model.
+/// Case: an application asks for `ED 3` to drop the scrollback
+/// before it redraws the screen.
 #[test]
 fn an_unanswered_erase_in_display_parameter_erases_nothing() {
     let device = interpret(b"ab\x1b[3J");
@@ -68,8 +68,8 @@ fn the_erase_in_line_sequence_clears_the_whole_row() {
     );
 }
 
-/// Asserts that `CSI Pn X` reaches the screen and erases `Pn` cells
-/// from the cursor without moving it.
+/// Asserts that `CSI Pn X` erases `Pn` cells from the cursor without
+/// moving it.
 ///
 /// Case: Neovim clears the padding of a file-tree pane, which does
 /// not reach the right edge of the screen.
@@ -84,8 +84,7 @@ fn the_erase_character_sequence_clears_the_span_at_the_cursor() {
     assert_eq!(screen.cursor_column(), GridColumn(1));
 }
 
-/// Asserts that an erase character raises the chunk liveness, so the
-/// row it cleared is repainted.
+/// Asserts that an erase character raises the chunk liveness.
 ///
 /// Case: Neovim clears the padding of a file-tree pane in a chunk
 /// that prints nothing of its own, having selected the background it

--- a/crates/orzma_vt/src/interpreter/tests/interpret_output.rs
+++ b/crates/orzma_vt/src/interpreter/tests/interpret_output.rs
@@ -3,11 +3,9 @@
 
 use super::*;
 
-/// Asserts that staging row damage through the executor marks the
-/// chunk damaged.
+/// Asserts that staging row damage marks the chunk damaged.
 ///
-/// Case: a shell echoes one character, and the owner must open its
-/// coalesce window for the frame that repaints the row.
+/// Case: a shell echoes the character the user just typed.
 #[test]
 fn staged_row_damage_marks_the_chunk_damaged() {
     assert!(damage_of(b"a"));
@@ -25,8 +23,7 @@ fn a_bell_reaches_the_signals() {
     assert!(!output.damaged);
 }
 
-/// Asserts that a reply leaves the chunk undamaged, so the owner
-/// does not open a coalesce window for a frame with nothing in it.
+/// Asserts that a reply leaves the chunk undamaged.
 ///
 /// Case: an application probes the terminal while the screen sits
 /// untouched at a prompt.

--- a/crates/orzma_vt/src/interpreter/tests/keypad.rs
+++ b/crates/orzma_vt/src/interpreter/tests/keypad.rs
@@ -16,7 +16,7 @@ fn keypad_application_mode_selects_application_sequences() {
 /// Asserts that `ESC >` puts the keypad back in numeric mode.
 ///
 /// Case: a full-screen editor exits and hands the keypad back to the
-/// shell, where the digit keys must type digits again.
+/// shell.
 #[test]
 fn keypad_numeric_mode_selects_ascii_numerals() {
     let device = interpret(b"\x1b=\x1b>");

--- a/crates/orzma_vt/src/interpreter/tests/line_editing.rs
+++ b/crates/orzma_vt/src/interpreter/tests/line_editing.rs
@@ -122,8 +122,8 @@ fn the_xterm_scroll_down_spelling_scrolls_the_region_down() {
 /// region down, rather than being ignored the way a multi-parameter
 /// `CSI T` is.
 ///
-/// Case: a program emits the caret spelling with a trailing parameter
-/// that xterm ignores, such as `CSI 1 ; 2 ^`.
+/// Case: a program emits the caret spelling with a trailing
+/// parameter, such as `CSI 1 ; 2 ^`.
 #[test]
 fn a_multi_parameter_xterm_scroll_down_spelling_still_scrolls() {
     let device = interpret(b"a\x1b[1;2^");

--- a/crates/orzma_vt/src/interpreter/tests/line_movement.rs
+++ b/crates/orzma_vt/src/interpreter/tests/line_movement.rs
@@ -6,9 +6,6 @@ use super::*;
 /// Asserts that `ESC D` moves the cursor down a row and leaves the
 /// column where it stood.
 ///
-/// IND indexes and nothing more. The carriage return belongs to NEL
-/// alone, so IND must not be folded into the arm that pairs the two.
-///
 /// Case: a full-screen program walks down one column of a form,
 /// emitting the seven-bit index between fields.
 #[test]
@@ -27,8 +24,7 @@ fn the_seven_bit_index_keeps_the_column() {
 /// Asserts that `ESC E` moves the cursor down a row and returns the
 /// carriage.
 ///
-/// Case: a program ends a log line with the seven-bit next line
-/// instead of writing a CR and an LF of its own.
+/// Case: a program ends a log line with the seven-bit next line.
 #[test]
 fn the_seven_bit_next_line_returns_the_carriage() {
     let device = interpret(b"a\x1bEb");

--- a/crates/orzma_vt/src/interpreter/tests/memory_lock.rs
+++ b/crates/orzma_vt/src/interpreter/tests/memory_lock.rs
@@ -7,7 +7,7 @@ use super::*;
 /// rather than locking them in place.
 ///
 /// Case: a stray `ESC l` reaches the terminal while a shell is filling
-/// the screen, and the output goes on scrolling up past the top row.
+/// the screen.
 #[test]
 fn memory_lock_holds_no_row_out_of_scrolling() {
     let device = interpret(b"a\r\nb\x1bl\n\n");

--- a/crates/orzma_vt/src/interpreter/tests/meta_key.rs
+++ b/crates/orzma_vt/src/interpreter/tests/meta_key.rs
@@ -1,5 +1,4 @@
-//! Tests that the eighth-bit meta mode is ignored, so the key encoder's
-//! ESC prefix stays the only Alt encoding.
+//! Tests that the eighth-bit meta mode is ignored.
 
 use super::*;
 use crate::device::modes::VtModes;

--- a/crates/orzma_vt/src/interpreter/tests/modes.rs
+++ b/crates/orzma_vt/src/interpreter/tests/modes.rs
@@ -15,7 +15,7 @@ fn a_set_mode_four_selects_insert_mode() {
 /// Asserts that `CSI 4 l` returns the device to replace mode.
 ///
 /// Case: the same application leaves insert mode as soon as the
-/// insertion is done, which curses always pairs with entering it.
+/// insertion is done.
 #[test]
 fn a_reset_mode_four_selects_replace_mode() {
     let device = interpret(b"\x1b[4h\x1b[4l");
@@ -32,8 +32,7 @@ fn a_device_that_saw_no_mode_sequence_replaces() {
     assert_eq!(device.modes().insert_replace, InsertReplaceMode::Replace);
 }
 
-/// Asserts that `CSI ? 4 h` leaves IRM alone, because the private marker
-/// selects DECSCLM rather than the ANSI mode of the same number.
+/// Asserts that `CSI ? 4 h` leaves IRM alone.
 ///
 /// Case: a program enables smooth scrolling on a terminal that also
 /// answers the ANSI mode numbered four.
@@ -65,8 +64,7 @@ fn a_reset_to_initial_state_returns_the_mode_to_replace() {
     assert_eq!(device.modes().insert_replace, InsertReplaceMode::Replace);
 }
 
-/// Asserts that switching to the alternate screen carries IRM across,
-/// because the flip saves only what DECSC saves.
+/// Asserts that switching to the alternate screen carries IRM across.
 ///
 /// Case: a shell in insert mode launches a full-screen editor, which
 /// enters the alternate screen.
@@ -77,8 +75,7 @@ fn an_alternate_screen_flip_keeps_the_mode() {
 }
 
 /// Asserts that a character printed while `CSI 4 h` is in force shifts
-/// the row right, so the mode the device carries reaches the screen's
-/// print path rather than stopping at the mode snapshot.
+/// the row right.
 ///
 /// Case: a curses application without `ich` enters insert mode and types
 /// one character into the middle of a line it has already drawn.
@@ -89,8 +86,7 @@ fn a_print_under_set_mode_four_shifts_the_row_right() {
 }
 
 /// Asserts that a character printed after `CSI 4 l` overwrites the cell
-/// at the cursor, so the print path reads the live mode instead of
-/// assuming insert once IRM has been set.
+/// at the cursor.
 ///
 /// Case: the same application leaves insert mode and keeps echoing over
 /// the line it drew.
@@ -100,8 +96,7 @@ fn a_print_under_reset_mode_four_overwrites_the_cell() {
     assert_eq!(first_row_glyphs(&device), vec!['a', 'X', 'c', 'd']);
 }
 
-/// Asserts that `DECRC` leaves IRM where the data stream last put it,
-/// because `DECSC` does not save the mode.
+/// Asserts that `DECRC` leaves IRM where the data stream last put it.
 ///
 /// Case: an application saves the cursor while in insert mode, leaves
 /// insert mode, and restores the cursor before drawing further.

--- a/crates/orzma_vt/src/interpreter/tests/mouse.rs
+++ b/crates/orzma_vt/src/interpreter/tests/mouse.rs
@@ -28,7 +28,7 @@ fn each_mouse_tracking_number_selects_its_level() {
 /// level leaves that level alone.
 ///
 /// Case: an application tears down every tracking mode it knows,
-/// including ones it never set, and must not disable the one it did.
+/// including ones it never set.
 #[test]
 fn resetting_an_inactive_tracking_number_keeps_the_active_level() {
     assert_eq!(
@@ -61,9 +61,8 @@ fn the_sgr_mouse_number_selects_its_encoding() {
 /// Asserts that `DECSET 1005` is not answered, leaving the default
 /// framing in force.
 ///
-/// Case: an application asks for the UTF-8 coordinate extension,
-/// which `MouseReport::encode` does not implement — selecting it
-/// would report wrong coordinates past column 95.
+/// Case: an application asks for the UTF-8 coordinate extension as
+/// it starts tracking the mouse.
 #[test]
 fn the_utf8_mouse_number_is_not_answered() {
     assert_eq!(

--- a/crates/orzma_vt/src/interpreter/tests/parser_limits.rs
+++ b/crates/orzma_vt/src/interpreter/tests/parser_limits.rs
@@ -19,12 +19,6 @@ fn a_parameter_list_past_the_parser_cap_loses_its_tail() {
 /// Asserts that a sequence carrying an intermediate does not reach
 /// the control function that shares its final byte.
 ///
-/// The agreed policy refuses every intermediate rather than
-/// whitelisting the ones this terminal implements. `vtparse` promotes
-/// intermediates into the parameter slice, so DECCARA and DECSTBM
-/// reach the dispatcher with the same final byte and differ only in
-/// that trailing byte.
-///
 /// Case: an application changes the attributes of a rectangle with
 /// `CSI 1 ; 2 $ r`.
 #[test]
@@ -37,26 +31,12 @@ fn an_intermediate_does_not_reach_the_scroll_region() {
 }
 
 /// Asserts that a sequence whose intermediate falls out of the
-/// parameter slice through `vtparse`'s own parameter limit still does
-/// not reach the control function that shares its final byte.
-///
-/// The agreed policy checks `parameters_truncated` as its own guard
-/// rather than trusting `has_intermediates()` alone to catch every
-/// intermediate the parser drops. `vtparse` promotes a trailing
-/// intermediate into the parameter slice only while `num_params` has
-/// room under its own 32-parameter limit; once a sequence's own
-/// parameters already fill every slot, the promotion is refused and
-/// the loss is reported through `parameters_truncated` instead, so
-/// the intermediate never lands in the slice for `has_intermediates()`
-/// to see. A dispatcher that trusted `has_intermediates()` alone would
-/// read such a sequence as a bare `CSI 1 ; 2 r` and apply it as
-/// DECSTBM instead of refusing it as the DECCARA-shaped sequence it
-/// is.
+/// parameter slice past the parser's parameter limit still does not
+/// reach the control function that shares its final byte.
 ///
 /// Case: an application changes the attributes of a rectangle with
 /// `CSI 1 ; 2 $ r`, sent with a parameter list long enough to exhaust
-/// `vtparse`'s own 32-parameter limit before the trailing `$`
-/// arrives.
+/// the parser's 32-parameter limit before the trailing `$` arrives.
 #[test]
 fn a_truncated_intermediate_does_not_reach_the_scroll_region() {
     let chunk = format!("\x1b[1;2{}$ra\n\nb", ";".repeat(29));

--- a/crates/orzma_vt/src/interpreter/tests/printing.rs
+++ b/crates/orzma_vt/src/interpreter/tests/printing.rs
@@ -5,12 +5,6 @@ use super::*;
 
 /// Asserts that DEL neither reaches a cell nor advances the cursor.
 ///
-/// vtparse hands DEL to the actor with the rest of GL and leaves the
-/// decision here. Every set in this terminal's repertoire holds 94
-/// characters, for which DEL displays nothing; a 96-character set
-/// would make it printable, and that decision would then belong to
-/// the character set mapping.
-///
 /// Case: a program pads a fixed-width record with DEL, as a paper
 /// tape editor does to strike a character out.
 #[test]

--- a/crates/orzma_vt/src/interpreter/tests/reset.rs
+++ b/crates/orzma_vt/src/interpreter/tests/reset.rs
@@ -16,11 +16,10 @@ fn the_seven_bit_reset_blanks_every_visible_row() {
 }
 
 /// Asserts that the repaint `ESC c` calls for reaches the chunk
-/// liveness rather than being dropped by the handler.
+/// liveness.
 ///
-/// Case: the user runs `reset` on a screen a previous command filled,
-/// and the owner must open its coalesce window for the frame that
-/// repaints it.
+/// Case: the user runs `reset` on a screen a previous command
+/// filled.
 #[test]
 fn the_seven_bit_reset_marks_its_own_chunk_damaged() {
     assert!(liveness_after(b"a", b"\x1bc"));
@@ -29,8 +28,8 @@ fn the_seven_bit_reset_marks_its_own_chunk_damaged() {
 /// Asserts that `ESC c` names the placements it strands in the
 /// chunk's own signals.
 ///
-/// Case: a companion app mounted a webview beside a prompt and the
-/// user runs `reset`, so the host must despawn it.
+/// Case: a companion app mounted a webview beside a prompt, and the
+/// user runs `reset`.
 #[test]
 fn the_seven_bit_reset_names_the_placements_it_strands() {
     let mut session = Session::new();

--- a/crates/orzma_vt/src/interpreter/tests/reverse_index.rs
+++ b/crates/orzma_vt/src/interpreter/tests/reverse_index.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-/// Asserts that the raw C1 byte for RI reaches the screen.
+/// Asserts that the raw C1 byte for RI reverse indexes.
 ///
 /// Case: a program emits an eight-bit reverse index on a terminal not
 /// running in UTF-8 mode.
@@ -15,7 +15,7 @@ fn the_raw_c1_byte_reverse_indexes() {
     );
 }
 
-/// Asserts that the UTF-8 encoding of U+008D reaches the same arm.
+/// Asserts that the UTF-8 encoding of U+008D reverse indexes too.
 ///
 /// Case: a program running on a UTF-8 stream emits the reverse index.
 #[test]

--- a/crates/orzma_vt/src/interpreter/tests/text_cursor_enable.rs
+++ b/crates/orzma_vt/src/interpreter/tests/text_cursor_enable.rs
@@ -10,8 +10,7 @@ fn cursor_visible(device: &DeviceState) -> bool {
 
 /// Asserts that `CSI ? 25 l` makes the cursor invisible.
 ///
-/// Case: nvim hides the caret before it repaints a pane, so the block
-/// does not sit on top of the text while the rows are rewritten.
+/// Case: nvim hides the caret before it repaints a pane.
 #[test]
 fn a_dectcem_reset_hides_the_cursor() {
     let device = interpret(b"\x1b[?25l");
@@ -20,8 +19,7 @@ fn a_dectcem_reset_hides_the_cursor() {
 
 /// Asserts that `CSI ? 25 h` makes a hidden cursor visible again.
 ///
-/// Case: nvim finishes the repaint and brings the caret back so the
-/// user can see where the next keystroke will land.
+/// Case: nvim finishes the repaint and brings the caret back.
 #[test]
 fn a_dectcem_set_shows_a_hidden_cursor() {
     let mut session = Session::new();
@@ -36,8 +34,7 @@ fn a_dectcem_set_shows_a_hidden_cursor() {
 /// Asserts that a terminal that has seen no DECTCEM reports a visible
 /// cursor.
 ///
-/// Case: a shell prints its prompt on a freshly spawned terminal, and
-/// the user has to see the caret waiting after it.
+/// Case: a shell prints its prompt on a freshly spawned terminal.
 #[test]
 fn a_fresh_terminal_reports_a_visible_cursor() {
     let device = interpret(b"$ ");
@@ -146,9 +143,8 @@ fn a_dectcem_write_that_changes_nothing_does_not_make_the_chunk_live() {
 /// Asserts that the frame a chunk emits carries the hidden cursor, and
 /// that a later re-show reaches an emitted frame the same way.
 ///
-/// Case: nvim hides the caret before a repaint and the host paints from
-/// the frame it receives, then nvim finishes the repaint and shows the
-/// caret again for the next frame.
+/// Case: nvim hides the caret before a repaint, then finishes the
+/// repaint and shows the caret again.
 #[test]
 fn an_emitted_frame_carries_the_hidden_cursor() {
     let mut session = Session::new();

--- a/crates/orzma_vt/src/interpreter/tests/title.rs
+++ b/crates/orzma_vt/src/interpreter/tests/title.rs
@@ -14,8 +14,7 @@ fn a_title_sequence_reports_the_new_title() {
 
 /// Asserts that setting a title leaves the chunk undamaged.
 ///
-/// Case: a prompt sets the title without printing anything, and the
-/// owner must not open a coalesce window for an empty frame.
+/// Case: a prompt sets the title without printing anything.
 #[test]
 fn a_title_sequence_leaves_the_chunk_undamaged() {
     assert!(!damage_of(b"\x1b]0;hi\x07"));
@@ -64,7 +63,7 @@ fn popping_an_unset_title_reports_a_reset() {
 }
 
 /// Asserts that a reset returns the title to its default and says
-/// so, rather than leaving the host showing a stale one.
+/// so.
 ///
 /// Case: the user runs `reset` after a program left a title behind.
 #[test]
@@ -85,8 +84,8 @@ fn a_reset_without_a_title_reports_nothing() {
     assert!(output.signals.is_empty());
 }
 
-/// Asserts that a title terminated by ST reaches the same handler
-/// as one terminated by BEL.
+/// Asserts that a title terminated by ST sets the window title just
+/// as one terminated by BEL does.
 ///
 /// Case: a program that emits the seven-bit string terminator sets
 /// the window title.
@@ -107,11 +106,11 @@ fn a_private_window_operation_does_not_reach_the_title_stack() {
     assert_eq!(output.signals, vec![VtSignal::Title("hi".to_owned())]);
 }
 
-/// Asserts that an operating system command is ignored rather than
-/// fatal, and that the parser returns to ground behind it.
+/// Asserts that an operating system command is not fatal, and that
+/// the parser returns to ground behind it.
 ///
-/// Case: a shell prompt sets the window title before printing, on a
-/// terminal whose OSC handlers have not landed yet.
+/// Case: a shell prompt sets the window title and goes on printing
+/// behind it.
 #[test]
 fn a_title_sequence_is_ignored_rather_than_fatal() {
     let device = interpret(b"\x1b]0;hi\x07a");

--- a/crates/orzma_vt/src/interpreter/tests/unsupported_sequences.rs
+++ b/crates/orzma_vt/src/interpreter/tests/unsupported_sequences.rs
@@ -7,12 +7,8 @@ use super::*;
 /// is ignored rather than fatal: it raises no chunk liveness and the
 /// byte behind it prints where it would have anyway.
 ///
-/// The agreed policy follows what VT terminals do with sequences
-/// they do not implement. It is also the point of the dispatcher:
-/// before it existed every CSI sequence reached a `todo!()`.
-///
-/// Case: a program emits a `CSI` sequence the dispatcher has no arm
-/// for and goes on printing behind it.
+/// Case: a program emits a `CSI` sequence this terminal does not
+/// implement and goes on printing behind it.
 #[test]
 fn an_unimplemented_sequence_is_ignored() {
     // NOTE: `_` (05/15) is a final byte ECMA-48 leaves unallocated, so no

--- a/crates/orzma_vt/src/interpreter/tests/webview_apc.rs
+++ b/crates/orzma_vt/src/interpreter/tests/webview_apc.rs
@@ -40,8 +40,7 @@ fn an_apc_mount_reports_the_placement_it_registered() {
 /// Asserts that an APC-mounted placement is listed in the next
 /// emitted frame.
 ///
-/// Case: a companion app mounts its instance, and the host must be told
-/// where to draw the webview on the frame that follows.
+/// Case: a companion app mounts its instance beside the prompt.
 #[test]
 fn an_apc_mount_reaches_the_next_frame() {
     let id: InstanceId = ID.parse().expect("the fixture is a valid id");
@@ -75,7 +74,7 @@ fn an_apc_unmount_reports_the_address_it_named() {
 /// raises no signal.
 ///
 /// Case: a program on the same terminal writes a kitty graphics APC
-/// sequence, which orzma must leave alone.
+/// sequence.
 #[test]
 fn a_foreign_apc_payload_raises_no_signal() {
     let (_device, output) = interpret_fully(b"\x1b_Ga=T,f=100\x1b\\");
@@ -85,8 +84,8 @@ fn a_foreign_apc_payload_raises_no_signal() {
 /// Asserts that a mount past the per-terminal cap is reported as a
 /// rejection naming the instance it refused, rather than as a mount.
 ///
-/// Case: a program mounts more instances than the terminal has overlay
-/// slots for.
+/// Case: a program mounts more instances than the terminal accepts
+/// at once.
 #[test]
 fn an_apc_mount_past_the_cap_is_rejected() {
     let mut session = Session::new();
@@ -127,7 +126,7 @@ fn a_hit_unmount_raises_the_chunk_liveness() {
 /// Asserts that a mount the cap rejected does not raise the chunk
 /// liveness.
 ///
-/// Case: a program mounts past the per-terminal overlay-slot cap in a
+/// Case: a program mounts past the per-terminal placement cap in a
 /// chunk that carries no other terminal output.
 #[test]
 fn a_capped_mount_does_not_raise_the_chunk_liveness() {

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -1,8 +1,4 @@
 //! Terminal emulation for orzma.
-//!
-//! [`prelude`] gathers the vocabulary; the crate root defines [`Vt`],
-//! the protocol between a self-contained terminal emulator and its
-//! owner, and [`OrzmaVt`], the implementation of that protocol.
 
 use crate::{
     device::DeviceState,
@@ -26,10 +22,6 @@ mod screen;
 mod vi;
 
 /// The crate's vocabulary, gathered for downstream consumers.
-///
-/// A consumer imports the terminal types from here rather than from the
-/// private modules that declare them, so the module tree stays free to
-/// move a type without breaking anyone.
 pub mod prelude {
     pub use crate::device::color::{Color, Palette, Rgb};
     pub use crate::device::modes::{
@@ -52,59 +44,48 @@ pub mod prelude {
     pub use crate::{InterpretOutput, OrzmaVt, ResizeChanged, Vt, VtSignal};
 }
 
-/// The terminal-emulation contract `OrzmaTty` drives and the host
-/// observes.
+/// The contract between a self-contained terminal emulator and its
+/// owner.
 ///
 /// An implementor is a complete VT: it interprets the PTY stream, owns
-/// the grid and scrollback, tracks damage, and builds frames. The
-/// trait has no constructor — a concrete VT is built with its own
-/// configuration and injected; spawn geometry arrives via
-/// [`Vt::resize`]. Vi mode arrives later.
+/// the grid and scrollback, tracks damage, and builds frames.
 ///
 /// The read surface exposes no per-cell seam: cell-level host features
 /// (e.g. hyperlink hover) resolve against the emitted
-/// [`crate::prelude::Row`] / [`crate::prelude::Run`] data, and the only
-/// text read, [`Vt::selection_text`], is a derived value, so the VT's
-/// storage cell never leaves the crate.
+/// [`crate::prelude::Row`] / [`crate::prelude::Run`] data.
+///
+/// The owner must forward [`InterpretOutput::signals`] and
+/// [`ResizeChanged::evicted`] before it requests the next frame.
+///
+/// TODO: implement vi mode: accept a [`crate::prelude::ViModeSwitch`]
+/// and vi motions, and report the vi cursor in [`Frame::vi_cursor`].
 ///
 /// # Invariants
 ///
-/// - Every operation that can strand a placement names it in its own
-///   result: [`Vt::interpret`] names it in [`InterpretOutput::signals`],
-///   and [`Vt::resize`] names it in [`ResizeChanged::evicted`]. The only
-///   other removal is the host-driven [`Vt::remove_placements`], which
-///   reports nothing because the caller already named the ids. There
-///   is no sweep for the owner to run.
-/// - An owner that forwards [`InterpretOutput::signals`] and
-///   [`ResizeChanged::evicted`] before it requests the next frame
-///   delivers every eviction no later than the first frame that
-///   reflects it; the VT does not promise that the two arrive in the
-///   same batch.
+/// Every operation that can strand a placement names it in its own
+/// result: [`Vt::interpret`] names it in [`InterpretOutput::signals`],
+/// and [`Vt::resize`] names it in [`ResizeChanged::evicted`]. The only
+/// other removal is the host-driven [`Vt::remove_placements`], which
+/// reports nothing.
+///
+/// Every eviction then reaches the owner no later than the first frame
+/// that reflects it, though not necessarily in the same batch.
 pub trait Vt {
     /// Interprets one PTY chunk, staging its damage internally and
     /// returning everything else it produced.
     ///
     /// An empty chunk returns [`InterpretOutput::default`].
-    ///
-    /// # Invariants
-    ///
-    /// - [`InterpretOutput::signals`] keeps the order its own doc
-    ///   states: parser-raised signals first, the chunk-end eviction last.
-    /// - [`InterpretOutput::replies`] must be written back to the PTY.
-    ///
-    /// # Webview placements
+    /// [`InterpretOutput::replies`] must be written back to the PTY.
     ///
     /// An APC webview `mount` the VT accepts becomes a
     /// [`VtSignal::WebviewMount`] carrying the [`InstanceId`] the mount
     /// named; one the placement cap refuses becomes a
     /// [`VtSignal::WebviewMountRejected`] instead, which registers
-    /// nothing. The VT owns the placement table and projects every
-    /// placement into [`Frame::placements`] on each emit; a mount, unmount,
-    /// eviction, or projected-geometry change always raises the chunk
-    /// liveness, so the frame carrying the new list is guaranteed to
-    /// follow. Evictions the VT performs on its own authority (history
-    /// trim, reset, alternate-screen teardown) surface as
-    /// [`VtSignal::WebviewEvicted`]. At any instant the live ids are unique.
+    /// nothing. A mount, unmount, eviction, or projected-geometry change
+    /// always sets [`InterpretOutput::damaged`], so the frame carrying the
+    /// new [`Frame::placements`] list is guaranteed to follow. Evictions
+    /// the VT performs on its own authority (history trim, reset,
+    /// alternate-screen teardown) surface as [`VtSignal::WebviewEvicted`].
     ///
     /// A placement projects only while the screen it was mounted on is
     /// active: while the alternate screen is shown, primary-screen
@@ -114,6 +95,12 @@ pub trait Vt {
     /// [`VtSignal::WebviewEvicted`]. A re-issued `mount` for a live
     /// instance updates that placement in place — the id does not
     /// change, and nothing is named by [`VtSignal::WebviewEvicted`].
+    ///
+    /// # Invariants
+    ///
+    /// - [`InterpretOutput::signals`] holds the parser-raised signals
+    ///   first and the chunk-end eviction last.
+    /// - At any instant the live placement ids are unique.
     fn interpret(&mut self, chunk: &[u8]) -> InterpretOutput;
 
     /// Builds the frame for the staged damage and section diffs,
@@ -125,10 +112,7 @@ pub trait Vt {
     ///
     /// - The first emitted frame carries every viewport row, as does
     ///   every frame after a viewport-basis change (resize, offset,
-    ///   alternate-screen flip), because every basis change stages full
-    ///   damage. The emit-time offset diff is only a liveness backstop:
-    ///   it guarantees such a frame is emitted, not that it carries
-    ///   rows.
+    ///   alternate-screen flip).
     /// - A frame's placements and display offset describe the same
     ///   instant as its rows.
     fn frame(&mut self) -> Option<Frame>;
@@ -138,12 +122,10 @@ pub trait Vt {
     /// registered, `false` when the cell lies outside the grid or the
     /// per-terminal cap is full.
     ///
-    /// This is the control-socket counterpart of the APC `mount`, for PTYs
-    /// that drop APC (ConPTY). The caller raises
-    /// [`VtSignal::WebviewMount`] or [`VtSignal::WebviewMountRejected`]
-    /// itself from the returned verdict. Like [`Vt::remove_placements`], it
-    /// stages no row damage: the changed placement list alone carries the
-    /// next frame.
+    /// The caller raises [`VtSignal::WebviewMount`] or
+    /// [`VtSignal::WebviewMountRejected`] itself from the returned verdict.
+    /// It stages no row damage: the changed placement list alone carries
+    /// the next frame.
     fn mount_placement_at(
         &mut self,
         row: ScreenLine,
@@ -155,32 +137,26 @@ pub trait Vt {
     /// Removes the placements the host names, on either screen; returns
     /// whether anything went.
     ///
-    /// This is the control plane's entry point, used when a registration
-    /// is released, its connection drops, or a mount the host refuses
-    /// left a reservation behind. The VT cannot know any of those facts —
-    /// they live on the control socket — so without this the placements
-    /// keep a cap slot until their anchor scrolls out of history.
+    /// A placement the host does not remove keeps a cap slot until its
+    /// anchor scrolls out of history.
     ///
     /// # Invariants
     ///
-    /// Unlike [`Vt::resize`], this stages no row damage. A placement list
-    /// is an emit-time diffed section, so a changed list is enough to
-    /// guarantee the frame that carries it; staging rows here would
-    /// repaint the whole viewport on every release.
+    /// This stages no row damage; the changed list alone guarantees the
+    /// frame that carries it.
     ///
-    /// No [`VtSignal::WebviewEvicted`] is raised: the caller already
-    /// knows the ids and drops its own entities in the same pass, so a
-    /// signal would hand it back its own removal.
+    /// No [`VtSignal::WebviewEvicted`] is raised.
     fn remove_placements(&mut self, instances: &[InstanceId]) -> bool;
 
     /// Resizes the grid, truncating rather than reflowing; `None` when
     /// the dimensions did not change. Only a real change stages (full)
     /// damage.
     ///
+    /// The caller must reject a `size` with a zero axis.
+    ///
     /// # Invariants
     ///
-    /// Both axes are nonzero; degenerate sizes are rejected by the
-    /// caller.
+    /// Both grid axes are nonzero.
     ///
     /// The placements the resize strands are named in the returned
     /// [`ResizeChanged::evicted`] and are already gone from the VT.
@@ -197,13 +173,13 @@ pub trait Vt {
     /// width) is rejected, leaving the current selection untouched.
     ///
     /// The return value reports the stored state, not the projection:
-    /// a start whose projection is empty still returns `true`, and the
-    /// emit-time diff decides on its own whether a frame is owed.
+    /// a start whose projection is empty still returns `true`, and it
+    /// says nothing about whether a frame is owed.
     fn start_selection(&mut self, cell: GridPoint, side: CellSide, kind: SelectionKind) -> bool;
 
     /// Moves the active selection's moving end to `cell`; returns
-    /// whether the moving end changed. A no-op returning `false` when
-    /// there is no active selection or `cell` is outside the grid.
+    /// whether the moving end changed. It is a no-op returning `false`
+    /// when there is no active selection or `cell` is outside the grid.
     ///
     /// Two cells naming the same boundary — the right half of one and
     /// the left half of the next — are the same moving end.
@@ -242,8 +218,7 @@ pub trait Vt {
 pub struct InterpretOutput {
     /// Whether this chunk produced anything frame-relevant — staged row
     /// damage, a change to the reported cursor (motion or visibility),
-    /// or a mutated frame-visible section — so the owner knows to open
-    /// its coalesce window.
+    /// or a mutated frame-visible section.
     pub damaged: bool,
     /// Out-of-band signals: the parser-raised ones in byte-stream order,
     /// then the chunk-end [`VtSignal::WebviewEvicted`] when the chunk
@@ -275,8 +250,7 @@ pub enum VtSignal {
     Bell,
     /// The OS title string changed, either because the application set
     /// one (OSC 0 or OSC 2) or because `CSI 23 t` restored a saved one.
-    /// An icon name (OSC 1) is ignored, because this terminal carries
-    /// one title.
+    /// An icon name (OSC 1) is ignored.
     Title(String),
     /// The OS title string returned to the host's default, either
     /// because `CSI 23 t` restored a saved absence or because `RIS`
@@ -284,6 +258,8 @@ pub enum VtSignal {
     /// empty string, not this.
     ResetTitle,
     /// The application copied data to the system clipboard via OSC 52.
+    ///
+    /// [`OrzmaVt`] never raises it.
     Clipboard {
         /// The clipboard content that was copied.
         content: String,
@@ -300,8 +276,7 @@ pub enum VtSignal {
     },
     /// A mount the VT refused because the per-terminal placement cap was
     /// already full. Nothing was registered, so there is nothing for the
-    /// consumer to place; it exists so a webview that never appears is
-    /// diagnosable rather than silent.
+    /// consumer to place.
     WebviewMountRejected {
         /// The instance the refused mount named.
         instance: InstanceId,
@@ -309,7 +284,7 @@ pub enum VtSignal {
     /// The placement the PTY unmounted, or — when `instance` is `None` —
     /// every placement on this terminal.
     WebviewUnmount {
-        /// The instance to unmount; `None` unmounts every placement.
+        /// The instance to unmount.
         instance: Option<InstanceId>,
     },
     /// Placements the VT dropped without the host naming them (history
@@ -321,8 +296,10 @@ pub enum VtSignal {
         /// The instances that were evicted.
         placements: Vec<InstanceId>,
     },
-    /// Tracked `TermMode` flags that transitioned since the previous
-    /// signal drain, as mode names (e.g. "alt-screen").
+    /// Mode flags that transitioned since the previous signal drain, as
+    /// mode names (e.g. "alt-screen").
+    ///
+    /// [`OrzmaVt`] never raises it.
     ModeChange {
         /// Mode names that were enabled.
         added: Vec<&'static str>,
@@ -333,17 +310,13 @@ pub enum VtSignal {
 
 impl VtSignal {
     /// The eviction naming `placements`; `None` when there is nothing
-    /// to name, so neither a sweep that found nothing, a resize that
-    /// stranded nothing, nor a flip that tore nothing down wakes the
-    /// owner.
+    /// to name.
     pub fn evicted(placements: Vec<InstanceId>) -> Option<Self> {
         (!placements.is_empty()).then_some(Self::WebviewEvicted { placements })
     }
 }
 
-/// The self-contained implementation of [`Vt`]: a byte interpreter, the
-/// emulated device it writes to, and the frame tracker that turns the
-/// staged damage into frames.
+/// The self-contained implementation of [`Vt`].
 pub struct OrzmaVt {
     /// Byte decoding plus the CSI ?2026 synchronized-update buffer.
     interpreter: Interpreter,
@@ -356,15 +329,11 @@ pub struct OrzmaVt {
 impl OrzmaVt {
     /// Builds a terminal whose first frame carries every viewport row.
     ///
+    /// The caller must reject a `size` with a zero axis.
+    ///
     /// # Invariants
     ///
-    /// Both grid axes are nonzero; degenerate sizes are rejected by the
-    /// caller (the same contract as [`Vt::resize`]).
-    ///
-    /// The tracker must come from `FrameTracker::new`: its seeded
-    /// full damage is what makes the first frame carry every viewport
-    /// row, so a constructor that starts from an empty ledger paints
-    /// nothing until the first PTY output arrives.
+    /// Both grid axes are nonzero.
     pub fn new(size: GridSize, max_history: usize) -> Self {
         Self {
             interpreter: Interpreter::default(),
@@ -950,8 +919,7 @@ mod tests {
     /// viewport row.
     ///
     /// Case: a terminal spawns and the renderer has nothing on screen
-    /// yet, so the shell's first prompt must arrive with the whole
-    /// viewport behind it.
+    /// yet.
     #[test]
     fn the_first_frame_carries_every_viewport_row() {
         let mut vt = vt();
@@ -973,8 +941,7 @@ mod tests {
     /// Asserts that emitting drains the staged damage and settles the
     /// diffs, so an immediate second poll emits nothing.
     ///
-    /// Case: the host polls for a frame twice in one tick, and the
-    /// second poll must not repaint what the first one already sent.
+    /// Case: the host polls for a frame twice in one tick.
     #[test]
     fn an_emitted_frame_leaves_nothing_to_emit() {
         let mut vt = vt();
@@ -1079,8 +1046,8 @@ mod tests {
     }
 
     /// Asserts that a host-driven removal drops the named placements,
-    /// reports whether anything went, and — unlike a resize — stages no
-    /// row damage of its own.
+    /// reports whether anything went, and stages no row damage of its
+    /// own.
     ///
     /// Case: a program's control-plane connection drops while two of its
     /// views are mounted, and the host clears what the registrations had

--- a/crates/orzma_vt/src/placement.rs
+++ b/crates/orzma_vt/src/placement.rs
@@ -1,9 +1,4 @@
-//! Webview placement vocabulary: the id a mount is addressed by, the
-//! rectangle it reserves, the grid-space geometry an emitted frame
-//! carries, and the per-terminal cap.
-//!
-//! The table itself belongs to each `Screen`; see
-//! [`crate::screen::placements`].
+//! Webview placement vocabulary.
 
 use crate::screen::grid::coords::GridPoint;
 use std::fmt;
@@ -11,16 +6,11 @@ use std::str::FromStr;
 
 /// Host-minted identity of one webview placement.
 ///
-/// The control plane mints it and hands it to the registering program
-/// before that program writes its mount, so the program can address the
-/// placement it is about to create. The VT never mints one.
-///
 /// # Invariants
 ///
 /// The wire spelling is exactly 32 lowercase hex digits, so a value and
 /// its spelling are in bijection. At any instant the live ids on one
-/// terminal are unique: `supersede` drops the existing entry for an id
-/// across both screens before a re-mount registers its successor.
+/// terminal are unique.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InstanceId(pub u128);
 
@@ -69,10 +59,6 @@ impl InstanceId {
     pub const WIRE_DIGITS: usize = 32;
 
     /// Builds an id from 16 bytes of caller-supplied entropy.
-    ///
-    /// The randomness stays with the caller: the control plane mints
-    /// ids, and putting a self-seeding constructor here would leave a
-    /// way for the VT to start minting again.
     pub fn from_bytes(bytes: [u8; 16]) -> Self {
         Self(u128::from_be_bytes(bytes))
     }
@@ -81,15 +67,16 @@ impl InstanceId {
 /// One placement's grid-space geometry at emit time.
 ///
 /// The point is in active-grid coordinates and does not move when the
-/// user scrolls, the same way a cursor point or a selection endpoint
-/// does not; the consumer projects it with the frame's display offset.
+/// user scrolls; the consumer projects it with the frame's display
+/// offset.
+///
+/// A re-mount of a live id keeps the id and may change the size, so the
+/// consumer re-reads `size` from every frame rather than caching it
+/// against the id.
 ///
 /// # Invariants
 ///
-/// `size` is the reservation the most recent mount for `id` made. A
-/// re-mount of a live id keeps the id and may change the size, so the
-/// consumer re-reads `size` from every frame rather than caching it
-/// against the id.
+/// `size` is the reservation the most recent mount for `id` made.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchoredPlacement {
     /// The placement this geometry belongs to.
@@ -101,10 +88,6 @@ pub struct AnchoredPlacement {
 }
 
 /// The cell rectangle a mount reserves, without its position.
-///
-/// This is deliberately not [`GridSize`](crate::prelude::GridSize), whose row count is the source
-/// of truth for one screenful; a placement's reservation is a sub-rectangle
-/// and must not be substitutable for a grid dimension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlacementSize {
     /// Reserved height in cells.
@@ -115,19 +98,13 @@ pub struct PlacementSize {
 
 /// Upper bound on live placements per terminal, across both screens.
 ///
-/// It matches the renderer's overlay slot count, so a mount the VT
-/// accepts is always one the host can place. The two are not mirrors:
-/// the host allocates slots per terminal among live children, while this
-/// cap counts both screens, so it is strictly the stricter of the two.
+/// A mount the VT accepts is always one the host can place.
 pub const MAX_PLACEMENTS: usize = 12;
 
-/// Upper bound on a mount's reserved rows. With the ~2:1 terminal cell
-/// aspect and DPR 2, a 200-row x 400-col mount is a near-square pixel
-/// region staying under the common 8192 px GPU texture dimension limit.
+/// Upper bound on a mount's reserved rows.
 pub const MAX_ROWS: u16 = 200;
 
-/// Upper bound on a mount's reserved cols; see [`MAX_ROWS`] for the sizing
-/// envelope.
+/// Upper bound on a mount's reserved cols.
 pub const MAX_COLS: u16 = 400;
 
 #[cfg(test)]
@@ -136,7 +113,7 @@ mod tests {
 
     /// Asserts that a wire spelling parses only as exactly 32 lowercase
     /// hex digits, rejecting the shorter, longer, uppercase, and
-    /// sign-prefixed forms `u128::from_str_radix` would otherwise accept.
+    /// sign-prefixed forms.
     ///
     /// Case: a program writes an instance id into a mount APC, and the
     /// terminal must decide whether the field is well-formed before it
@@ -186,8 +163,7 @@ mod tests {
         );
     }
 
-    /// Asserts that the largest wire spelling is representable, so the
-    /// parser needs no overflow branch.
+    /// Asserts that the largest wire spelling is representable.
     ///
     /// Case: a mount names the maximal id the 32-digit grammar admits.
     #[test]

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -1,10 +1,4 @@
 //! The atomic grid + cursor operation unit for one terminal screen.
-//!
-//! [`Screen`] owns cell storage ([`grid::Grid`]) and the write cursor,
-//! and updates them together; a mutation that damages rows returns the
-//! [`DamageSpan`] it produced for the caller to stage, and pure cursor
-//! motion returns nothing, because the per-chunk cursor diff reports
-//! it.
 
 pub mod cell;
 pub mod character_sets;
@@ -47,10 +41,15 @@ use std::ops::Range;
 /// One terminal screen: cell storage plus the write cursor, updated
 /// atomically by each operation.
 ///
+/// A mutation that damages rows returns the [`DamageSpan`] it produced
+/// for the caller to stage; pure cursor motion returns nothing.
+///
+/// The caller must reject a size with a zero axis before it reaches
+/// [`Self::new`] or [`Self::resize`].
+///
 /// # Invariants
 ///
-/// Both grid axes are nonzero; degenerate sizes are rejected by the
-/// caller (the same contract as [`crate::Vt::resize`]).
+/// Both grid axes are nonzero.
 #[derive(Debug)]
 pub struct Screen {
     grid: Grid,
@@ -103,8 +102,8 @@ impl EraseScreenMode {
     /// The span an `ED` (`CSI Ps J`) parameter selects; `None` for a
     /// value this terminal does not answer.
     ///
-    /// `ED 3` erases the scrollback, which this terminal does not model:
-    /// every span here is confined to the visible screen.
+    /// `ED 3`, which erases the scrollback, is not answered: every span
+    /// here is confined to the visible screen.
     pub fn from_ed(ps: u16) -> Option<Self> {
         match ps {
             0 => Some(Self::Below),
@@ -145,8 +144,8 @@ impl Screen {
     /// rest of the row shifts right one column before the character lands.
     ///
     /// `auto_wrap` is `DECAWM`. While it is reset, a character at the right
-    /// border replaces the last column, and an armed wrap is not resolved
-    /// either, because a `DECRC` can restore one.
+    /// border replaces the last column, and an armed wrap, such as one a
+    /// `DECRC` restored, is not resolved either.
     ///
     /// Reports [`DamageSpan::Full`] when the wrap scrolled, and otherwise
     /// the row the character landed on, or `None` when that row has
@@ -188,9 +187,12 @@ impl Screen {
     /// Disarms the deferred wrap, leaving the cursor and the cells
     /// alone.
     ///
-    /// This is the half of `DECRST 7` that `Screen` owns. The saved
-    /// cursor keeps its own flag: DEC STD-070 has `DECSC` carry the
-    /// last-column flag, so a reset of the mode must not reach it.
+    /// The saved cursor keeps its own flag: DEC STD-070 has `DECSC` carry
+    /// the last-column flag.
+    ///
+    /// # Control Functions
+    ///
+    /// - `DECRST 7` (`CSI ? 7 l`) — the pending-wrap part
     pub fn disarm_pending_wrap(&mut self) {
         self.state.pending_wrap = false;
     }
@@ -198,16 +200,11 @@ impl Screen {
 
 /// Cursor addressing.
 ///
-/// None of these report damage. A move that only repositions the write
-/// cursor is carried by the per-chunk cursor diff, so returning a
-/// `DamageSpan` would repaint rows that did not change.
+/// None of these report damage.
 impl Screen {
     /// Moves the cursor one column left and disarms the deferred wrap.
     ///
-    /// A backspace at column zero stays there: xterm reaches the
-    /// previous row only under reverse-wraparound, which is off by
-    /// default. Cursor motion reaches the renderer through the
-    /// per-chunk cursor diff, so nothing is reported here.
+    /// A backspace at column zero stays there.
     ///
     /// # Control Functions
     ///
@@ -221,10 +218,6 @@ impl Screen {
     ///
     /// The top margin is the barrier: a cursor at or below it stops
     /// there, and only a cursor already above it reaches the first row.
-    ///
-    /// `DECOM` needs no branch here. Setting it seats the cursor inside
-    /// the vertical region, and this clamp keeps it there, so a cursor
-    /// origin mode confined can never step out of the region.
     ///
     /// # Control Functions
     ///
@@ -244,9 +237,8 @@ impl Screen {
     /// Moves the cursor down `count` rows in the same column, never
     /// scrolling.
     ///
-    /// The bottom margin is the barrier, mirroring
-    /// [`Self::move_cursor_up`]: a cursor at or above it stops there,
-    /// and only a cursor already below it reaches the last row.
+    /// The bottom margin is the barrier: a cursor at or above it stops
+    /// there, and only a cursor already below it reaches the last row.
     ///
     /// # Control Functions
     ///
@@ -267,8 +259,7 @@ impl Screen {
     /// column.
     ///
     /// The page border is the barrier, not a margin: this terminal has
-    /// no left margin, because `DECSLRM` needs the vertical split screen
-    /// mode it does not implement.
+    /// no left margin.
     ///
     /// # Control Functions
     ///
@@ -281,8 +272,7 @@ impl Screen {
     /// Moves the cursor `count` columns right, stopping at the last
     /// column.
     ///
-    /// The page border is the barrier, mirroring
-    /// [`Self::move_cursor_left`].
+    /// The page border is the barrier.
     ///
     /// # Control Functions
     ///
@@ -306,9 +296,9 @@ impl Screen {
     /// an omitted parameter.
     ///
     /// A zero addresses the first line or column, the same as a one.
-    /// [`Self::seat_cursor`] resolves the line against the origin mode
-    /// and clamps both axes, so a line outside the addressable region
-    /// stops at its edge rather than being refused.
+    /// The line is resolved against the current [`OriginMode`] and both
+    /// axes are clamped, so a line outside the addressable region stops
+    /// at its edge rather than being refused.
     ///
     /// # Control Functions
     ///
@@ -325,11 +315,8 @@ impl Screen {
     /// `None` for an omitted parameter.
     ///
     /// A zero addresses the first column, the same as a one, and a column
-    /// past the last stops there. The row is never touched: this seats the
-    /// column alone, so neither origin resolution nor a line clamp can move
-    /// the cursor off the row it is on. [`Self::seat_column`] also discards
-    /// a pending deferred wrap, the same disarm the other addressing
-    /// methods perform.
+    /// past the last stops there. The row is never touched, whatever the
+    /// origin mode, and a pending deferred wrap is discarded.
     ///
     /// # Control Functions
     ///
@@ -345,9 +332,8 @@ impl Screen {
     /// A zero addresses the first line, the same as a one. The line is
     /// resolved against the current [`OriginMode`] and clamped, so a line
     /// past the addressable region stops at its edge rather than being
-    /// refused. The column is never touched, but [`Self::seat_line`] still
-    /// discards a pending deferred wrap, the same disarm the other
-    /// addressing methods perform.
+    /// refused. The column is never touched, but a pending deferred wrap
+    /// is still discarded.
     ///
     /// # Control Functions
     ///
@@ -358,16 +344,7 @@ impl Screen {
 
     /// Seats the cursor at `line` — measured from the origin the current
     /// [`OriginMode`] defines — and `column`, clamping both axes and
-    /// disarming the deferred wrap. The disarm follows xterm, whose
-    /// `CursorSet` ends in `ResetWrap`, unlike a linefeed, which
-    /// preserves the wrap on purpose.
-    ///
-    /// This composes the two single-axis helpers, [`Self::seat_line`] and
-    /// [`Self::seat_column`], which absolute single-axis addressing
-    /// reaches directly, so the origin and each clamp are decided in one
-    /// place apiece and cannot drift. Vertical relative motion, line
-    /// feeding, and tabulation keep their own barriers and stay outside
-    /// these helpers on purpose.
+    /// disarming the deferred wrap.
     fn seat_cursor(&mut self, line: ScreenLine, column: GridColumn) {
         self.seat_line(line);
         self.seat_column(column);
@@ -411,18 +388,13 @@ impl Screen {
 /// Line feeding, region scrolling, and in-row character editing.
 impl Screen {
     /// Moves the cursor down one row, scrolling at the bottom margin;
-    /// the deferred-wrap flag is deliberately preserved.
+    /// the deferred-wrap flag is preserved.
     ///
-    /// A move inside the screen reports nothing: neither the departed nor
-    /// the arrived row changes contents, and the cursor motion reaches the
-    /// renderer through the per-chunk cursor diff. Scrolling moves content
-    /// and reports [`DamageSpan::Full`].
+    /// A move inside the screen reports nothing, and a scroll reports
+    /// [`DamageSpan::Full`].
     ///
     /// A cursor below a non-zero bottom margin and already on the last
     /// row moves nothing and scrolls nothing.
-    ///
-    /// [`Self::print`] also calls this to complete a deferred wrap, so
-    /// the operation is not reached only from a control function.
     ///
     /// # Control Functions
     ///
@@ -469,10 +441,8 @@ impl Screen {
     ///
     /// A cursor outside the margins inserts nothing (VT510 "IL — Insert
     /// Line"). The count is clamped to the rows from the cursor through
-    /// the bottom margin. An insert never feeds history: the rows it
-    /// discards leave from the bottom margin, not the top of the page.
-    /// The cursor homing follows xterm, kitty, and ECMA-48 § 8.3.67
-    /// rather than alacritty and wezterm, which leave the column alone.
+    /// the bottom margin. An insert never feeds history, and the cursor
+    /// homing follows ECMA-48 § 8.3.67.
     ///
     /// # Control Functions
     ///
@@ -494,10 +464,8 @@ impl Screen {
     /// A cursor outside the margins deletes nothing (VT510 "DL — Delete
     /// Line"). The count is clamped to the rows from the cursor through
     /// the bottom margin. A delete with the cursor on the first row of
-    /// the page feeds the deleted rows to history, as xterm, alacritty,
-    /// and wezterm do; the cursor homing follows xterm, kitty, and
-    /// ECMA-48 § 8.3.32 rather than alacritty and wezterm, which leave
-    /// the column alone.
+    /// the page feeds the deleted rows to history, and the cursor homing
+    /// follows ECMA-48 § 8.3.32.
     ///
     /// # Control Functions
     ///
@@ -517,12 +485,12 @@ impl Screen {
     ///
     /// The count is clamped to the columns from the cursor through the
     /// last one, and the blanks carry the pen's erase cell. A shift
-    /// disarms the deferred wrap; a zero count returns before anything
-    /// is touched, that flag included. Unlike [`Self::insert_lines`],
-    /// the edit applies wherever the cursor sits, ignoring the
-    /// scrolling margins VT510 gates `ICH` on, as xterm, alacritty,
-    /// kitty, ghostty, VTE and foot do. Selection and placement
-    /// anchors hold absolute columns and do not move with the content.
+    /// disarms the deferred wrap; a zero count touches nothing, that
+    /// flag included.
+    ///
+    /// The edit applies wherever the cursor sits, ignoring the scrolling
+    /// margins VT510 gates `ICH` on. Selection and placement anchors hold
+    /// absolute columns and do not move with the content.
     ///
     /// # Control Functions
     ///
@@ -544,10 +512,12 @@ impl Screen {
     /// cursor stays where it is.
     ///
     /// The count is clamped to the columns from the cursor through the
-    /// last one, never to the row width, which would blank a column
-    /// left of the cursor. Everything [`Self::insert_characters`]
-    /// records about the zero count, the scrolling margins, the
-    /// deferred wrap, and the column anchors holds here too.
+    /// last one. A shift disarms the deferred wrap; a zero count touches
+    /// nothing, that flag included.
+    ///
+    /// The edit applies wherever the cursor sits, ignoring the scrolling
+    /// margins VT510 gates `DCH` on. Selection and placement anchors hold
+    /// absolute columns and do not move with the content.
     ///
     /// # Control Functions
     ///
@@ -596,16 +566,13 @@ impl Screen {
     /// Follows a one-row scroll with the offset that keeps a scrolled
     /// viewport on the content it was showing.
     ///
-    /// A viewport pinned to the live tail stays pinned — that is what
-    /// following the newest output means. A scrolled one counts one row
-    /// further back, because the row it shows just moved that far from
-    /// the tail.
+    /// A viewport pinned to the live tail stays pinned, and a scrolled one
+    /// counts one row further back. At capacity the row the user was
+    /// reading has been evicted, so the view drifts by one.
     ///
     /// # Invariants
     ///
     /// The offset is clamped to the history that survives the scroll.
-    /// At capacity the row the user was reading has been evicted, so
-    /// the view drifts by one; there is nothing left to hold on.
     fn hold_scrolled_viewport(&mut self) {
         if self.viewport.offset == DisplayOffset(0) {
             return;
@@ -622,8 +589,7 @@ impl Screen {
     ///
     /// A shift that starts on the first row of the page feeds each
     /// departing row to history and holds a scrolled-back viewport on
-    /// the row it was showing, one row at a time, the way
-    /// [`Self::line_feed`] does.
+    /// the row it was showing.
     fn shift_rows_up(&mut self, first: ScreenLine, count: u16) -> Option<DamageSpan> {
         let bottom = self.scroll_region.bottom_margin();
         let count = self.clamped_rows(first, count)?;
@@ -642,9 +608,8 @@ impl Screen {
     /// `count` rows, filling the rows that open at `first` with the
     /// pen's erase cell; `None` when the clamped count is zero.
     ///
-    /// The rows pushed past the bottom margin are discarded. Nothing
-    /// reaches history on this path, because the rows that leave do so
-    /// at the bottom margin rather than at the top of the page.
+    /// The rows pushed past the bottom margin are discarded, and nothing
+    /// reaches history.
     fn shift_rows_down(&mut self, first: ScreenLine, count: u16) -> Option<DamageSpan> {
         let bottom = self.scroll_region.bottom_margin();
         let count = self.clamped_rows(first, count)?;
@@ -659,12 +624,7 @@ impl Screen {
     /// clamped to the rows through the bottom margin, and `None` when
     /// that leaves nothing to do.
     ///
-    /// A `first` below the bottom margin also yields `None`, because it
-    /// names no row the shift could move. The callers never produce one
-    /// — they check the cursor against the margins or pass the top
-    /// margin itself — so the guard exists to keep a future caller that
-    /// does neither from wrapping the subtraction into a count that
-    /// would walk the ring outside the region.
+    /// A `first` below the bottom margin also yields `None`.
     fn clamped_rows(&self, first: ScreenLine, count: u16) -> Option<u16> {
         let bottom = self.scroll_region.bottom_margin();
         let count = count.min(bottom.0.checked_sub(first.0)? + 1);
@@ -674,12 +634,6 @@ impl Screen {
     /// The columns an in-row edit at the cursor may actually touch:
     /// `count` clamped to the columns from the cursor through the last
     /// one, and `None` when that leaves nothing to do.
-    ///
-    /// A zero count therefore ends the call before anything is read or
-    /// written. The cursor column is always inside the row, so the
-    /// subtraction cannot fail; the guard exists to keep a future caller
-    /// that seats it outside from wrapping into a count the row cannot
-    /// hold.
     fn clamped_columns(&self, count: u16) -> Option<u16> {
         let count = count.min(self.grid.size().cols.checked_sub(self.state.column.0)?);
         (count > 0).then_some(count)
@@ -708,10 +662,11 @@ impl Screen {
 
 /// Erasure.
 impl Screen {
-    /// Erases part of the cursor row with the pen background (BCE);
-    /// [`EraseLineMode::ToEnd`] is a no-op while the cursor logically
-    /// sits past the row, as [`Self::cursor_parked_past_the_row`]
-    /// decides.
+    /// Erases part of the cursor row with the pen background (BCE).
+    ///
+    /// [`EraseLineMode::ToEnd`] is a no-op while the cursor logically sits
+    /// past the row, with the deferred wrap armed on the last column and
+    /// `DECAWM` set.
     ///
     /// # Control Functions
     ///
@@ -734,9 +689,10 @@ impl Screen {
     }
 
     /// Erases `count` characters from the cursor rightward with the
-    /// pen background (BCE), leaving the cursor where it is; a no-op
-    /// while the cursor logically sits past the row, as
-    /// [`Self::erase_in_line`]'s [`EraseLineMode::ToEnd`] is.
+    /// pen background (BCE), leaving the cursor where it is.
+    ///
+    /// It is a no-op while the cursor logically sits past the row, with
+    /// the deferred wrap armed on the last column and `DECAWM` set.
     ///
     /// # Control Functions
     ///
@@ -793,23 +749,17 @@ impl Screen {
     }
 
     /// Fills the given column range of the cursor row with the pen's
-    /// erase cell and reports that row, which is the whole contract
-    /// every single-row erasure shares.
+    /// erase cell and reports that row.
     fn erase_cursor_row_columns(&mut self, columns: Range<u16>) -> Option<DamageSpan> {
         self.grid
             .fill_visible_row_range(self.state.line, columns, self.state.pen.erase_cell());
         self.damage_span(self.state.line, self.state.line)
     }
 
-    /// Whether the cursor logically sits past the row's last cell, so
-    /// that an erase from the cursor rightward finds nothing to erase.
+    /// Whether the cursor logically sits past the row's last cell.
     ///
     /// All three conditions are required: the deferred wrap armed,
-    /// `DECAWM` set so the next character really does move to the next
-    /// row, and the cursor on the last column. The column test is not
-    /// redundant — [`Self::tab_to`] carries an armed flag off the right
-    /// border, so without it a `CBT` out of a full row would leave
-    /// `EL 0` and `ECH` declining mid-row.
+    /// `DECAWM` set, and the cursor on the last column.
     fn cursor_parked_past_the_row(&self, auto_wrap: AutoWrap) -> bool {
         self.state.pending_wrap && auto_wrap.wraps() && self.at_right_edge()
     }
@@ -824,9 +774,7 @@ impl Screen {
 impl Screen {
     /// Moves the cursor forward `count` tabulation stops.
     ///
-    /// The right edge is this screen's last column, so the same stop
-    /// table lands the cursor differently on a narrow screen than on a
-    /// wide one.
+    /// The right edge is this screen's last column.
     ///
     /// # Control Functions
     ///
@@ -840,8 +788,10 @@ impl Screen {
 
     /// Moves the cursor back `count` tabulation stops.
     ///
-    /// The left edge is column zero until DECSLRM and DECOM land, at
-    /// which point the margin supplies it instead.
+    /// The left edge is column zero.
+    ///
+    /// TODO: take the left edge from the left margin once `DECSLRM` is
+    /// implemented.
     ///
     /// # Control Functions
     ///
@@ -853,9 +803,8 @@ impl Screen {
 
     /// Sets a tabulation stop at the cursor column.
     ///
-    /// Routed through the same edit vocabulary `CTC 0` uses, because the
-    /// two control functions request the identical edit. TABULATION STOP
-    /// MODE scoping, when it lands, has to reach HTS as well.
+    /// TODO: scope HTS by TABULATION STOP MODE once that mode is
+    /// implemented.
     ///
     /// # Control Functions
     ///
@@ -898,10 +847,7 @@ impl Screen {
     ///
     /// # Invariants
     ///
-    /// The deferred wrap is deliberately left as it is, unlike
-    /// [`Screen::carriage_return`]. Disarming it would make a tab after
-    /// a full row seat the cursor back onto the row the application had
-    /// already filled.
+    /// The deferred wrap is left as it is.
     fn tab_to(&mut self, column: GridColumn) {
         self.state.column = column;
     }
@@ -946,10 +892,6 @@ impl Screen {
 }
 
 /// Graphic rendition.
-///
-/// The pen is handed out mutably because applying an `SGR` sequence is
-/// the caller's job; this screen only supplies the attributes a print
-/// stamps into a cell.
 impl Screen {
     /// Mutably borrows the SGR pen.
     pub fn pen_mut(&mut self) -> &mut Pen {
@@ -963,14 +905,13 @@ impl Screen {
     /// home; a request the margins cannot satisfy is refused whole.
     ///
     /// Both parameters are one-based line numbers as sent, with `None`
-    /// for an omitted one; [`Margins::resolve`] owns the defaults, the
-    /// clamp, and the refusal.
+    /// for an omitted one. An omitted or zero top means the first line
+    /// and an omitted or zero bottom the last, and a bottom past the page
+    /// is clamped to the last line. A request whose top is not above its
+    /// bottom is refused.
     ///
     /// The cursor goes to the home the origin mode defines rather than
-    /// to the "column 1, line 1 of the page" VT510 p.276 states,
-    /// because homing to the page while the origin is within the
-    /// margins would seat the cursor outside them, which p.195 forbids;
-    /// xterm homes through the same origin-aware path.
+    /// to the "column 1, line 1 of the page" VT510 p.276 states.
     ///
     /// # Control Functions
     ///
@@ -986,10 +927,7 @@ impl Screen {
     /// Sets the cursor origin and seats the cursor at the home the new
     /// mode defines.
     ///
-    /// Both directions seat the cursor. VT510 says only what home *is*
-    /// under each setting and never that `DECOM` moves the cursor; xterm,
-    /// kitty, wezterm, Windows Terminal, and `vttest` settle it by homing
-    /// on set and on reset alike.
+    /// Both directions seat the cursor.
     ///
     /// # Control Functions
     ///
@@ -1011,14 +949,12 @@ impl Screen {
     ///
     /// The viewport is the window the user sees: at the live tail it is
     /// the active screen, and a scrolled viewport reaches back into
-    /// history. [`crate::screen::grid::Grid`]'s own index resolves
-    /// against the live tail alone, so a scrolled read has to come
-    /// through here.
+    /// history. A scrolled read must come through here.
     pub fn viewport_row(&self, line: ViewportLine) -> &Row<Cell> {
         self.grid.row(line.to_grid(self.viewport.offset))
     }
 
-    /// Number of scrollback rows the viewport sits above the live tail; always zero until scroll operations arrive.
+    /// Number of scrollback rows the viewport sits above the live tail.
     #[inline]
     pub const fn display_offset(&self) -> DisplayOffset {
         self.viewport.offset
@@ -1027,16 +963,12 @@ impl Screen {
     /// Moves the viewport by one [`Scroll`] motion; `None` when the
     /// motion was zero or entirely clamped away.
     ///
+    /// A screen that keeps no history never moves, so this is a no-op on
+    /// the alternate screen.
+    ///
     /// # Invariants
     ///
-    /// A motion that moves the viewport reports [`DamageSpan::Full`]:
-    /// the emit-time offset diff only guarantees that a frame is
-    /// emitted, not that it carries rows, so anything less would
-    /// repaint stale content at the new offset.
-    ///
-    /// A screen that keeps no history never moves, because every target
-    /// clamps to the live tail. That is what makes this a silent no-op
-    /// on the alternate screen without a caller having to check.
+    /// A motion that moves the viewport reports [`DamageSpan::Full`].
     pub fn scroll(&mut self, scroll: Scroll) -> Option<DamageSpan> {
         let before = self.viewport.offset;
         self.set_display_offset(self.scroll_target(scroll));
@@ -1046,15 +978,7 @@ impl Screen {
     /// Seats the viewport at `offset`, clamped to the history that
     /// currently exists.
     ///
-    /// [`Self::hold_scrolled_viewport`] also writes the offset, so this is
-    /// not the only seam that does; it is the seam a future
-    /// `DeviceState::scroll` will drive.
-    ///
-    /// # Invariants
-    ///
-    /// The caller must stage full damage: this moves the viewport
-    /// basis, so a frame that carried the new offset without every row
-    /// would repaint stale content.
+    /// The caller must stage full damage.
     pub fn set_display_offset(&mut self, offset: DisplayOffset) {
         let history =
             u32::try_from(self.grid.history_len()).expect("scrollback never exceeds u32::MAX rows");
@@ -1063,9 +987,6 @@ impl Screen {
 }
 
 /// What an emitted frame reads back.
-///
-/// The damage projection lives here because it converts screen rows into
-/// the viewport coordinates a frame repaints by.
 impl Screen {
     /// Returns the grid size.
     pub fn grid_size(&self) -> GridSize {
@@ -1074,10 +995,7 @@ impl Screen {
 
     /// The write cursor as an emitted frame carries it.
     ///
-    /// `text_cursor_enable` is `DECTCEM`, which the device owns rather
-    /// than either screen. Production callers reach this through
-    /// `DeviceState::cursor`, which records why pairing a screen read
-    /// with a separately-read mode silently drops a `CSI ? 25 l`.
+    /// `text_cursor_enable` is `DECTCEM`.
     // TODO: Report the real shape and blink once DECSCUSR lands. Block /
     // steady is what the terminal starts at.
     pub fn cursor(&self, text_cursor_enable: TextCursorEnable) -> Cursor {
@@ -1119,7 +1037,7 @@ impl Screen {
         }
     }
 
-    /// The id of the row the cursor sits on — the anchor a mount samples.
+    /// The id of the row the cursor sits on.
     pub fn cursor_line_id(&self) -> LineId {
         self.grid.line_id(self.state.line)
     }
@@ -1166,12 +1084,11 @@ impl Screen {
     }
 
     /// Applies the state saved in memory to each actual state.
-    /// If no saved state exists, perform a DECRC-compliant action.
+    /// If no saved state exists, it performs a DECRC-compliant action.
     ///
     /// The saved position is put back verbatim. Restoring an origin mode
     /// whose margins moved in between can therefore seat the cursor
-    /// outside them; DECSC saves no margins to clamp against, and the
-    /// manuals leave the collision undefined.
+    /// outside them.
     ///
     /// # Control Functions
     ///
@@ -1207,24 +1124,17 @@ impl Screen {
     ///
     /// Reports [`DamageSpan::Full`], or nothing when the grid was
     /// already blank and carried no history; the cursor homes either
-    /// way, because cursor motion reaches the renderer through the
-    /// per-chunk cursor diff rather than through damage. A selection the
-    /// reset drops also reports `Full`, so the frame that no longer
-    /// carries it is owed even on a blank grid.
+    /// way. A selection the reset drops also reports `Full`, even on a
+    /// blank grid.
     ///
     /// # Invariants
     ///
     /// The cursor lands at the screen's upper-left corner whatever
-    /// origin mode was in force, because the state is replaced wholesale
-    /// rather than homed through the origin.
+    /// origin mode was in force.
     ///
-    /// Every placement on this screen becomes evictable here without
-    /// this method touching the table: [`crate::screen::grid::Grid::reset`]
-    /// mints fresh row ids without rewinding its counter, so no anchor
-    /// taken before the reset can resolve afterwards and the next
-    /// [`Self::evict_lost_anchors`] names all of them. A rewrite of
-    /// `Grid::reset` that renumbers from zero would silently keep the
-    /// placements alive.
+    /// Every placement on this screen stays in the table but becomes
+    /// evictable: no anchor taken before the reset resolves after it, so
+    /// the next [`Self::evict_lost_anchors`] names every placement.
     ///
     /// # Control Functions
     ///
@@ -1246,39 +1156,25 @@ impl Screen {
     /// the dimensions already matched.
     ///
     /// A shrink pushes as many rows off the top as it takes to keep the
-    /// cursor on screen and drops the rest from the bottom, so a prompt
-    /// at the bottom survives and a mostly-blank screen keeps its
-    /// content. A growth reclaims rows from history before it appends
-    /// blank ones.
+    /// cursor on screen and drops the rest from the bottom. A growth
+    /// reclaims rows from history before it appends blank ones.
     ///
     /// # Invariants
     ///
-    /// A resize that changes the dimensions reports [`DamageSpan::Full`]:
-    /// every emitted frame carries the new size but nothing diffs it, so
-    /// partial row damage would hand the renderer new dimensions with
-    /// stale rows behind them.
+    /// A resize that changes the dimensions reports [`DamageSpan::Full`].
     ///
     /// The cursor and the saved cursor both land inside the new grid.
-    /// Leaving either out of bounds would panic the next write, which is
-    /// why the saved one is clamped here rather than on restore.
     ///
     /// The saved cursor follows the rows a resize moves exactly as the
     /// live one does, so a `DECRC` after the resize — the one
     /// `DECRST 1049` performs on the way back from the alternate screen
     /// included — lands on the row `DECSC` saved rather than the rows
     /// the resize reclaimed above it. A never-saved checkpoint drifts
-    /// off the home position by the same amount, the trade alacritty
-    /// makes too.
+    /// off the home position by the same amount.
     ///
-    /// A height change returns the margins to the whole page. Keeping a
-    /// region whose rows still fit would leave a cursor below its bottom
-    /// margin, and [`Self::line_feed`] scrolls only on an exact match
-    /// with that margin, so the screen would never scroll again.
+    /// A height change returns the margins to the whole page.
     ///
-    /// A scrolled-back viewport tracks the rows it was showing: each
-    /// scroll pairs with [`Self::hold_scrolled_viewport`] the way line
-    /// feeding does, and a growth walks the offset back by the rows it
-    /// reclaims.
+    /// A scrolled-back viewport tracks the rows it was showing.
     pub fn resize(&mut self, size: GridSize) -> Option<DamageSpan> {
         let old = self.grid.size();
         if old == size {
@@ -1311,8 +1207,7 @@ impl Screen {
     /// the page-wide scroll region and the absolute cursor origin.
     ///
     /// The pattern is drawn with default attributes rather than the
-    /// current pen, because a screen tinted by the application's colors
-    /// is useless as an adjustment reference.
+    /// current pen.
     ///
     /// # Control Functions
     ///
@@ -1367,11 +1262,6 @@ impl Screen {
 /// The anchor a mount records is a `LineId` from this screen's own grid,
 /// so a placement can only ever be resolved against the grid that minted
 /// its anchor.
-///
-/// Five of these forward to [`ScreenPlacements`] unchanged. They stay
-/// rather than exposing the table, so `DeviceState` never holds a
-/// `&mut ScreenPlacements` and every mutation of a screen's placements
-/// goes through the screen that owns them.
 impl Screen {
     /// Registers a mount at the write cursor under the id the host minted.
     pub fn mount_placement(&mut self, id: InstanceId, size: PlacementSize) {
@@ -1383,11 +1273,8 @@ impl Screen {
     /// Registers a mount anchored at the visible row `row` and column
     /// `column` under the id the host minted.
     ///
-    /// # Invariants
-    ///
-    /// `row` and `column` lie inside the grid: `Grid::line_id` indexes the
-    /// ring unchecked, so the device bounds-checks against `grid_size`
-    /// before calling this.
+    /// `row` and `column` must lie inside the grid; the caller must
+    /// bounds-check them against [`Self::grid_size`].
     pub fn mount_placement_at(
         &mut self,
         id: InstanceId,
@@ -1431,10 +1318,8 @@ impl Screen {
     ///
     /// # Invariants
     ///
-    /// The anchors resolve through the same expression
-    /// [`Self::evict_lost_anchors`] passes. A placement this omits is
-    /// exactly a placement the sweep evicts, so no placement can become
-    /// unresolvable without also becoming evictable.
+    /// A placement this omits is exactly one [`Self::evict_lost_anchors`]
+    /// evicts.
     pub fn project_placements(&self) -> Vec<AnchoredPlacement> {
         self.placements
             .project(|anchor| self.grid.grid_line(anchor))
@@ -1450,9 +1335,8 @@ impl Screen {
 
 /// The selection this screen owns.
 ///
-/// The endpoints are resolved through the same expression
-/// [`Self::project_placements`] passes for anchors, so a selection can
-/// only ever be resolved against the grid that minted its rows.
+/// A selection can only ever be resolved against the grid that minted
+/// its rows.
 impl Screen {
     /// Anchors a new selection at `cell`, replacing any active one;
     /// returns whether the state changed. A cell outside the grid is
@@ -1470,8 +1354,8 @@ impl Screen {
     }
 
     /// Moves the active selection's moving end to `cell`; returns
-    /// whether it moved. A no-op without an active selection or for a
-    /// cell outside the grid.
+    /// whether it moved. It is a no-op without an active selection or for
+    /// a cell outside the grid.
     pub fn extend_selection(&mut self, cell: GridPoint, side: CellSide) -> bool {
         let Some(end) = self.selection_end(cell, side) else {
             return false;

--- a/crates/orzma_vt/src/screen/cell.rs
+++ b/crates/orzma_vt/src/screen/cell.rs
@@ -6,17 +6,12 @@ use crate::screen::grid::run::Style;
 /// One stored character cell: a glyph plus the attributes it was
 /// printed with.
 ///
-/// This is the storage representation, never exposed outside the
-/// crate: it carries no coordinate (position is implied by the cell's
-/// slot in the grid) and holds a single `char` (grapheme composition
-/// is a later extension). The host reads cells only through the
-/// emitted [`crate::prelude::Row`] / [`crate::prelude::Run`]
-/// projection.
+/// TODO: hold a grapheme cluster rather than a single `char`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Cell {
     /// The stored glyph.
     pub c: char,
-    /// Foreground color, symbolic (palette-resolved at emit time).
+    /// Foreground color, symbolic.
     pub fg: Color,
     /// Background color, symbolic.
     pub bg: Color,
@@ -46,10 +41,6 @@ impl Cell {
 }
 
 /// The current SGR attributes applied to subsequently printed cells.
-///
-/// Applying an `SGR` sequence to one lives in `interpreter::sgr`, which
-/// holds this type's other `impl` block so the screen layer stays free
-/// of the parser.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Pen {
     /// Foreground selected by SGR 30-38/39/90-97.
@@ -95,8 +86,7 @@ mod tests {
     /// Asserts that the default cell is a blank space with default
     /// colors and no styling.
     ///
-    /// Case: a terminal spawns with an untouched screen, whose cells
-    /// must render as the terminal's default background.
+    /// Case: a terminal spawns with an untouched screen.
     #[test]
     fn the_default_cell_is_a_default_colored_blank() {
         let cell = Cell::default();
@@ -109,7 +99,7 @@ mod tests {
     /// Asserts that stamping burns all pen attributes into the cell.
     ///
     /// Case: an application selects bold red text with SGR before
-    /// printing, and every printed cell carries those attributes.
+    /// printing.
     #[test]
     fn stamping_copies_the_pen_attributes() {
         let pen = Pen {

--- a/crates/orzma_vt/src/screen/character_sets.rs
+++ b/crates/orzma_vt/src/screen/character_sets.rs
@@ -1,12 +1,6 @@
 //! Graphic character set designation (SCS) and invocation (locking and
-//! single shifts) for one screen.
-//!
-//! Only the GL half of the code table is modelled. Reaching a set
-//! invoked into GR takes raw `0xA0`–`0xFF` input bytes, and the UTF-8
-//! parser this crate feeds on consumes that range as multi-byte
-//! encoding instead, so such a set could never be selected. `LS1R`,
-//! `LS2R`, and `LS3R` stay out of scope until an 8-bit input mode
-//! exists.
+//! single shifts) for one screen. Only the GL half of the code table is
+//! modelled.
 
 use std::ops::{Index, IndexMut};
 
@@ -32,11 +26,7 @@ impl CharacterSet {
     /// The character set an `SCS` final character selects.
     ///
     /// A final this terminal has no set for resolves to ASCII instead
-    /// of leaving the previous designation standing. Leaving it would
-    /// keep an earlier `ESC ( 0` in force, so the text that followed
-    /// would print as line segments; the national replacement sets this
-    /// arm mostly catches differ from ASCII in a handful of positions,
-    /// which makes ASCII the closer answer.
+    /// of leaving the previous designation standing.
     pub fn from_dscs(dscs: u8) -> Self {
         match dscs {
             b'B' => Self::Ascii,
@@ -104,8 +94,7 @@ impl GCode {
     /// designates nothing this terminal implements.
     ///
     /// The 96-character designators `-`, `.`, and `/` are among the
-    /// bytes answered with `None`: every set in the repertoire holds 94
-    /// characters, so there is nothing to designate through them.
+    /// bytes answered with `None`.
     pub fn from_designator(designator: u8) -> Option<Self> {
         match designator {
             b'(' => Some(Self::G0),
@@ -119,8 +108,7 @@ impl GCode {
 
 /// The G code a single shift invokes into GL for one graphic character.
 ///
-/// SS2 and SS3 are the only single shifts the VT220 defines, so G0 and
-/// G1 are excluded by construction.
+/// SS2 and SS3 are the only single shifts the VT220 defines.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SingleShift {
     /// `SS2` (`0x8E`, `ESC N`) invokes G2.
@@ -152,10 +140,8 @@ impl IndexMut<GCode> for GSets {
 /// # Invariants
 ///
 /// A `pending_single_shift` outranks `gl` for exactly one graphic
-/// character. [`Self::translate`] clears it as it maps that character,
-/// and a locking shift leaves it alone: the two invocations are
-/// independent state, not one field the newer control function
-/// overwrites.
+/// character: [`Self::translate`] clears it as it maps that character,
+/// and a locking shift leaves it armed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CharacterSetMapping {
     /// The G code the latest locking shift invoked into GL.
@@ -178,6 +164,9 @@ impl CharacterSetMapping {
     }
 
     /// Invokes `g_code` into GL.
+    ///
+    /// TODO: implement `LS1R`, `LS2R`, and `LS3R` once an 8-bit input
+    /// mode exists.
     ///
     /// # Control Functions
     ///
@@ -213,10 +202,7 @@ impl CharacterSetMapping {
     /// Restores the power-up designations and invocations, dropping any
     /// pending single shift.
     ///
-    /// # Control Functions
-    ///
-    /// - `DECSTR` (`CSI ! p`)
-    /// - `RIS` (`ESC c`)
+    /// TODO: reach this reset from DECSTR (CSI ! p).
     #[expect(
         dead_code,
         reason = "the executor reaches this reset once DECSTR lands; RIS goes through `Screen::reset`"
@@ -238,8 +224,7 @@ mod tests {
         ///
         /// Case: an application designates line drawing into a
         /// different bank with each of `ESC ( 0`, `ESC ) 0`, `ESC * 0`,
-        /// and `ESC + 0`, so the four spellings have to be told apart by
-        /// the designator alone.
+        /// and `ESC + 0`.
         #[test]
         fn each_designator_selects_its_own_g_code() {
             assert_eq!(GCode::from_designator(b'('), Some(GCode::G0));
@@ -248,13 +233,9 @@ mod tests {
             assert_eq!(GCode::from_designator(b'+'), Some(GCode::G3));
         }
 
-        /// Asserts that the 96-character designators select no G code.
-        ///
-        /// The agreed policy is to answer these with `None` rather than
-        /// fold them onto G1 through G3 alongside their 94-character
-        /// spellings: every set in the repertoire holds 94 characters,
-        /// so accepting the designator would designate a set that does
-        /// not exist.
+        /// Asserts that the 96-character designators select no G code
+        /// rather than folding onto G1 through G3 alongside their
+        /// 94-character spellings.
         ///
         /// Case: an application designates ISO Latin-1 supplemental
         /// into G1 with `ESC - A`.
@@ -283,15 +264,8 @@ mod tests {
             );
         }
 
-        /// Asserts that a final with no set behind it resolves to
-        /// ASCII.
-        ///
-        /// The agreed policy is to designate ASCII rather than drop the
-        /// sequence and leave the previous designation standing. Leaving
-        /// it would keep an earlier `ESC ( 0` in force and print the
-        /// following text as line segments, whereas the national
-        /// replacement sets this arm mostly catches differ from ASCII in
-        /// a handful of positions.
+        /// Asserts that a final with no set behind it resolves to ASCII
+        /// rather than leaving the previous designation standing.
         ///
         /// Case: an application running under a Finnish locale
         /// designates its national replacement set with `ESC ( C`.
@@ -369,8 +343,7 @@ mod tests {
         /// the character set the first one put there.
         ///
         /// Case: an application finishes drawing a box with DEC Special
-        /// Graphics on G0 and emits `ESC ( B`, so that the next `q`
-        /// prints as a letter again instead of a horizontal line.
+        /// Graphics on G0 and emits `ESC ( B`.
         #[test]
         fn redesignating_a_g_code_replaces_the_previous_set() {
             let mut state = CharacterSetMapping::default();
@@ -411,15 +384,6 @@ mod tests {
         /// Asserts that a locking shift replaces the G code in GL and
         /// leaves a pending single shift armed.
         ///
-        /// The agreed policy models GL and the pending single shift as
-        /// independent state, so a locking shift arriving between `SS2`
-        /// and the character it applies to changes neither. The VT220
-        /// describes a single shift as returning to "the previous
-        /// character set", which a save-and-restore model reads as
-        /// undoing the locking shift; foot implements that reading,
-        /// while xterm and Windows Terminal use the override model
-        /// pinned here.
-        ///
         /// Case: an application emits `SS2`, then `SO` before the
         /// character the single shift applies to.
         #[test]
@@ -445,14 +409,8 @@ mod tests {
         use super::*;
 
         /// Asserts that a later single shift replaces the pending one
-        /// and leaves the locking shift alone.
-        ///
-        /// The agreed policy is that successive single shifts replace
-        /// rather than queue, because only one graphic character
-        /// follows and the later control is the one that names it.
-        /// xterm and Windows Terminal each store a single scalar, which
-        /// forces the same choice; the VT220 manual does not settle the
-        /// collision.
+        /// rather than queueing behind it, and leaves the locking shift
+        /// alone.
         ///
         /// Case: an application has shifted GL to G1 with `SO`, emits
         /// `SS2`, then changes its mind and emits `SS3` before printing.

--- a/crates/orzma_vt/src/screen/checkpoint.rs
+++ b/crates/orzma_vt/src/screen/checkpoint.rs
@@ -8,39 +8,24 @@ use crate::screen::state::ScreenState;
 
 /// What `DECSC` copies aside so that `DECRC` can put it back.
 ///
-/// Although a name such as `Save(d) Cursor` is used in the VT510 specification,
-/// we use the name `Checkpoint` instead because the saved data actually includes information other than the cursor state.
-///
 /// The default value is what `DECRC` restores when no `DECSC` ever ran,
 /// as far as this crate models that state: the home position, a reset
 /// origin mode, no character attributes, and the default character set
-/// mapping. The manual's fourth item also maps a set into GR, and its
-/// separate selective erase attribute has no field here; both stay out
-/// of scope for the reasons [`super::character_sets`] records. A
-/// resize moves the saved row with the grid, so after one the
-/// never-saved position may sit below home; [`super::Screen::resize`]
-/// records why.
+/// mapping. The VT510 manual's fourth item also maps a set into GR, and its
+/// separate selective erase attribute has no field here. A resize moves
+/// the saved row with the grid, so after one the never-saved position
+/// may sit below home.
 ///
-/// `IRM` is deliberately absent: it is not among the items `DECSC`
-/// saves, and xterm masks the insert flag out of what `DECRC` restores,
-/// so a later mutation that adds it here would make an alternate-screen
-/// flip carry a mode no reference terminal carries.
+/// `DECRC` restores neither `IRM` nor `DECTCEM`.
 ///
 /// The `Wrap flag (autowrap or no autowrap)` the VT420 and VT520
-/// manuals list among the items `DECSC` saves is the last-column flag,
-/// not `DECAWM`: DEC STD-070 p.D-14 has the flag "saved when a Save
-/// Cursor operation is performed, and restored when a Restore Cursor
-/// operation is performed", while xterm masks `WRAPAROUND` out of what
-/// `DECRC` restores. `Self::pending_wrap` is therefore the field that
-/// answers the manuals' line, and the mode is not saved at all.
+/// manuals list among the items `DECSC` saves is the last-column flag
+/// `Self::pending_wrap` holds, not `DECAWM`: DEC STD-070 p.D-14 has the
+/// flag "saved when a Save Cursor operation is performed, and restored
+/// when a Restore Cursor operation is performed". `DECAWM` is not saved.
 ///
-/// `DECTCEM` is absent for the same reason as `IRM`: the VT510
-/// saved-item list does not name cursor visibility, so a mutation that
-/// added it here would make a `DECRC` restore a visibility no reference
-/// terminal restores.
-///
-/// `DECSTR` and `RIS` reset the saved state as well, and put back this
-/// same default rather than leaving the last `DECSC` reachable.
+/// `RIS` resets the saved state as well, and puts back this same default
+/// rather than leaving the last `DECSC` reachable.
 ///
 /// # Control Functions
 ///
@@ -67,9 +52,8 @@ pub struct Checkpoint {
 impl Checkpoint {
     /// Reads off everything `DECSC` saves from the state that holds it.
     ///
-    /// The scroll margins are deliberately absent: `DECSC` saves the
-    /// origin mode but not the region it is relative to, so a `DECRC`
-    /// after a `DECSTBM` restores the mode against the newer margins.
+    /// The scroll margins are not saved, so a `DECRC` after a `DECSTBM`
+    /// restores the origin mode against the newer margins.
     pub(super) fn capture(
         state: &ScreenState,
         origin_mode: OriginMode,

--- a/crates/orzma_vt/src/screen/cursor.rs
+++ b/crates/orzma_vt/src/screen/cursor.rs
@@ -3,10 +3,7 @@
 use crate::screen::grid::coords::GridPoint;
 
 /// Bit 0 of the packed `cursor_style` u32 — set when the cursor
-/// should be drawn. The WGSL shader short-circuits when this bit is
-/// clear (see `paint_cursor` in `terminal_ui_material.wgsl`). Exposed
-/// so app-level overrides (e.g., `TerminalGrid.suppress_cursor`) can
-/// mask it out without re-deriving the literal `1`.
+/// should be drawn.
 pub const CURSOR_VISIBLE_BIT: u32 = 1;
 
 /// Cursor state at snapshot time.
@@ -24,10 +21,9 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    /// Packs the style into the u32 the WGSL shader decodes: bit 0 is
-    /// [`CURSOR_VISIBLE_BIT`], bits 1-2 carry the shape (Block `0`,
-    /// Underline `1`, Bar `2`), and bit 3 carries the blinking flag
-    /// (see the `CURSOR_*` constants in `terminal_ui_material.wgsl`).
+    /// Packs the style into one u32: bit 0 is [`CURSOR_VISIBLE_BIT`],
+    /// bits 1-2 carry the shape (Block `0`, Underline `1`, Bar `2`), and
+    /// bit 3 carries the blinking flag.
     pub fn pack_cursor_style(&self) -> u32 {
         let visible = if self.visible { CURSOR_VISIBLE_BIT } else { 0 };
         let shape = match self.shape {
@@ -69,8 +65,7 @@ mod tests {
     /// Asserts that every cursor shape occupies its assigned wire bits.
     ///
     /// Case: a terminal application switches among the steady block,
-    /// underline, and bar DECSCUSR variants, and the selected caret
-    /// shape is forwarded to the GPU.
+    /// underline, and bar DECSCUSR variants.
     #[test]
     fn each_shape_lands_in_the_shape_bits() {
         assert_eq!(
@@ -90,8 +85,7 @@ mod tests {
     /// Asserts that blinking is encoded independently for every shape.
     ///
     /// Case: a terminal application selects a blinking caret variant
-    /// while the terminal stays focused, so the shader's time-based
-    /// blink phase controls whether the caret is painted.
+    /// while the terminal stays focused.
     #[test]
     fn blinking_sets_bit_three_independent_of_shape() {
         assert_eq!(
@@ -112,8 +106,7 @@ mod tests {
     /// leaving the packed shape and blink policy intact.
     ///
     /// Case: vim hides the cursor with DECTCEM (`CSI ?25l`) while it
-    /// redraws, and on `CSI ?25h` the caret returns with the same
-    /// shape and blink policy the application had selected.
+    /// redraws, and on `CSI ?25h` the caret returns.
     #[test]
     fn a_hidden_cursor_clears_only_the_visible_bit() {
         assert_eq!(
@@ -133,10 +126,9 @@ mod tests {
     /// Asserts that the cursor position does not participate in style
     /// packing.
     ///
-    /// Case: the user scrolls through history while the live cursor
-    /// keeps its application-selected shape and blink policy, even as
-    /// its grid position projects to a different viewport cell or to
-    /// no cell at all.
+    /// Case: the user scrolls through history, and the cursor's grid
+    /// position projects to a different viewport cell or to no cell at
+    /// all.
     #[test]
     fn the_cursor_position_does_not_participate_in_style_packing() {
         let at_origin = Cursor {

--- a/crates/orzma_vt/src/screen/grid.rs
+++ b/crates/orzma_vt/src/screen/grid.rs
@@ -14,9 +14,6 @@ use std::collections::VecDeque;
 use std::ops::{Index, IndexMut, Range};
 
 /// Grid dimensions in cells.
-///
-/// The row count is the source of truth for "one screenful" (scroll
-/// paging) and for verifying an applied resize.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GridSize {
     /// Visible column count.
@@ -27,49 +24,32 @@ pub struct GridSize {
 
 /// Stable identity of one grid row, minted when the row enters the ring.
 ///
+/// An id must be resolved against the grid that minted it: uniqueness is
+/// per grid, not per terminal.
+///
 /// # Invariants
 ///
 /// An id is the row's identity, not its address: it follows the row
-/// wherever the row moves inside the ring. Ids are minted monotonically
-/// per grid and never reused, so a placement anchored to one can never be
-/// re-pointed at later content on the same grid.
-///
-/// Nothing orders the ring by id. A reverse scroll inserts a freshly
-/// minted row above rows minted earlier, and two consequences follow that
-/// each invalidate a short-circuit a reader would otherwise reach for.
-///
-/// History becomes unordered as well, because such a row later scrolls
-/// into it like any other, so binary-searching the history segment alone
-/// is equally unsound. The front row is not necessarily the lowest id
-/// either, because on a grid built without history a reverse scroll
-/// inserts at ring index zero. History is therefore resolved through an
-/// id-keyed index rather than by position, and only the visible rows are
-/// scanned.
-///
-/// The uniqueness is per grid, NOT per terminal: the primary and
-/// alternate screens own separate grids that both start at zero, so
-/// resolving an id against the wrong one silently names a different row.
+/// wherever the row moves inside the ring. Ids are never reused within
+/// one grid, so a placement anchored to one can never be re-pointed at
+/// later content on the same grid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LineId(u64);
 
 /// Storage-only grid: scrollback history plus the visible screen in
 /// one ring.
-///
-/// The grid knows nothing about cursors, pens, or viewports.
 #[derive(Debug)]
 pub struct Grid {
     /// One logical ring holding history and the active screen:
     /// the last `size.rows` entries are the active screen, everything
-    /// before them is history, oldest first. Indices are logical
-    /// (`VecDeque` hides the physical rotation), so index `0` is
-    /// always the oldest surviving history row and the boundary sits
-    /// at `history_len`.
+    /// before them is history, oldest first. Index `0` is always the
+    /// oldest surviving history row, and the boundary sits at
+    /// `history_len`.
     rows: VecDeque<GridRow>,
     /// Active-screen dimensions; `rows` always keeps at least this
     /// many entries as its tail window.
     size: GridSize,
-    /// History row cap: `history_len` never exceeds it, and a scroll
-    /// at the cap recycles the evicted row as the incoming blank.
+    /// History row cap: `history_len` never exceeds it.
     max_history: usize,
     /// The id the next row to enter the ring will carry.
     next_line_id: u64,
@@ -78,10 +58,6 @@ pub struct Grid {
 }
 
 /// One stored row: its identity together with its cells.
-///
-/// The id lives here rather than on [`Row`] because `Row<Cell>` is the
-/// storage row while `Row<Run>` is the emitted one, so a field on `Row`
-/// would carry grid identity into the frame's wire type.
 #[derive(Debug)]
 struct GridRow {
     id: LineId,
@@ -125,9 +101,8 @@ impl Grid {
 
     /// Whether every visible cell is blank and no history survives.
     ///
-    /// Content only: row ids and the mint counter are deliberately out of
-    /// scope, so a grid that has scrolled and then been erased still
-    /// reports blank.
+    /// Row ids do not count, so a grid that has scrolled and then been
+    /// erased still reports blank.
     pub fn is_blank(&self) -> bool {
         self.history_len() == 0
             && self
@@ -145,13 +120,10 @@ impl Grid {
     /// Shifts one visible row's cells from `column` right by `count`
     /// columns, filling the columns that open with `fill`.
     ///
-    /// The cells pushed past the last column are discarded. Row
-    /// identity is untouched: an in-row edit neither creates nor
-    /// retires a row, so no id is minted and nothing reaches history.
+    /// The cells pushed past the last column are discarded. The row
+    /// keeps its id, and nothing reaches history.
     ///
-    /// # Invariants
-    ///
-    /// `count` is clamped by the caller to the columns from `column`
+    /// The caller must clamp `count` to the columns from `column`
     /// through the row's end.
     pub fn insert_visible_row_cells(
         &mut self,
@@ -177,12 +149,10 @@ impl Grid {
     /// `fill`.
     ///
     /// The `count` cells starting at `column` are overwritten by the
-    /// cells that shift into them. Row identity is untouched, for the
-    /// same reason [`Self::insert_visible_row_cells`] leaves it alone.
+    /// cells that shift into them. The row keeps its id, and nothing
+    /// reaches history.
     ///
-    /// # Invariants
-    ///
-    /// `count` is clamped by the caller to the columns from `column`
+    /// The caller must clamp `count` to the columns from `column`
     /// through the row's end.
     pub fn delete_visible_row_cells(
         &mut self,
@@ -208,8 +178,7 @@ impl Grid {
     ///
     /// The departing row becomes the newest history row only when `top`
     /// is the first screen line. A region with content pinned above it
-    /// discards the row instead, because it never reached the top of the
-    /// screen and so was never something the user could scroll back to.
+    /// discards the row instead.
     pub fn scroll_up_one(&mut self, top: ScreenLine, bottom: ScreenLine, fill: Cell) {
         let base = self.history_len();
         let id = self.mint();
@@ -293,9 +262,8 @@ impl Grid {
     /// The active-grid line the row `id` now sits at; `None` once it has
     /// left the ring.
     ///
-    /// A history row resolves in constant time through the history
-    /// index; a visible row is found by a scan bounded by the screen
-    /// height.
+    /// A history row resolves in constant time; a visible row costs a
+    /// scan bounded by the screen height.
     pub fn grid_line(&self, id: LineId) -> Option<GridLine> {
         let history = self.history_len();
         if let Some(index) = self.history_index.index_of(id) {
@@ -313,11 +281,10 @@ impl Grid {
     /// Borrows the row at an active-grid line; a negative line reaches
     /// into scrollback history.
     ///
-    /// # Invariants
+    /// # Panics
     ///
-    /// The line must resolve inside the ring — `-history_len <= line`
-    /// and `line < rows`. [`crate::screen::Screen`] guarantees that by
-    /// clamping the viewport to the history it actually has.
+    /// Panics unless the line resolves inside the ring, that is
+    /// `-history_len <= line` and `line < rows`.
     pub fn row(&self, line: GridLine) -> &Row<Cell> {
         let index = self
             .ring_index(line)
@@ -333,10 +300,8 @@ impl Grid {
     /// Resizes the grid, truncating rather than reflowing; returns
     /// whether the dimensions changed.
     ///
-    /// A shrink drops rows from the bottom. Pushing rows off the top
-    /// into history is the caller's job, done before this call: it owns
-    /// the cursor that decides how many rows must go, and the viewport
-    /// that has to follow them.
+    /// A shrink drops rows from the bottom. Rows that should reach
+    /// history must be scrolled off the top before this call.
     ///
     /// # Invariants
     ///
@@ -358,9 +323,8 @@ impl Grid {
     ///
     /// # Invariants
     ///
-    /// The row is minted from the running counter rather than renumbered
-    /// from zero: a [`LineId`] an anchor still holds must never come back
-    /// around and name one of the rows this appends.
+    /// The row carries a freshly minted [`LineId`] that no anchor can
+    /// already hold.
     fn push_blank_row(&mut self) {
         let id = self.mint();
         self.rows.push_back(GridRow {
@@ -402,8 +366,7 @@ impl Grid {
     ///
     /// # Invariants
     ///
-    /// Ids only ever move forward, which is what makes them unique for
-    /// the grid's lifetime; the overflow guard is what keeps that true.
+    /// An id is never handed out twice in the grid's lifetime.
     fn mint(&mut self) -> LineId {
         let id = LineId(self.next_line_id);
         self.next_line_id = self
@@ -438,8 +401,8 @@ impl Grid {
     }
 }
 
-/// Indexes the row at a screen line; history rows are structurally
-/// unreachable because [`ScreenLine`] cannot be negative.
+/// Indexes the row at a screen line; history rows are unreachable
+/// through it.
 impl Index<ScreenLine> for Grid {
     type Output = Row<Cell>;
 
@@ -539,8 +502,7 @@ mod tests {
     /// to history and drops only the blanks that scroll left behind.
     ///
     /// Case: the shell's prompt sits on the last row of a tall window
-    /// and the user drags the window shorter, so `Screen::resize`
-    /// scrolls before it resizes.
+    /// and the user drags the window shorter.
     #[test]
     fn a_shrink_after_a_scroll_keeps_what_the_scroll_saved() {
         let mut grid = grid(4, 10);
@@ -558,9 +520,8 @@ mod tests {
         assert_eq!(grid.row(GridLine(-2))[0].c, 'a');
     }
 
-    /// Asserts that the same shrink works when the preceding scrolls
-    /// ran against a full history and so recycled rows instead of
-    /// lengthening the ring.
+    /// Asserts that a shrink keeps the rows the preceding scrolls handed
+    /// to history when those scrolls ran against a full history.
     ///
     /// Case: a long-running session has filled its scrollback to the
     /// cap when the user drags the window shorter.
@@ -586,8 +547,7 @@ mod tests {
     /// appends blank ones.
     ///
     /// Case: the user drags a window taller after scrolling output
-    /// off the top, and expects the earlier lines back rather than
-    /// blank space.
+    /// off the top.
     #[test]
     fn a_growth_reclaims_history_before_it_appends_blanks() {
         let mut grid = grid(2, 10);
@@ -699,7 +659,7 @@ mod tests {
     /// and no history.
     ///
     /// Case: a terminal spawns and the shell has not written anything
-    /// yet, so the whole screen shows default blanks.
+    /// yet.
     #[test]
     fn a_fresh_grid_is_blank_with_no_history() {
         let grid = grid(3, 10);
@@ -714,8 +674,7 @@ mod tests {
     /// given cell.
     ///
     /// Case: a shell at the bottom of the screen emits a newline while
-    /// scrollback still has room, so the oldest visible line becomes
-    /// history instead of disappearing.
+    /// scrollback still has room.
     #[test]
     fn a_scroll_with_room_pushes_into_history() {
         let mut grid = grid(2, 10);
@@ -732,8 +691,7 @@ mod tests {
     /// and keeps the history length at the cap.
     ///
     /// Case: a long-running shell session has filled the scrollback
-    /// limit, and every further bottom-line newline drops the oldest
-    /// history line.
+    /// limit and keeps emitting newlines on the bottom line.
     #[test]
     fn a_scroll_at_capacity_evicts_the_oldest_row() {
         let mut grid = grid(2, 1);
@@ -745,8 +703,8 @@ mod tests {
     /// Asserts that a zero-capacity grid evicts on every scroll and
     /// keeps no history.
     ///
-    /// Case: the user configures scrollback off, so a bottom-line
-    /// newline discards the top visible row outright.
+    /// Case: the user configures scrollback off and the shell emits a
+    /// newline on the bottom line.
     #[test]
     fn zero_capacity_history_evicts_on_every_scroll() {
         let mut grid = grid(2, 0);
@@ -894,8 +852,8 @@ mod tests {
     /// Asserts that a freshly minted bottom row carries an id no earlier
     /// row shares.
     ///
-    /// Case: output scrolls the screen and the blank row entering at the
-    /// bottom must not inherit the identity of the row that left.
+    /// Case: output scrolls the screen and a blank row enters at the
+    /// bottom.
     #[test]
     fn a_scroll_mints_a_fresh_id_for_the_incoming_row() {
         let mut grid = grid(3, 10);
@@ -910,7 +868,7 @@ mod tests {
         use super::*;
 
         /// A grid whose visible rows are labelled `a`, `b`, `c`, … in
-        /// column zero, so a scroll is legible in the row contents.
+        /// column zero.
         fn labelled(rows: u16, max_history: usize) -> Grid {
             let mut grid = grid(rows, max_history);
             for line in 0..rows {
@@ -939,14 +897,9 @@ mod tests {
             assert_eq!(grid[ScreenLine(2)][0].c, 'b');
         }
 
-        /// Asserts that a reverse scroll leaves the history untouched.
-        ///
-        /// The agreed policy discards the row that falls off the bottom
-        /// rather than pushing it into history, and fills the incoming top
-        /// row blank rather than pulling the newest history row back. A
-        /// reverse scroll is deliberately not the inverse of a forward
-        /// one: scrollback records what the terminal has emitted, and a
-        /// reverse scroll emits nothing.
+        /// Asserts that a reverse scroll leaves the history untouched,
+        /// neither pushing the row that falls off the bottom into it nor
+        /// pulling its newest row back.
         ///
         /// Case: a full-screen editor scrolls its view backwards while the
         /// shell's earlier output still sits in scrollback behind it.
@@ -965,8 +918,7 @@ mod tests {
         /// Asserts that the row entering at the top carries the fill.
         ///
         /// Case: an application sets a background colour and scrolls
-        /// backwards, expecting the exposed row to carry that colour
-        /// rather than the terminal default.
+        /// backwards.
         #[test]
         fn the_row_entering_at_the_top_carries_the_fill() {
             let mut grid = labelled(3, 10);
@@ -1060,12 +1012,11 @@ mod tests {
         }
 
         /// Asserts that an anchor still resolves once the history holds
-        /// ids that are no longer ascending, which is why the lookup
-        /// indexes history by id rather than binary-searching it.
+        /// ids that are no longer ascending.
         ///
-        /// Case: a full-screen application scrolls backwards — minting a
-        /// row with a high id above older rows — and then output pushes
-        /// that row into history ahead of the ones it was inserted above.
+        /// Case: a full-screen application scrolls backwards, and output
+        /// then pushes the row that scroll inserted into history ahead of
+        /// the rows it was inserted above.
         #[test]
         fn an_anchor_still_resolves_once_the_history_ids_are_unordered() {
             let mut grid = grid(3, 10);

--- a/crates/orzma_vt/src/screen/grid/coords.rs
+++ b/crates/orzma_vt/src/screen/grid/coords.rs
@@ -1,6 +1,5 @@
-//! Active-grid coordinates: the line and column types writes and grid
-//! indexing address cells with, plus their projection into the
-//! viewport.
+//! Active-grid coordinates, which writes and grid indexing address
+//! cells with, and their projection into the viewport.
 
 use crate::screen::viewport::{DisplayOffset, ViewportLine};
 
@@ -35,11 +34,9 @@ impl GridLine {
 /// A row of the active screen: `0` is the top row, and the value never
 /// reaches history.
 ///
-/// It is the non-negative half of [`GridLine`] — same origin, narrower
-/// domain — so writes and grid indexing that take one cannot address
-/// scrollback at all. [`ViewportLine`] measures the same row from the
-/// viewport's top instead, and the two coincide only at
-/// [`DisplayOffset`] zero.
+/// It is the non-negative half of [`GridLine`], with the same origin.
+/// [`ViewportLine`] measures the same row from the viewport's top
+/// instead, and the two coincide only at [`DisplayOffset`] zero.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct ScreenLine(pub u16);
 
@@ -57,15 +54,14 @@ impl From<ScreenLine> for GridLine {
 
 /// A 0-based grid column.
 ///
-/// Columns are shared between the grid and viewport spaces: with no
-/// horizontal scrolling, only the line axis differs between the two.
+/// Columns are shared between the grid and viewport spaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct GridColumn(pub u16);
 
 /// A cell in active-grid coordinates.
 ///
-/// Pairs a [`GridLine`] with a [`GridColumn`]. The position does not
-/// depend on where the user has scrolled the viewport.
+/// The position does not depend on where the user has scrolled the
+/// viewport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct GridPoint {
     /// Line in active-grid coordinates.
@@ -129,8 +125,7 @@ mod tests {
     /// while the bottommost visible row still projects.
     ///
     /// Case: the user scrolls back while the shell keeps its caret on
-    /// the last screen line, which falls below the window, so the
-    /// renderer has no caret cell to paint.
+    /// the last screen line, which falls below the window.
     #[test]
     fn a_line_below_the_viewport_projects_to_none() {
         let offset = DisplayOffset(5);

--- a/crates/orzma_vt/src/screen/grid/coords.rs
+++ b/crates/orzma_vt/src/screen/grid/coords.rs
@@ -107,9 +107,8 @@ mod tests {
     /// Asserts that a line above the visible area projects to `None`,
     /// while the topmost visible row still projects.
     ///
-    /// Case: the vi cursor rests on a history row and the user scrolls
-    /// the viewport back toward the live tail, leaving that row above
-    /// the window, so the renderer has no caret cell to paint.
+    /// Case: the user scrolls back toward the live tail, and a webview
+    /// anchored to a history row falls above the window.
     #[test]
     fn a_line_above_the_viewport_projects_to_none() {
         let offset = DisplayOffset(3);

--- a/crates/orzma_vt/src/screen/grid/history_index.rs
+++ b/crates/orzma_vt/src/screen/grid/history_index.rs
@@ -6,21 +6,14 @@ use std::collections::HashMap;
 
 /// Where each history row sits, by id, in constant time.
 ///
-/// Only history is indexed: a row enters it at the newest end, leaves
-/// it from the oldest end (the cap) or the newest end (a growth
-/// reclaiming it), and is never recycled while inside. Each entry
-/// therefore gets a running sequence number, and its ring index is
-/// that number minus the count popped so far, so a pop moves nothing.
-///
-/// The visible rows stay unindexed: a region scroll recycles and
-/// reorders them freely, and a scan over them is bounded by the screen
-/// height rather than the history cap.
+/// Only history is indexed. A row must enter it at the newest end and
+/// leave it from the oldest end (the cap) or the newest end (a growth
+/// reclaiming it), and must not be recycled while inside.
 ///
 /// # Invariants
 ///
-/// The live sequence numbers form the contiguous interval
-/// `[popped, popped + seq_of.len())`, whose length equals the grid's
-/// `history_len`.
+/// The index names exactly the grid's history rows, so its length
+/// equals the grid's `history_len`.
 #[derive(Debug, Default)]
 pub(super) struct HistoryIndex {
     seq_of: HashMap<LineId, u64>,

--- a/crates/orzma_vt/src/screen/grid/row.rs
+++ b/crates/orzma_vt/src/screen/grid/row.rs
@@ -7,13 +7,8 @@ use std::ops::{Deref, DerefMut, Index, IndexMut};
 
 /// A single row of `T`, left to right.
 ///
-/// Storage rows are `Row<Cell>` and emitted rows are [`Row<Run>`], so
-/// the two differ only in what one element spans: a cell is one
-/// column, a run is as many as its text.
-///
-/// The element type is deliberately not defaulted — a bare `Row` in a
-/// wire struct silently meaning `Row<Cell>` is exactly the mistake
-/// that would compile and then fail far from its cause.
+/// Storage rows are `Row<Cell>` and emitted rows are [`Row<Run>`]; a
+/// cell spans one column, and a run one column per `char` of its text.
 ///
 /// [`Row<Run>`]: crate::screen::grid::run::Run
 #[derive(Debug, Clone, PartialEq)]
@@ -33,10 +28,7 @@ impl<T: Clone> Row<T> {
 }
 
 impl Row<Cell> {
-    /// How many runs [`Row::to_runs`] reserves up front. A single-attribute
-    /// row then carries capacity for a few runs instead of one per column,
-    /// and geometric growth reaches a highlighted row's twenty to forty runs
-    /// in one to three reallocations.
+    /// How many runs [`Row::to_runs`] reserves up front.
     const RUNS_RESERVE: usize = 8;
 
     /// Coalesces the row's cells into the attribute runs a frame
@@ -89,8 +81,8 @@ impl<T> DerefMut for Row<T> {
 /// Indexes the element at a 0-based position.
 ///
 /// The position is a column only for `Row<Cell>`; one
-/// [`Run`](crate::screen::grid::run::Run) spans as many columns as its
-/// text is wide.
+/// [`Run`](crate::screen::grid::run::Run) spans one column per `char`
+/// of its text.
 impl<T> Index<u16> for Row<T> {
     type Output = T;
 
@@ -106,10 +98,6 @@ impl<T> IndexMut<u16> for Row<T> {
 }
 
 /// Indexes the cell at a grid column.
-///
-/// Meaningful only for `Row<Cell>`, where one element is one column; a
-/// [`Run`](crate::screen::grid::run::Run) spans as many columns as its
-/// text is wide.
 impl Index<GridColumn> for Row<Cell> {
     type Output = Cell;
 
@@ -144,8 +132,7 @@ mod tests {
     /// Asserts that a resize to a longer length appends copies of the
     /// fill and leaves the existing elements untouched.
     ///
-    /// Case: the user widens the terminal window, so every stored row
-    /// has to gain blank cells on its right.
+    /// Case: the user widens the terminal window.
     #[test]
     fn a_resize_to_a_longer_length_appends_the_fill() {
         let mut row = Row::from(vec![plain('a'), plain('b')]);
@@ -159,8 +146,7 @@ mod tests {
     /// Asserts that a resize to a shorter length drops the elements past
     /// the new end and keeps the ones before it.
     ///
-    /// Case: the user drags the window narrower, so every stored row
-    /// loses the columns that no longer fit.
+    /// Case: the user drags the window narrower.
     #[test]
     fn a_resize_to_a_shorter_length_drops_the_tail() {
         let mut row = Row::from(vec![plain('a'), plain('b'), plain('c'), plain('d')]);
@@ -174,7 +160,7 @@ mod tests {
     /// unchanged.
     ///
     /// Case: the window manager replays the same geometry after a focus
-    /// change, so every stored row is asked for the width it already has.
+    /// change.
     #[test]
     fn a_resize_to_the_same_length_changes_nothing() {
         let mut row = Row::from(vec![plain('a'), plain('b'), plain('c')]);

--- a/crates/orzma_vt/src/screen/grid/run.rs
+++ b/crates/orzma_vt/src/screen/grid/run.rs
@@ -1,7 +1,4 @@
 //! One attribute run of an emitted row.
-//!
-//! The row itself is [`Row`](crate::screen::grid::row::Row); a run
-//! is one of its elements.
 
 use crate::device::color::Color;
 use crate::hyperlink::HyperlinkId;
@@ -29,12 +26,9 @@ bitflags! {
 }
 
 /// A run of cells sharing identical fg/bg/style attributes.
-///
-/// Wide-char spacers (alacritty internal) are absorbed by this crate and
-/// do not appear in `text`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Run {
-    /// Total column span (sum of grapheme cluster widths in `text`).
+    /// Total column span: one column per `char` in `text`.
     pub cols: u16,
     /// Foreground color.
     pub fg: Color,
@@ -42,10 +36,11 @@ pub struct Run {
     pub bg: Color,
     /// The SGR attributes every cell in the run shares.
     pub style: Style,
-    /// UTF-8 text; the consumer uses Unicode East Asian Width to position
-    /// each grapheme cluster within the run.
+    /// UTF-8 text.
     pub text: String,
-    /// Hyperlink id (OSC 8); always `None` until Phase 3.
+    /// Hyperlink id (OSC 8); it is always `None`.
+    ///
+    /// TODO: set it once OSC 8 handling reaches the hyperlink interner.
     pub hyperlink_id: Option<HyperlinkId>,
 }
 

--- a/crates/orzma_vt/src/screen/margins.rs
+++ b/crates/orzma_vt/src/screen/margins.rs
@@ -41,10 +41,10 @@ impl ScrollRegion {
 
     /// Replaces the cursor origin, and does nothing else.
     ///
-    /// This is the plain assignment `DECRC` needs to put a saved mode
-    /// back. `DECOM` itself additionally homes the cursor, which this
-    /// type cannot do because it does not own one; that half belongs to
-    /// the `Screen` method the control function reaches.
+    /// # Control Functions
+    ///
+    /// - `DECOM` (the origin part)
+    /// - `DECRC` (the origin-mode part)
     pub fn set_origin_mode(&mut self, origin_mode: OriginMode) {
         self.origin_mode = origin_mode;
     }
@@ -52,18 +52,16 @@ impl ScrollRegion {
     /// The rows a scroll moves: the top margin through the bottom
     /// margin, inclusive.
     ///
-    /// The span never consults [`OriginMode`], because DECSTBM confines
-    /// scrolling to the margins whichever way the origin is set.
+    /// The span does not depend on the [`OriginMode`].
     pub fn scroll_span(&self) -> RangeInclusive<ScreenLine> {
         self.margins.top..=self.margins.bottom
     }
 
     /// Replaces the margins, and does nothing else.
     ///
-    /// This is the plain assignment `DECSTBM` needs. Seating the cursor
-    /// at the new home is the other half of that control function and
-    /// belongs to the `Screen` method that reaches it, because this type
-    /// owns no cursor.
+    /// # Control Functions
+    ///
+    /// - `DECSTBM` (the margin part)
     pub(crate) fn set_margins(&mut self, margins: Margins) {
         self.margins = margins;
     }
@@ -206,11 +204,8 @@ mod tests {
             );
         }
 
-        /// Asserts that a zero resolves the same way an omission does.
-        ///
-        /// The agreed policy follows ECMA-48 §5.4.2's default rule and
-        /// xterm's `one_if_default`, which folds any value at or below
-        /// zero to the default. VT510 does not define a zero here.
+        /// Asserts that a zero resolves to the default margin, the same
+        /// way an omission does.
         ///
         /// Case: a program that builds its sequences from unset integer
         /// variables emits `CSI 0 ; 0 r`.
@@ -238,11 +233,8 @@ mod tests {
             );
         }
 
-        /// Asserts that a bottom margin past the last row clamps to it.
-        ///
-        /// The agreed policy clamps rather than refusing, because VT510
-        /// p.276 describes the page size as the region's maximum rather
-        /// than as a precondition. Windows Terminal refuses instead.
+        /// Asserts that a bottom margin past the last row clamps to it
+        /// rather than refusing the request.
         ///
         /// Case: an application sized for a taller window asks for a
         /// region reaching row 40 on a 24-row screen.
@@ -258,13 +250,7 @@ mod tests {
         }
 
         /// Asserts that a top margin at or below the bottom margin
-        /// refuses the request.
-        ///
-        /// The agreed policy refuses rather than repairing the request:
-        /// VT510 p.276 requires "The value of the top margin (Pt) must
-        /// be less than the bottom margin (Pb)", and clamping into the
-        /// nearest legal region would leave the application drawing
-        /// somewhere it never asked for.
+        /// refuses the request rather than repairing it.
         ///
         /// Case: an application inverts its two parameters and sends
         /// `CSI 5 ; 3 r`.
@@ -284,11 +270,6 @@ mod tests {
 
         /// Asserts that the clamp runs before the comparison, so a
         /// bottom that clamps below the top is refused.
-        ///
-        /// The agreed policy orders it the way xterm does — default,
-        /// clamp, then compare. alacritty compares first, which lets
-        /// this request through and collapses it into a degenerate
-        /// region.
         ///
         /// Case: an application sized for a taller window asks for rows
         /// 30 through 40 on a 24-row screen.

--- a/crates/orzma_vt/src/screen/placements.rs
+++ b/crates/orzma_vt/src/screen/placements.rs
@@ -7,9 +7,6 @@ use crate::screen::grid::LineId;
 use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint};
 
 /// The placements mounted on one screen.
-///
-/// Which screen owns the table answers which screen a placement belongs
-/// to, so no placement records its own screen.
 #[derive(Debug)]
 pub(crate) struct ScreenPlacements {
     placements: Vec<Placement>,
@@ -29,10 +26,6 @@ impl ScreenPlacements {
     }
 
     /// Whether this screen holds no placement.
-    ///
-    /// [`Self::evict_lost_anchors`] returns on this before it touches
-    /// the table, which states in one line that a screen holding no
-    /// webview resolves no anchor.
     pub fn is_empty(&self) -> bool {
         self.placements.is_empty()
     }
@@ -48,10 +41,6 @@ impl ScreenPlacements {
     }
 
     /// Drops the placement a re-mount of `id` replaces, without reporting it.
-    ///
-    /// A superseded id is deliberately unnamed: the re-mount registers a
-    /// successor under the same id, and reporting the predecessor as
-    /// evicted would tell the host to despawn the live view.
     pub fn supersede(&mut self, id: InstanceId) {
         self.placements.retain(|p| p.id != id);
     }
@@ -77,13 +66,6 @@ impl ScreenPlacements {
 
     /// Resolves every placement's anchor through `line_of` — the complete
     /// list, not a diff.
-    ///
-    /// # Invariants
-    ///
-    /// Resolution reads; it never evicts, repairs an anchor, or refreshes
-    /// a cache. Those belong to [`Self::evict_lost_anchors`], which runs
-    /// while damage can still be staged — a mutation here would land
-    /// after the ledger was drained and reach no frame.
     pub fn project(
         &self,
         mut line_of: impl FnMut(LineId) -> Option<GridLine>,
@@ -106,13 +88,14 @@ impl ScreenPlacements {
     /// Drops the placements `line_of` can no longer resolve and names
     /// them.
     ///
+    /// `line_of` must resolve anchors exactly as the expression handed to
+    /// [`Self::project`] does.
+    ///
     /// # Invariants
     ///
-    /// `line_of` must resolve anchors exactly as the expression handed to
-    /// [`Self::project`] does; the matching bound does not enforce it, so
-    /// the owning screen passes one expression to both. A placement this
-    /// rejects is exactly a placement projection would omit, so no
-    /// placement can become unresolvable without also becoming evictable.
+    /// A placement this rejects is exactly a placement projection would
+    /// omit, so no placement can become unresolvable without also
+    /// becoming evictable.
     pub fn evict_lost_anchors(
         &mut self,
         mut line_of: impl FnMut(LineId) -> Option<GridLine>,

--- a/crates/orzma_vt/src/screen/selection.rs
+++ b/crates/orzma_vt/src/screen/selection.rs
@@ -1,6 +1,4 @@
-//! Selection vocabulary — the span a selection covers, how it is shaped,
-//! and which side of a cell an endpoint sits on — plus the selection one
-//! screen owns and its projection into that vocabulary.
+//! The selection one screen owns and the range a frame reports it as.
 
 use crate::screen::grid::LineId;
 use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint};
@@ -25,9 +23,7 @@ pub struct SelectionRange {
 }
 
 impl SelectionRange {
-    /// The inclusive column span the selection covers on `line`: the
-    /// same expression the renderer's shader evaluates, so the copied
-    /// text and the painted highlight always agree.
+    /// The inclusive column span the selection covers on `line`.
     pub(crate) fn span_on(&self, line: i32, last_column: u16) -> (u16, u16) {
         match self.geometry {
             SelectionGeometry::Lines => (0, last_column),
@@ -49,10 +45,8 @@ impl SelectionRange {
 
 /// The shape a [`SelectionRange`] spans between its endpoints.
 ///
-/// Wider than [`SelectionKind`]: the two current selection kinds only
-/// ever convert to `Linear` or `Lines`. `Block` exists for the
-/// renderer to support once a future selection kind needs it, but the
-/// conversion does not produce it yet.
+/// Every [`SelectionKind`] converts to `Linear` or `Lines`; nothing
+/// produces `Block`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SelectionGeometry {
     /// A cell run wrapping at the end of each row.
@@ -99,9 +93,7 @@ pub enum CellSide {
 /// The selection one screen owns: two endpoints on that screen's rows
 /// plus the granularity between them.
 ///
-/// Endpoints are stored as a row identity and a cell boundary, so the
-/// selection follows its rows when output scrolls them into history and
-/// does not depend on the projection the frame carries.
+/// The selection follows its rows when output scrolls them into history.
 #[derive(Debug)]
 pub(crate) struct ScreenSelection {
     state: Option<SelectionState>,
@@ -153,7 +145,7 @@ impl SelectionEnd {
 }
 
 impl ScreenSelection {
-    /// Builds a screen with nothing selected.
+    /// Builds a screen selection with nothing selected.
     pub fn new() -> Self {
         Self { state: None }
     }
@@ -201,11 +193,6 @@ impl ScreenSelection {
     /// previous row's last cell; ends that coincide or cross after that
     /// enclose no cell. A Lines selection spans whole rows between the
     /// two endpoints' rows and never wraps.
-    ///
-    /// # Invariants
-    ///
-    /// Endpoints are ordered only after resolving to [`GridLine`];
-    /// nothing orders the ring by [`LineId`].
     pub fn resolve(
         &self,
         mut line_of: impl FnMut(LineId) -> Option<GridLine>,
@@ -317,7 +304,8 @@ mod tests {
         assert_eq!(end(&grid, 0, 1, CellSide::Right).boundary, 2);
     }
 
-    /// Asserts that an empty table resolves to `Resolved::None`.
+    /// Asserts that a selection with nothing selected resolves to
+    /// `Resolved::None`.
     ///
     /// Case: a frame is emitted on a terminal nothing has been selected
     /// on.
@@ -394,8 +382,8 @@ mod tests {
     /// on the left edge of a row ends it on the last cell of the row
     /// above.
     ///
-    /// Case: drags that begin on the right half of the last column or
-    /// land on the left half of the first column.
+    /// Case: the user starts a drag on the right half of the last
+    /// column, or ends one on the left half of the first column.
     #[test]
     fn edge_boundaries_wrap_to_the_adjacent_row() {
         let grid = grid();

--- a/crates/orzma_vt/src/screen/tabs.rs
+++ b/crates/orzma_vt/src/screen/tabs.rs
@@ -9,9 +9,8 @@ use crate::screen::grid::coords::GridColumn;
 /// One character tabulation stop edit, independent of which control
 /// function asked for it.
 ///
-/// TBC and CTC number their parameters differently — `TBC 3` and
-/// `CTC 5` both mean "clear every character stop" — so the two
-/// parameter spaces are normalised into one vocabulary here.
+/// TBC and CTC number their parameters differently: `TBC 3` and
+/// `CTC 5` both mean "clear every character stop".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CharacterTabEdit {
     /// Set a stop at the cursor column (HTS, CTC 0).
@@ -45,25 +44,19 @@ impl CharacterTabEdit {
     }
 }
 
-/// The device's character tabulation stops, one bit per column.
+/// One screen's character tabulation stops.
 ///
-/// ECMA-48 scopes a stop edit by TABULATION STOP MODE (§ 7.2.17), whose
-/// reset state MULTIPLE makes every line share one set of columns. This
-/// type implements that reset state alone, so one bit per column
-/// describes the whole device.
+/// Every line shares one set of stops: this type implements only the
+/// reset state, MULTIPLE, of ECMA-48's TABULATION STOP MODE (§ 7.2.17).
 ///
 /// # Invariants
 ///
-/// The table spans more columns than any grid, so a resize never has to
-/// decide what the columns it widens into should contain: a stop past
-/// the old right edge was already written at reset, and a `TBC 3`
-/// already cleared it. Sizing the table to the grid instead would make
-/// those two states indistinguishable.
+/// A resize never touches the table: within its `COLUMN_COUNT`
+/// columns, the columns a widening grid gains already hold the stops a
+/// reset installed, or none after a `TBC 3`.
 ///
-/// Each screen owns one, so a stop an application sets on the alternate
-/// screen never reaches the primary. xterm shares a single table across
-/// both instead, and ECMA-48 settles nothing here because it has no
-/// alternate screen at all.
+/// A stop an application sets on the alternate screen never reaches the
+/// primary.
 #[derive(Debug, PartialEq)]
 pub(super) struct TabStops([u64; TabStops::WORDS]);
 
@@ -71,9 +64,6 @@ impl TabStops {
     /// Columns between the stops a device reset installs.
     const DEFAULT_INTERVAL: u16 = 8;
     /// How many columns the table addresses, i.e. `0..COLUMN_COUNT`.
-    ///
-    /// Deliberately wider than any real grid; xterm's equivalent is
-    /// 1024.
     const COLUMN_COUNT: u16 = 4096;
     const BITS_PER_WORD: usize = u64::BITS as usize;
     const WORDS: usize = Self::COLUMN_COUNT as usize / Self::BITS_PER_WORD;
@@ -243,14 +233,8 @@ mod tests {
             }
         }
 
-        /// Asserts that the reset stride leaves column zero without a
-        /// stop.
-        ///
-        /// The agreed policy starts the stride at column eight, the way
-        /// xterm's `OkTAB` guard does. A stop there would be
-        /// unreachable in any case, because a forward search begins one
-        /// column past the cursor and a backward search falls back to
-        /// the left edge.
+        /// Asserts that the reset stride starts at column eight, leaving
+        /// column zero without a stop.
         ///
         /// Case: the user presses Shift-Tab with the cursor at the
         /// start of a line.
@@ -259,15 +243,9 @@ mod tests {
             assert!(!tabs().is_set(GridColumn(0)));
         }
 
-        /// Asserts that the reset stride reaches columns no ordinary
-        /// grid shows.
-        ///
-        /// The agreed policy seeds the whole table rather than stopping
-        /// at the grid's right edge, which is what xterm's own DECST8C
-        /// does. Seeding only to the edge would force the table to
-        /// remember whether the application had ever edited it, so that
-        /// a later widening could tell "not covered yet" apart from
-        /// "cleared on purpose".
+        /// Asserts that the reset stride covers the whole table, reaching
+        /// columns no ordinary grid shows, rather than stopping at the
+        /// grid's right edge.
         ///
         /// Case: the user starts an eighty-column terminal and later
         /// drags the window out to two hundred columns.
@@ -312,11 +290,7 @@ mod tests {
         }
 
         /// Asserts that a set past the table's last column is dropped
-        /// rather than panicking.
-        ///
-        /// The agreed policy drops the edit silently. Growing the table
-        /// instead would reintroduce the resize-time ambiguity that a
-        /// fixed width exists to remove.
+        /// silently rather than growing the table or panicking.
         ///
         /// Case: a grid wider than the table puts the cursor past its
         /// last column when HTS arrives.
@@ -341,11 +315,6 @@ mod tests {
 
         /// Asserts that a stop at column zero is never the answer to a
         /// forward search.
-        ///
-        /// The agreed policy accepts the edit rather than rejecting it
-        /// the way xterm does. A forward search starts one column past
-        /// the cursor and so can never return column zero, so a guard
-        /// would buy nothing observable.
         ///
         /// Case: an application clears the table and sends HTS with the
         /// cursor still at the start of the line.
@@ -405,11 +374,6 @@ mod tests {
         /// Asserts that clearing every stop empties the columns past
         /// the grid as well as the ones it shows.
         ///
-        /// The agreed policy clears the whole table so a later widening
-        /// finds nothing there. Clearing only the columns the grid
-        /// shows would let the stride reappear on the next resize,
-        /// undoing the edit the application just made.
-        ///
         /// Case: an application sends TBC 3 to take the tab table over,
         /// and the user then widens the window.
         #[test]
@@ -439,13 +403,7 @@ mod tests {
         use super::*;
 
         /// Asserts that a reset reinstalls the stride across the whole
-        /// table.
-        ///
-        /// The agreed policy seeds the same columns a fresh device
-        /// carries, including the ones past the grid's right edge.
-        /// xterm's DECST8C stops at the edge instead, which makes a
-        /// widening after DECST8C behave differently from one after
-        /// RIS; that inconsistency is not reproduced.
+        /// table, including the columns past the grid's right edge.
         ///
         /// Case: an application that cleared the table sends DECST8C to
         /// get the default tab positions back.
@@ -503,12 +461,8 @@ mod tests {
         }
 
         /// Asserts that a forward search past the last stop the grid
-        /// shows lands on the right edge.
-        ///
-        /// ECMA-48 § 6.1.7 leaves a movement to a non-existing position
-        /// undefined and lists seven options; the agreed policy clamps
-        /// to the right edge rather than wrapping to the next line or
-        /// refusing the move.
+        /// shows lands on the right edge rather than wrapping to the next
+        /// line or refusing the move.
         ///
         /// Case: the shell emits a tab with the cursor already past the
         /// last tab position an eighty-column screen shows.
@@ -551,12 +505,7 @@ mod tests {
         }
 
         /// Asserts that a forward search counting no stops leaves the
-        /// column alone.
-        ///
-        /// The agreed policy keeps this layer mechanical: turning a
-        /// missing or zero CSI parameter into the default of one
-        /// belongs to the parameter layer, so a count of zero here
-        /// means no movement rather than one stop.
+        /// column alone rather than moving one stop.
         ///
         /// Case: the parameter layer hands down a count it has not
         /// defaulted.
@@ -598,11 +547,8 @@ mod tests {
             assert_eq!(tabs().cbt(GridColumn(24), 2, GridColumn(0)), GridColumn(8));
         }
 
-        /// Asserts that a backward search past the first stop lands on
-        /// the left edge.
-        ///
-        /// The agreed policy makes the left edge a fallback rather than
-        /// a stop, because the reset stride leaves column zero empty.
+        /// Asserts that a backward search past the first stop falls back
+        /// to the left edge.
         ///
         /// Case: the user presses Shift-Tab near the start of a line,
         /// before the first tab position.
@@ -657,12 +603,7 @@ mod tests {
         }
 
         /// Asserts that a backward search counting no stops leaves the
-        /// column alone.
-        ///
-        /// The agreed policy keeps this layer mechanical: turning a
-        /// missing or zero CSI parameter into the default of one
-        /// belongs to the parameter layer, so a count of zero here
-        /// means no movement rather than one stop.
+        /// column alone rather than moving one stop.
         ///
         /// Case: the parameter layer hands down a count it has not
         /// defaulted.
@@ -703,12 +644,6 @@ mod tests {
         /// Asserts that adding one stop leaves the stride past the
         /// right edge intact.
         ///
-        /// The agreed policy keeps the two edits independent. A table
-        /// sized to the grid would instead have to record that the
-        /// application had edited it at all, and would then stop
-        /// extending the stride on every later widening — so a single
-        /// HTS would silently disable tabs past the old edge.
-        ///
         /// Case: an application adds one tab position of its own to the
         /// default stride, and the user later widens the window.
         #[test]
@@ -734,13 +669,8 @@ mod tests {
             );
         }
 
-        /// Asserts that `TBC 2` and `TBC 3` both select the full clear.
-        ///
-        /// ECMA-48 § 8.3.154 makes TBC 2 depend on the TABULATION STOP
-        /// MODE, whose reset state MULTIPLE — the only state
-        /// implemented here — widens "the active line" to every line,
-        /// so the two parameters coincide. kitty and Windows Terminal
-        /// instead treat TBC 2 as a no-op; that reading is rejected.
+        /// Asserts that `TBC 2` and `TBC 3` both select the full clear,
+        /// rather than `TBC 2` doing nothing.
         ///
         /// Case: an application clears the tab table before installing
         /// its own layout.
@@ -769,11 +699,8 @@ mod tests {
         }
 
         /// Asserts that the TBC parameters only line tabulation stops
-        /// answer select nothing.
-        ///
-        /// The agreed policy drops them rather than routing them to the
-        /// character stops, so a later line-tabulation layer can claim
-        /// them without changing what these parameters already did.
+        /// answer select nothing rather than falling back to the
+        /// character stops.
         ///
         /// Case: an application written for a printer sends TBC 1 to
         /// drop the line tab stop on the cursor's line.
@@ -801,10 +728,6 @@ mod tests {
         }
 
         /// Asserts that `CTC 4` and `CTC 5` both select the full clear.
-        ///
-        /// TBC and CTC number the same effects differently — `TBC 2`
-        /// pairs with `CTC 4` and `TBC 3` with `CTC 5` — so the two
-        /// parameter spaces are read by separate constructors.
         ///
         /// Case: an application uses CTC rather than TBC to clear the
         /// tab table.

--- a/crates/orzma_vt/src/screen/tests.rs
+++ b/crates/orzma_vt/src/screen/tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for [`Screen`], one module per method under test.
+//! Unit tests for [`Screen`].
 
 use super::*;
 use crate::device::color::Color;
@@ -20,8 +20,7 @@ fn tall_screen() -> Screen {
     Screen::new(GridSize { cols: 4, rows: 4 }, 10)
 }
 
-/// Moves every item `DECSC` saves off its default, so a later
-/// assertion that the state came back cannot pass by accident.
+/// Moves every item `DECSC` saves off its default.
 fn dirty_screen() -> Screen {
     let mut screen = screen();
     screen.state.line = ScreenLine(2);
@@ -36,8 +35,7 @@ fn dirty_screen() -> Screen {
     screen
 }
 
-/// Seeds one glyph into the first column of each leading row, so a
-/// shifted row can be told apart from an erased one.
+/// Seeds one glyph into the first column of each leading row.
 fn seed(screen: &mut Screen, glyphs: &[char]) {
     for (line, glyph) in (0u16..).zip(glyphs) {
         screen.grid[ScreenLine(line)][0].c = *glyph;

--- a/crates/orzma_vt/src/screen/tests/backspace.rs
+++ b/crates/orzma_vt/src/screen/tests/backspace.rs
@@ -27,12 +27,8 @@ fn a_backspace_at_column_zero_does_not_move() {
 }
 
 /// Asserts that a backspace after a full row both steps back and
-/// disarms the deferred wrap.
-///
-/// The agreed policy lands one column short of the cell just
-/// written rather than on it. xterm's `CursorBack` decrements
-/// unconditionally without reverse-wraparound and then calls
-/// `ResetWrap`, so the step and the disarm both happen.
+/// disarms the deferred wrap, landing one column short of the cell
+/// just written rather than on it.
 ///
 /// Case: an application fills a row to its last cell and then
 /// backs up to overwrite the character before the last one.

--- a/crates/orzma_vt/src/screen/tests/delete_characters.rs
+++ b/crates/orzma_vt/src/screen/tests/delete_characters.rs
@@ -122,8 +122,7 @@ fn a_delete_in_the_last_column_blanks_that_cell_alone() {
 }
 
 /// Asserts that a delete applies on the cursor's row even when that row
-/// lies outside the scroll region, following xterm rather than VT510's
-/// "no effect outside the scrolling margins".
+/// lies outside the scroll region.
 ///
 /// Case: a full-screen application parks its cursor on a status row
 /// below the region it scrolls and edits that row in place.

--- a/crates/orzma_vt/src/screen/tests/delete_lines.rs
+++ b/crates/orzma_vt/src/screen/tests/delete_lines.rs
@@ -66,7 +66,7 @@ fn a_count_past_the_bottom_margin_deletes_only_the_remaining_rows() {
 }
 
 /// Asserts that the rows a delete opens carry the pen's background
-/// rather than a default cell, so background-colour erase holds.
+/// rather than a default cell.
 ///
 /// Case: a program paints a pane with a blue background and then
 /// deletes a line inside it.

--- a/crates/orzma_vt/src/screen/tests/display_offset.rs
+++ b/crates/orzma_vt/src/screen/tests/display_offset.rs
@@ -3,13 +3,8 @@
 use super::*;
 
 /// Asserts that output arriving while the user is scrolled back
-/// leaves the viewed content where it was.
-///
-/// The agreed policy holds the viewport still rather than letting
-/// it drift with the live tail: DECSET 1010 (`scrollTtyOutput`)
-/// stays off, so the viewport holds its position while the PTY
-/// emits output, and every terminal that keeps scrollback
-/// behaves this way.
+/// leaves the viewed content where it was, rather than letting the
+/// view drift with the live tail.
 ///
 /// Case: the user is reading an earlier command's output when a
 /// background build prints its next line.
@@ -30,10 +25,6 @@ fn output_below_a_scrolled_viewport_holds_the_view_still() {
 
 /// Asserts that a scroll inside a region below a non-zero top
 /// margin leaves a scrolled-back viewport's offset untouched.
-///
-/// The offset counts rows of scrollback, and such a scroll adds
-/// none, so advancing it would slide the view a row further back
-/// than the user put it.
 ///
 /// Case: the user is reading scrollback while a full-screen
 /// application with a pinned header scrolls its pane.
@@ -59,8 +50,8 @@ fn a_scroll_that_adds_no_history_leaves_the_offset_alone() {
 /// Asserts that output at the live tail leaves the viewport pinned
 /// there.
 ///
-/// Case: an unscrolled terminal keeps printing, and the window has
-/// to follow the newest line rather than freeze.
+/// Case: the user watches an unscrolled terminal while a program
+/// keeps printing new lines.
 #[test]
 fn output_at_the_live_tail_keeps_the_viewport_pinned() {
     let mut screen = screen();
@@ -69,12 +60,9 @@ fn output_at_the_live_tail_keeps_the_viewport_pinned() {
     assert_eq!(screen.display_offset(), DisplayOffset(0));
 }
 
-/// Asserts that a scroll at history capacity clamps the offset
-/// instead of naming a row the ring no longer holds.
-///
-/// The agreed policy accepts that the view drifts once scrollback
-/// is full: the row the user was reading has been evicted, so there
-/// is nothing left to hold still on.
+/// Asserts that a scroll at history capacity clamps the offset,
+/// letting the view drift rather than naming a row the ring no
+/// longer holds.
 ///
 /// Case: the user is parked at the top of a full scrollback while
 /// output keeps arriving.

--- a/crates/orzma_vt/src/screen/tests/erase_chars.rs
+++ b/crates/orzma_vt/src/screen/tests/erase_chars.rs
@@ -56,7 +56,7 @@ fn erasing_past_the_last_column_stops_at_the_row_end() {
 }
 
 /// Asserts that a cursor outside the scrolling region erases all
-/// the same, because ECH ignores the margins.
+/// the same.
 ///
 /// Case: an application reserves a status line below its scrolling
 /// region and clears a field on it.
@@ -100,8 +100,7 @@ fn erasing_characters_below_a_scrolled_viewport_reports_no_damage() {
     assert_eq!(damage, None);
 }
 
-/// Asserts that the cursor stays where it was after an erase,
-/// which is what separates ECH from a write.
+/// Asserts that the cursor stays where it was after an erase.
 ///
 /// Case: an application clears a field and then writes its new
 /// value starting from the same position.
@@ -118,8 +117,8 @@ fn erasing_characters_leaves_the_cursor_on_its_column() {
 }
 
 /// Asserts that erasing characters is a no-op while the deferred wrap
-/// is armed and autowrap is set, matching `EL 0` rather than erasing
-/// the row's last cell.
+/// is armed and autowrap is set, rather than erasing the row's last
+/// cell.
 ///
 /// Case: an application fills a row to its last column and then
 /// issues `CSI 1 X` before printing anything further.
@@ -135,8 +134,7 @@ fn erasing_characters_is_a_no_op_under_pending_wrap() {
 }
 
 /// Asserts that a cursor resting on the last column with no wrap
-/// armed erases that column, so an armed deferred wrap is necessary
-/// for the no-op and the column alone does not reach it.
+/// armed erases that column.
 ///
 /// Case: an application addresses the last column directly and
 /// clears the single character standing there.
@@ -209,9 +207,8 @@ fn erasing_characters_runs_under_pending_wrap_while_autowrap_is_reset() {
 /// the cursor off the last column, even though the deferred wrap is
 /// still armed.
 ///
-/// Case: the same program clears the character under the cursor with
-/// `ECH` after stepping back a tab stop, instead of clearing to the end
-/// of the line.
+/// Case: a program fills a row, steps back a tab stop, and clears the
+/// character under the cursor with `ECH`.
 #[test]
 fn erasing_characters_runs_once_a_backward_tab_leaves_the_last_column() {
     let mut screen = screen();

--- a/crates/orzma_vt/src/screen/tests/erase_in_display.rs
+++ b/crates/orzma_vt/src/screen/tests/erase_in_display.rs
@@ -56,11 +56,6 @@ fn erase_display_above_clears_through_the_cursor() {
 /// Asserts that erase-all clears the visible screen in place while
 /// scrollback history survives.
 ///
-/// The agreed policy is the classic xterm behavior: `ED 2` erases
-/// in place and does not push the cleared rows into history (a
-/// deliberate divergence from alacritty, which scrolls them out
-/// first).
-///
 /// Case: the user runs `clear` in a session that already
 /// accumulated scrollback, then scrolls back to check older
 /// output.

--- a/crates/orzma_vt/src/screen/tests/erase_in_line.rs
+++ b/crates/orzma_vt/src/screen/tests/erase_in_line.rs
@@ -29,9 +29,6 @@ fn erase_to_end_clears_from_the_cursor_with_the_pen_background() {
 /// Asserts that erase-to-start clears through the cursor column
 /// inclusively.
 ///
-/// The agreed convention matches `EL 1`: the erased span is
-/// `0..=cursor.column`, the classic off-by-one of this operation.
-///
 /// Case: an application rewrites the head of a line and clears
 /// what it had written so far, cursor included.
 #[test]
@@ -48,8 +45,7 @@ fn erase_to_start_includes_the_cursor_column() {
 }
 
 /// Asserts that `EL 0` erases nothing while the deferred wrap is armed
-/// and autowrap is set, following alacritty rather than erasing the
-/// just-printed last cell.
+/// and autowrap is set, rather than erasing the just-printed last cell.
 ///
 /// Case: an application fills a row to its last column and then issues
 /// `EL 0` before printing anything further.

--- a/crates/orzma_vt/src/screen/tests/insert_characters.rs
+++ b/crates/orzma_vt/src/screen/tests/insert_characters.rs
@@ -122,8 +122,7 @@ fn an_insert_in_the_last_column_replaces_that_cell_alone() {
 }
 
 /// Asserts that an insert applies on the cursor's row even when that row
-/// lies outside the scroll region, following xterm rather than VT510's
-/// "no effect outside the scrolling margins".
+/// lies outside the scroll region.
 ///
 /// Case: a full-screen application parks its cursor on a status row
 /// below the region it scrolls and edits that row in place.

--- a/crates/orzma_vt/src/screen/tests/insert_lines.rs
+++ b/crates/orzma_vt/src/screen/tests/insert_lines.rs
@@ -83,8 +83,8 @@ fn an_insert_homes_the_cursor_and_disarms_the_deferred_wrap() {
 }
 
 /// Asserts that an insert on the first row of the page feeds nothing
-/// to history, because the row it pushes off the bottom margin is
-/// discarded rather than scrolled past.
+/// to history, discarding the row it pushes off the bottom margin
+/// rather than scrolling it past.
 ///
 /// Case: a program inserts a line at the top of the primary screen
 /// while the user has scrollback to return to.

--- a/crates/orzma_vt/src/screen/tests/line_feed.rs
+++ b/crates/orzma_vt/src/screen/tests/line_feed.rs
@@ -18,8 +18,7 @@ fn a_linefeed_above_the_bottom_moves_the_cursor() {
 /// Asserts that a linefeed at the bottom margin scrolls the screen and
 /// pushes the departing row into history.
 ///
-/// Case: a shell prints past the last row and the earlier output has to
-/// remain reachable by scrolling back.
+/// Case: a shell prints past the last row.
 #[test]
 fn a_bottom_linefeed_scrolls_and_pushes_history() {
     let mut screen = screen();
@@ -45,13 +44,8 @@ fn a_scrolled_in_row_carries_the_pen_background() {
 }
 
 /// Asserts that a linefeed below the bottom margin moves the
-/// cursor down and scrolls nothing.
-///
-/// The agreed policy gates the scroll on the cursor sitting
-/// exactly at the bottom margin, the way VT510 writes IND and
-/// NEL, rather than on the cursor having reached it: a cursor
-/// outside the region moves like an ordinary cursor-down instead
-/// of scrolling rows it is not among.
+/// cursor down and scrolls nothing, the scroll being gated on the
+/// cursor sitting exactly at the margin (VT510 p.318 IND, p.325 NEL).
 ///
 /// Case: an application reserves a two-row footer below its
 /// scrolling pane and emits a linefeed while the cursor rests on
@@ -71,12 +65,8 @@ fn a_linefeed_below_a_bottom_margin_moves_the_cursor_down() {
 }
 
 /// Asserts that a linefeed below the bottom margin, already on
-/// the last row, moves and scrolls nothing.
-///
-/// The agreed policy mirrors the reverse index above a top
-/// margin: a cursor that hits the screen edge outside the
-/// scrolling region stays put, rather than scrolling the region
-/// it is not inside.
+/// the last row, moves and scrolls nothing, rather than scrolling
+/// the region it is not inside.
 ///
 /// Case: an application reserves a footer below its scrolling
 /// pane and emits a linefeed while the cursor rests on the last
@@ -99,13 +89,8 @@ fn a_linefeed_below_a_bottom_margin_at_the_last_row_does_nothing() {
 
 /// Asserts that a linefeed at the bottom of a region below a
 /// non-zero top margin rotates the region and leaves history and
-/// the rows above it alone.
-///
-/// The agreed policy feeds scrollback only when the top margin is
-/// row zero, following alacritty: rows leaving a region that has
-/// content pinned above it never reached the top of the screen,
-/// so treating them as scrollback would interleave them with
-/// output the user never scrolled past.
+/// the rows above it alone; only a region whose top margin is row
+/// zero feeds scrollback.
 ///
 /// Case: an application pins a header on the first row and
 /// scrolls the pane below it forward.
@@ -157,10 +142,6 @@ fn a_linefeed_at_a_bottom_margin_feeds_history_and_holds_the_rows_below() {
 }
 
 /// Asserts that a linefeed preserves the deferred-wrap flag.
-///
-/// The agreed policy follows alacritty: only a carriage return or
-/// an explicit cursor motion clears the pending wrap; a bare
-/// linefeed does not.
 ///
 /// Case: an application writes a full-width line, then emits a bare
 /// linefeed before continuing to print on the next row.

--- a/crates/orzma_vt/src/screen/tests/move_backward_tabs.rs
+++ b/crates/orzma_vt/src/screen/tests/move_backward_tabs.rs
@@ -16,10 +16,7 @@ fn cbt_moves_back_to_the_previous_stop() {
 }
 
 /// Asserts that a backward tab before the first stop lands on
-/// column zero.
-///
-/// The agreed policy makes the left edge a fallback rather than
-/// a stop, because the reset stride leaves column zero empty.
+/// column zero, which is a fallback rather than a stop.
 ///
 /// Case: the user presses Shift-Tab near the start of a line,
 /// before the first tab position.

--- a/crates/orzma_vt/src/screen/tests/move_cursor_relative.rs
+++ b/crates/orzma_vt/src/screen/tests/move_cursor_relative.rs
@@ -26,7 +26,7 @@ fn a_cursor_up_inside_the_region_stops_at_the_top_margin() {
 }
 
 /// Asserts that a cursor below the region also stops at the top
-/// margin, because the margin lies on the way.
+/// margin.
 ///
 /// Case: an application parks the cursor on a status line under its
 /// pane and then moves it back up into the pane.
@@ -39,7 +39,7 @@ fn a_cursor_up_below_the_region_stops_at_the_top_margin() {
 }
 
 /// Asserts that a cursor already above the region reaches the first
-/// row, the margin being behind it.
+/// row.
 ///
 /// Case: an application writes into a header above its pane and moves
 /// the cursor to the very top of the screen.
@@ -66,7 +66,7 @@ fn a_cursor_down_inside_the_region_stops_at_the_bottom_margin() {
 }
 
 /// Asserts that a cursor above the region also stops at the bottom
-/// margin, mirroring the upward case.
+/// margin.
 ///
 /// Case: an application writes a header, then moves the cursor down
 /// into its pane.
@@ -151,7 +151,7 @@ fn a_motion_at_the_boundary_still_disarms_the_deferred_wrap() {
 }
 
 /// Asserts that a relative motion under origin mode keeps the cursor
-/// inside the region, which is where setting the mode seated it.
+/// inside the region.
 ///
 /// Case: a full-screen application sets origin mode and its pane, then
 /// walks the cursor to the extremes of that pane.
@@ -167,7 +167,7 @@ fn a_relative_motion_under_origin_mode_stays_inside_the_region() {
 }
 
 /// Asserts that a backspace lands where a one-column leftward motion
-/// does, the two sharing one primitive.
+/// does.
 ///
 /// Case: a shell erases the last character the user typed.
 #[test]

--- a/crates/orzma_vt/src/screen/tests/move_cursor_to.rs
+++ b/crates/orzma_vt/src/screen/tests/move_cursor_to.rs
@@ -17,11 +17,7 @@ fn omitted_parameters_address_the_first_cell() {
 }
 
 /// Asserts that a zero addresses the first line and column, the
-/// same as a one.
-///
-/// The agreed policy follows VT510 p.116 — "If Pl or Pc is not
-/// selected or selected as 0, then the cursor moves to the first
-/// line or column".
+/// same as a one (VT510 p.115).
 ///
 /// Case: a program that builds its sequences from zero-based
 /// variables emits `CSI 0 ; 0 H`.
@@ -63,11 +59,7 @@ fn a_margin_origin_measures_the_line_from_the_top_margin() {
 }
 
 /// Asserts that the line is absolute and reaches outside the
-/// margins while the origin is the upper-left corner.
-///
-/// The agreed policy follows VT510 p.195: with `DECOM` reset the
-/// line numbering is independent of the margins and the cursor
-/// can move outside them.
+/// margins while the origin is the upper-left corner (VT510 p.195).
 ///
 /// Case: an application keeps a scrolling pane but addresses the
 /// header row above it to update a title.

--- a/crates/orzma_vt/src/screen/tests/move_cursor_to_column.rs
+++ b/crates/orzma_vt/src/screen/tests/move_cursor_to_column.rs
@@ -33,8 +33,7 @@ fn an_omitted_parameter_addresses_the_first_column() {
 }
 
 /// Asserts that addressing a column leaves the cursor's row unchanged
-/// even while origin mode makes the seating helper's line argument
-/// relative to the top margin.
+/// even while origin mode is on.
 ///
 /// Case: an application reserves rows 2 through 4 as a pane, turns on
 /// origin mode, and moves along a row inside that pane.
@@ -123,7 +122,7 @@ fn a_zero_addresses_the_first_column() {
 }
 
 /// Asserts that addressing a column discards a pending deferred wrap
-/// rather than preserving it as a linefeed does.
+/// rather than preserving it.
 ///
 /// Case: an application fills a row to its last column and then jumps
 /// back along that row instead of printing again.

--- a/crates/orzma_vt/src/screen/tests/move_cursor_to_line.rs
+++ b/crates/orzma_vt/src/screen/tests/move_cursor_to_line.rs
@@ -32,8 +32,7 @@ fn an_omitted_parameter_addresses_the_first_line() {
     assert_eq!(screen.state.column, GridColumn(2));
 }
 
-/// Asserts that an explicit one addresses the first line, agreeing
-/// with the omitted-parameter default.
+/// Asserts that an explicit one addresses the first line.
 ///
 /// Case: an application that always writes its parameters out emits
 /// `CSI 1 d` instead of a bare `CSI d`.
@@ -137,12 +136,10 @@ fn an_upper_left_origin_reaches_a_line_below_the_margins() {
     assert_eq!(screen.state.column, GridColumn(2));
 }
 
-/// Asserts that an omitted parameter resolves to the default line
-/// before the origin is applied, reaching the top margin rather than
-/// the top of the screen.
+/// Asserts that an omitted parameter under a margin origin reaches the
+/// top margin rather than the top of the screen.
 ///
-/// Case: an application with origin mode on emits a bare `CSI d`
-/// expecting the first row of its own pane.
+/// Case: an application with origin mode on emits a bare `CSI d`.
 #[test]
 fn an_omitted_parameter_under_a_margin_origin_addresses_the_top_margin() {
     let mut screen = tall_screen();
@@ -187,7 +184,7 @@ fn a_zero_addresses_the_first_line() {
 }
 
 /// Asserts that addressing a line discards a pending deferred wrap
-/// rather than preserving it as a linefeed does.
+/// rather than preserving it.
 ///
 /// Case: an application fills a row to its last column and then jumps
 /// to another row instead of printing again.

--- a/crates/orzma_vt/src/screen/tests/move_forward_tabs.rs
+++ b/crates/orzma_vt/src/screen/tests/move_forward_tabs.rs
@@ -14,11 +14,7 @@ fn ht_moves_to_the_next_stop() {
 }
 
 /// Asserts that a tab past the last reachable stop lands on this
-/// screen's own right edge.
-///
-/// ECMA-48 § 6.1.7 leaves a movement to a non-existing position
-/// undefined and lists seven options; the agreed policy clamps
-/// to the right edge rather than wrapping to the next line or
+/// screen's own right edge rather than wrapping to the next line or
 /// refusing the move.
 ///
 /// Case: a twenty-column window shows text that has already run

--- a/crates/orzma_vt/src/screen/tests/new.rs
+++ b/crates/orzma_vt/src/screen/tests/new.rs
@@ -5,8 +5,7 @@ use super::*;
 /// Asserts that a fresh screen starts at the origin, pinned to the
 /// live tail, with an empty history.
 ///
-/// Case: a terminal spawns and the first shell output must land at
-/// the top-left of an unscrolled screen.
+/// Case: a terminal spawns and the shell prints its first prompt.
 #[test]
 fn a_fresh_screen_starts_at_the_origin() {
     let screen = screen();

--- a/crates/orzma_vt/src/screen/tests/placements.rs
+++ b/crates/orzma_vt/src/screen/tests/placements.rs
@@ -24,8 +24,7 @@ fn a_mount_anchors_at_the_write_cursor() {
 }
 
 /// Asserts that a placement whose anchor row left the ring is
-/// omitted by the projection and named by the sweep, so the two
-/// cannot disagree.
+/// omitted by the projection and named by the sweep.
 ///
 /// Case: a webview sits on the last row of the screen and a
 /// full-screen application scrolls backwards until that row is

--- a/crates/orzma_vt/src/screen/tests/print.rs
+++ b/crates/orzma_vt/src/screen/tests/print.rs
@@ -44,7 +44,7 @@ fn a_replace_mode_print_overwrites_the_cell_without_shifting_the_row() {
 
 /// Asserts that a print in insert mode at the last column drops the cell
 /// it pushes past the border and stamps the character there, arming the
-/// deferred wrap as an ordinary print would.
+/// deferred wrap.
 ///
 /// Case: a program in insert mode types into the rightmost column of a
 /// full row.
@@ -137,7 +137,7 @@ fn an_insert_mode_print_keeps_the_shifted_cells_attributes() {
 }
 
 /// Asserts that an insert-mode print on a one-column screen replaces the
-/// only cell, because the character it shifts falls past the border.
+/// only cell.
 ///
 /// Case: the window is dragged down to a single column while a program
 /// in insert mode keeps printing.
@@ -180,8 +180,7 @@ fn print_stamps_the_pen_and_advances() {
 /// wrap and leaves the cursor in place.
 ///
 /// Case: an application emits a line exactly as wide as the
-/// screen, and the terminal must not move to the next row until
-/// more text actually arrives.
+/// screen, and no further text has arrived yet.
 #[test]
 fn print_at_the_last_column_arms_the_deferred_wrap() {
     let mut screen = screen();

--- a/crates/orzma_vt/src/screen/tests/reset.rs
+++ b/crates/orzma_vt/src/screen/tests/reset.rs
@@ -23,8 +23,7 @@ fn a_reset_empties_every_visible_cell() {
 }
 
 /// Asserts that a reset fills the grid with default cells rather
-/// than carrying the pen background into them the way an erase
-/// does.
+/// than carrying the pen background into them.
 ///
 /// Case: an application paints a red-backgrounded banner and the
 /// shell resets the terminal without the application restoring

--- a/crates/orzma_vt/src/screen/tests/resize.rs
+++ b/crates/orzma_vt/src/screen/tests/resize.rs
@@ -58,7 +58,7 @@ fn a_shrink_that_would_cut_the_cursor_off_scrolls_into_history() {
 /// reclaims from history.
 ///
 /// Case: the user drags a window taller after output has scrolled off
-/// the top, and the prompt must stay under the line it follows.
+/// the top.
 #[test]
 fn a_growth_moves_the_cursor_down_with_the_reclaimed_rows() {
     let mut screen = screen();

--- a/crates/orzma_vt/src/screen/tests/restore_checkpoint.rs
+++ b/crates/orzma_vt/src/screen/tests/restore_checkpoint.rs
@@ -54,10 +54,6 @@ fn an_unsaved_restore_returns_the_power_up_state() {
 /// Asserts that a restored deferred wrap really wraps the next
 /// character.
 ///
-/// The flag is pinned through behaviour rather than by reading it
-/// back, because only the wrap it produces is observable to the
-/// application that saved it.
-///
 /// Case: an application fills a row to its last column, saves,
 /// goes away to draw elsewhere, restores, and prints one more
 /// character.

--- a/crates/orzma_vt/src/screen/tests/reverse_index.rs
+++ b/crates/orzma_vt/src/screen/tests/reverse_index.rs
@@ -19,11 +19,6 @@ fn a_reverse_index_below_the_top_moves_the_cursor_up() {
 /// Asserts that a reverse index at the top margin scrolls the
 /// screen down instead of moving the cursor.
 ///
-/// ECMA-48 § 6.1.7 leaves a movement past the first line undefined
-/// and lists seven permitted behaviours; the agreed policy takes
-/// (f), scrolling, rather than blocking the position or leaving
-/// the cursor where it is.
-///
 /// Case: a pager scrolls backwards with its cursor already parked
 /// on the first line of the screen.
 #[test]
@@ -38,14 +33,6 @@ fn a_reverse_index_at_the_top_margin_scrolls_the_screen_down() {
 
 /// Asserts that a reverse index disarms the deferred wrap on both
 /// the moving and the scrolling path.
-///
-/// The agreed policy follows xterm and VTE, whose reverse index
-/// reaches its cursor-up helper on both paths and resets the
-/// flag there. It is a deliberate divergence from kitty and
-/// wezterm, which clear it only when the cursor moves, and
-/// from alacritty, which clears it on neither — and
-/// `Screen::line_feed` preserves the flag, so the split is
-/// not accidental.
 ///
 /// Case: a program fills the last column of a row and then emits a
 /// reverse index instead of the newline the pending wrap was
@@ -68,8 +55,7 @@ fn a_reverse_index_disarms_the_deferred_wrap_on_both_paths() {
 /// background.
 ///
 /// Case: an application paints a coloured panel and scrolls it
-/// backwards, expecting the newly exposed row to match rather than
-/// show the terminal default.
+/// backwards.
 #[test]
 fn the_exposed_row_carries_the_pen_background() {
     let mut screen = screen();
@@ -80,12 +66,6 @@ fn the_exposed_row_carries_the_pen_background() {
 
 /// Asserts that a reverse index leaves a scrolled-back viewport
 /// showing what it was showing.
-///
-/// The agreed policy leaves the display offset alone rather than
-/// adjusting it the way `Screen::line_feed` does. A forward scroll grows
-/// history, so holding the view still requires moving the offset;
-/// a reverse scroll leaves history untouched, so moving the offset
-/// would push the viewport onto different history instead.
 ///
 /// Case: the user has scrolled back to read earlier output while a
 /// full-screen application keeps scrolling its own view backwards.
@@ -107,11 +87,8 @@ fn a_reverse_index_leaves_a_scrolled_viewport_where_it_is() {
 }
 
 /// Asserts that a reverse index with the cursor above a non-zero
-/// top margin, already on the first row, moves and scrolls nothing.
-///
-/// The agreed policy follows DEC STD 070 and xterm: a cursor that
-/// hits the screen edge outside the scrolling region stays put,
-/// rather than scrolling the region it is not inside.
+/// top margin, already on the first row, moves and scrolls nothing
+/// rather than scrolling the region it is not inside (DEC STD-070).
 ///
 /// Case: an application sets a scroll region below a status line
 /// and emits a reverse index while the cursor sits on that status
@@ -131,12 +108,8 @@ fn a_reverse_index_above_a_top_margin_at_row_zero_does_nothing() {
 }
 
 /// Asserts that a cursor above a non-zero top margin still walks
-/// up toward the first row.
-///
-/// The agreed policy bounds this movement by the screen edge
-/// rather than by the margin: the region gates the scroll alone,
-/// so a cursor outside it moves like an ordinary cursor-up
-/// instead of being pinned at the margin.
+/// up toward the first row, bounded by the screen edge rather than
+/// by the margin.
 ///
 /// Case: an application sets a scroll region below a two-line
 /// header and emits a reverse index while the cursor sits on the

--- a/crates/orzma_vt/src/screen/tests/save_checkpoint.rs
+++ b/crates/orzma_vt/src/screen/tests/save_checkpoint.rs
@@ -21,8 +21,7 @@ fn a_save_copies_every_item_decsc_lists() {
 /// Asserts that work done after a save leaves the saved copy
 /// alone.
 ///
-/// Case: an application saves its cursor and then keeps printing,
-/// expecting the save to still describe where it was.
+/// Case: an application saves its cursor and then keeps printing.
 #[test]
 fn later_work_does_not_reach_the_saved_copy() {
     let mut screen = dirty_screen();

--- a/crates/orzma_vt/src/screen/tests/scroll.rs
+++ b/crates/orzma_vt/src/screen/tests/scroll.rs
@@ -106,7 +106,7 @@ fn a_zero_delta_reports_no_motion() {
 }
 
 /// Asserts that a motion toward the live tail from the live tail
-/// reports no motion, so it arms no repaint.
+/// reports no motion.
 ///
 /// Case: the scroll-on-input policy snaps to the tail on a keystroke
 /// typed while the viewport was already there.

--- a/crates/orzma_vt/src/screen/tests/seat_cursor.rs
+++ b/crates/orzma_vt/src/screen/tests/seat_cursor.rs
@@ -76,7 +76,7 @@ fn a_column_past_the_right_edge_clamps() {
 }
 
 /// Asserts that seating the cursor discards a pending deferred
-/// wrap rather than preserving it as a linefeed does.
+/// wrap rather than preserving it.
 ///
 /// Case: an application fills a row to its last column and then
 /// addresses a cell elsewhere instead of printing again.

--- a/crates/orzma_vt/src/screen/tests/set_origin_mode.rs
+++ b/crates/orzma_vt/src/screen/tests/set_origin_mode.rs
@@ -35,8 +35,8 @@ fn resetting_the_origin_seats_the_cursor_at_the_corner() {
 /// Asserts that the mode reaches the region the cursor motion
 /// reads.
 ///
-/// Case: an application turns on origin mode and the terminal
-/// has to answer later cursor addressing against the margins.
+/// Case: an application turns on origin mode before addressing
+/// the cursor.
 #[test]
 fn the_mode_reaches_the_scroll_region() {
     let mut screen = tall_screen();

--- a/crates/orzma_vt/src/screen/tests/set_scroll_region.rs
+++ b/crates/orzma_vt/src/screen/tests/set_scroll_region.rs
@@ -18,8 +18,7 @@ fn a_resolved_region_reaches_the_scroll_span() {
 }
 
 /// Asserts that applying a region seats the cursor at the
-/// origin-aware home rather than VT510's "column 1, line 1 of
-/// the page".
+/// origin-aware home rather than at the first cell of the page.
 ///
 /// Case: an application sets a region while its cursor sits
 /// somewhere in the middle of the screen.

--- a/crates/orzma_vt/src/screen/tests/tab_stop_edits.rs
+++ b/crates/orzma_vt/src/screen/tests/tab_stop_edits.rs
@@ -19,11 +19,6 @@ fn hts_adds_a_stop_the_next_ht_finds() {
 
 /// Asserts that setting a stop leaves the cursor where it was.
 ///
-/// HTS edits the stop table and nothing else; the neighbouring
-/// name HT is the one that moves. Nothing on screen changes
-/// either, which is why `set_horizontal_tab_stop` reports no
-/// damage to stage.
-///
 /// Case: an application installs a tab position at the column it
 /// is already writing at, then keeps printing on the same line.
 #[test]
@@ -35,10 +30,6 @@ fn hts_does_not_move_the_cursor() {
 }
 
 /// Asserts that HTS and `CTC 0` install the same stop.
-///
-/// The two are one edit in the vocabulary rather than two
-/// parallel implementations, so that a later TABULATION STOP
-/// MODE cannot scope one of them and miss the other.
 ///
 /// Case: an application uses CTC rather than HTS to install its
 /// tab positions, having found the CSI form easier to generate.

--- a/crates/orzma_vt/src/screen/tests/tab_to.rs
+++ b/crates/orzma_vt/src/screen/tests/tab_to.rs
@@ -16,12 +16,6 @@ fn a_tab_seats_the_cursor_at_the_target_column() {
 /// Asserts that seating the cursor leaves an armed deferred
 /// wrap alone.
 ///
-/// The agreed policy preserves the flag, unlike
-/// [`Screen::carriage_return`]. Disarming it would seat the
-/// cursor back onto the row the application had already filled,
-/// which is the behaviour both VTE and Windows Terminal found
-/// real DEC hardware never had.
-///
 /// Case: an application fills a row to its last cell and then
 /// emits a tab instead of more text.
 #[test]

--- a/crates/orzma_vt/src/screen/viewport.rs
+++ b/crates/orzma_vt/src/screen/viewport.rs
@@ -1,6 +1,5 @@
 //! Viewport state: where the visible window sits relative to the live
-//! tail, the coordinates measured from its top, and the motions that
-//! move it.
+//! tail, and how it moves.
 
 use crate::screen::grid::coords::GridLine;
 
@@ -9,11 +8,9 @@ use crate::screen::grid::coords::GridLine;
 /// `0` means the viewport is pinned to the live tail; a positive value
 /// counts the scrollback rows showing above it. The unit is grid rows.
 ///
-/// # Invariants
-///
-/// The producing backend keeps the value within the scrollback
-/// capacity and at `0` while the alternate screen is active; this type
-/// does not enforce either bound itself.
+/// This type bounds nothing: its producer must keep the value within
+/// the scrollback capacity and at `0` while the alternate screen is
+/// active.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DisplayOffset(pub u32);
 
@@ -32,11 +29,9 @@ impl ViewportLine {
     /// Projects the line into active-grid coordinates, the inverse of
     /// [`GridLine::to_viewport`]: `grid_line = viewport_line - offset`.
     ///
-    /// # Invariants
+    /// # Panics
     ///
-    /// The offset must fit `i32`, which the scrollback capacity
-    /// guarantees for every offset the VT produces; a larger one is a
-    /// producer bug and panics rather than wrapping.
+    /// Panics rather than wrapping when the offset does not fit `i32`.
     #[inline]
     pub fn to_grid(self, offset: DisplayOffset) -> GridLine {
         let offset = i32::try_from(offset.0).expect("scrollback never exceeds i32::MAX rows");
@@ -47,10 +42,7 @@ impl ViewportLine {
 /// A viewport motion over the scrollback, clamped by the VT at both
 /// the oldest retained line and the live tail.
 ///
-/// `Delta` is signed: positive moves toward older output (deeper into
-/// scrollback), negative toward the live tail. Page-sized variants are
-/// resolved against the live grid height by the VT backend, so callers
-/// never need to know the row count.
+/// Page-sized variants are resolved against the live grid height.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scroll {
     /// Moves by a signed line count: positive toward older output,

--- a/crates/orzma_vt/src/vi.rs
+++ b/crates/orzma_vt/src/vi.rs
@@ -5,9 +5,8 @@ use crate::screen::grid::coords::GridPoint;
 /// Vi-mode cursor position in active-grid coordinates.
 ///
 /// The line goes negative while the vi cursor sits in scrollback
-/// history. The sign is not a visibility signal — scrolling clamps
-/// the vi cursor into the viewport, so a negative line can still be
-/// visible; project `point` with
+/// history. The sign is not a visibility signal: a negative line can
+/// still be visible, so project `point` with
 /// [`crate::prelude::GridLine::to_viewport`] to decide whether there
 /// is a cell to paint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,13 +17,12 @@ pub struct ViCursor {
 
 /// The direction of a vi-mode switch.
 ///
-/// Named variants rather than a `bool` so the intent is readable at the
-/// trigger site, where a bare `true` says nothing about which state it means.
+/// This terminal does not implement vi mode, so nothing in it acts on a
+/// switch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViModeSwitch {
-    /// Enter vi mode: the vi cursor starts tracking and keyboard input is
-    /// interpreted as motions rather than forwarded to the PTY.
+    /// Enter vi mode.
     Enter,
-    /// Leave vi mode and snap the viewport back to the live tail.
+    /// Leave vi mode.
     Exit,
 }

--- a/crates/orzmux/src/backend.rs
+++ b/crates/orzmux/src/backend.rs
@@ -33,8 +33,7 @@ pub(crate) struct Backend {
     processed: CommandSeq,
     /// Set when the GUI's event receiver is gone; the loop exits.
     gui_gone: bool,
-    /// What each `Select` index of the last `wait_ready` referred to;
-    /// kept so the table is not reallocated on every wake.
+    /// What each `Select` index of the last `wait_ready` referred to.
     sources: Vec<Ready>,
     /// Per-queue peaks between samples; logged once a second.
     sampler: QueueSampler,
@@ -65,10 +64,6 @@ impl Backend {
     /// Runs until the command channel disconnects (the GUI dropped its
     /// client) or the GUI stops receiving events. Dropping the panes on
     /// return kills every child.
-    ///
-    /// Queue depths are recorded right after the wake, before any pump
-    /// or command drain shrinks a queue, and the sample is reported
-    /// after the deadlines are serviced.
     pub(crate) fn run(mut self) {
         loop {
             let ready = self.wait_ready();
@@ -90,8 +85,7 @@ impl Backend {
     /// Applies one command. Unknown panes and an unresolvable `Active`
     /// are dropped with a debug log; `CopySelection` always answers,
     /// `SelectPane` always publishes a layout, and `SelectPaneDirection`
-    /// publishes one only when the active pane moved. `pub(crate)` so
-    /// tests drive the backend without a thread.
+    /// publishes one only when the active pane moved.
     pub(crate) fn handle_command(&mut self, seq: CommandSeq, command: OrzmuxCommand) {
         self.processed = seq;
         match command {
@@ -234,9 +228,7 @@ impl Backend {
 
     /// Blocks until a command or a pane stream is ready, or the earliest
     /// of the coalescer deadlines and the sampler's report deadline
-    /// passes. Returns the ready source, `None` on timeout. The
-    /// `Select` is dropped before returning so the pane receivers it
-    /// borrowed can be pumped.
+    /// passes. Returns the ready source, `None` on timeout.
     fn wait_ready(&mut self) -> Option<Ready> {
         let mut select = Select::new();
         self.sources.clear();
@@ -484,8 +476,8 @@ impl Backend {
         resolved
     }
 
-    /// Resolves a target to its pane's mutable state, logging via
-    /// [`Self::resolve_or_log`] when it does not resolve.
+    /// Resolves a target to its pane's mutable state, logging a debug
+    /// line naming `command` when it does not resolve.
     fn pane_mut(&mut self, target: PaneTarget, command: &'static str) -> Option<&mut Pane> {
         let id = self.resolve_or_log(target, command)?;
         self.panes.get_mut(&id)
@@ -578,8 +570,7 @@ mod tests {
         sink: CaptureSink,
     }
 
-    /// What the factory recorded, shared with the harness through `Arc`
-    /// because the backend only holds the factory as `dyn PaneFactory`.
+    /// What the factory recorded, shared with the harness through `Arc`.
     #[derive(Default)]
     struct FactoryLog {
         fail_next: AtomicBool,
@@ -632,9 +623,7 @@ mod tests {
         panes: Receiver<FakePane>,
         log: Arc<FactoryLog>,
         seq: u64,
-        /// Held so the command channel stays connected; a disconnected
-        /// channel is permanently ready and would wake `wait_ready` at
-        /// once.
+        /// Held so the command channel stays connected.
         _commands: Sender<(CommandSeq, OrzmuxCommand)>,
     }
 

--- a/crates/orzmux/src/backend/pane.rs
+++ b/crates/orzmux/src/backend/pane.rs
@@ -1,5 +1,5 @@
-//! One pane as the backend owns it: the terminal plus the geometry the
-//! backend last applied to it, and the factory that spawns terminals.
+//! One pane as the backend owns it, together with the factory that
+//! spawns a pane's terminal.
 
 use orzma_tty::prelude::{OrzmaTty, OrzmaTtyResult};
 use orzma_tty::{CellPixels, EnvKey, EnvValue, SpawnOptions};
@@ -18,8 +18,7 @@ pub(crate) struct Pane {
     pub(crate) cwd: Option<PathBuf>,
 }
 
-/// Spawns terminals for the backend. Abstracted so tests can hand the
-/// backend PTY-less terminals.
+/// Spawns terminals for the backend.
 pub(crate) trait PaneFactory: Send {
     fn spawn(
         &mut self,
@@ -30,7 +29,7 @@ pub(crate) trait PaneFactory: Send {
     ) -> OrzmaTtyResult<OrzmaTty<OrzmaVt>>;
 }
 
-/// The production factory: spawns the login shell under a real PTY.
+/// Spawns the resolved shell under a real PTY.
 pub(crate) struct ShellFactory {
     shell: String,
     scrollback_rows: usize,
@@ -96,8 +95,7 @@ fn resolve_shell(
 
 /// The Windows default: `pwsh` (PowerShell 7) if `exists` finds it, then
 /// `powershell` (Windows PowerShell), then a non-empty `comspec`, then
-/// `cmd.exe`. Bare names are resolved through `PATH` by `portable-pty`
-/// at spawn.
+/// `cmd.exe`. Bare names are resolved through `PATH` at spawn.
 #[cfg_attr(
     all(unix, not(test)),
     expect(
@@ -120,8 +118,8 @@ fn default_shell() -> String {
     "/bin/sh".to_string()
 }
 
-/// On Unix `$SHELL` is spawned verbatim, as it always was; a bad value
-/// fails the spawn and is reported there.
+/// On Unix `$SHELL` is spawned verbatim; a bad value fails the spawn
+/// and is reported there.
 #[cfg(unix)]
 fn shell_exists(_shell: &str) -> bool {
     true
@@ -140,7 +138,7 @@ fn shell_exists(shell: &str) -> bool {
 
 /// Whether `name` is a file: as given when it carries a directory, else
 /// in some `PATH` entry, as given or with each `PATHEXT` extension
-/// appended — the lookup `portable-pty` performs at spawn.
+/// appended.
 #[cfg(windows)]
 fn on_path(name: &str) -> bool {
     if name.contains(['/', '\\']) {

--- a/crates/orzmux/src/backend/queue_sample.rs
+++ b/crates/orzmux/src/backend/queue_sample.rs
@@ -6,8 +6,8 @@ use crate::protocol::PaneId;
 use std::mem;
 use std::time::{Duration, Instant};
 
-/// How many reader chunks wait unparsed in one pane's chunk channel
-/// (path A), in units of one `read(2)` result of up to 4 KiB.
+/// How many reader chunks wait unparsed in one pane's chunk channel, in
+/// units of one `read(2)` result of up to 4 KiB.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ChunkDepth(pub usize);
 
@@ -29,10 +29,9 @@ pub(crate) struct QueueSample {
     /// Every pane whose chunk peak was recorded, in first-recorded
     /// order.
     pub chunks: Vec<(PaneId, ChunkDepth)>,
-    /// The event channel (path B) peak, or zero when none was recorded.
+    /// The event channel peak, or zero when none was recorded.
     pub events: usize,
-    /// The command channel (path C) peak, or zero when none was
-    /// recorded.
+    /// The command channel peak, or zero when none was recorded.
     pub commands: usize,
 }
 
@@ -92,11 +91,9 @@ impl QueueSampler {
         (!self.peaks.is_empty()).then(|| self.last_sample + Self::SAMPLE_INTERVAL)
     }
 
-    /// The depth a wake implies on its own: the `Select` returns only
-    /// once the woken queue holds one item, and one emitted frame waits
-    /// in the event channel until the GUI's next update. A depth at or
-    /// below the floor is not a peak and records nothing, so an
-    /// interactive terminal neither logs nor adds a wake.
+    /// The depth a wake implies on its own. A depth at or below the
+    /// floor is not a peak and records nothing, so an interactive
+    /// terminal neither logs nor adds a wake.
     const BACKLOG_FLOOR: usize = 1;
 
     fn above_floor(depth: usize) -> usize {
@@ -121,8 +118,8 @@ mod tests {
 
     const PANE: PaneId = PaneId(1);
 
-    /// A sampler built at `start`, plus `start` itself so tests advance
-    /// time arithmetically instead of sleeping.
+    /// A sampler built at `start`, plus `start` itself so the caller can
+    /// advance time arithmetically instead of sleeping.
     fn sampler() -> (QueueSampler, Instant) {
         let start = Instant::now();
         (QueueSampler::new(start), start)
@@ -148,7 +145,7 @@ mod tests {
     /// carries the peaks once it has.
     ///
     /// Case: the backend asks for a sample on every wake while output
-    /// streams, and must log only once a second.
+    /// streams.
     #[test]
     fn a_sample_is_none_before_the_interval_and_some_after_it() {
         let (mut sampler, start) = sampler();
@@ -206,7 +203,7 @@ mod tests {
     /// peak does, and names the end of the current interval.
     ///
     /// Case: the backend goes idle right after one wake recorded a
-    /// depth, and must wake once more to log it.
+    /// depth.
     #[test]
     fn the_report_deadline_exists_only_while_a_peak_is_unreported() {
         let (mut sampler, start) = sampler();

--- a/crates/orzmux/src/client.rs
+++ b/crates/orzmux/src/client.rs
@@ -96,8 +96,8 @@ impl OrzmuxClient {
         self.disconnected.load(Ordering::Acquire)
     }
 
-    /// A client with no thread: the test holds the backend's ends of
-    /// both channels.
+    /// A client with no backend thread: the caller holds the backend's
+    /// ends of both channels.
     #[cfg(any(test, feature = "test-support"))]
     pub fn detached() -> (
         Self,

--- a/crates/orzmux/src/layout.rs
+++ b/crates/orzmux/src/layout.rs
@@ -1,7 +1,5 @@
 //! The cell-unit pane layout: a binary split tree whose leaves are
 //! panes, solved into whole-window rectangles with one-cell separators.
-//! Pure data, with no PTY and no VT dependency, so every operation is
-//! unit-testable.
 
 use crate::protocol::{PaneDirection, PaneId, PaneRect, Separator, SplitOrientation};
 use orzma_vt::prelude::GridSize;
@@ -27,7 +25,7 @@ impl Solved {
 }
 
 /// A split was refused because the target leaf is narrower than three
-/// cells along the split axis (one cell per side plus the separator).
+/// cells along the split axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SplitRefused;
 
@@ -35,8 +33,7 @@ pub struct SplitRefused;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RootOccupied;
 
-/// The split tree plus the activation history, whose last entry is the
-/// active pane.
+/// The split tree plus the activation history.
 #[derive(Debug, Default)]
 pub struct LayoutTree {
     root: Option<Node>,
@@ -370,8 +367,7 @@ impl Node {
     /// The tree without `pane`: the split immediately containing the
     /// removed leaf collapses into its sibling, while an ancestor split
     /// whose child only shrank keeps its structure around that child.
-    /// Returns `(new subtree or None when emptied, removed)`. Both
-    /// children are walked; pane ids are unique, so at most one removes.
+    /// Returns `(new subtree or None when emptied, removed)`.
     fn without(self, pane: PaneId) -> (Option<Node>, bool) {
         match self {
             Node::Leaf(id) if id == pane => (None, true),
@@ -402,7 +398,7 @@ impl Node {
 
 /// `first`'s cells out of `avail`, rounded from `ratio` and clamped so
 /// both children keep their minimum. `avail >= min_first + min_second`
-/// holds because the caller solves against the tree's minimum.
+/// must hold.
 fn share(avail: u16, ratio: f32, min_first: u16, min_second: u16) -> u16 {
     let wanted = (f32::from(avail) * ratio).round() as u16;
     wanted.clamp(min_first, avail - min_second)
@@ -541,11 +537,10 @@ mod tests {
     }
 
     /// Asserts that removing a leaf can change a pane that was not its
-    /// sibling, because an ancestor's minimum-size clamp is released.
+    /// sibling.
     ///
     /// Case: a width-11 window holds `(A | B) | C` with the left subtree
-    /// at ratio 0.1; killing B collapses the subtree to a leaf whose
-    /// minimum drops from 3 to 1, so C also grows.
+    /// at ratio 0.1, and the user kills B.
     #[test]
     fn removing_a_leaf_can_resize_a_pane_outside_its_subtree() {
         let window = GridSize { cols: 11, rows: 5 };

--- a/crates/orzmux/src/protocol.rs
+++ b/crates/orzmux/src/protocol.rs
@@ -1,8 +1,5 @@
-//! The wire vocabulary between the GUI and the multiplexer backend:
-//! identifiers, the commands the GUI sends, the events the backend
-//! emits, and the layout snapshot. Everything here is plain data (no
-//! Bevy types, no GPU handles) so the transport can later become a
-//! socket.
+//! The wire vocabulary between the GUI and the multiplexer backend.
+//! Everything here is plain data: no Bevy types and no GPU handles.
 
 use orzma_tty::prelude::{CellPixels, MouseReport, TerminalKey, TerminalModifiers};
 use orzma_vt::prelude::{
@@ -16,8 +13,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PaneId(pub u32);
 
-/// A window (tab). PR-1 has exactly one, `WindowId(0)`; the type exists
-/// so later protocol additions do not renumber anything.
+/// A window (tab).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct WindowId(pub u32);
 
@@ -48,8 +44,7 @@ pub enum PaneTarget {
     Id(PaneId),
 }
 
-/// Which way a split divides a pane, named after the divider the user
-/// sees.
+/// Which way a split divides a pane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SplitOrientation {
     /// A vertical divider: the panes end up side by side.
@@ -105,8 +100,6 @@ pub enum OrzmuxCommand {
         /// Where the new pane goes in the layout tree.
         at: NewPaneAt,
         /// The working directory to spawn the shell in, when given.
-        /// Reserved for a client-chosen directory (tmux's `-c`); the
-        /// host sends `None` today.
         cwd: Option<PathBuf>,
         /// Extra environment variables forwarded to the shell.
         env: Vec<(String, String)>,
@@ -343,8 +336,8 @@ mod tests {
 
     /// Asserts that request ids mint strictly increasing values.
     ///
-    /// Case: the GUI fires two pane spawns in one frame and must
-    /// correlate each `PaneOpened` back to its own entity.
+    /// Case: the GUI fires two pane spawns in one frame and must tell
+    /// the two `PaneOpened` answers apart.
     #[test]
     fn request_ids_are_strictly_increasing() {
         let a = RequestId::next();
@@ -352,10 +345,11 @@ mod tests {
         assert!(a.0 < b.0);
     }
 
-    /// Asserts that the default layout is the empty snapshot the GUI
-    /// compares against to detect the session ending.
+    /// Asserts that the default layout has no panes, no separators, and
+    /// no active pane.
     ///
-    /// Case: the GUI initializes `CurrentLayout` before the first pane.
+    /// Case: the GUI holds a layout of its own before the backend opens
+    /// the first pane.
     #[test]
     fn the_default_layout_has_no_panes() {
         let layout = Layout::default();

--- a/src/action/clipboard/copy.rs
+++ b/src/action/clipboard/copy.rs
@@ -4,20 +4,14 @@
 use bevy::{clipboard::ClipboardError, prelude::*};
 
 /// Requests that `text` be written to the system clipboard.
-///
-/// A global (non-entity) event: the clipboard is process-global, so copy /
-/// yank observers `commands.trigger` this and `on_copy` performs the single
-/// `Clipboard::set_text`. Decoupling this way keeps the copy observers
-/// testable by capturing the request instead of round-tripping a real
-/// clipboard.
 #[derive(Event, Debug, Clone)]
 pub(crate) struct CopyAction {
     /// The text to place on the system clipboard.
     pub text: String,
 }
 
-/// Registers the clipboard write-seam observer. Bevy's `Clipboard` resource
-/// comes from `DefaultPlugins`; this plugin only adds orzma's write path.
+/// Adds orzma's clipboard write path onto Bevy's `Clipboard` resource,
+/// provided by `DefaultPlugins`.
 pub(super) struct ClipboardCopyActionPlugin;
 
 impl Plugin for ClipboardCopyActionPlugin {

--- a/src/action/clipboard/paste.rs
+++ b/src/action/clipboard/paste.rs
@@ -14,7 +14,7 @@ pub(crate) struct PasteAction {
     pub entity: Entity,
 }
 
-/// Registers the paste pipeline observers.
+/// Adds orzma's paste pipeline.
 pub(super) struct ClipboardPasteActionPlugin;
 
 impl Plugin for ClipboardPasteActionPlugin {
@@ -23,10 +23,7 @@ impl Plugin for ClipboardPasteActionPlugin {
     }
 }
 
-/// The decision `on_paste` derives from a clipboard read poll. Keeping the
-/// branch logic a pure function of the poll result lets every arm be
-/// unit-tested without a real clipboard backend (bevy's `Clipboard` exposes no
-/// in-memory seam).
+/// The outcome of polling a clipboard read for a paste.
 enum PasteRead {
     /// Non-empty clipboard text ready to paste.
     Ready(String),

--- a/src/action/terminal/open_uri.rs
+++ b/src/action/terminal/open_uri.rs
@@ -17,7 +17,7 @@ pub(crate) struct TerminalOpenUri {
     pub uri: String,
 }
 
-/// Registers the open-uri apply observer.
+/// Adds the apply path for `TerminalOpenUri`.
 pub(super) struct OpenUriPlugin;
 
 impl Plugin for OpenUriPlugin {
@@ -26,9 +26,8 @@ impl Plugin for OpenUriPlugin {
     }
 }
 
-/// Applies a `TerminalOpenUri`: opens the link in the host handler, but only
-/// while the target terminal still exists — parity with the legacy apply
-/// path, which gated every effect behind the target's presence.
+/// Applies a `TerminalOpenUri` by opening the link in the host handler while
+/// the target terminal still exists.
 fn on_terminal_open_uri(ev: On<TerminalOpenUri>, terminals: Query<(), With<OrzmaTerminal>>) {
     if terminals.get(ev.entity).is_ok() {
         try_open_uri(&ev.uri);

--- a/src/action/terminal/selection.rs
+++ b/src/action/terminal/selection.rs
@@ -143,10 +143,9 @@ fn on_selection_text(ev: On<TtySelectionTextSignal>, mut commands: Commands) {
 }
 
 /// Converts a viewport-relative point (`mouse.rs`'s contract: line `0` is
-/// the top of the displayed viewport) into the active-grid coordinates
-/// `RequestTtySelectionStart`/`RequestTtySelectionUpdate` document their
-/// `cell` field as expecting, delegating the projection to
-/// `ViewportLine::to_grid`.
+/// the top of the displayed viewport) into active-grid coordinates: line
+/// `0` is the top of the active screen area and negative lines reach into
+/// scrollback history, while the column carries through unchanged.
 fn to_grid_point(viewport_point: GridPoint, offset: DisplayOffset) -> GridPoint {
     let viewport_line = u16::try_from(viewport_point.line.0)
         .expect("the selection events document a non-negative viewport line");

--- a/src/action/terminal/selection.rs
+++ b/src/action/terminal/selection.rs
@@ -55,15 +55,14 @@ pub(crate) struct TerminalSelectionCopy {
     pub entity: Entity,
 }
 
-/// Triggers a `TerminalSelectionCopy` on the focused terminal, if any. Used by
-/// the shortcut applier's `Shortcut::Copy` arm.
+/// Triggers a `TerminalSelectionCopy` on the focused terminal, if any.
 pub(crate) fn trigger_selection_copy(commands: &mut Commands, focused: Option<Entity>) {
     if let Some(entity) = focused {
         commands.trigger(TerminalSelectionCopy { entity });
     }
 }
 
-/// Registers the selection apply observers.
+/// Adds the local-selection actions.
 pub(super) struct SelectionPlugin;
 
 impl Plugin for SelectionPlugin {

--- a/src/action/terminal/viewport_scroll.rs
+++ b/src/action/terminal/viewport_scroll.rs
@@ -17,7 +17,7 @@ pub(crate) struct TerminalViewportScroll {
     pub lines: i32,
 }
 
-/// Registers the viewport-scroll apply observer.
+/// Adds the viewport-scroll action.
 pub(super) struct ViewportScrollPlugin;
 
 impl Plugin for ViewportScrollPlugin {

--- a/src/action/vi/applier.rs
+++ b/src/action/vi/applier.rs
@@ -15,7 +15,7 @@ use bevy_orzmux::prelude::{
 use orzma_configs::vi_mode::ViModeScroll;
 use orzma_vt::prelude::Scroll;
 
-/// Registers the local VI apply observers.
+/// Adds the local VI apply path.
 pub(super) struct ViApplierPlugin;
 
 impl Plugin for ViApplierPlugin {
@@ -44,8 +44,8 @@ fn on_vi_scroll(ev: On<ViScrollRequest>, mut commands: Commands) {
     });
 }
 
-/// Resolves a selection toggle against the (currently stubbed) current
-/// selection and requests the matching operation.
+/// Resolves a selection toggle against the current selection and requests
+/// the matching operation.
 fn on_vi_selection_toggle(ev: On<ViSelectionToggleRequest>, mut commands: Commands) {
     match SelectionOp::resolve(selection_type(), ev.ty) {
         SelectionOp::Start(kind) => {
@@ -68,9 +68,9 @@ fn on_vi_selection_toggle(ev: On<ViSelectionToggleRequest>, mut commands: Comman
     }
 }
 
-/// Asks for the selection's text (answered later as a clipboard write)
-/// and always leaves vi mode. FIFO on the backend keeps the copy ahead
-/// of the exit's selection clear.
+/// Requests the selection's text, answered later as a clipboard write, and
+/// always leaves vi mode; the copy request is sent before the exit, so it
+/// stays ahead of the exit's selection clear.
 fn on_vi_yank(
     ev: On<ViYankRequest>,
     mut commands: Commands,

--- a/src/action/vi/keymap.rs
+++ b/src/action/vi/keymap.rs
@@ -1,7 +1,6 @@
 //! Startup-resolved `[vi-mode]` key table: normalizes each configured key
 //! into a lookup form (`Plain` logical char / `Named` / `Ctrl` physical key)
-//! and maps a matched action to the shared VI events. Used by both modes'
-//! vi-mode key gathers.
+//! and maps a matched action to the shared VI events.
 
 use crate::action::vi::{
     ViExitRequest, ViMotionRequest, ViScrollRequest, ViSelectionToggleRequest, ViYankRequest,
@@ -16,7 +15,7 @@ use orzma_configs::vi_mode::{
 };
 use std::collections::HashMap;
 
-/// Registers the `Startup` resolution of the `[vi-mode]` table.
+/// Adds the resolved `[vi-mode]` key table.
 pub(super) struct ViModeKeymapPlugin;
 
 impl Plugin for ViModeKeymapPlugin {
@@ -69,7 +68,7 @@ impl ResolvedViModeKeys {
 }
 
 /// Fires the VI event for a matched action on `entity`, converting the
-/// config-crate vocabulary to engine types. Shared by both modes' gathers.
+/// config-crate vocabulary to engine types.
 pub(crate) fn trigger_vi_mode_action(
     commands: &mut Commands,
     entity: Entity,
@@ -105,8 +104,8 @@ enum ResolvedKey {
     Ctrl(KeyCode),
 }
 
-/// `Startup` system: resolves `[vi-mode]` into the lookup map. Config
-/// validation already rejected duplicates, so plain inserts are safe.
+/// Resolves `[vi-mode]` into the lookup map. Config validation already
+/// rejected duplicates, so plain inserts are safe.
 fn build_vi_mode_keys(
     mut resolved: ResMut<ResolvedViModeKeys>,
     configs: Res<OrzmaConfigsResource>,

--- a/src/action/vi/mode.rs
+++ b/src/action/vi/mode.rs
@@ -1,8 +1,6 @@
-//! Vi mode state. This component is a pure marker — its presence on a
-//! Surface entity means "vi mode is active". Entering and exiting request a
-//! selection clear and a `RequestTtyViMode` switch on the underlying tty;
-//! where the vi cursor and the active selection actually live is an
-//! implementation detail of whatever `Vt` capability eventually backs them.
+//! Vi mode state: a pure marker component whose presence on a surface
+//! entity means vi mode is active. Entering and exiting request a selection
+//! clear and a `RequestTtyViMode` switch on the underlying tty.
 
 use crate::input::focus::{KeyboardDisabled, MouseDisabled};
 use bevy::app::{App, Plugin};
@@ -14,11 +12,7 @@ use bevy::ecs::query::With;
 use bevy::ecs::system::{Commands, Query};
 use bevy_orzmux::prelude::{OrzmuxPane, RequestTtySelectionClear, RequestTtyViMode, ViModeSwitch};
 
-/// Bevy Plugin: registers the two observers. The `Clipboard` resource is
-/// provided by `DefaultPlugins` (`bevy_clipboard::ClipboardPlugin`); orzma's
-/// `crate::action::clipboard` copy plugin adds the write-seam observer.
-/// `ViModeState` is inserted/removed per-entity by the observers
-/// themselves; no global system needed.
+/// Adds vi-mode enter and exit handling.
 pub(super) struct ViModePlugin;
 
 impl Plugin for ViModePlugin {
@@ -39,17 +33,16 @@ pub struct EnterViModeActionEvent {
     pub entity: Entity,
 }
 
-/// Request to exit vi mode. The observer requests a selection clear and a
-/// `RequestTtyViMode { switch: Exit }`, and removes `ViModeState`.
+/// Requests exiting vi mode on `entity`: clears the selection, switches the
+/// tty out of vi mode, and removes `ViModeState`.
 #[derive(EntityEvent, Debug)]
 pub struct ExitViMode {
     /// The Surface entity to exit vi mode on.
     pub entity: Entity,
 }
 
-/// Observer for `EnterViModeActionEvent`. Inserts `ViModeState` on the
-/// target entity and requests a selection clear followed by the vi-mode
-/// enter switch.
+/// Inserts `ViModeState` on the target entity and requests a selection
+/// clear followed by the vi-mode enter switch.
 fn handle_enter_vi_mode_request(
     ev: On<EnterViModeActionEvent>,
     mut commands: Commands,
@@ -73,9 +66,8 @@ fn handle_enter_vi_mode_request(
         .insert((ViModeState, KeyboardDisabled, MouseDisabled));
 }
 
-/// Observer for `ExitViMode`. Removes `ViModeState`, and requests a
-/// selection clear followed by the vi-mode exit switch (which snaps the
-/// viewport to the live tail).
+/// Removes `ViModeState`, and requests a selection clear followed by the
+/// vi-mode exit switch, which snaps the viewport to the live tail.
 fn handle_exit_vi_mode(
     ev: On<ExitViMode>,
     mut commands: Commands,

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,21 +1,16 @@
 //! Loads `OrzmaConfigs` synchronously at app build time and exposes it as
-//! a Bevy Resource. Config validation errors (duplicate direct or prefix
-//! chords, duplicate `[vi-mode]` keys, a leader that shadows a direct
-//! binding, prefix bindings with no leader, an unmappable leader key, an
-//! out-of-range font size, an unparseable `[font]` face `style`) are fatal
-//! (exit 2) so a mistake in one field never silently discards the whole
-//! config. Parse / IO errors warn and fall back to defaults so the GUI
-//! remains startable for users with stale or invalid config files.
+//! a Bevy Resource. Validation errors exit the process (code 2); parse and
+//! IO errors warn and fall back to defaults.
 
 use bevy::prelude::*;
 use orzma_configs::OrzmaConfigs;
 
-/// Bevy Resource wrapping the resolved `OrzmaConfigs`.
+/// The resolved `OrzmaConfigs`, loaded once at app build time.
 #[derive(Resource, Debug, Default, Deref)]
 pub(crate) struct OrzmaConfigsResource(pub(crate) OrzmaConfigs);
 
-/// Bevy Plugin that loads orzma config from disk at `Plugin::build` and
-/// inserts it as [`OrzmaConfigsResource`]. Synchronous; uses `std::fs`.
+/// Loads orzma config from disk and inserts it as [`OrzmaConfigsResource`];
+/// synchronous, using `std::fs`.
 pub(crate) struct OrzmaConfigsPlugin;
 
 impl Plugin for OrzmaConfigsPlugin {

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,13 +1,6 @@
-//! Bridge between `OrzmaConfigsResource.font` and the renderer's
-//! `TerminalFonts` Resource, plus the `TerminalUiFont` handle that UI
-//! text builders consume. Runs at Startup, ordered
-//! `.before(TerminalFontInitSet::InitCellMetrics)` so the renderer's
-//! cell-metrics computation sees any overridden font.
-//!
-//! Startup-only: font changes require a process restart. If a future
-//! feature adds config hot-reload, `bridge_font_config` must move to a
-//! change-detection system in Update (and additionally re-issue cell
-//! metrics + invalidate the glyph atlas — see the renderer crate).
+//! Bridges `OrzmaConfigsResource.font` into the renderer's `TerminalFonts`
+//! Resource and the `TerminalUiFont` handle that UI text builders consume.
+//! Font changes require a process restart.
 
 use crate::configs::OrzmaConfigsResource;
 use bevy::prelude::*;
@@ -24,8 +17,8 @@ use std::sync::Arc;
 mod resolve;
 
 /// UI-chrome font: the family `source` plus the `weight`/`slant` applied at
-/// every UI `TextFont` site (window bar, prompts, indicators). Built by
-/// `bridge_font_config` from `[font].ui`, inheriting `[font].normal` per field.
+/// every UI `TextFont` site (window bar, prompts, indicators). Resolved from
+/// `[font].ui`, inheriting `[font].normal` per field.
 #[derive(Resource, Clone, Default)]
 pub struct TerminalUiFont {
     /// Family or bundled-handle source handed to `TextFont.font`.
@@ -50,11 +43,10 @@ impl TerminalUiFont {
     }
 
     /// Resolves the UI face from `[font].ui`, inheriting `normal` per field:
-    /// `family` falls back to `normal`'s (using its already-resolved result via
-    /// `regular_from_family`), `style` falls back to `normal.style` then
-    /// Regular. A configured `ui.family` that is absent aborts startup. When no
-    /// family resolves, the bundled face matching the resolved weight/slant is
-    /// used (bundled has only four faces).
+    /// `family` falls back to `normal`'s already-resolved family, `style`
+    /// falls back to `normal.style` then Regular. A configured `ui.family`
+    /// that is absent aborts startup. When no family resolves, the bundled
+    /// face matching the resolved weight/slant is used.
     fn resolve(
         collection: &mut Collection,
         fonts_assets: &mut Assets<Font>,
@@ -99,7 +91,7 @@ impl TerminalUiFont {
     }
 }
 
-/// Bevy plugin that wires `bridge_font_config` into Startup.
+/// Adds orzma's font bridge.
 pub struct FontBridgePlugin;
 
 impl Plugin for FontBridgePlugin {
@@ -115,19 +107,13 @@ impl Plugin for FontBridgePlugin {
 }
 
 /// Registers the bundled CJK fallback font into parley's fontique
-/// collection and appends its family to the Han / Hiragana / Katakana
-/// script-fallback chains, making it discoverable for spans whose
-/// primary `TextFont` lacks CJK coverage.
-///
-/// NOTE: Bevy's `Assets<Font>::add(...)` is NOT sufficient here —
-/// `bevy_text::load_font_assets_into_font_collection` registers every
-/// `Font` asset in the collection, but fontique resolves missing glyphs
-/// only through per-script fallback chains, which stay empty without
-/// system font discovery. `append_fallbacks` is what makes the family
-/// reachable. Conversely, that same bevy_text system CLEARS the
-/// collection (dropping this registration and its fallback chains) if
-/// any `Font` asset is ever removed — orzma never removes font assets
-/// after Startup; re-run this registration if that changes.
+/// collection via `append_fallbacks`, appending its family to the Han /
+/// Hiragana / Katakana script-fallback chains so a span whose primary
+/// `TextFont` lacks CJK coverage can resolve it there.
+// NOTE: bevy_text's `load_font_assets_into_font_collection` clears the whole
+// fontique collection whenever a `Font` asset is removed, silently dropping
+// this registration and its fallback chains. orzma must never remove a
+// `Font` asset after Startup; re-run this registration if that changes.
 fn register_cjk_fallback(mut font_cx: ResMut<FontCx>) {
     let blob = Blob::new(Arc::new(FALLBACK_REGULAR) as Arc<dyn AsRef<[u8]> + Send + Sync>);
     let registered = font_cx.collection.register_fonts(blob, None);
@@ -302,7 +288,7 @@ fn ui_text_attrs(spec: FontStyleSpec) -> (FontWeight, FontStyle) {
 
 /// Picks the bundled static face nearest to `spec`. The bundle ships only four
 /// faces, so intermediate weights (Light/Medium/SemiBold) round to Regular or
-/// Bold. Used only when no system family resolves for the UI face.
+/// Bold.
 fn bundled_face_bytes(spec: FontStyleSpec) -> &'static [u8] {
     let bold = spec.weight >= 600;
     let italic = spec.slant != FontSlant::Normal;
@@ -328,13 +314,10 @@ mod tests {
     use std::sync::Arc;
 
     /// RAII guard for a process-environment variable. Constructing it via
-    /// `EnvVarGuard::set(...)` sets the variable; dropping it removes
-    /// it. The Drop runs even on panic, so a test that panics inside
-    /// `app.update()` no longer leaks the stale env var into the next
-    /// test (which would then run against a misconfigured `ORZMA_CONFIG`
-    /// after recovering from the poisoned `env_guard` mutex).
+    /// `EnvVarGuard::set(...)` sets the variable; dropping it removes it,
+    /// even on panic.
     ///
-    /// The caller MUST hold `crate::configs::env_guard()` for the full
+    /// The caller must hold `crate::configs::env_guard()` for the full
     /// lifetime of every `EnvVarGuard` to keep env mutations serialized
     /// across tests.
     struct EnvVarGuard {
@@ -498,10 +481,12 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
     }
 
-    /// Registers the bundled JBM regular/bold faces into the test app's
-    /// `FontCx` collection under known family names BEFORE `app.update()`
-    /// runs `bridge_font_config`, so the resolution is deterministic and
-    /// does not depend on any host-installed font.
+    /// Asserts that configuring `[font.normal]` and `[font.bold]` resolves
+    /// the terminal faces, the UI font, and the bold override from the
+    /// matching registered families.
+    ///
+    /// Case: the user points `normal` and `bold` at two distinct families
+    /// registered in the font collection before the app starts.
     #[test]
     fn configured_family_resolves_terminal_fonts_ui_font_and_bold_override() {
         let tmp = std::env::temp_dir().join("orzma_font_family_success_path.toml");
@@ -567,12 +552,12 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
     }
 
-    /// Registers TWO faces (weight 400 and weight 700) under the SAME family
-    /// name, then configures `normal.style = "Bold"`. A single-face family
-    /// would resolve regardless of style, so this proves the style-derived
-    /// attributes actually drove weight selection: the `normal` slot must
-    /// pick the weight-700 face, not the family's first-registered weight-400
-    /// face.
+    /// Asserts that `normal.style` selects the matching weight within a
+    /// family that carries multiple weights, rather than the family's
+    /// first-registered face.
+    ///
+    /// Case: the user configures `[font.normal]` with `style = "Bold"`
+    /// against a family registered under both a regular and a bold weight.
     #[test]
     fn configured_style_selects_weight_within_same_family() {
         let tmp = std::env::temp_dir().join("orzma_font_style_selects_weight.toml");

--- a/src/font/resolve.rs
+++ b/src/font/resolve.rs
@@ -1,7 +1,6 @@
 //! Resolves a font-family name and face attributes to font-file bytes plus a
-//! collection face index, via a `fontique` collection. Pure over the borrowed
-//! collection + source cache, so tests inject a collection preloaded from known
-//! font files instead of relying on the host's installed fonts.
+//! collection face index, via a `fontique` collection. Pure over the
+//! borrowed collection and source cache.
 
 use bevy_orzma_tty_renderer::FontFace;
 use fontique::{
@@ -45,10 +44,8 @@ pub(super) fn attributes_of(spec: FontStyleSpec) -> Attributes {
 #[derive(Debug)]
 pub(super) struct FamilyNotFound;
 
-/// Whether `family` exists in the collection, without resolving or copying any
-/// font bytes. Used by the UI-font path, which hands parley a
-/// `FontSource::Family` and needs only a presence check (parley selects the
-/// face at render time).
+/// Whether `family` exists in the collection, without resolving or copying
+/// any font bytes.
 pub(super) fn family_present(collection: &mut Collection, family: &str) -> bool {
     collection.family_id(family).is_some()
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
-//! Root of the host input pipeline: keyboard, mouse, focus, gesture and
-//! binding primitives, IME, hyperlink-hover, shortcuts, and option-as-alt.
+//! Root of the host input pipeline, turning window input events into
+//! terminal input and UI focus state.
 
 mod bindings;
 pub(crate) mod focus;
@@ -34,8 +34,8 @@ pub(crate) enum InputPhase {
     FocusedKey,
 }
 
-/// Bevy Plugin that registers the host input pipeline (keyboard, mouse, IME,
-/// focus gates, hyperlink hover, shortcuts).
+/// The host input pipeline: keyboard, mouse, IME, focus gates, hyperlink
+/// hover, and shortcuts.
 pub struct OrzmaInputPlugin;
 
 impl Plugin for OrzmaInputPlugin {
@@ -64,8 +64,7 @@ impl Plugin for OrzmaInputPlugin {
 
 /// Returns the current modifier state from the `ButtonInput<KeyCode>` resource.
 ///
-/// The result is stable within a single Update tick because `ButtonInput`
-/// is updated in `PreUpdate`.
+/// The result is stable within a single Update tick.
 pub(crate) fn current_modifiers(keys: &ButtonInput<KeyCode>) -> Modifiers {
     Modifiers {
         ctrl: keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight),

--- a/src/input/bindings.rs
+++ b/src/input/bindings.rs
@@ -1,13 +1,11 @@
-//! Host-owned mouse input policy: `OrzmaMouseConfig` / `FineModifier`, populated
-//! from `orzma_configs` at startup
-//! (`crate::input::shortcuts::populate_mouse_config`).
+//! Host-owned mouse input policy, populated from `orzma_configs` at startup.
 
 use bevy::prelude::*;
 use std::time::Duration;
 
 /// Which modifier activates "fine" (1 line per notch) wheel scrolling.
-/// Default `Alt`: on macOS Shift+wheel becomes horizontal scroll at the OS
-/// level, so Shift never reaches the app as vertical `y`.
+/// On macOS, Shift+wheel becomes horizontal scroll at the OS level, so
+/// Shift never reaches the app as vertical `y`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub(crate) enum FineModifier {
     /// Shift key activates fine scrolling.
@@ -21,11 +19,9 @@ pub(crate) enum FineModifier {
     None,
 }
 
-/// Host-side burst cap for PTY-bound button reports, mirroring the old
-/// engine's `ButtonConfig`. Unused until mouse-button routing is
-/// reintroduced against `orzma_tty` (tracked as out-of-scope work in the
-/// engine-swap design); kept so `OrzmaMouseConfig` and its `orzma_configs`
-/// populate path (`orzma_mouse_config`) keep compiling unchanged.
+/// Host-side burst cap for PTY-bound button reports. Currently unused.
+///
+/// TODO: reintroduce mouse-button routing against `orzma_tty`.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ButtonConfig {
     /// Hard cap on the number of PTY-bound reports emitted per route call.
@@ -39,10 +35,11 @@ pub(crate) struct ButtonConfig {
     pub max_protocol_events_per_frame: u32,
 }
 
-/// Host-side wheel-routing policy, mirroring the old engine's `WheelConfig`.
-/// `lines_per_notch` / `fine_lines` still drive the local viewport-scroll
-/// computation in `mouse::wheel`; `max_protocol_events_per_frame` is unused
-/// until mouse-wheel PTY reporting is reintroduced against `orzma_tty`.
+/// Host-side wheel-routing policy. `lines_per_notch` and `fine_lines` drive
+/// the viewport-scroll computation; `max_protocol_events_per_frame` is
+/// currently unused.
+///
+/// TODO: reintroduce mouse-wheel PTY reporting against `orzma_tty`.
 #[derive(Clone, Debug)]
 pub(crate) struct WheelConfig {
     /// Lines scrolled per notch in the scrollback path.

--- a/src/input/focus.rs
+++ b/src/input/focus.rs
@@ -1,9 +1,6 @@
-//! Focus & input suppression: defines `KeyboardFocused`, `KeyboardDisabled`,
-//! and `MouseDisabled` — the three components the host uses to route keyboard
-//! and mouse input — maintains the two `*Disabled` markers from the coarse
-//! guards (IME, window focus, webview rect-claim, vi mode) in
-//! `maintain_input_gates`, and keeps bevy_cef's `FocusedWebview` in step with
-//! the active pane.
+//! Focus and input suppression: gates which pane receives keyboard and
+//! mouse input, and keeps `bevy_cef`'s webview focus in step with the
+//! active pane.
 
 use crate::action::vi::mode::ViModeState;
 use crate::configs::OrzmaConfigsResource;
@@ -51,8 +48,8 @@ pub(crate) struct PaneClicked {
     pub entity: Entity,
 }
 
-/// Registers `maintain_input_gates`, the webview focus-sync system, and the
-/// active-pane / click-to-focus observers.
+/// Keeps focus and input gating in sync with the active pane and
+/// click-to-focus requests.
 pub(super) struct FocusSyncPlugin;
 
 impl Plugin for FocusSyncPlugin {
@@ -145,22 +142,17 @@ fn inactive_style(config: &InactivePaneConfig) -> PaneInactiveStyle {
 
 /// Keeps `bevy_cef`'s `FocusedWebview` in step with orzma's active pane.
 ///
-/// bevy_cef only updates `FocusedWebview` when a *webview* node is clicked
-/// (`set_focus_on_press`), so moving focus to a terminal pane (a non-webview)
-/// leaves the webview focused: its DOM text area keeps the caret and
-/// `send_key_event` keeps routing keystrokes to it. Driving `FocusedWebview`
-/// from the active pane fixes both — keyboard follows the focused pane, and CEF
-/// blurs the webview on focus-leave (`bevy_cef`'s `apply_webview_focus` releases
-/// CEF focus when `FocusedWebview` becomes `None`).
+/// Driving `FocusedWebview` from the active pane keeps keyboard input
+/// following the focused pane, and lets CEF blur the webview once it loses
+/// focus.
 ///
-/// One case is PRESERVED instead of driven: when `FocusedWebview` holds a
+/// One case is preserved instead of driven: when `FocusedWebview` holds a
 /// webview child (`Webview`) whose `ChildOf` parent is a live
-/// `OrzmaTerminal` surface, that inline focus stands (spec §7, single
-/// focus source). This covers click-granted focus and the app-declared
-/// focus set via the control-plane `SetFocus` op. Releasing that focus
-/// when the active pane moves elsewhere is `on_active_pane_changed`'s
-/// job; this sync only clears it once the child despawns or focus moves
-/// off it, falling through to the clear path below.
+/// `OrzmaTerminal` surface, that inline focus stands as the single focus
+/// source. This covers click-granted focus and the app-declared focus set
+/// via the control-plane `SetFocus` op. This sync does not clear that focus
+/// when the active pane changes elsewhere; it clears it only once the
+/// child despawns or focus moves off it.
 fn sync_focused_webview(
     mut focused: ResMut<FocusedWebview>,
     active_pane: Query<Entity, (With<OrzmaTerminal>, With<KeyboardFocused>)>,
@@ -195,9 +187,9 @@ fn should_disable_input(composing: bool, window_focused: bool, webview_focused: 
     composing || !window_focused || webview_focused
 }
 
-/// Inline-webview hit-test inputs for the mouse rect-claim, bundled to stay
-/// within Bevy's system-parameter limit. `metrics` is optional so the gate still
-/// runs before cell metrics exist (no claim possible yet).
+/// Inline-webview hit-test inputs for the mouse rect-claim. `metrics` is
+/// optional: the gate still runs before cell metrics exist, when no claim
+/// is possible yet.
 #[derive(SystemParam)]
 struct WebviewClaimParams<'w, 's> {
     metrics: Option<Res<'w, TerminalCellMetricsResource>>,
@@ -260,11 +252,9 @@ fn maintain_input_gates(
     }
 }
 
-/// The shell surface whose INTERACTIVE inline webview rect is under the cursor,
-/// or `None`. Resolves the topmost `OrzmaTerminal` under the cursor, then
-/// hit-tests its active overlay rects (`webview_hit_at` skips `NonInteractive`
-/// children). A claimed surface is marked `MouseDisabled` so
-/// `dispatch_mouse_buttons` yields the click to the webview router.
+/// The shell surface whose INTERACTIVE inline webview rect is under the
+/// cursor, or `None`. Considers only the topmost surface under the cursor;
+/// a `NonInteractive` child never claims it.
 fn cursor_claims_webview(window: &Window, claim: &WebviewClaimParams) -> Option<Entity> {
     let metrics = claim.metrics.as_deref()?;
     let scale = window.scale_factor();

--- a/src/input/hyperlink.rs
+++ b/src/input/hyperlink.rs
@@ -1,16 +1,6 @@
-//! OSC 8 hyperlink hover detection and cursor-icon control — the single
-//! authority for `HyperlinkHoverState` (the renderer underline) and the window
-//! `CursorIcon` over every terminal surface: the shell terminal and
-//! webview hosts (all are `OrzmaTerminal` entities). Over a linked cell the
-//! cursor becomes a pointer while the platform activation modifier
-//! (`link_modifier_held`) is held, and text otherwise; over a webview host the
-//! cursor is left to `bevy_cef`'s `SystemCursorIconPlugin`. Surfaces with input
-//! suppressed (`MouseDisabled`: vi mode, IME, focused webview, unfocused
-//! window) are skipped, so hover never advertises a link the mouse dispatcher
-//! would refuse to open. Hyperlink activation (Cmd/Ctrl-click → `OpenUri`) now lives in
-//! `crate::input::mouse` (deciders `decide_button`/`resolve_button_event`);
-//! `crate::action::terminal` keeps only the apply observer
-//! (`on_terminal_open_uri` → `try_open_uri`).
+//! OSC 8 hyperlink hover detection and cursor-icon control across every
+//! terminal surface (the shell terminal and webview hosts): the only
+//! writer of `HyperlinkHoverState` and the window's `CursorIcon`.
 
 use crate::input::focus::MouseDisabled;
 use crate::input::{InputPhase, current_modifiers};
@@ -29,8 +19,8 @@ use bevy_orzma_tty_renderer::TerminalCellMetricsResource;
 use bevy_orzma_tty_renderer::schema::{HyperlinkHoverState, TerminalGrid};
 use orzma_configs::shortcuts::Modifiers;
 
-/// Plugin: registers `insert_initial_cursor_icon` at `Startup` and
-/// `hyperlink_hover_and_cursor` in `InputPhase::Hover`.
+/// Adds hyperlink hover detection and cursor-icon control for every
+/// terminal surface.
 pub(super) struct HyperlinkInputPlugin;
 
 impl Plugin for HyperlinkInputPlugin {
@@ -59,6 +49,8 @@ pub(crate) fn link_modifier_held(mods: &Modifiers) -> bool {
     }
 }
 
+/// Skips any surface with input suppressed (`MouseDisabled`), so hover
+/// never advertises a link the mouse dispatcher would refuse to open.
 fn hyperlink_hover_and_cursor(
     mut hover: ResMut<HyperlinkHoverState>,
     mut cursor_icons: Query<&mut CursorIcon, With<PrimaryWindow>>,
@@ -135,8 +127,8 @@ fn hyperlink_hover_and_cursor(
 }
 
 /// Clears every per-cursor field of the hover state, including
-/// `modifier_held`. Used on the early-return paths where the keyboard
-/// was not read, so the modifier state cannot be trusted.
+/// `modifier_held`. Call this when the keyboard was not read this frame,
+/// since the modifier state cannot be trusted otherwise.
 fn reset_hover_state(hover: &mut HyperlinkHoverState) {
     hover.entity = None;
     hover.hyperlink_id = None;
@@ -198,10 +190,10 @@ fn cursor_decision(target: HoverTarget) -> Option<SystemCursorIcon> {
 }
 
 /// Inserts an initial `CursorIcon::System(SystemCursorIcon::Default)`
-/// (the arrow) on the primary window so the hover system in this module
-/// can mutate the component without first having to insert it. The arrow
-/// is the default for non-terminal regions; the hover system narrows it to
-/// the I-beam over terminal text.
+/// (the arrow) on the primary window so the hover system can mutate the
+/// component without first having to insert it. The arrow is the default
+/// for non-terminal regions; the hover system narrows it to the I-beam
+/// over terminal text.
 fn insert_initial_cursor_icon(
     mut commands: Commands,
     windows: Query<Entity, (With<PrimaryWindow>, Without<CursorIcon>)>,

--- a/src/input/ime.rs
+++ b/src/input/ime.rs
@@ -1,10 +1,5 @@
-//! IME composition state for the terminal overlay.
-//!
-//! Provides `Composition` (a validated preedit snapshot), `ImeState`
-//! (the active-composition resource), `read_ime_events` (the Bevy
-//! system that drains `Ime` events and triggers `ImeCommit` to the
-//! keyboard-focused surface), and `ime_policy_system` (toggles
-//! `Window::ime_enabled` and `.ime_position`).
+//! IME composition state for the terminal overlay: drains IME events into
+//! `ImeState` and derives window IME policy from keyboard focus.
 
 use crate::action::vi::mode::ViModeState;
 use crate::input::InputPhase;
@@ -32,8 +27,7 @@ use orzma_tty::prelude::{KeyText, TerminalKey, TerminalModifiers};
 
 /// IME-committed text destined for the keyboard-focused terminal surface.
 ///
-/// The `apply_ime_commit_to_terminal` observer below applies it, writing the
-/// active pane via `RequestActiveKeyInput`.
+/// Applying it writes the committed text to the active pane.
 #[derive(EntityEvent, Debug, Clone)]
 pub(crate) struct ImeCommit {
     #[event_target]
@@ -41,11 +35,7 @@ pub(crate) struct ImeCommit {
     pub(crate) text: String,
 }
 
-/// Bevy plugin that registers `ImeState` and the IME-event handling
-/// systems. Ordering: `ime_policy_system` runs before `read_ime_events`
-/// (chained); both run in `InputPhase::Dispatch`, ahead of
-/// `InputPhase::FocusedKey`, whose dispatcher gates on `ImeState`, so IME
-/// must apply first.
+/// Adds `ImeState`, IME event handling, and the window IME policy.
 pub(super) struct ImePlugin;
 
 impl Plugin for ImePlugin {
@@ -71,19 +61,16 @@ pub(crate) struct Composition {
 
 impl Composition {
     /// Validates and constructs a `Composition`. Returns `None` when:
-    ///   - `text` is empty (treat any empty-value Preedit as
-    ///     "no composition").
+    ///   - `text` is empty (an empty-value `Preedit` means "no composition").
     ///
     /// Sets `caret = None` when:
     ///   - either endpoint is out of bounds (`> text.len()`);
-    ///   - either endpoint lands on a non-UTF-8 boundary byte
-    ///     (defensive: winit returns byte offsets that we later slice into);
-    ///   - `begin > end` (invariant violation; winit's spec is `(begin, end)`).
+    ///   - either endpoint lands on a non-UTF-8 boundary byte;
+    ///   - `begin > end`.
     ///
     /// `begin == end` is the normal caret-only case. `begin != end`
     /// represents a clause-selection range (macOS IME during clause
-    /// conversion, etc.) and is rendered as a hollow block over the
-    /// span by `position_ime_overlay`.
+    /// conversion, etc.).
     pub(crate) fn try_new(text: String, raw_caret: Option<(usize, usize)>) -> Option<Self> {
         if text.is_empty() {
             return None;
@@ -117,8 +104,7 @@ impl Composition {
 /// suppressed.
 ///
 /// The window's `ime_enabled` field is the single source of truth for
-/// whether IME is allowed; this resource intentionally does not mirror
-/// it.
+/// whether IME is allowed; this resource does not mirror it.
 #[derive(Resource, Default, Debug)]
 pub(crate) struct ImeState(Option<Composition>);
 
@@ -135,10 +121,6 @@ impl ImeState {
 /// Pure-function state machine: applies one `Ime` event to `state` and
 /// returns the text that should be committed to the active pane (only set on
 /// `Ime::Commit`).
-///
-/// Keeping this pure makes the state transitions unit-testable without
-/// a Bevy `App` harness; the Bevy system in `read_ime_events` is a thin
-/// wrapper around this.
 pub(crate) fn apply_event(state: &mut ImeState, event: &Ime) -> Option<String> {
     match event {
         Ime::Enabled { .. } => None,
@@ -170,18 +152,15 @@ pub(crate) fn resolve_focused_surface(
 /// Derives whether IME should be on this tick and writes
 /// `PrimaryWindow.ime_enabled` and `.ime_position`.
 ///
-/// `ime_enabled` is `true` iff a CEF webview owns focus (it drives its own
-/// IME through bevy_cef's `Ime` → CEF bridge), OR a surface exists that does
-/// NOT have `ViModeState`. The surface is the `KeyboardFocused` `OrzmaTerminal`
-/// surface.
+/// `ime_enabled` is `true` iff a CEF webview owns focus, or a surface
+/// exists that does NOT have `ViModeState`. The surface is the
+/// `KeyboardFocused` `OrzmaTerminal` surface.
 ///
-/// `ime_position` is the logical-pixel anchor for the OS candidate
-/// window — computed from the surface's `UiGlobalTransform`
-/// translation + `TerminalGrid.cursor` × cell pitch, then divided by
-/// the window scale factor. When the focused webview is an INLINE child of
+/// `ime_position` anchors the OS candidate window at the focused
+/// surface's cursor cell. When the focused webview is an INLINE child of
 /// the active pane, the anchor instead comes from that child's overlay
-/// rect origin (`webview_ime_position`), since inline entities carry no UI
-/// node for `webview_anchors` to read (spec §7).
+/// rect origin (`webview_ime_position`), since inline entities carry no
+/// UI node for `webview_anchors` to read.
 fn ime_policy_system(
     mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
     focused: Query<Entity, With<KeyboardFocused>>,
@@ -208,7 +187,7 @@ fn ime_policy_system(
         if !window.ime_enabled {
             window.ime_enabled = true;
         }
-        // NOTE: Inline arm (spec §7): an inline child has no UI node, so the
+        // NOTE: Inline arm: an inline child has no UI node, so the
         // tab-webview `webview_anchors` arm below cannot anchor it. Derive the
         // candidate-window position from the owning terminal's node transform
         // plus the inline placement rect's origin — the SAME px conversion the
@@ -302,9 +281,7 @@ fn ime_policy_system(
 /// Drains `Ime` events, updates `ImeState`, and on `Ime::Commit` triggers
 /// `ImeCommit` to the keyboard-focused surface. The commit is suppressed (the
 /// state machine still runs, so `ImeState` stays consistent) when EITHER any
-/// webview owns keyboard focus OR the focused surface is in vi mode. The
-/// commit transport is applied by the `apply_ime_commit_to_terminal` observer
-/// in this module.
+/// webview owns keyboard focus OR the focused surface is in vi mode.
 fn read_ime_events(
     mut commands: Commands,
     mut events: MessageReader<Ime>,

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,8 +1,5 @@
-//! Host keyboard input primitives: registers the `KeyboardInput` message stream
-//! and provides the key/modifier mapping helpers used elsewhere in the input
-//! pipeline — `bevy_key_to_terminal_key` (the Default applier's raw-key
-//! forwarding) and `current_terminal_modifiers` (the Default applier plus the
-//! mouse dispatch).
+//! Host keyboard input primitives: maps host key/modifier state to the
+//! terminal's encoding.
 
 use crate::input::current_modifiers;
 use crate::input::keyboard::handler::KeyboardHandlerPlugin;
@@ -14,7 +11,7 @@ use orzma_tty::prelude::{KeyText, TerminalKey, TerminalModifiers};
 mod handler;
 pub mod key_effect;
 
-/// Registers the `KeyboardInput` message stream.
+/// Adds the `KeyboardInput` message stream.
 pub(super) struct KeyboardInputPlugin;
 
 impl Plugin for KeyboardInputPlugin {
@@ -175,7 +172,7 @@ mod tests {
 
     /// Asserts an empty character payload maps to `None` rather than a
     /// zero-length `TerminalKey::Character`, since `KeyText` cannot represent
-    /// empty text (D12 of the engine-swap design).
+    /// empty text.
     ///
     /// Case: a platform IME or compose sequence delivers a `Key::Character`
     /// event carrying an empty string.

--- a/src/input/keyboard/handler.rs
+++ b/src/input/keyboard/handler.rs
@@ -1,10 +1,5 @@
-//! Resolves the frame's pressed keys through the pure
-//! `crate::input::resolve::classify_key_batch` decider, handles the two
-//! mode-independent effects inline (Quit → `AppExit`, release-webview-focus →
-//! clear `FocusedWebview`), and fans out the remaining effects as a single
-//! press-order `KeyEffectMessage` stream. `apply_key_effects`
-//! (`crate::input::shortcuts::apply`) consumes that stream and applies the
-//! events. This is the sole system that steps `LeaderPhase`.
+//! Resolves the frame's pressed keys into shortcut and key-forwarding
+//! effects, and fans them out as a `KeyEffectMessage` stream.
 
 use crate::action::vi::ResolvedViModeKeys;
 use crate::action::vi::mode::ViModeState;
@@ -27,7 +22,7 @@ use bevy_cef::prelude::{CefKeyboardFilter, FocusedWebview, KeyboardDeliverSet, M
 use bevy_orzma_webview::ForwardKeys;
 use orzma_configs::shortcuts::Shortcut;
 
-/// Registers `resolve_key_effects` and the `ShortcutSet` ordering.
+/// Adds per-frame keyboard-effect resolution.
 pub(super) struct KeyboardHandlerPlugin;
 
 impl Plugin for KeyboardHandlerPlugin {
@@ -43,7 +38,7 @@ impl Plugin for KeyboardHandlerPlugin {
     }
 }
 
-/// The classifier inputs `resolve_key_effects` feeds to `classify_key_batch`: the
+/// The classifier inputs used to resolve the frame's key effects: the
 /// shortcut table, resolved vi-mode keys, held modifier keys, and the
 /// real-time clock the leader timeout is measured against.
 #[derive(SystemParam)]
@@ -55,14 +50,12 @@ struct ClassifyInputs<'w> {
 }
 
 /// Resolves the frame's pressed keys and fans out `KeyEffectMessage` in
-/// press order. Runs unconditionally (gated only on
-/// `on_message::<KeyboardInput>`), in `InputPhase::FocusedKey` /
-/// `ShortcutSet::Resolve` / `LeaderGate::Advance`. The sole `LeaderPhase`-stepping
-/// system: on a coarse guard (IME composition or an unfocused window) it
-/// clears the leader, drains the frame's keys, and writes no messages;
-/// otherwise it classifies the keys, applies `Quit` (`AppExit`) and
-/// `ReleaseWebviewFocus` (clear `FocusedWebview`) inline, and writes every
-/// other effect to `KeyEffectMessage`.
+/// press order. The sole `LeaderPhase`-stepping system: on a coarse guard
+/// (IME composition or an unfocused window) it clears the leader, drains
+/// the frame's keys, and writes no messages; otherwise it classifies the
+/// keys, applies `Quit` (`AppExit`) and `ReleaseWebviewFocus` (clear
+/// `FocusedWebview`) inline, and writes every other effect to
+/// `KeyEffectMessage`.
 fn resolve_key_effects(
     mut exit: MessageWriter<AppExit>,
     mut events: MessageReader<KeyboardInput>,
@@ -168,8 +161,8 @@ fn resolve_key_effects(
     }
 }
 
-/// Empties `CefKeyboardFilter`. Used on the coarse-guard early return and when no
-/// webview owns the keyboard, so a stale leader claim never withholds a later key.
+/// Empties `CefKeyboardFilter`, so a stale leader claim never withholds a
+/// later key.
 fn clear_cef_filter(cef_filter: &mut CefKeyboardFilter) {
     cef_filter.set(Vec::<(Entity, KeyCode, ModifiersState)>::new());
 }

--- a/src/input/keyboard/key_effect.rs
+++ b/src/input/keyboard/key_effect.rs
@@ -1,7 +1,5 @@
-//! Pure decision layer for keyboard-shortcut dispatch: the `KeyEffect`
-//! intermediate representation plus the single decider `classify_key_batch`
-//! that the keyboard dispatcher wires into. No ECS handles —
-//! fully unit-testable without a Bevy `App`.
+//! Pure decision layer for keyboard-shortcut dispatch: decides each
+//! pressed key's effect, with no ECS handles.
 
 use crate::action::vi::ResolvedViModeKeys;
 use crate::input::shortcuts::{
@@ -14,9 +12,8 @@ use orzma_configs::shortcuts::{Modifiers, Shortcut};
 use orzma_configs::vi_mode::ViModeAction;
 use std::time::Duration;
 
-/// One decided effect of a single pressed key, produced by `classify_key_batch`.
-/// The appliers interpret each variant; this type carries no ECS
-/// handles so the decider stays pure.
+/// One decided effect of a single pressed key. The appliers interpret
+/// each variant; this type carries no ECS handles.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum KeyEffect {
     /// Run a bound `Shortcut`. `via_leader` distinguishes a leader-scoped
@@ -48,8 +45,8 @@ pub(crate) enum KeyEffect {
     },
 }
 
-/// Per-batch context `classify_key_batch` needs beyond the leader/shortcut
-/// state threaded through `leader_phase`.
+/// Per-batch context needed to classify one frame's pressed keys, beyond
+/// the leader/shortcut state threaded through `leader_phase`.
 pub(crate) struct BatchContext<'a> {
     /// The frame's modifier snapshot, shared by every event in the batch.
     pub(crate) mods: Modifiers,
@@ -63,18 +60,19 @@ pub(crate) struct BatchContext<'a> {
     pub(crate) forward_chords: &'a [NormalizedChord],
 }
 
-/// The decided output of `classify_key_batch`: the per-key `KeyEffect`s, plus the
-/// physical keys the leader claimed while a webview owned the keyboard. The caller
-/// applies the frame's modifier snapshot when withholding `webview_suppressed`
-/// from CEF via `CefKeyboardFilter`; it is empty on the non-webview path.
+/// The result of classifying one frame's pressed keys: the per-key
+/// `KeyEffect`s, plus the physical keys the leader claimed while a
+/// webview owned the keyboard. The caller applies the frame's modifier
+/// snapshot when withholding `webview_suppressed` from CEF via
+/// `CefKeyboardFilter`; it is empty on the non-webview path.
 pub(crate) struct ClassifiedKeys {
     pub(crate) effects: Vec<KeyEffect>,
     pub(crate) webview_suppressed: Vec<KeyCode>,
 }
 
 /// Classifies one frame's pressed `KeyboardInput` events into `KeyEffect`s,
-/// threading the shared leader state machine across the batch. Pure: no ECS
-/// handles, so callers can drive it in a unit test with no `App`.
+/// threading the shared leader state machine across the batch. Pure: no
+/// ECS handles.
 ///
 /// A stale repeat window is closed before the batch is processed whenever
 /// `ctx.in_vi_mode` is set, so a repeat-marked key that doubles as a

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -1,10 +1,6 @@
-//! Shared mouse-dispatch plumbing for every `OrzmaTerminal` surface. Hosts the
-//! `MouseInputPlugin` aggregator, the hit-test primitives (`CellContext`,
-//! `cell_at_*`, `hit_candidates`, the `TerminalSurfaces` query alias) shared by
-//! the per-path dispatchers in `button` and `wheel`, and the `MouseEffect` IR +
-//! `trigger_mouse_effects` used by the `button` path only (the `wheel` path
-//! triggers its `EntityEvent`s directly). Gated per entity by `MouseDisabled`,
-//! so dispatch runs for every surface that still owns the mouse.
+//! Shared mouse-dispatch plumbing for every `OrzmaTerminal` surface, gated
+//! per entity by `MouseDisabled` so dispatch runs only for a surface that
+//! still owns the mouse.
 
 use crate::action::terminal::{
     TerminalOpenUri, TerminalSelectionClear, TerminalSelectionCopy, TerminalSelectionStart,
@@ -29,10 +25,8 @@ mod gesture;
 mod webview;
 mod wheel;
 
-/// Aggregates the per-path mouse dispatch plugins and the shared config
-/// resource. The button and wheel dispatchers live in `button` / `wheel` and
-/// register themselves; the webview pointer routers are aggregated via
-/// `webview::MouseWebviewPlugin`.
+/// Adds mouse button, wheel, and webview-pointer dispatch for every
+/// terminal surface.
 pub(super) struct MouseInputPlugin;
 
 impl Plugin for MouseInputPlugin {
@@ -46,20 +40,17 @@ impl Plugin for MouseInputPlugin {
     }
 }
 
-/// Run condition shared by the button and wheel dispatchers: true on any frame
-/// carrying a mouse message (button, cursor move, or wheel). A cursor-only frame
-/// must still run so the dispatchers retarget / reset; defining it once keeps the
-/// two per-file plugins' gating in lockstep.
+/// True on any frame carrying a mouse button, cursor-move, or wheel
+/// message. A cursor-only frame must still run so the dispatchers
+/// retarget / reset.
 fn on_any_mouse_message() -> impl SystemCondition<()> {
     on_message::<MouseButtonInput>
         .or_else(on_message::<CursorMoved>)
         .or_else(on_message::<MouseWheel>)
 }
 
-/// Host-private decision IR for the button path: `decide_button` returns an
-/// ordered `Vec` of these, which `trigger_mouse_effects` fans out to
-/// per-operation `EntityEvent`s on the target terminal. The wheel path does
-/// not go through this IR; it triggers `TerminalViewportScroll` directly.
+/// An ordered operation to apply to the target terminal: a selection
+/// start/update/clear, a copy, or an opened URI.
 #[derive(Debug, Clone, PartialEq)]
 enum MouseEffect {
     SelStart {
@@ -77,8 +68,8 @@ enum MouseEffect {
 }
 
 /// Fans an ordered `Vec<MouseEffect>` out to per-operation `EntityEvent`s on
-/// `entity`, preserving order (Bevy's command queue is FIFO and each trigger
-/// resolves before the next).
+/// `entity`, preserving order: the command queue is FIFO, and each trigger
+/// resolves before the next.
 fn trigger_mouse_effects(commands: &mut Commands, entity: Entity, effects: Vec<MouseEffect>) {
     for effect in effects {
         match effect {
@@ -147,8 +138,8 @@ fn cell_at_local(
     (CellCoord { col, row }, side)
 }
 
-/// The terminal-surface query shared by the button and wheel dispatchers,
-/// aliased so the long type is not repeated across their helper signatures.
+/// A terminal-surface query matching every mouse-enabled `OrzmaTerminal`
+/// surface.
 type TerminalSurfaces<'w, 's> = Query<
     'w,
     's,
@@ -163,8 +154,7 @@ type TerminalSurfaces<'w, 's> = Query<
 >;
 
 /// The `(entity, node, stack, transform)` candidates `topmost_surface_at`
-/// hit-tests, projected from the surface query — one adapter shared by both
-/// dispatchers.
+/// hit-tests, projected from the surface query.
 fn hit_candidates<'a>(
     terminals: &'a TerminalSurfaces<'_, '_>,
 ) -> impl Iterator<
@@ -180,9 +170,8 @@ fn hit_candidates<'a>(
         .map(|(e, node, stack, transform, _)| (e, node, stack, transform))
 }
 
-/// The `(cell_w, cell_h)` pitch in physical px, floored and clamped to `>= 1` so
-/// a degenerate metric cannot divide by zero. Shared by the mouse dispatchers
-/// and webview pointer routing's cursor → cell projection.
+/// The `(cell_w, cell_h)` pitch in physical px, floored and clamped to
+/// `>= 1` so a degenerate metric cannot divide by zero.
 fn cell_dims(metrics: &TerminalCellMetricsResource) -> (f32, f32) {
     (
         metrics.metrics.advance_phys.floor().max(1.0),
@@ -190,9 +179,8 @@ fn cell_dims(metrics: &TerminalCellMetricsResource) -> (f32, f32) {
     )
 }
 
-/// Read-only hit-test context for one gather run: the terminal node geometry,
-/// cell pitch, and grid dimensions — so helpers resolve a cursor to a cell
-/// without re-threading seven arguments.
+/// Read-only hit-test context for one gather run: the terminal node
+/// geometry, cell pitch, and grid dimensions.
 struct CellContext<'a> {
     node: &'a ComputedNode,
     transform: &'a UiGlobalTransform,
@@ -215,9 +203,8 @@ impl CellContext<'_> {
     }
 }
 
-/// Resolves `target` to its `CellContext` at the given cell pitch, or `None`
-/// when it is no longer a live surface. The button dispatcher builds its
-/// hit-test context through this for both live events and synthesized drags.
+/// Resolves `target` to its `CellContext` at the given cell pitch, or
+/// `None` when it is no longer a live surface.
 fn cell_context_for<'a>(
     terminals: &'a TerminalSurfaces<'_, '_>,
     target: Entity,

--- a/src/input/mouse/button.rs
+++ b/src/input/mouse/button.rs
@@ -1,12 +1,8 @@
 //! Mouse-button dispatch for every `OrzmaTerminal` surface: local text
-//! selection + copy, Cmd-click hyperlink open, and click-to-focus. Hit-tests
-//! the cursor to a cell, drives the local-only `LocalButtonAction::route`
-//! router, and fans effects out via the shared `trigger_mouse_effects`. A
-//! press that a URI open did not consume also triggers `PaneClicked` on the
-//! target surface. App-forward mouse reporting is out of scope until mouse
-//! routing is reintroduced against `orzma_tty` (D17 of the engine-swap
-//! design). Registered by `MouseButtonInputPlugin`; skips `MouseDisabled`
-//! surfaces.
+//! selection and copy, Cmd-click hyperlink open, and click-to-focus.
+//!
+//! TODO: reintroduce app-forward mouse-button PTY reporting against
+//! `orzma_tty`.
 
 use super::{
     CellContext, MouseEffect, TerminalSurfaces, cell_context_for, cell_dims, hit_candidates,
@@ -31,10 +27,7 @@ use orzma_tty::prelude::{CellCoord, MouseReportKind, ProtocolModifiers};
 use orzma_vt::prelude::{GridColumn, GridLine};
 use std::time::Duration;
 
-/// Registers the mouse-button dispatcher and its gesture resource. Runs in
-/// `InputPhase::Dispatch`, gated to frames carrying any mouse message — the
-/// focus/empty-candidate guard must still run on wheel-only frames to drain
-/// readers and reset the gesture.
+/// Adds mouse-button dispatch and its gesture resource.
 pub(super) struct MouseButtonInputPlugin;
 
 impl Plugin for MouseButtonInputPlugin {
@@ -50,9 +43,9 @@ impl Plugin for MouseButtonInputPlugin {
 
 /// Logical mouse-button identity accepted by the local-selection router.
 ///
-/// Deliberately narrower than [`orzma_tty::prelude::MouseButton`]: only the
-/// three physical buttons a Bevy `MouseButtonInput` can carry, with no wheel
-/// variants to exhaustively (and uselessly) match against.
+/// Narrower than [`orzma_tty::prelude::MouseButton`]: only the three
+/// physical buttons a Bevy `MouseButtonInput` can carry, with no wheel
+/// variants.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::input::mouse) enum MouseButtonKind {
     Left,
@@ -98,16 +91,15 @@ enum LocalButtonAction {
 }
 
 impl LocalButtonAction {
-    /// Ports the local-selection branches of the removed engine's
-    /// `ButtonAction::route`. The app-forward branch (mouse-mode PTY
-    /// reporting) is not ported — that is out of scope until mouse routing
-    /// returns against `orzma_tty` (D17b).
+    /// The local-selection branches of the button-decision router; the
+    /// app-forward branch (mouse-mode PTY reporting) is currently
+    /// unsupported.
     fn route(evt: ButtonEvent, mods: ProtocolModifiers) -> Self {
         match (evt.kind, evt.button) {
             (MouseReportKind::Press, MouseButtonKind::Left) => {
                 if mods.alt {
                     // TODO: switch to `SelectionKind::Block` once `orzma_vt`
-                    // gains it (D16); an Alt+click rounds down to `Lines`
+                    // gains it; an Alt+click rounds down to `Lines`
                     // until then.
                     return Self::StartLocalSelection {
                         kind: SelectionKind::Lines,
@@ -122,7 +114,7 @@ impl LocalButtonAction {
                         side: evt.side,
                     },
                     // TODO: switch to a word-snapped Semantic kind once
-                    // `orzma_vt` gains one (D16); a double-click rounds down
+                    // `orzma_vt` gains one; a double-click rounds down
                     // to plain `Simple` until then.
                     2 => Self::StartLocalSelection {
                         kind: SelectionKind::Simple,
@@ -246,7 +238,8 @@ fn resolve_frame(
 
 /// Processes one `MouseButtonInput`: hit-tests the target (press) or the locked
 /// held entity (release), drives `resolve_button_event` + `decide_button`,
-/// updates the held-pointer state, and triggers the decided effects.
+/// updates the held-pointer state, and triggers the decided effects. A press
+/// that a URI open did not consume also triggers `PaneClicked` on the target.
 fn process_button_event(
     commands: &mut Commands,
     gesture: &mut OrzmaMouseGesture,
@@ -331,11 +324,10 @@ fn synthesize_held_drag(
     }
 }
 
-/// Pure per-event decision for a mouse button. Mutates `gesture` (drag phase /
-/// click state) and returns the effects to apply. A Cmd/Ctrl-click on a linked
-/// cell opens the URL and consumes the event; otherwise
-/// `LocalButtonAction::route` decides the local-selection response —
-/// app-forward reporting is out of scope (D17b of the engine-swap design).
+/// Pure per-event decision for a mouse button. Mutates `gesture` (drag
+/// phase / click state) and returns the effects to apply. A Cmd/Ctrl-click
+/// on a linked cell opens the URL and consumes the event; otherwise
+/// `LocalButtonAction::route` decides the local-selection response.
 fn decide_button(
     gesture: &mut OrzmaMouseGesture,
     evt: ButtonEvent,
@@ -419,13 +411,9 @@ fn protocol_mods(keys: &ButtonInput<KeyCode>) -> ProtocolModifiers {
 
 /// Converts a 1-indexed protocol `CellCoord` into a 0-indexed,
 /// viewport-relative `GridPoint` (row 0 = top of the currently displayed
-/// viewport). This dispatcher has no read access to the VT (a pane entity's
-/// `OrzmuxPane` names the backend pane, but the VT itself lives on the
-/// multiplexer backend thread, a backend that may later run out of
-/// process), so it cannot resolve scrollback itself —
-/// `action/terminal/selection.rs`'s apply observer offsets this by the
-/// terminal's live display offset before firing `RequestTtySelectionStart`
-/// / `RequestTtySelectionUpdate`.
+/// viewport). This dispatcher cannot resolve scrollback itself; the offset
+/// to the terminal's live display line is applied downstream, before the
+/// selection request is sent.
 fn to_grid_point(cell: CellCoord) -> GridPoint {
     GridPoint {
         line: GridLine(cell.row as i32 - 1),
@@ -970,10 +958,9 @@ mod tests {
 
     /// Asserts a double-click starts a selection immediately (no arm-then-drag
     /// defer) using `SelectionKind::Simple` — `orzma_vt` has no word-snapped
-    /// Semantic kind yet, so double-click rounds down to plain Simple (D16).
+    /// Semantic kind yet, so double-click rounds down to plain Simple.
     ///
-    /// Case: the user double-clicks a word, expecting an immediate selection
-    /// rather than the single-click arm-and-defer behavior.
+    /// Case: the user double-clicks a word.
     #[test]
     fn double_click_starts_selection_immediately_pending_semantic_kind() {
         let mut g = OrzmaMouseGesture::default();

--- a/src/input/mouse/gesture.rs
+++ b/src/input/mouse/gesture.rs
@@ -1,6 +1,4 @@
-//! Click, wheel, and drag gesture primitives (multi-click tracking, drag-phase
-//! state, and wheel-notch accumulation) consumed by the shared mouse dispatch in
-//! `crate::input::mouse`.
+//! Click, wheel, and drag gesture primitives.
 
 use crate::input::mouse::button::MouseButtonKind;
 use bevy::input::mouse::MouseScrollUnit;
@@ -154,8 +152,8 @@ pub(in crate::input::mouse) fn accumulate_notches(
     notches
 }
 
-/// Dominant-axis lock for a single frame's `(vertical, horizontal)` cell delta,
-/// Alacritty-style: keeps the axis the gesture is travelling along and zeros the
+/// Dominant-axis lock for a single frame's `(vertical, horizontal)` cell
+/// delta: keeps the axis the gesture is travelling along and zeros the
 /// other, so trackpad jitter on the off-axis cannot leak a stray notch.
 ///
 /// `ratio` is the share of the gesture's magnitude the horizontal component must

--- a/src/input/mouse/webview.rs
+++ b/src/input/mouse/webview.rs
@@ -1,12 +1,6 @@
-//! Shared CEF pointer routing helpers for the router: forwards left
-//! press/release and pointer motion to the inline CEF child under the cursor, on
-//! ANY `OrzmaTerminal` surface. The router system
-//! (`crate::input::mouse::webview::router`) resolves which surface is
-//! under the cursor — the single shell surface — and then delegates the
-//! CEF forwarding + focus to the helpers here. Inline webviews are Node/Mesh-free
-//! `ChildOf` children (`bevy_orzma_webview`), so `bevy_cef`'s native picking cannot
-//! reach them; this manual forwarding is the only path that delivers clicks to
-//! them.
+//! Shared CEF pointer routing for the inline webview children `bevy_cef`'s
+//! native picking cannot reach: forwards left press/release and pointer
+//! motion to the CEF child under the cursor.
 
 use crate::input::mouse::cell_dims;
 use crate::surface::OrzmaTerminal;
@@ -27,7 +21,7 @@ use bevy_orzma_webview::{
 
 mod router;
 
-/// Registers the shared webview pointer resource and the webview router.
+/// Adds webview pointer routing for inline CEF children.
 pub(super) struct MouseWebviewPlugin;
 
 impl Plugin for MouseWebviewPlugin {
@@ -44,10 +38,10 @@ impl Plugin for MouseWebviewPlugin {
 #[derive(Resource, Default)]
 pub(in crate::input::mouse) struct WebviewPress(pub Option<Entity>);
 
-/// Queries/resources the webview routing needs, bundled to stay within Bevy's
-/// system-parameter limit. The surface-geometry lookup is `With<OrzmaTerminal>`,
-/// matching every terminal surface. `focused_webview` / `browsers` are optional
-/// so CEF-less tests construct it (state effects still apply).
+/// Queries and resources the webview routing needs. The surface-geometry
+/// lookup is `With<OrzmaTerminal>`, matching every terminal surface.
+/// `focused_webview` and `browsers` are optional; other state effects
+/// still apply when either is absent.
 #[derive(SystemParam)]
 pub(in crate::input::mouse) struct WebviewRouteParams<'w, 's> {
     focused_webview: Option<ResMut<'w, FocusedWebview>>,
@@ -64,13 +58,13 @@ pub(in crate::input::mouse) struct WebviewRouteParams<'w, 's> {
 /// `(terminal, local_phys)`, returning `true` when the event was CONSUMED and
 /// must NOT reach the host's terminal mouse pipeline.
 ///
-/// A press inside an interactive rect sets `FocusedWebview`, issues the UNGATED
-/// `set_focus` BEFORE the gated `send_mouse_click` (CEF drops clicks to a
-/// browser with no `focused_frame()`, so the first click would otherwise be
-/// swallowed), forwards the press in DIP, and records the in-flight press. A
-/// press outside every rect clears an inline `FocusedWebview` and returns
-/// `false` (so the press falls through to the terminal). Release forwards the
-/// click-up to the recorded child (drift-tolerant) and clears.
+/// A press inside an interactive rect sets `FocusedWebview`, issues the
+/// UNGATED `set_focus` before the gated `send_mouse_click` so the first
+/// click is not swallowed by an unfocused browser, forwards the press in
+/// DIP, and records the in-flight press. A press outside every rect
+/// clears an inline `FocusedWebview` and returns `false` (so the press
+/// falls through to the terminal). Release forwards the click-up to the
+/// recorded child (drift-tolerant) and clears.
 #[expect(
     clippy::too_many_arguments,
     reason = "inline routing needs the webview press state, route params, and pointer geometry"
@@ -138,11 +132,12 @@ pub(in crate::input::mouse) fn route_webview_left_click(
     }
 }
 
-/// Releases an in-flight webview press to CEF (mouse-up at the last cursor) and
-/// clears the marker. Called on the suppressed path (modal open / window
-/// unfocused) so the focused web page is not left logically pressed with no
-/// matching mouse-up. `cursor_phys` is `None` when there is no placeable cursor
-/// (off-window): then the press is dropped WITHOUT a CEF mouse-up.
+/// Releases an in-flight webview press to CEF (mouse-up at the last
+/// cursor) and clears the marker. Call this when input is suppressed (a
+/// modal opens, or the window loses focus), so the focused web page is
+/// not left logically pressed with no matching mouse-up. `cursor_phys` is
+/// `None` when there is no placeable cursor (off-window): then the press
+/// is dropped WITHOUT a CEF mouse-up.
 pub(in crate::input::mouse) fn release_webview_press(
     webview_press: &mut WebviewPress,
     route: &WebviewRouteParams,
@@ -191,11 +186,8 @@ pub(in crate::input::mouse) fn webview_pointer_frame(
     }
 }
 
-/// The queries, browsers handle, and held buttons `forward_webview_move_at`
-/// forwards through to `forward_webview_move`, bundled as one borrowed struct so
-/// the wrapper takes a single reference instead of expanded positional args
-/// (which would re-trip `clippy::too_many_arguments`). Both mode move systems own
-/// these params and borrow them into this bundle each frame.
+/// The queries, browsers handle, and held buttons needed to forward pointer
+/// motion to an inline CEF child.
 pub(in crate::input::mouse) struct WebviewMoveDeps<'a> {
     pub children: &'a Query<'a, 'a, &'static Children>,
     pub webviews: &'a Query<'a, 'a, (&'static Webview, Has<NonInteractive>)>,
@@ -231,11 +223,11 @@ pub(in crate::input::mouse) fn forward_webview_move_at(
     );
 }
 
-/// The inline webview child that should receive a wheel event for a resolved
-/// `(terminal, local_phys)`, with the pointer in webview-local DIP — `Some` only
-/// when the FOCUSED webview of `terminal` is the interactive rect under the
-/// cursor (CEF's `send_mouse_wheel` is focus-gated, so an unfocused rect cannot
-/// usefully receive it). `None` cedes the wheel to terminal scrollback.
+/// The inline webview child that should receive a wheel event for a
+/// resolved `(terminal, local_phys)`, with the pointer in webview-local
+/// DIP — `Some` only when the FOCUSED webview of `terminal` is the
+/// interactive rect under the cursor, since an unfocused rect cannot
+/// usefully receive it. `None` cedes the wheel to terminal scrollback.
 #[expect(
     clippy::too_many_arguments,
     reason = "wheel targeting needs the focus state, inline queries, and pointer geometry"
@@ -302,13 +294,11 @@ fn webview_release_dip(
     )
 }
 
-/// Forwards pointer motion over an interactive inline rect of `terminal` to the
-/// child's CEF browser (`send_mouse_move`, webview-local DIP), forwarding
-/// whatever mouse buttons are held so one call serves both hover and an in-rect
-/// drag. Focus-gated inside `bevy_cef`, so motion over an unfocused browser is
-/// dropped browser-side. Takes granular query refs (not `WebviewRouteParams`)
-/// because the mode move systems read `ButtonInput<MouseButton>`, which the
-/// click `SystemParam` does not carry.
+/// Forwards pointer motion over an interactive inline rect of `terminal`
+/// to the child's CEF browser (`send_mouse_move`, webview-local DIP),
+/// forwarding whatever mouse buttons are held so one call serves both
+/// hover and an in-rect drag. Motion over an unfocused browser is dropped
+/// browser-side.
 #[expect(
     clippy::too_many_arguments,
     reason = "the move forward needs the inline queries, browsers, held buttons, and pointer geometry"

--- a/src/input/mouse/webview/router.rs
+++ b/src/input/mouse/webview/router.rs
@@ -1,16 +1,6 @@
-//! Webview pointer routing for the shell surface: forwards left press/release
-//! and pointer motion to the inline CEF child under the cursor on the single
-//! shell surface, via the core in
-//! `crate::input::mouse::webview`.
-//!
-//! The pointer system runs EVERY frame (not message-gated) so an in-flight
-//! press is released when input is suppressed (window unfocused), never
-//! leaving CEF logically pressed. Double-handling with the
-//! terminal's `dispatch_mouse_buttons` is avoided by the `MouseDisabled`
-//! rect-claim gate in `crate::input::focus::maintain_input_gates`: over an
-//! interactive rect the shell is `MouseDisabled` (dispatch yields, the webview
-//! gets the click); off-rect the press clears webview focus here and falls
-//! through to the terminal.
+//! Webview pointer routing for the shell surface: forwards left
+//! press/release and pointer motion to the inline CEF child under the
+//! cursor.
 
 use crate::input::InputPhase;
 use crate::input::mouse::cell_dims;
@@ -32,8 +22,7 @@ use bevy_orzma_tty_renderer::TerminalCellMetricsResource;
 use bevy_orzma_tty_renderer::prelude::TerminalOverlays;
 use bevy_orzma_webview::{NonInteractive, Webview};
 
-/// Registers the webview pointer systems. The shared
-/// `WebviewPress` resource is owned by the parent `MouseWebviewPlugin`.
+/// Adds the webview pointer-forwarding systems for the shell surface.
 pub(super) struct MouseWebviewRouterPlugin;
 
 impl Plugin for MouseWebviewRouterPlugin {
@@ -54,10 +43,10 @@ impl Plugin for MouseWebviewRouterPlugin {
     }
 }
 
-/// Forwards left press/release to the inline CEF child under the cursor on the
-/// shell surface. Runs EVERY frame: a suppressed frame (window unfocused)
-/// drains the reader and releases an in-flight press so the focused page is
-/// not left logically pressed.
+/// Forwards left press/release to the inline CEF child under the cursor
+/// on the shell surface. A suppressed frame (window unfocused) drains the
+/// reader and releases an in-flight press so the focused page is not left
+/// logically pressed.
 fn route_webview_pointer(
     mut webview_press: ResMut<WebviewPress>,
     mut webview_route: WebviewRouteParams,
@@ -170,12 +159,13 @@ fn forward_webview_mouse_moves(
     );
 }
 
-/// Forwards the mouse wheel to the FOCUSED inline webview under the cursor on the
-/// shell surface (raw CEF wheel, focus-gated). When no focused webview is under
-/// the pointer the reader is drained and the wheel cedes to
-/// `crate::input::mouse::wheel::dispatch_mouse_wheel` (terminal scrollback) through its own
-/// reader; over the rect the shell is `MouseDisabled` (rect-claim gate), so that
-/// dispatcher yields and only the page scrolls. Gated to wheel frames.
+/// Forwards the mouse wheel to the FOCUSED inline webview under the
+/// cursor on the shell surface (raw CEF wheel, focus-gated). When no
+/// focused webview is under the pointer the reader is drained and the
+/// wheel cedes to `crate::input::mouse::wheel::dispatch_mouse_wheel`
+/// (terminal scrollback) through its own reader; over the rect the shell
+/// is `MouseDisabled` (rect-claim gate), so that dispatcher yields and
+/// only the page scrolls.
 fn forward_webview_wheel(
     mut wheel: MessageReader<MouseWheel>,
     focused_webview: Res<FocusedWebview>,

--- a/src/input/mouse/wheel.rs
+++ b/src/input/mouse/wheel.rs
@@ -1,10 +1,8 @@
-//! Mouse-wheel dispatch for every `OrzmaTerminal` surface: scrollback with
-//! sub-notch accumulation and dominant-axis lock. Vertical wheel motion
-//! always scrolls the terminal's viewport (`TerminalViewportScroll`);
-//! horizontal wheel motion is ignored — app-forward wheel reporting is
-//! out of scope until mouse routing is reintroduced against `orzma_tty`
-//! (D17 of the engine-swap design). Registered by `MouseWheelInputPlugin`;
-//! skips `MouseDisabled` surfaces.
+//! Mouse-wheel dispatch for every `OrzmaTerminal` surface: scrollback
+//! with sub-notch accumulation and dominant-axis lock. Vertical motion
+//! scrolls the viewport; horizontal motion is ignored.
+//!
+//! TODO: reintroduce app-forward wheel-reporting against `orzma_tty`.
 
 use super::{TerminalSurfaces, cell_dims, hit_candidates, on_any_mouse_message};
 use crate::action::terminal::TerminalViewportScroll;
@@ -21,11 +19,7 @@ use bevy::window::PrimaryWindow;
 use bevy_orzma_tty_renderer::TerminalCellMetricsResource;
 use orzma_tty::prelude::TerminalModifiers;
 
-/// Registers the mouse-wheel dispatcher and its accumulator resource. Runs in
-/// `InputPhase::Dispatch`, gated to frames carrying any mouse message — a
-/// cursor-only frame must still run `WheelAccumulator::retarget` so a
-/// terminal's sub-notch residual is cleared when the cursor moves to another
-/// terminal.
+/// Adds mouse-wheel dispatch and its notch-accumulator resource.
 pub(super) struct MouseWheelInputPlugin;
 
 impl Plugin for MouseWheelInputPlugin {
@@ -50,8 +44,7 @@ struct WheelTarget {
 ///
 /// The horizontal axis is still accumulated so the dominant-axis lock can
 /// stop a horizontal-dominant gesture from leaking a vertical scroll, but
-/// it is never routed anywhere: D17a of the engine-swap design drops
-/// horizontal wheel reporting entirely.
+/// it is never routed anywhere.
 fn dispatch_mouse_wheel(
     mut commands: Commands,
     mut gesture_acc: ResMut<WheelAccumulator>,
@@ -126,9 +119,9 @@ fn accumulate_wheel(
     (raw_v, raw_h)
 }
 
-/// Applies the vertical axis of one wheel dispatch: a non-zero notch count
-/// always scrolls the target's viewport by `scroll_lines`. Horizontal notches
-/// are never routed (D17a) — the caller already discards `raw_h`.
+/// Applies the vertical axis of one wheel dispatch: a non-zero notch
+/// count always scrolls the target's viewport by `scroll_lines`.
+/// Horizontal notches are never routed.
 fn apply_vertical_scroll(
     commands: &mut Commands,
     target: Entity,
@@ -147,12 +140,10 @@ fn apply_vertical_scroll(
     });
 }
 
-/// Converts a signed notch count into a viewport-scroll line count, honoring
-/// the fine-scroll modifier. Ports the scrollback branch of the removed
-/// engine's `WheelAction::route`, which received `-raw_v` and returned
-/// `-(-raw_v) * lines_per`. `raw_v` carries
-/// Bevy's wheel sign (positive = wheel up = toward older output), which is
-/// also the positive direction of `Scroll::Delta`, so no negation is applied:
+/// Converts a signed notch count into a viewport-scroll line count,
+/// honoring the fine-scroll modifier. `raw_v` carries the wheel's sign
+/// (positive = wheel up = toward older output), which is also the
+/// positive direction of `Scroll::Delta`, so no negation is applied:
 /// `TerminalViewportScroll.lines` positive = deeper into scrollback.
 fn scroll_lines(raw_v: i32, fine: bool, cfg: &WheelConfig) -> i32 {
     let lines_per = if fine {

--- a/src/input/option_as_alt.rs
+++ b/src/input/option_as_alt.rs
@@ -1,12 +1,11 @@
-//! macOS "Option as Meta" support: applies the `[keyboard] option_as_alt`
-//! config to the native winit window via `WindowExtMacOS::set_option_as_alt`,
-//! so the configured Option side is delivered as Alt (Meta) below the IME
-//! layer instead of composing into special characters. No-op on non-macOS.
+//! macOS "Option as Meta" support: makes the configured Option side
+//! deliver Alt (Meta) below the IME layer instead of composing into
+//! special characters. No-op on non-macOS.
 
 use bevy::prelude::*;
 
-/// Bevy plugin that applies the configured macOS Option-as-Alt mode to the
-/// primary window. Empty on non-macOS targets.
+/// Applies the configured macOS Option-as-Alt mode to the primary
+/// window. Empty on non-macOS targets.
 pub(super) struct OptionAsAltPlugin;
 
 impl Plugin for OptionAsAltPlugin {

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -1,7 +1,5 @@
 //! Resolves configured shortcut chords (logical keys) into physical
 //! `KeyCode`-based entries the runtime input dispatcher matches against.
-//! The translation lives here (not in `orzma_configs`) so the config crate
-//! stays free of any `bevy` dependency.
 
 use crate::configs::OrzmaConfigsResource;
 use crate::input::InputPhase;
@@ -91,8 +89,6 @@ pub(in crate::input) enum ShortcutSet {
 }
 
 /// Shared leader phase: where the leader state machine is between keys.
-/// Owned by `ShortcutsPlugin`; advanced by `crate::input::keyboard::handler::resolve_key_effects`
-/// (the sole `LeaderGate::Advance` member) as it classifies each frame's keys.
 #[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LeaderPhase {
     /// No leader sequence in progress.
@@ -109,12 +105,11 @@ pub(crate) enum LeaderPhase {
 }
 
 /// The physical key currently held that fired a repeat-marked `<Leader:r>`
-/// binding. OS auto-repeats of this key re-fire the binding regardless of the
-/// `LeaderPhase::Repeat` time window: that window (`repeat_time_ms`) only
-/// bridges discrete re-presses and is far shorter than the OS initial
-/// key-repeat delay, so without this a held key would drop out of the repeat
-/// and leak into the terminal. Armed on a fresh press that opens or renews the
-/// repeat window; cleared on any fresh press that does not.
+/// binding. OS auto-repeats of this key re-fire the binding regardless of
+/// the `LeaderPhase::Repeat` time window: that window (`repeat_time_ms`)
+/// only bridges discrete re-presses and is far shorter than the OS
+/// initial key-repeat delay. Armed on a fresh press that opens or renews
+/// the repeat window; cleared on any fresh press that does not.
 #[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct HeldRepeatKey(pub(crate) Option<KeyCode>);
 
@@ -155,7 +150,7 @@ struct OrzmaShortcut {
 }
 
 /// The startup-resolved orzma shortcut tables. Built once from
-/// `OrzmaConfigsResource`; consumed by the keyboard dispatcher.
+/// `OrzmaConfigsResource`.
 #[derive(Resource, Default, Debug, Clone)]
 pub(crate) struct Shortcuts {
     direct: Vec<OrzmaShortcut>,
@@ -173,8 +168,7 @@ impl Shortcuts {
     }
 
     /// Returns the leader-scoped action bound to `(keycode, mods)` when the
-    /// binding is repeat-marked (`<Leader:r>`). Drives the repeat-window
-    /// re-fire in `step_leader` and the held-key re-fire in `refire_held_repeat`.
+    /// binding is repeat-marked (`<Leader:r>`).
     fn match_repeat_prefix(&self, keycode: KeyCode, mods: Modifiers) -> Option<Shortcut> {
         self.match_prefix_entry(keycode, mods)
             .filter(|s| s.repeat)
@@ -299,18 +293,17 @@ pub(crate) fn refire_held_repeat(
     Some(action)
 }
 
-/// Resets the shared leader phase to `Idle`, writing through the `ResMut` only
-/// on a real change so Bevy change detection fires exactly when the phase was
-/// engaged. The single reset idiom for every dispatcher drain/abort site.
+/// Resets the shared leader phase to `Idle`, writing through the `ResMut`
+/// only on a real change so change detection fires exactly when the
+/// phase was engaged.
 pub(crate) fn clear_leader_phase(leader_phase: &mut ResMut<LeaderPhase>) {
     if **leader_phase != LeaderPhase::Idle {
         **leader_phase = LeaderPhase::Idle;
     }
 }
 
-/// Test-only constructor: a `Shortcuts` with one repeat-marked, modifier-less
-/// prefix binding and a `Ctrl+A` chord leader. Used by the keyboard and
-/// dispatcher tests, which cannot name this module's private fields.
+/// Test-only constructor: a `Shortcuts` with one repeat-marked,
+/// modifier-less prefix binding and a `Ctrl+A` chord leader.
 #[cfg(test)]
 pub(crate) fn test_shortcuts_with_repeat_prefix(
     keycode: KeyCode,
@@ -339,9 +332,8 @@ pub(crate) fn test_shortcuts_with_repeat_prefix(
     }
 }
 
-/// Test-only constructor: a `Shortcuts` with one direct (non-leader) chord and
-/// no leader/prefix bindings. Used by `resolve.rs`'s decider tests, which
-/// cannot name this module's private fields.
+/// Test-only constructor: a `Shortcuts` with one direct (non-leader)
+/// chord and no leader/prefix bindings.
 #[cfg(test)]
 pub(crate) fn test_shortcuts_with_direct_chord(
     keycode: KeyCode,
@@ -382,19 +374,18 @@ fn reset_leader_phase(
     }
 }
 
-/// Run condition: only run `detect_modifier_tap` when the leader is a tap.
+/// True when the configured leader is a modifier tap.
 fn tap_leader_enabled(shortcuts: Res<Shortcuts>) -> bool {
     shortcuts.tap_modifier().is_some()
 }
 
 /// Detects a bare modifier tap (press+release within the timeout, no
 /// intervening key or mouse press) and engages `LeaderPhase::Pending`.
-/// Mode-agnostic; runs in `LeaderGate::Detect` before the dispatchers
-/// read/advance the leader.
+/// Mode-agnostic.
 ///
-/// Gated with `run_if(tap_leader_enabled)`. Reads press AND release
-/// `KeyboardInput` (the dispatchers only read `Pressed`), so it owns the tap
-/// gesture; the second key is handled by the existing `step_leader` pending arm.
+/// Reads press AND release `KeyboardInput` (the dispatchers only read
+/// `Pressed`), so it owns the tap gesture; the second key is handled by
+/// the existing `step_leader` pending arm.
 fn detect_modifier_tap(
     mut state: ResMut<ModifierTapState>,
     mut leader_phase: ResMut<LeaderPhase>,
@@ -446,13 +437,13 @@ fn detect_modifier_tap(
     }
 }
 
-/// `Startup` system: resolves the configured shortcut bindings into
-/// `Shortcuts`, replacing the empty default inserted at plugin build.
+/// Resolves the configured shortcut bindings into `Shortcuts`, replacing
+/// the empty default inserted at plugin build.
 ///
 /// Writes through `ResMut` (an immediate change, unlike a deferred
 /// `Commands::insert_resource`) so the table is populated the moment this
-/// system runs, with no window in which a same-schedule reader could observe
-/// the empty default.
+/// system runs, with no window in which a same-schedule reader could
+/// observe the empty default.
 fn build_shortcuts(mut resolved: ResMut<Shortcuts>, configs: Res<OrzmaConfigsResource>) {
     let sc = &configs.shortcuts;
     resolved.direct = resolve_from_chords(
@@ -487,7 +478,7 @@ fn build_shortcuts(mut resolved: ResMut<Shortcuts>, configs: Res<OrzmaConfigsRes
     }
 }
 
-/// `Startup` system: inserts `OrzmaMouseConfig` from the resolved `[mouse]` block.
+/// Inserts `OrzmaMouseConfig` from the resolved `[mouse]` block.
 fn populate_mouse_config(mut commands: Commands, configs: Res<OrzmaConfigsResource>) {
     commands.insert_resource(orzma_mouse_config(&configs.mouse));
 }

--- a/src/input/shortcuts/apply.rs
+++ b/src/input/shortcuts/apply.rs
@@ -1,8 +1,6 @@
 //! The single key-effect dispatcher: reads `KeyEffectMessage` in press
-//! order and, for each effect, `commands.trigger`s the matching event —
-//! vi-mode entry, paste, copy, pane split/select/kill, or typed input —
-//! so the mux backend receives every effect in the order the keys were
-//! pressed.
+//! order and triggers the matching event for each effect, so the mux
+//! backend receives every effect in the order the keys were pressed.
 
 use crate::input::keyboard::terminal_modifiers;
 use crate::{
@@ -43,8 +41,6 @@ impl Plugin for ShortcutsApplyPlugin {
 /// Applies the frame's key effects in press order: shortcuts, vi-mode
 /// keys, and typed keys all go through `commands.trigger`, never a
 /// direct backend send, so the mux receives them in this order.
-/// Registered in `ShortcutSet::Apply`, gated on
-/// `on_message::<KeyEffectMessage>`.
 fn apply_key_effects(mut commands: Commands, mut effects: MessageReader<KeyEffectMessage>) {
     for msg in effects.read() {
         match &msg.effect {
@@ -81,9 +77,11 @@ fn apply_key_effects(mut commands: Commands, mut effects: MessageReader<KeyEffec
 /// fires outside vi mode; a leader paste fires unconditionally), copy
 /// (fires unconditionally — vi mode included; no-selection is a no-op
 /// downstream), and the pane actions (select/split/kill, targeting the
-/// backend's active pane). Window actions and `Quit` /
-/// `ReleaseWebviewFocus` (handled upstream in `resolve_key_effects`) are
-/// no-ops until the built-in multiplexer grows window support.
+/// backend's active pane). Window actions are no-ops; `Quit` and
+/// `ReleaseWebviewFocus` are handled upstream in `resolve_key_effects`.
+///
+/// TODO: implement window actions once the built-in multiplexer supports
+/// windows.
 fn apply_shortcut(
     commands: &mut Commands,
     action: Shortcut,
@@ -131,8 +129,7 @@ fn apply_shortcut(
 }
 
 /// Converts `orzma_configs`' shortcut-facing pane direction to the mux
-/// backend's. The two crates must not depend on each other, so orphan
-/// rules forbid a `From` impl here; this match is the conversion.
+/// backend's.
 fn pane_direction(direction: ConfigPaneDirection) -> OrzmuxPaneDirection {
     match direction {
         ConfigPaneDirection::Left => OrzmuxPaneDirection::Left,
@@ -143,7 +140,7 @@ fn pane_direction(direction: ConfigPaneDirection) -> OrzmuxPaneDirection {
 }
 
 /// Converts `orzma_configs`' shortcut-facing split orientation to the mux
-/// backend's, for the same orphan-rule reason as `pane_direction`.
+/// backend's.
 fn split_orientation(orientation: ConfigSplitOrientation) -> OrzmuxSplitOrientation {
     match orientation {
         ConfigSplitOrientation::Vertical => OrzmuxSplitOrientation::Vertical,

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,11 +93,11 @@ fn main() {
 
 /// The primary window descriptor.
 ///
-/// `ime_enabled` starts `false` deliberately: bevy_winit applies the IME state
-/// to the OS window only on a live `false -> true` change of `Window::ime_enabled`
-/// (`bevy_winit-0.19.0/src/system.rs:539-540`) and never at window creation, so
-/// starting `true` would leave the OS IME un-armed. `ime_policy_system` flips it
-/// to `true` on the first focused-surface tick, producing the arming transition.
+/// `ime_enabled` starts `false` deliberately: the window backend applies the
+/// IME state to the OS window only on a live `false -> true` change of
+/// `Window::ime_enabled`, never at window creation, so starting `true` would
+/// leave the OS IME un-armed. `ime_policy_system` flips it to `true` on the
+/// first focused-surface tick, producing the arming transition.
 fn primary_window() -> Window {
     Window {
         title: "orzma".to_string(),
@@ -106,16 +106,9 @@ fn primary_window() -> Window {
     }
 }
 
-/// Fills `TERM`/`COLORTERM` with a portable default when the inherited `TERM`
-/// is unset or empty, mirroring `alacritty_terminal::tty::setup_env`.
-///
-/// A child shell (the native orzma PTY) whose `TERM` is empty
-/// cannot load terminfo, so zsh's line editor (ZLE) — Backspace included —
-/// silently breaks; a bundled `.app` launched from Finder inherits launchd's
-/// empty `TERM`. `xterm-256color` is exactly Alacritty's fallback when the
-/// `alacritty` terminfo is absent (it is, on stock macOS); `COLORTERM`
-/// advertises the 24-bit color that entry omits. A usable inherited `TERM` is
-/// left untouched, so terminal launches are unchanged.
+/// Fills `TERM`/`COLORTERM` with a portable default when the inherited
+/// `TERM` is unset or empty. Sets `TERM` to `xterm-256color` and
+/// `COLORTERM` to `truecolor`; a usable inherited `TERM` is left untouched.
 ///
 /// # Invariants
 ///
@@ -151,11 +144,7 @@ fn term_fallback(current: Option<&str>) -> Option<&'static str> {
 const UTF8_CTYPE_FALLBACK: &str = "en_US.UTF-8";
 
 /// Ensures `LC_CTYPE` advertises a UTF-8 locale when the inherited environment
-/// selects none, so PTY children see a sane character type.
-///
-/// A bundled `.app` launched from Finder inherits launchd's environment with
-/// no `LANG`/`LC_*`, so it falls into the C locale and spawned shells
-/// misclassify multibyte input; this restores a UTF-8 `LC_CTYPE`. A usable
+/// selects none, so PTY children see a sane character type. A usable
 /// inherited UTF-8 locale is left untouched.
 ///
 /// # Invariants
@@ -175,10 +164,7 @@ fn ensure_utf8_locale_env() {
     set_utf8_ctype_fallback();
 }
 
-/// Writes the `en_US.UTF-8` `LC_CTYPE` fallback. macOS is the only platform that
-/// ships the bundled `.app` hitting launchd's stripped env; elsewhere the locale
-/// may be absent and forcing it would fail `setlocale`, so this is a no-op there
-/// (see the `#[cfg(not(...))]` sibling).
+/// Writes the `en_US.UTF-8` `LC_CTYPE` fallback.
 #[cfg(target_os = "macos")]
 fn set_utf8_ctype_fallback() {
     // SAFETY: the caller (`ensure_utf8_locale_env`) runs before `App::new()`

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@ mod layout;
 
 use bevy::prelude::*;
 
-/// Bevy plugin for the shell session lifecycle (spawn / layout / exit).
+/// Aggregates the shell session lifecycle plugins (spawn / layout / exit).
 pub(crate) struct SessionPlugin;
 
 impl Plugin for SessionPlugin {

--- a/src/session/exit.rs
+++ b/src/session/exit.rs
@@ -4,7 +4,7 @@
 use bevy::prelude::*;
 use bevy_orzmux::prelude::OrzmuxSessionEnded;
 
-/// Registers the session-end observer.
+/// Adds session-end handling.
 pub(super) struct ExitPlugin;
 
 impl Plugin for ExitPlugin {

--- a/src/session/layout.rs
+++ b/src/session/layout.rs
@@ -11,7 +11,7 @@ use bevy_orzmux::prelude::{OrzmuxConnection, PaneGeometry};
 use orzma_tty::CellPixels;
 use orzmux::prelude::OrzmuxCommand;
 
-/// Registers the window-geometry sender.
+/// Adds the window-geometry sender.
 pub(super) struct LayoutPlugin;
 
 impl Plugin for LayoutPlugin {

--- a/src/session/spawn.rs
+++ b/src/session/spawn.rs
@@ -15,7 +15,7 @@ pub(crate) struct PaneSpawnRequest {
     pub at: NewPaneAt,
 }
 
-/// Registers the spawn observer.
+/// Adds pane-spawn handling.
 pub(super) struct SpawnPlugin;
 
 impl Plugin for SpawnPlugin {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -15,7 +15,7 @@ use bevy_orzma_tty_renderer::material::TerminalUiMaterial;
 #[derive(Component)]
 pub(crate) struct OrzmaTerminal;
 
-/// Registers the material-injection observer.
+/// Adds GPU material injection for `OrzmaTerminal` entities.
 pub(crate) struct SurfacePlugin;
 
 impl Plugin for SurfacePlugin {
@@ -24,9 +24,8 @@ impl Plugin for SurfacePlugin {
     }
 }
 
-/// Bevy observer that injects a `MaterialNode<TerminalUiMaterial>` whenever
-/// `OrzmaTerminal` is added to an entity, allocating the GPU material on
-/// demand.
+/// Injects a `MaterialNode<TerminalUiMaterial>` whenever `OrzmaTerminal` is
+/// added to an entity, allocating the GPU material on demand.
 fn on_add_inject_render(
     ev: On<Add, OrzmaTerminal>,
     mut commands: Commands,

--- a/src/surface/geometry.rs
+++ b/src/surface/geometry.rs
@@ -1,7 +1,5 @@
 //! Shared terminal-surface geometry: cursor physical-pixel → pane-local px →
-//! cell (column/row/side). Used by the pointer router
-//! (`crate::input::mouse::webview`), the input pipeline, and
-//! hyperlink hover.
+//! cell (column/row/side).
 
 use bevy::ecs::entity::Entity;
 use bevy::math::Vec2;
@@ -85,8 +83,7 @@ pub(crate) fn cells_for(w_px: u32, h_px: u32, cell_w: f32, cell_h: f32) -> (u16,
 /// Returns the topmost `OrzmaTerminal` surface whose node contains `cursor_phys`,
 /// or `None` when the cursor is over none. "Topmost" is the highest
 /// `ComputedStackIndex` (Bevy's resolved front-to-back UI order); ties
-/// break by `Entity` for determinism. The pointer/gate path uses
-/// this to pick the single shell (or the frontmost surface) under the cursor.
+/// break by `Entity` for determinism.
 pub(crate) fn topmost_surface_at<'a>(
     cursor_phys: Vec2,
     candidates: impl Iterator<

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-/// The label enum labeling the types of systems in Orzma
+/// Labels for orzma's Bevy system sets.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum OrzmaSystems {
     /// Per-frame input handling — keyboard and mouse. Members run in

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,7 +17,8 @@ pub(crate) use shell_surface::ShellSurfaceUi;
 #[derive(Component)]
 pub struct UiRoot;
 
-/// Bevy Plugin spawning the singleton UI root Node tree.
+/// Aggregates the UI plugins: the root Node tree, the shell-surface subtree,
+/// the IME overlay, and the vi-mode indicator.
 pub struct OrzmaUiPlugin;
 
 impl Plugin for OrzmaUiPlugin {

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -744,8 +744,8 @@ mod tests {
     /// Asserts that the overlay's background takes the focused pane's
     /// palette background while a composition is active.
     ///
-    /// Case: the user composes IME text over a terminal whose
-    /// application recolored the background with OSC 11.
+    /// Case: the user composes IME text over a terminal whose palette
+    /// background already differs from the default.
     #[test]
     fn overlay_background_matches_pane_palette_background_while_composing() {
         use crate::surface::OrzmaTerminal;

--- a/src/ui/ime_overlay.rs
+++ b/src/ui/ime_overlay.rs
@@ -1,9 +1,5 @@
-//! IME preedit overlay.
-//!
-//! Provides `ImeOverlayPlugin` (Bevy plugin that spawns the overlay
-//! entity tree at Startup and schedules `position_ime_overlay`) and the
-//! marker components identifying the root, caret bar, clause highlight,
-//! underline, and grapheme-cell pool.
+//! IME preedit overlay: renders the composition (grapheme cells, caret,
+//! clause highlight, underline) over the focused terminal's cursor cell.
 
 mod layout;
 
@@ -36,8 +32,7 @@ use bevy_orzma_tty_renderer::material::TerminalMaterialSystems;
 use bevy_orzma_tty_renderer::prelude::TerminalGrid;
 use layout::{CaretVisual, PlacedCell, compute_overlay_layout};
 
-/// Bevy plugin that spawns the IME overlay entity tree at Startup and
-/// schedules `position_ime_overlay` in PostUpdate.
+/// Adds the IME preedit overlay.
 pub(super) struct ImeOverlayPlugin;
 
 impl Plugin for ImeOverlayPlugin {
@@ -98,8 +93,7 @@ pub struct ImeCaretBar;
 
 /// Marker for the hollow-block `Node` that highlights the macOS-IME
 /// clause-selection range. Spawned as a top-level UI entity (NOT a
-/// child of [`ImeOverlayNode`] — same constraint as [`ImeCaretBar`]
-/// per the parent's leaf-only measure requirement).
+/// child of [`ImeOverlayNode`]).
 ///
 /// Visible only when the composition's caret range has `begin != end`;
 /// in that state, [`ImeCaretBar`] is hidden. The two markers are
@@ -130,26 +124,25 @@ struct ImeGraphemePool(Vec<Entity>);
 /// the pool on demand.
 const INITIAL_POOL_CAP: usize = 16;
 
-/// Run condition: true while an IME preedit composition is active. Takes
+/// True while an IME preedit composition is active. Takes
 /// `Option<Res<ImeState>>` so it returns `false` rather than panicking when
 /// `ImeState` is absent, keeping the `.or_else()` / `.and_then()` gates safe.
 fn ime_is_composing(state: Option<Res<ImeState>>) -> bool {
     state.is_some_and(|state| state.is_composing())
 }
 
-/// PostUpdate system that grid-aligns the IME preedit overlay at the attached
-/// terminal's cursor cell. Lays out the composition as one cell-anchored
-/// `Text` node per grapheme cluster (pooled in [`ImeGraphemePool`], grown on
-/// demand), draws an occluding background rect and a continuous underline bar,
-/// and positions the caret beam (`begin == end`) or clause highlight
+/// Grid-aligns the IME preedit overlay at the attached terminal's cursor
+/// cell. Lays out the composition as one cell-anchored `Text` node per
+/// grapheme cluster (pooled in [`ImeGraphemePool`], grown on demand), draws
+/// an occluding background rect and a continuous underline bar, and
+/// positions the caret beam (`begin == end`) or clause highlight
 /// (`begin != end`). Every visible element uses the same cell arithmetic, so
 /// the caret cannot drift from the text.
 ///
-/// Gated by `run_if(ime_is_composing)`, so it runs only while a composition is
-/// active; the end-of-composition hide (commit / cancel / `Ime::Disabled`) is
-/// owned by [`hide_ime_overlay`]. If the focused surface, its anchor, or the
-/// window is missing while composing, it hides every overlay part defensively
-/// and returns.
+/// The end-of-composition hide (commit / cancel / `Ime::Disabled`) is owned
+/// by [`hide_ime_overlay`]. If the focused surface, its anchor, or the
+/// window is missing while composing, it hides every overlay part
+/// defensively and returns.
 fn position_ime_overlay(
     mut commands: Commands,
     mut pool: ResMut<ImeGraphemePool>,
@@ -399,9 +392,8 @@ fn apply_caret_visual(
 
 /// Sets `TerminalGrid.suppress_cursor = true` on the keyboard-focused
 /// terminal surface while IME composition is active; clears it on all
-/// other grids. Runs in `PostUpdate.before(TerminalMaterialSystems::UpdateMaterial)`
-/// so the override takes effect in the same frame the IME caret
-/// appears (and clears the same frame composition ends).
+/// other grids. The suppression takes effect the same frame the IME caret
+/// appears, and clears the same frame composition ends.
 ///
 /// If there is no keyboard-focused surface while composition is active (e.g., a
 /// race window between focus loss and `Ime::Disabled`), every grid gets
@@ -425,10 +417,8 @@ fn suppress_terminal_cursor_during_ime(
     }
 }
 
-/// PostUpdate system that hides every IME overlay part. Gated to run only on
-/// the frame composition ends (commit / cancel / `Ime::Disabled`); see
-/// `ImeOverlayPlugin`. Shares `hide_all_overlay_parts` with
-/// `position_ime_overlay`'s internal precondition guards.
+/// Hides every IME overlay part. Runs when the composition ends
+/// (commit / cancel / `Ime::Disabled`).
 fn hide_ime_overlay(
     mut nodes: Query<&mut Node>,
     pool: Res<ImeGraphemePool>,
@@ -456,38 +446,29 @@ const IME_OVERLAY_Z: i32 = 200;
 
 /// Z-index for the opaque occluding background rect — one below
 /// [`IME_OVERLAY_Z`] so the preedit glyph cells, underline, caret, and clause
-/// box (all at [`IME_OVERLAY_Z`]) always render in front of it, rather than
-/// relying on Bevy's equal-z spawn-order tie-break (which entity reuse as the
-/// pool grows/shrinks could otherwise flip, hiding the composition).
+/// box (all at [`IME_OVERLAY_Z`]) always render in front of it.
 const IME_OVERLAY_BG_Z: i32 = IME_OVERLAY_Z - 1;
 
 /// Spawns the overlay entity tree.
 ///
-/// NOTE: `Text` root and caret bar are spawned as INDEPENDENT
-/// top-level UI entities (no `ChildOf` between them). Required by
-/// Bevy 0.19 + Taffy 0.10.1: `NodeMeasure::Text` is only consulted by
-/// `compute_leaf_layout`, dispatched at `(_, has_children == false)`
-/// in `taffy-0.10.1/src/tree/taffy_tree.rs:304-330`. Adding any UI
-/// child (even an absolute-positioned one that contributes 0 to flex
-/// container size) puts the Text node on the `compute_flexbox_layout`
-/// branch, which ignores the measure function — `ComputedNode.size`
-/// becomes (0, 0), `bevy_ui_render` then skips text + underline at
-/// `uinode.is_empty()` (`bevy_ui_render-0.19.0/src/lib.rs:997, 1308`),
-/// while the child caret bar still renders because its own
-/// `ComputedNode` is non-empty (explicit width/height). Both
-/// entities are positioned in window-absolute coords each frame in
-/// `position_ime_overlay`.
-///
-/// `LineBreak::NoWrap` is set as defense-in-depth: with it,
-/// `measure_text_system` uses `FixedMeasure { size: measure.max }`
-/// (`bevy_ui-0.19.0/src/widget/text.rs:301-302`) and `text_system`
-/// uses `TextBounds::UNBOUNDED` (`:363-365`) — bypassing any residual
-/// zero-bound shaping. Single-line preedit text never needs wrapping
+/// `LineBreak::NoWrap` is set as defense-in-depth against residual
+/// zero-bound text shaping; single-line preedit text never needs wrapping
 /// anyway.
 ///
 /// TODO: bind TextColor / UnderlineColor / BackgroundColor to theme
 /// tokens (`text-foreground` / `bg-background`) once the theme-token
-/// helper is integrated. Placeholder white for now.
+/// helper is integrated.
+// NOTE: the `Text` root and caret bar must stay INDEPENDENT top-level UI
+// entities (no `ChildOf` between them). The text-measure function that
+// drives a Text node's `ComputedNode.size` is only consulted for a leaf
+// node with no children; giving it any UI child — even an
+// absolute-positioned one that contributes 0 to flex container size —
+// switches it onto the flexbox layout path, which ignores the measure
+// function. `ComputedNode.size` then becomes (0, 0) and the renderer skips
+// the text and underline as empty nodes, while a child caret bar still
+// renders because its own `ComputedNode` is non-empty (explicit
+// width/height). Both entities are positioned in window-absolute
+// coordinates each frame in `position_ime_overlay`.
 fn spawn_ime_overlay_once(
     mut commands: Commands,
     mut pool: ResMut<ImeGraphemePool>,
@@ -582,10 +563,8 @@ fn set_node_display(nodes: &mut Query<&mut Node>, entity: Entity, display: Displ
 }
 
 /// Writes `left`/`top`/`width`/`height` (logical px) into `entity`'s `Node`,
-/// each guarded by an equality check so change detection fires only on a real
-/// change. Resolving the node inside the helper (rather than accepting an
-/// already-dereferenced `&mut Node`) keeps the `DerefMut` — and thus the change
-/// tick — from firing on an unchanged frame.
+/// each guarded by an equality check so change detection fires only on a
+/// real change.
 fn set_node_rect(
     nodes: &mut Query<&mut Node>,
     entity: Entity,
@@ -616,8 +595,8 @@ fn set_node_rect(
 }
 
 /// Hides every IME overlay part (background, underline, caret, clause, and all
-/// pooled grapheme cells). Called on every path where the overlay must not be
-/// shown, so no part leaks past a commit, cancel, or focus loss.
+/// pooled grapheme cells). Must be called on every path where the overlay
+/// must not be shown, so no part leaks past a commit, cancel, or focus loss.
 fn hide_all_overlay_parts(
     nodes: &mut Query<&mut Node>,
     bg: Entity,
@@ -636,8 +615,7 @@ fn hide_all_overlay_parts(
 }
 
 /// Spawns one `ImeGraphemeCell` leaf `Text` node, configured with `text`, an
-/// absolute `left`/`top`, and `display`. Used both to pre-spawn hidden pool
-/// nodes and to grow the pool with already-positioned nodes.
+/// absolute `left`/`top`, and `display`.
 fn spawn_grapheme_cell(
     commands: &mut Commands,
     ui_font: &TerminalUiFont,

--- a/src/ui/ime_overlay/layout.rs
+++ b/src/ui/ime_overlay/layout.rs
@@ -1,6 +1,6 @@
 //! Pure pixel-math for the IME preedit overlay: grapheme cell layout, caret /
-//! clause cell offsets, and the window-anchored overlay position. No Bevy ECS
-//! — unit-testable without an `App`.
+//! clause cell offsets, and the window-anchored overlay position. No Bevy
+//! ECS dependency.
 
 use bevy::math::Vec2;
 use bevy_orzma_tty_renderer::CellMetrics;
@@ -56,8 +56,7 @@ pub(super) struct OverlayLayout {
 ///
 /// Pure: composes [`compute_overlay_pos`], [`layout_preedit_cells`], and
 /// [`caret_cell_offsets`] with the underline / caret / clause cell arithmetic,
-/// returning logical-px rects relative to the window origin. The occlusion
-/// color is intentionally not returned — the caller reads `grid.palette.background`.
+/// returning logical-px rects relative to the window origin.
 pub(super) fn compute_overlay_layout(
     text: &str,
     caret: Option<(usize, usize)>,
@@ -138,12 +137,12 @@ pub(super) fn compute_overlay_layout(
 }
 
 /// Computes the overlay's top-left logical-pixel position relative to the
-/// window origin. Caller writes this into `Node.left` / `Node.top`.
+/// window origin.
 ///
 /// All metric inputs are physical px; the function does the physical→logical
-/// conversion via `scale`. The overlay sits at the cursor row (Alacritty
-/// parity), clamped so its right edge stays inside the host rect, then so its
-/// left edge does not escape the host's left side.
+/// conversion via `scale`. The overlay sits at the cursor row, clamped so
+/// its right edge stays inside the host rect, then so its left edge does
+/// not escape the host's left side.
 fn compute_overlay_pos(
     ui_global_translation_phys: Vec2,
     host_size_phys: Vec2,

--- a/src/ui/vi_mode_indicator.rs
+++ b/src/ui/vi_mode_indicator.rs
@@ -1,8 +1,6 @@
-//! Vi-mode indicator chip. A `Display::None` chip Node is
-//! attached as a child of each Surface host the first frame
-//! `OrzmuxPane` is observed there; it becomes visible while the
-//! host carries `ViModeState` and shows `[offset/total]` over the
-//! pane's top-right corner.
+//! Vi-mode indicator chip: attached to each Surface host, it becomes
+//! visible while the host carries `ViModeState`, showing `[offset/total]`
+//! over the pane's top-right corner.
 
 use crate::action::vi::mode::ViModeState;
 use crate::font::TerminalUiFont;
@@ -15,23 +13,16 @@ use bevy::prelude::*;
 use bevy_orzma_tty_renderer::schema::TerminalGrid;
 use bevy_orzmux::prelude::OrzmuxPane;
 
-/// Background color of the vi-mode indicator chip. Bright
-/// yellow so the chip reads as a deliberate HUD element on top of the
-/// terminal grid.
+/// Background color of the vi-mode indicator chip: bright yellow.
 const VI_MODE_INDICATOR_BG: Color = Color::srgb(0.95, 0.85, 0.20);
-/// Foreground (text) color of the vi-mode indicator chip. Near-black
-/// for contrast against `VI_MODE_INDICATOR_BG`.
+/// Foreground (text) color of the vi-mode indicator chip: near-black.
 const VI_MODE_INDICATOR_FG: Color = Color::srgb(0.10, 0.10, 0.10);
-/// Font size of the vi-mode indicator chip's text. Smaller than Bevy's
-/// 20px default so the chip reads as a compact HUD label instead of
-/// competing with the terminal grid.
+/// Font size of the vi-mode indicator chip's text, in pixels.
 const VI_MODE_INDICATOR_FONT_SIZE_PX: f32 = 11.0;
-/// Horizontal padding inside the vi-mode indicator chip. Kept tight
-/// because the chip's text is also smaller than the surrounding UI.
+/// Horizontal padding inside the vi-mode indicator chip.
 const VI_MODE_INDICATOR_PADDING_X_PX: f32 = 4.0;
 
-/// Bevy Plugin: wires the vi-mode indicator's attach + refresh systems
-/// and the exit observer.
+/// Adds the vi-mode indicator.
 pub(super) struct ViModeIndicatorPlugin;
 
 impl Plugin for ViModeIndicatorPlugin {
@@ -103,8 +94,7 @@ fn attach_indicator_to_surface_host(
 }
 
 /// Updates each visible chip's `Text` and `IndicatorCache` from the
-/// host's live scroll offset. Gated by `any_with_component::<ViModeState>`
-/// so the schedule short-circuits when nothing is in vi mode.
+/// host's live scroll offset.
 // TODO: `total` is stubbed to 0 until `bevy_orzmux` exposes a
 // history-size read; only the live scroll offset is real.
 fn refresh_indicator(
@@ -135,10 +125,10 @@ fn refresh_indicator(
     }
 }
 
-/// Observer for `On<Remove, ViModeState>`. Hides the indicator chip
-/// belonging to the entity whose `ViModeState` was just removed.
-/// Runs at the sync point that applies the remove, so the chip flips
-/// to `Display::None` before the next render — no per-frame poll needed.
+/// Hides the indicator chip belonging to the entity whose `ViModeState` was
+/// just removed. Runs at the sync point that applies the remove, so the
+/// chip flips to `Display::None` before the next render — no per-frame poll
+/// needed.
 fn hide_indicator_on_vi_mode_exit(
     ev: On<Remove, ViModeState>,
     hosts: Query<&Children>,


### PR DESCRIPTION
## Problem

`.claude/rules/rust.md` says where doc comments are required (`pub` items, file-level `//!`) and how their prose should read (complete sentences, 1–3 per paragraph), but never what they may contain. Doc comments had drifted into design rationale, other terminals' behavior, implementation mechanism, caller inventories, ECS registration recital, and roadmap wording — 13,824 doc lines across `src/` and `crates/`, with one block at 55 lines.

Comments that describe the code's history rather than its contract also go stale silently: this branch found and corrected 71 sentences that no longer matched the code, including a `TermMode` type that does not exist, a focus sync and a teardown observer that were removed, a link-hint engine that is gone, "spawns the login shell" (macOS only), "one reader thread" (Windows starts two), and a VT510 page citation off by one.

## Solution

**Rule.** Adds "Doc comment content — only what the reader needs" to `.claude/rules/rust.md`: a whitelist of what a doc comment may say (summary, observable behavior and return meaning, input meaning, side effects, preconditions, edge cases, `# Panics`/`# Errors`/`# Safety`, `# Invariants`, caller-visible limitations, spec mapping, test contract + `Case:`, `# Examples`, `TODO:`), a table of representative forbidden content, and boundary cases. Forbidden content is deleted, not relocated. Nine existing clauses that contradicted the new section were aligned with it ("Comment references", "Comment prose", "Test doc comments", "System optimization", "Enforcement").

**Sweep.** Twelve commits then bring every doc comment under `src/` and `crates/` into line with it, one work unit per commit, reading all 3,811 doc blocks. Doc lines drop from 13,854 to 12,002. Every diff is comment-only; no `pub` item's doc, `#[test]` doc, or file-level `//!` was removed. The 71 sentences corrected against the code are listed in the bodies of the commits that changed them.

Affected: `.claude/rules/rust.md`, and doc comments only in `orzma_vt`, `orzma_tty`, `bevy_orzma_tty_renderer`, `bevy_orzma_webview`, `orzmux`, `bevy_orzmux`, `orzma_configs`, `bevy_orzma_webview_host`, and the root binary. No code, no `sdk/`, no `apps/`, no `typescript.md`.

<details><summary>Representative before → after</summary>

```rust
// Screen::resize, before
/// A resize that changes the dimensions reports [`DamageSpan::Full`] …
/// The saved cursor follows the rows a resize moves exactly as the live
/// one does … A never-saved checkpoint drifts off the home position by
/// the same amount, the trade alacritty makes too.
/// Leaving either out of bounds would panic the next write, which is why
/// the saved one is clamped here rather than on restore.

// after
/// A resize that changes the dimensions reports [`DamageSpan::Full`] …
/// The cursor and the saved cursor both land inside the new grid.
```
</details>

Three things are deliberately left out of scope and are worth follow-ups:

- **16 code issues** the sweep surfaced but did not fix (a kill reported as a child exit; a module whose body is entirely commented out; body comments naming a function that no longer exists; a test whose name contradicts what it asserts).
- **Items with no doc at all** — about 600 `#[test]` fns and 112 `missing_docs` hits. The rule governs content, not coverage.
- **Plugin docs.** The rule that a `Plugin` doc states the capability it adds rather than its system list was settled partway through the sweep, so `bevy_orzma_tty_renderer` and `bevy_orzma_webview` still carry a few enumerations.

Verified on this branch: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, and `cargo test --workspace --tests -- --test-threads=1` all pass; the diff against `main` touches only comment lines. Code behind non-macOS `cfg`s was not exercised locally and is left to CI.
