### PR TITLE
refactor(orzma_vt): ignore DECCOLM on purpose rather than by fall-through

### DIFF
--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -621,6 +621,18 @@ impl Executor<'_> {
             match mode {
                 // DECCKM
                 1 => self.device.modes_mut().app_cursor = enabled,
+                // DECCOLM
+                // NOTE: The column mode is ignored rather than honored, the
+                // side effects included. A pane's width is not the VT's to
+                // set — the size flows one way, from the window geometry
+                // through the multiplexer layout to the PTY — so the erase
+                // and the margin reset vt510.pdf p.143 gives DECCOLM would
+                // destroy the page for a width change that never follows,
+                // and `xterm-256color` puts `CSI ? 3 l` in the `is2` string
+                // every `tput init` sends. xterm, whose entry that is, gates
+                // the whole sequence behind a resource that is off by
+                // default and so reaches the same no-op.
+                3 => {}
                 // DECOM
                 6 => self
                     .device

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -141,6 +141,7 @@ mod alternate_screen;
 mod auto_wrap;
 mod character_editing;
 mod character_set;
+mod column_mode;
 mod cursor;
 mod cursor_checkpoint;
 mod device_attributes;

--- a/crates/orzma_vt/src/interpreter/tests/column_mode.rs
+++ b/crates/orzma_vt/src/interpreter/tests/column_mode.rs
@@ -1,0 +1,68 @@
+//! Tests that the column mode is ignored, so an initialization string
+//! neither erases the page nor returns the scrolling margins.
+
+use super::*;
+
+/// Asserts that neither column-mode direction erases the page or moves
+/// the cursor.
+///
+/// Case: a script runs `tput init`, whose `is2` string carries
+/// `CSI ? 3 l`, while the shell's earlier output is still on screen.
+#[test]
+fn neither_column_mode_direction_erases_the_page() {
+    for chunk in [&b"a\r\nb\x1b[?3hc"[..], b"a\r\nb\x1b[?3lc"] {
+        let device = interpret(chunk);
+        assert_eq!(glyph_at(&device, 0, 0), 'a', "{chunk:?} keeps the page");
+        assert_eq!(glyph_at(&device, 1, 0), 'b', "{chunk:?} keeps the page");
+        assert_eq!(glyph_at(&device, 1, 1), 'c', "{chunk:?} keeps the cursor");
+    }
+}
+
+/// Asserts that neither column-mode direction returns the scrolling
+/// margins to the full page, leaving a later linefeed scrolling against
+/// the region the application set.
+///
+/// Case: a full-screen application reserves the last row for a status
+/// line, and a `CSI ? 3 l` reaches it from an initialization string a
+/// child process emitted.
+#[test]
+fn neither_column_mode_direction_returns_the_margins() {
+    for chunk in [&b"\x1b[1;2r\x1b[?3ha\n\nb"[..], b"\x1b[1;2r\x1b[?3la\n\nb"] {
+        let device = interpret(chunk);
+        assert_eq!(glyph_at(&device, 1, 1), 'b', "{chunk:?} keeps the region");
+        assert_eq!(glyph_at(&device, 2, 1), ' ', "{chunk:?} keeps the region");
+    }
+}
+
+/// Asserts that a column mode reaching the alternate screen erases
+/// neither that screen nor the one behind it, and leaves the alternate
+/// screen shown.
+///
+/// Case: a user runs `tput init` from a full-screen editor's shell
+/// escape while the editor's page is on the alternate screen.
+#[test]
+fn a_column_mode_leaves_the_alternate_screen_alone() {
+    let mut session = Session::new();
+    session.feed(b"a\x1b[?1049hb\x1b[?3lc");
+    assert_eq!(session.active_screen(), ScreenKind::Alternate);
+    assert_eq!(session.char_at(0, 0), 'b');
+    assert_eq!(session.char_at(0, 1), 'c');
+
+    session.feed(b"\x1b[?1049l");
+    assert_eq!(session.char_at(0, 0), 'a');
+}
+
+/// Asserts that neither column-mode direction raises chunk liveness, a
+/// reply, or a signal.
+///
+/// Case: a legacy VT application selects 132 columns as it starts and
+/// returns to 80 columns as it exits.
+#[test]
+fn neither_column_mode_direction_raises_anything() {
+    for request in [&b"\x1b[?3h"[..], b"\x1b[?3l"] {
+        let output = interpret_fully(request).1;
+        assert!(!output.damaged, "{request:?} raises no liveness");
+        assert!(output.replies.is_empty(), "{request:?} sends no reply");
+        assert!(output.signals.is_empty(), "{request:?} raises no signal");
+    }
+}

--- a/docs/todo/vt-conformance-scope.md
+++ b/docs/todo/vt-conformance-scope.md
@@ -59,9 +59,9 @@ xterm-ctlseqs.pdf 全体の網羅は目標にしない。
 
 | シーケンス | 機能 | terminfo | 現状 | 影響 |
 |---|---|---|---|---|
-| `CSI ! p` | DECSTR ソフトリセット | `is2`, `rs2` | `INTER∅` | **terminfo 経由の初期化列の先頭**。毎回無視されモードが残留する。`CharacterSetMapping::reset()` は DECSTR 待ちで `#[expect(dead_code)]` のまま（`character_sets.rs:220`）。**DECTCEM 実装後、優先度が上がった**: vt510 p.277 Table 5-9 は DECSTR 後の DECTCEM を "Cursor enabled." と定めており、`is2`/`rs2` の先頭が `\E[!p` なので **`tput init` が隠れたカーソルを回復できない**。RIS (`\Ec`) は `VtModes::default()` で回復するが、DECSTR は名指しした一部だけを戻すので `text_cursor_enable = Shown` を明示的に含める必要がある。**DECAWM も同じ Table 5-9 に載っている**（"Autowrap / DECAWM / No autowrap."、IRM の "Replace mode." も同様）。IRM は `InsertReplaceMode::default()` が既に `Replace` なので一致するが、`AutoWrap::default()` は `Enabled` なので **DECAWM だけ default が表の値と逆**であり、値そのものが要判断（`am` を広告する端末で本当に off に落とすか）。含める場合は `modes_mut` への直書きではなく `DeviceState::set_auto_wrap` を通すこと — reset 方向は両画面の LCF 解除を伴う（§4 の LCF 一覧を参照） |
+| `CSI ! p` | DECSTR ソフトリセット | `is2`, `rs2` | `INTER∅` | **terminfo 経由の初期化列の先頭**。毎回無視されモードが残留する。`CharacterSetMapping::reset()` は DECSTR 待ちで `#[expect(dead_code)]` のまま（`character_sets.rs:220`）。**DECTCEM 実装後、優先度が上がった**: vt510 p.277 Table 5-9 は DECSTR 後の DECTCEM を "Cursor enabled." と定めており、`is2`/`rs2` の先頭が `\E[!p` なので **`tput init` が隠れたカーソルを回復できない**。RIS (`\Ec`) は `VtModes::default()` で回復するが、DECSTR は名指しした一部だけを戻すので `text_cursor_enable = Shown` を明示的に含める必要がある。**DECAWM も同じ Table 5-9 に載っている**（"Autowrap / DECAWM / No autowrap."、IRM の "Replace mode." も同様）。IRM は `InsertReplaceMode::default()` が既に `Replace` なので一致するが、`AutoWrap::default()` は `Enabled` なので **DECAWM だけ default が表の値と逆**であり、値そのものが要判断（`am` を広告する端末で本当に off に落とすか）。含める場合は `modes_mut` への直書きではなく `DeviceState::set_auto_wrap` を通すこと — reset 方向は両画面の LCF 解除を伴う（§4 の LCF 一覧を参照）。**DECCOLM 調査で判明した 2 点（2026-09-12）**: (a) xterm の `ReallyReset` はマージン既定化（`resetMarginMode()`）を RIS と DECSTR の**両方**で呼ぶが、`CursorSet(screen, 0, 0, …)` は `if (full)` ＝ RIS 側にしか無い。DECSTR が (0,0) に戻すのは**保存カーソルのスロットだけ**である（`CursorSave(xw); screen->sc[whichBuf].row = col = 0;`）。したがって **`Screen::set_scroll_region(None, None)` は DECSTR にそのまま使えない** — `seat_home()` を含むのでライブカーソルまで動く。カーソルを動かさずマージンだけ戻す経路が要る。(b) 同じ DECSTR 腕は `bitcpy(&xw->flags, xw->initflags, WRAPAROUND | …)` で **DECAWM をリソース既定（`autoWrap` = true）に戻す**ので、Table 5-9 の "No autowrap" とは逆。`am` を広告する `xterm-256color` を名乗る以上 **orzma も on に戻す**のが整合する — これが上の「値そのものが要判断」への答え |
 | `CSI ?12 h/l` | カーソル点滅 | `cnorm`, `cvvis` | `MODE∅`。`blinking: false` 固定 | 点滅指定が効かない |
-| `CSI ?3 l` | DECCOLM リセット | `is2`, `rs2` の一部 | `MODE∅` | 初期化列に含まれる |
+| ~~`CSI ?3 h/l`~~ | ~~DECCOLM~~ | `is2`, `rs2` の一部 | **✅ 意図的に無視と明示（2026-09-12）**。`set_private_modes` に `3 => {}`。理由は `// NOTE:` に記録: ペインの幅は VT の持ち物ではなく（サイズは ウィンドウ形状 → レイアウト木 → PTY の一方通行）、vt510 p.143 が DECCOLM に定める副作用（左右上下マージンの既定化とページ全消去）だけを実行すると、来ない幅変更の代償にページを壊すことになる。`is2` に `\E[?3l` が入るので、これは **`tput init` のたびに**起きる。**xterm 自身がこのシーケンス全体を `c132` リソース（既定 off）で塞いでおり、同じ no-op に落ちる**（manpage `-132`: *"Normally, the VT102 DECCOLM escape sequence … is ignored"*、`charproc.c` の `srm_DECCOLM` は本体すべてが `if (screen->c132)` の中）。参照実装は割れている: ghostty も `?40`（既定 off）で完全無視、foot は `decset_decrst` に `case 3:` 自体が無い。kitty は **set 方向だけ**全消去＋ホーム、alacritty と wezterm は双方向でマージン既定化＋ホーム＋全消去（いずれもリサイズはしない）。テストは `interpreter/tests/column_mode.rs`（副作用を入れる変異で 4 本とも落ちることを確認済み） | ~~初期化列に含まれる~~ |
 | ~~`CSI ?1034 h/l`~~ | ~~8bit Meta~~ | `smm`/`rmm`, `km` | **✅ 意図的に無視と明示（2026-09-11）**。`set_private_modes` に `1034 => {}`。Alt は常に ESC 前置（xterm の metaSendsEscape 相当）で、xterm と foot は 1036 を 1034 より優先するので、この設定では 8 ビット符号化に到達しない。bash / readline が起動時に送る `smm` は変更前から無視されており、挙動は変わらない。テストは `interpreter/tests/meta_key.rs` | ~~Meta キーのバイト表現が食い違う~~ |
 | `CSI ?5 h/l` | DECSCNM 反転 | `flash` | `MODE∅` | ビジュアルベルが無反応 |
 | `CSI 5 m` | SGR blink | `blink`, `sgr` | **意図的に no-op**（`sgr.rs:112` の `5 \| 6 \| 25 \| ... => {}`） | 点滅が普通の文字になる。`Style` へのビット追加＋レンダラ対応が要る |
@@ -94,7 +94,7 @@ terminfo には出ないが実際の TUI が直接叩くもの。`—` は「ロ
 | `OSC 10/11/12` | 前景/背景/カーソル色（問い合わせ含む） | `OSC∅` | vim/nvim の `background` 自動判定 |
 | `OSC 52` | クリップボード | `OSC∅` | nvim の osc52 provider、tmux |
 | `OSC 8` | ハイパーリンク | `OSC∅`。interner は未接続（`hyperlink.rs:15`） | nvim。レンダラ側に受け皿は既にある |
-| `CSI ?Ps $ p` → `$ y` | DECRQM / DECRPM | `INTER∅` | nvim が 69 や 2026 の対応可否を問い合わせる。**返answerが無いと機能検出が常に失敗する**。DECAWM / DECTCEM 実装により **7 と 25 も報告可能な状態を持つようになった**（`CSI ?7;1$y` / `CSI ?25;2$y` など）が応答路が無い。§6 のとおり、`CSI ?7 $ p` を実装すれば `vttest` の `tst_DEC_DECRPM` が mode 7 を機械判定できるようになる |
+| `CSI ?Ps $ p` → `$ y` | DECRQM / DECRPM | `INTER∅` | nvim が 69 や 2026 の対応可否を問い合わせる。**返answerが無いと機能検出が常に失敗する**。DECAWM / DECTCEM 実装により **7 と 25 も報告可能な状態を持つようになった**（`CSI ?7;1$y` / `CSI ?25;2$y` など）が応答路が無い。§6 のとおり、`CSI ?7 $ p` を実装すれば `vttest` の `tst_DEC_DECRPM` が mode 7 を機械判定できるようになる。**mode 3 / 40 / 95 は `0`（not recognized）で答える**（2026-09-12 決定）。orzma は DECCOLM の状態も変更経路も持たないので、`4`（permanently reset）だと任意幅のペインが「80 桁モード」を名乗ることになる。foot と alacritty も 0 を返す（wezterm は set を返す） |
 | `DCS $ q … ST` / `DCS + q … ST` | DECRQSS / XTGETTCAP | DCS コールバックが空（`interpreter.rs:157`-`168`） | vim のカーソル形状復元・capability 検出 |
 | ``CSI Ps ` `` / `CSI Ps a` / `CSI Ps e` | HPA / HPR / VPR | HPA は **✅ 実装済み（2026-09-11、CHA と同じメソッド）**。HPR も **✅ 実装済み（2026-09-11、CUF と同じメソッド。DECLRMM が無い間は停止点が一致する）**。VPR は `CSI∅` | vttest。**VPR は `move_cursor_down` の別名にできない** — VT510 p.351 は VPR を最終行で止めるが CUD は下マージンで止まるため、DECOM リセット時にスクロール領域があると挙動が食い違う |
 | `CSI Ps b` | REP | `CSI∅` | **ローカルエントリは `rep` を広告していない**ため Tier 2。vttest |
@@ -106,6 +106,24 @@ terminfo には出ないが実際の TUI が直接叩くもの。`—` は「ロ
 > 観察（2026-09-11、未修正）: xterm は `GetParam(0) == 0` の `CSI 0 T` を XTHIMOUSE と読むが、
 > orzma は SD として 1 行スクロールする（`interpreter/tests/line_editing.rs` の
 > `the_scroll_down_sequence_scrolls_the_region_down` が固定）。
+
+### アプリ主導のリサイズは受けない（決着済み）
+
+**決着（2026-09-12）: 端末サイズを変えるシーケンスは実装しない。** orzma のサイズは
+ウィンドウ形状 → `OrzmuxCommand::Resize` → レイアウト木 → `OrzmaTty::resize` →
+PTY ioctl + `Vt::resize` の一方通行で、VT から上流へ要求を返す経路が無い。分割ペインが
+ある以上「このペインが 132 桁を要求する」はレイアウトの裁定を伴うので、経路を足すこと
+自体が別規模の変更になる。
+
+| シーケンス | 機能 | 判断 |
+|---|---|---|
+| `CSI ?3 h/l` | DECCOLM | §1-B のとおり明示的に無視（実装済み） |
+| `CSI Ps $ \|` | DECSCPP | **実装しない。** vt510 p.143 / p.249 の Note *"It is recommended that new applications use DECSCPP rather than DECCOLM"* は主語が **applications** ＝ ホストプログラムで、**書く側への推奨であって端末実装への推奨ではない**。DECSCPP は「消さない DECCOLM」ではなく論理ページ幅そのものを 80/132 にする命令で、p.249 が定めるのは幅変更・フォント変更・新しい幅を越えたカーソルの右端クランプ・はみ出した桁のデータ破棄。幅を変えられない orzma では観測可能な効果がゼロになるので腕を置く意味が無く、`csi_dispatch` 冒頭の `has_intermediates()` ガードを外す理由にもならない（そちらは DECSTR / DECSCUSR / DECRQM が決める）。調べた範囲で実装しているのは **xterm だけ**（kitty・foot・wezterm・alacritty・ghostty にヒット無し）で、その `CASE_DECSCPP` の実体も `RequestResize` である。terminfo も広告していない |
+| `CSI Pn t` / `CSI Ps * \|` | DECSLPP / DECSNLS | 同上。`CSI t` は 22 / 23（タイトルの push / pop）だけ実装済み |
+| `CSI 4 t` / `CSI 8 t` | XTWINOPS リサイズ | 同上。DA1 も `CSI ?6c`（VT102）で、132 桁対応（DA1 パラメータ `1`）は名乗っていない |
+
+> 上の一方通行を双方向にした（Vt → OrzmaTty → orzmux → レイアウト木 → ウィンドウ）
+> ときに限り、DECSCPP を実装する意味が出る。そのときは DECCOLM も同時に裁定する。
 
 ### `CSI s` の曖昧性
 
@@ -213,7 +231,9 @@ STD-070 が LCF をリセットすると規定する操作:
    `VtModes::default()` 任せにはできない。**同じ Table 5-9 は DECAWM と IRM も名指し
    している**ので、この 2 つも同時に裁定する。DECAWM は `modes_mut` への直書きではなく
    `DeviceState::set_auto_wrap` を通すこと（`DeviceState::reset` と違って画面リセットを
-   伴わないので、LCF が自動では解除されない）。
+   伴わないので、LCF が自動では解除されない）。**DECSTR はマージンを既定化するが
+   ライブカーソルは動かさない**ので `Screen::set_scroll_region(None, None)` は使えず、
+   DECAWM は Table 5-9 の "No autowrap" ではなく on に戻す — 根拠は §1-B の DECSTR 行。
 5. **入力側の契約修正**（`kbs` の方針決定 → ファンクションキー → 修飾キー）。~~Shift-Tab~~ と Insert は **完了（2026-09-11）**。~~Meta~~ は §1-B の `CSI ?1034 h/l` 行のとおり意図的に無視と決着（2026-09-11）。
 6. **OSC 4/10/11/12** とその問い合わせ・リセット。
 7. **DECRQM/DECRPM と 2026 同期出力**、**DECRQSS/XTGETTCAP**。


### PR DESCRIPTION
## Problem

Tier 1-B of [`docs/todo/vt-conformance-scope.md`](docs/todo/vt-conformance-scope.md) lists `CSI ? 3 l` (DECCOLM reset), which `xterm-256color` carries inside `is2` / `rs2` (`\E[!p\E[?3;4l\E[4l\E>`). It fell through `set_private_modes` into `set_mouse_mode`, which ignores numbers it does not know. So it was ignored, but nothing in the code or tests told a reader whether that was a decision or an oversight.

The sequence does arrive in practice: every `tput init` sends it.

The question behind the row is whether orzma should honor it. vt510.pdf p.143 gives DECCOLM two side effects besides the width change — reset the left, right, top and bottom margins to their defaults, and erase all of page memory — and the manual's Note recommends DECSCPP (`CSI Ps $ |`) over DECCOLM for "new applications".

## Solution

**Behavior is unchanged.** `set_private_modes` gets an explicit `3 => {}` arm, placed in numeric order between 1 and 6, with a `// NOTE:` recording why honoring the mode would be harmful:

- **A pane's width is not the VT's to set.** The size flows one way — window geometry → `OrzmuxCommand::Resize` → the multiplexer layout tree → `OrzmaTty::resize` → PTY ioctl + `Vt::resize`. There is no upward channel, and split panes would need layout arbitration. Running only the side effects therefore destroys the page for a width change that never follows.
- **That would happen on every `tput init`**, because of the `is2` string above.
- **xterm, whose entry that is, reaches the same no-op.** `charproc.c`'s `case srm_DECCOLM:` has its entire body inside `if (screen->c132)`, and `Bres(XtNc132, XtCC132, screen.c132, False)` defaults that resource to false. The manpage says so directly under `-132`: *"Normally, the VT102 DECCOLM escape sequence that switches between 80 and 132 column mode is ignored."*

Reference implementations are split, and none of them resizes except xterm and ghostty:

| | `CSI ? 3 h/l` | gate |
| --- | --- | --- |
| xterm | clear (unless mode 95) + reset margins + home + resize | `c132` / mode 40, **off by default ⇒ full no-op** |
| ghostty | resize to 80/132 + erase + home | mode 40, **off by default ⇒ full no-op** |
| kitty | erase + home, **set direction only**; reset just stores the mode | none |
| alacritty | reset margins (which homes) + clear grid, both directions | none |
| wezterm | reset top/bottom and left/right margins + home + ED, both directions | none |
| foot | no `case 3:` in `decset_decrst` at all | — |

This is the same shape as #288 and #291.

### DECSCPP is deliberately not implemented

The vt510 Note (p.143 and p.249) reads *"It is recommended that new **applications** use DECSCPP rather than DECCOLM"* — its subject is applications, i.e. host programs, not terminal implementations. DECSCPP is not "DECCOLM without the clear": p.249 defines it as changing the logical page width itself (plus the font, clamping a cursor past the new right column, and discarding the columns that no longer fit). With no way to change the width, every one of those effects is unobservable in orzma, so an arm would pin nothing. Of the six terminals surveyed, only xterm implements it, and its `CASE_DECSCPP` is a `RequestResize` call.

A new §2 subsection therefore gathers DECSCPP, DECSLPP, DECSNLS and the XTWINOPS resize operations under one decision: **orzma accepts no application-driven size change.** DA1 already agrees — it answers `CSI ?6c` (VT102) and claims neither 132-column support (DA1 parameter `1`) nor window operations.

### Two DECSTR questions settled on the way

Surveying xterm's `ReallyReset` answered two questions the §1-B DECSTR row had left open. Both are recorded there and in step 4 of the implementation order:

- `resetMarginMode()` runs for RIS **and** DECSTR, but `CursorSet(screen, 0, 0, …)` sits inside `if (full)` — the RIS branch. DECSTR sends only the *saved* cursor slot to (0,0) (`CursorSave(xw); screen->sc[whichBuf].row = col = 0;`). So `Screen::set_scroll_region(None, None)` cannot serve DECSTR: it calls `seat_home()` and would move the live cursor.
- The same arm does `bitcpy(&xw->flags, xw->initflags, WRAPAROUND | …)`, returning DECAWM to the resource default (`autoWrap` = true) rather than to the "No autowrap" of vt510 Table 5-9. Naming ourselves `xterm-256color`, which advertises `am`, we should return it to on — which answers the row's open "値そのものが要判断".

### Commits

| | |
| --- | --- |
| `c263c1d` | characterization tests, which pass against the pre-change fall-through |
| `85ed8f3` | the explicit arm and its `// NOTE:` (behavior-neutral) |
| `fc79a19` | scope doc: the §1-B row, the new resize subsection, the DECRQM answer, and the DECSTR findings |

## Tests

`interpreter/tests/column_mode.rs` adds four cases, taking `orzma_vt` from 811 to 815 tests:

- Neither direction erases the page or moves the cursor.
- Neither direction returns the scrolling margins to the full page.
- A column mode on the alternate screen leaves that screen and the one behind it alone.
- Neither direction raises chunk liveness, a reply, or a signal.

These are characterization tests: all four pass before the arm lands, because the old fall-through already ignored the mode. I checked them with a mutation — implementing the side effects (`set_scroll_region(None, None)` + `erase_in_display(All)`) makes **all four** fail.

`cargo test --workspace`, `cargo clippy --workspace --all-targets` and `cargo fmt --check` pass.

## For the reviewer

- The label is `skip-changelog` rather than `enhancement` because no user-visible behavior changes, as with #288 and #291.
- The branch is named `decscpp` from the original question ("vt510 recommends DECSCPP, should we implement it?"); the investigation's answer was that the recommendation addresses applications, so the change landed on DECCOLM instead.
- When DECRQM lands, modes 3, 40 and 95 should answer `0` (not recognized) — recorded in the §2 DECRQM row. `4` (permanently reset) would have an arbitrary-width pane claiming to be in "80 column mode". foot and alacritty also answer 0; wezterm answers "set".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNvYvzhiJ8aFWFkCXCB1cP
