### PR TITLE
feat(orzma_vt): implement cursor blink (DECSET 12) and DECSCUSR

### DIFF
--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -149,7 +149,7 @@ impl DeviceState {
     ///
     /// - `DECSTR` (`CSI ! p`)
     pub fn soft_reset(&mut self) -> Option<DamageSpan> {
-        self.modes.text_cursor_enable = TextCursorEnable::Shown;
+        self.modes.text_cursor.enable = TextCursorEnable::Shown;
         self.modes.insert_replace = InsertReplaceMode::Replace;
         self.modes.app_cursor = false;
         self.modes.keypad_mode = KeypadMode::Numeric;
@@ -215,12 +215,12 @@ impl DeviceState {
     }
 
     /// The cursor an emitted frame carries: the active screen's write
-    /// position with this device's DECTCEM state folded in.
+    /// position with this device's cursor presentation folded in.
     ///
     /// A frame-ready cursor must be read through here rather than by
     /// pairing a screen read with a separately-read mode.
     pub fn cursor(&self) -> Cursor {
-        self.active_screen().cursor(self.modes.text_cursor_enable)
+        self.active_screen().cursor(self.modes.text_cursor)
     }
 
     /// Snapshot of the modes the device owns.
@@ -1023,7 +1023,7 @@ mod tests {
     fn a_soft_reset_returns_the_named_modes_to_their_defaults() {
         let mut device = device();
         let modes = device.modes_mut();
-        modes.text_cursor_enable = TextCursorEnable::Hidden;
+        modes.text_cursor.enable = TextCursorEnable::Hidden;
         modes.insert_replace = InsertReplaceMode::Insert;
         modes.app_cursor = true;
         modes.keypad_mode = KeypadMode::Application;
@@ -1031,7 +1031,7 @@ mod tests {
 
         let _ = device.soft_reset();
 
-        assert_eq!(device.modes().text_cursor_enable, TextCursorEnable::Shown);
+        assert_eq!(device.modes().text_cursor.enable, TextCursorEnable::Shown);
         assert_eq!(device.modes().insert_replace, InsertReplaceMode::Replace);
         assert!(!device.modes().app_cursor);
         assert_eq!(device.modes().keypad_mode, KeypadMode::Numeric);

--- a/crates/orzma_vt/src/device.rs
+++ b/crates/orzma_vt/src/device.rs
@@ -5,7 +5,8 @@ pub(crate) mod modes;
 
 use crate::device::color::{Palette, Rgb};
 use crate::device::modes::{
-    AutoWrap, InsertReplaceMode, KeypadMode, ScreenKind, TextCursorEnable, VtModes,
+    AutoWrap, CursorBlink, CursorShape, InsertReplaceMode, KeypadMode, ScreenKind,
+    TextCursorEnable, VtModes,
 };
 use crate::frame::damage::DamageSpan;
 use crate::placement::{InstanceId, MAX_PLACEMENTS, PlacementSize};
@@ -150,6 +151,8 @@ impl DeviceState {
     /// - `DECSTR` (`CSI ! p`)
     pub fn soft_reset(&mut self) -> Option<DamageSpan> {
         self.modes.text_cursor.enable = TextCursorEnable::Shown;
+        self.modes.text_cursor.shape = CursorShape::default();
+        self.modes.text_cursor.blink = CursorBlink::default();
         self.modes.insert_replace = InsertReplaceMode::Replace;
         self.modes.app_cursor = false;
         self.modes.keypad_mode = KeypadMode::Numeric;

--- a/crates/orzma_vt/src/device/modes.rs
+++ b/crates/orzma_vt/src/device/modes.rs
@@ -168,6 +168,10 @@ pub enum CursorShape {
 /// Whether the text cursor blinks or is drawn continuously.
 ///
 /// Both screens share one value, and `DECSC` does not carry it.
+///
+/// # Control Functions
+///
+/// - `DECSET 12` / `DECRST 12` (AT&T 610)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CursorBlink {
     /// The cursor is drawn continuously; this is the power-up default.
@@ -175,6 +179,23 @@ pub enum CursorBlink {
     Steady,
     /// The cursor alternates between drawn and not drawn.
     Blinking,
+}
+
+impl CursorBlink {
+    /// The state `DECSET 12` selects when set and `DECRST 12` when
+    /// reset.
+    ///
+    /// # References
+    ///
+    /// - xterm-ctlseqs.pdf p.18 — "Start blinking cursor (AT&T 610)."
+    /// - xterm-ctlseqs.pdf p.21 — "Stop blinking cursor (AT&T 610)."
+    pub fn from_decset(enabled: bool) -> Self {
+        if enabled {
+            Self::Blinking
+        } else {
+            Self::Steady
+        }
+    }
 }
 
 /// How the text cursor is presented.

--- a/crates/orzma_vt/src/device/modes.rs
+++ b/crates/orzma_vt/src/device/modes.rs
@@ -40,11 +40,12 @@ pub struct VtModes {
     pub alternate_scroll: bool,
     /// DECSET 1004: the app wants `CSI I` / `CSI O` focus reports.
     pub focus_in_out: bool,
-    /// DECTCEM (DECSET 25): whether the text cursor is drawn.
+    /// How the text cursor is presented: its visibility, shape, and
+    /// blink.
     ///
     /// A switch to the alternate screen keeps the state the application
     /// set, and DECSC does not save it either.
-    pub text_cursor_enable: TextCursorEnable,
+    pub text_cursor: TextCursorModes,
     /// Coordinate encoding for mouse reports.
     pub mouse_encoding: MouseEncoding,
     /// Which mouse events the app asked to receive.
@@ -162,6 +163,31 @@ pub enum CursorShape {
     Underline,
     /// A vertical line at the left of the cell.
     Bar,
+}
+
+/// Whether the text cursor blinks or is drawn continuously.
+///
+/// Both screens share one value, and `DECSC` does not carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorBlink {
+    /// The cursor is drawn continuously; this is the power-up default.
+    #[default]
+    Steady,
+    /// The cursor alternates between drawn and not drawn.
+    Blinking,
+}
+
+/// How the text cursor is presented.
+///
+/// Both screens share one value, and `DECSC` does not carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TextCursorModes {
+    /// Whether the cursor is drawn at all.
+    pub enable: TextCursorEnable,
+    /// The shape it takes.
+    pub shape: CursorShape,
+    /// Whether it blinks.
+    pub blink: CursorBlink,
 }
 
 /// The mode selects whether the numeric keypad sends ASCII numerals or application function.
@@ -336,7 +362,7 @@ mod tests {
     #[test]
     fn the_text_cursor_starts_shown() {
         assert_eq!(
-            VtModes::default().text_cursor_enable,
+            VtModes::default().text_cursor.enable,
             TextCursorEnable::Shown
         );
     }

--- a/crates/orzma_vt/src/device/modes.rs
+++ b/crates/orzma_vt/src/device/modes.rs
@@ -154,6 +154,12 @@ impl TextCursorEnable {
 }
 
 /// The shape the text cursor is drawn with.
+///
+/// Both screens share one value, and `DECSC` does not carry it.
+///
+/// # Control Functions
+///
+/// - `DECSCUSR` (`CSI Ps SP q`)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CursorShape {
     /// A block filling the cell; this is the power-up default.
@@ -172,6 +178,7 @@ pub enum CursorShape {
 /// # Control Functions
 ///
 /// - `DECSET 12` / `DECRST 12` (AT&T 610)
+/// - `DECSCUSR` (`CSI Ps SP q`)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CursorBlink {
     /// The cursor is drawn continuously; this is the power-up default.
@@ -209,6 +216,41 @@ pub struct TextCursorModes {
     pub shape: CursorShape,
     /// Whether it blinks.
     pub blink: CursorBlink,
+}
+
+impl TextCursorModes {
+    /// The presentation `DECSCUSR` selects for the parameter in its
+    /// first slot; `None` for a parameter this terminal assigns no
+    /// style to.
+    ///
+    /// An omitted parameter, a zero, and a one all select the blinking
+    /// block. A seven restores the power-up shape and blink. The
+    /// cursor's visibility is carried through unchanged.
+    ///
+    /// # References
+    ///
+    /// - vt510.pdf p.251 — "0, 1 or none Blink Block (Default)", and
+    ///   the note that "The escape sequence DECTCEM can enable or
+    ///   disable the cursor display."
+    /// - xterm-ctlseqs.pdf p.29-30 — the bar variants (5 and 6) and
+    ///   "Ps = 7 ⇒ initial resources".
+    pub fn with_decscusr(self, ps: Option<u16>) -> Option<Self> {
+        let (shape, blink) = match ps.unwrap_or(0) {
+            0 | 1 => (CursorShape::Block, CursorBlink::Blinking),
+            2 => (CursorShape::Block, CursorBlink::Steady),
+            3 => (CursorShape::Underline, CursorBlink::Blinking),
+            4 => (CursorShape::Underline, CursorBlink::Steady),
+            5 => (CursorShape::Bar, CursorBlink::Blinking),
+            6 => (CursorShape::Bar, CursorBlink::Steady),
+            7 => (CursorShape::default(), CursorBlink::default()),
+            _ => return None,
+        };
+        Some(Self {
+            shape,
+            blink,
+            ..self
+        })
+    }
 }
 
 /// The mode selects whether the numeric keypad sends ASCII numerals or application function.
@@ -400,5 +442,90 @@ mod tests {
             TextCursorEnable::from_decset(false),
             TextCursorEnable::Hidden
         );
+    }
+
+    /// Asserts that an omitted parameter, a zero, and a one all select
+    /// the blinking block rather than a terminal-specific default.
+    ///
+    /// Case: vim restores the cursor it found by sending `CSI 0 SP q`,
+    /// and a shell prompt framework sends the bare `CSI SP q`.
+    #[test]
+    fn an_omitted_zero_and_one_all_select_the_blinking_block() {
+        let start = TextCursorModes::default();
+        for ps in [None, Some(0), Some(1)] {
+            let next = start.with_decscusr(ps).expect("the parameter is assigned");
+            assert_eq!(next.shape, CursorShape::Block, "ps {ps:?}");
+            assert_eq!(next.blink, CursorBlink::Blinking, "ps {ps:?}");
+        }
+    }
+
+    /// Asserts that each assigned parameter selects its documented
+    /// shape and blink pair.
+    ///
+    /// Case: nvim switches the caret per mode, taking a steady block in
+    /// normal mode and a blinking bar in insert mode.
+    #[test]
+    fn each_assigned_parameter_selects_its_shape_and_blink() {
+        let start = TextCursorModes::default();
+        let expected = [
+            (2, CursorShape::Block, CursorBlink::Steady),
+            (3, CursorShape::Underline, CursorBlink::Blinking),
+            (4, CursorShape::Underline, CursorBlink::Steady),
+            (5, CursorShape::Bar, CursorBlink::Blinking),
+            (6, CursorShape::Bar, CursorBlink::Steady),
+        ];
+        for (ps, shape, blink) in expected {
+            let next = start
+                .with_decscusr(Some(ps))
+                .expect("the parameter is assigned");
+            assert_eq!(next.shape, shape, "ps {ps}");
+            assert_eq!(next.blink, blink, "ps {ps}");
+        }
+    }
+
+    /// Asserts that a seven restores the power-up shape and blink
+    /// rather than being ignored, carrying the cursor's visibility
+    /// through unchanged.
+    ///
+    /// Case: an application that changed the caret hands the terminal
+    /// back by asking for the style it was configured with, while the
+    /// caret is hidden mid-repaint.
+    #[test]
+    fn a_seven_restores_the_power_up_style() {
+        let changed = TextCursorModes {
+            enable: TextCursorEnable::Hidden,
+            ..TextCursorModes::default()
+        }
+        .with_decscusr(Some(5))
+        .expect("the parameter is assigned");
+        let restored = changed
+            .with_decscusr(Some(7))
+            .expect("the parameter is assigned");
+        assert_eq!(restored.shape, TextCursorModes::default().shape);
+        assert_eq!(restored.blink, TextCursorModes::default().blink);
+        assert_eq!(restored.enable, TextCursorEnable::Hidden);
+    }
+
+    /// Asserts that a parameter this terminal assigns no style to
+    /// changes nothing, and that an assigned one leaves the cursor's
+    /// visibility alone.
+    ///
+    /// Case: a full-screen editor hides the caret, then picks a bar
+    /// while it is hidden; a later program sends a parameter from a
+    /// terminal whose style table is longer.
+    #[test]
+    fn an_unassigned_parameter_changes_nothing_and_visibility_is_untouched() {
+        let hidden = TextCursorModes {
+            enable: TextCursorEnable::Hidden,
+            ..TextCursorModes::default()
+        };
+        assert_eq!(hidden.with_decscusr(Some(8)), None);
+        assert_eq!(hidden.with_decscusr(Some(99)), None);
+
+        let barred = hidden
+            .with_decscusr(Some(5))
+            .expect("the parameter is assigned");
+        assert_eq!(barred.enable, TextCursorEnable::Hidden);
+        assert_eq!(barred.shape, CursorShape::Bar);
     }
 }

--- a/crates/orzma_vt/src/device/modes.rs
+++ b/crates/orzma_vt/src/device/modes.rs
@@ -152,6 +152,18 @@ impl TextCursorEnable {
     }
 }
 
+/// The shape the text cursor is drawn with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorShape {
+    /// A block filling the cell; this is the power-up default.
+    #[default]
+    Block,
+    /// A line along the bottom of the cell.
+    Underline,
+    /// A vertical line at the left of the cell.
+    Bar,
+}
+
 /// The mode selects whether the numeric keypad sends ASCII numerals or application function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum KeypadMode {

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -697,7 +697,7 @@ impl Executor<'_> {
                 7 => self.device.set_auto_wrap(AutoWrap::from_decset(enabled)),
                 // DECTCEM
                 25 => {
-                    self.device.modes_mut().text_cursor_enable =
+                    self.device.modes_mut().text_cursor.enable =
                         TextCursorEnable::from_decset(enabled);
                 }
                 // Alternate screen

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -470,6 +470,17 @@ impl VTActor for Executor<'_> {
                 let damage = self.device.soft_reset();
                 self.stage(damage);
             }
+            // DECSCUSR
+            (None, [b' '], b'q') => {
+                if let Some(next) = self
+                    .device
+                    .modes()
+                    .text_cursor
+                    .with_decscusr(params.value(0))
+                {
+                    self.device.modes_mut().text_cursor = next;
+                }
+            }
             _ => {}
         }
     }

--- a/crates/orzma_vt/src/interpreter.rs
+++ b/crates/orzma_vt/src/interpreter.rs
@@ -7,7 +7,9 @@ mod csi;
 mod osc;
 mod sgr;
 
-use crate::device::modes::{AutoWrap, InsertReplaceMode, KeypadMode, ScreenKind, TextCursorEnable};
+use crate::device::modes::{
+    AutoWrap, CursorBlink, InsertReplaceMode, KeypadMode, ScreenKind, TextCursorEnable,
+};
 use crate::interpreter::apc::WebviewApcRequest;
 use crate::interpreter::csi::CsiParams;
 use crate::interpreter::osc::{
@@ -695,6 +697,8 @@ impl Executor<'_> {
                     .set_origin_mode(OriginMode::from_decset(enabled)),
                 // DECAWM
                 7 => self.device.set_auto_wrap(AutoWrap::from_decset(enabled)),
+                // Blinking cursor (AT&T 610)
+                12 => self.device.modes_mut().text_cursor.blink = CursorBlink::from_decset(enabled),
                 // DECTCEM
                 25 => {
                     self.device.modes_mut().text_cursor.enable =

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::device::color::{Color, Rgb};
-use crate::device::modes::{InsertReplaceMode, MouseEncoding, MouseTracking};
+use crate::device::modes::{CursorShape, InsertReplaceMode, MouseEncoding, MouseTracking};
 use crate::frame::Frame;
 use crate::placement::{AnchoredPlacement, InstanceId, MAX_PLACEMENTS, PlacementSize};
 use crate::screen::cell::Cell;
@@ -122,6 +122,10 @@ impl Session {
 
     fn cursor_blinking(&self) -> bool {
         self.0.device.cursor().blinking
+    }
+
+    fn cursor_shape(&self) -> CursorShape {
+        self.0.device.cursor().shape
     }
 
     fn cursor_column(&self) -> u16 {

--- a/crates/orzma_vt/src/interpreter/tests.rs
+++ b/crates/orzma_vt/src/interpreter/tests.rs
@@ -120,6 +120,10 @@ impl Session {
         self.0.device.cursor().visible
     }
 
+    fn cursor_blinking(&self) -> bool {
+        self.0.device.cursor().blinking
+    }
+
     fn cursor_column(&self) -> u16 {
         self.0.device.active_screen().cursor_column().0
     }
@@ -149,6 +153,7 @@ mod character_set;
 mod column_mode;
 mod cursor;
 mod cursor_checkpoint;
+mod cursor_style;
 mod device_attributes;
 mod device_status;
 mod erase;

--- a/crates/orzma_vt/src/interpreter/tests/cursor_style.rs
+++ b/crates/orzma_vt/src/interpreter/tests/cursor_style.rs
@@ -1,5 +1,6 @@
 //! Tests for the cursor presentation an application selects: the blink
-//! `DECSET 12` toggles.
+//! `DECSET 12` toggles and the shape and blink `DECSCUSR` picks
+//! together.
 
 use super::*;
 use crate::device::modes::CursorShape;
@@ -171,4 +172,208 @@ fn an_emitted_frame_carries_the_blinking_cursor() {
     session.feed(b"\x1b[?12h");
     let blinking = session.frame().expect("turning the blink on owes a frame");
     assert!(blinking.cursor.blinking);
+}
+
+/// Asserts that each `DECSCUSR` parameter reaches the device through
+/// the parser.
+///
+/// Case: nvim switches the caret per mode as the user moves between
+/// normal and insert mode.
+#[test]
+fn each_decscusr_parameter_reaches_the_device() {
+    let expected = [
+        (b"\x1b[2 q".as_slice(), CursorShape::Block, false),
+        (b"\x1b[3 q".as_slice(), CursorShape::Underline, true),
+        (b"\x1b[4 q".as_slice(), CursorShape::Underline, false),
+        (b"\x1b[5 q".as_slice(), CursorShape::Bar, true),
+        (b"\x1b[6 q".as_slice(), CursorShape::Bar, false),
+    ];
+    for (chunk, shape, blinking) in expected {
+        let device = interpret(chunk);
+        assert_eq!(cursor_shape(&device), shape, "chunk {chunk:?}");
+        assert_eq!(cursor_blinking(&device), blinking, "chunk {chunk:?}");
+    }
+}
+
+/// Asserts that an omitted parameter, a zero, and a one all reach the
+/// device as the blinking block.
+///
+/// Case: a prompt framework sends the bare `CSI SP q`, and vim sends
+/// `CSI 0 SP q` when it restores the caret on exit.
+#[test]
+fn an_omitted_zero_and_one_reach_the_device_as_the_blinking_block() {
+    for chunk in [
+        b"\x1b[ q".as_slice(),
+        b"\x1b[0 q".as_slice(),
+        b"\x1b[1 q".as_slice(),
+    ] {
+        let device = interpret(chunk);
+        assert_eq!(cursor_shape(&device), CursorShape::Block, "chunk {chunk:?}");
+        assert!(cursor_blinking(&device), "chunk {chunk:?}");
+    }
+}
+
+/// Asserts that `CSI 7 SP q` restores the power-up style through the
+/// parser.
+///
+/// Case: an application that took a blinking bar hands the terminal
+/// back to the shell as it exits.
+#[test]
+fn a_decscusr_seven_restores_the_power_up_style() {
+    let device = interpret(b"\x1b[5 q\x1b[7 q");
+    assert_eq!(cursor_shape(&device), CursorShape::Block);
+    assert!(!cursor_blinking(&device));
+}
+
+/// Asserts that a `DECSCUSR` parameter this terminal assigns no style
+/// to leaves the cursor alone, and that the parser returns to ground so
+/// the text after it still prints.
+///
+/// Case: a program written for a terminal with a longer style table
+/// sends a parameter past this one's, and keeps writing.
+#[test]
+fn an_unassigned_decscusr_parameter_changes_nothing_and_the_text_prints() {
+    let mut session = Session::new();
+    session.feed(b"\x1b[5 q");
+    session.feed(b"\x1b[99 qa");
+
+    assert_eq!(session.cursor_shape(), CursorShape::Bar);
+    assert!(session.cursor_blinking());
+    assert_eq!(session.char_at(0, 0), 'a');
+}
+
+/// Asserts that a `SP q` carrying a private marker is not read as
+/// `DECSCUSR`.
+///
+/// Case: a program mistakenly prefixes the sequence with `?`, the way
+/// the private modes beside it are spelled.
+#[test]
+fn a_private_marker_does_not_reach_decscusr() {
+    let device = interpret(b"\x1b[?5 q");
+    assert_eq!(cursor_shape(&device), CursorShape::Block);
+    assert!(!cursor_blinking(&device));
+}
+
+/// Asserts that the control functions sharing `DECSCUSR`'s intermediate
+/// or its final byte do not reach `DECSCUSR`.
+///
+/// Case: a program drives SL, SR, DECSWBV, DECLL, and DECSCA, none of
+/// which this terminal answers.
+#[test]
+fn the_neighbours_of_decscusr_stay_unanswered() {
+    for chunk in [
+        b"\x1b[5 @".as_slice(),
+        b"\x1b[5 A".as_slice(),
+        b"\x1b[5 t".as_slice(),
+        b"\x1b[1q".as_slice(),
+        b"\x1b[1\"q".as_slice(),
+    ] {
+        let device = interpret(chunk);
+        assert_eq!(cursor_shape(&device), CursorShape::Block, "chunk {chunk:?}");
+        assert!(!cursor_blinking(&device), "chunk {chunk:?}");
+    }
+}
+
+/// Asserts that `DECSCUSR` reads only its first parameter slot.
+///
+/// Case: a program pads the sequence with a second parameter copied
+/// from a different control function's spelling.
+#[test]
+fn decscusr_reads_only_its_first_slot() {
+    let device = interpret(b"\x1b[5;2 q");
+    assert_eq!(cursor_shape(&device), CursorShape::Bar);
+    assert!(cursor_blinking(&device));
+}
+
+/// Asserts that a `DECSCUSR` whose first slot carries subparameters is
+/// read from that slot's first integer rather than being rejected.
+///
+/// Case: a program spells the parameter with a colon, the way the
+/// direct-colour SGR forms beside it are spelled.
+#[test]
+fn a_colon_in_the_first_slot_does_not_reject_decscusr() {
+    let device = interpret(b"\x1b[5:2 q");
+    assert_eq!(cursor_shape(&device), CursorShape::Bar);
+    assert!(cursor_blinking(&device));
+}
+
+/// Asserts that `DECSET 12` and `DECSCUSR` write one shared blink, the
+/// last writer winning, and that turning the blink off leaves the shape
+/// `DECSCUSR` chose in place.
+///
+/// Case: nvim picks a blinking bar for insert mode, and the terminfo
+/// `cnorm` string later turns the blink off without naming a shape.
+#[test]
+fn the_blink_mode_and_decscusr_share_one_state() {
+    let mut session = Session::new();
+
+    session.feed(b"\x1b[5 q");
+    assert!(session.cursor_blinking());
+
+    session.feed(b"\x1b[?12l");
+    assert!(!session.cursor_blinking());
+    assert_eq!(session.cursor_shape(), CursorShape::Bar);
+
+    session.feed(b"\x1b[?12h");
+    assert!(session.cursor_blinking());
+
+    session.feed(b"\x1b[2 q");
+    assert!(!session.cursor_blinking());
+    assert_eq!(session.cursor_shape(), CursorShape::Block);
+}
+
+/// Asserts that the shape is not carried by a cursor checkpoint,
+/// survives a round trip through the alternate screen, and returns to
+/// the power-up block on a reset to initial state.
+///
+/// Case: a full-screen editor picks a bar, saves and restores the
+/// cursor while it draws, opens and leaves the alternate screen, and
+/// the shell later runs `tput reset`.
+#[test]
+fn the_shape_follows_the_device_mode_lifetime() {
+    let mut session = Session::new();
+
+    session.feed(b"\x1b[5 q\x1b7\x1b[2 q\x1b8");
+    assert_eq!(session.cursor_shape(), CursorShape::Block);
+
+    session.feed(b"\x1b[3 q\x1b[?1049h\x1b[?1049l");
+    assert_eq!(session.cursor_shape(), CursorShape::Underline);
+
+    session.feed(b"\x1bc");
+    assert_eq!(session.cursor_shape(), CursorShape::Block);
+}
+
+/// Asserts that a shape change is frame-relevant and reaches an emitted
+/// frame, while a `DECSCUSR` that changes nothing does not make the
+/// chunk live.
+///
+/// Case: nvim sends its per-mode caret sequence on every mode change,
+/// including the ones that re-assert the caret already in force.
+#[test]
+fn a_shape_change_reaches_a_frame_and_a_repeat_does_not() {
+    assert!(damage_of(b"\x1b[5 q"));
+    assert!(!liveness_after(b"\x1b[5 q", b"\x1b[5 q"));
+
+    let mut session = Session::new();
+    session.feed(b"$ ");
+    session
+        .frame()
+        .expect("the first chunk emits the bootstrap frame");
+
+    session.feed(b"\x1b[5 q");
+    let frame = session.frame().expect("a shape change owes a frame");
+    assert_eq!(frame.cursor.shape, CursorShape::Bar);
+    assert!(frame.cursor.blinking);
+}
+
+/// Asserts that `DECSCUSR` leaves the cursor's visibility alone, so a
+/// caret hidden by DECTCEM stays hidden while its shape changes.
+///
+/// Case: a full-screen editor hides the caret for a repaint and picks
+/// the shape it wants before showing it again.
+#[test]
+fn decscusr_leaves_the_cursor_visibility_alone() {
+    let device = interpret(b"\x1b[?25l\x1b[5 q");
+    assert!(!device.cursor().visible);
+    assert_eq!(cursor_shape(&device), CursorShape::Bar);
 }

--- a/crates/orzma_vt/src/interpreter/tests/cursor_style.rs
+++ b/crates/orzma_vt/src/interpreter/tests/cursor_style.rs
@@ -1,0 +1,174 @@
+//! Tests for the cursor presentation an application selects: the blink
+//! `DECSET 12` toggles.
+
+use super::*;
+use crate::device::modes::CursorShape;
+
+/// Whether the device's frame-ready cursor blinks.
+fn cursor_blinking(device: &DeviceState) -> bool {
+    device.cursor().blinking
+}
+
+/// The shape the device's frame-ready cursor carries.
+fn cursor_shape(device: &DeviceState) -> CursorShape {
+    device.cursor().shape
+}
+
+/// Asserts that a terminal that has seen no blink control reports a
+/// steady block, which is the reset state of `DECSET 12`.
+///
+/// Case: a shell prints its first prompt on a freshly spawned terminal.
+#[test]
+fn a_fresh_terminal_reports_a_steady_block() {
+    let device = interpret(b"$ ");
+    assert!(!cursor_blinking(&device));
+    assert_eq!(cursor_shape(&device), CursorShape::Block);
+}
+
+/// Asserts that `CSI ? 12 h` makes the cursor blink.
+///
+/// Case: the terminfo `cvvis` string asks for the very visible cursor
+/// a pager uses to mark the read position.
+#[test]
+fn a_blink_mode_set_makes_the_cursor_blink() {
+    let device = interpret(b"\x1b[?12h");
+    assert!(cursor_blinking(&device));
+}
+
+/// Asserts that `CSI ? 12 l` returns a blinking cursor to steady.
+///
+/// Case: the terminfo `cnorm` string, which spells the normal cursor
+/// `\E[?12l\E[?25h`, runs when a full-screen application exits.
+#[test]
+fn a_blink_mode_reset_returns_the_cursor_to_steady() {
+    let mut session = Session::new();
+
+    session.feed(b"\x1b[?12h");
+    assert!(session.cursor_blinking());
+
+    session.feed(b"\x1b[?12l");
+    assert!(!session.cursor_blinking());
+}
+
+/// Asserts that `? 12` is applied when it shares a list with other
+/// modes.
+///
+/// Case: the terminfo `cvvis` string sends `\E[?12;25h`, turning the
+/// blink and the caret on in one sequence.
+#[test]
+fn a_blink_mode_set_inside_a_multi_mode_list_is_applied() {
+    let device = interpret(b"\x1b[?25l\x1b[?12;25h");
+    assert!(cursor_blinking(&device));
+    assert!(device.cursor().visible);
+}
+
+/// Asserts that the ANSI-mode spelling `CSI 12 h`, which carries no
+/// `?`, leaves the cursor steady.
+///
+/// Case: a program drives the terminal through non-private SM and RM,
+/// and one of the numbers in its parameter list happens to be 12.
+#[test]
+fn an_ansi_mode_set_of_twelve_does_not_make_the_cursor_blink() {
+    let device = interpret(b"\x1b[12h");
+    assert!(!cursor_blinking(&device));
+}
+
+/// Asserts that the two blink modes reserved for a user preference,
+/// `? 13` and `? 14`, are ignored in both directions.
+///
+/// Case: an application probes the terminal by driving the whole
+/// documented blink family, not just the one mode it can set.
+#[test]
+fn the_user_preference_blink_modes_are_ignored() {
+    for chunk in [b"\x1b[?13h".as_slice(), b"\x1b[?14h".as_slice()] {
+        let device = interpret(chunk);
+        assert!(
+            !cursor_blinking(&device),
+            "chunk {chunk:?} must not start the blink"
+        );
+    }
+
+    for chunk in [b"\x1b[?13l".as_slice(), b"\x1b[?14l".as_slice()] {
+        let mut session = Session::new();
+        session.feed(b"\x1b[?12h");
+        session.feed(chunk);
+        assert!(
+            session.cursor_blinking(),
+            "chunk {chunk:?} must not stop the blink"
+        );
+    }
+}
+
+/// Asserts that a cursor checkpoint leaves the blink alone, so `DECRC`
+/// does not restore the blink in force when `DECSC` ran.
+///
+/// Case: a program saves the cursor, turns the blink on to draw
+/// attention to a prompt, and restores the cursor afterwards.
+#[test]
+fn a_cursor_checkpoint_leaves_the_blink_alone() {
+    let device = interpret(b"\x1b7\x1b[?12h\x1b8");
+    assert!(cursor_blinking(&device));
+}
+
+/// Asserts that a reset to initial state returns the cursor to steady.
+///
+/// Case: a script that left the blink on ends, and the shell runs
+/// `tput reset`, whose `rs1` string is `\Ec`.
+#[test]
+fn a_reset_to_initial_state_returns_the_cursor_to_steady() {
+    let device = interpret(b"\x1b[?12h\x1bc");
+    assert!(!cursor_blinking(&device));
+}
+
+/// Asserts that the blink survives a round trip through the alternate
+/// screen: a change made while there is still in force after the flip
+/// back to the primary screen.
+///
+/// Case: a full-screen editor opens the alternate screen, turns the
+/// blink on while it draws, and exits back to the shell.
+#[test]
+fn the_alternate_screen_keeps_the_blink() {
+    let mut session = Session::new();
+
+    session.feed(b"\x1b[?1049h\x1b[?12h");
+    assert!(session.cursor_blinking());
+
+    session.feed(b"\x1b[?1049l");
+    assert!(session.cursor_blinking());
+}
+
+/// Asserts that a chunk turning the blink on is reported as
+/// frame-relevant.
+///
+/// Case: a pager sends nothing but `CSI ? 12 h` between two repaints.
+#[test]
+fn turning_the_blink_on_makes_the_chunk_frame_relevant() {
+    assert!(damage_of(b"\x1b[?12h"));
+}
+
+/// Asserts that a blink write that changes nothing leaves the chunk out
+/// of the frame-relevant set.
+///
+/// Case: an application re-asserts the blink it already has as part of
+/// the escape sequence it emits on every redraw.
+#[test]
+fn a_blink_write_that_changes_nothing_does_not_make_the_chunk_live() {
+    assert!(!liveness_after(b"\x1b[?12h", b"\x1b[?12h"));
+}
+
+/// Asserts that the frame a chunk emits carries the blinking cursor.
+///
+/// Case: a pager turns the blink on, and the renderer must be told
+/// before it draws the next frame.
+#[test]
+fn an_emitted_frame_carries_the_blinking_cursor() {
+    let mut session = Session::new();
+    session.feed(b"$ ");
+    session
+        .frame()
+        .expect("the first chunk emits the bootstrap frame");
+
+    session.feed(b"\x1b[?12h");
+    let blinking = session.frame().expect("turning the blink on owes a frame");
+    assert!(blinking.cursor.blinking);
+}

--- a/crates/orzma_vt/src/interpreter/tests/soft_reset.rs
+++ b/crates/orzma_vt/src/interpreter/tests/soft_reset.rs
@@ -1,7 +1,7 @@
 //! Tests for the soft terminal reset.
 
 use super::*;
-use crate::device::modes::{AutoWrap, KeypadMode};
+use crate::device::modes::{AutoWrap, CursorShape, KeypadMode};
 
 /// Asserts that a soft reset shows a cursor an application hid.
 ///
@@ -11,6 +11,18 @@ use crate::device::modes::{AutoWrap, KeypadMode};
 fn a_soft_reset_shows_a_hidden_cursor() {
     let device = interpret(b"\x1b[?25l\x1b[!p");
     assert!(device.cursor().visible);
+}
+
+/// Asserts that a soft reset returns the cursor shape and blink to
+/// their power-up values.
+///
+/// Case: nvim sets a blinking bar for insert mode and is killed before
+/// it restores the caret, and the shell runs `tput init` behind it.
+#[test]
+fn a_soft_reset_returns_the_cursor_shape_and_blink_to_their_defaults() {
+    let device = interpret(b"\x1b[5 q\x1b[!p");
+    assert_eq!(device.cursor().shape, CursorShape::Block);
+    assert!(!device.cursor().blinking);
 }
 
 /// Asserts that a soft reset returns the terminal to replace mode.

--- a/crates/orzma_vt/src/interpreter/tests/text_cursor_enable.rs
+++ b/crates/orzma_vt/src/interpreter/tests/text_cursor_enable.rs
@@ -47,8 +47,7 @@ fn a_fresh_terminal_reports_a_visible_cursor() {
 ///
 /// Case: an application turns cursor visibility off together with focus
 /// reporting and a mode this terminal does not implement, then the
-/// terminfo `cvvis` string turns the caret back on beside the blink
-/// mode this terminal also does not implement.
+/// terminfo `cvvis` string turns the caret back on beside the blink.
 #[test]
 fn a_dectcem_reset_inside_a_multi_mode_list_is_applied() {
     let device = interpret(b"\x1b[?1004h\x1b[?25;9999;1004l");

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -25,13 +25,13 @@ mod vi;
 pub mod prelude {
     pub use crate::device::color::{Color, Palette, Rgb};
     pub use crate::device::modes::{
-        AutoWrap, InsertReplaceMode, KeypadMode, MouseEncoding, MouseTracking, ScreenKind,
-        TextCursorEnable, VtModes,
+        AutoWrap, CursorShape, InsertReplaceMode, KeypadMode, MouseEncoding, MouseTracking,
+        ScreenKind, TextCursorEnable, VtModes,
     };
     pub use crate::frame::{DirtyRow, Frame};
     pub use crate::hyperlink::{Hyperlink, HyperlinkId, HyperlinkUri, is_allowed};
     pub use crate::placement::{AnchoredPlacement, InstanceId, MAX_COLS, MAX_ROWS, PlacementSize};
-    pub use crate::screen::cursor::{CURSOR_VISIBLE_BIT, Cursor, CursorShape};
+    pub use crate::screen::cursor::{CURSOR_VISIBLE_BIT, Cursor};
     pub use crate::screen::grid::GridSize;
     pub use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};
     pub use crate::screen::grid::row::Row;

--- a/crates/orzma_vt/src/lib.rs
+++ b/crates/orzma_vt/src/lib.rs
@@ -25,8 +25,8 @@ mod vi;
 pub mod prelude {
     pub use crate::device::color::{Color, Palette, Rgb};
     pub use crate::device::modes::{
-        AutoWrap, CursorShape, InsertReplaceMode, KeypadMode, MouseEncoding, MouseTracking,
-        ScreenKind, TextCursorEnable, VtModes,
+        AutoWrap, CursorBlink, CursorShape, InsertReplaceMode, KeypadMode, MouseEncoding,
+        MouseTracking, ScreenKind, TextCursorEnable, TextCursorModes, VtModes,
     };
     pub use crate::frame::{DirtyRow, Frame};
     pub use crate::hyperlink::{Hyperlink, HyperlinkId, HyperlinkUri, is_allowed};

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -18,7 +18,9 @@ use self::cell::{Cell, Pen};
 use self::grid::Grid;
 use self::grid::LineId;
 use self::grid::row::Row;
-use crate::device::modes::{AutoWrap, CursorShape, InsertReplaceMode, TextCursorEnable};
+use crate::device::modes::{
+    AutoWrap, CursorBlink, InsertReplaceMode, TextCursorEnable, TextCursorModes,
+};
 use crate::frame::damage::DamageSpan;
 use crate::placement::{AnchoredPlacement, InstanceId, PlacementSize};
 use crate::screen::character_sets::{
@@ -995,18 +997,17 @@ impl Screen {
 
     /// The write cursor as an emitted frame carries it.
     ///
-    /// `text_cursor_enable` is `DECTCEM`.
-    // TODO: Report the real shape and blink once DECSCUSR lands. Block /
-    // steady is what the terminal starts at.
-    pub fn cursor(&self, text_cursor_enable: TextCursorEnable) -> Cursor {
+    /// The screen supplies the position; `text_cursor` supplies every
+    /// presentation field.
+    pub fn cursor(&self, text_cursor: TextCursorModes) -> Cursor {
         Cursor {
             point: GridPoint {
                 line: GridLine::from(self.state.line),
                 column: self.state.column,
             },
-            shape: CursorShape::Block,
-            blinking: false,
-            visible: matches!(text_cursor_enable, TextCursorEnable::Shown),
+            shape: text_cursor.shape,
+            blinking: matches!(text_cursor.blink, CursorBlink::Blinking),
+            visible: matches!(text_cursor.enable, TextCursorEnable::Shown),
         }
     }
 

--- a/crates/orzma_vt/src/screen.rs
+++ b/crates/orzma_vt/src/screen.rs
@@ -18,14 +18,14 @@ use self::cell::{Cell, Pen};
 use self::grid::Grid;
 use self::grid::LineId;
 use self::grid::row::Row;
-use crate::device::modes::{AutoWrap, InsertReplaceMode, TextCursorEnable};
+use crate::device::modes::{AutoWrap, CursorShape, InsertReplaceMode, TextCursorEnable};
 use crate::frame::damage::DamageSpan;
 use crate::placement::{AnchoredPlacement, InstanceId, PlacementSize};
 use crate::screen::character_sets::{
     CharacterSet, CharacterSetMapping, GCode, GraphicChar, SingleShift,
 };
 use crate::screen::checkpoint::Checkpoint;
-use crate::screen::cursor::{Cursor, CursorShape};
+use crate::screen::cursor::Cursor;
 use crate::screen::grid::GridSize;
 use crate::screen::grid::coords::{GridColumn, GridLine, GridPoint, ScreenLine};
 use crate::screen::margins::{Margins, OriginMode, ScrollRegion};

--- a/crates/orzma_vt/src/screen/checkpoint.rs
+++ b/crates/orzma_vt/src/screen/checkpoint.rs
@@ -16,7 +16,7 @@ use crate::screen::state::ScreenState;
 /// the saved row with the grid, so after one the never-saved position
 /// may sit below home.
 ///
-/// `DECRC` restores neither `IRM` nor `DECTCEM`.
+/// `DECRC` restores neither `IRM` nor any of the text cursor modes.
 ///
 /// The `Wrap flag (autowrap or no autowrap)` the VT420 and VT520
 /// manuals list among the items `DECSC` saves is the last-column flag

--- a/crates/orzma_vt/src/screen/cursor.rs
+++ b/crates/orzma_vt/src/screen/cursor.rs
@@ -14,8 +14,8 @@ pub struct Cursor {
     pub point: GridPoint,
     /// Visual shape selected by DECSCUSR.
     pub shape: CursorShape,
-    /// True when DECSCUSR selects a blinking variant.
-    /// Steady variants (`\033[2 q`, `\033[4 q`, `\033[6 q`) set this to false.
+    /// True when the cursor blinks rather than being drawn
+    /// continuously.
     pub blinking: bool,
     /// True when the application wants the cursor drawn, which DECTCEM alone decides.
     pub visible: bool,

--- a/crates/orzma_vt/src/screen/cursor.rs
+++ b/crates/orzma_vt/src/screen/cursor.rs
@@ -1,5 +1,6 @@
-//! The cursor snapshot a screen reports and the shape DECSCUSR selects.
+//! The cursor snapshot a screen reports.
 
+use crate::device::modes::CursorShape;
 use crate::screen::grid::coords::GridPoint;
 
 /// Bit 0 of the packed `cursor_style` u32 — set when the cursor
@@ -34,18 +35,6 @@ impl Cursor {
         let blinking = if self.blinking { 1u32 } else { 0 };
         visible | (shape << 1) | (blinking << 3)
     }
-}
-
-/// Terminal cursor shape.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum CursorShape {
-    /// Block cursor.
-    #[default]
-    Block,
-    /// Underline cursor.
-    Underline,
-    /// Bar (vertical line) cursor.
-    Bar,
 }
 
 #[cfg(test)]

--- a/crates/orzma_vt/src/screen/tests/cursor.rs
+++ b/crates/orzma_vt/src/screen/tests/cursor.rs
@@ -1,30 +1,34 @@
 //! Tests for the cursor snapshot a screen reports.
 
 use super::*;
+use crate::device::modes::{CursorBlink, CursorShape, TextCursorModes};
 
-/// Asserts that the reported cursor carries the write position, and
-/// that the caller's DECTCEM state decides visibility while shape and
-/// blink stay at the terminal's power-up values.
+/// Asserts that the reported cursor carries the write position and the
+/// presentation handed in, the screen contributing only the position.
 ///
 /// Case: a shell prints its prompt and the caller asks for the caret
-/// shown after it. The same screen, mid-repaint, has a full-screen
-/// application asking the caller to report the caret hidden instead.
+/// the terminal starts with. The same screen, mid-repaint, has a
+/// full-screen application asking for a hidden blinking bar instead.
 #[test]
-fn the_cursor_reports_the_write_position_and_the_callers_visibility() {
+fn the_cursor_reports_the_write_position_and_the_callers_presentation() {
     let mut screen = screen();
     screen.print('a', InsertReplaceMode::Replace, AutoWrap::Enabled);
     screen.print('b', InsertReplaceMode::Replace, AutoWrap::Enabled);
 
-    let shown = screen.cursor(TextCursorEnable::Shown);
+    let shown = screen.cursor(TextCursorModes::default());
     assert_eq!(shown.point.line, GridLine(0));
     assert_eq!(shown.point.column, GridColumn(2));
     assert_eq!(shown.shape, CursorShape::Block);
     assert!(!shown.blinking);
     assert!(shown.visible);
 
-    let hidden = screen.cursor(TextCursorEnable::Hidden);
-    assert!(!hidden.visible);
+    let hidden = screen.cursor(TextCursorModes {
+        enable: TextCursorEnable::Hidden,
+        shape: CursorShape::Bar,
+        blink: CursorBlink::Blinking,
+    });
     assert_eq!(hidden.point, shown.point);
-    assert_eq!(hidden.shape, shown.shape);
-    assert_eq!(hidden.blinking, shown.blinking);
+    assert!(!hidden.visible);
+    assert_eq!(hidden.shape, CursorShape::Bar);
+    assert!(hidden.blinking);
 }

--- a/docs/todo/vt-conformance-scope.md
+++ b/docs/todo/vt-conformance-scope.md
@@ -60,7 +60,7 @@ xterm-ctlseqs.pdf 全体の網羅は目標にしない。
 | シーケンス | 機能 | terminfo | 現状 | 影響 |
 |---|---|---|---|---|
 | `CSI ! p` | DECSTR ソフトリセット | `is2`, `rs2` | **✅ 実装済み（2026-09-12）**。`DeviceState::soft_reset` が Table 5-9 の名指しする 5 つのモード（DECTCEM / IRM / DECCKM / DECNKM / DECAWM）と**インデックス色パレット**を戻し、`Screen::soft_reset` が margins・DECOM・文字集合・pen・checkpoint を戻す。`CharacterSetMapping::reset()` の `#[expect(dead_code)]` はここで外れた。**決定 4 つ**: (1) **DECAWM は有効に戻す** — 表の "No autowrap" に従わない。`is2` は折り返しを戻すシーケンスを含まないので、表どおりだと `tput init` のたびにシェルの長い行が折り返さなくなる。xterm の DECSTR 腕は `bitcpy(&xw->flags, xw->initflags, WRAPAROUND \| …)` でリソース既定（`autoWrap` = true）に戻し、DECSTR を実装した 8 実装すべてが有効側。xterm 自身の適合性テスト `esctest2` の `test_DECSTR_DECAWM` もこの逸脱を期待値として `@intentionalDeviationFromSpec` 付きで持つ。(2) **ライブカーソルは動かさない** — xterm の `CursorSet(screen, 0, 0, …)` は `if (full)` ＝ RIS 側にしかなく、DECSTR が (0,0) に戻すのは保存カーソルのスロットだけ（`CursorSave(xw); screen->sc[whichBuf].row = col = 0;`）。vt220 Table 4-10 の脚注 `*` も "Applies only to later restore cursor commands (DECRC)" と限定する。したがって `Screen::set_scroll_region(None, None)` は `seat_home()` を含むので使えず、`Screen::soft_reset` は `scroll_region` を直接差し替える。(3) **アクティブ画面のみ** — 画面ごとの状態は DECSTR を受けた画面だけを戻す。両画面に効かせると `1049h` の入場時にプライマリの checkpoint へ保存したカーソルが消え、`1049l` での復帰が壊れる（kitty が実際に抱えている事故。Windows Terminal は GH#19918 で両画面からアクティブのみへ変更した）。(4) **パラメータは読み捨てる** — `CSI Ps ! p` を占める制御機能は無く、xterm も数を見ない。**LCF は解除しない** — (1) により `set_auto_wrap` の set 方向を通るため（§4 の LCF 一覧）。テストは `interpreter/tests/soft_reset.rs` と `screen/tests/soft_reset.rs` | ~~**terminfo 経由の初期化列の先頭**。毎回無視されモードが残留する。`CharacterSetMapping::reset()` は DECSTR 待ちで `#[expect(dead_code)]` のまま（`character_sets.rs:220`）~~ |
-| `CSI ?12 h/l` | カーソル点滅 | `cnorm`, `cvvis` | `MODE∅`。`blinking: false` 固定 | 点滅指定が効かない |
+| ~~`CSI ?12 h/l`~~ | ~~カーソル点滅~~ | `cnorm`, `cvvis` | **✅ 実装済み（2026-09-12）**。`VtModes::text_cursor.blink`（`CursorBlink`）に置き、DECSCUSR と同じ状態を last-writer-wins で共有する。**この共有は普遍ではない**: xterm（両方 `cursor_blink_esc`）・kitty（両方 `non_blinking`）・alacritty・ghostty・Windows Terminal・iTerm2 の 6 実装は 1 状態を共有するが、**foot は `decset` と `deccsusr` の 2 ビットを独立に持って OR する**（CHANGELOG: "blink if **either** … has been used"）ので `CSI 5 SP q` の後の `?12l` でも点滅が続き、**VTE は `?12` をモード表に持つが誰も読まない**、**wezterm は空の match 腕**。`xterm-256color` を名乗るので xterm 側に揃えた。**`?13` / `?14` は実装しない** — xterm が DECSET / DECRST の両方で `/* intentionally ignored (this is user-preference) */` としている。設定は入れていない。既定は steady で、xterm の `cursorBlink` 既定 `false`・alacritty の `Off`・foot の `no`・wezterm の `SteadyBlock` と一致する（kitty と ghostty だけが既定で点滅する） | ~~点滅指定が効かない~~ |
 | ~~`CSI ?3 h/l`~~ | ~~DECCOLM~~ | `is2`, `rs2` の一部 | **✅ 意図的に無視と明示（2026-09-12）**。`set_private_modes` に `3 => {}`。理由は `// NOTE:` に記録: ペインの幅は VT の持ち物ではなく（サイズは ウィンドウ形状 → レイアウト木 → PTY の一方通行）、vt510 p.143 が DECCOLM に定める副作用（左右上下マージンの既定化とページ全消去）だけを実行すると、来ない幅変更の代償にページを壊すことになる。`is2` に `\E[?3l` が入るので、これは **`tput init` のたびに**起きる。**xterm 自身がこのシーケンス全体を `c132` リソース（既定 off）で塞いでおり、同じ no-op に落ちる**（manpage `-132`: *"Normally, the VT102 DECCOLM escape sequence … is ignored"*、`charproc.c` の `srm_DECCOLM` は本体すべてが `if (screen->c132)` の中）。参照実装は割れている: ghostty も `?40`（既定 off）で完全無視、foot は `decset_decrst` に `case 3:` 自体が無い。kitty は **set 方向だけ**全消去＋ホーム、alacritty と wezterm は双方向でマージン既定化＋ホーム＋全消去（いずれもリサイズはしない）。テストは `interpreter/tests/column_mode.rs`（副作用を入れる変異で 4 本とも落ちることを確認済み） | ~~初期化列に含まれる~~ |
 | ~~`CSI ?1034 h/l`~~ | ~~8bit Meta~~ | `smm`/`rmm`, `km` | **✅ 意図的に無視と明示（2026-09-11）**。`set_private_modes` に `1034 => {}`。Alt は常に ESC 前置（xterm の metaSendsEscape 相当）で、xterm と foot は 1036 を 1034 より優先するので、この設定では 8 ビット符号化に到達しない。bash / readline が起動時に送る `smm` は変更前から無視されており、挙動は変わらない。テストは `interpreter/tests/meta_key.rs` | ~~Meta キーのバイト表現が食い違う~~ |
 | `CSI ?5 h/l` | DECSCNM 反転 | `flash` | `MODE∅` | ビジュアルベルが無反応 |
@@ -91,7 +91,7 @@ terminfo には出ないが実際の TUI が直接叩くもの。`—` は「ロ
 
 | シーケンス | 機能 | 現状 | 直接叩く実例 |
 |---|---|---|---|
-| `CSI Ps SP q` | DECSCUSR カーソル形状 | `CSI∅`（DECSTR で intermediate 経路が開いたので `(None, [b' '], b'q')` の腕 1 本で入る）。`Cursor` 型と `CursorShape` は既にある。**実装時に `DeviceState::soft_reset` も要更新**: xterm の `ReallyReset` は `InitCursorShape` と `SetCursorBlink` を RIS と DECSTR の共通経路で呼ぶので、DECSCUSR で `shape` / `blinking` が動かせるようになった時点で DECSTR もそれらを power-up 値へ戻す必要がある（今は `Screen::cursor()` の固定値なので対象が無い） | **nvim が実測 5 回**（`CSI 0 q` / `1 q` / `2 q`）。vim の `term.c` |
+| ~~`CSI Ps SP q`~~ | ~~DECSCUSR カーソル形状~~ | **✅ 実装済み（2026-09-12）**。DECSTR が開けた intermediate 経路に `(None, [b' '], b'q')` の腕 1 本で入った。値は vt510.pdf p.251 の 0〜4 と xterm-ctlseqs.pdf p.29–30 の 5/6（bar）。**`7` は no-op ではなく電源投入時の style に戻す** — xterm の `CASE_DECSCUSR` は `7` を `screen->initial_cursor` に書き換えてから同じ switch を通し、その既定リソース値が STEADY_BLOCK。ただし `Self::default()` はコンパイル時定数なので、**設定層が入ったら `7` 腕と `DeviceState::reset` を設定済みの初期 style から読むように直すこと**（そうしないと `CSI 7 SP q` はハードコードされた block に戻る）。**`なし / 0 / 1` はすべて blinking block に潰した** — 規範資料は一致しているが実装は割れており、`0` を「端末既定」と読むのは alacritty・ghostty・foot・tmux・termwiz、xterm/vt510 どおりに読むのは xterm だけ。**`DeviceState::soft_reset` も shape / blink を戻す**（この行が予告していたとおり。`ReallyReset` の `InitCursorShape` と `SetCursorBlink` は最初の `if (full)` より前にあり DECSTR 経路でも走る） | ~~nvim が実測 5 回~~（解消済み） |
 | ~~`CSI s` / `CSI u`~~ | ~~SCOSC / SCORC~~ | **✅ 実装済み（2026-09-11）**。パラメータ無しのときだけ DECSC / DECRC と同じ保存枠を使う（xterm の `only_default()` に揃えた。下の「`CSI s` の曖昧性」を参照） | blessed の `saveCursorA`/`restoreCursorA`、btop |
 | `CSI ?2026 h/l` | 同期出力 | `MODE∅`。`struct SyncBuffer {}` は**空のプレースホルダ**（`interpreter.rs:83`） | fzf がフレーム毎に発行。nvim/tmux/kitty |
 | `CSI ?1004` → `CSI I` / `CSI O` | フォーカス通知 | **モードは保存されるが送信側が存在しない**（`focus_in_out` の参照は定義と代入の 2 箇所のみ） | vim/nvim。フォーカス復帰時の再描画が来ない |
@@ -223,8 +223,9 @@ STD-070 が LCF をリセットすると規定する操作:
    `VtModes::text_cursor_enable` に置き、`Screen::cursor()` が引数で受け取って
    `DeviceState::cursor()` が畳む。DECAWM は `VtModes::auto_wrap` に置き、
    `DeviceState::set_auto_wrap` 経由でのみ書く（§4 の LCF 一覧を参照）。
-   残るのは **カーソル点滅（`?12`）/ DECSCUSR**。`Screen::cursor()` の固定値のうち
-   `shape` と `blinking` は DECSCUSR 待ちのまま。
+   ~~残るのは **カーソル点滅（`?12`）/ DECSCUSR**~~ **完了（2026-09-12）**。3 つのモードは
+   `VtModes::text_cursor`（`TextCursorModes`）にまとめ、`Screen::cursor()` が 1 引数で
+   受け取る形は保った。`CursorShape` は `device/modes.rs` に移してある。
 
    **訂正**: DECTCEM 実装時に「DECAWM は `Checkpoint` に入れる必要がある」と記録したが
    これは誤りで、どちらのモードも `Checkpoint` に入らない。根拠は §4 の
@@ -236,12 +237,34 @@ STD-070 が LCF をリセットすると規定する操作:
    画面ごとの状態はアクティブ画面のみ（決定 3）。`DeviceState::reset_indexed_colors` も呼び、
    パレットが実際に動いたときだけ `DamageSpan::Full` を stage する。intermediate 付き CSI が
    match に届くようになったので、DECSCUSR と DECRQM は腕 1 本で入る。
-   残るのは **`CSI ?12`（カーソル点滅）** と **1049 の pen 修正**。
+   ~~残るのは **`CSI ?12`（カーソル点滅）**~~ も完了（2026-09-12）。残るのは **1049 の pen 修正**。
 5. **入力側の契約修正**（`kbs` の方針決定 → ファンクションキー → 修飾キー）。~~Shift-Tab~~ と Insert は **完了（2026-09-11）**。~~Meta~~ は §1-B の `CSI ?1034 h/l` 行のとおり意図的に無視と決着（2026-09-11）。
 6. ~~**OSC 4**~~ **完了（2026-09-12、OSC 104 と `?` 問い合わせを含む）** → 残るのは **OSC 10/11/12** とその問い合わせ・リセット（OSC 110/111/112）。OSC 4 で入れた `PaletteRequest` を広げて扱う。RIS での復帰は `Palette::reset`（全色を既定値へ戻す）が既に賄うので、ハンドラ側は `Palette` の `foreground` / `background` を書くのと、full repaint の staging（`frame.rs` の `palette` フィールドの TODO）を足すだけでよい。なお `OSC 104` は xterm-ctlseqs.pdf のとおりインデックス表だけを戻す（`Palette::reset_all_indexed`）ので、そちらに前景/背景を巻き込まないこと。
 7. **DECRQM/DECRPM と 2026 同期出力**、**DECRQSS/XTGETTCAP**。
 8. **OSC 8 / OSC 52**、**DECLRMM/DECSLRM**、**1015**。
-9. **残りの厳密準拠**: SGR blink、DECSCNM。~~メモリロック、プリンタ制御~~ は
+9. **コロン付きサブパラメータの扱い（リポジトリ全体）**。xterm は SGR と modifyOtherKeys 以外の
+   すべての CSI でサブパラメータを拒否する（`charproc.c` の `parms.has_subparams` 分岐）が、orzma は
+   `CsiParams::first_value` がグループ内の最初の整数を拾うので `CSI 1:2 H` が CUP として通る。
+   DECSCUSR 実装時（2026-09-12）に判明。**DECSCUSR だけ拒否すると二重基準になるので受理側に
+   揃えた**。直すなら全 CSI をまとめて裁定すること。
+10. **カーソル描画側（設定 PR とセット）**。VT 側は完了したが、**この PR まで到達不能だった
+   シェーダ経路が初めて生きた**（`Screen::cursor()` が Block/steady を直書きしていたため
+   Underline / Bar / 点滅の分岐は一度も実行されていなかった）。そこに欠陥が 2 つある:
+   (a) `terminal_ui_material.wgsl` の bar/underline の太さが `thickness = 2.0` の**物理ピクセル
+   直書きで DPR にもフォントサイズにも追随しない** — 同じファイルの他のストローク幅は
+   `underline_thickness_phys`（DPR・フォント由来）を使う。Retina では nvim の `CSI 5 SP q` が
+   論理 1px のヘアラインになる。(b) 最終列のアンダーラインカーソルが `paint_right_strip` の
+   帯にはみ出す。加えて点滅位相が `fract(time_seconds)` の自由走行で、**打鍵でリセットされず
+   非フォーカスでも止まらない**（調べた 6 実装すべてがリセットし、6/6 が非フォーカスで中空に
+   倒す。周期は xterm 600/300ms・alacritty 750ms・foot 500ms・wezterm 800ms・kitty は system、
+   orzma は 500/500ms。点滅停止は kitty 15s・alacritty 5s）。
+11. **非アクティブペインのカーソル（マルチプレクサ側）**。orzma は非アクティブペインにも
+   カーソルを描き続け dim/tint がかかるだけ。**tmux は実カーソルを 1 本しか持たず
+   `server_client_reset_state()` が `w->active` しか見ないので、非アクティブペインには
+   カーソル系シーケンスを一切送らない**。orzma は自前描画なので裁定が要る。
+   `bevy_orzma_tty_renderer` の `current_cursor_pos_and_style` が vi カーソルの shape/blink を
+   直書きで捨てている件も、方針を明文化するならここ。
+12. **残りの厳密準拠**: SGR blink、DECSCNM。~~メモリロック、プリンタ制御~~ は
    **意図的に無視と明示して完了（2026-09-11、§1-C）**。
 
 ## 6. 検証方法


### PR DESCRIPTION
`?12`（AT&T 610 カーソル点滅）と DECSCUSR（`CSI Ps SP q`）を実装し、`Cursor.blinking` と `Cursor.shape` を実際に駆動する。

`xterm-256color` を名乗る以上 `cvvis` = `\E[?12;25h` は契約だが、`?12` 未実装のため `cnorm` と区別できていなかった。DECSCUSR は nvim がモード切替のたびに送る。レンダラのワイヤ（`pack_cursor_style` → シェーダ）は既に通っており、欠けていたのは VT 層だけ。

## 変更

| コミット | 内容 | 挙動変化 |
|---|---|---|
| `1e590d39` | `CursorShape` を `screen/cursor.rs` → `device/modes.rs` へ移設 | なし |
| `f366f797` | `CursorBlink` 新設、3 モードを `VtModes::text_cursor`（`TextCursorModes`）に集約 | なし |
| `d87fa921` | `DECSET/DECRST 12` | あり |
| `ebfbaf3d` | DECSCUSR ＋ `soft_reset` の更新 | あり |
| `7bc6bee2` | 適合台帳 | ドキュメント |

`orzma_vt` 958 テスト（main の 929 ＋ 29）、workspace clippy / fmt クリーン。

## 決定事項

**`?12` と DECSCUSR は 1 つの blink 状態を last-writer-wins で共有する。** xterm（両方 `cursor_blink_esc`）・kitty（両方 `non_blinking`）・alacritty・ghostty・Windows Terminal・iTerm2 の 6 実装がそう。ただし普遍ではなく、**foot は 2 ビットを独立に持って OR し**（`CSI 5 SP q` の後の `?12l` でも点滅が続く）、**VTE は `?12` をモード表に持つが誰も読まず**、wezterm は空の match 腕。名乗った terminfo に従って xterm 側に揃えた。

**DECSCUSR の `7` は no-op ではなく電源投入時の style へ戻す。** xterm の `CASE_DECSCUSR` は `7` を `screen->initial_cursor` に書き換えてから同じ switch を通し、既定リソース値は STEADY_BLOCK。alacritty / wezterm / ghostty は `7` を捨てるが、それらは `0` を設定既定に割り当てており前提が違う。

**`なし / 0 / 1` はすべて blinking block。** 規範資料（vt510 p.251 / xterm-ctlseqs p.29）は一致しているが実装は割れており、`0` を「端末既定」と読むのは alacritty・ghostty・foot・tmux・termwiz。

**`?13` / `?14` は実装しない。** xterm が DECSET / DECRST の両方で `intentionally ignored (this is user-preference)` としている。

**既定は steady のまま。設定は入れない。** xterm の `cursorBlink` 既定 `false`・alacritty の `Off`・foot の `no`・wezterm の `SteadyBlock` と一致（kitty と ghostty だけが既定で点滅）。

**`DeviceState::soft_reset` も shape / blink を戻す。** xterm の `ReallyReset` は `InitCursorShape` と `SetCursorBlink` を最初の `if (full)` より**前**で呼ぶので、RIS だけでなく DECSTR 経路でも走る。#300 の台帳が予告していた要件。

## レビューで見てほしいところ

DECSCUSR は #300 が開けた intermediate 経路に `(None, [b' '], b'q')` の腕 1 本で入る。**このブランチは当初 2 つ目の dispatch 表を持っていたが、#300 が単一 match に畳んだのでその足場（約 30 行）ごと捨てた。**

## 既知の積み残し（別 PR）

**このブランチは、これまで到達不能だったシェーダ経路を初めて生かす。** `Screen::cursor()` が Block/steady を直書きしていたため、Underline / Bar / 点滅の分岐は一度も実行されていなかった。そこに 2 件の欠陥がある。

- bar / underline の太さが `thickness = 2.0` の**物理ピクセル直書きで DPR に追随しない**。Retina で nvim の `CSI 5 SP q` は論理 1px のヘアラインになり、同じセルの SGR アンダーライン（DPR スケール済み）より細い。
- 最終列のアンダーラインカーソルが右のオーバーフロー帯にはみ出す。

加えて点滅位相が自由走行で、打鍵でリセットされず非フォーカスでも止まらない（調べた 6 実装すべてがリセットし、6/6 が非フォーカスで中空に倒す）。いずれも `bevy_orzma_tty_renderer` にあり、このブランチのスコープ外。台帳の項目 10・11 に記録済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1vESEGhUrtbesFEyY4GBJ